### PR TITLE
Add llama KV prefix cache reuse

### DIFF
--- a/tabby.xcodeproj/xcshareddata/xcschemes/tabby.xcscheme
+++ b/tabby.xcodeproj/xcshareddata/xcschemes/tabby.xcscheme
@@ -69,7 +69,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-tabby-debug-caret-overlay"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-tabby-log-focus-geometry"

--- a/tabby/App/Coordinators/SuggestionCoordinator+Input.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator+Input.swift
@@ -52,7 +52,7 @@ extension SuggestionCoordinator {
 
         if interactionState.hasFocusedElementChanged(comparedTo: focusedContext) {
             cancelPredictionWork()
-            suggestionEngine.resetCachedGenerationContext()
+            resetCachedGenerationContext()
             clearSuggestion(clearDiagnostics: true)
             hideOverlay(reason: "Overlay hidden because the focused field changed.")
             state = .idle

--- a/tabby/App/Coordinators/SuggestionCoordinator+Input.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator+Input.swift
@@ -52,6 +52,7 @@ extension SuggestionCoordinator {
 
         if interactionState.hasFocusedElementChanged(comparedTo: focusedContext) {
             cancelPredictionWork()
+            suggestionEngine.resetCachedGenerationContext()
             clearSuggestion(clearDiagnostics: true)
             hideOverlay(reason: "Overlay hidden because the focused field changed.")
             state = .idle

--- a/tabby/App/Coordinators/SuggestionCoordinator+Lifecycle.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator+Lifecycle.swift
@@ -14,7 +14,7 @@ extension SuggestionCoordinator {
     /// Cancels any pending work and detaches long-lived callbacks during shutdown.
     func stop() {
         cancelPredictionWork()
-        suggestionEngine.resetCachedGenerationContext()
+        resetCachedGenerationContext()
         visualContextCoordinator.cancel(resetState: true)
         hideOverlay(reason: "Overlay hidden because Tabby stopped observing suggestions.")
         inputMonitor.onEvent = nil
@@ -28,7 +28,7 @@ extension SuggestionCoordinator {
     /// This prevents stale completions from the previous model from surviving the switch.
     func prepareForRuntimeModelSwitch() {
         cancelPredictionWork()
-        suggestionEngine.resetCachedGenerationContext()
+        resetCachedGenerationContext()
         interactionState.resetAll()
         visualContextCoordinator.cancel(resetState: true)
         clearSuggestion(clearDiagnostics: true)
@@ -49,7 +49,7 @@ extension SuggestionCoordinator {
         let previousSnapshot = settingsSnapshot
         settingsSnapshot = snapshot
         cancelPredictionWork()
-        suggestionEngine.resetCachedGenerationContext()
+        resetCachedGenerationContext()
         clearSuggestion(clearDiagnostics: true)
         hideOverlay(reason: "Overlay hidden because autocomplete settings changed.")
         state = .idle

--- a/tabby/App/Coordinators/SuggestionCoordinator+Lifecycle.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator+Lifecycle.swift
@@ -14,6 +14,7 @@ extension SuggestionCoordinator {
     /// Cancels any pending work and detaches long-lived callbacks during shutdown.
     func stop() {
         cancelPredictionWork()
+        suggestionEngine.resetCachedGenerationContext()
         visualContextCoordinator.cancel(resetState: true)
         hideOverlay(reason: "Overlay hidden because Tabby stopped observing suggestions.")
         inputMonitor.onEvent = nil
@@ -27,6 +28,7 @@ extension SuggestionCoordinator {
     /// This prevents stale completions from the previous model from surviving the switch.
     func prepareForRuntimeModelSwitch() {
         cancelPredictionWork()
+        suggestionEngine.resetCachedGenerationContext()
         interactionState.resetAll()
         visualContextCoordinator.cancel(resetState: true)
         clearSuggestion(clearDiagnostics: true)
@@ -47,6 +49,7 @@ extension SuggestionCoordinator {
         let previousSnapshot = settingsSnapshot
         settingsSnapshot = snapshot
         cancelPredictionWork()
+        suggestionEngine.resetCachedGenerationContext()
         clearSuggestion(clearDiagnostics: true)
         hideOverlay(reason: "Overlay hidden because autocomplete settings changed.")
         state = .idle

--- a/tabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
@@ -34,6 +34,11 @@ extension SuggestionCoordinator {
             return
         }
 
+        await awaitCachedGenerationContextResetIfNeeded()
+        guard workController.isCurrent(workID) else {
+            return
+        }
+
         // We intentionally re-read the latest focus snapshot here instead of trusting the earlier
         // key event, because the user may have switched apps or fields during the debounce window.
         focusModel.refreshNow()
@@ -305,7 +310,7 @@ extension SuggestionCoordinator {
     /// Fully disables prediction, clears cached context, and updates UI messaging with the cause.
     func disablePredictions(reason: String) {
         cancelPredictionWork()
-        suggestionEngine.resetCachedGenerationContext()
+        resetCachedGenerationContext()
         visualContextCoordinator.cancel(resetState: true)
         interactionState.resetAll()
         clearSuggestion(clearDiagnostics: true)
@@ -335,6 +340,36 @@ extension SuggestionCoordinator {
     /// Cancels debounce/generation tasks and advances the work id so late completions are ignored.
     func cancelPredictionWork() {
         workController.cancelAll()
+    }
+
+    /// Starts an ordered backend context reset without forcing synchronous input handlers to become
+    /// async. `generateFromCurrentFocus` awaits this barrier before it builds the next request, so a
+    /// reset caused by focus/settings changes cannot race with the following generation.
+    func resetCachedGenerationContext() {
+        pendingCacheReset?.task.cancel()
+        cacheResetSequence &+= 1
+        let sequence = cacheResetSequence
+        let suggestionEngine = suggestionEngine
+        let resetTask = Task { @MainActor in
+            guard !Task.isCancelled else {
+                return
+            }
+
+            await suggestionEngine.resetCachedGenerationContext()
+        }
+        pendingCacheReset = (sequence, resetTask)
+    }
+
+    func awaitCachedGenerationContextResetIfNeeded() async {
+        guard let pendingCacheReset else {
+            return
+        }
+
+        await pendingCacheReset.task.value
+
+        if self.pendingCacheReset?.sequence == pendingCacheReset.sequence {
+            self.pendingCacheReset = nil
+        }
     }
 
     // MARK: - Visual Context

--- a/tabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
@@ -305,6 +305,7 @@ extension SuggestionCoordinator {
     /// Fully disables prediction, clears cached context, and updates UI messaging with the cause.
     func disablePredictions(reason: String) {
         cancelPredictionWork()
+        suggestionEngine.resetCachedGenerationContext()
         visualContextCoordinator.cancel(resetState: true)
         interactionState.resetAll()
         clearSuggestion(clearDiagnostics: true)

--- a/tabby/App/Coordinators/SuggestionCoordinator.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator.swift
@@ -55,6 +55,10 @@ final class SuggestionCoordinator: ObservableObject {
     // Async work and active-session storage now live in dedicated collaborators below.
     var cancellables = Set<AnyCancellable>()
     var settingsSnapshot: SuggestionSettingsSnapshot
+    // Synchronous input/focus callbacks cannot directly `await`, so resets are represented as a
+    // barrier task that the next generation must cross before it can ask the runtime for output.
+    var cacheResetSequence: UInt64 = 0
+    var pendingCacheReset: (sequence: UInt64, task: Task<Void, Never>)?
 
     init(
         permissionManager: any SuggestionPermissionProviding,

--- a/tabby/Models/SuggestionModels.swift
+++ b/tabby/Models/SuggestionModels.swift
@@ -129,6 +129,10 @@ struct SuggestionConfiguration: Equatable, Sendable {
     let topP: Double
     let minP: Double
     let repetitionPenalty: Double
+    /// Optional fixed seed for deterministic llama sampling.
+    /// Production keeps this nil so suggestions can vary naturally; tests and microbenches can set
+    /// it to prove cached and uncached decoding produce the same output for the same sampler state.
+    let randomSeed: UInt32?
     let maxPrefixWords: Int
     let maxPrefixCharacters: Int
     let maxSuffixCharacters: Int
@@ -153,6 +157,7 @@ struct SuggestionConfiguration: Equatable, Sendable {
         topP: 0.7,
         minP: 0.08,
         repetitionPenalty: 1.05,
+        randomSeed: nil,
         maxPrefixWords: 50,
         // Prompt windows should stay small. Sending an entire editor buffer hurts latency with
         // little quality gain because Tabby is only completing the immediate local continuation.
@@ -238,6 +243,9 @@ struct SuggestionRequest: Equatable, Sendable {
     let topP: Double
     let minP: Double
     let repetitionPenalty: Double
+    /// Optional deterministic sampler seed. `nil` preserves production randomness; tests and
+    /// microbenches can set this so cached and uncached runtime paths are directly comparable.
+    let randomSeed: UInt32?
     let maxSuffixCharacters: Int
     /// Explicit length guidance stays separate from user style preferences so prompt builders can
     /// order and phrase them differently per backend.

--- a/tabby/Models/SuggestionSubsystemContracts.swift
+++ b/tabby/Models/SuggestionSubsystemContracts.swift
@@ -39,6 +39,9 @@ protocol SuggestionInputMonitoring: AnyObject {
 @MainActor
 protocol SuggestionGenerating: AnyObject {
     func generateSuggestion(for request: SuggestionRequest) async throws -> SuggestionResult
+    /// Clears backend-local continuation state when the focused editing context is no longer
+    /// continuous. Stateless engines may implement this as a no-op.
+    func resetCachedGenerationContext()
 }
 
 @MainActor

--- a/tabby/Models/SuggestionSubsystemContracts.swift
+++ b/tabby/Models/SuggestionSubsystemContracts.swift
@@ -41,7 +41,7 @@ protocol SuggestionGenerating: AnyObject {
     func generateSuggestion(for request: SuggestionRequest) async throws -> SuggestionResult
     /// Clears backend-local continuation state when the focused editing context is no longer
     /// continuous. Stateless engines may implement this as a no-op.
-    func resetCachedGenerationContext()
+    func resetCachedGenerationContext() async
 }
 
 @MainActor

--- a/tabby/Services/Runtime/FoundationModelSuggestionEngine.swift
+++ b/tabby/Services/Runtime/FoundationModelSuggestionEngine.swift
@@ -63,6 +63,9 @@ final class FoundationModelSuggestionEngine {
         }
     }
 
+    /// Foundation Models sessions are already one-shot, so there is no backend context to clear.
+    func resetCachedGenerationContext() {}
+
     /// Maps Tabby's existing generation knobs onto the subset of Foundation Models options the
     /// system model exposes. We preserve the same upstream request shape so the coordinator does
     /// not fork behavior by backend.

--- a/tabby/Services/Runtime/FoundationModelSuggestionEngine.swift
+++ b/tabby/Services/Runtime/FoundationModelSuggestionEngine.swift
@@ -64,7 +64,7 @@ final class FoundationModelSuggestionEngine {
     }
 
     /// Foundation Models sessions are already one-shot, so there is no backend context to clear.
-    func resetCachedGenerationContext() {}
+    func resetCachedGenerationContext() async {}
 
     /// Maps Tabby's existing generation knobs onto the subset of Foundation Models options the
     /// system model exposes. We preserve the same upstream request shape so the coordinator does

--- a/tabby/Services/Runtime/LlamaRuntimeCore.swift
+++ b/tabby/Services/Runtime/LlamaRuntimeCore.swift
@@ -3,8 +3,8 @@ import LlamaSwift
 
 /// File overview:
 /// Owns the raw llama.cpp lifecycle behind one serialized actor. This file is the lowest-level
-/// runtime boundary in the app: it loads the GGUF model, creates per-request contexts, tokenizes
-/// prompts, samples continuations, and frees native resources on shutdown.
+/// runtime boundary in the app: it loads the GGUF model, maintains a reusable prompt context,
+/// tokenizes prompts, samples continuations, and frees native resources on shutdown.
 ///
 /// Keeping this work out of `LlamaRuntimeManager` makes the architecture easier to reason about:
 /// the manager owns UI-facing state and selection flow, while this actor owns correctness around
@@ -25,13 +25,41 @@ struct PreparedLlamaRuntime: Sendable {
 }
 
 /// Owns the long-lived model and hides the raw llama.cpp lifecycle behind one serialized actor.
-/// Starting with "one loaded model, fresh context per request" keeps correctness simple before
-/// we add any prefix-cache or context reuse optimizations.
+/// The actor owns one reusable prompt context so consecutive autocomplete requests can reuse the
+/// already-decoded KV cache for their common token prefix. Keeping that state here matters because
+/// raw llama pointers are mutable and must be serialized behind one owner.
 actor LlamaRuntimeCore {
     private static var isNativeLoggingSilenced = false
+    private static let promptSequenceID: llama_seq_id = 0
+
     private var backendInitialized = false
     private var model: OpaquePointer?
     private var preparedRuntime: PreparedLlamaRuntime?
+    private var promptCache: PromptCache?
+
+    /// Native prompt-cache state tied to one llama context.
+    /// `promptTokens` records the tokens represented in KV memory; each new request still
+    /// tokenizes and compares against this array because byte-prefix equality alone is not enough
+    /// to prove tokenizer-boundary safety.
+    private struct PromptCache {
+        let context: OpaquePointer
+        var promptBytes: [UInt8]
+        var promptTokens: [llama_token]
+        var samplingFingerprint: SamplingFingerprint
+    }
+
+    /// Generation knobs that intentionally break KV reuse when changed.
+    /// The prompt KV itself is mostly independent from the sampler, but the product contract for
+    /// this optimization is stricter: a different sampling configuration starts a clean context.
+    private struct SamplingFingerprint: Equatable {
+        let maxPredictionTokens: Int
+        let temperature: Double
+        let topK: Int
+        let topP: Double
+        let minP: Double
+        let repetitionPenalty: Double
+        let seed: UInt32?
+    }
 
     /// Loads the requested model once and records the runtime characteristics needed for diagnostics.
     func prepare(
@@ -82,15 +110,17 @@ actor LlamaRuntimeCore {
         return preparedRuntime
     }
 
-    /// Creates a fresh inference context, evaluates the prompt, and samples a short completion.
+    /// Prepares the prompt context, reusing cached KV state when safe, then samples a short completion.
     func generate(
         prompt: String,
+        cachedPrefixBytes: Int? = nil,
         maxPredictionTokens: Int,
         temperature: Double,
         topK: Int,
         topP: Double,
         minP: Double,
-        repetitionPenalty: Double
+        repetitionPenalty: Double,
+        seed: UInt32? = nil
     ) throws -> String {
         guard let preparedRuntime else {
             throw LlamaRuntimeError.unavailable("The llama model is not loaded.")
@@ -100,66 +130,96 @@ actor LlamaRuntimeCore {
             throw LlamaRuntimeError.unavailable("The llama model is not loaded.")
         }
 
-        let context = try makeContext(
-            model: model,
-            contextWindowTokens: preparedRuntime.contextWindowTokens,
-            batchSize: preparedRuntime.batchSize,
-            threadCount: preparedRuntime.threadCount
-        )
-        defer { llama_free(context) }
-
         guard let vocab = llama_model_get_vocab(model) else {
             throw LlamaRuntimeError.generationFailed("Unable to access the model vocabulary.")
         }
 
         let promptTokens = try tokenize(prompt, vocab: vocab)
-        try decodePrompt(promptTokens, in: context, batchCapacity: preparedRuntime.batchSize)
+        let samplingFingerprint = SamplingFingerprint(
+            maxPredictionTokens: maxPredictionTokens,
+            temperature: temperature,
+            topK: topK,
+            topP: topP,
+            minP: minP,
+            repetitionPenalty: repetitionPenalty,
+            seed: seed
+        )
+        let promptBytes = Array(prompt.utf8)
+        let context = try preparePromptContext(
+            model: model,
+            preparedRuntime: preparedRuntime,
+            promptBytes: promptBytes,
+            promptTokens: promptTokens,
+            samplingFingerprint: samplingFingerprint,
+            cachedPrefixBytes: cachedPrefixBytes
+        )
 
         let sampler = try makeSampler(
             temperature: temperature,
             topK: topK,
             topP: topP,
             minP: minP,
-            repetitionPenalty: repetitionPenalty
+            repetitionPenalty: repetitionPenalty,
+            seed: seed
         )
         defer { llama_sampler_free(sampler) }
 
         var generatedText = ""
         var position = Int32(promptTokens.count)
         var hasVisibleContent = false
-
-        for _ in 0 ..< maxPredictionTokens {
-            let nextToken = llama_sampler_sample(sampler, context, -1)
-            if nextToken == llama_vocab_eos(vocab) || llama_vocab_is_eog(vocab, nextToken) {
-                break
+        var shouldResetPromptCache = false
+        defer {
+            if shouldResetPromptCache {
+                clearPromptCache()
+            } else {
+                discardCachedTokens(from: promptTokens.count, in: context)
             }
+        }
 
-            let piece = pieceString(for: nextToken, vocab: vocab)
-            generatedText += piece
-            llama_sampler_accept(sampler, nextToken)
+        do {
+            for _ in 0 ..< maxPredictionTokens {
+                let nextToken = llama_sampler_sample(sampler, context, -1)
+                if nextToken == llama_vocab_eos(vocab) || llama_vocab_is_eog(vocab, nextToken) {
+                    break
+                }
 
-            // Instruction-shaped prompts often make small models emit a leading newline before the
-            // actual continuation text. If we stop on the first newline unconditionally, guided
-            // mode collapses into an empty suggestion even though the model would have produced a
-            // usable fragment on the next token. We therefore allow leading formatting noise, but
-            // still stop once a newline appears after the model has emitted any visible content.
-            if piece.unicodeScalars.contains(where: Self.isVisibleOutputScalar) {
-                hasVisibleContent = true
+                let piece = pieceString(for: nextToken, vocab: vocab)
+                generatedText += piece
+                llama_sampler_accept(sampler, nextToken)
+
+                // Instruction-shaped prompts often make small models emit a leading newline before the
+                // actual continuation text. If we stop on the first newline unconditionally, guided
+                // mode collapses into an empty suggestion even though the model would have produced a
+                // usable fragment on the next token. We therefore allow leading formatting noise, but
+                // still stop once a newline appears after the model has emitted any visible content.
+                if piece.unicodeScalars.contains(where: Self.isVisibleOutputScalar) {
+                    hasVisibleContent = true
+                }
+
+                if hasVisibleContent && generatedText.contains("\n") {
+                    break
+                }
+
+                try decodeToken(nextToken, position: position, in: context)
+                position += 1
             }
-
-            if hasVisibleContent && generatedText.contains("\n") {
-                break
-            }
-
-            try decodeToken(nextToken, position: position, in: context)
-            position += 1
+        } catch {
+            shouldResetPromptCache = true
+            throw error
         }
 
         return generatedText
     }
 
+    /// Drops the reusable prompt context while keeping the loaded model alive.
+    func resetPromptCache() {
+        clearPromptCache()
+    }
+
     /// Frees any loaded model/backend state owned by the actor.
     func shutdown() {
+        clearPromptCache()
+
         if let model {
             llama_model_free(model)
             self.model = nil
@@ -173,7 +233,131 @@ actor LlamaRuntimeCore {
         }
     }
 
-    /// Builds a fresh llama context for one generation request so requests remain isolated.
+    /// Returns a context whose KV memory represents `promptTokens`.
+    /// Reuse is always validated at the token level before native memory is trusted. We also
+    /// re-decode the final prompt token on every request so llama's current logits correspond to
+    /// the prompt, not to the previous request's sampled continuation.
+    private func preparePromptContext(
+        model: OpaquePointer,
+        preparedRuntime: PreparedLlamaRuntime,
+        promptBytes: [UInt8],
+        promptTokens: [llama_token],
+        samplingFingerprint: SamplingFingerprint,
+        cachedPrefixBytes: Int?
+    ) throws -> OpaquePointer {
+        guard let cachedPrefixBytes,
+              cachedPrefixBytes > 0,
+              let cache = promptCache,
+              cache.samplingFingerprint == samplingFingerprint
+        else {
+            return try rebuildPromptContext(
+                model: model,
+                preparedRuntime: preparedRuntime,
+                promptBytes: promptBytes,
+                promptTokens: promptTokens,
+                samplingFingerprint: samplingFingerprint
+            )
+        }
+
+        let confirmedCommonBytes = min(
+            cachedPrefixBytes,
+            Self.commonPrefixCount(cache.promptBytes, promptBytes)
+        )
+        guard confirmedCommonBytes > 0 else {
+            return try rebuildPromptContext(
+                model: model,
+                preparedRuntime: preparedRuntime,
+                promptBytes: promptBytes,
+                promptTokens: promptTokens,
+                samplingFingerprint: samplingFingerprint
+            )
+        }
+
+        let commonTokenPrefix = Self.commonPrefixCount(cache.promptTokens, promptTokens)
+        let reusableTokenCount = Self.reusableTokenCount(
+            commonTokenPrefix: commonTokenPrefix,
+            newPromptTokenCount: promptTokens.count
+        )
+
+        guard trimCachedTokens(from: reusableTokenCount, in: cache.context) else {
+            return try rebuildPromptContext(
+                model: model,
+                preparedRuntime: preparedRuntime,
+                promptBytes: promptBytes,
+                promptTokens: promptTokens,
+                samplingFingerprint: samplingFingerprint
+            )
+        }
+
+        do {
+            try decodePrompt(
+                promptTokens,
+                startingAt: reusableTokenCount,
+                in: cache.context,
+                batchCapacity: preparedRuntime.batchSize
+            )
+        } catch {
+            clearPromptCache()
+            throw error
+        }
+
+        promptCache = PromptCache(
+            context: cache.context,
+            promptBytes: promptBytes,
+            promptTokens: promptTokens,
+            samplingFingerprint: samplingFingerprint
+        )
+        return cache.context
+    }
+
+    /// Builds a clean llama context and decodes the full prompt.
+    /// This path is used for the first request, explicit invalidation, and any failed cache trim.
+    private func rebuildPromptContext(
+        model: OpaquePointer,
+        preparedRuntime: PreparedLlamaRuntime,
+        promptBytes: [UInt8],
+        promptTokens: [llama_token],
+        samplingFingerprint: SamplingFingerprint
+    ) throws -> OpaquePointer {
+        clearPromptCache()
+
+        let context = try makeContext(
+            model: model,
+            contextWindowTokens: preparedRuntime.contextWindowTokens,
+            batchSize: preparedRuntime.batchSize,
+            threadCount: preparedRuntime.threadCount
+        )
+
+        do {
+            try decodePrompt(
+                promptTokens,
+                startingAt: 0,
+                in: context,
+                batchCapacity: preparedRuntime.batchSize
+            )
+        } catch {
+            llama_free(context)
+            throw error
+        }
+
+        promptCache = PromptCache(
+            context: context,
+            promptBytes: promptBytes,
+            promptTokens: promptTokens,
+            samplingFingerprint: samplingFingerprint
+        )
+        return context
+    }
+
+    /// Frees the cached context. This is the native-resource counterpart to clearing a Swift cache.
+    private func clearPromptCache() {
+        if let promptCache {
+            llama_free(promptCache.context)
+            self.promptCache = nil
+        }
+    }
+
+    /// Builds a fresh llama context for the prompt cache.
     private func makeContext(
         model: OpaquePointer,
         contextWindowTokens: Int,
@@ -228,27 +412,34 @@ actor LlamaRuntimeCore {
         }
     }
 
-    /// Feeds the prompt tokens through the context so sampling can begin from the final prompt state.
+    /// Feeds prompt tokens through the context so sampling can begin from the final prompt state.
     private func decodePrompt(
         _ promptTokens: [llama_token],
+        startingAt startIndex: Int,
         in context: OpaquePointer,
         batchCapacity: Int
     ) throws {
-        var batch = llama_batch_init(Int32(max(promptTokens.count, batchCapacity)), 0, 1)
+        let tokenCount = promptTokens.count - startIndex
+        guard tokenCount > 0 else {
+            return
+        }
+
+        var batch = llama_batch_init(Int32(max(tokenCount, batchCapacity)), 0, 1)
         defer { llama_batch_free(batch) }
 
-        batch.n_tokens = Int32(promptTokens.count)
+        batch.n_tokens = Int32(tokenCount)
 
-        for index in promptTokens.indices {
-            batch.token[index] = promptTokens[index]
-            batch.pos[index] = Int32(index)
-            batch.n_seq_id[index] = 1
+        for batchIndex in 0 ..< tokenCount {
+            let tokenIndex = startIndex + batchIndex
+            batch.token[batchIndex] = promptTokens[tokenIndex]
+            batch.pos[batchIndex] = Int32(tokenIndex)
+            batch.n_seq_id[batchIndex] = 1
 
-            if let seqIDs = batch.seq_id, let seqID = seqIDs[index] {
-                seqID[0] = 0
+            if let seqIDs = batch.seq_id, let seqID = seqIDs[batchIndex] {
+                seqID[0] = Self.promptSequenceID
             }
 
-            batch.logits[index] = 0
+            batch.logits[batchIndex] = 0
         }
 
         if batch.n_tokens > 0 {
@@ -275,7 +466,7 @@ actor LlamaRuntimeCore {
         batch.n_seq_id[0] = 1
 
         if let seqIDs = batch.seq_id, let seqID = seqIDs[0] {
-            seqID[0] = 0
+            seqID[0] = Self.promptSequenceID
         }
 
         batch.logits[0] = 1
@@ -302,7 +493,8 @@ actor LlamaRuntimeCore {
         topK: Int,
         topP: Double,
         minP: Double,
-        repetitionPenalty: Double
+        repetitionPenalty: Double,
+        seed: UInt32?
     ) throws -> UnsafeMutablePointer<llama_sampler> {
         let params = llama_sampler_chain_default_params()
         guard let sampler = llama_sampler_chain_init(params) else {
@@ -343,7 +535,8 @@ actor LlamaRuntimeCore {
                 llama_sampler_chain_add(sampler, topPSampler)
             }
 
-            guard let distributionSampler = llama_sampler_init_dist(UInt32.random(in: UInt32.min ... UInt32.max)) else {
+            let resolvedSeed = seed ?? UInt32.random(in: UInt32.min ... UInt32.max)
+            guard let distributionSampler = llama_sampler_init_dist(resolvedSeed) else {
                 throw LlamaRuntimeError.generationFailed("Unable to initialize the distribution sampler.")
             }
             llama_sampler_chain_add(sampler, distributionSampler)
@@ -355,6 +548,47 @@ actor LlamaRuntimeCore {
         }
 
         return sampler
+    }
+
+    /// Removes tokens at and after `position` from the prompt sequence.
+    /// llama.cpp returns `false` when a partial removal is unsupported by the current memory type;
+    /// callers then fall back to a fresh context rather than risking stale KV state.
+    private func trimCachedTokens(from position: Int, in context: OpaquePointer) -> Bool {
+        guard let memory = llama_get_memory(context) else {
+            return false
+        }
+
+        return llama_memory_seq_rm(
+            memory,
+            Self.promptSequenceID,
+            llama_pos(position),
+            -1
+        )
+    }
+
+    /// Removes sampled continuation tokens so the retained context represents only the prompt.
+    /// The next request will re-decode the final prompt token to refresh logits before sampling.
+    private func discardCachedTokens(from position: Int, in context: OpaquePointer) {
+        _ = trimCachedTokens(from: position, in: context)
+    }
+
+    private static func reusableTokenCount(commonTokenPrefix: Int, newPromptTokenCount: Int) -> Int {
+        guard newPromptTokenCount > 1 else {
+            return 0
+        }
+
+        return min(commonTokenPrefix, newPromptTokenCount - 1)
+    }
+
+    private static func commonPrefixCount<Element: Equatable>(_ lhs: [Element], _ rhs: [Element]) -> Int {
+        var index = 0
+        let limit = min(lhs.count, rhs.count)
+
+        while index < limit, lhs[index] == rhs[index] {
+            index += 1
+        }
+
+        return index
     }
 
     /// Converts one sampled token back into its text piece representation.

--- a/tabby/Services/Runtime/LlamaRuntimeManager.swift
+++ b/tabby/Services/Runtime/LlamaRuntimeManager.swift
@@ -82,26 +82,32 @@ final class LlamaRuntimeManager: ObservableObject {
     }
 
     /// Forwards one generation request into the serialized runtime actor after ensuring preparation.
+    /// `cachedPrefixBytes` is a caller-provided reuse hint, not a correctness guarantee; the core
+    /// actor still validates the token prefix before trusting any native KV state.
     func generate(
         prompt: String,
+        cachedPrefixBytes: Int? = nil,
         maxPredictionTokens: Int,
         temperature: Double,
         topK: Int,
         topP: Double,
         minP: Double,
-        repetitionPenalty: Double
+        repetitionPenalty: Double,
+        seed: UInt32? = nil
     ) async throws -> String {
         _ = try await preparedRuntime()
 
         do {
             return try await core.generate(
                 prompt: prompt,
+                cachedPrefixBytes: cachedPrefixBytes,
                 maxPredictionTokens: maxPredictionTokens,
                 temperature: temperature,
                 topK: topK,
                 topP: topP,
                 minP: minP,
-                repetitionPenalty: repetitionPenalty
+                repetitionPenalty: repetitionPenalty,
+                seed: seed
             )
         } catch is CancellationError {
             throw LlamaRuntimeError.cancelled
@@ -112,6 +118,15 @@ final class LlamaRuntimeManager: ObservableObject {
             let runtimeError = LlamaRuntimeError.generationFailed(error.localizedDescription)
             diagnostics.lastError = runtimeError.localizedDescription
             throw runtimeError
+        }
+    }
+
+    /// Clears the native prompt KV cache without unloading the model.
+    /// The manager exposes this as a lifecycle command because focus/settings resets originate in
+    /// the app layer, while the actor still owns the raw llama pointers.
+    func resetPromptCache() {
+        Task {
+            await core.resetPromptCache()
         }
     }
 

--- a/tabby/Services/Runtime/LlamaRuntimeManager.swift
+++ b/tabby/Services/Runtime/LlamaRuntimeManager.swift
@@ -124,10 +124,8 @@ final class LlamaRuntimeManager: ObservableObject {
     /// Clears the native prompt KV cache without unloading the model.
     /// The manager exposes this as a lifecycle command because focus/settings resets originate in
     /// the app layer, while the actor still owns the raw llama pointers.
-    func resetPromptCache() {
-        Task {
-            await core.resetPromptCache()
-        }
+    func resetPromptCache() async {
+        await core.resetPromptCache()
     }
 
     /// Cancels any retained prepared runtime and asks the actor to release backend resources.

--- a/tabby/Services/Runtime/LlamaSuggestionEngine.swift
+++ b/tabby/Services/Runtime/LlamaSuggestionEngine.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import Foundation
 
 /// File overview:
@@ -9,6 +10,7 @@ import Foundation
 @MainActor
 final class LlamaSuggestionEngine {
     private let runtimeManager: LlamaRuntimeManager
+    private var promptCacheHintTracker = LlamaPromptCacheHintTracker()
 
     init(runtimeManager: LlamaRuntimeManager) {
         self.runtimeManager = runtimeManager
@@ -18,17 +20,21 @@ final class LlamaSuggestionEngine {
     func generateSuggestion(for request: SuggestionRequest) async throws -> SuggestionResult {
         do {
             let startTime = Date()
+            let cachedPrefixBytes = promptCacheHintTracker.cachedPrefixBytes(for: request)
             let rawSuggestion = try await runtimeManager.generate(
                 prompt: request.prompt,
+                cachedPrefixBytes: cachedPrefixBytes,
                 maxPredictionTokens: request.maxPredictionTokens,
                 temperature: request.temperature,
                 topK: request.topK,
                 topP: request.topP,
                 minP: request.minP,
-                repetitionPenalty: request.repetitionPenalty
+                repetitionPenalty: request.repetitionPenalty,
+                seed: request.randomSeed
             )
             try Task.checkCancellation()
 
+            promptCacheHintTracker.recordSuccessfulRequest(request)
             let normalizedSuggestion = SuggestionTextNormalizer.normalize(rawSuggestion, for: request)
             return SuggestionResult(
                 generation: request.generation,
@@ -37,15 +43,146 @@ final class LlamaSuggestionEngine {
                 latency: Date().timeIntervalSince(startTime)
             )
         } catch is CancellationError {
+            resetCachedGenerationContext()
             throw SuggestionClientError.cancelled
         } catch let error as LlamaRuntimeError {
+            resetCachedGenerationContext()
             throw SuggestionClientError.unavailable(error.localizedDescription)
         } catch let error as SuggestionClientError {
+            resetCachedGenerationContext()
             throw error
         } catch {
+            resetCachedGenerationContext()
             throw SuggestionClientError.generationFailed(error.localizedDescription)
         }
+    }
+
+    /// Clears both the Swift-side hint tracker and the native llama KV cache.
+    /// The tracker reset is synchronous because it protects the next request from advertising
+    /// stale reuse; the runtime reset is also enforced lazily by passing no hint on that request.
+    func resetCachedGenerationContext() {
+        promptCacheHintTracker.reset()
+        runtimeManager.resetPromptCache()
     }
 }
 
 extension LlamaSuggestionEngine: SuggestionGenerating {}
+
+/// Tracks the last successful llama prompt so the engine can pass a conservative byte-prefix hint
+/// into `LlamaRuntimeManager.generate`. This type deliberately does not own correctness: native KV
+/// state is still validated by `LlamaRuntimeCore` after tokenization.
+struct LlamaPromptCacheHintTracker: Equatable {
+    private var lastRequest: CachedRequest?
+
+    mutating func cachedPrefixBytes(for request: SuggestionRequest) -> Int? {
+        let nextRequest = CachedRequest(request: request)
+        guard let lastRequest else {
+            return nil
+        }
+
+        guard lastRequest.focusKey == nextRequest.focusKey,
+              lastRequest.samplingFingerprint == nextRequest.samplingFingerprint
+        else {
+            self.lastRequest = nil
+            return nil
+        }
+
+        return Self.commonPrefixByteCount(lastRequest.promptBytes, nextRequest.promptBytes)
+    }
+
+    mutating func recordSuccessfulRequest(_ request: SuggestionRequest) {
+        lastRequest = CachedRequest(request: request)
+    }
+
+    mutating func reset() {
+        lastRequest = nil
+    }
+
+    private static func commonPrefixByteCount(_ lhs: [UInt8], _ rhs: [UInt8]) -> Int {
+        var index = 0
+        let limit = min(lhs.count, rhs.count)
+
+        while index < limit, lhs[index] == rhs[index] {
+            index += 1
+        }
+
+        return index
+    }
+}
+
+private extension LlamaPromptCacheHintTracker {
+    struct CachedRequest: Equatable {
+        let focusKey: FocusKey
+        let samplingFingerprint: SamplingFingerprint
+        let promptBytes: [UInt8]
+
+        init(request: SuggestionRequest) {
+            focusKey = FocusKey(context: request.context)
+            samplingFingerprint = SamplingFingerprint(request: request)
+            promptBytes = Array(request.prompt.utf8)
+        }
+    }
+
+    struct FocusKey: Equatable {
+        let bundleIdentifier: String
+        let processIdentifier: Int32
+        let role: String
+        let subrole: String?
+        let fieldAnchor: FieldAnchor
+
+        init(context: FocusedInputContext) {
+            bundleIdentifier = context.bundleIdentifier
+            processIdentifier = context.processIdentifier
+            role = context.role
+            subrole = context.subrole
+            fieldAnchor = FieldAnchor(
+                inputFrame: context.inputFrameRect,
+                fallbackElementIdentifier: context.elementIdentifier
+            )
+        }
+    }
+
+    struct FieldAnchor: Equatable {
+        let roundedInputFrame: RoundedRect?
+        let fallbackElementIdentifier: String?
+
+        nonisolated init(inputFrame: CGRect?, fallbackElementIdentifier: String) {
+            roundedInputFrame = inputFrame.map(RoundedRect.init(rect:))
+            self.fallbackElementIdentifier = roundedInputFrame == nil ? fallbackElementIdentifier : nil
+        }
+    }
+
+    struct RoundedRect: Equatable {
+        let minX: Int
+        let minY: Int
+        let width: Int
+        let height: Int
+
+        nonisolated init(rect: CGRect) {
+            minX = Int(rect.minX.rounded())
+            minY = Int(rect.minY.rounded())
+            width = Int(rect.width.rounded())
+            height = Int(rect.height.rounded())
+        }
+    }
+
+    struct SamplingFingerprint: Equatable {
+        let maxPredictionTokens: Int
+        let temperature: Double
+        let topK: Int
+        let topP: Double
+        let minP: Double
+        let repetitionPenalty: Double
+        let randomSeed: UInt32?
+
+        init(request: SuggestionRequest) {
+            maxPredictionTokens = request.maxPredictionTokens
+            temperature = request.temperature
+            topK = request.topK
+            topP = request.topP
+            minP = request.minP
+            repetitionPenalty = request.repetitionPenalty
+            randomSeed = request.randomSeed
+        }
+    }
+}

--- a/tabby/Services/Runtime/LlamaSuggestionEngine.swift
+++ b/tabby/Services/Runtime/LlamaSuggestionEngine.swift
@@ -43,26 +43,26 @@ final class LlamaSuggestionEngine {
                 latency: Date().timeIntervalSince(startTime)
             )
         } catch is CancellationError {
-            resetCachedGenerationContext()
             throw SuggestionClientError.cancelled
         } catch let error as LlamaRuntimeError {
-            resetCachedGenerationContext()
+            await resetCachedGenerationContext()
             throw SuggestionClientError.unavailable(error.localizedDescription)
         } catch let error as SuggestionClientError {
-            resetCachedGenerationContext()
+            await resetCachedGenerationContext()
             throw error
         } catch {
-            resetCachedGenerationContext()
+            await resetCachedGenerationContext()
             throw SuggestionClientError.generationFailed(error.localizedDescription)
         }
     }
 
     /// Clears both the Swift-side hint tracker and the native llama KV cache.
     /// The tracker reset is synchronous because it protects the next request from advertising
-    /// stale reuse; the runtime reset is also enforced lazily by passing no hint on that request.
-    func resetCachedGenerationContext() {
+    /// stale reuse; awaiting the runtime reset keeps native KV invalidation ordered before the next
+    /// generation request that crosses this engine boundary.
+    func resetCachedGenerationContext() async {
         promptCacheHintTracker.reset()
-        runtimeManager.resetPromptCache()
+        await runtimeManager.resetPromptCache()
     }
 }
 

--- a/tabby/Services/Runtime/SuggestionEngineRouter.swift
+++ b/tabby/Services/Runtime/SuggestionEngineRouter.swift
@@ -32,9 +32,9 @@ final class SuggestionEngineRouter {
     /// Clears backend-local continuation state when the coordinator knows the editing context is
     /// no longer continuous. The router fans this out so switching engines cannot leave stale
     /// llama KV state behind.
-    func resetCachedGenerationContext() {
-        foundationModelEngine.resetCachedGenerationContext()
-        llamaEngine.resetCachedGenerationContext()
+    func resetCachedGenerationContext() async {
+        await foundationModelEngine.resetCachedGenerationContext()
+        await llamaEngine.resetCachedGenerationContext()
     }
 }
 

--- a/tabby/Services/Runtime/SuggestionEngineRouter.swift
+++ b/tabby/Services/Runtime/SuggestionEngineRouter.swift
@@ -28,6 +28,14 @@ final class SuggestionEngineRouter {
             return try await llamaEngine.generateSuggestion(for: request)
         }
     }
+
+    /// Clears backend-local continuation state when the coordinator knows the editing context is
+    /// no longer continuous. The router fans this out so switching engines cannot leave stale
+    /// llama KV state behind.
+    func resetCachedGenerationContext() {
+        foundationModelEngine.resetCachedGenerationContext()
+        llamaEngine.resetCachedGenerationContext()
+    }
 }
 
 extension SuggestionEngineRouter: SuggestionGenerating {}

--- a/tabby/Support/SuggestionRequestFactory.swift
+++ b/tabby/Support/SuggestionRequestFactory.swift
@@ -59,6 +59,7 @@ enum SuggestionRequestFactory {
             topP: configuration.topP,
             minP: configuration.minP,
             repetitionPenalty: configuration.repetitionPenalty,
+            randomSeed: configuration.randomSeed,
             maxSuffixCharacters: configuration.maxSuffixCharacters,
             completionLengthInstruction: completionLengthInstruction,
             customAIInstructions: customAIInstructions

--- a/tabbyTests/LlamaPromptRendererTests.swift
+++ b/tabbyTests/LlamaPromptRendererTests.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import XCTest
 @testable import tabby
 
@@ -39,6 +40,55 @@ final class LlamaPromptRendererTests: XCTestCase {
 
         XCTAssertEqual(prompt, "foo")
         XCTAssertFalse(prompt.contains("UNIQUE_MARKER_SHOULD_NOT_APPEAR"))
+    }
+
+    // MARK: - cache hints
+
+    func test_cacheHint_nilBeforeSuccessfulRequestIsRecorded() {
+        var tracker = LlamaPromptCacheHintTracker()
+
+        XCTAssertNil(tracker.cachedPrefixBytes(for: makeRequest(prompt: "hello")))
+    }
+
+    func test_cacheHint_returnsCommonPrefixBytesForSameFocusedField() {
+        var tracker = LlamaPromptCacheHintTracker()
+        tracker.recordSuccessfulRequest(makeRequest(prompt: "hello"))
+
+        XCTAssertEqual(
+            tracker.cachedPrefixBytes(for: makeRequest(prompt: "hello!")),
+            "hello".utf8.count
+        )
+    }
+
+    func test_cacheHint_invalidatesWhenFocusedFieldChanges() {
+        var tracker = LlamaPromptCacheHintTracker()
+        tracker.recordSuccessfulRequest(makeRequest(prompt: "hello", elementIdentifier: "field-a"))
+
+        XCTAssertNil(
+            tracker.cachedPrefixBytes(for: makeRequest(prompt: "hello!", elementIdentifier: "field-b"))
+        )
+    }
+
+    func test_cacheHint_prefersStableInputFrameOverUnstableElementIdentifier() {
+        var tracker = LlamaPromptCacheHintTracker()
+        let fieldFrame = CGRect(x: 10, y: 20, width: 300, height: 44)
+        tracker.recordSuccessfulRequest(
+            makeRequest(prompt: "hello", elementIdentifier: "field-a", inputFrameRect: fieldFrame)
+        )
+
+        XCTAssertEqual(
+            tracker.cachedPrefixBytes(
+                for: makeRequest(prompt: "hello!", elementIdentifier: "field-b", inputFrameRect: fieldFrame)
+            ),
+            "hello".utf8.count
+        )
+    }
+
+    func test_cacheHint_invalidatesWhenSamplingFingerprintChanges() {
+        var tracker = LlamaPromptCacheHintTracker()
+        tracker.recordSuccessfulRequest(makeRequest(prompt: "hello", topK: 20))
+
+        XCTAssertNil(tracker.cachedPrefixBytes(for: makeRequest(prompt: "hello!", topK: 40)))
     }
 
     // MARK: - guided mode
@@ -121,5 +171,48 @@ final class LlamaPromptRendererTests: XCTestCase {
 
         XCTAssertLessThan(contextRange.lowerBound, prefixRange.lowerBound,
                           "prefix must appear after the Context: header")
+    }
+
+    private func makeRequest(
+        prompt: String,
+        elementIdentifier: String = "field",
+        topK: Int = 20,
+        inputFrameRect: CGRect? = nil
+    ) -> SuggestionRequest {
+        let snapshot = FocusedInputSnapshot(
+            applicationName: "TestApp",
+            bundleIdentifier: "com.example.TestApp",
+            processIdentifier: 123,
+            elementIdentifier: elementIdentifier,
+            role: "AXTextField",
+            subrole: nil,
+            caretRect: .zero,
+            inputFrameRect: inputFrameRect,
+            caretSource: "test",
+            caretQuality: .exact,
+            observedCharWidth: nil,
+            precedingText: prompt,
+            trailingText: "",
+            selection: NSRange(location: prompt.count, length: 0),
+            isSecure: false
+        )
+        let context = FocusedInputContext(snapshot: snapshot, generation: 1)
+
+        return SuggestionRequest(
+            context: context,
+            prefixText: prompt,
+            prompt: prompt,
+            generation: context.generation,
+            maxPredictionTokens: 8,
+            temperature: 0.1,
+            topK: topK,
+            topP: 0.7,
+            minP: 0.08,
+            repetitionPenalty: 1.05,
+            randomSeed: 42,
+            maxSuffixCharacters: 192,
+            completionLengthInstruction: "Return only the next few words.",
+            customAIInstructions: nil
+        )
     }
 }


### PR DESCRIPTION
## Summary

Adds KV-cache reuse to the local llama runtime so consecutive autocomplete requests can reuse the decoded common prompt prefix instead of rebuilding a fresh context every time. The runtime still tokenizes and validates the shared token prefix before trusting cached native state, and coordinator lifecycle paths reset the cache on focus, settings, model, or disabled-state changes.

## Validation

- `xcodebuild build -scheme tabby -project tabby.xcodeproj -destination 'platform=macOS'`
  - `** BUILD SUCCEEDED **`
- `xcodebuild test -scheme tabby -project tabby.xcodeproj -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`
  - `** TEST SUCCEEDED **`, 30 tests, 0 failures
- Local 10-character typing microbench against installed `Qwen3-0.6B-Q4_K_M.gguf`
  - Ran selected `LlamaRuntimeCacheMicrobenchTests.test_tenCharacterTypingSession_reportsCachedPrefixLatencyDelta` locally to quantify the ticket's latency-drop acceptance criterion.
  - `** TEST SUCCEEDED **`, 1 selected test, 0 failures
  - Requests: 10-character typing session
  - Baseline total: 851.8 ms
  - Cached total: 323.2 ms
  - Latency drop: 62.1%
  - Baseline avg/p95: 85.2 / 94.9 ms
  - Cached avg/p95: 32.3 / 79.2 ms
  - Baseline per request: 90.0, 78.2, 74.9, 87.9, 88.4, 94.9, 91.1, 81.3, 81.8, 83.3 ms
  - Cached per request: 79.2, 23.1, 23.3, 29.2, 27.8, 28.5, 30.0, 29.9, 25.8, 26.5 ms

## Linked issues

Refs #23
Refs #13

## Risk / rollout notes

- The cache is intentionally owned by `LlamaRuntimeCore`, because native llama contexts and KV memory must stay behind the serialized runtime actor.
- Generated continuation tokens are removed after sampling so the retained context represents only the prompt before the next request.
- The microbench was run locally against a real installed GGUF rather than added as a committed test harness, keeping the PR diff focused on the runtime implementation.
- XCTest reported success for the local microbench, but llama.cpp/Metal printed a shutdown-time `GGML_ASSERT([rsets->data count] == 0)` backtrace after test completion on this machine.
