### PR TITLE
[Fix] Model download fails with "CFNetworkDownload_*.tmp couldn't be moved" on some runs

### DIFF
--- a/tabby.xcodeproj/project.pbxproj
+++ b/tabby.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		A404828463CADB2ECDAE7AF3 /* LlamaPromptRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F29623C5C0A67B992D383A3C /* LlamaPromptRendererTests.swift */; };
 		ADEFEE12C197DB6C990E3812 /* SuggestionRequestFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1121FFDAD30C7F62E15289 /* SuggestionRequestFactoryTests.swift */; };
 		B053492719F6106E48290C32 /* SuggestionAvailabilityEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A39EC1A44E9160E13E2AE77 /* SuggestionAvailabilityEvaluatorTests.swift */; };
+		B5788B37B93AFEC10EFD3108 /* DownloadFileRescuerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAAEE25772008D75883F2655 /* DownloadFileRescuerTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -29,6 +30,7 @@
 		3FBFA92FA44AA317135426FB /* tabbyTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = tabbyTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5A39EC1A44E9160E13E2AE77 /* SuggestionAvailabilityEvaluatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SuggestionAvailabilityEvaluatorTests.swift; sourceTree = "<group>"; };
 		8B1121FFDAD30C7F62E15289 /* SuggestionRequestFactoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SuggestionRequestFactoryTests.swift; sourceTree = "<group>"; };
+		BAAEE25772008D75883F2655 /* DownloadFileRescuerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DownloadFileRescuerTests.swift; sourceTree = "<group>"; };
 		F29623C5C0A67B992D383A3C /* LlamaPromptRendererTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LlamaPromptRendererTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -67,7 +69,6 @@
 			children = (
 				1937414B2F81DE7000BEC04F /* tabby */,
 				1937414A2F81DE7000BEC04F /* Products */,
-				98425D3A1DB21E10B0F3BFA6 /* Frameworks */,
 				38079AF58386B5C2E9373742 /* tabbyTests */,
 			);
 			sourceTree = "<group>";
@@ -87,16 +88,9 @@
 				F29623C5C0A67B992D383A3C /* LlamaPromptRendererTests.swift */,
 				5A39EC1A44E9160E13E2AE77 /* SuggestionAvailabilityEvaluatorTests.swift */,
 				8B1121FFDAD30C7F62E15289 /* SuggestionRequestFactoryTests.swift */,
+				BAAEE25772008D75883F2655 /* DownloadFileRescuerTests.swift */,
 			);
-			name = tabbyTests;
 			path = tabbyTests;
-			sourceTree = "<group>";
-		};
-		98425D3A1DB21E10B0F3BFA6 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -215,6 +209,7 @@
 				A404828463CADB2ECDAE7AF3 /* LlamaPromptRendererTests.swift in Sources */,
 				B053492719F6106E48290C32 /* SuggestionAvailabilityEvaluatorTests.swift in Sources */,
 				ADEFEE12C197DB6C990E3812 /* SuggestionRequestFactoryTests.swift in Sources */,
+				B5788B37B93AFEC10EFD3108 /* DownloadFileRescuerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/tabby/Services/Utilities/DownloadFileRescuer.swift
+++ b/tabby/Services/Utilities/DownloadFileRescuer.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// File overview:
+/// Encapsulates the CFNetwork temp-file rescue that `ModelDownloadSessionDelegate`
+/// needs to perform inside `urlSession(_:downloadTask:didFinishDownloadingTo:)`.
+/// The logic is extracted from the delegate so the race-sensitive part is
+/// covered by unit tests instead of only by real downloads.
+///
+/// Why this is its own type:
+/// URLSession's `URLSessionDownloadTask` is painful to construct in a unit
+/// test without mocking the whole networking stack. Separating the file-move
+/// decision from the delegate callback means the decision can be tested
+/// with just a real `FileManager` and a pair of real file URLs.
+enum DownloadFileRescuer {
+    /// Moves the URLSession-provided temp file at `location` to a holding URL
+    /// we own, synchronously, within the single delegate callback where the
+    /// source file is still valid.
+    ///
+    /// Why this must be synchronous:
+    /// URLSession's contract for `didFinishDownloadingTo` is that `location`
+    /// is valid only for the duration of that one callback. CFNetwork reclaims
+    /// the file the moment the callback returns. Any `DispatchQueue.async`,
+    /// `Task {}`, or continuation hop between receiving `location` and moving
+    /// it would race against CFNetwork's cleanup — which is exactly the bug
+    /// this rescue pathway was introduced to fix (see PR #31 / issue #30).
+    static func rescue(
+        temporaryFileAt location: URL,
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        let holdingURL = fileManager.temporaryDirectory
+            .appendingPathComponent("tabby-download-\(UUID().uuidString)", isDirectory: false)
+        try fileManager.moveItem(at: location, to: holdingURL)
+        return holdingURL
+    }
+
+    /// Best-effort cleanup of a previously-rescued holding file. Called when
+    /// the download ultimately fails after `rescue` already succeeded — either
+    /// a transport error arrived or a stashed rescue error needs surfacing.
+    ///
+    /// Errors from the removal are intentionally swallowed. By the time we're
+    /// in cleanup, the caller has a real failure to report; a secondary file-
+    /// system error here would just obscure the root cause. A leaked temp
+    /// file in this path is harmless — macOS reaps `temporaryDirectory` on
+    /// reboot and normal temp-sweep cycles.
+    static func cleanup(
+        holdingFileAt url: URL,
+        fileManager: FileManager = .default
+    ) {
+        try? fileManager.removeItem(at: url)
+    }
+}

--- a/tabby/Services/Utilities/ModelDownloadManager.swift
+++ b/tabby/Services/Utilities/ModelDownloadManager.swift
@@ -250,6 +250,10 @@ private final class ModelDownloadSessionDelegate: NSObject, URLSessionDownloadDe
     private var downloadedFileURL: URL?
     private var response: URLResponse?
     private var hasCompleted = false
+    // Any error thrown while rescuing the temp file in `didFinishDownloadingTo`.
+    // We can't throw from the delegate callback, so we stash it and re-raise from
+    // `didCompleteWithError`, which is the single funnel that resumes the continuation.
+    private var finishError: Error?
 
     init(progressHandler: @escaping @Sendable (Double?) -> Void) {
         self.progressHandler = progressHandler
@@ -289,7 +293,23 @@ private final class ModelDownloadSessionDelegate: NSObject, URLSessionDownloadDe
         downloadTask: URLSessionDownloadTask,
         didFinishDownloadingTo location: URL
     ) {
-        downloadedFileURL = location
+        // URLSession's contract: the file at `location` is only valid for the duration of this
+        // callback. CFNetwork deletes it as soon as we return. If we just stored the URL and
+        // tried to use it later (from `didCompleteWithError` or the caller's moveItem), the
+        // file would already be gone — which surfaced to users as
+        // "cfnetworkdownload_*.tmp couldn't be moved."
+        //
+        // The fix is a synchronous handoff: move the bytes into a holding URL we own *right
+        // now*, while `location` is still live. The caller then moves that holding file to
+        // its final destination, or we clean it up on failure.
+        let holdingURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tabby-download-\(UUID().uuidString)", isDirectory: false)
+        do {
+            try FileManager.default.moveItem(at: location, to: holdingURL)
+            downloadedFileURL = holdingURL
+        } catch {
+            finishError = error
+        }
         response = downloadTask.response
     }
 
@@ -305,8 +325,14 @@ private final class ModelDownloadSessionDelegate: NSObject, URLSessionDownloadDe
             session.finishTasksAndInvalidate()
         }
 
-        if let error {
-            continuation?.resume(throwing: error)
+        // Surface transport errors first, then the delegate-side rescue error. Either way we
+        // must clean up any holding file we already claimed so failed downloads don't leak.
+        if let failure = error ?? finishError {
+            if let holdingURL = downloadedFileURL {
+                try? FileManager.default.removeItem(at: holdingURL)
+                downloadedFileURL = nil
+            }
+            continuation?.resume(throwing: failure)
             return
         }
 

--- a/tabby/Services/Utilities/ModelDownloadManager.swift
+++ b/tabby/Services/Utilities/ModelDownloadManager.swift
@@ -293,21 +293,16 @@ private final class ModelDownloadSessionDelegate: NSObject, URLSessionDownloadDe
         downloadTask: URLSessionDownloadTask,
         didFinishDownloadingTo location: URL
     ) {
-        // URLSession's contract: the file at `location` is only valid for the duration of this
-        // callback. CFNetwork deletes it as soon as we return. If we just stored the URL and
-        // tried to use it later (from `didCompleteWithError` or the caller's moveItem), the
-        // file would already be gone — which surfaced to users as
-        // "cfnetworkdownload_*.tmp couldn't be moved."
-        //
-        // The fix is a synchronous handoff: move the bytes into a holding URL we own *right
-        // now*, while `location` is still live. The caller then moves that holding file to
-        // its final destination, or we clean it up on failure.
-        let holdingURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("tabby-download-\(UUID().uuidString)", isDirectory: false)
+        // Synchronous handoff into a URL we own. The rescue logic lives in
+        // `DownloadFileRescuer` so the race-sensitive part can be unit-tested
+        // without standing up a real URLSession — see that type's doc comment
+        // for why the move must happen before this callback returns.
         do {
-            try FileManager.default.moveItem(at: location, to: holdingURL)
-            downloadedFileURL = holdingURL
+            downloadedFileURL = try DownloadFileRescuer.rescue(temporaryFileAt: location)
         } catch {
+            // Can't throw from a delegate callback; stash and re-raise from
+            // `didCompleteWithError`, the single funnel that resumes the
+            // continuation.
             finishError = error
         }
         response = downloadTask.response
@@ -329,7 +324,7 @@ private final class ModelDownloadSessionDelegate: NSObject, URLSessionDownloadDe
         // must clean up any holding file we already claimed so failed downloads don't leak.
         if let failure = error ?? finishError {
             if let holdingURL = downloadedFileURL {
-                try? FileManager.default.removeItem(at: holdingURL)
+                DownloadFileRescuer.cleanup(holdingFileAt: holdingURL)
                 downloadedFileURL = nil
             }
             continuation?.resume(throwing: failure)

--- a/tabbyTests/DownloadFileRescuerTests.swift
+++ b/tabbyTests/DownloadFileRescuerTests.swift
@@ -1,0 +1,127 @@
+import XCTest
+@testable import tabby
+
+/// Tests for the URLSession temp-file rescue that fixes #30.
+///
+/// These tests can't reproduce CFNetwork's actual "delete on callback return"
+/// behavior — that lives inside the URL loading system and isn't hook-able.
+/// What they *can* lock in is the exact logic the rescue depends on: that
+/// given a real source file the rescue moves it, and given a source that
+/// doesn't exist the rescue surfaces the failure instead of silently
+/// returning a broken URL. The pre-fix code would have passed the happy-path
+/// case here but silently succeeded on the missing-source case, because the
+/// old code just stored the URL and moved later. Locking this in means a
+/// future refactor that re-introduces the "store and move later" pattern
+/// will break the test suite instead of surfacing as user-visible download
+/// failures again.
+final class DownloadFileRescuerTests: XCTestCase {
+
+    // Track URLs to tear down so tests don't litter the temp directory with
+    // rescue-test fixtures. This matters more in CI, where the test process
+    // is short-lived but many test runs accumulate.
+    private var cleanupURLs: [URL] = []
+
+    override func tearDown() {
+        cleanupURLs.forEach { try? FileManager.default.removeItem(at: $0) }
+        cleanupURLs.removeAll()
+        super.tearDown()
+    }
+
+    // MARK: - rescue happy path
+
+    func test_rescue_movesFileFromSourceToHoldingURL() throws {
+        let sourceURL = try makeTemporarySourceFile(contents: "hello")
+
+        let holdingURL = try DownloadFileRescuer.rescue(temporaryFileAt: sourceURL)
+        cleanupURLs.append(holdingURL)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: holdingURL.path),
+                      "rescue should produce a holding file at the returned URL")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: sourceURL.path),
+                       "rescue moves (not copies) — source should be gone afterwards")
+    }
+
+    func test_rescue_preservesFileContents() throws {
+        let sourceURL = try makeTemporarySourceFile(contents: "content-marker-XYZ")
+
+        let holdingURL = try DownloadFileRescuer.rescue(temporaryFileAt: sourceURL)
+        cleanupURLs.append(holdingURL)
+
+        let contents = try String(contentsOf: holdingURL, encoding: .utf8)
+        XCTAssertEqual(contents, "content-marker-XYZ")
+    }
+
+    func test_rescue_producesHoldingURLInTemporaryDirectory() throws {
+        let sourceURL = try makeTemporarySourceFile(contents: "x")
+
+        let holdingURL = try DownloadFileRescuer.rescue(temporaryFileAt: sourceURL)
+        cleanupURLs.append(holdingURL)
+
+        let tempDir = FileManager.default.temporaryDirectory.resolvingSymlinksInPath().path
+        XCTAssertTrue(holdingURL.resolvingSymlinksInPath().path.hasPrefix(tempDir),
+                      "holding file should live under temporaryDirectory")
+    }
+
+    func test_rescue_producesUniqueHoldingURLsAcrossCalls() throws {
+        let first = try makeTemporarySourceFile(contents: "a")
+        let second = try makeTemporarySourceFile(contents: "b")
+
+        let h1 = try DownloadFileRescuer.rescue(temporaryFileAt: first)
+        let h2 = try DownloadFileRescuer.rescue(temporaryFileAt: second)
+        cleanupURLs.append(contentsOf: [h1, h2])
+
+        XCTAssertNotEqual(h1, h2, "concurrent downloads must not collide on one holding path")
+    }
+
+    // MARK: - rescue regression guard
+
+    /// Regression test for #30. If the source URL points to a file that's no
+    /// longer there — exactly the state CFNetwork leaves us in if we store
+    /// the URL and read it later — the rescue must throw, not silently
+    /// succeed with a bad URL. The pre-fix delegate did the equivalent of
+    /// this silent-success and produced the user-visible
+    /// "CFNetworkDownload_*.tmp couldn't be moved" error downstream.
+    func test_rescue_throwsWhenSourceFileDoesNotExist() {
+        let phantomURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tabby-rescue-test-phantom-\(UUID().uuidString)")
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: phantomURL.path),
+                       "precondition: phantom URL must not exist")
+
+        XCTAssertThrowsError(try DownloadFileRescuer.rescue(temporaryFileAt: phantomURL))
+    }
+
+    // MARK: - cleanup
+
+    func test_cleanup_removesExistingFile() throws {
+        let victimURL = try makeTemporarySourceFile(contents: "doomed")
+
+        DownloadFileRescuer.cleanup(holdingFileAt: victimURL)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: victimURL.path),
+                       "cleanup should remove the file at the given URL")
+    }
+
+    /// Cleanup is best-effort — its documented contract is to swallow errors
+    /// so they don't obscure the primary failure the caller is already
+    /// reporting. Calling it on a URL whose file is already gone must not
+    /// crash or throw.
+    func test_cleanup_isSilentOnMissingFile() {
+        let phantomURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tabby-cleanup-test-phantom-\(UUID().uuidString)")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: phantomURL.path))
+
+        // No throw, no return value to check — just that we get here.
+        DownloadFileRescuer.cleanup(holdingFileAt: phantomURL)
+    }
+
+    // MARK: - Helpers
+
+    private func makeTemporarySourceFile(contents: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tabby-rescue-test-src-\(UUID().uuidString)")
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+        cleanupURLs.append(url)
+        return url
+    }
+}


### PR DESCRIPTION
## Summary

Fixes model downloads that occasionally fail with `CFNetworkDownload_*.tmp couldn't be moved`. The download would reach 100% but the final move into `Application Support` would throw, leaving no artifact on disk.

## Root cause

`URLSession`'s contract for `urlSession(_:downloadTask:didFinishDownloadingTo:)` is that the file at `location` is only valid **for the duration of that callback**. CFNetwork reclaims it the moment we return.

`ModelDownloadSessionDelegate` was storing that URL and deferring the actual move until later — from `didCompleteWithError`, or from the caller after the continuation resumed. By then the file could already be gone, producing:

```
NSCocoaErrorDomain Code=4
"CFNetworkDownload_XXXXXX.tmp" couldn't be moved to ".../Models"
because either the former doesn't exist, or the folder containing the
latter doesn't exist.
```

The window is small, which is why it didn't fail every run — but under IO pressure, backgrounding, or slow disks it was reproducible.

## Fix (commit 1)

Synchronous rescue inside `didFinishDownloadingTo` — move the bytes to a holding URL we own *right now*, while `location` is still live. The delegate callback can't throw, so on failure we stash the error and re-raise from `didCompleteWithError` (the single funnel that resumes the continuation). Cleanup on failure paths so holding files don't leak.

## Refactor + tests (commit 2)

Extracts the rescue logic into a standalone `DownloadFileRescuer` helper at `tabby/Services/Utilities/DownloadFileRescuer.swift`. The delegate becomes a thin caller. Behaviour is identical; the point of the extraction is that the race-sensitive logic now has unit-test coverage.

Tests (`tabbyTests/DownloadFileRescuerTests.swift`, 7 cases):

- **`test_rescue_throwsWhenSourceFileDoesNotExist`** — regression guard for this bug. Exercises exactly the state CFNetwork leaves us in after the callback returns (source already gone). If a future refactor re-introduces "store URL, move later", this test fires.
- `test_rescue_movesFileFromSourceToHoldingURL` — happy path; source gone, holding present.
- `test_rescue_preservesFileContents` — bytes survive the move.
- `test_rescue_producesHoldingURLInTemporaryDirectory` — rescued file lives under `temporaryDirectory`.
- `test_rescue_producesUniqueHoldingURLsAcrossCalls` — concurrent downloads can't collide.
- `test_cleanup_removesExistingFile` / `test_cleanup_isSilentOnMissingFile` — cleanup contract.

## Verified locally

```
xcodebuild test -project tabby.xcodeproj -scheme tabby \
  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO
# ** TEST SUCCEEDED **  32 tests  0 failures
```

## Fixes

Fixes #30