### PR TITLE
Add Sparkle release pipeline + Signing/Notorization Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,360 @@
+# Tag-driven release pipeline for Tabby.
+#
+# Release ordering matters:
+# 1. build and Developer ID sign the app
+# 2. package and notarize the DMG
+# 3. Sparkle-sign the final bytes
+# 4. create the GitHub Release with the DMG attached
+# 5. publish appcast.xml to Pages last
+#
+# The appcast is the update pointer Sparkle clients poll. Publishing it before
+# the release asset exists would expose users to a broken update.
+
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: "Version without the leading v, for manual validation runs"
+        required: true
+        type: string
+      publish:
+        description: "Create the GitHub Release and publish appcast.xml"
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  APP_NAME: tabby
+  DMG_NAME: Tabby.dmg
+  PROJECT_PATH: tabby.xcodeproj
+  SCHEME: tabby
+  CONFIGURATION: Release
+  PAGES_CUSTOM_DOMAIN: tabbyapp.dev
+
+jobs:
+  release:
+    name: Build, notarize, sign, and publish
+    runs-on: macos-26
+    timeout-minutes: 60
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy-pages.outputs.page_url }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Toolchain info
+        run: |
+          xcodebuild -version
+          swift --version
+
+      - name: Resolve release metadata
+        id: metadata
+        env:
+          INPUT_RELEASE_VERSION: ${{ github.event.inputs.release_version }}
+          INPUT_PUBLISH: ${{ github.event.inputs.publish }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            release_tag="${GITHUB_REF_NAME}"
+            release_version="${release_tag#v}"
+            publish="true"
+          else
+            release_version="${INPUT_RELEASE_VERSION}"
+            release_tag="v${release_version}"
+            publish="${INPUT_PUBLISH:-false}"
+          fi
+
+          if [[ -z "${release_version}" || "${release_version}" == "${release_tag}" ]]; then
+            echo "Release version must not be empty and must not include the leading v." >&2
+            exit 1
+          fi
+
+          build_number="$(xcodebuild \
+            -project "${PROJECT_PATH}" \
+            -scheme "${SCHEME}" \
+            -configuration "${CONFIGURATION}" \
+            -showBuildSettings |
+            awk -F '= ' '/CURRENT_PROJECT_VERSION/ { print $2; exit }')"
+
+          echo "release_tag=${release_tag}" >> "$GITHUB_OUTPUT"
+          echo "release_version=${release_version}" >> "$GITHUB_OUTPUT"
+          echo "build_number=${build_number}" >> "$GITHUB_OUTPUT"
+          echo "publish=${publish}" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure release does not already exist
+        if: steps.metadata.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.metadata.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+
+          if gh release view "${RELEASE_TAG}" >/dev/null 2>&1; then
+            echo "GitHub Release ${RELEASE_TAG} already exists. Refusing to overwrite release assets." >&2
+            exit 1
+          fi
+
+      - name: Import Developer ID certificate
+        env:
+          DEVELOPER_ID_APPLICATION_CERT: ${{ secrets.DEVELOPER_ID_APPLICATION_CERT }}
+          DEVELOPER_ID_CERT_PASSWORD: ${{ secrets.DEVELOPER_ID_CERT_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          keychain_path="${RUNNER_TEMP}/tabby-release.keychain-db"
+          keychain_password="$(uuidgen)"
+          certificate_path="${RUNNER_TEMP}/developer-id-application.p12"
+
+          printf '%s' "${DEVELOPER_ID_APPLICATION_CERT}" | base64 --decode > "${certificate_path}"
+
+          security create-keychain -p "${keychain_password}" "${keychain_path}"
+          security set-keychain-settings -lut 21600 "${keychain_path}"
+          security unlock-keychain -p "${keychain_password}" "${keychain_path}"
+          security import "${certificate_path}" \
+            -P "${DEVELOPER_ID_CERT_PASSWORD}" \
+            -A \
+            -t cert \
+            -f pkcs12 \
+            -k "${keychain_path}"
+          security list-keychains -d user -s "${keychain_path}" $(security list-keychains -d user | tr -d '"')
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s \
+            -k "${keychain_password}" \
+            "${keychain_path}"
+
+      - name: Configure Apple notarization credentials
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          xcrun notarytool store-credentials "tabby-notarytool-profile" \
+            --apple-id "${APPLE_ID}" \
+            --team-id "${APPLE_TEAM_ID}" \
+            --password "${APPLE_APP_SPECIFIC_PASSWORD}"
+
+      - name: Archive signed app
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p build
+
+          xcodebuild archive \
+            -project "${PROJECT_PATH}" \
+            -scheme "${SCHEME}" \
+            -configuration "${CONFIGURATION}" \
+            -archivePath "build/${APP_NAME}.xcarchive" \
+            -derivedDataPath "build/DerivedData" \
+            -destination 'generic/platform=macOS' \
+            DEVELOPMENT_TEAM="${APPLE_TEAM_ID}" \
+            CODE_SIGN_STYLE=Manual \
+            CODE_SIGN_IDENTITY="Developer ID Application" \
+            OTHER_CODE_SIGN_FLAGS="--timestamp" \
+            archive
+
+      - name: Package DMG
+        run: |
+          set -euo pipefail
+
+          app_path="build/${APP_NAME}.xcarchive/Products/Applications/${APP_NAME}.app"
+          dmg_path="build/${DMG_NAME}"
+
+          if [[ ! -d "${app_path}" ]]; then
+            echo "Archived app not found at ${app_path}" >&2
+            exit 1
+          fi
+
+          codesign --verify --deep --strict --verbose=2 "${app_path}"
+
+          rm -f "${dmg_path}"
+          hdiutil create \
+            -volname "Tabby" \
+            -srcfolder "${app_path}" \
+            -ov \
+            -format UDZO \
+            "${dmg_path}"
+
+      - name: Notarize and staple DMG
+        run: |
+          set -euo pipefail
+
+          dmg_path="build/${DMG_NAME}"
+
+          xcrun notarytool submit "${dmg_path}" \
+            --keychain-profile "tabby-notarytool-profile" \
+            --wait
+          xcrun stapler staple "${dmg_path}"
+          xcrun stapler validate "${dmg_path}"
+
+      - name: Locate Sparkle tools
+        id: sparkle-tools
+        run: |
+          set -euo pipefail
+
+          sign_update="$(find build/DerivedData "$HOME/Library/Developer/Xcode/DerivedData" \
+            -type f \
+            -path '*/Sparkle/bin/sign_update' \
+            -print \
+            2>/dev/null |
+            head -n 1)"
+
+          generate_keys="$(find build/DerivedData "$HOME/Library/Developer/Xcode/DerivedData" \
+            -type f \
+            -path '*/Sparkle/bin/generate_keys' \
+            -print \
+            2>/dev/null |
+            head -n 1)"
+
+          if [[ -z "${sign_update}" || -z "${generate_keys}" ]]; then
+            echo "Could not locate Sparkle sign_update and generate_keys tools." >&2
+            exit 1
+          fi
+
+          echo "sign_update=${sign_update}" >> "$GITHUB_OUTPUT"
+          echo "generate_keys=${generate_keys}" >> "$GITHUB_OUTPUT"
+
+      - name: Write Sparkle private key
+        env:
+          SPARKLE_ED25519_PRIVATE_KEY: ${{ secrets.SPARKLE_ED25519_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${SPARKLE_ED25519_PRIVATE_KEY}" ]]; then
+            echo "SPARKLE_ED25519_PRIVATE_KEY is not configured." >&2
+            exit 1
+          fi
+
+          sparkle_key_file="${RUNNER_TEMP}/sparkle-ed25519-private-key.txt"
+          printf '%s' "${SPARKLE_ED25519_PRIVATE_KEY}" > "${sparkle_key_file}"
+          chmod 600 "${sparkle_key_file}"
+
+          echo "SPARKLE_KEY_FILE=${sparkle_key_file}" >> "$GITHUB_ENV"
+
+      - name: Verify Sparkle key matches Info.plist
+        env:
+          GENERATE_KEYS_TOOL: ${{ steps.sparkle-tools.outputs.generate_keys }}
+        run: |
+          set -euo pipefail
+
+          "${GENERATE_KEYS_TOOL}" -f "${SPARKLE_KEY_FILE}"
+
+          expected_public_key="$(/usr/libexec/PlistBuddy \
+            -c 'Print :SUPublicEDKey' \
+            TabbyInfo.plist)"
+          actual_public_key="$("${GENERATE_KEYS_TOOL}" -p)"
+
+          if [[ "${actual_public_key}" != "${expected_public_key}" ]]; then
+            echo "Sparkle private key does not match SUPublicEDKey in TabbyInfo.plist." >&2
+            exit 1
+          fi
+
+      - name: Generate signed appcast
+        env:
+          SIGN_UPDATE_TOOL: ${{ steps.sparkle-tools.outputs.sign_update }}
+          RELEASE_VERSION: ${{ steps.metadata.outputs.release_version }}
+          BUILD_NUMBER: ${{ steps.metadata.outputs.build_number }}
+        run: |
+          set -euo pipefail
+
+          python3 scripts/generate_appcast.py \
+            --release-version "${RELEASE_VERSION}" \
+            --build-number "${BUILD_NUMBER}" \
+            --archive "build/${DMG_NAME}" \
+            --output "build/appcast.xml" \
+            --sign-update-tool "${SIGN_UPDATE_TOOL}" \
+            --ed-key-file "${SPARKLE_KEY_FILE}"
+
+          grep -q 'sparkle:edSignature="' build/appcast.xml
+          grep -q 'length="' build/appcast.xml
+
+      - name: Verify Sparkle signature against final DMG
+        env:
+          SIGN_UPDATE_TOOL: ${{ steps.sparkle-tools.outputs.sign_update }}
+        run: |
+          set -euo pipefail
+
+          signature="$(python3 -c 'import re; from pathlib import Path; match = re.search(r"sparkle:edSignature=\"([^\"]+)\"", Path("build/appcast.xml").read_text()); print(match.group(1) if match else "")')"
+          if [[ -z "${signature}" ]]; then
+            echo "appcast.xml does not contain sparkle:edSignature." >&2
+            exit 1
+          fi
+
+          "${SIGN_UPDATE_TOOL}" \
+            --verify \
+            --ed-key-file "${SPARKLE_KEY_FILE}" \
+            "build/${DMG_NAME}" \
+            "${signature}"
+
+      - name: Create GitHub Release
+        if: steps.metadata.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.metadata.outputs.release_tag }}
+          RELEASE_VERSION: ${{ steps.metadata.outputs.release_version }}
+        run: |
+          set -euo pipefail
+
+          gh release create "${RELEASE_TAG}" "build/${DMG_NAME}" \
+            --title "Tabby ${RELEASE_VERSION}" \
+            --generate-notes
+
+      - name: Prepare Pages artifact
+        if: steps.metadata.outputs.publish == 'true'
+        run: |
+          set -euo pipefail
+
+          mkdir -p build/pages/tabby
+          cp build/appcast.xml build/pages/appcast.xml
+          cp build/appcast.xml build/pages/tabby/appcast.xml
+          printf '%s\n' "${PAGES_CUSTOM_DOMAIN}" > build/pages/CNAME
+
+      - name: Configure GitHub Pages
+        if: steps.metadata.outputs.publish == 'true'
+        uses: actions/configure-pages@v5
+
+      - name: Upload GitHub Pages artifact
+        if: steps.metadata.outputs.publish == 'true'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build/pages
+
+      - name: Deploy GitHub Pages
+        if: steps.metadata.outputs.publish == 'true'
+        id: deploy-pages
+        uses: actions/deploy-pages@v4
+
+      - name: Upload local release artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-artifacts
+          path: |
+            build/${{ env.DMG_NAME }}
+            build/appcast.xml
+          if-no-files-found: ignore

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,137 @@
+# Releasing Tabby With Sparkle
+
+This guide explains how Tabby signs Sparkle updates and which local tools are available.
+
+## Mental Model
+
+Sparkle update trust has two halves:
+
+- `SUPublicEDKey` in `TabbyInfo.plist` is the public trust anchor shipped inside the app.
+- The private Ed25519 key signs each release artifact before the appcast is published.
+
+Sparkle downloads the appcast, reads the update enclosure's `sparkle:edSignature`, downloads the
+artifact, and verifies that signature with the public key embedded in the installed app. If the
+artifact is unsigned, signed by the wrong key, or modified after signing, Sparkle rejects it.
+
+## Current Configuration
+
+Tabby's Sparkle settings live in `TabbyInfo.plist`:
+
+- `SUFeedURL`: `https://fujacob.github.io/tabby/appcast.xml`
+- `SUPublicEDKey`: `efJeZNfUISOs6npbxI2MLLe7sBB5tT/sVnTk9t/qBSY=`
+
+That public key is safe to commit. The matching private key is secret and must never be committed.
+
+## Available Sparkle Tools
+
+After Xcode resolves the Sparkle Swift package, the tools are available in DerivedData. On this
+machine they are currently located at:
+
+- `~/Library/Developer/Xcode/DerivedData/tabby-bjuhrhutqnwwjrbkuugwtoosmmqx/SourcePackages/artifacts/sparkle/Sparkle/bin/generate_keys`
+- `~/Library/Developer/Xcode/DerivedData/tabby-bjuhrhutqnwwjrbkuugwtoosmmqx/SourcePackages/artifacts/sparkle/Sparkle/bin/sign_update`
+- `~/Library/Developer/Xcode/DerivedData/tabby-bjuhrhutqnwwjrbkuugwtoosmmqx/SourcePackages/artifacts/sparkle/Sparkle/bin/generate_appcast`
+
+DerivedData folder names can change. To find the tools again, run:
+
+```sh
+find "$HOME/Library/Developer/Xcode/DerivedData" -type f \
+  \( -name generate_keys -o -name sign_update -o -name generate_appcast \) -print
+```
+
+## Key Generation
+
+Use Sparkle's `generate_keys` tool to create or look up the Ed25519 key pair:
+
+```sh
+"$HOME/Library/Developer/Xcode/DerivedData/tabby-bjuhrhutqnwwjrbkuugwtoosmmqx/SourcePackages/artifacts/sparkle/Sparkle/bin/generate_keys"
+```
+
+What this does:
+
+- Creates a private key in your macOS Keychain if one does not already exist.
+- Reuses the existing private key if one already exists for the selected account.
+- Prints the public key value that belongs in `SUPublicEDKey`.
+
+To print the public key later without generating a new key:
+
+```sh
+"$HOME/Library/Developer/Xcode/DerivedData/tabby-bjuhrhutqnwwjrbkuugwtoosmmqx/SourcePackages/artifacts/sparkle/Sparkle/bin/generate_keys" -p
+```
+
+For organization-specific signing, prefer an explicit account name:
+
+```sh
+"$HOME/Library/Developer/Xcode/DerivedData/tabby-bjuhrhutqnwwjrbkuugwtoosmmqx/SourcePackages/artifacts/sparkle/Sparkle/bin/generate_keys" --account tabby-release
+```
+
+If you use a non-default account, pass the same `--account` value to `sign_update` when signing.
+
+## Private Key Storage
+
+The private key is equivalent to release authority for Tabby updates.
+
+Recommended storage:
+
+- Keep the primary private key in a restricted password manager or offline secret store.
+- Limit access to release owners only.
+- Do not commit exported private key files.
+- Do not paste private key material into issue comments, PRs, logs, or shell history.
+
+To export the private key for backup or transfer:
+
+```sh
+"$HOME/Library/Developer/Xcode/DerivedData/tabby-bjuhrhutqnwwjrbkuugwtoosmmqx/SourcePackages/artifacts/sparkle/Sparkle/bin/generate_keys" -x /secure/path/tabby-sparkle-private-key.txt
+```
+
+To import it on another release machine:
+
+```sh
+"$HOME/Library/Developer/Xcode/DerivedData/tabby-bjuhrhutqnwwjrbkuugwtoosmmqx/SourcePackages/artifacts/sparkle/Sparkle/bin/generate_keys" -f /secure/path/tabby-sparkle-private-key.txt
+```
+
+## Signing A Release
+
+Tabby's appcast is rendered by `scripts/generate_appcast.py`. The script finds `sign_update`,
+signs the release DMG, and writes the generated `sparkle:edSignature` into `build/appcast.xml`.
+
+Example:
+
+```sh
+python3 scripts/generate_appcast.py \
+  --release-version 1.0.0 \
+  --build-number 100 \
+  --archive /path/to/notarized/Tabby.dmg \
+  --output build/appcast.xml
+```
+
+The generated appcast is based on `scripts/appcast.template.xml`. Its `<enclosure>` must include:
+
+- `url`: where Sparkle downloads the release artifact
+- `sparkle:edSignature`: the Ed25519 signature from `sign_update`
+- `length`: the signed artifact byte length
+- `type`: the artifact MIME type
+
+Publish the signed appcast to the URL configured by `SUFeedURL`.
+
+## Checking The Signature Values
+
+Before publishing, rerun `sign_update` against the exact DMG you plan to publish:
+
+```sh
+"$HOME/Library/Developer/Xcode/DerivedData/tabby-bjuhrhutqnwwjrbkuugwtoosmmqx/SourcePackages/artifacts/sparkle/Sparkle/bin/sign_update" /path/to/notarized/Tabby.dmg
+```
+
+The output should include `sparkle:edSignature="..."` and `length="..."`. Those values must match
+the generated appcast. If the DMG changes after signing, regenerate the appcast because the old
+signature no longer represents the artifact bytes.
+
+For an end-to-end app check, launch a build with Sparkle configured and test against the published
+appcast. Unsigned or mis-signed updates should be rejected by Sparkle before installation.
+
+## Key Rotation Warning
+
+Do not regenerate the Sparkle key casually after users have installed a public build.
+
+Existing installed apps trust the `SUPublicEDKey` they already contain. If a future update is signed
+with a different private key, those installed apps will reject it. Rotate only with a deliberate
+migration plan.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,137 +1,204 @@
-# Releasing Tabby With Sparkle
+# Releasing Tabby (Sparkle)
 
-This guide explains how Tabby signs Sparkle updates and which local tools are available.
+Short, practical guide to signing + releasing updates.
 
-## Mental Model
+---
 
-Sparkle update trust has two halves:
+## Mental Model (keep this)
 
-- `SUPublicEDKey` in `TabbyInfo.plist` is the public trust anchor shipped inside the app.
-- The private Ed25519 key signs each release artifact before the appcast is published.
+Two separate systems:
 
-Sparkle downloads the appcast, reads the update enclosure's `sparkle:edSignature`, downloads the
-artifact, and verifies that signature with the public key embedded in the installed app. If the
-artifact is unsigned, signed by the wrong key, or modified after signing, Sparkle rejects it.
+1. **Apple signing (codesign + notarization)**
+   → lets macOS run your app
 
-## Current Configuration
+2. **Sparkle signing (Ed25519)**
+   → lets your app trust updates
 
-Tabby's Sparkle settings live in `TabbyInfo.plist`:
+Do not mix them.
 
-- `SUFeedURL`: `https://fujacob.github.io/tabby/appcast.xml`
-- `SUPublicEDKey`: `efJeZNfUISOs6npbxI2MLLe7sBB5tT/sVnTk9t/qBSY=`
+---
 
-That public key is safe to commit. The matching private key is secret and must never be committed.
+## Current Config
 
-## Available Sparkle Tools
+- Feed: https://tabbyapp.dev/tabby/appcast.xml
+- Public key (`SUPublicEDKey`):
+  `efJeZNfUISOs6npbxI2MLLe7sBB5tT/sVnTk9t/qBSY=`
 
-After Xcode resolves the Sparkle Swift package, the tools are available in DerivedData. On this
-machine they are currently located at:
+Private key = secret. Never commit it.
 
-- `~/Library/Developer/Xcode/DerivedData/tabby-bjuhrhutqnwwjrbkuugwtoosmmqx/SourcePackages/artifacts/sparkle/Sparkle/bin/generate_keys`
-- `~/Library/Developer/Xcode/DerivedData/tabby-bjuhrhutqnwwjrbkuugwtoosmmqx/SourcePackages/artifacts/sparkle/Sparkle/bin/sign_update`
-- `~/Library/Developer/Xcode/DerivedData/tabby-bjuhrhutqnwwjrbkuugwtoosmmqx/SourcePackages/artifacts/sparkle/Sparkle/bin/generate_appcast`
+---
 
-DerivedData folder names can change. To find the tools again, run:
+## One-Time Setup
 
-```sh
-find "$HOME/Library/Developer/Xcode/DerivedData" -type f \
-  \( -name generate_keys -o -name sign_update -o -name generate_appcast \) -print
-```
-
-## Key Generation
-
-Use Sparkle's `generate_keys` tool to create or look up the Ed25519 key pair:
+### Make Sparkle commands easy
 
 ```sh
-"$HOME/Library/Developer/Xcode/DerivedData/tabby-bjuhrhutqnwwjrbkuugwtoosmmqx/SourcePackages/artifacts/sparkle/Sparkle/bin/generate_keys"
+mkdir -p ~/bin
+
+ln -sf "$(find ~/Library/Developer/Xcode/DerivedData -name generate_keys -type f | head -n 1)" ~/bin/sparkle-generate-keys
+ln -sf "$(find ~/Library/Developer/Xcode/DerivedData -name sign_update -type f | head -n 1)" ~/bin/sparkle-sign-update
+ln -sf "$(find ~/Library/Developer/Xcode/DerivedData -name generate_appcast -type f | head -n 1)" ~/bin/sparkle-generate-appcast
+
+echo 'export PATH="$HOME/bin:$PATH"' >> ~/.zshrc
+source ~/.zshrc
 ```
 
-What this does:
-
-- Creates a private key in your macOS Keychain if one does not already exist.
-- Reuses the existing private key if one already exists for the selected account.
-- Prints the public key value that belongs in `SUPublicEDKey`.
-
-To print the public key later without generating a new key:
-
+Check:
 ```sh
-"$HOME/Library/Developer/Xcode/DerivedData/tabby-bjuhrhutqnwwjrbkuugwtoosmmqx/SourcePackages/artifacts/sparkle/Sparkle/bin/generate_keys" -p
+which sparkle-generate-keys
 ```
 
-For organization-specific signing, prefer an explicit account name:
+---
 
+## Sparkle Key
+
+### Generate (once)
 ```sh
-"$HOME/Library/Developer/Xcode/DerivedData/tabby-bjuhrhutqnwwjrbkuugwtoosmmqx/SourcePackages/artifacts/sparkle/Sparkle/bin/generate_keys" --account tabby-release
+sparkle-generate-keys
 ```
 
-If you use a non-default account, pass the same `--account` value to `sign_update` when signing.
-
-## Private Key Storage
-
-The private key is equivalent to release authority for Tabby updates.
-
-Recommended storage:
-
-- Keep the primary private key in a restricted password manager or offline secret store.
-- Limit access to release owners only.
-- Do not commit exported private key files.
-- Do not paste private key material into issue comments, PRs, logs, or shell history.
-
-To export the private key for backup or transfer:
-
+### Print public key
 ```sh
-"$HOME/Library/Developer/Xcode/DerivedData/tabby-bjuhrhutqnwwjrbkuugwtoosmmqx/SourcePackages/artifacts/sparkle/Sparkle/bin/generate_keys" -x /secure/path/tabby-sparkle-private-key.txt
+sparkle-generate-keys -p
 ```
 
-To import it on another release machine:
+Must match `SUPublicEDKey`.
 
+### Backup private key
 ```sh
-"$HOME/Library/Developer/Xcode/DerivedData/tabby-bjuhrhutqnwwjrbkuugwtoosmmqx/SourcePackages/artifacts/sparkle/Sparkle/bin/generate_keys" -f /secure/path/tabby-sparkle-private-key.txt
+sparkle-generate-keys -x ~/secure/tabby-key.txt
 ```
 
-## Signing A Release
+### Import on another machine
+```sh
+sparkle-generate-keys -f ~/secure/tabby-key.txt
+```
 
-Tabby's appcast is rendered by `scripts/generate_appcast.py`. The script finds `sign_update`,
-signs the release DMG, and writes the generated `sparkle:edSignature` into `build/appcast.xml`.
+---
 
-Example:
+## Release Flow (every release)
 
+### 1. Sign app (Apple)
+```sh
+codesign --force --deep --options runtime \
+--sign "Developer ID Application: Jacob Fu (G946M8K23B)" \
+./tabby.app
+```
+
+### 2. Notarize
+```sh
+ditto -c -k --keepParent ./tabby.app Tabby.zip
+xcrun notarytool submit Tabby.zip --keychain-profile "AC_PASSWORD" --wait
+xcrun stapler staple ./tabby.app
+```
+
+---
+
+### 3. Create DMG (your existing process)
+
+---
+
+### 4. Sign update (Sparkle)
+```sh
+sparkle-sign-update /path/to/Tabby.dmg
+```
+
+---
+
+### 5. Generate appcast
 ```sh
 python3 scripts/generate_appcast.py \
   --release-version 1.0.0 \
   --build-number 100 \
-  --archive /path/to/notarized/Tabby.dmg \
-  --output build/appcast.xml
+  --archive /path/to/Tabby.dmg \
+  --output build/appcast.xml \
+  --ed-key-file ~/secure/tabby-key.txt
 ```
 
-The generated appcast is based on `scripts/appcast.template.xml`. Its `<enclosure>` must include:
+On your Mac, `--ed-key-file` is optional if the key is already in Keychain.
+In GitHub Actions, we pass the key file explicitly from the `SPARKLE_ED25519_PRIVATE_KEY` secret.
 
-- `url`: where Sparkle downloads the release artifact
-- `sparkle:edSignature`: the Ed25519 signature from `sign_update`
-- `length`: the signed artifact byte length
-- `type`: the artifact MIME type
+---
 
-Publish the signed appcast to the URL configured by `SUFeedURL`.
+## GitHub Actions Release
 
-## Checking The Signature Values
+Workflow:
+`.github/workflows/release.yml`
 
-Before publishing, rerun `sign_update` against the exact DMG you plan to publish:
+Trigger:
+- Push a tag like `v1.0.0`
+- Or run manually with `workflow_dispatch` for validation
 
+Required repo secrets:
+- `APPLE_ID`
+- `APPLE_TEAM_ID`
+- `APPLE_APP_SPECIFIC_PASSWORD`
+- `DEVELOPER_ID_APPLICATION_CERT`
+- `DEVELOPER_ID_CERT_PASSWORD`
+- `SPARKLE_ED25519_PRIVATE_KEY`
+
+What CI does:
+1. Imports the Developer ID certificate into a temporary keychain.
+2. Archives a Release build.
+3. Packages `Tabby.dmg`.
+4. Sends the DMG to Apple notarization.
+5. Staples and validates the notarization ticket.
+6. Verifies the Sparkle private key matches `SUPublicEDKey`.
+7. Signs the final DMG with Sparkle.
+8. Creates a GitHub Release with `Tabby.dmg`.
+9. Publishes `appcast.xml` to GitHub Pages last.
+
+Pages output:
+- `/appcast.xml`
+- `/tabby/appcast.xml`
+
+The `/tabby/appcast.xml` path matches the current feed URL.
+
+---
+
+## Sanity Checks
+
+Check Apple signing:
 ```sh
-"$HOME/Library/Developer/Xcode/DerivedData/tabby-bjuhrhutqnwwjrbkuugwtoosmmqx/SourcePackages/artifacts/sparkle/Sparkle/bin/sign_update" /path/to/notarized/Tabby.dmg
+spctl -a -t exec -vv ./tabby.app
 ```
 
-The output should include `sparkle:edSignature="..."` and `length="..."`. Those values must match
-the generated appcast. If the DMG changes after signing, regenerate the appcast because the old
-signature no longer represents the artifact bytes.
+Check Sparkle signature:
+```sh
+sparkle-sign-update /path/to/Tabby.dmg
+```
 
-For an end-to-end app check, launch a build with Sparkle configured and test against the published
-appcast. Unsigned or mis-signed updates should be rejected by Sparkle before installation.
+Signature must match appcast.
 
-## Key Rotation Warning
+---
 
-Do not regenerate the Sparkle key casually after users have installed a public build.
+## Rules (important)
 
-Existing installed apps trust the `SUPublicEDKey` they already contain. If a future update is signed
-with a different private key, those installed apps will reject it. Rotate only with a deliberate
-migration plan.
+- Never lose Sparkle private key → breaks updates
+- Never rotate key casually → old installs will reject updates
+- Never commit private key
+- Always sign AFTER final DMG is built (no changes after)
+- Always publish appcast AFTER the GitHub Release asset exists
+
+---
+
+## Rollback
+
+Sparkle follows the appcast, not the GitHub Releases page.
+
+To rollback:
+1. Find the previous successful release run.
+2. Restore that run's `appcast.xml`.
+3. Redeploy it to GitHub Pages.
+4. Leave the bad GitHub Release alone unless there is a security reason to remove it.
+
+---
+
+## If something breaks
+
+Common issues:
+- Wrong Sparkle key → updates rejected
+- DMG changed after signing → signature invalid
+- Missing notarization → macOS blocks app
+
+Fix those first.

--- a/TabbyInfo.plist
+++ b/TabbyInfo.plist
@@ -31,7 +31,7 @@
 	<key>SUEnableAutomaticChecks</key>
 	<false/>
 	<key>SUFeedURL</key>
-	<string>https://fujacob.github.io/tabby/appcast.xml</string>
+	<string>https://tabbyapp.dev/tabby/appcast.xml</string>
     <key>SUPublicEDKey</key>
     <string>efJeZNfUISOs6npbxI2MLLe7sBB5tT/sVnTk9t/qBSY=</string>
 </dict>

--- a/scripts/generate_appcast.py
+++ b/scripts/generate_appcast.py
@@ -50,6 +50,14 @@ def parse_args() -> argparse.Namespace:
         help="Explicit path to Sparkle's sign_update tool",
     )
     parser.add_argument(
+        "--ed-key-file",
+        default=None,
+        help=(
+            "Optional path to the Sparkle Ed25519 private key file. "
+            "Useful in CI where the key is supplied from a repository secret."
+        ),
+    )
+    parser.add_argument(
         "--github-owner",
         default=DEFAULT_OWNER,
         help="GitHub owner used to build release and repository URLs",
@@ -114,9 +122,14 @@ def resolve_sign_update_tool(explicit_path: str | None) -> Path:
     )
 
 
-def sign_archive(sign_update_tool: Path, archive: Path) -> tuple[str, str]:
+def sign_archive(sign_update_tool: Path, archive: Path, ed_key_file: Path | None) -> tuple[str, str]:
+    command = [str(sign_update_tool)]
+    if ed_key_file is not None:
+        command.extend(["--ed-key-file", str(ed_key_file)])
+    command.append(str(archive))
+
     process = subprocess.run(
-        [str(sign_update_tool), str(archive)],
+        command,
         check=True,
         capture_output=True,
         text=True,
@@ -175,7 +188,14 @@ def main() -> int:
         raise SystemExit(f"Template does not exist: {template_path}")
 
     sign_update_tool = resolve_sign_update_tool(args.sign_update_tool)
-    ed_signature, archive_length = sign_archive(sign_update_tool, archive)
+
+    ed_key_file = None
+    if args.ed_key_file:
+        ed_key_file = Path(args.ed_key_file).expanduser().resolve()
+        if not ed_key_file.is_file():
+            raise SystemExit(f"Sparkle Ed25519 private key file does not exist: {ed_key_file}")
+
+    ed_signature, archive_length = sign_archive(sign_update_tool, archive, ed_key_file)
 
     repository_url = f"https://github.com/{args.github_owner}/{args.github_repository}"
     release_tag = f"v{args.release_version}"


### PR DESCRIPTION
## Summary
- Add a tag-triggered GitHub Actions release workflow for building, notarizing, Sparkle-signing, and publishing Tabby releases.
- Teach `scripts/generate_appcast.py` to sign with an explicit Sparkle Ed25519 key file for CI.
- Update `RELEASING.md` and the Sparkle feed URL for the custom-domain Pages appcast.

## Validation
- `python3 -m py_compile scripts/generate_appcast.py`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml parsed"'`
- `plutil -lint TabbyInfo.plist`
- `git diff --check`

## Notes
- The workflow publishes only on `v*` tag pushes; manual dispatch defaults to validation without publishing.
- Closing #36 still requires a successful tag release run.
