### PR TITLE
Fix release notarization diagnostics

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,6 +178,65 @@ jobs:
             OTHER_CODE_SIGN_FLAGS="--timestamp" \
             archive
 
+      - name: Re-sign nested code for notarization
+        run: |
+          set -euo pipefail
+
+          app_path="build/${APP_NAME}.xcarchive/Products/Applications/${APP_NAME}.app"
+          signing_identity="Developer ID Application"
+
+          # Xcode signs the top-level app and frameworks, but Sparkle's embedded helper
+          # executables can remain ad-hoc signed after package integration. Apple
+          # notarization rejects ad-hoc nested executables in a Developer ID app, so we
+          # perform a final inside-out signing pass over the archived product.
+          nested_code=(
+            "${app_path}/Contents/Frameworks/Sparkle.framework/Versions/B/Autoupdate"
+            "${app_path}/Contents/Frameworks/Sparkle.framework/Versions/B/Updater.app"
+            "${app_path}/Contents/Frameworks/Sparkle.framework/Versions/B/XPCServices/Downloader.xpc"
+            "${app_path}/Contents/Frameworks/Sparkle.framework/Versions/B/XPCServices/Installer.xpc"
+            "${app_path}/Contents/Frameworks/Sparkle.framework"
+            "${app_path}/Contents/Frameworks/llama.framework"
+            "${app_path}"
+          )
+
+          for code_path in "${nested_code[@]}"; do
+            if [[ -e "${code_path}" ]]; then
+              codesign \
+                --force \
+                --options runtime \
+                --timestamp \
+                --sign "${signing_identity}" \
+                "${code_path}"
+            fi
+          done
+
+          codesign --verify --deep --strict --verbose=4 "${app_path}"
+
+      - name: Assert no ad-hoc nested signatures remain
+        run: |
+          set -euo pipefail
+
+          app_path="build/${APP_NAME}.xcarchive/Products/Applications/${APP_NAME}.app"
+          failed=0
+
+          while IFS= read -r executable_path; do
+            if ! file "${executable_path}" | grep -q 'Mach-O'; then
+              continue
+            fi
+
+            signature="$(codesign -dv --verbose=4 "${executable_path}" 2>&1 || true)"
+            if grep -q 'flags=.*adhoc' <<< "${signature}"; then
+              echo "Ad-hoc signature remains: ${executable_path}" >&2
+              failed=1
+            fi
+            if ! grep -q 'Authority=Developer ID Application' <<< "${signature}"; then
+              echo "Missing Developer ID Application authority: ${executable_path}" >&2
+              failed=1
+            fi
+          done < <(find "${app_path}" -type f -perm -111 -print)
+
+          exit "${failed}"
+
       - name: Package DMG
         run: |
           set -euo pipefail
@@ -206,9 +265,22 @@ jobs:
 
           dmg_path="build/${DMG_NAME}"
 
-          xcrun notarytool submit "${dmg_path}" \
+          submit_json="$(xcrun notarytool submit "${dmg_path}" \
             --keychain-profile "tabby-notarytool-profile" \
-            --wait
+            --wait \
+            --output-format json)"
+          echo "${submit_json}"
+
+          submission_id="$(python3 -c 'import json, sys; print(json.load(sys.stdin)["id"])' <<< "${submit_json}")"
+          submission_status="$(python3 -c 'import json, sys; print(json.load(sys.stdin)["status"])' <<< "${submit_json}")"
+
+          if [[ "${submission_status}" != "Accepted" ]]; then
+            echo "Notarization failed with status: ${submission_status}" >&2
+            xcrun notarytool log "${submission_id}" \
+              --keychain-profile "tabby-notarytool-profile" || true
+            exit 1
+          fi
+
           xcrun stapler staple "${dmg_path}"
           xcrun stapler validate "${dmg_path}"
 


### PR DESCRIPTION
## Summary
Resolves: https://github.com/FuJacob/tabby/issues/36

Turns out my last PR [here](https://github.com/FuJacob/tabby/pull/42) failed at the notarization stage. This is because we needed to:
- Re-sign Sparkle's nested helper executables after archive so notarization does not see ad-hoc nested code.


In this PR, I also added:
- Add a release-workflow assertion that fails if any Mach-O executable remains ad-hoc or lacks Developer ID authority.
- Capture `notarytool` JSON output and print the Apple notarization log before exiting on rejected submissions.

## Validation
- Reproduced the release archive locally from `origin/main` with Developer ID signing.
- Confirmed Sparkle helpers were ad-hoc signed before the post-archive re-sign pass.
- Confirmed the re-sign pass gives nested Sparkle executables Developer ID authority and removes ad-hoc flags.
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml parsed"'`
- `git diff --check`

## Notes
This should address the invalid notarization run where Apple rejected the DMG before stapling. If notarization still rejects the artifact, the workflow will now print Apple's detailed rejection log instead of failing later at `stapler`.
