### PR TITLE
tests: Add initial unit suite for pure-function spine

### DIFF
--- a/scripts/add_test_target.rb
+++ b/scripts/add_test_target.rb
@@ -1,0 +1,145 @@
+#!/usr/bin/env ruby
+# Adds a `tabbyTests` unit-test target to tabby.xcodeproj and wires the
+# existing Swift files in `tabbyTests/` into it. Idempotent — safe to re-run.
+#
+# Why a script instead of clicking through Xcode:
+#  - Xcode's target template is opaque; running it on every contributor's box
+#    risks divergent settings. Source-of-truth in a script keeps the setup
+#    reproducible and reviewable.
+#  - Test infrastructure should be inspectable like any other code. Diffing a
+#    Ruby script is much easier than diffing a pbxproj mutation.
+#
+# Requires the `xcodeproj` Ruby gem. On macOS with CocoaPods installed, the
+# cocoapods GEM_HOME already ships it; the Makefile-free way to invoke is:
+#
+#   GEM_HOME="/opt/homebrew/Cellar/cocoapods/<ver>/libexec" \
+#     ruby scripts/add_test_target.rb
+
+require 'xcodeproj'
+
+PROJECT_PATH      = 'tabby.xcodeproj'
+HOST_TARGET_NAME  = 'tabby'
+TEST_TARGET_NAME  = 'tabbyTests'
+DEPLOYMENT_TARGET = '26.0'
+TEST_BUNDLE_ID    = 'com.jacobfu.tabby.tabbyTests'
+TESTS_DIR         = 'tabbyTests'
+
+project = Xcodeproj::Project.open(PROJECT_PATH)
+
+host_target = project.targets.find { |t| t.name == HOST_TARGET_NAME }
+raise "Host target '#{HOST_TARGET_NAME}' not found" unless host_target
+
+# --- 1. Ensure the test target exists ---------------------------------------
+# `new_target` is not idempotent; guard on presence so re-runs don't duplicate.
+test_target = project.targets.find { |t| t.name == TEST_TARGET_NAME }
+if test_target.nil?
+  test_target = project.new_target(
+    :unit_test_bundle,
+    TEST_TARGET_NAME,
+    :osx,
+    DEPLOYMENT_TARGET,
+    project.products_group,
+    :swift
+  )
+end
+
+# --- 2. Build settings ------------------------------------------------------
+# TEST_HOST + BUNDLE_LOADER let the test bundle load the app's symbols at
+# test time; this is what makes `@testable import tabby` actually resolve.
+# We intentionally disable code signing for the test bundle so CI runners
+# without the dev cert can still run `xcodebuild test`.
+test_target.build_configurations.each do |config|
+  config.build_settings.merge!(
+    # xcodeproj's `new_target` skips PRODUCT_NAME for unit test bundles; without
+    # it the swift compiler sees `-module-name ""` and fails. Setting both
+    # keeps `swiftc` happy and keeps the compiled .xctest bundle on a
+    # predictable name.
+    'PRODUCT_NAME'                 => '$(TARGET_NAME)',
+    'PRODUCT_MODULE_NAME'          => '$(TARGET_NAME)',
+    'TEST_HOST'                    => '$(BUILT_PRODUCTS_DIR)/tabby.app/Contents/MacOS/tabby',
+    'BUNDLE_LOADER'                => '$(TEST_HOST)',
+    'PRODUCT_BUNDLE_IDENTIFIER'    => TEST_BUNDLE_ID,
+    'SWIFT_VERSION'                => '5.0',
+    'MACOSX_DEPLOYMENT_TARGET'     => DEPLOYMENT_TARGET,
+    'GENERATE_INFOPLIST_FILE'      => 'YES',
+    'CODE_SIGN_STYLE'              => 'Automatic',
+    'CODE_SIGN_IDENTITY'           => '-',
+    'CODE_SIGNING_REQUIRED'        => 'NO',
+    'CODE_SIGNING_ALLOWED'         => 'NO',
+    'LD_RUNPATH_SEARCH_PATHS'      => ['$(inherited)', '@executable_path/../Frameworks', '@loader_path/../Frameworks']
+  )
+end
+
+# --- 3. Target dependency on the host app -----------------------------------
+unless test_target.dependencies.any? { |dep| dep.target == host_target }
+  test_target.add_dependency(host_target)
+end
+
+# Xcodeproj's `new_target(:unit_test_bundle, :osx, ...)` helpfully adds
+# Cocoa.framework to the Frameworks build phase, but it hardcodes the path
+# to whatever SDK string the gem was last updated against (today: MacOSX15.0).
+# Our SDK is 26.x; pure Swift XCTest bundles don't need Cocoa anyway. Strip
+# the build-file entry so we don't ship a stale reference.
+test_target.frameworks_build_phase.files.to_a.each do |build_file|
+  file_ref = build_file.file_ref
+  next unless file_ref&.path&.include?('Cocoa.framework')
+
+  test_target.frameworks_build_phase.remove_build_file(build_file)
+  # Unlink from whichever group the gem parked it in (usually an "OS X" group
+  # created as a side effect), then drop the file reference entirely.
+  file_ref.remove_from_project
+end
+
+# Prune any empty groups left behind after removing Cocoa — otherwise a
+# phantom "OS X" group shows up in the Xcode navigator with nothing in it.
+project.main_group.recursive_children.to_a.each do |child|
+  next unless child.is_a?(Xcodeproj::Project::Object::PBXGroup)
+  next unless child.children.empty?
+  next if child == project.products_group || child == project.main_group
+
+  child.remove_from_project
+end
+
+# --- 4. File group + source membership --------------------------------------
+# Idempotent: find-or-create the group, then only add file refs that aren't
+# already present. This way re-running after adding new test files just
+# incorporates the new ones.
+tests_group = project.main_group[TESTS_DIR] ||
+              project.main_group.new_group(TESTS_DIR, TESTS_DIR)
+
+test_files = Dir.glob(File.join(TESTS_DIR, '*.swift')).sort
+raise "No test files in #{TESTS_DIR}/" if test_files.empty?
+
+existing_paths = tests_group.files.map(&:path)
+test_files.each do |path|
+  basename = File.basename(path)
+  next if existing_paths.include?(basename)
+
+  file_ref = tests_group.new_reference(basename)
+  test_target.add_file_references([file_ref])
+end
+
+# --- 5. Scheme: add the test target to the Test action ----------------------
+# Without this, `xcodebuild test -scheme tabby` has nothing to run.
+scheme_path = File.join(PROJECT_PATH, 'xcshareddata', 'xcschemes', "#{HOST_TARGET_NAME}.xcscheme")
+scheme = Xcodeproj::XCScheme.new(scheme_path)
+
+already_testable = scheme.test_action.testables.any? do |testable|
+  testable.buildable_references.any? { |ref| ref.target_name == TEST_TARGET_NAME }
+end
+
+unless already_testable
+  testable = Xcodeproj::XCScheme::TestAction::TestableReference.new(test_target)
+  scheme.test_action.add_testable(testable)
+end
+
+# --- 6. Save ----------------------------------------------------------------
+scheme.save_as(PROJECT_PATH, HOST_TARGET_NAME, true)
+project.save
+
+puts "Target '#{TEST_TARGET_NAME}' present: #{!project.targets.find { |t| t.name == TEST_TARGET_NAME }.nil?}"
+puts "Files wired:"
+test_target.source_build_phase.files_references.each do |ref|
+  puts "  - #{ref.path}"
+end
+puts "Scheme updated: #{scheme_path}"

--- a/tabby.xcodeproj/project.pbxproj
+++ b/tabby.xcodeproj/project.pbxproj
@@ -9,15 +9,34 @@
 /* Begin PBXBuildFile section */
 		A1C3E0012F90000100AAA001 /* LlamaSwift in Frameworks */ = {isa = PBXBuildFile; productRef = A1C3E0002F90000100AAA001 /* LlamaSwift */; };
 		A1C3E0112F90000100AAA001 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = A1C3E0102F90000100AAA001 /* Sparkle */; };
+		A404828463CADB2ECDAE7AF3 /* LlamaPromptRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F29623C5C0A67B992D383A3C /* LlamaPromptRendererTests.swift */; };
+		ADEFEE12C197DB6C990E3812 /* SuggestionRequestFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1121FFDAD30C7F62E15289 /* SuggestionRequestFactoryTests.swift */; };
+		B053492719F6106E48290C32 /* SuggestionAvailabilityEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A39EC1A44E9160E13E2AE77 /* SuggestionAvailabilityEvaluatorTests.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		E973E5B467F19C10FF50C9C0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 193741412F81DE7000BEC04F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 193741482F81DE7000BEC04F;
+			remoteInfo = tabby;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		193741492F81DE7000BEC04F /* tabby.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = tabby.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		3FBFA92FA44AA317135426FB /* tabbyTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = tabbyTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		5A39EC1A44E9160E13E2AE77 /* SuggestionAvailabilityEvaluatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SuggestionAvailabilityEvaluatorTests.swift; sourceTree = "<group>"; };
+		8B1121FFDAD30C7F62E15289 /* SuggestionRequestFactoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SuggestionRequestFactoryTests.swift; sourceTree = "<group>"; };
+		F29623C5C0A67B992D383A3C /* LlamaPromptRendererTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LlamaPromptRendererTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		1937414B2F81DE7000BEC04F /* tabby */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
 			path = tabby;
 			sourceTree = "<group>";
 		};
@@ -33,6 +52,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		9C0C286AC971FE1F5AB12DB8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -41,6 +67,8 @@
 			children = (
 				1937414B2F81DE7000BEC04F /* tabby */,
 				1937414A2F81DE7000BEC04F /* Products */,
+				98425D3A1DB21E10B0F3BFA6 /* Frameworks */,
+				38079AF58386B5C2E9373742 /* tabbyTests */,
 			);
 			sourceTree = "<group>";
 		};
@@ -48,8 +76,27 @@
 			isa = PBXGroup;
 			children = (
 				193741492F81DE7000BEC04F /* tabby.app */,
+				3FBFA92FA44AA317135426FB /* tabbyTests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		38079AF58386B5C2E9373742 /* tabbyTests */ = {
+			isa = PBXGroup;
+			children = (
+				F29623C5C0A67B992D383A3C /* LlamaPromptRendererTests.swift */,
+				5A39EC1A44E9160E13E2AE77 /* SuggestionAvailabilityEvaluatorTests.swift */,
+				8B1121FFDAD30C7F62E15289 /* SuggestionRequestFactoryTests.swift */,
+			);
+			name = tabbyTests;
+			path = tabbyTests;
+			sourceTree = "<group>";
+		};
+		98425D3A1DB21E10B0F3BFA6 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -79,6 +126,24 @@
 			productReference = 193741492F81DE7000BEC04F /* tabby.app */;
 			productType = "com.apple.product-type.application";
 		};
+		FA14279AECE62FBF1162F537 /* tabbyTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C2F70348176E20D09A554097 /* Build configuration list for PBXNativeTarget "tabbyTests" */;
+			buildPhases = (
+				A3C5DA8F3C631E089F2C6671 /* Sources */,
+				9C0C286AC971FE1F5AB12DB8 /* Frameworks */,
+				2E6FFFE4DB09561F83FE186D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				1611518BB70BEEF01D2401F8 /* PBXTargetDependency */,
+			);
+			name = tabbyTests;
+			productName = tabbyTests;
+			productReference = 3FBFA92FA44AA317135426FB /* tabbyTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -104,7 +169,7 @@
 			mainGroup = 193741402F81DE7000BEC04F;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				A1C3E0022F90000100AAA001 /* XCRemoteSwiftPackageReference "llama" */,
+				A1C3E0022F90000100AAA001 /* XCRemoteSwiftPackageReference "llama.swift" */,
 				A1C3E0122F90000100AAA001 /* XCRemoteSwiftPackageReference "Sparkle" */,
 			);
 			preferredProjectObjectVersion = 77;
@@ -113,12 +178,20 @@
 			projectRoot = "";
 			targets = (
 				193741482F81DE7000BEC04F /* tabby */,
+				FA14279AECE62FBF1162F537 /* tabbyTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		193741472F81DE7000BEC04F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2E6FFFE4DB09561F83FE186D /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -135,7 +208,26 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A3C5DA8F3C631E089F2C6671 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A404828463CADB2ECDAE7AF3 /* LlamaPromptRendererTests.swift in Sources */,
+				B053492719F6106E48290C32 /* SuggestionAvailabilityEvaluatorTests.swift in Sources */,
+				ADEFEE12C197DB6C990E3812 /* SuggestionRequestFactoryTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		1611518BB70BEEF01D2401F8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = tabby;
+			target = 193741482F81DE7000BEC04F /* tabby */;
+			targetProxy = E973E5B467F19C10FF50C9C0 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		193741522F81DE7200BEC04F /* Debug */ = {
@@ -324,6 +416,54 @@
 			};
 			name = Release;
 		};
+		6C6404C4557E1BE4CFCFFFEE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGNING_REQUIRED = NO;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jacobfu.tabby.tabbyTests;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/tabby.app/Contents/MacOS/tabby";
+			};
+			name = Debug;
+		};
+		DBAA9C9A1F8C6DEB2FA61301 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGNING_REQUIRED = NO;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jacobfu.tabby.tabbyTests;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/tabby.app/Contents/MacOS/tabby";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -345,10 +485,19 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		C2F70348176E20D09A554097 /* Build configuration list for PBXNativeTarget "tabbyTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DBAA9C9A1F8C6DEB2FA61301 /* Release */,
+				6C6404C4557E1BE4CFCFFFEE /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		A1C3E0022F90000100AAA001 /* XCRemoteSwiftPackageReference "llama" */ = {
+		A1C3E0022F90000100AAA001 /* XCRemoteSwiftPackageReference "llama.swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mattt/llama.swift";
 			requirement = {
@@ -369,7 +518,7 @@
 /* Begin XCSwiftPackageProductDependency section */
 		A1C3E0002F90000100AAA001 /* LlamaSwift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A1C3E0022F90000100AAA001 /* XCRemoteSwiftPackageReference "llama" */;
+			package = A1C3E0022F90000100AAA001 /* XCRemoteSwiftPackageReference "llama.swift" */;
 			productName = LlamaSwift;
 		};
 		A1C3E0102F90000100AAA001 /* Sparkle */ = {

--- a/tabby.xcodeproj/xcshareddata/xcschemes/tabby.xcscheme
+++ b/tabby.xcodeproj/xcshareddata/xcschemes/tabby.xcscheme
@@ -29,6 +29,18 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FA14279AECE62FBF1162F537"
+               BuildableName = "tabbyTests.xctest"
+               BlueprintName = "tabbyTests"
+               ReferencedContainer = "container:tabby.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/tabbyTests/LlamaPromptRendererTests.swift
+++ b/tabbyTests/LlamaPromptRendererTests.swift
@@ -1,0 +1,125 @@
+import XCTest
+@testable import tabby
+
+/// Tests for the prompt-rendering boundary between DECIDE and GENERATE.
+///
+/// These are pure-function tests — no mocks, no I/O. The whole point of
+/// LlamaPromptRenderer is that given the same inputs, it returns the exact
+/// same string, so every assertion here is deterministic.
+final class LlamaPromptRendererTests: XCTestCase {
+
+    // MARK: - prefixOnly mode
+
+    /// Fast path must return the prefix verbatim. If this ever breaks, base
+    /// models will see unexpected framing tokens and start hallucinating
+    /// "Sure," / "Here's" continuations.
+    func test_prefixOnly_returnsPrefixVerbatim() {
+        let prompt = LlamaPromptRenderer.prompt(
+            prefixText: "Hello, wor",
+            applicationName: "TestApp",
+            promptMode: .prefixOnly,
+            completionLengthInstruction: "Keep it short.",
+            customAIInstructions: nil
+        )
+
+        XCTAssertEqual(prompt, "Hello, wor")
+    }
+
+    /// prefixOnly deliberately ignores custom instructions — documented as the
+    /// "low-overhead path" in the renderer. If these ever leak in, base models
+    /// would suddenly see chat framing they don't know how to handle.
+    func test_prefixOnly_ignoresCustomInstructions() {
+        let prompt = LlamaPromptRenderer.prompt(
+            prefixText: "foo",
+            applicationName: "TestApp",
+            promptMode: .prefixOnly,
+            completionLengthInstruction: "Short.",
+            customAIInstructions: "UNIQUE_MARKER_SHOULD_NOT_APPEAR"
+        )
+
+        XCTAssertEqual(prompt, "foo")
+        XCTAssertFalse(prompt.contains("UNIQUE_MARKER_SHOULD_NOT_APPEAR"))
+    }
+
+    // MARK: - guided mode
+
+    /// The structural contract of guided mode: three labelled sections the
+    /// instruct model is trained to parse. Losing any of them would silently
+    /// degrade output quality without throwing.
+    func test_guided_containsTaskAndOutputContract() {
+        let prompt = LlamaPromptRenderer.prompt(
+            prefixText: "Once upon",
+            applicationName: "Messages",
+            promptMode: .guided,
+            completionLengthInstruction: "Keep completion short.",
+            customAIInstructions: nil
+        )
+
+        XCTAssertTrue(prompt.contains("Task:"), "guided prompt should include Task section")
+        XCTAssertTrue(prompt.contains("Output contract:"), "guided prompt should include Output contract section")
+        XCTAssertTrue(prompt.contains("Context:"), "guided prompt should include Context section")
+    }
+
+    func test_guided_includesApplicationNameAndPrefix() {
+        let prompt = LlamaPromptRenderer.prompt(
+            prefixText: "My prefix text here",
+            applicationName: "Slack",
+            promptMode: .guided,
+            completionLengthInstruction: "Short.",
+            customAIInstructions: nil
+        )
+
+        XCTAssertTrue(prompt.contains("App: Slack"))
+        XCTAssertTrue(prompt.contains("My prefix text here"))
+    }
+
+    /// The completion-length instruction is chosen from the user's word-count
+    /// preset. It must reach the prompt verbatim so the model sees the exact
+    /// guidance the UI showed the user.
+    func test_guided_includesCompletionLengthInstruction() {
+        let prompt = LlamaPromptRenderer.prompt(
+            prefixText: "x",
+            applicationName: "App",
+            promptMode: .guided,
+            completionLengthInstruction: "UNIQUE_LENGTH_MARKER_7_TO_12_WORDS",
+            customAIInstructions: nil
+        )
+
+        XCTAssertTrue(prompt.contains("UNIQUE_LENGTH_MARKER_7_TO_12_WORDS"))
+    }
+
+    func test_guided_includesCustomInstructionsWhenProvided() {
+        let prompt = LlamaPromptRenderer.prompt(
+            prefixText: "x",
+            applicationName: "App",
+            promptMode: .guided,
+            completionLengthInstruction: "Short.",
+            customAIInstructions: "UNIQUE_CUSTOM_MARKER_ZQRT"
+        )
+
+        XCTAssertTrue(prompt.contains("UNIQUE_CUSTOM_MARKER_ZQRT"),
+                      "guided prompt should carry user-provided custom instructions")
+    }
+
+    /// The prefix is always the *last* section of guided mode — the model
+    /// continues from the last token, so the prefix has to come last.
+    /// Tests the contract that prefix comes after Context:/App:/Text before caret:.
+    func test_guided_prefixAppearsAfterContextHeader() {
+        let prompt = LlamaPromptRenderer.prompt(
+            prefixText: "PREFIX_BODY_XYZ",
+            applicationName: "App",
+            promptMode: .guided,
+            completionLengthInstruction: "Short.",
+            customAIInstructions: nil
+        )
+
+        guard let contextRange = prompt.range(of: "Context:"),
+              let prefixRange = prompt.range(of: "PREFIX_BODY_XYZ") else {
+            XCTFail("Expected both Context: and PREFIX_BODY_XYZ in the prompt")
+            return
+        }
+
+        XCTAssertLessThan(contextRange.lowerBound, prefixRange.lowerBound,
+                          "prefix must appear after the Context: header")
+    }
+}

--- a/tabbyTests/SuggestionAvailabilityEvaluatorTests.swift
+++ b/tabbyTests/SuggestionAvailabilityEvaluatorTests.swift
@@ -1,0 +1,137 @@
+import XCTest
+@testable import tabby
+
+/// Tests for the gate every coordinator path runs through before starting a
+/// generation. The value of concentrating these checks in one function is
+/// precisely that UI copy and the gate logic can't drift; these tests lock
+/// that contract in.
+final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
+
+    // Build a FocusSnapshot with only the capability varied — none of the gate
+    // logic we're testing here touches `context` or `inspection`, so leaving
+    // them nil keeps each test focused on the single axis under test.
+    private func makeSnapshot(capability: FocusCapability) -> FocusSnapshot {
+        FocusSnapshot(
+            applicationName: "TestApp",
+            bundleIdentifier: "app.test",
+            capability: capability,
+            context: nil,
+            inspection: nil
+        )
+    }
+
+    // MARK: - disabledReason: exact-string contracts
+
+    /// If this string ever changes, the menu-bar status copy will silently
+    /// change alongside it. Pin it so any copy edit is deliberate.
+    func test_disabledReason_whenGloballyDisabled_returnsFixedCopy() {
+        let reason = SuggestionAvailabilityEvaluator.disabledReason(
+            globallyEnabled: false,
+            inputMonitoringGranted: true,
+            focusSnapshot: makeSnapshot(capability: .supported)
+        )
+
+        XCTAssertEqual(reason, "Tabby is turned off.")
+    }
+
+    func test_disabledReason_whenInputMonitoringDenied_mentionsPermission() {
+        let reason = SuggestionAvailabilityEvaluator.disabledReason(
+            globallyEnabled: true,
+            inputMonitoringGranted: false,
+            focusSnapshot: makeSnapshot(capability: .supported)
+        )
+
+        XCTAssertNotNil(reason)
+        XCTAssertTrue(reason?.contains("Input Monitoring") ?? false,
+                      "reason should point the user at the permission they need to grant")
+    }
+
+    // MARK: - disabledReason: guard ordering
+
+    /// Global-off takes precedence over permission-denied. Important because
+    /// the copy the user sees should be the thing they most need to know; if
+    /// Tabby is off, the Input Monitoring message is a distraction.
+    func test_disabledReason_globalDisabled_winsOverInputMonitoringDenied() {
+        let reason = SuggestionAvailabilityEvaluator.disabledReason(
+            globallyEnabled: false,
+            inputMonitoringGranted: false,
+            focusSnapshot: makeSnapshot(capability: .supported)
+        )
+
+        XCTAssertEqual(reason, "Tabby is turned off.")
+    }
+
+    // MARK: - disabledReason: capability passthrough
+
+    /// The .blocked and .unsupported cases both surface their own reason
+    /// string so the menu can explain which field Tabby is refusing to
+    /// handle. Test that the evaluator passes these through verbatim.
+    func test_disabledReason_blockedCapability_returnsCapabilityReason() {
+        let blockReason = "Secure field — Tabby intentionally won't run here."
+        let reason = SuggestionAvailabilityEvaluator.disabledReason(
+            globallyEnabled: true,
+            inputMonitoringGranted: true,
+            focusSnapshot: makeSnapshot(capability: .blocked(blockReason))
+        )
+
+        XCTAssertEqual(reason, blockReason)
+    }
+
+    func test_disabledReason_unsupportedCapability_returnsCapabilityReason() {
+        let unsupportedReason = "No focused text input"
+        let reason = SuggestionAvailabilityEvaluator.disabledReason(
+            globallyEnabled: true,
+            inputMonitoringGranted: true,
+            focusSnapshot: makeSnapshot(capability: .unsupported(unsupportedReason))
+        )
+
+        XCTAssertEqual(reason, unsupportedReason)
+    }
+
+    // MARK: - disabledReason: happy path
+
+    func test_disabledReason_whenEverythingAllowed_returnsNil() {
+        let reason = SuggestionAvailabilityEvaluator.disabledReason(
+            globallyEnabled: true,
+            inputMonitoringGranted: true,
+            focusSnapshot: makeSnapshot(capability: .supported)
+        )
+
+        XCTAssertNil(reason)
+    }
+
+    // MARK: - shouldSchedulePrediction (boolean wrapper)
+
+    /// shouldSchedulePrediction is the bool collapse of disabledReason == nil.
+    /// Tests both sides of the nil boundary so a future refactor of one
+    /// function without the other would trip.
+    func test_shouldSchedulePrediction_trueWhenNoDisabledReason() {
+        let ok = SuggestionAvailabilityEvaluator.shouldSchedulePrediction(
+            globallyEnabled: true,
+            inputMonitoringGranted: true,
+            focusSnapshot: makeSnapshot(capability: .supported)
+        )
+
+        XCTAssertTrue(ok)
+    }
+
+    func test_shouldSchedulePrediction_falseWhenGloballyDisabled() {
+        let ok = SuggestionAvailabilityEvaluator.shouldSchedulePrediction(
+            globallyEnabled: false,
+            inputMonitoringGranted: true,
+            focusSnapshot: makeSnapshot(capability: .supported)
+        )
+
+        XCTAssertFalse(ok)
+    }
+
+    func test_shouldSchedulePrediction_falseWhenCapabilityUnsupported() {
+        let ok = SuggestionAvailabilityEvaluator.shouldSchedulePrediction(
+            globallyEnabled: true,
+            inputMonitoringGranted: true,
+            focusSnapshot: makeSnapshot(capability: .unsupported("No focused text input"))
+        )
+
+        XCTAssertFalse(ok)
+    }
+}

--- a/tabbyTests/SuggestionRequestFactoryTests.swift
+++ b/tabbyTests/SuggestionRequestFactoryTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import tabby
+
+/// Tests for the shouldGenerate gate in the request factory.
+///
+/// The factory's comment is explicit that it does NOT require a trailing
+/// space — debounce handles keystroke settling, the output normalizer
+/// handles spacing. This suite locks that contract in so a future refactor
+/// that adds "one more guard, just in case" doesn't silently remove
+/// completions that used to work.
+final class SuggestionRequestFactoryTests: XCTestCase {
+
+    // MARK: - degenerate inputs
+
+    func test_shouldGenerate_falseForEmptyString() {
+        XCTAssertFalse(SuggestionRequestFactory.shouldGenerateSuggestion(for: ""))
+    }
+
+    func test_shouldGenerate_falseForPureWhitespace() {
+        XCTAssertFalse(SuggestionRequestFactory.shouldGenerateSuggestion(for: "   \t  "))
+    }
+
+    func test_shouldGenerate_falseForPureNewlines() {
+        XCTAssertFalse(SuggestionRequestFactory.shouldGenerateSuggestion(for: "\n\n"))
+    }
+
+    func test_shouldGenerate_falseForMixedPureWhitespaceAndNewlines() {
+        XCTAssertFalse(SuggestionRequestFactory.shouldGenerateSuggestion(for: " \n\t \n  "))
+    }
+
+    // MARK: - meaningful inputs
+
+    func test_shouldGenerate_trueForSingleCharacter() {
+        XCTAssertTrue(SuggestionRequestFactory.shouldGenerateSuggestion(for: "a"))
+    }
+
+    func test_shouldGenerate_trueForPartialWord() {
+        XCTAssertTrue(SuggestionRequestFactory.shouldGenerateSuggestion(for: "Hello, wor"))
+    }
+
+    /// The key documented behavior: no trailing-space requirement. If this
+    /// test starts failing, someone added a settling heuristic that belongs
+    /// in the debounce layer, not here.
+    func test_shouldGenerate_trueMidWordWithoutTrailingSpace() {
+        XCTAssertTrue(SuggestionRequestFactory.shouldGenerateSuggestion(for: "word"))
+    }
+
+    func test_shouldGenerate_trueWhenLeadingWhitespacePrecedesRealContent() {
+        XCTAssertTrue(SuggestionRequestFactory.shouldGenerateSuggestion(for: "  hello"))
+    }
+
+    func test_shouldGenerate_trueWhenContentPrecedesTrailingWhitespace() {
+        XCTAssertTrue(SuggestionRequestFactory.shouldGenerateSuggestion(for: "hello  "))
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `tabbyTests` target and 25 tests covering the three pure-function modules on the coordinator's decide path.

## What's tested

| Module | Tests | Focus |
|---|---|---|
| `SuggestionAvailabilityEvaluator` | 9 | Guard ordering (global → permission → capability), exact user-facing copy, `.blocked`/`.unsupported` passthrough, `shouldSchedulePrediction` bool collapse |
| `LlamaPromptRenderer` | 7 | `prefixOnly` verbatim return, `guided` template structure (Task / Output contract / Context), custom-instruction inclusion, prefix-at-end positional contract |
| `SuggestionRequestFactory.shouldGenerateSuggestion` | 9 | Pure-whitespace rejection, mid-word acceptance without trailing space (explicit contract), leading/trailing whitespace handling |

Scope deliberately bounded to the pure-function spine — functions that take data in and return data out, no I/O, no mocking. Highest test value per line of test code and the easiest baseline to keep green.

## Target wiring

A test target has to mutate `project.pbxproj`, which is a painful thing to review when hand-edited. I scripted it instead: `scripts/add_test_target.rb` uses the `xcodeproj` Ruby gem to create the target idempotently — safe to re-run when new test files land.

The script also has to prune the Cocoa.framework reference the gem adds automatically for macOS test bundles (it hardcodes `Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk/...`, which is stale on current SDKs). Pure-Swift XCTest bundles don't need Cocoa anyway.

## Verified locally

```
xcodebuild test -project tabby.xcodeproj -scheme tabby \
  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO
```

Result: `** TEST SUCCEEDED **`, 25 tests, 0 failures, ~1.4s.

## What this unblocks

- **#35 CI test runner** — currently blocked on this PR. Will land as a separate PR that adds `.github/workflows/tests.yml` once this merges.
- **More test coverage** — `SuggestionTextNormalizer`, more of `SuggestionRequestFactory`, `SuggestionInteractionState` actor behaviour. Intentionally left for follow-up PRs so this one stays focused.

## Refs

Refs #12