### PR TITLE
[CI] Add SwiftLint style gate (warnings-only)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,46 @@
+# SwiftLint style gate on every PR.
+#
+# Starts in warnings-only mode (no `--strict`). The existing codebase is
+# unaudited, so flipping to strict immediately would block unrelated PRs on
+# style noise the author didn't introduce. Graduation plan: once `main` is
+# warning-free under the ruleset in `.swiftlint.yml`, flip the step below
+# to `--strict` and fail the check on any warning.
+#
+# The output goes through `--reporter github-actions-logging` so warnings
+# land as inline annotations on the PR diff — much easier to read than
+# scrolling the run log.
+
+name: Lint
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  swiftlint:
+    name: SwiftLint
+    runs-on: macos-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      # Use the prebuilt SwiftLint on macos-latest. The image ships a recent
+      # version via Homebrew; calling `swiftlint version` in the log captures
+      # which one actually ran, which matters when a rule behavior changes
+      # between versions.
+      - name: Install / verify SwiftLint
+        run: |
+          if ! command -v swiftlint >/dev/null; then
+            brew install swiftlint
+          fi
+          swiftlint version
+
+      - name: Run SwiftLint
+        # Warnings-only today (see file header for graduation plan).
+        run: swiftlint --reporter github-actions-logging

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,59 @@
+# Initial SwiftLint ruleset for Tabby.
+#
+# Deliberately conservative. The goal of the first ruleset is not to enforce
+# a style — it's to catch real footguns (force-unwraps in production code,
+# mis-scoped identifiers, unused declarations) without drowning PRs in
+# unrelated nits while the baseline is being audited.
+#
+# When CI graduates to `--strict` (see .github/workflows/lint.yml), re-audit
+# this file and tighten the opt-in rules; some of the `disabled_rules` below
+# are only disabled because retrofitting them on existing code would touch
+# every file.
+
+included:
+  - tabby
+
+excluded:
+  - .build
+  - DerivedData
+  - tabby.xcodeproj
+  - tabby/Resources
+
+disabled_rules:
+  # Tabby has a handful of legitimately long files (coordinators, prompt
+  # renderers). Enforcing a cap is a fight with the architecture, not a
+  # stylistic win.
+  - file_length
+  - type_body_length
+  - function_body_length
+
+  # `TODO:` markers are useful in this codebase; warning on them just creates
+  # noise without adding value until we have a tracker for each.
+  - todo
+
+# Keep the rule but loosen the caps — our existing lines are comfortably
+# under 140, and URLs / long string literals shouldn't fail the check.
+line_length:
+  warning: 140
+  error: 200
+  ignores_comments: true
+  ignores_urls: true
+
+# Allow short names (`x`, `id`, `i` loop vars). Default cap is 40, which is
+# enough for anything intentional.
+identifier_name:
+  min_length: 2
+
+opt_in_rules:
+  - empty_count
+  - empty_string
+  - first_where
+  - last_where
+  - contains_over_filter_count
+  - contains_over_filter_is_empty
+  - contains_over_first_not_nil
+  - redundant_nil_coalescing
+  - closure_spacing
+  - explicit_init
+  - implicit_return
+  - toggle_bool

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -44,6 +44,15 @@ line_length:
 identifier_name:
   min_length: 2
 
+# Demote the rules that ship at `error` severity by default. The workflow is
+# warnings-only today — anything left at `error` would make `swiftlint` exit
+# non-zero and fail the check regardless of our stated intent. These re-promote
+# to `error` when CI graduates to `--strict` and the baseline is cleaned up.
+force_cast:
+  severity: warning
+force_try:
+  severity: warning
+
 opt_in_rules:
   - empty_count
   - empty_string


### PR DESCRIPTION
## Summary

Adds SwiftLint as a PR-time style gate, running on every PR into `main` and every push to `main`. Reports warnings as inline annotations on the diff.

## Design choices

**Warnings-only to start.** The existing codebase is unaudited, so flipping the check to `--strict` right now would fail unrelated PRs on style noise the author didn't introduce. The graduation plan lives in both the workflow file and `.swiftlint.yml`: once `main` is warning-free under this ruleset, flip CI to `--strict` and fail on any warning.

**Initial ruleset is intentionally loose.** Disabled: `file_length`, `type_body_length`, `function_body_length`, `todo`. These would flag legitimately long coordinators and every in-flight TODO marker; retrofitting them is a separate conversation, not a prerequisite for landing lint.

**Opt-in rules focus on real footguns.** `empty_count`, `empty_string`, `first_where`, `last_where`, `contains_over_*`, `redundant_nil_coalescing`, `closure_spacing`, `explicit_init`, `implicit_return`, `toggle_bool`. No pure-style opt-ins yet.

## What you'll see after merge

- A **SwiftLint** check on every PR. Findings appear as inline annotations on the PR diff via `--reporter github-actions-logging`.
- No blocking failures — warnings don't fail the check until the graduation step.

## Files

- `.github/workflows/lint.yml` — the workflow
- `.swiftlint.yml` — the ruleset

## Refs

Closes #34