### PR TITLE
Replace focus polling with AXObserver tracking

### DIFF
--- a/tabby/App/Core/AppDelegate.swift
+++ b/tabby/App/Core/AppDelegate.swift
@@ -84,6 +84,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
             .store(in: &cancellables)
 
+        focusModel.$latestObserverEvent
+            .compactMap { $0 }
+            .sink { [weak self] event in
+                self?.focusDebugOverlayController?.flashAXObserverHit(event: event)
+            }
+            .store(in: &cancellables)
+
     }
 
     /// Starts runtime and observer services once AppKit reports that app launch finished.

--- a/tabby/App/Core/TabbyAppEnvironment.swift
+++ b/tabby/App/Core/TabbyAppEnvironment.swift
@@ -41,7 +41,6 @@ final class TabbyAppEnvironment {
             suppressionController: suppressionController
         )
         let focusModel = FocusTrackingModel(
-            pollInterval: 0.25,
             permissionProvider: { permissionManager.accessibilityGranted },
             ignoredBundleIdentifier: Bundle.main.bundleIdentifier
         )

--- a/tabby/Models/FocusModels.swift
+++ b/tabby/Models/FocusModels.swift
@@ -139,7 +139,7 @@ struct FocusedInputSnapshot: Equatable {
     /// The signature lets later pipeline stages detect whether a completion result is stale.
     /// This is the same idea you would use in a React app with a derived cache key.
     /// Content-only fingerprint for staleness detection. Deliberately excludes `elementIdentifier`
-    /// because Chrome recycles AX node tokens between polls, making `CFHash`-based identity unstable.
+    /// because Chrome recycles AX node tokens between observations, making `CFHash`-based identity unstable.
     /// Text and selection state is sufficient to detect real content changes.
     var contentSignature: String {
         [
@@ -196,6 +196,21 @@ struct FocusSnapshot: Equatable {
             applicationName: applicationName,
             bundleIdentifier: bundleIdentifier
         )
+    }
+}
+
+/// Debug-only signal that an `AXObserver` notification reached Tabby.
+///
+/// This intentionally stays separate from `FocusSnapshot`: a notification can be useful diagnostic
+/// information even when the resolved focus snapshot does not change. The sequence number gives
+/// Combine/SwiftUI consumers an always-unique value for repeated identical notifications.
+struct FocusObserverEvent: Equatable {
+    let sequence: Int
+    let notificationName: String
+    let occurredAt: Date
+
+    var displayName: String {
+        notificationName.replacingOccurrences(of: "AX", with: "")
     }
 }
 

--- a/tabby/Models/FocusTrackingModel.swift
+++ b/tabby/Models/FocusTrackingModel.swift
@@ -3,26 +3,27 @@ import Foundation
 
 /// File overview:
 /// Publishes focused-input snapshots to SwiftUI and other main-actor consumers. It keeps
-/// AX polling details hidden behind a small observable interface.
+/// AX observation details hidden behind a small observable interface.
 ///
-/// Bridges the polling tracker into SwiftUI-facing published state.
+/// Bridges the event-driven focus tracker into SwiftUI-facing published state.
 @MainActor
 final class FocusTrackingModel: ObservableObject {
     @Published private(set) var snapshot: FocusSnapshot
     @Published private(set) var latestExternalApplication: FocusedApplicationIdentity?
+    /// Debug-only pulse source for the caret overlay; not used by suggestion generation.
+    @Published private(set) var latestObserverEvent: FocusObserverEvent?
 
     private let tracker: FocusTracker
     private let ignoredBundleIdentifier: String?
     private var isStarted = false
+    private var observerEventSequence = 0
 
     init(
-        pollInterval: TimeInterval,
         permissionProvider: @escaping @MainActor () -> Bool,
         ignoredBundleIdentifier: String?
     ) {
         self.ignoredBundleIdentifier = ignoredBundleIdentifier
         tracker = FocusTracker(
-            pollInterval: pollInterval,
             permissionProvider: permissionProvider,
             ignoredBundleIdentifier: ignoredBundleIdentifier
         )
@@ -35,9 +36,13 @@ final class FocusTrackingModel: ObservableObject {
             self?.snapshot = snapshot
             self?.updateLatestExternalApplication(from: snapshot)
         }
+
+        tracker.onAXNotification = { [weak self] notificationName in
+            self?.publishObserverEvent(named: notificationName)
+        }
     }
 
-    /// Starts focus polling once and treats later calls as a request for an immediate refresh.
+    /// Starts focus observation once and treats later calls as a request for an immediate refresh.
     func start() {
         guard !isStarted else {
             tracker.refreshNow()
@@ -48,14 +53,14 @@ final class FocusTrackingModel: ObservableObject {
         tracker.start()
     }
 
-    /// Stops polling while leaving the last captured snapshot available for UI consumers.
+    /// Stops observation while leaving the last captured snapshot available for UI consumers.
     func stop() {
         isStarted = false
         tracker.stop()
     }
 
     /// A manual refresh is useful when another subsystem already knows "input just changed"
-    /// and wants the latest AX snapshot immediately instead of waiting for the poll timer.
+    /// and wants the latest AX snapshot immediately instead of waiting for an AX notification.
     func refreshNow() {
         tracker.refreshNow()
     }
@@ -84,6 +89,15 @@ final class FocusTrackingModel: ObservableObject {
         }
 
         latestExternalApplication = application
+    }
+
+    private func publishObserverEvent(named notificationName: String) {
+        observerEventSequence += 1
+        latestObserverEvent = FocusObserverEvent(
+            sequence: observerEventSequence,
+            notificationName: notificationName,
+            occurredAt: Date()
+        )
     }
 }
 

--- a/tabby/Services/Focus/FocusSnapshotResolver.swift
+++ b/tabby/Services/Focus/FocusSnapshotResolver.swift
@@ -5,7 +5,7 @@ import Foundation
 /// File overview:
 /// Resolves the most usable editable candidate around the current AX focus and materializes a
 /// stable `FocusSnapshot`. This keeps AX candidate search and snapshot assembly separate from the
-/// timer-driven polling shell in `FocusTracker`.
+/// event-observation shell in `FocusTracker`.
 @MainActor
 struct FocusSnapshotResolver {
     private let geometryResolver: AXTextGeometryResolver
@@ -33,7 +33,7 @@ struct FocusSnapshotResolver {
         let focusedElementIdentifier = AXHelper.elementIdentifier(
             for: focusedElement, bundleIdentifier: bundleIdentifier)
 
-        // Dump once per element change so it doesn't spam on every poll tick.
+        // Dump once per element change so it doesn't spam on repeated focus/value notifications.
         if Self.dumpAXTree, Self.lastDumpedElementID != focusedElementIdentifier {
             Self.lastDumpedElementID = focusedElementIdentifier
             printAXTreeDump(

--- a/tabby/Services/Focus/FocusTracker.swift
+++ b/tabby/Services/Focus/FocusTracker.swift
@@ -3,14 +3,44 @@ import ApplicationServices
 import Foundation
 
 /// File overview:
-/// Polls the Accessibility tree on a timer and publishes the latest `FocusSnapshot`.
+/// Observes Accessibility focus notifications and publishes the latest `FocusSnapshot`.
 ///
-/// This file is now intentionally small: it owns poll timing, permission/frontmost-app guards, and
-/// the final `snapshot` publication contract. AX candidate resolution lives in
-/// `FocusSnapshotResolver`, and caret/frame heuristics live in `AXTextGeometryResolver`.
+/// This experimental version removes the polling timer entirely. `FocusTracker` owns observer
+/// lifecycle, permission/frontmost-app guards, and the final `snapshot` publication contract.
+/// AX candidate resolution lives in `FocusSnapshotResolver`, and caret/frame heuristics live in
+/// `AXTextGeometryResolver`.
+nonisolated private let focusTrackerObserverCallback: AXObserverCallback = { _, _, notification, refcon in
+    guard let refcon else {
+        return
+    }
+
+    let notificationName = notification as String
+    let tracker = Unmanaged<FocusTracker>.fromOpaque(refcon).takeUnretainedValue()
+    Task { @MainActor in
+        tracker.handleAXNotification(named: notificationName)
+    }
+}
+
 @MainActor
 final class FocusTracker {
+    private enum AXNotificationSet {
+        static let application: [CFString] = [
+            kAXFocusedUIElementChangedNotification as CFString,
+            kAXFocusedWindowChangedNotification as CFString,
+            kAXApplicationDeactivatedNotification as CFString,
+        ]
+
+        static let focusedElement: [CFString] = [
+            kAXValueChangedNotification as CFString,
+            kAXSelectedTextChangedNotification as CFString,
+            kAXUIElementDestroyedNotification as CFString,
+        ]
+    }
+
     var onSnapshotChange: ((FocusSnapshot) -> Void)?
+    /// Debug hook for raw AX notification hits. The tracker still publishes snapshots separately
+    /// because several notifications can collapse into the same resolved focus state.
+    var onAXNotification: ((String) -> Void)?
 
     private(set) var snapshot: FocusSnapshot = .inactive {
         didSet {
@@ -18,20 +48,22 @@ final class FocusTracker {
         }
     }
 
-    private let pollInterval: TimeInterval
     private let permissionProvider: @MainActor () -> Bool
     private let ignoredBundleIdentifier: String?
     private let snapshotResolver: FocusSnapshotResolver
 
-    private var timer: Timer?
+    private var observer: AXObserver?
+    private var observedApplicationElement: AXUIElement?
+    private var observedFocusedElement: AXUIElement?
+    private var observedApplicationPID: pid_t?
+    private var workspaceActivationObserver: NSObjectProtocol?
+    private var scheduledRefreshTask: Task<Void, Never>?
 
     init(
-        pollInterval: TimeInterval,
         permissionProvider: @escaping @MainActor () -> Bool,
         ignoredBundleIdentifier: String?,
         snapshotResolver: FocusSnapshotResolver? = nil
     ) {
-        self.pollInterval = pollInterval
         self.permissionProvider = permissionProvider
         self.ignoredBundleIdentifier = ignoredBundleIdentifier
         // Default resolver construction must happen inside the actor-isolated initializer body.
@@ -39,80 +71,241 @@ final class FocusTracker {
         self.snapshotResolver = snapshotResolver ?? FocusSnapshotResolver()
     }
 
-    /// Starts periodic AX polling and immediately captures an initial snapshot.
+    /// Starts event-driven AX observation and immediately captures an initial snapshot.
     func start() {
-        guard timer == nil else {
+        guard workspaceActivationObserver == nil else {
             refreshNow()
             return
         }
 
-        refreshNow()
-
-        let timer = Timer(timeInterval: pollInterval, repeats: true) { [weak self] _ in
+        workspaceActivationObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didActivateApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
             Task { @MainActor [weak self] in
                 self?.refreshNow()
             }
         }
-        self.timer = timer
-        RunLoop.main.add(timer, forMode: .common)
+
+        refreshNow()
     }
 
-    /// Stops polling while leaving the most recent snapshot available to callers.
+    /// Stops event observation while leaving the most recent snapshot available to callers.
     func stop() {
-        timer?.invalidate()
-        timer = nil
+        scheduledRefreshTask?.cancel()
+        scheduledRefreshTask = nil
+
+        if let workspaceActivationObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(workspaceActivationObserver)
+            self.workspaceActivationObserver = nil
+        }
+
+        clearAXObserver()
     }
 
-    /// Performs a synchronous snapshot capture outside the normal polling cadence.
+    /// Performs a synchronous snapshot capture outside the normal notification cadence.
     func refreshNow() {
-        snapshot = captureSnapshot()
+        scheduledRefreshTask?.cancel()
+        scheduledRefreshTask = nil
+
+        let capture = captureSnapshot()
+        snapshot = capture.snapshot
+
+        if let focusedElement = capture.focusedElement {
+            registerFocusedElementNotifications(on: focusedElement)
+        } else {
+            clearFocusedElementNotifications()
+        }
+    }
+
+    fileprivate func handleAXNotification(named notificationName: String) {
+        onAXNotification?(notificationName)
+
+        if notificationName == kAXApplicationDeactivatedNotification as String {
+            scheduleRefresh(after: 0)
+            return
+        }
+
+        // AX notifications can fire before the app has updated value/selection attributes.
+        // A tiny coalescing delay avoids reading the old state while still feeling immediate.
+        scheduleRefresh(after: 0.005)
+    }
+
+    private func scheduleRefresh(after delay: TimeInterval) {
+        scheduledRefreshTask?.cancel()
+        scheduledRefreshTask = Task { [weak self] in
+            guard delay > 0 else {
+                self?.refreshNow()
+                return
+            }
+
+            try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            guard !Task.isCancelled else {
+                return
+            }
+
+            self?.refreshNow()
+        }
     }
 
     /// Captures the current frontmost application's focused element and reduces it into a snapshot.
-    private func captureSnapshot() -> FocusSnapshot {
+    private func captureSnapshot() -> FocusCaptureResult {
         guard permissionProvider() else {
-            return FocusSnapshot(
-                applicationName: "Accessibility permission missing",
-                bundleIdentifier: nil,
-                capability: .blocked("Accessibility permission is required."),
-                context: nil,
-                inspection: nil
+            clearAXObserver()
+            return FocusCaptureResult(
+                snapshot: FocusSnapshot(
+                    applicationName: "Accessibility permission missing",
+                    bundleIdentifier: nil,
+                    capability: .blocked("Accessibility permission is required."),
+                    context: nil,
+                    inspection: nil
+                )
             )
         }
 
         guard let application = NSWorkspace.shared.frontmostApplication else {
-            return FocusSnapshot(
-                applicationName: "No active application",
-                bundleIdentifier: nil,
-                capability: .unsupported("No active application."),
-                context: nil,
-                inspection: nil
+            clearAXObserver()
+            return FocusCaptureResult(
+                snapshot: FocusSnapshot(
+                    applicationName: "No active application",
+                    bundleIdentifier: nil,
+                    capability: .unsupported("No active application."),
+                    context: nil,
+                    inspection: nil
+                )
             )
         }
 
         if application.bundleIdentifier == ignoredBundleIdentifier {
-            return FocusSnapshot(
-                applicationName: application.localizedName ?? "Tabby",
-                bundleIdentifier: application.bundleIdentifier,
-                capability: .blocked("Tabby is focused."),
-                context: nil,
-                inspection: nil
+            clearAXObserver()
+            return FocusCaptureResult(
+                snapshot: FocusSnapshot(
+                    applicationName: application.localizedName ?? "Tabby",
+                    bundleIdentifier: application.bundleIdentifier,
+                    capability: .blocked("Tabby is focused."),
+                    context: nil,
+                    inspection: nil
+                )
             )
         }
+
+        configureAXObserver(for: application)
 
         guard let focusedElement = AXHelper.focusedElement() else {
-            return FocusSnapshot(
-                applicationName: application.localizedName ?? "Unknown",
-                bundleIdentifier: application.bundleIdentifier,
-                capability: .unsupported("No focused Accessibility element."),
-                context: nil,
-                inspection: nil
+            return FocusCaptureResult(
+                snapshot: FocusSnapshot(
+                    applicationName: application.localizedName ?? "Unknown",
+                    bundleIdentifier: application.bundleIdentifier,
+                    capability: .unsupported("No focused Accessibility element."),
+                    context: nil,
+                    inspection: nil
+                )
             )
         }
 
-        return snapshotResolver.resolveSnapshot(
-            focusedElement: focusedElement,
-            application: application
+        return FocusCaptureResult(
+            snapshot: snapshotResolver.resolveSnapshot(
+                focusedElement: focusedElement,
+                application: application
+            ),
+            focusedElement: focusedElement
         )
+    }
+
+    private func configureAXObserver(for application: NSRunningApplication) {
+        let pid = application.processIdentifier
+        guard observer == nil || observedApplicationPID != pid else {
+            return
+        }
+
+        clearAXObserver()
+
+        var newObserver: AXObserver?
+        let result = AXObserverCreate(pid, focusTrackerObserverCallback, &newObserver)
+        guard result == .success, let newObserver else {
+            return
+        }
+
+        let applicationElement = AXUIElementCreateApplication(pid)
+        observer = newObserver
+        observedApplicationElement = applicationElement
+        observedApplicationPID = pid
+
+        let source = AXObserverGetRunLoopSource(newObserver)
+        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+
+        for notification in AXNotificationSet.application {
+            addNotification(notification, to: applicationElement)
+        }
+    }
+
+    private func registerFocusedElementNotifications(on focusedElement: AXUIElement) {
+        guard observer != nil else {
+            return
+        }
+
+        if let observedFocusedElement,
+           AXHelper.elementIdentity(for: observedFocusedElement) == AXHelper.elementIdentity(for: focusedElement)
+        {
+            return
+        }
+
+        clearFocusedElementNotifications()
+        observedFocusedElement = focusedElement
+
+        for notification in AXNotificationSet.focusedElement {
+            addNotification(notification, to: focusedElement)
+        }
+    }
+
+    private func clearFocusedElementNotifications() {
+        guard let observer, let observedFocusedElement else {
+            self.observedFocusedElement = nil
+            return
+        }
+
+        for notification in AXNotificationSet.focusedElement {
+            AXObserverRemoveNotification(observer, observedFocusedElement, notification)
+        }
+
+        self.observedFocusedElement = nil
+    }
+
+    private func clearAXObserver() {
+        scheduledRefreshTask?.cancel()
+        scheduledRefreshTask = nil
+
+        clearFocusedElementNotifications()
+
+        if let observer {
+            let source = AXObserverGetRunLoopSource(observer)
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
+        }
+
+        observer = nil
+        observedApplicationElement = nil
+        observedApplicationPID = nil
+    }
+
+    @discardableResult
+    private func addNotification(_ notification: CFString, to element: AXUIElement) -> Bool {
+        guard let observer else {
+            return false
+        }
+
+        let refcon = Unmanaged.passUnretained(self).toOpaque()
+        let result = AXObserverAddNotification(observer, element, notification, refcon)
+        return result == .success || result == .notificationAlreadyRegistered
+    }
+}
+
+private struct FocusCaptureResult {
+    let snapshot: FocusSnapshot
+    let focusedElement: AXUIElement?
+
+    init(snapshot: FocusSnapshot, focusedElement: AXUIElement? = nil) {
+        self.snapshot = snapshot
+        self.focusedElement = focusedElement
     }
 }

--- a/tabby/Services/UI/FocusDebugOverlayController.swift
+++ b/tabby/Services/UI/FocusDebugOverlayController.swift
@@ -15,6 +15,9 @@ final class FocusDebugOverlayController {
 
     private lazy var caretPanel: NSPanel = makePanel()
     private lazy var framePanel: NSPanel = makePanel()
+    private lazy var observerPulsePanel: NSPanel = makePanel()
+    private var latestCaretRect: CGRect?
+    private var pulseHideTask: Task<Void, Never>?
 
     func update(for snapshot: FocusSnapshot) {
         guard let context = snapshot.context else {
@@ -22,13 +25,54 @@ final class FocusDebugOverlayController {
             return
         }
 
+        latestCaretRect = context.caretRect
         showCaretIndicator(context: context)
         showFrameOutline(context: context)
     }
 
+    /// Flashes when an AX notification reaches `FocusTracker`.
+    ///
+    /// This answers a different question than the caret/frame overlay: "did the observer fire at all?"
+    /// The snapshot may not visibly change for every notification, so this pulse is driven by the raw
+    /// observer event instead of by `FocusSnapshot` updates.
+    func flashAXObserverHit(event: FocusObserverEvent) {
+        pulseHideTask?.cancel()
+
+        let color = event.sequence.isMultiple(of: 2) ? Color.green : Color.cyan
+        let contentView = NSHostingView(rootView: AXObserverPulseView(
+            notificationName: event.displayName,
+            sequence: event.sequence,
+            color: color
+        ))
+        contentView.layoutSubtreeIfNeeded()
+        let contentSize = contentView.fittingSize
+
+        observerPulsePanel.alphaValue = 1
+        observerPulsePanel.contentView = contentView
+        observerPulsePanel.setFrame(
+            CGRect(origin: pulseOrigin(for: contentSize), size: contentSize).integral,
+            display: true
+        )
+        observerPulsePanel.orderFrontRegardless()
+
+        pulseHideTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 180_000_000)
+            guard !Task.isCancelled else {
+                return
+            }
+
+            self?.observerPulsePanel.orderOut(nil)
+            self?.pulseHideTask = nil
+        }
+    }
+
     func hide() {
+        latestCaretRect = nil
+        pulseHideTask?.cancel()
+        pulseHideTask = nil
         caretPanel.orderOut(nil)
         framePanel.orderOut(nil)
+        observerPulsePanel.orderOut(nil)
     }
 
     // MARK: - Caret indicator
@@ -102,6 +146,23 @@ final class FocusDebugOverlayController {
         if source.contains("derived") { return .yellow }
         return .red
     }
+
+    private func pulseOrigin(for contentSize: CGSize) -> CGPoint {
+        if let latestCaretRect {
+            return CGPoint(
+                x: latestCaretRect.maxX + 8,
+                y: latestCaretRect.maxY + 4
+            )
+        }
+
+        // If the observer fires before we have a supported caret snapshot, keep the pulse visible
+        // near the top-right of the active screen so the debug signal is still discoverable.
+        let screenFrame = NSScreen.main?.visibleFrame ?? CGRect(x: 0, y: 0, width: 800, height: 600)
+        return CGPoint(
+            x: screenFrame.maxX - contentSize.width - 20,
+            y: screenFrame.maxY - contentSize.height - 20
+        )
+    }
 }
 
 // MARK: - SwiftUI views
@@ -128,6 +189,32 @@ private struct CaretDebugView: View {
                 .fill(color)
                 .frame(width: 2, height: caretHeight)
         }
+        .fixedSize()
+    }
+}
+
+private struct AXObserverPulseView: View {
+    let notificationName: String
+    let sequence: Int
+    let color: Color
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Circle()
+                .fill(color)
+                .frame(width: 7, height: 7)
+
+            Text("AX \(sequence) \(notificationName)")
+                .font(.system(size: 9, weight: .bold, design: .monospaced))
+                .foregroundStyle(.black)
+                .lineLimit(1)
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3)
+        .background(
+            Capsule()
+                .fill(color.opacity(0.92))
+        )
         .fixedSize()
     }
 }


### PR DESCRIPTION
## Summary

- Replaces the timer-based focus polling path with process-scoped `AXObserver` notifications for focus/window changes, value/selection changes, element destruction, and app deactivation.
- Publishes raw AXObserver hit events through the focus model and flashes a short debug-overlay pulse so we can see when observer callbacks actually fire.
- Removes `pollInterval` wiring from the app environment and updates focus docs/comments around the event-driven model.

## Validation

```bash
xcodebuild test -scheme tabby -project tabby.xcodeproj -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
# ** TEST SUCCEEDED **
# Executed 61 tests, with 0 failures (0 unexpected)
```

Note: the test process still printed the existing llama.cpp/ggml Metal teardown `GGML_ASSERT([rsets->data count] == 0)` after XCTest reported success; `xcodebuild` exited 0. I did not record a live-app screen capture for the new debug pulse yet.

## Linked issues

Refs #18
Refs #16

## Risk / rollout notes

- This is intentionally experimental: it removes polling entirely and does not include the fallback polling path from the full ticket acceptance criteria.
- Apps that do not reliably emit Accessibility notifications may leave focus state stale until another activation or observer event occurs.
- Non-deactivation AX notifications are coalesced with a `0.005s` delay before reading AX state so value/selection attributes can settle.
- Idle CPU still needs to be measured against the old polling implementation before treating this as production-ready.