### PR TITLE
docs: Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,41 @@
+## Summary
+
+<!--
+One or two sentences: what changed and why. Skip the play-by-play.
+The diff already shows what; this section should explain why.
+-->
+
+## Validation
+
+<!--
+What you actually ran and what you actually saw — not what you intended to run.
+Examples:
+
+  xcodebuild test -project tabby.xcodeproj -scheme tabby \
+    -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO
+  # ** TEST SUCCEEDED **  N tests, 0 failures
+
+  swiftlint lint --config .swiftlint.yml --quiet
+  # exit 0
+
+For UI changes, attach a screenshot or short screen recording.
+For changes that can't be verified end-to-end yet, say so explicitly.
+-->
+
+## Linked issues
+
+<!--
+Use `Fixes #N` to auto-close on merge, `Refs #N` to link without closing.
+-->
+
+## Risk / rollout notes
+
+<!--
+Anything reviewers should know that isn't visible from the diff:
+- Schema, settings, or pbxproj migrations
+- Behavior changes that touch existing user flows
+- Performance characteristics worth flagging
+- Follow-up issues filed (link them)
+
+Skip this section entirely if there's nothing to flag.
+-->


### PR DESCRIPTION
## Summary

Adds `.github/PULL_REQUEST_TEMPLATE.md` so GitHub prefills new PR descriptions with a four-section skeleton: Summary, Validation, Linked issues, Risk/rollout notes.

## Validation

- Template renders correctly when opening a new PR (visible on the "open PR" page after this merges).
- Section guidance lives in HTML comments — they prompt the author without rendering in the final PR body, so small PRs aren't buried in headers.

## Linked issues

Refs #43

## Risk / rollout notes

- Existing in-flight PRs aren't retroactively prefilled; only PRs opened after this merges see the template.
- The Validation section explicitly asks for "what you actually ran and saw, not what you intended" — aimed at the failure mode where a PR claims test coverage that wasn't actually executed.