### PR TITLE
Add streaming autocomplete mode

### DIFF
--- a/tabby.xcodeproj/project.pbxproj
+++ b/tabby.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		A1C3E0012F90000100AAA001 /* LlamaSwift in Frameworks */ = {isa = PBXBuildFile; productRef = A1C3E0002F90000100AAA001 /* LlamaSwift */; };
 		A1C3E0112F90000100AAA001 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = A1C3E0102F90000100AAA001 /* Sparkle */; };
+		A1C3E0312F94000100AAA001 /* SuggestionStreamChunkerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C3E0302F94000100AAA001 /* SuggestionStreamChunkerTests.swift */; };
 		A404828463CADB2ECDAE7AF3 /* LlamaPromptRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F29623C5C0A67B992D383A3C /* LlamaPromptRendererTests.swift */; };
 		ADEFEE12C197DB6C990E3812 /* SuggestionRequestFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1121FFDAD30C7F62E15289 /* SuggestionRequestFactoryTests.swift */; };
 		B053492719F6106E48290C32 /* SuggestionAvailabilityEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A39EC1A44E9160E13E2AE77 /* SuggestionAvailabilityEvaluatorTests.swift */; };
@@ -29,6 +30,7 @@
 		3FBFA92FA44AA317135426FB /* tabbyTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = tabbyTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5A39EC1A44E9160E13E2AE77 /* SuggestionAvailabilityEvaluatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SuggestionAvailabilityEvaluatorTests.swift; sourceTree = "<group>"; };
 		8B1121FFDAD30C7F62E15289 /* SuggestionRequestFactoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SuggestionRequestFactoryTests.swift; sourceTree = "<group>"; };
+		A1C3E0302F94000100AAA001 /* SuggestionStreamChunkerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SuggestionStreamChunkerTests.swift; sourceTree = "<group>"; };
 		F29623C5C0A67B992D383A3C /* LlamaPromptRendererTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LlamaPromptRendererTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -87,6 +89,7 @@
 				F29623C5C0A67B992D383A3C /* LlamaPromptRendererTests.swift */,
 				5A39EC1A44E9160E13E2AE77 /* SuggestionAvailabilityEvaluatorTests.swift */,
 				8B1121FFDAD30C7F62E15289 /* SuggestionRequestFactoryTests.swift */,
+				A1C3E0302F94000100AAA001 /* SuggestionStreamChunkerTests.swift */,
 			);
 			name = tabbyTests;
 			path = tabbyTests;
@@ -215,6 +218,7 @@
 				A404828463CADB2ECDAE7AF3 /* LlamaPromptRendererTests.swift in Sources */,
 				B053492719F6106E48290C32 /* SuggestionAvailabilityEvaluatorTests.swift in Sources */,
 				ADEFEE12C197DB6C990E3812 /* SuggestionRequestFactoryTests.swift in Sources */,
+				A1C3E0312F94000100AAA001 /* SuggestionStreamChunkerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/tabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
@@ -20,7 +20,7 @@ extension SuggestionCoordinator {
             return passTabThrough(reason: snapshot.capability.summary)
         }
 
-        guard case .ready = state else {
+        guard state.canAcceptSuggestion else {
             return passTabThrough(reason: "Tab passed through because no valid suggestion was ready.")
         }
 
@@ -59,7 +59,9 @@ extension SuggestionCoordinator {
 
         recordAcceptedWords(from: acceptedChunk)
 
-        cancelPredictionWork()
+        if !sessionForAcceptance.isStreaming {
+            cancelPredictionWork()
+        }
 
         switch interactionState.commitAcceptedChunk(
             acceptedChunk,
@@ -85,7 +87,6 @@ extension SuggestionCoordinator {
         case let .advanced(advancedSession, _):
             latestGenerationNumber = liveContext.generation
             applySessionDiagnostics(advancedSession, acceptanceAction: "Accepted next chunk with Tab.")
-            state = .ready(text: advancedSession.remainingText, latency: advancedSession.latency)
             // Predict where the caret will land after the inserted chunk. This eliminates the
             // visible jump where the overlay stays at the old position then snaps rightward
             // when AX catches up 100–250ms later.
@@ -95,11 +96,19 @@ extension SuggestionCoordinator {
                 caretQuality: liveContext.caretQuality,
                 observedCharWidth: liveContext.observedCharWidth
             )
-            presentOverlay(
-                text: advancedSession.remainingText,
-                at: predictedCaret,
-                caretQuality: liveContext.caretQuality
-            )
+            if advancedSession.isWaitingForMoreStreamedText {
+                state = .streaming(text: "", latency: advancedSession.latency)
+                hideOverlay(reason: "Overlay hidden while waiting for more streamed suggestion text.")
+            } else {
+                state = advancedSession.isStreaming
+                    ? .streaming(text: advancedSession.remainingText, latency: advancedSession.latency)
+                    : .ready(text: advancedSession.remainingText, latency: advancedSession.latency)
+                presentOverlay(
+                    text: advancedSession.remainingText,
+                    at: predictedCaret,
+                    caretQuality: liveContext.caretQuality
+                )
+            }
             // Force an early AX refresh so the real caret position corrects any prediction
             // error faster than the normal 250ms poll interval.
             schedulePostInsertionRefresh()
@@ -155,12 +164,19 @@ extension SuggestionCoordinator {
             return true
         }
 
-        state = .ready(text: advancedSession.remainingText, latency: advancedSession.latency)
-        presentOverlay(
-            text: advancedSession.remainingText,
-            at: session.baseContext.caretRect,
-            caretQuality: session.baseContext.caretQuality
-        )
+        if advancedSession.isWaitingForMoreStreamedText {
+            state = .streaming(text: "", latency: advancedSession.latency)
+            hideOverlay(reason: "Overlay hidden while waiting for more streamed suggestion text.")
+        } else {
+            state = advancedSession.isStreaming
+                ? .streaming(text: advancedSession.remainingText, latency: advancedSession.latency)
+                : .ready(text: advancedSession.remainingText, latency: advancedSession.latency)
+            presentOverlay(
+                text: advancedSession.remainingText,
+                at: session.baseContext.caretRect,
+                caretQuality: session.baseContext.caretQuality
+            )
+        }
         logStage(
             "typed-match-advanced",
             workID: currentWorkID,

--- a/tabby/App/Coordinators/SuggestionCoordinator+Lifecycle.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator+Lifecycle.swift
@@ -58,6 +58,10 @@ extension SuggestionCoordinator {
             latestStageMessage = "Updated autocomplete engine to \(snapshot.selectedEngine.displayLabel)."
         } else if previousSnapshot.selectedWordCountPreset != snapshot.selectedWordCountPreset {
             latestStageMessage = "Updated suggestion length to \(snapshot.selectedWordCountPreset.displayLabel)."
+        } else if previousSnapshot.streamingAutocompleteEnabled != snapshot.streamingAutocompleteEnabled {
+            latestStageMessage = snapshot.streamingAutocompleteEnabled
+                ? "Enabled streaming autocomplete."
+                : "Disabled streaming autocomplete."
         } else if previousSnapshot.effectivePromptMode != snapshot.effectivePromptMode {
             latestStageMessage = "Updated prompt mode to \(snapshot.effectivePromptMode.displayLabel)."
         } else {

--- a/tabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
@@ -86,12 +86,23 @@ extension SuggestionCoordinator {
             }
 
             do {
-                let result = try await suggestionEngine.generateSuggestion(for: request)
-                guard !Task.isCancelled, self.workController.isCurrent(workID) else {
-                    return
-                }
+                if self.settingsSnapshot.streamingAutocompleteEnabled {
+                    let updateStream = suggestionEngine.streamSuggestion(for: request)
+                    for try await update in updateStream {
+                        guard !Task.isCancelled, self.workController.isCurrent(workID) else {
+                            return
+                        }
 
-                await apply(result: result, workID: workID)
+                        await apply(streamUpdate: update, workID: workID)
+                    }
+                } else {
+                    let result = try await suggestionEngine.generateSuggestion(for: request)
+                    guard !Task.isCancelled, self.workController.isCurrent(workID) else {
+                        return
+                    }
+
+                    await apply(result: result, workID: workID)
+                }
             } catch SuggestionClientError.cancelled {
                 return
             } catch {
@@ -207,6 +218,210 @@ extension SuggestionCoordinator {
         )
     }
 
+    /// Promotes one streamed stable-prefix update when it is still valid for the focused field.
+    /// Unlike final one-shot results, later streaming updates remain valid after Tab acceptance as
+    /// long as the live editor still contains the original prefix plus the accepted stream prefix.
+    func apply(streamUpdate update: SuggestionStreamUpdate, workID: UInt64) async {
+        guard workController.isCurrent(workID) else {
+            return
+        }
+
+        focusModel.refreshNow()
+        let snapshot = focusModel.snapshot
+
+        if let disabledReason = SuggestionAvailabilityEvaluator.disabledReason(
+            globallyEnabled: settingsSnapshot.isGloballyEnabled,
+            inputMonitoringGranted: permissionManager.inputMonitoringGranted,
+            focusSnapshot: snapshot
+        ) {
+            disablePredictions(reason: disabledReason)
+            return
+        }
+
+        guard let rawContext = snapshot.context else {
+            disablePredictions(reason: snapshot.capability.summary)
+            return
+        }
+
+        latestRawModelOutput = SuggestionDebugLogger.debugPreview(update.rawText)
+
+        if let activeSession = interactionState.activeSession,
+           activeSession.baseContext.generation == update.generation
+        {
+            await applyStreamUpdateToExistingSession(
+                update,
+                rawContext: rawContext,
+                workID: workID
+            )
+            return
+        }
+
+        let liveContext = interactionState.materializeContext(from: rawContext)
+
+        guard liveContext.generation == update.generation else {
+            logStage(
+                "stream-stale-drop",
+                workID: workID,
+                generation: update.generation,
+                message: "Dropped stale stream update because live generation is \(liveContext.generation).",
+                rawOutput: update.rawText,
+                normalizedOutput: update.text
+            )
+            return
+        }
+
+        guard !update.text.isEmpty else {
+            if update.isFinal {
+                clearSuggestion()
+                hideOverlay(reason: "Overlay hidden because the stream ended with an empty continuation.")
+                state = .idle
+                logStage(
+                    "stream-empty-result",
+                    workID: workID,
+                    generation: update.generation,
+                    message: "Streaming generation ended without a non-empty normalized suggestion.",
+                    rawOutput: update.rawText,
+                    normalizedOutput: update.text
+                )
+            }
+            return
+        }
+
+        guard liveContext.selection.length == 0 else {
+            clearSuggestion(clearDiagnostics: true)
+            hideOverlay(reason: "Overlay hidden because text is selected.")
+            state = .idle
+            logStage(
+                "stream-selected-text",
+                workID: workID,
+                generation: update.generation,
+                message: "Ignored the streamed suggestion because the current field has selected text.",
+                rawOutput: update.rawText,
+                normalizedOutput: update.text
+            )
+            return
+        }
+
+        latestLatencyMilliseconds = Int(update.latency * 1000)
+        latestGenerationNumber = liveContext.generation
+        let session = interactionState.startSession(
+            fullText: update.text,
+            liveContext: liveContext,
+            latency: update.latency,
+            isStreaming: !update.isFinal
+        )
+        applySessionDiagnostics(
+            session,
+            acceptanceAction: update.isFinal ? "Generated streamed suggestion." : "Streaming suggestion started."
+        )
+        displayStreamingSession(
+            session,
+            liveContext: liveContext,
+            update: update,
+            workID: workID
+        )
+    }
+
+    private func applyStreamUpdateToExistingSession(
+        _ update: SuggestionStreamUpdate,
+        rawContext: FocusedInputSnapshot,
+        workID: UInt64
+    ) async {
+        guard let reconciliation = interactionState.reconcileActiveSession(with: rawContext) else {
+            invalidateActiveSuggestion(reason: "Overlay hidden because no ready suggestion remains.")
+            cancelPredictionWork()
+            return
+        }
+
+        let liveContext: FocusedInputContext
+        switch reconciliation {
+        case let .valid(reconciledLiveContext, _, _):
+            liveContext = reconciledLiveContext
+
+        case let .invalid(reason):
+            invalidateActiveSuggestion(reason: reason)
+            cancelPredictionWork()
+            return
+        }
+
+        guard let updatedSession = interactionState.updateStreamingSession(
+            stableText: update.text,
+            latency: update.latency,
+            isStreaming: !update.isFinal
+        ) else {
+            invalidateActiveSuggestion(
+                reason: "Overlay hidden because streamed text diverged from the accepted prefix.",
+                clearDiagnostics: false
+            )
+            cancelPredictionWork()
+            return
+        }
+
+        latestLatencyMilliseconds = Int(update.latency * 1000)
+        latestGenerationNumber = liveContext.generation
+        applySessionDiagnostics(
+            updatedSession,
+            acceptanceAction: update.isFinal ? "Streaming finished." : latestAcceptanceAction
+        )
+        displayStreamingSession(
+            updatedSession,
+            liveContext: liveContext,
+            update: update,
+            workID: workID
+        )
+    }
+
+    private func displayStreamingSession(
+        _ session: ActiveSuggestionSession,
+        liveContext: FocusedInputContext,
+        update: SuggestionStreamUpdate,
+        workID: UInt64
+    ) {
+        if session.isExhausted {
+            completeActiveSuggestion(
+                reason: "Overlay hidden because the streamed suggestion was fully consumed.",
+                scheduleNextPrediction: true,
+                stage: "stream-session-exhausted",
+                message: "The streamed suggestion was fully consumed.",
+                acceptanceAction: "Streamed suggestion was fully consumed."
+            )
+            return
+        }
+
+        if session.isWaitingForMoreStreamedText {
+            hideOverlay(reason: "Overlay hidden while waiting for more streamed suggestion text.")
+            state = .streaming(text: "", latency: session.latency)
+            logStage(
+                "stream-awaiting-more",
+                workID: workID,
+                generation: update.generation,
+                message: "The user consumed all stable streamed text; waiting for the backend to append more.",
+                rawOutput: update.rawText,
+                normalizedOutput: session.fullText
+            )
+            return
+        }
+
+        state = update.isFinal
+            ? .ready(text: session.remainingText, latency: session.latency)
+            : .streaming(text: session.remainingText, latency: session.latency)
+        presentOverlay(
+            text: session.remainingText,
+            at: liveContext.caretRect,
+            caretQuality: liveContext.caretQuality
+        )
+        logStage(
+            update.isFinal ? "stream-ready" : "stream-partial-ready",
+            workID: workID,
+            generation: update.generation,
+            message: update.isFinal
+                ? "Streaming finished with a non-empty normalized suggestion."
+                : "Displayed a stable streamed suggestion chunk.",
+            rawOutput: update.rawText,
+            normalizedOutput: session.remainingText
+        )
+    }
+
     /// Converts a runtime or engine failure into visible coordinator state and clears stale UI.
     func applyFailure(_ message: String, workID: UInt64) async {
         guard workController.isCurrent(workID) else {
@@ -281,12 +496,19 @@ extension SuggestionCoordinator {
                 return
             }
 
-            state = .ready(text: reconciledSession.remainingText, latency: reconciledSession.latency)
-            presentOverlay(
-                text: reconciledSession.remainingText,
-                at: liveContext.caretRect,
-                caretQuality: liveContext.caretQuality
-            )
+            if reconciledSession.isWaitingForMoreStreamedText {
+                state = .streaming(text: "", latency: reconciledSession.latency)
+                hideOverlay(reason: "Overlay hidden while waiting for more streamed suggestion text.")
+            } else {
+                state = reconciledSession.isStreaming
+                    ? .streaming(text: reconciledSession.remainingText, latency: reconciledSession.latency)
+                    : .ready(text: reconciledSession.remainingText, latency: reconciledSession.latency)
+                presentOverlay(
+                    text: reconciledSession.remainingText,
+                    at: liveContext.caretRect,
+                    caretQuality: liveContext.caretQuality
+                )
+            }
             if let advancement {
                 logStage(
                     advancement.stage,

--- a/tabby/Models/SuggestionEngineModels.swift
+++ b/tabby/Models/SuggestionEngineModels.swift
@@ -62,6 +62,9 @@ struct SuggestionSettingsSnapshot: Equatable, Sendable {
     let isGloballyEnabled: Bool
     let selectedEngine: SuggestionEngineKind
     let selectedWordCountPreset: SuggestionWordCountPreset
+    /// Enables incremental rendering when a backend can produce partial output.
+    /// This belongs in the snapshot because streaming changes generation lifecycle, not just UI.
+    let streamingAutocompleteEnabled: Bool
     let effectivePromptMode: SuggestionPromptMode
     /// Normalized user-authored guidance for the instructions-based completion style.
     /// This travels in the snapshot so generation uses the same value the Settings UI shows.

--- a/tabby/Models/SuggestionModels.swift
+++ b/tabby/Models/SuggestionModels.swift
@@ -263,7 +263,29 @@ struct SuggestionResult: Equatable, Sendable {
     let latency: TimeInterval
 }
 
-/// Represents one active inline-completion session after the model has produced a suggestion.
+/// One ordered update from a streaming backend.
+///
+/// `text` is the normalized stable suggestion prefix available so far, not the latest raw token.
+/// That distinction is central to streaming safety: runtime layers may emit token fragments, but
+/// the coordinator should only ever render or accept normalized text that passed chunk stability.
+struct SuggestionStreamUpdate: Equatable, Sendable {
+    let generation: UInt64
+    let rawText: String
+    let text: String
+    let latency: TimeInterval
+    let isFinal: Bool
+
+    var result: SuggestionResult {
+        SuggestionResult(
+            generation: generation,
+            rawText: rawText,
+            text: text,
+            latency: latency
+        )
+    }
+}
+
+/// Represents one active inline-completion session after the model has produced suggestion text.
 /// The key architectural shift is that a suggestion is no longer "fire once and forget."
 /// Instead, it becomes durable interaction state that can be partially consumed over time.
 struct ActiveSuggestionSession: Equatable, Sendable {
@@ -271,20 +293,27 @@ struct ActiveSuggestionSession: Equatable, Sendable {
     /// We keep this as the anchor so later text changes can be interpreted as:
     /// "user consumed part of the suggestion" vs "user diverged from it."
     let baseContext: FocusedInputContext
+    /// The normalized stable suggestion text known so far.
+    /// For non-streaming generations this is the final model output. For streaming generations it
+    /// can grow as more stable chunks arrive from the backend.
     let fullText: String
     let consumedCharacterCount: Int
     let latency: TimeInterval
+    /// True while the backend may still append more stable text to `fullText`.
+    let isStreaming: Bool
 
     init(
         baseContext: FocusedInputContext,
         fullText: String,
         consumedCharacterCount: Int = 0,
-        latency: TimeInterval
+        latency: TimeInterval,
+        isStreaming: Bool = false
     ) {
         self.baseContext = baseContext
         self.fullText = fullText
         self.consumedCharacterCount = min(max(consumedCharacterCount, 0), fullText.count)
         self.latency = latency
+        self.isStreaming = isStreaming
     }
 
     var acceptedText: String {
@@ -306,7 +335,13 @@ struct ActiveSuggestionSession: Equatable, Sendable {
     /// A whitespace-only tail is effectively exhausted for inline UX.
     /// Showing "ghost spaces" is visually confusing and not worth preserving.
     var isExhausted: Bool {
-        remainingText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        !isStreaming && remainingText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    /// During streaming, accepting everything currently visible is not final exhaustion; it means
+    /// Tabby should keep the session alive and wait for the backend to append more stable text.
+    var isWaitingForMoreStreamedText: Bool {
+        isStreaming && remainingText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     /// Returns a new session advanced by the accepted or typed character count.
@@ -316,7 +351,8 @@ struct ActiveSuggestionSession: Equatable, Sendable {
             baseContext: baseContext,
             fullText: fullText,
             consumedCharacterCount: self.consumedCharacterCount + max(consumedCharacters, 0),
-            latency: latency
+            latency: latency,
+            isStreaming: isStreaming
         )
     }
 
@@ -327,7 +363,20 @@ struct ActiveSuggestionSession: Equatable, Sendable {
             baseContext: baseContext,
             fullText: fullText,
             consumedCharacterCount: consumedCharacters,
-            latency: latency
+            latency: latency,
+            isStreaming: isStreaming
+        )
+    }
+
+    /// Replaces the stable suggestion text while preserving what the user already consumed.
+    /// Streaming uses this when a backend emits a larger stable prefix after the session exists.
+    func withStableText(_ stableText: String, isStreaming: Bool, latency: TimeInterval) -> ActiveSuggestionSession {
+        ActiveSuggestionSession(
+            baseContext: baseContext,
+            fullText: stableText,
+            consumedCharacterCount: consumedCharacterCount,
+            latency: latency,
+            isStreaming: isStreaming
         )
     }
 }
@@ -338,6 +387,7 @@ enum SuggestionDebugState: Equatable {
     case disabled(String)
     case debouncing
     case generating
+    case streaming(text: String, latency: TimeInterval)
     case ready(text: String, latency: TimeInterval)
     case failed(String)
 
@@ -351,6 +401,8 @@ enum SuggestionDebugState: Equatable {
             return "Debouncing"
         case .generating:
             return "Generating"
+        case .streaming:
+            return "Streaming"
         case .ready:
             return "Ready"
         case .failed:
@@ -368,8 +420,19 @@ enum SuggestionDebugState: Equatable {
             return "Waiting for typing to settle."
         case .generating:
             return "Requesting a completion from the active suggestion backend."
+        case .streaming:
+            return "Rendering stable streamed chunks while the backend continues generating."
         case .ready:
             return "Ready means Tabby has buffered a non-empty normalized completion for this field and can render it as ghost text."
+        }
+    }
+
+    var canAcceptSuggestion: Bool {
+        switch self {
+        case .ready, .streaming:
+            return true
+        case .idle, .disabled, .debouncing, .generating, .failed:
+            return false
         }
     }
 }

--- a/tabby/Models/SuggestionSettingsModel.swift
+++ b/tabby/Models/SuggestionSettingsModel.swift
@@ -16,6 +16,7 @@ final class SuggestionSettingsModel: ObservableObject {
     @Published private(set) var customSuggestionTextColorHex: String?
     @Published private(set) var selectedEngine: SuggestionEngineKind
     @Published private(set) var selectedWordCountPreset: SuggestionWordCountPreset
+    @Published private(set) var streamingAutocompleteEnabled: Bool
     @Published private(set) var selectedLocalPromptMode: SuggestionPromptMode
     @Published private(set) var customAIInstructions: String
 
@@ -28,6 +29,7 @@ final class SuggestionSettingsModel: ObservableObject {
     private static let customSuggestionTextColorHexDefaultsKey = "tabbyCustomSuggestionTextColorHex"
     private static let selectedEngineDefaultsKey = "selectedSuggestionEngine"
     private static let selectedWordCountPresetDefaultsKey = "selectedSuggestionWordCountPreset"
+    private static let streamingAutocompleteEnabledDefaultsKey = "tabbyStreamingAutocompleteEnabled"
     private static let selectedLocalPromptModeDefaultsKey = "selectedLocalSuggestionPromptMode"
     private static let customAIInstructionsDefaultsKey = "tabbyCustomAIInstructions"
 
@@ -54,6 +56,8 @@ final class SuggestionSettingsModel: ObservableObject {
             .string(forKey: Self.selectedWordCountPresetDefaultsKey)
             .flatMap(SuggestionWordCountPreset.init(rawValue:))
             ?? configuration.defaultWordCountPreset
+        let resolvedStreamingAutocompleteEnabled = userDefaults
+            .object(forKey: Self.streamingAutocompleteEnabledDefaultsKey) as? Bool ?? false
         let resolvedLocalPromptMode = userDefaults
             .string(forKey: Self.selectedLocalPromptModeDefaultsKey)
             .flatMap(SuggestionPromptMode.init(rawValue:))
@@ -69,6 +73,7 @@ final class SuggestionSettingsModel: ObservableObject {
         customSuggestionTextColorHex = resolvedCustomSuggestionTextColorHex
         selectedEngine = resolvedEngine
         selectedWordCountPreset = resolvedWordCountPreset
+        streamingAutocompleteEnabled = resolvedStreamingAutocompleteEnabled
         selectedLocalPromptMode = resolvedLocalPromptMode
         customAIInstructions = resolvedCustomAIInstructions
 
@@ -77,6 +82,7 @@ final class SuggestionSettingsModel: ObservableObject {
         persistCustomSuggestionTextColorHex(resolvedCustomSuggestionTextColorHex)
         persistSelectedEngine(resolvedEngine)
         persistSelectedWordCountPreset(resolvedWordCountPreset)
+        persistStreamingAutocompleteEnabled(resolvedStreamingAutocompleteEnabled)
         persistSelectedLocalPromptMode(resolvedLocalPromptMode)
         persistCustomAIInstructions(resolvedCustomAIInstructions)
     }
@@ -103,6 +109,7 @@ final class SuggestionSettingsModel: ObservableObject {
             isGloballyEnabled: isGloballyEnabled,
             selectedEngine: selectedEngine,
             selectedWordCountPreset: selectedWordCountPreset,
+            streamingAutocompleteEnabled: streamingAutocompleteEnabled,
             effectivePromptMode: effectivePromptMode,
             customAIInstructions: CustomAIInstructionFormatter.normalized(customAIInstructions)
         )
@@ -124,6 +131,15 @@ final class SuggestionSettingsModel: ObservableObject {
 
         selectedWordCountPreset = preset
         persistSelectedWordCountPreset(preset)
+    }
+
+    func setStreamingAutocompleteEnabled(_ enabled: Bool) {
+        guard streamingAutocompleteEnabled != enabled else {
+            return
+        }
+
+        streamingAutocompleteEnabled = enabled
+        persistStreamingAutocompleteEnabled(enabled)
     }
 
     func selectLocalPromptMode(_ mode: SuggestionPromptMode) {
@@ -197,6 +213,10 @@ final class SuggestionSettingsModel: ObservableObject {
         userDefaults.set(preset.rawValue, forKey: Self.selectedWordCountPresetDefaultsKey)
     }
 
+    private func persistStreamingAutocompleteEnabled(_ enabled: Bool) {
+        userDefaults.set(enabled, forKey: Self.streamingAutocompleteEnabledDefaultsKey)
+    }
+
     private func persistSelectedLocalPromptMode(_ mode: SuggestionPromptMode) {
         userDefaults.set(mode.rawValue, forKey: Self.selectedLocalPromptModeDefaultsKey)
     }
@@ -251,16 +271,21 @@ extension SuggestionSettingsModel: SuggestionSettingsProviding {
                 $isGloballyEnabled,
                 $selectedEngine,
                 $selectedWordCountPreset,
-                $selectedLocalPromptMode
+                $streamingAutocompleteEnabled
             ),
-            $customAIInstructions
+            Publishers.CombineLatest(
+                $selectedLocalPromptMode,
+                $customAIInstructions
+            )
         )
-        .map { combinedSettings, customAIInstructions in
-            let (globallyEnabled, engine, wordCountPreset, localPromptMode) = combinedSettings
+        .map { combinedSettings, promptSettings in
+            let (globallyEnabled, engine, wordCountPreset, streamingAutocompleteEnabled) = combinedSettings
+            let (localPromptMode, customAIInstructions) = promptSettings
             return SuggestionSettingsSnapshot(
                 isGloballyEnabled: globallyEnabled,
                 selectedEngine: engine,
                 selectedWordCountPreset: wordCountPreset,
+                streamingAutocompleteEnabled: streamingAutocompleteEnabled,
                 effectivePromptMode: Self.effectivePromptMode(
                     engine: engine,
                     localPromptMode: localPromptMode

--- a/tabby/Models/SuggestionSubsystemContracts.swift
+++ b/tabby/Models/SuggestionSubsystemContracts.swift
@@ -39,9 +39,42 @@ protocol SuggestionInputMonitoring: AnyObject {
 @MainActor
 protocol SuggestionGenerating: AnyObject {
     func generateSuggestion(for request: SuggestionRequest) async throws -> SuggestionResult
+    /// Emits normalized, stable suggestion prefixes as they become available.
+    ///
+    /// Backends that cannot stream yet may use the default implementation below, which preserves
+    /// coordinator behavior by yielding a single final update after regular generation completes.
+    func streamSuggestion(for request: SuggestionRequest) -> AsyncThrowingStream<SuggestionStreamUpdate, Error>
     /// Clears backend-local continuation state when the focused editing context is no longer
     /// continuous. Stateless engines may implement this as a no-op.
     func resetCachedGenerationContext()
+}
+
+extension SuggestionGenerating {
+    func streamSuggestion(for request: SuggestionRequest) -> AsyncThrowingStream<SuggestionStreamUpdate, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task { @MainActor in
+                do {
+                    let result = try await generateSuggestion(for: request)
+                    continuation.yield(
+                        SuggestionStreamUpdate(
+                            generation: result.generation,
+                            rawText: result.rawText,
+                            text: result.text,
+                            latency: result.latency,
+                            isFinal: true
+                        )
+                    )
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
+        }
+    }
 }
 
 @MainActor

--- a/tabby/Services/Runtime/FoundationModelSuggestionEngine.swift
+++ b/tabby/Services/Runtime/FoundationModelSuggestionEngine.swift
@@ -63,6 +63,104 @@ final class FoundationModelSuggestionEngine {
         }
     }
 
+    /// Streams partial snapshots from Apple's Foundation Models framework through Tabby's shared
+    /// stable-prefix contract. Apple snapshots are already accumulated strings for this use case,
+    /// but they still pass through the same normalizer and chunker as llama output so the overlay
+    /// never accepts backend-specific fragments.
+    func streamSuggestion(for request: SuggestionRequest) -> AsyncThrowingStream<SuggestionStreamUpdate, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task { @MainActor [weak self] in
+                guard let self else {
+                    continuation.finish(throwing: SuggestionClientError.cancelled)
+                    return
+                }
+
+                availabilityService.refresh()
+
+                guard availabilityService.isAvailable else {
+                    continuation.finish(
+                        throwing: SuggestionClientError.unavailable(availabilityService.userVisibleMessage)
+                    )
+                    return
+                }
+
+                let startTime = Date()
+                let session = LanguageModelSession(
+                    model: availabilityService.model,
+                    instructions: FoundationModelPromptRenderer.sessionInstructions(for: request)
+                )
+                var lastRawSuggestion = ""
+                var lastStableSuggestion = ""
+
+                do {
+                    let responseStream = session.streamResponse(
+                        to: FoundationModelPromptRenderer.prompt(for: request),
+                        options: generationOptions(for: request)
+                    )
+
+                    for try await snapshot in responseStream {
+                        try Task.checkCancellation()
+                        let rawSuggestion = snapshot.content
+                        lastRawSuggestion = rawSuggestion
+                        let normalizedSuggestion = SuggestionTextNormalizer.normalize(
+                            rawSuggestion,
+                            for: request
+                        )
+                        let stableSuggestion = SuggestionStreamChunker.stablePrefix(
+                            from: normalizedSuggestion,
+                            isFinal: false
+                        )
+
+                        guard !stableSuggestion.isEmpty,
+                              stableSuggestion != lastStableSuggestion
+                        else {
+                            continue
+                        }
+
+                        lastStableSuggestion = stableSuggestion
+                        continuation.yield(
+                            SuggestionStreamUpdate(
+                                generation: request.generation,
+                                rawText: rawSuggestion,
+                                text: stableSuggestion,
+                                latency: Date().timeIntervalSince(startTime),
+                                isFinal: false
+                            )
+                        )
+                    }
+
+                    try Task.checkCancellation()
+                    let finalSuggestion = SuggestionTextNormalizer.normalize(
+                        lastRawSuggestion,
+                        for: request
+                    )
+                    continuation.yield(
+                        SuggestionStreamUpdate(
+                            generation: request.generation,
+                            rawText: lastRawSuggestion,
+                            text: finalSuggestion,
+                            latency: Date().timeIntervalSince(startTime),
+                            isFinal: true
+                        )
+                    )
+                    continuation.finish()
+                } catch is CancellationError {
+                    continuation.finish(throwing: SuggestionClientError.cancelled)
+                } catch let error as LanguageModelSession.GenerationError {
+                    continuation.finish(throwing: mapGenerationError(error))
+                } catch let error as SuggestionClientError {
+                    continuation.finish(throwing: error)
+                } catch {
+                    continuation.finish(throwing: SuggestionClientError.generationFailed(error.localizedDescription))
+                }
+            }
+
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
+        }
+    }
+
     /// Foundation Models sessions are already one-shot, so there is no backend context to clear.
     func resetCachedGenerationContext() {}
 

--- a/tabby/Services/Runtime/LlamaRuntimeCore.swift
+++ b/tabby/Services/Runtime/LlamaRuntimeCore.swift
@@ -122,6 +122,61 @@ actor LlamaRuntimeCore {
         repetitionPenalty: Double,
         seed: UInt32? = nil
     ) throws -> String {
+        try generateInternal(
+            prompt: prompt,
+            cachedPrefixBytes: cachedPrefixBytes,
+            maxPredictionTokens: maxPredictionTokens,
+            temperature: temperature,
+            topK: topK,
+            topP: topP,
+            minP: minP,
+            repetitionPenalty: repetitionPenalty,
+            seed: seed,
+            onPartialRawText: nil
+        )
+    }
+
+    /// Samples a completion and reports the growing raw model text after each decoded token.
+    /// Callers still normalize/chunk the text above this runtime boundary because token pieces are
+    /// backend details, not safe UI text.
+    func generateStreaming(
+        prompt: String,
+        cachedPrefixBytes: Int? = nil,
+        maxPredictionTokens: Int,
+        temperature: Double,
+        topK: Int,
+        topP: Double,
+        minP: Double,
+        repetitionPenalty: Double,
+        seed: UInt32? = nil,
+        onPartialRawText: @Sendable @escaping (String) -> Void
+    ) throws -> String {
+        try generateInternal(
+            prompt: prompt,
+            cachedPrefixBytes: cachedPrefixBytes,
+            maxPredictionTokens: maxPredictionTokens,
+            temperature: temperature,
+            topK: topK,
+            topP: topP,
+            minP: minP,
+            repetitionPenalty: repetitionPenalty,
+            seed: seed,
+            onPartialRawText: onPartialRawText
+        )
+    }
+
+    private func generateInternal(
+        prompt: String,
+        cachedPrefixBytes: Int? = nil,
+        maxPredictionTokens: Int,
+        temperature: Double,
+        topK: Int,
+        topP: Double,
+        minP: Double,
+        repetitionPenalty: Double,
+        seed: UInt32? = nil,
+        onPartialRawText: (@Sendable (String) -> Void)?
+    ) throws -> String {
         guard let preparedRuntime else {
             throw LlamaRuntimeError.unavailable("The llama model is not loaded.")
         }
@@ -178,6 +233,7 @@ actor LlamaRuntimeCore {
 
         do {
             for _ in 0 ..< maxPredictionTokens {
+                try Task.checkCancellation()
                 let nextToken = llama_sampler_sample(sampler, context, -1)
                 if nextToken == llama_vocab_eos(vocab) || llama_vocab_is_eog(vocab, nextToken) {
                     break
@@ -185,6 +241,7 @@ actor LlamaRuntimeCore {
 
                 let piece = pieceString(for: nextToken, vocab: vocab)
                 generatedText += piece
+                onPartialRawText?(generatedText)
                 llama_sampler_accept(sampler, nextToken)
 
                 // Instruction-shaped prompts often make small models emit a leading newline before the

--- a/tabby/Services/Runtime/LlamaRuntimeManager.swift
+++ b/tabby/Services/Runtime/LlamaRuntimeManager.swift
@@ -121,6 +121,63 @@ final class LlamaRuntimeManager: ObservableObject {
         }
     }
 
+    /// Starts a raw llama generation stream after ensuring the selected model is prepared.
+    ///
+    /// The stream yields the accumulated raw model text after each sampled token. It intentionally
+    /// does not normalize or chunk text because the manager is still a runtime boundary; suggestion
+    /// policy belongs in `LlamaSuggestionEngine` and pure support helpers.
+    func rawGenerationStream(
+        prompt: String,
+        cachedPrefixBytes: Int? = nil,
+        maxPredictionTokens: Int,
+        temperature: Double,
+        topK: Int,
+        topP: Double,
+        minP: Double,
+        repetitionPenalty: Double,
+        seed: UInt32? = nil
+    ) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task { [weak self] in
+                guard let self else {
+                    continuation.finish(throwing: LlamaRuntimeError.cancelled)
+                    return
+                }
+
+                do {
+                    _ = try await preparedRuntime()
+                    _ = try await core.generateStreaming(
+                        prompt: prompt,
+                        cachedPrefixBytes: cachedPrefixBytes,
+                        maxPredictionTokens: maxPredictionTokens,
+                        temperature: temperature,
+                        topK: topK,
+                        topP: topP,
+                        minP: minP,
+                        repetitionPenalty: repetitionPenalty,
+                        seed: seed
+                    ) { rawText in
+                        continuation.yield(rawText)
+                    }
+                    continuation.finish()
+                } catch is CancellationError {
+                    continuation.finish(throwing: LlamaRuntimeError.cancelled)
+                } catch let error as LlamaRuntimeError {
+                    diagnostics.lastError = error.localizedDescription
+                    continuation.finish(throwing: error)
+                } catch {
+                    let runtimeError = LlamaRuntimeError.generationFailed(error.localizedDescription)
+                    diagnostics.lastError = runtimeError.localizedDescription
+                    continuation.finish(throwing: runtimeError)
+                }
+            }
+
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
+        }
+    }
+
     /// Clears the native prompt KV cache without unloading the model.
     /// The manager exposes this as a lifecycle command because focus/settings resets originate in
     /// the app layer, while the actor still owns the raw llama pointers.

--- a/tabby/Services/Runtime/LlamaSuggestionEngine.swift
+++ b/tabby/Services/Runtime/LlamaSuggestionEngine.swift
@@ -57,6 +57,104 @@ final class LlamaSuggestionEngine {
         }
     }
 
+    /// Streams stable normalized prefixes from the local llama runtime.
+    ///
+    /// The runtime yields raw accumulated token text. This adapter owns the inline-autocomplete
+    /// policy above that: normalize the accumulated text, expose only stable word/phrase prefixes,
+    /// and emit a final update when generation completes.
+    func streamSuggestion(for request: SuggestionRequest) -> AsyncThrowingStream<SuggestionStreamUpdate, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task { @MainActor [weak self] in
+                guard let self else {
+                    continuation.finish(throwing: SuggestionClientError.cancelled)
+                    return
+                }
+
+                let startTime = Date()
+                let cachedPrefixBytes = promptCacheHintTracker.cachedPrefixBytes(for: request)
+                var lastRawSuggestion = ""
+                var lastStableSuggestion = ""
+
+                do {
+                    let rawStream = runtimeManager.rawGenerationStream(
+                        prompt: request.prompt,
+                        cachedPrefixBytes: cachedPrefixBytes,
+                        maxPredictionTokens: request.maxPredictionTokens,
+                        temperature: request.temperature,
+                        topK: request.topK,
+                        topP: request.topP,
+                        minP: request.minP,
+                        repetitionPenalty: request.repetitionPenalty,
+                        seed: request.randomSeed
+                    )
+
+                    for try await rawSuggestion in rawStream {
+                        try Task.checkCancellation()
+                        lastRawSuggestion = rawSuggestion
+                        let normalizedSuggestion = SuggestionTextNormalizer.normalize(
+                            rawSuggestion,
+                            for: request
+                        )
+                        let stableSuggestion = SuggestionStreamChunker.stablePrefix(
+                            from: normalizedSuggestion,
+                            isFinal: false
+                        )
+
+                        guard !stableSuggestion.isEmpty,
+                              stableSuggestion != lastStableSuggestion
+                        else {
+                            continue
+                        }
+
+                        lastStableSuggestion = stableSuggestion
+                        continuation.yield(
+                            SuggestionStreamUpdate(
+                                generation: request.generation,
+                                rawText: rawSuggestion,
+                                text: stableSuggestion,
+                                latency: Date().timeIntervalSince(startTime),
+                                isFinal: false
+                            )
+                        )
+                    }
+
+                    try Task.checkCancellation()
+                    promptCacheHintTracker.recordSuccessfulRequest(request)
+                    let finalSuggestion = SuggestionTextNormalizer.normalize(
+                        lastRawSuggestion,
+                        for: request
+                    )
+                    continuation.yield(
+                        SuggestionStreamUpdate(
+                            generation: request.generation,
+                            rawText: lastRawSuggestion,
+                            text: finalSuggestion,
+                            latency: Date().timeIntervalSince(startTime),
+                            isFinal: true
+                        )
+                    )
+                    continuation.finish()
+                } catch is CancellationError {
+                    resetCachedGenerationContext()
+                    continuation.finish(throwing: SuggestionClientError.cancelled)
+                } catch let error as LlamaRuntimeError {
+                    resetCachedGenerationContext()
+                    continuation.finish(throwing: SuggestionClientError.unavailable(error.localizedDescription))
+                } catch let error as SuggestionClientError {
+                    resetCachedGenerationContext()
+                    continuation.finish(throwing: error)
+                } catch {
+                    resetCachedGenerationContext()
+                    continuation.finish(throwing: SuggestionClientError.generationFailed(error.localizedDescription))
+                }
+            }
+
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
+        }
+    }
+
     /// Clears both the Swift-side hint tracker and the native llama KV cache.
     /// The tracker reset is synchronous because it protects the next request from advertising
     /// stale reuse; the runtime reset is also enforced lazily by passing no hint on that request.

--- a/tabby/Services/Runtime/SuggestionEngineRouter.swift
+++ b/tabby/Services/Runtime/SuggestionEngineRouter.swift
@@ -29,6 +29,15 @@ final class SuggestionEngineRouter {
         }
     }
 
+    func streamSuggestion(for request: SuggestionRequest) -> AsyncThrowingStream<SuggestionStreamUpdate, Error> {
+        switch suggestionSettings.selectedEngine {
+        case .appleIntelligence:
+            return foundationModelEngine.streamSuggestion(for: request)
+        case .llamaOpenSource:
+            return llamaEngine.streamSuggestion(for: request)
+        }
+    }
+
     /// Clears backend-local continuation state when the coordinator knows the editing context is
     /// no longer continuous. The router fans this out so switching engines cannot leave stale
     /// llama KV state behind.

--- a/tabby/Services/Suggestion/SuggestionInteractionState.swift
+++ b/tabby/Services/Suggestion/SuggestionInteractionState.swift
@@ -50,15 +50,46 @@ final class SuggestionInteractionState {
         clearSuggestion()
     }
 
-    func startSession(fullText: String, liveContext: FocusedInputContext, latency: TimeInterval) -> ActiveSuggestionSession {
+    func startSession(
+        fullText: String,
+        liveContext: FocusedInputContext,
+        latency: TimeInterval,
+        isStreaming: Bool = false
+    ) -> ActiveSuggestionSession {
         let session = ActiveSuggestionSession(
             baseContext: liveContext,
             fullText: fullText,
-            latency: latency
+            latency: latency,
+            isStreaming: isStreaming
         )
         activeSession = session
         pendingInsertionConsumedCount = nil
         return session
+    }
+
+    /// Extends the current session with a newer stable prefix from a streaming backend.
+    /// The accepted prefix is immutable: if new streamed text no longer starts with what the user
+    /// already accepted, the stream belongs to stale model state and must be discarded.
+    func updateStreamingSession(
+        stableText: String,
+        latency: TimeInterval,
+        isStreaming: Bool
+    ) -> ActiveSuggestionSession? {
+        guard let activeSession else {
+            return nil
+        }
+
+        guard stableText.hasPrefix(activeSession.acceptedText) else {
+            return nil
+        }
+
+        let updatedSession = activeSession.withStableText(
+            stableText,
+            isStreaming: isStreaming,
+            latency: latency
+        )
+        self.activeSession = updatedSession
+        return updatedSession
     }
 
     /// Uses process-level identity instead of AX element identity because Chrome recycles

--- a/tabby/Support/SuggestionStreamChunker.swift
+++ b/tabby/Support/SuggestionStreamChunker.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Converts a growing normalized model response into the stable prefix Tabby may show or accept.
+///
+/// Runtime token boundaries are model implementation details, not user-facing word boundaries.
+/// This helper waits until normalized text reaches a word or punctuation boundary before exposing
+/// it to the overlay, so streaming never renders broken fragments such as "autocom".
+enum SuggestionStreamChunker {
+    static func stablePrefix(from normalizedText: String, isFinal: Bool) -> String {
+        if isFinal {
+            return normalizedText
+        }
+
+        var lastStableBoundary: String.Index?
+        var hasVisibleTextInCurrentToken = false
+
+        var index = normalizedText.startIndex
+        while index < normalizedText.endIndex {
+            let character = normalizedText[index]
+
+            if character.isWhitespace {
+                if hasVisibleTextInCurrentToken {
+                    lastStableBoundary = index
+                }
+                hasVisibleTextInCurrentToken = false
+            } else {
+                hasVisibleTextInCurrentToken = true
+
+                if character.isStablePhrasePunctuation {
+                    lastStableBoundary = normalizedText.index(after: index)
+                }
+            }
+
+            index = normalizedText.index(after: index)
+        }
+
+        guard let lastStableBoundary else {
+            return ""
+        }
+
+        let stablePrefix = String(normalizedText[..<lastStableBoundary])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard stablePrefix.containsVisibleSuggestionContent else {
+            return ""
+        }
+
+        if normalizedText.first?.isWhitespace == true,
+           !stablePrefix.firstIsWhitespace
+        {
+            return " " + stablePrefix
+        }
+
+        return stablePrefix
+    }
+}
+
+private extension Character {
+    var isStablePhrasePunctuation: Bool {
+        guard unicodeScalars.count == 1, let scalar = unicodeScalars.first else {
+            return false
+        }
+
+        return CharacterSet(charactersIn: ".,!?;:)]}").contains(scalar)
+    }
+}
+
+private extension String {
+    var firstIsWhitespace: Bool {
+        first?.isWhitespace == true
+    }
+
+    var containsVisibleSuggestionContent: Bool {
+        unicodeScalars.contains { CharacterSet.alphanumerics.contains($0) }
+    }
+}

--- a/tabby/UI/MenuBarView.swift
+++ b/tabby/UI/MenuBarView.swift
@@ -68,6 +68,10 @@ struct MenuBarView: View {
                 .toggleStyle(.switch)
                 .controlSize(.small)
 
+            Toggle("Streaming", isOn: streamingAutocompleteBinding)
+                .toggleStyle(.switch)
+                .controlSize(.small)
+
             MenuBarPickerRow(title: "Indicator") {
                 Picker("Indicator", selection: selectedIndicatorModeBinding) {
                     ForEach(ActivationIndicatorMode.allCases) { mode in
@@ -225,6 +229,13 @@ struct MenuBarView: View {
             set: { preset in
                 suggestionSettings.selectWordCountPreset(preset)
             }
+        )
+    }
+
+    private var streamingAutocompleteBinding: Binding<Bool> {
+        Binding(
+            get: { suggestionSettings.streamingAutocompleteEnabled },
+            set: { suggestionSettings.setStreamingAutocompleteEnabled($0) }
         )
     }
 

--- a/tabby/UI/SettingsView.swift
+++ b/tabby/UI/SettingsView.swift
@@ -164,6 +164,12 @@ struct SettingsView: View {
                 }
             }
 
+            Toggle("Streaming Autocomplete", isOn: streamingAutocompleteBinding)
+
+            Text("Shows stable word chunks as the active engine generates, while preserving Tab acceptance for the visible suggestion.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
             if suggestionSettings.selectedEngine.supportsPromptModeSelection {
                 Picker("Completion Style", selection: selectedLocalPromptModeBinding) {
                     ForEach(suggestionSettings.availablePromptModes) { mode in
@@ -403,6 +409,15 @@ struct SettingsView: View {
             get: { suggestionSettings.selectedWordCountPreset },
             set: { preset in
                 suggestionSettings.selectWordCountPreset(preset)
+            }
+        )
+    }
+
+    private var streamingAutocompleteBinding: Binding<Bool> {
+        Binding(
+            get: { suggestionSettings.streamingAutocompleteEnabled },
+            set: { enabled in
+                suggestionSettings.setStreamingAutocompleteEnabled(enabled)
             }
         )
     }

--- a/tabbyTests/SuggestionStreamChunkerTests.swift
+++ b/tabbyTests/SuggestionStreamChunkerTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import tabby
+
+/// Tests for streaming-safe output boundaries.
+///
+/// These are intentionally pure. The runtime may emit arbitrary token pieces, but the overlay
+/// should only receive completed user-facing chunks.
+final class SuggestionStreamChunkerTests: XCTestCase {
+    func test_stablePrefix_waitsForWordBoundary() {
+        XCTAssertEqual(
+            SuggestionStreamChunker.stablePrefix(from: " autocom", isFinal: false),
+            ""
+        )
+
+        XCTAssertEqual(
+            SuggestionStreamChunker.stablePrefix(from: " autocomplete systems", isFinal: false),
+            " autocomplete"
+        )
+    }
+
+    func test_stablePrefix_keepsPhrasePunctuation() {
+        XCTAssertEqual(
+            SuggestionStreamChunker.stablePrefix(from: " sounds good,", isFinal: false),
+            " sounds good,"
+        )
+    }
+
+    func test_stablePrefix_returnsFinalTextEvenWithoutBoundary() {
+        XCTAssertEqual(
+            SuggestionStreamChunker.stablePrefix(from: " autocomplete", isFinal: true),
+            " autocomplete"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Adds an opt-in streaming autocomplete mode so Tabby can render stable word/phrase chunks while the active suggestion backend continues generating. The coordinator keeps using backend-agnostic suggestion events, and partial Tab acceptance now works with growable streamed sessions as long as the live editor text still matches the accepted stream prefix.

## Validation

- `xcodebuild test -scheme tabby -project tabby.xcodeproj -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`
  - `** TEST SUCCEEDED **`, 33 tests, 0 failures

## Linked issues

Refs #11
Refs #13

## Risk / rollout notes

- This is stacked on #74 and targets `codex/kv-cache-reuse` so reviewers can separate KV-cache reuse from streaming behavior.
- Streaming is off by default and exposed through the menu/settings toggle for safer rollout and side-by-side comparison.
- The new chunker only exposes normalized stable word/phrase prefixes; raw llama token pieces are never rendered or accepted directly.
- Apple Foundation Models streaming is wired through `LanguageModelSession.streamResponse` and compile-tested, but I did not manually exercise Apple Intelligence end-to-end in this run.
- XCTest reports success, but llama.cpp/Metal still prints the existing shutdown-time `GGML_ASSERT([rsets->data count] == 0)` backtrace after test completion on this machine.
