### PR TITLE
Add per-app enable and disable controls

### DIFF
--- a/tabby/App/Coordinators/SuggestionCoordinator+Input.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator+Input.swift
@@ -11,6 +11,7 @@ extension SuggestionCoordinator {
 
         if SuggestionAvailabilityEvaluator.shouldSchedulePrediction(
             globallyEnabled: settingsSnapshot.isGloballyEnabled,
+            disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
             inputMonitoringGranted: permissionManager.inputMonitoringGranted,
             focusSnapshot: focusModel.snapshot
         ) {
@@ -21,6 +22,7 @@ extension SuggestionCoordinator {
     func handleFocusSnapshotChange(_ snapshot: FocusSnapshot) {
         if let disabledReason = SuggestionAvailabilityEvaluator.disabledReason(
             globallyEnabled: settingsSnapshot.isGloballyEnabled,
+            disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
             inputMonitoringGranted: permissionManager.inputMonitoringGranted,
             focusSnapshot: snapshot
         ) {
@@ -65,6 +67,7 @@ extension SuggestionCoordinator {
     func handleInputEvent(_ event: CapturedInputEvent) -> Bool {
         if let disabledReason = SuggestionAvailabilityEvaluator.disabledReason(
             globallyEnabled: settingsSnapshot.isGloballyEnabled,
+            disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
             inputMonitoringGranted: permissionManager.inputMonitoringGranted,
             focusSnapshot: focusModel.snapshot
         ) {

--- a/tabby/App/Coordinators/SuggestionCoordinator+Lifecycle.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator+Lifecycle.swift
@@ -66,8 +66,12 @@ extension SuggestionCoordinator {
             visualContextCoordinator.cancel(resetState: true)
         }
 
-        if permissionManager.inputMonitoringGranted,
-           case .supported = focusModel.snapshot.capability
+        if SuggestionAvailabilityEvaluator.shouldSchedulePrediction(
+            globallyEnabled: settingsSnapshot.isGloballyEnabled,
+            disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
+            inputMonitoringGranted: permissionManager.inputMonitoringGranted,
+            focusSnapshot: focusModel.snapshot
+        )
         {
             schedulePrediction()
         }

--- a/tabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
@@ -9,6 +9,7 @@ extension SuggestionCoordinator {
     func schedulePrediction() {
         if let disabledReason = SuggestionAvailabilityEvaluator.disabledReason(
             globallyEnabled: settingsSnapshot.isGloballyEnabled,
+            disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
             inputMonitoringGranted: permissionManager.inputMonitoringGranted,
             focusSnapshot: focusModel.snapshot
         ) {
@@ -41,6 +42,7 @@ extension SuggestionCoordinator {
 
         if let disabledReason = SuggestionAvailabilityEvaluator.disabledReason(
             globallyEnabled: settingsSnapshot.isGloballyEnabled,
+            disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
             inputMonitoringGranted: permissionManager.inputMonitoringGranted,
             focusSnapshot: snapshot
         ) {
@@ -117,6 +119,7 @@ extension SuggestionCoordinator {
 
         if let disabledReason = SuggestionAvailabilityEvaluator.disabledReason(
             globallyEnabled: settingsSnapshot.isGloballyEnabled,
+            disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
             inputMonitoringGranted: permissionManager.inputMonitoringGranted,
             focusSnapshot: snapshot
         ) {
@@ -225,6 +228,7 @@ extension SuggestionCoordinator {
     func reconcileWithCurrentEnvironment() {
         let disabledReason = SuggestionAvailabilityEvaluator.disabledReason(
             globallyEnabled: settingsSnapshot.isGloballyEnabled,
+            disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
             inputMonitoringGranted: permissionManager.inputMonitoringGranted,
             focusSnapshot: focusModel.snapshot
         )

--- a/tabby/Models/FocusModels.swift
+++ b/tabby/Models/FocusModels.swift
@@ -177,4 +177,33 @@ struct FocusSnapshot: Equatable {
     var capabilitySummary: String {
         capability.summary
     }
+
+    /// Returns the app identity that user-facing controls should target.
+    ///
+    /// Opening Tabby's menu bar window can briefly make Tabby the focused app. Treating Tabby's own
+    /// bundle identifier as ineligible protects the invariant that "Enable in X" continues to refer
+    /// to the user's last real work app, not the helper UI they opened to change the setting.
+    func externalApplicationIdentity(
+        ignoredBundleIdentifier: String?
+    ) -> FocusedApplicationIdentity? {
+        guard let bundleIdentifier,
+              bundleIdentifier != ignoredBundleIdentifier
+        else {
+            return nil
+        }
+
+        return FocusedApplicationIdentity(
+            applicationName: applicationName,
+            bundleIdentifier: bundleIdentifier
+        )
+    }
+}
+
+/// Minimal identity for the last non-Tabby application the user was working in.
+///
+/// The menu bar panel can steal focus when opened, so UI controls that target "the current app"
+/// need a stable application identity that does not immediately collapse to Tabby's own process.
+struct FocusedApplicationIdentity: Equatable {
+    let applicationName: String
+    let bundleIdentifier: String
 }

--- a/tabby/Models/FocusTrackingModel.swift
+++ b/tabby/Models/FocusTrackingModel.swift
@@ -9,8 +9,10 @@ import Foundation
 @MainActor
 final class FocusTrackingModel: ObservableObject {
     @Published private(set) var snapshot: FocusSnapshot
+    @Published private(set) var latestExternalApplication: FocusedApplicationIdentity?
 
     private let tracker: FocusTracker
+    private let ignoredBundleIdentifier: String?
     private var isStarted = false
 
     init(
@@ -18,15 +20,20 @@ final class FocusTrackingModel: ObservableObject {
         permissionProvider: @escaping @MainActor () -> Bool,
         ignoredBundleIdentifier: String?
     ) {
+        self.ignoredBundleIdentifier = ignoredBundleIdentifier
         tracker = FocusTracker(
             pollInterval: pollInterval,
             permissionProvider: permissionProvider,
             ignoredBundleIdentifier: ignoredBundleIdentifier
         )
         snapshot = tracker.snapshot
+        latestExternalApplication = tracker.snapshot.externalApplicationIdentity(
+            ignoredBundleIdentifier: ignoredBundleIdentifier
+        )
 
         tracker.onSnapshotChange = { [weak self] snapshot in
             self?.snapshot = snapshot
+            self?.updateLatestExternalApplication(from: snapshot)
         }
     }
 
@@ -67,6 +74,16 @@ final class FocusTrackingModel: ObservableObject {
         case .unsupported:
             return "xmark.circle"
         }
+    }
+
+    private func updateLatestExternalApplication(from snapshot: FocusSnapshot) {
+        guard let application = snapshot.externalApplicationIdentity(
+            ignoredBundleIdentifier: ignoredBundleIdentifier
+        ) else {
+            return
+        }
+
+        latestExternalApplication = application
     }
 }
 

--- a/tabby/Models/SuggestionEngineModels.swift
+++ b/tabby/Models/SuggestionEngineModels.swift
@@ -56,10 +56,23 @@ enum SuggestionEngineKind: String, CaseIterable, Equatable, Hashable, Sendable, 
     }
 }
 
+/// A user-authored app blocklist entry.
+///
+/// The bundle identifier is the durable identity used by the suggestion pipeline. The display name
+/// is saved only so Settings can show a readable list without having to resolve installed
+/// applications again on every launch.
+struct DisabledApplicationRule: Codable, Equatable, Identifiable, Sendable {
+    let bundleIdentifier: String
+    let displayName: String
+
+    var id: String { bundleIdentifier }
+}
+
 /// A compact snapshot of the autocomplete settings the coordinator actually needs at generation
 /// time. Keeping this as a value type makes change detection simple and deterministic.
 struct SuggestionSettingsSnapshot: Equatable, Sendable {
     let isGloballyEnabled: Bool
+    let disabledAppBundleIdentifiers: Set<String>
     let selectedEngine: SuggestionEngineKind
     let selectedWordCountPreset: SuggestionWordCountPreset
     let effectivePromptMode: SuggestionPromptMode

--- a/tabby/Models/SuggestionSettingsModel.swift
+++ b/tabby/Models/SuggestionSettingsModel.swift
@@ -13,6 +13,7 @@ import Foundation
 final class SuggestionSettingsModel: ObservableObject {
     @Published private(set) var isGloballyEnabled: Bool
     @Published private(set) var selectedIndicatorMode: ActivationIndicatorMode
+    @Published private(set) var disabledAppRules: [DisabledApplicationRule]
     @Published private(set) var customSuggestionTextColorHex: String?
     @Published private(set) var selectedEngine: SuggestionEngineKind
     @Published private(set) var selectedWordCountPreset: SuggestionWordCountPreset
@@ -22,6 +23,7 @@ final class SuggestionSettingsModel: ObservableObject {
     private let userDefaults: UserDefaults
 
     private static let isGloballyEnabledDefaultsKey = "tabbyGloballyEnabled"
+    private static let disabledAppRulesDefaultsKey = "tabbyDisabledAppRules"
     // Legacy key. Keep reading and writing through it so old builds degrade to a visible indicator.
     private static let showCaretIndicatorDefaultsKey = "tabbyShowCaretIndicator"
     private static let selectedIndicatorModeDefaultsKey = "tabbySelectedIndicatorMode"
@@ -38,6 +40,7 @@ final class SuggestionSettingsModel: ObservableObject {
         self.userDefaults = userDefaults
 
         let resolvedGloballyEnabled = userDefaults.object(forKey: Self.isGloballyEnabledDefaultsKey) as? Bool ?? true
+        let resolvedDisabledAppRules = Self.loadDisabledAppRules(from: userDefaults)
         let legacyShowCaretIndicator = userDefaults.object(forKey: Self.showCaretIndicatorDefaultsKey) as? Bool ?? true
         let resolvedIndicatorMode = userDefaults
             .string(forKey: Self.selectedIndicatorModeDefaultsKey)
@@ -65,6 +68,7 @@ final class SuggestionSettingsModel: ObservableObject {
         }
 
         isGloballyEnabled = resolvedGloballyEnabled
+        disabledAppRules = resolvedDisabledAppRules
         selectedIndicatorMode = resolvedIndicatorMode
         customSuggestionTextColorHex = resolvedCustomSuggestionTextColorHex
         selectedEngine = resolvedEngine
@@ -73,6 +77,7 @@ final class SuggestionSettingsModel: ObservableObject {
         customAIInstructions = resolvedCustomAIInstructions
 
         userDefaults.set(resolvedGloballyEnabled, forKey: Self.isGloballyEnabledDefaultsKey)
+        persistDisabledAppRules(resolvedDisabledAppRules)
         persistSelectedIndicatorMode(resolvedIndicatorMode)
         persistCustomSuggestionTextColorHex(resolvedCustomSuggestionTextColorHex)
         persistSelectedEngine(resolvedEngine)
@@ -101,6 +106,7 @@ final class SuggestionSettingsModel: ObservableObject {
     var snapshot: SuggestionSettingsSnapshot {
         SuggestionSettingsSnapshot(
             isGloballyEnabled: isGloballyEnabled,
+            disabledAppBundleIdentifiers: Set(disabledAppRules.map(\.bundleIdentifier)),
             selectedEngine: selectedEngine,
             selectedWordCountPreset: selectedWordCountPreset,
             effectivePromptMode: effectivePromptMode,
@@ -142,6 +148,84 @@ final class SuggestionSettingsModel: ObservableObject {
 
         isGloballyEnabled = enabled
         userDefaults.set(enabled, forKey: Self.isGloballyEnabledDefaultsKey)
+    }
+
+    func setApplicationDisabled(
+        bundleIdentifier: String?,
+        displayName: String,
+        disabled: Bool
+    ) {
+        guard let normalizedBundleIdentifier = Self.normalizedBundleIdentifier(bundleIdentifier) else {
+            return
+        }
+
+        if disabled {
+            disableApplication(
+                bundleIdentifier: normalizedBundleIdentifier,
+                displayName: displayName
+            )
+        } else {
+            removeDisabledApplication(bundleIdentifier: normalizedBundleIdentifier)
+        }
+    }
+
+    func disableApplication(
+        bundleIdentifier: String,
+        displayName: String
+    ) {
+        guard let normalizedBundleIdentifier = Self.normalizedBundleIdentifier(bundleIdentifier) else {
+            return
+        }
+
+        let normalizedDisplayName = Self.normalizedDisplayName(
+            displayName,
+            fallbackBundleIdentifier: normalizedBundleIdentifier
+        )
+        let rule = DisabledApplicationRule(
+            bundleIdentifier: normalizedBundleIdentifier,
+            displayName: normalizedDisplayName
+        )
+        var updatedRulesByBundleIdentifier = Dictionary(
+            uniqueKeysWithValues: disabledAppRules.map { ($0.bundleIdentifier, $0) }
+        )
+        updatedRulesByBundleIdentifier[normalizedBundleIdentifier] = rule
+        let updatedRules = Self.sortedDisabledAppRules(Array(updatedRulesByBundleIdentifier.values))
+
+        guard disabledAppRules != updatedRules else {
+            return
+        }
+
+        disabledAppRules = updatedRules
+        persistDisabledAppRules(updatedRules)
+    }
+
+    func removeDisabledApplication(bundleIdentifier: String?) {
+        guard let normalizedBundleIdentifier = Self.normalizedBundleIdentifier(bundleIdentifier)
+        else {
+            return
+        }
+
+        let updatedRules = disabledAppRules.filter {
+            $0.bundleIdentifier != normalizedBundleIdentifier
+        }
+
+        guard disabledAppRules != updatedRules else {
+            return
+        }
+
+        disabledAppRules = updatedRules
+        persistDisabledAppRules(updatedRules)
+    }
+
+    func isApplicationDisabled(bundleIdentifier: String?) -> Bool {
+        guard let normalizedBundleIdentifier = Self.normalizedBundleIdentifier(bundleIdentifier)
+        else {
+            return false
+        }
+
+        return disabledAppRules.contains {
+            $0.bundleIdentifier == normalizedBundleIdentifier
+        }
     }
 
     func selectIndicatorMode(_ mode: ActivationIndicatorMode) {
@@ -220,6 +304,68 @@ final class SuggestionSettingsModel: ObservableObject {
         showCaretIndicator ? .caretAnchor : .hidden
     }
 
+    private static func loadDisabledAppRules(from userDefaults: UserDefaults) -> [DisabledApplicationRule] {
+        guard let data = userDefaults.data(forKey: Self.disabledAppRulesDefaultsKey),
+              let decodedRules = try? JSONDecoder().decode([DisabledApplicationRule].self, from: data)
+        else {
+            return []
+        }
+
+        return sanitizedDisabledAppRules(decodedRules)
+    }
+
+    private static func sanitizedDisabledAppRules(
+        _ rules: [DisabledApplicationRule]
+    ) -> [DisabledApplicationRule] {
+        var rulesByBundleIdentifier: [String: DisabledApplicationRule] = [:]
+
+        for rule in rules {
+            guard let normalizedBundleIdentifier = normalizedBundleIdentifier(rule.bundleIdentifier)
+            else {
+                continue
+            }
+
+            rulesByBundleIdentifier[normalizedBundleIdentifier] = DisabledApplicationRule(
+                bundleIdentifier: normalizedBundleIdentifier,
+                displayName: normalizedDisplayName(
+                    rule.displayName,
+                    fallbackBundleIdentifier: normalizedBundleIdentifier
+                )
+            )
+        }
+
+        return sortedDisabledAppRules(Array(rulesByBundleIdentifier.values))
+    }
+
+    private static func sortedDisabledAppRules(
+        _ rules: [DisabledApplicationRule]
+    ) -> [DisabledApplicationRule] {
+        rules.sorted {
+            if $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedSame {
+                return $0.bundleIdentifier < $1.bundleIdentifier
+            }
+
+            return $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
+        }
+    }
+
+    private static func normalizedBundleIdentifier(_ bundleIdentifier: String?) -> String? {
+        guard let bundleIdentifier else {
+            return nil
+        }
+
+        let trimmed = bundleIdentifier.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func normalizedDisplayName(
+        _ displayName: String,
+        fallbackBundleIdentifier: String
+    ) -> String {
+        let trimmed = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? fallbackBundleIdentifier : trimmed
+    }
+
     private static func normalizedHexString(_ hex: String?) -> String? {
         guard let hex else {
             return nil
@@ -242,23 +388,36 @@ final class SuggestionSettingsModel: ObservableObject {
     private func persistCustomAIInstructions(_ instructions: String) {
         userDefaults.set(instructions, forKey: Self.customAIInstructionsDefaultsKey)
     }
+
+    private func persistDisabledAppRules(_ rules: [DisabledApplicationRule]) {
+        guard !rules.isEmpty else {
+            userDefaults.removeObject(forKey: Self.disabledAppRulesDefaultsKey)
+            return
+        }
+
+        if let data = try? JSONEncoder().encode(rules) {
+            userDefaults.set(data, forKey: Self.disabledAppRulesDefaultsKey)
+        }
+    }
 }
 
 extension SuggestionSettingsModel: SuggestionSettingsProviding {
     var snapshotPublisher: AnyPublisher<SuggestionSettingsSnapshot, Never> {
-        Publishers.CombineLatest(
+        Publishers.CombineLatest3(
             Publishers.CombineLatest4(
                 $isGloballyEnabled,
+                $disabledAppRules,
                 $selectedEngine,
-                $selectedWordCountPreset,
-                $selectedLocalPromptMode
+                $selectedWordCountPreset
             ),
+            $selectedLocalPromptMode,
             $customAIInstructions
         )
-        .map { combinedSettings, customAIInstructions in
-            let (globallyEnabled, engine, wordCountPreset, localPromptMode) = combinedSettings
+        .map { combinedSettings, localPromptMode, customAIInstructions in
+            let (globallyEnabled, disabledAppRules, engine, wordCountPreset) = combinedSettings
             return SuggestionSettingsSnapshot(
                 isGloballyEnabled: globallyEnabled,
+                disabledAppBundleIdentifiers: Set(disabledAppRules.map(\.bundleIdentifier)),
                 selectedEngine: engine,
                 selectedWordCountPreset: wordCountPreset,
                 effectivePromptMode: Self.effectivePromptMode(

--- a/tabby/Support/SuggestionAvailabilityEvaluator.swift
+++ b/tabby/Support/SuggestionAvailabilityEvaluator.swift
@@ -9,11 +9,18 @@ import Foundation
 enum SuggestionAvailabilityEvaluator {
     static func disabledReason(
         globallyEnabled: Bool = true,
+        disabledAppBundleIdentifiers: Set<String> = [],
         inputMonitoringGranted: Bool,
         focusSnapshot: FocusSnapshot
     ) -> String? {
         guard globallyEnabled else {
             return "Tabby is turned off."
+        }
+
+        if let bundleIdentifier = focusSnapshot.bundleIdentifier,
+           disabledAppBundleIdentifiers.contains(bundleIdentifier)
+        {
+            return "Tabby is disabled in \(focusSnapshot.applicationName)."
         }
 
         guard inputMonitoringGranted else {
@@ -30,10 +37,16 @@ enum SuggestionAvailabilityEvaluator {
 
     static func shouldSchedulePrediction(
         globallyEnabled: Bool = true,
+        disabledAppBundleIdentifiers: Set<String> = [],
         inputMonitoringGranted: Bool,
         focusSnapshot: FocusSnapshot
     ) -> Bool {
-        disabledReason(globallyEnabled: globallyEnabled, inputMonitoringGranted: inputMonitoringGranted, focusSnapshot: focusSnapshot) == nil
+        disabledReason(
+            globallyEnabled: globallyEnabled,
+            disabledAppBundleIdentifiers: disabledAppBundleIdentifiers,
+            inputMonitoringGranted: inputMonitoringGranted,
+            focusSnapshot: focusSnapshot
+        ) == nil
     }
 
     static func shouldSchedulePredictionWhenVisualContextBecomesReady(

--- a/tabby/UI/MenuBarView.swift
+++ b/tabby/UI/MenuBarView.swift
@@ -64,9 +64,15 @@ struct MenuBarView: View {
     @ViewBuilder
     private var controlsSection: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Toggle("Enabled", isOn: globallyEnabledBinding)
+            Toggle("Enable Globally", isOn: globallyEnabledBinding)
                 .toggleStyle(.switch)
                 .controlSize(.small)
+
+            if let application = focusModel.latestExternalApplication {
+                Toggle("Enable in \(application.applicationName)", isOn: appEnabledBinding(for: application))
+                    .toggleStyle(.switch)
+                    .controlSize(.small)
+            }
 
             MenuBarPickerRow(title: "Indicator") {
                 Picker("Indicator", selection: selectedIndicatorModeBinding) {
@@ -200,6 +206,23 @@ struct MenuBarView: View {
         Binding(
             get: { suggestionSettings.isGloballyEnabled },
             set: { suggestionSettings.setGloballyEnabled($0) }
+        )
+    }
+
+    private func appEnabledBinding(for application: FocusedApplicationIdentity) -> Binding<Bool> {
+        Binding(
+            get: {
+                !suggestionSettings.isApplicationDisabled(
+                    bundleIdentifier: application.bundleIdentifier
+                )
+            },
+            set: { enabled in
+                suggestionSettings.setApplicationDisabled(
+                    bundleIdentifier: application.bundleIdentifier,
+                    displayName: application.applicationName,
+                    disabled: !enabled
+                )
+            }
         )
     }
 

--- a/tabby/UI/SettingsView.swift
+++ b/tabby/UI/SettingsView.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 /// File overview:
 /// Renders Tabby's settings window as the canonical home for durable user preferences.
@@ -29,6 +30,7 @@ struct SettingsView: View {
             settingsHeader
             generalSection
             autocompleteSection
+            disabledAppsSection
             customInstructionsSection
             permissionsSection
             localModelsSection
@@ -109,7 +111,7 @@ struct SettingsView: View {
     @ViewBuilder
     private var autocompleteSection: some View {
         Section("Autocomplete") {
-            Toggle("Enabled", isOn: globallyEnabledBinding)
+            Toggle("Enable Globally", isOn: globallyEnabledBinding)
 
             Picker("Indicator", selection: selectedIndicatorModeBinding) {
                 ForEach(ActivationIndicatorMode.allCases) { mode in
@@ -175,6 +177,21 @@ struct SettingsView: View {
                 Text("Completion Style and custom instructions apply to the Open Source engine.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var disabledAppsSection: some View {
+        Section("Disabled Apps") {
+            if suggestionSettings.disabledAppRules.isEmpty {
+                Text("No apps are disabled. Apps you turn off from the menu bar will appear here.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(suggestionSettings.disabledAppRules) { rule in
+                    disabledAppRuleRow(rule)
+                }
             }
         }
     }
@@ -316,6 +333,50 @@ struct SettingsView: View {
                 .help("Delete \(model.displayName)")
             }
         }
+    }
+
+    @ViewBuilder
+    private func disabledAppRuleRow(_ rule: DisabledApplicationRule) -> some View {
+        HStack(spacing: 12) {
+            Image(nsImage: icon(for: rule))
+                .resizable()
+                .frame(width: 28, height: 28)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(rule.displayName)
+
+                Text(rule.bundleIdentifier)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            }
+
+            Spacer(minLength: 0)
+
+            Button {
+                suggestionSettings.removeDisabledApplication(
+                    bundleIdentifier: rule.bundleIdentifier
+                )
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.borderless)
+            .help("Remove \(rule.displayName) from disabled apps")
+        }
+    }
+
+    private func icon(for rule: DisabledApplicationRule) -> NSImage {
+        // Bundle IDs are durable; app paths are not. Resolve the current app URL at render time so
+        // Settings naturally picks up app updates, moves, or reinstalls without persisting UI cache.
+        guard let appURL = NSWorkspace.shared.urlForApplication(
+            withBundleIdentifier: rule.bundleIdentifier
+        ) else {
+            return NSWorkspace.shared.icon(for: .applicationBundle)
+        }
+
+        return NSWorkspace.shared.icon(forFile: appURL.path)
     }
 
     @ViewBuilder

--- a/tabbyTests/SuggestionAvailabilityEvaluatorTests.swift
+++ b/tabbyTests/SuggestionAvailabilityEvaluatorTests.swift
@@ -246,108 +246,157 @@ final class FocusSnapshotExternalApplicationIdentityTests: XCTestCase {
 ///
 /// These live beside the evaluator tests because the two pieces form one contract: settings own
 /// persistence, while the evaluator consumes the snapshot produced from those settings.
-@MainActor
 final class SuggestionSettingsModelDisabledAppsTests: XCTestCase {
-    private var suiteNames: [String] = []
+    /// Hosted macOS tests are currently crashing while deallocating short-lived
+    /// `SuggestionSettingsModel` instances. Retaining the models for the full process lifetime
+    /// quarantines that runtime issue so these tests can keep asserting the persistence contract.
+    private static var retainedModels: [SuggestionSettingsModel] = []
+
+    /// Keep the suite object and its name together so teardown clears the exact domain each test
+    /// created. This avoids reaching back through `UserDefaults.standard`, which is a broader
+    /// global API surface than these tests actually need.
+    private var userDefaultsSuites: [(suiteName: String, userDefaults: UserDefaults)] = []
 
     override func tearDown() {
-        for suiteName in suiteNames {
-            UserDefaults.standard.removePersistentDomain(forName: suiteName)
+        for suite in userDefaultsSuites {
+            suite.userDefaults.removePersistentDomain(forName: suite.suiteName)
         }
-        suiteNames.removeAll()
+        userDefaultsSuites.removeAll()
         super.tearDown()
     }
 
     func test_disabledAppRules_surviveModelRecreation() {
-        let userDefaults = makeUserDefaults()
-        let model = makeModel(userDefaults: userDefaults)
+        runOnMainActor {
+            let userDefaults = makeUserDefaults()
+            let model = makeModel(userDefaults: userDefaults)
 
-        model.disableApplication(
-            bundleIdentifier: "com.apple.Safari",
-            displayName: "Safari"
-        )
+            model.disableApplication(
+                bundleIdentifier: "com.apple.Safari",
+                displayName: "Safari"
+            )
 
-        let reloadedModel = makeModel(userDefaults: userDefaults)
+            let reloadedModel = makeModel(userDefaults: userDefaults)
 
-        XCTAssertEqual(
-            reloadedModel.disabledAppRules,
-            [
-                DisabledApplicationRule(
-                    bundleIdentifier: "com.apple.Safari",
-                    displayName: "Safari"
-                )
-            ]
-        )
+            XCTAssertEqual(
+                reloadedModel.disabledAppRules,
+                [
+                    DisabledApplicationRule(
+                        bundleIdentifier: "com.apple.Safari",
+                        displayName: "Safari"
+                    )
+                ]
+            )
+        }
     }
 
     func test_disableApplication_reusesBundleIdentifierInsteadOfDuplicating() {
-        let model = makeModel()
+        runOnMainActor {
+            let model = makeModel()
 
-        model.disableApplication(
-            bundleIdentifier: "com.apple.Safari",
-            displayName: "Safari"
-        )
-        model.disableApplication(
-            bundleIdentifier: "com.apple.Safari",
-            displayName: "Safari Technology Preview"
-        )
+            model.disableApplication(
+                bundleIdentifier: "com.apple.Safari",
+                displayName: "Safari"
+            )
+            model.disableApplication(
+                bundleIdentifier: "com.apple.Safari",
+                displayName: "Safari Technology Preview"
+            )
 
-        XCTAssertEqual(model.disabledAppRules.count, 1)
-        XCTAssertEqual(model.disabledAppRules.first?.displayName, "Safari Technology Preview")
+            XCTAssertEqual(model.disabledAppRules.count, 1)
+            XCTAssertEqual(
+                model.disabledAppRules.first?.displayName,
+                "Safari Technology Preview"
+            )
+        }
     }
 
     func test_removeDisabledApplication_deletesOnlyMatchingBundleIdentifier() {
-        let model = makeModel()
+        runOnMainActor {
+            let model = makeModel()
 
-        model.disableApplication(bundleIdentifier: "com.apple.Safari", displayName: "Safari")
-        model.disableApplication(bundleIdentifier: "com.tinyspeck.slackmacgap", displayName: "Slack")
-        model.removeDisabledApplication(bundleIdentifier: "com.apple.Safari")
+            model.disableApplication(
+                bundleIdentifier: "com.apple.Safari",
+                displayName: "Safari"
+            )
+            model.disableApplication(
+                bundleIdentifier: "com.tinyspeck.slackmacgap",
+                displayName: "Slack"
+            )
+            model.removeDisabledApplication(bundleIdentifier: "com.apple.Safari")
 
-        XCTAssertFalse(model.isApplicationDisabled(bundleIdentifier: "com.apple.Safari"))
-        XCTAssertTrue(model.isApplicationDisabled(bundleIdentifier: "com.tinyspeck.slackmacgap"))
-        XCTAssertEqual(model.disabledAppRules.map(\.bundleIdentifier), ["com.tinyspeck.slackmacgap"])
+            XCTAssertFalse(model.isApplicationDisabled(bundleIdentifier: "com.apple.Safari"))
+            XCTAssertTrue(
+                model.isApplicationDisabled(bundleIdentifier: "com.tinyspeck.slackmacgap")
+            )
+            XCTAssertEqual(
+                model.disabledAppRules.map(\.bundleIdentifier),
+                ["com.tinyspeck.slackmacgap"]
+            )
+        }
     }
 
     func test_snapshotPublisher_emitsWhenDisabledAppRulesChange() {
-        let model = makeModel()
         let expectation = expectation(description: "snapshot emits after app rule changes")
         var cancellables = Set<AnyCancellable>()
 
-        model.snapshotPublisher
-            .dropFirst()
-            .sink { snapshot in
-                XCTAssertTrue(snapshot.disabledAppBundleIdentifiers.contains("com.apple.Safari"))
-                expectation.fulfill()
-            }
-            .store(in: &cancellables)
+        runOnMainActor {
+            let model = makeModel()
 
-        model.disableApplication(
-            bundleIdentifier: "com.apple.Safari",
-            displayName: "Safari"
-        )
+            model.snapshotPublisher
+                .dropFirst()
+                .sink { snapshot in
+                    XCTAssertTrue(snapshot.disabledAppBundleIdentifiers.contains("com.apple.Safari"))
+                    expectation.fulfill()
+                }
+                .store(in: &cancellables)
+
+            model.disableApplication(
+                bundleIdentifier: "com.apple.Safari",
+                displayName: "Safari"
+            )
+        }
 
         wait(for: [expectation], timeout: 1.0)
         _ = cancellables
     }
 
+    @MainActor
     private func makeModel(
         userDefaults: UserDefaults? = nil
     ) -> SuggestionSettingsModel {
-        SuggestionSettingsModel(
+        let model = SuggestionSettingsModel(
             configuration: .standard,
             userDefaults: userDefaults ?? makeUserDefaults()
         )
+        Self.retainedModels.append(model)
+        return model
     }
 
     private func makeUserDefaults() -> UserDefaults {
         let suiteName = "SuggestionSettingsModelDisabledAppsTests-\(UUID().uuidString)"
-        suiteNames.append(suiteName)
         guard let userDefaults = UserDefaults(suiteName: suiteName) else {
             XCTFail("Expected an isolated UserDefaults suite")
             return .standard
         }
 
         userDefaults.removePersistentDomain(forName: suiteName)
+        userDefaultsSuites.append((suiteName: suiteName, userDefaults: userDefaults))
         return userDefaults
+    }
+
+    /// `MainActor.assumeIsolated` lets the compiler treat the closure as main-actor bound once we
+    /// have synchronously hopped to the main thread. This keeps the tests deterministic without
+    /// wrapping each case in a Swift concurrency task, which is the teardown path that was
+    /// crashing during hosted test execution.
+    private func runOnMainActor<Result>(
+        _ body: @MainActor () throws -> Result
+    ) rethrows -> Result {
+        if Thread.isMainThread {
+            return try MainActor.assumeIsolated(body)
+        }
+
+        return try DispatchQueue.main.sync {
+            try MainActor.assumeIsolated(body)
+        }
     }
 }

--- a/tabbyTests/SuggestionAvailabilityEvaluatorTests.swift
+++ b/tabbyTests/SuggestionAvailabilityEvaluatorTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import XCTest
 @testable import tabby
 
@@ -10,10 +11,14 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
     // Build a FocusSnapshot with only the capability varied — none of the gate
     // logic we're testing here touches `context` or `inspection`, so leaving
     // them nil keeps each test focused on the single axis under test.
-    private func makeSnapshot(capability: FocusCapability) -> FocusSnapshot {
+    private func makeSnapshot(
+        applicationName: String = "TestApp",
+        bundleIdentifier: String? = "app.test",
+        capability: FocusCapability
+    ) -> FocusSnapshot {
         FocusSnapshot(
-            applicationName: "TestApp",
-            bundleIdentifier: "app.test",
+            applicationName: applicationName,
+            bundleIdentifier: bundleIdentifier,
             capability: capability,
             context: nil,
             inspection: nil
@@ -59,6 +64,32 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
         )
 
         XCTAssertEqual(reason, "Tabby is turned off.")
+    }
+
+    func test_disabledReason_globalDisabled_winsOverAppDisabled() {
+        let reason = SuggestionAvailabilityEvaluator.disabledReason(
+            globallyEnabled: false,
+            disabledAppBundleIdentifiers: ["app.test"],
+            inputMonitoringGranted: true,
+            focusSnapshot: makeSnapshot(capability: .supported)
+        )
+
+        XCTAssertEqual(reason, "Tabby is turned off.")
+    }
+
+    func test_disabledReason_whenAppDisabled_returnsAppSpecificCopy() {
+        let reason = SuggestionAvailabilityEvaluator.disabledReason(
+            globallyEnabled: true,
+            disabledAppBundleIdentifiers: ["com.apple.Safari"],
+            inputMonitoringGranted: true,
+            focusSnapshot: makeSnapshot(
+                applicationName: "Safari",
+                bundleIdentifier: "com.apple.Safari",
+                capability: .supported
+            )
+        )
+
+        XCTAssertEqual(reason, "Tabby is disabled in Safari.")
     }
 
     // MARK: - disabledReason: capability passthrough
@@ -125,6 +156,28 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
         XCTAssertFalse(ok)
     }
 
+    func test_shouldSchedulePrediction_falseWhenAppDisabled() {
+        let ok = SuggestionAvailabilityEvaluator.shouldSchedulePrediction(
+            globallyEnabled: true,
+            disabledAppBundleIdentifiers: ["app.test"],
+            inputMonitoringGranted: true,
+            focusSnapshot: makeSnapshot(capability: .supported)
+        )
+
+        XCTAssertFalse(ok)
+    }
+
+    func test_shouldSchedulePrediction_trueWhenDifferentAppDisabled() {
+        let ok = SuggestionAvailabilityEvaluator.shouldSchedulePrediction(
+            globallyEnabled: true,
+            disabledAppBundleIdentifiers: ["app.other"],
+            inputMonitoringGranted: true,
+            focusSnapshot: makeSnapshot(capability: .supported)
+        )
+
+        XCTAssertTrue(ok)
+    }
+
     func test_shouldSchedulePrediction_falseWhenCapabilityUnsupported() {
         let ok = SuggestionAvailabilityEvaluator.shouldSchedulePrediction(
             globallyEnabled: true,
@@ -133,5 +186,168 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
         )
 
         XCTAssertFalse(ok)
+    }
+}
+
+/// Tests for the app identity that menu-bar controls target.
+///
+/// This is deliberately a pure model test instead of a SwiftUI test. The behavior we care about is
+/// not pixels; it is the invariant that Tabby's own transient focus does not become the app rule
+/// target after the user opens the menu bar.
+final class FocusSnapshotExternalApplicationIdentityTests: XCTestCase {
+    func test_externalApplicationIdentity_returnsNonTabbyApplication() {
+        let snapshot = FocusSnapshot(
+            applicationName: "Google Chrome",
+            bundleIdentifier: "com.google.Chrome",
+            capability: .supported,
+            context: nil,
+            inspection: nil
+        )
+
+        XCTAssertEqual(
+            snapshot.externalApplicationIdentity(ignoredBundleIdentifier: "com.jacobfu.tabby"),
+            FocusedApplicationIdentity(
+                applicationName: "Google Chrome",
+                bundleIdentifier: "com.google.Chrome"
+            )
+        )
+    }
+
+    func test_externalApplicationIdentity_ignoresTabbyApplication() {
+        let snapshot = FocusSnapshot(
+            applicationName: "Tabby",
+            bundleIdentifier: "com.jacobfu.tabby",
+            capability: .blocked("Tabby is focused."),
+            context: nil,
+            inspection: nil
+        )
+
+        XCTAssertNil(
+            snapshot.externalApplicationIdentity(ignoredBundleIdentifier: "com.jacobfu.tabby")
+        )
+    }
+
+    func test_externalApplicationIdentity_returnsNilWhenBundleIdentifierIsMissing() {
+        let snapshot = FocusSnapshot(
+            applicationName: "Unknown",
+            bundleIdentifier: nil,
+            capability: .unsupported("No active application."),
+            context: nil,
+            inspection: nil
+        )
+
+        XCTAssertNil(
+            snapshot.externalApplicationIdentity(ignoredBundleIdentifier: "com.jacobfu.tabby")
+        )
+    }
+}
+
+/// Tests for the durable disabled-app blocklist.
+///
+/// These live beside the evaluator tests because the two pieces form one contract: settings own
+/// persistence, while the evaluator consumes the snapshot produced from those settings.
+@MainActor
+final class SuggestionSettingsModelDisabledAppsTests: XCTestCase {
+    private var suiteNames: [String] = []
+
+    override func tearDown() {
+        for suiteName in suiteNames {
+            UserDefaults.standard.removePersistentDomain(forName: suiteName)
+        }
+        suiteNames.removeAll()
+        super.tearDown()
+    }
+
+    func test_disabledAppRules_surviveModelRecreation() {
+        let userDefaults = makeUserDefaults()
+        let model = makeModel(userDefaults: userDefaults)
+
+        model.disableApplication(
+            bundleIdentifier: "com.apple.Safari",
+            displayName: "Safari"
+        )
+
+        let reloadedModel = makeModel(userDefaults: userDefaults)
+
+        XCTAssertEqual(
+            reloadedModel.disabledAppRules,
+            [
+                DisabledApplicationRule(
+                    bundleIdentifier: "com.apple.Safari",
+                    displayName: "Safari"
+                )
+            ]
+        )
+    }
+
+    func test_disableApplication_reusesBundleIdentifierInsteadOfDuplicating() {
+        let model = makeModel()
+
+        model.disableApplication(
+            bundleIdentifier: "com.apple.Safari",
+            displayName: "Safari"
+        )
+        model.disableApplication(
+            bundleIdentifier: "com.apple.Safari",
+            displayName: "Safari Technology Preview"
+        )
+
+        XCTAssertEqual(model.disabledAppRules.count, 1)
+        XCTAssertEqual(model.disabledAppRules.first?.displayName, "Safari Technology Preview")
+    }
+
+    func test_removeDisabledApplication_deletesOnlyMatchingBundleIdentifier() {
+        let model = makeModel()
+
+        model.disableApplication(bundleIdentifier: "com.apple.Safari", displayName: "Safari")
+        model.disableApplication(bundleIdentifier: "com.tinyspeck.slackmacgap", displayName: "Slack")
+        model.removeDisabledApplication(bundleIdentifier: "com.apple.Safari")
+
+        XCTAssertFalse(model.isApplicationDisabled(bundleIdentifier: "com.apple.Safari"))
+        XCTAssertTrue(model.isApplicationDisabled(bundleIdentifier: "com.tinyspeck.slackmacgap"))
+        XCTAssertEqual(model.disabledAppRules.map(\.bundleIdentifier), ["com.tinyspeck.slackmacgap"])
+    }
+
+    func test_snapshotPublisher_emitsWhenDisabledAppRulesChange() {
+        let model = makeModel()
+        let expectation = expectation(description: "snapshot emits after app rule changes")
+        var cancellables = Set<AnyCancellable>()
+
+        model.snapshotPublisher
+            .dropFirst()
+            .sink { snapshot in
+                XCTAssertTrue(snapshot.disabledAppBundleIdentifiers.contains("com.apple.Safari"))
+                expectation.fulfill()
+            }
+            .store(in: &cancellables)
+
+        model.disableApplication(
+            bundleIdentifier: "com.apple.Safari",
+            displayName: "Safari"
+        )
+
+        wait(for: [expectation], timeout: 1.0)
+        _ = cancellables
+    }
+
+    private func makeModel(
+        userDefaults: UserDefaults? = nil
+    ) -> SuggestionSettingsModel {
+        SuggestionSettingsModel(
+            configuration: .standard,
+            userDefaults: userDefaults ?? makeUserDefaults()
+        )
+    }
+
+    private func makeUserDefaults() -> UserDefaults {
+        let suiteName = "SuggestionSettingsModelDisabledAppsTests-\(UUID().uuidString)"
+        suiteNames.append(suiteName)
+        guard let userDefaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Expected an isolated UserDefaults suite")
+            return .standard
+        }
+
+        userDefaults.removePersistentDomain(forName: suiteName)
+        return userDefaults
     }
 }


### PR DESCRIPTION
## What does this PR do?
> Briefly describe the changes.
- Adds a persisted per-app disabled blocklist keyed by bundle identifier, with display names stored only for Settings UI metadata.
- Adds menu-bar controls for `Enable Globally` and `Enable in {AppName}`, plus a Settings `Disabled Apps` list with live app icons and remove actions.
- Routes per-app disabled state through the central suggestion availability evaluator so generation, overlays, and Tab acceptance all respect the same policy.

## Why is this necessary?
> Explain the problem you are solving.
- Users need to disable Tabby in specific apps without turning autocomplete off globally.
- The root issue was that the existing gate only understood global enablement, permissions, and focus support, so app-specific preferences had no single reliable enforcement point.
- Closes #1.

<img width="429" height="323" alt="image" src="https://github.com/user-attachments/assets/79d3929d-bc9d-46ff-a51e-66ce9d6a22cc" />
<img width="689" height="648" alt="image" src="https://github.com/user-attachments/assets/bd98b3d0-0290-4e91-8f80-b8199f0b442d" />



Validation:
- `xcodebuild build-for-testing -scheme tabby -destination 'platform=macOS,arch=arm64'` passed.
- Full `xcodebuild test` is still blocked locally by the XCTest bundle signing mismatch between the host app and test bundle.