### PR TITLE
feat: integrate screen recording as core permission and optimize visual context bounds

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,10 +1,84 @@
-# Claude Instructions for leet-canvas
+# Claude Instructions for Tabby
 
-## Code style
+Tabby is a macOS menu bar app that provides on-device inline autocomplete in the
+text field the user is already editing. It watches Accessibility focus, monitors
+global input, generates a local continuation through Apple Intelligence or
+llama.cpp, renders ghost text near the caret, and inserts accepted text when the
+user presses `Tab`.
 
-- comments should **teach**, not just describe — explain _why_ a design decision was made, not just what the line does
-- Call out distributed systems concepts when they appear (concurrency, race conditions, fan-out, statefulness, etc.)
+## How To Work In This Repo
 
-- Talk through architecture before coding when the design isn't clear
-- Don't use superpower skills / subagent planning tools — just implement directly
-- When something isn't working, diagnose step by step before touching code
+- Read the relevant subsystem before editing. Tabby is stateful, permission-heavy,
+  and tied to macOS Accessibility behavior, so guessing usually creates regressions.
+- Talk through architecture before coding when ownership, lifecycle, or async
+  cancellation is unclear.
+- Diagnose failures step by step before touching code. Many bugs come from stale
+  focus snapshots, AX timing, permission state, runtime lifecycle, or cancellation.
+- Keep changes narrow. Prefer pure helpers in `Support/` before changing services,
+  coordinators, or SwiftUI views.
+- Protect the user's worktree. Do not revert unrelated dirty files.
+
+## Project Map
+
+- `tabby/App/`: app lifecycle, dependency construction, and coordinators.
+- `tabby/UI/`: SwiftUI/AppKit presentation such as settings, onboarding, overlays,
+  and menu-facing state.
+- `tabby/Services/`: side-effectful boundaries: Accessibility, input monitoring,
+  screenshots/OCR, llama runtime, permissions, downloads, updates, and insertion.
+- `tabby/Models/`: shared value types, settings snapshots, state machines, and
+  protocol contracts.
+- `tabby/Support/`: pure rules and low-level helper logic that should be easy to
+  test.
+- `tabbyTests/`: focused tests for prompt rendering, request building, availability,
+  runtime behavior, and pure state transitions.
+
+## Key Subsystems
+
+- App ownership starts in `TabbyAppEnvironment` and `AppDelegate`. These construct
+  and retain the long-lived services. SwiftUI views should observe this graph,
+  not recreate service objects.
+- The suggestion state machine lives in `SuggestionCoordinator` plus its extension
+  files: lifecycle, input, prediction, and acceptance. Keep pure rules out of the
+  coordinator when they can live in `Support/`.
+- Focus comes from `FocusTracker`, `FocusSnapshotResolver`, `AXTextGeometryResolver`,
+  and `AXHelper`. Treat AX data as eventually consistent and app-specific.
+- Visual context flows through `VisualContextCoordinator`,
+  `ScreenshotContextGenerator`, `ScreenTextExtractor`, `WindowScreenshotService`,
+  and `LlamaVisualContextSummarizer`.
+- Runtime generation flows through `SuggestionEngineRouter`,
+  `FoundationModelSuggestionEngine`, `LlamaSuggestionEngine`,
+  `LlamaRuntimeManager`, and the serialized `LlamaRuntimeCore` actor.
+
+## Teaching Comments
+
+- Comments should teach, not narrate. Explain why a design exists, which invariant
+  it protects, or which macOS/Swift pitfall it avoids.
+- Prefer file-level and type-level `///` comments for new important files/types.
+- Add targeted inline comments for tricky lifecycle, `@MainActor`, `Task`,
+  cancellation, Accessibility/Core Foundation bridging, unsafe pointer work, and
+  llama.cpp runtime state.
+- Avoid comments that merely restate the next line of code.
+
+## Swift And macOS Expectations
+
+- UI, AppKit, SwiftUI, and most Accessibility interactions belong on the main actor.
+- CPU-heavy work, OCR, screenshots, and llama.cpp generation must not block the UI.
+- Keep cancellation and stale-result handling explicit. The focused field can change
+  while async work is still running.
+- Use protocol contracts in `SuggestionSubsystemContracts.swift` when the coordinator
+  only needs a behavior-shaped dependency.
+- Do not show dev-only diagnostics as normal user settings unless the feature is
+  intentionally productized.
+
+## Validation
+
+Prefer the narrowest useful validation first, then broaden when the change touches
+shared behavior:
+
+```bash
+xcodebuild -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' build
+xcodebuild -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' build-for-testing
+```
+
+Run targeted tests when possible. If app-hosted tests fail because of local signing
+or Team ID mismatch, report the exact failure and still run `build-for-testing`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,50 +1,209 @@
-# Tabby App Collaboration Rules
+# Tabby Codex Instructions
 
-## Learning-first expectation
+## Project Identity
+
+Tabby is a macOS menu bar app for on-device inline autocomplete. The core loop is:
+
+1. Track the currently focused editable field through Accessibility.
+2. Monitor global keyboard input without stealing focus.
+3. Decide whether the field, permissions, settings, and runtime are eligible.
+4. Build an autocomplete request from the focused text context and optional visual context.
+5. Generate locally through Apple Intelligence or llama.cpp.
+6. Normalize the model output into a short continuation.
+7. Render ghost text near the caret.
+8. Insert accepted chunks when the user presses `Tab` while keeping the remaining tail alive.
+
+Privacy and local-first behavior matter. Do not introduce hosted API dependencies unless the user
+explicitly asks for that direction.
+
+## Learning-First Collaboration
 
 - Explain both the "what" and the "why" for architecture and code changes.
-- Assume the user is actively learning Swift, AppKit, Accessibility APIs, and macOS app architecture.
+- Assume the user is actively learning Swift, AppKit, Accessibility APIs, llama.cpp integration,
+  async/await, actor isolation, and macOS app architecture.
 - Teach at the file, type, and subsystem level, not just the line level.
-- Call out tradeoffs when there are multiple valid implementation choices.
-- Prefer clean boundaries (App, UI, Services, Models, Support) over quick coupling.
+- Call out tradeoffs when there are multiple valid approaches.
+- Prefer clean boundaries over quick coupling, especially across `App`, `UI`, `Services`, `Models`,
+  and `Support`.
 
-## Teaching depth requirements
+When creating or editing a file, explain:
 
-- When creating or editing a file, explain what the file is for, why it exists, and how it fits into the overall architecture.
-- When adding a type such as a `struct`, `class`, `enum`, or protocol, explain:
-  - what responsibility it owns
-  - what other objects it collaborates with
-  - why it should exist as its own type instead of being folded into another file
-- When using Swift-specific syntax or Apple-specific APIs, explain the concept in plain language.
-  Examples include:
-  - property wrappers such as `@Published`, `@ObservedObject`, `@StateObject`, `@MainActor`
-  - `Task`, async/await, actor isolation, closures, convenience initializers
-  - Core Foundation / Accessibility APIs like `AXUIElement`, `CFTypeRef`, `unsafeBitCast`
-- Do not assume the user already understands lifecycle ownership. Explain who owns what, how long it lives, and why that matters.
-- When fixing a bug, explain the root cause in engineering terms, not just the patch.
-- When adding architecture, explain data flow end-to-end: where state originates, where it is transformed, and where it is rendered.
+- what the file is responsible for
+- why the file exists as its own boundary
+- which objects own it or collaborate with it
+- how data flows into and out of it
 
-## Code comment expectations
+When adding a `struct`, `class`, `enum`, actor, or protocol, explain:
 
-- Add real teaching comments, not just labels.
-- Prefer file-level and type-level doc comments that explain purpose and design.
-- Add targeted inline comments for tricky logic, lifecycle behavior, concurrency, Core Foundation bridging, and macOS quirks.
-- Comments should explain why the code is written this way, what invariant it protects, or what pitfall it avoids.
+- what responsibility it owns
+- what other objects it collaborates with
+- why it should exist as its own type instead of being folded into another file
+- how long it lives and who owns it
+
+## Repository Map
+
+- `tabby/App/`: app entrypoint, composition root, lifecycle wiring, and coordinators.
+- `tabby/UI/`: SwiftUI/AppKit presentation: settings, onboarding, menu views, overlays, and
+  visual affordances.
+- `tabby/Services/`: side-effectful boundaries: Accessibility, input monitoring, text insertion,
+  screenshots/OCR, visual context, llama runtime, permissions, downloads, updates, and launch
+  services.
+- `tabby/Models/`: shared value types, settings snapshots, states, domain models, and protocol
+  contracts.
+- `tabby/Support/`: pure helper logic, prompt rendering, availability rules, normalization,
+  reconciliation, geometry helpers, and low-level bridging utilities.
+- `tabbyTests/`: unit and microbench tests. Prefer testing pure `Support/` and `Models/` logic
+  when possible.
+- `LlamaRuntime/`: local llama.swift / llama.cpp integration artifacts.
+
+## App Ownership
+
+Start here when you need to understand lifecycle:
+
+1. `tabby/App/Core/TabbyApp.swift`
+2. `tabby/App/Core/AppDelegate.swift`
+3. `tabby/App/Core/TabbyAppEnvironment.swift`
+
+`TabbyAppEnvironment` builds the long-lived dependency graph once. `AppDelegate` starts, stops,
+and wires cross-subsystem subscriptions. SwiftUI views should observe objects from that graph
+rather than creating services directly.
+
+This ownership rule prevents duplicate Accessibility observers, duplicate input monitors, runtime
+reload races, and mismatched settings state.
+
+## Suggestion Pipeline
+
+Read the coordinator in this order:
+
+1. `tabby/App/Coordinators/SuggestionCoordinator.swift`
+2. `tabby/App/Coordinators/SuggestionCoordinator+Lifecycle.swift`
+3. `tabby/App/Coordinators/SuggestionCoordinator+Input.swift`
+4. `tabby/App/Coordinators/SuggestionCoordinator+Prediction.swift`
+5. `tabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift`
+
+The coordinator owns orchestration and user-facing state. It should not absorb every rule. Prefer:
+
+- `SuggestionRequestFactory` for pure request construction
+- `SuggestionAvailabilityEvaluator` for pure gating decisions
+- `SuggestionSessionReconciler` for acceptance and active-tail reconciliation
+- `SuggestionTextNormalizer` for backend-independent output cleanup
+- `SuggestionWorkController` for generation task identity/cancellation
+- `SuggestionInteractionState` for active suggestion session storage
+
+This split matters because autocomplete is a state machine. Pure rules are easier to test and reason
+about than coordinator mutations.
+
+## Focus And Accessibility
+
+Focus and geometry live in:
+
+- `FocusTracker`: observes focus/value/selection changes and publishes snapshots.
+- `FocusSnapshotResolver`: reduces raw AX elements into Tabby-supported focus snapshots.
+- `AXTextGeometryResolver`: resolves caret and input geometry.
+- `AXHelper`: low-level Accessibility/Core Foundation helper calls.
+- `FocusModels`: pure focus values, identities, capabilities, and debug inspection data.
+
+Accessibility data is eventually consistent and app-specific. Browser editors, Electron apps,
+native AppKit fields, and secure fields expose different AX shapes. Preserve stale-result guards,
+`focusChangeSequence`, and capability checks unless the change explicitly replaces them.
+
+## Visual Context And OCR
+
+Visual context currently flows through:
+
+- `VisualContextCoordinator`: field-scoped visual-context session lifecycle.
+- `ScreenshotContextGenerator`: screenshot -> OCR -> optional summary -> bounded excerpt.
+- `WindowScreenshotService`: captures the relevant window or region.
+- `ScreenTextExtractor`: Vision OCR extraction.
+- `LlamaVisualContextSummarizer`: optional local summary using the selected llama runtime.
+- `VisualContextModels`: configuration, status, and excerpt values.
+
+Do not put raw screenshots, unbounded OCR dumps, or noisy AX tree text directly into prompts.
+Normalize, bound, and mark unavailable states explicitly. Screen Recording permission is separate
+from Accessibility and Input Monitoring.
+
+## Runtime And Prompting
+
+Runtime generation is split by responsibility:
+
+- `SuggestionEngineRouter`: selects Apple Intelligence vs Open Source.
+- `FoundationModelSuggestionEngine`: Apple on-device generation path.
+- `LlamaSuggestionEngine`: request-to-prompt, llama result handling, and cache reset handoff.
+- `LlamaRuntimeManager`: UI-facing runtime state, model selection, warmup, and lifecycle control.
+- `LlamaRuntimeCore`: serialized actor around mutable llama.cpp pointers, prompt tokenization,
+  KV-cache reuse, sampling, and shutdown.
+- `LlamaPromptRenderer`: prompt construction.
+
+Keep llama.cpp pointer work serialized inside `LlamaRuntimeCore`. The manager should publish state;
+the core should own native correctness.
+
+## UI And Overlays
+
+- `OverlayController` owns the ghost-text panel lifecycle and positioning.
+- `SuggestionOverlayPresenter` decides whether a suggestion should be shown or hidden.
+- `ActivationIndicatorController` owns the optional caret/field-edge indicator.
+- `FocusDebugOverlayController` is for developer visibility and should stay gated behind debug
+  options, not normal user settings.
+- `SettingsView` and onboarding views should remain presentation-focused. Push behavior into
+  services, models, or support helpers.
+
+## Swift And Concurrency Rules
+
+- Use `@MainActor` for UI, AppKit, SwiftUI state, most Accessibility access, and published models.
+- Use actors or explicit serialization for mutable native/runtime state.
+- Do not block the main actor with OCR, screenshots, model loading, or generation.
+- Make cancellation and stale-result checks explicit around async work. The user can keep typing,
+  switch apps, focus another field, or accept a partial suggestion while work is still running.
+- Prefer narrow protocols from `SuggestionSubsystemContracts.swift` when the coordinator only needs
+  behavior, not a concrete service.
+- Treat Core Foundation and AX bridging as unsafe boundaries. Add comments that explain ownership,
+  casting, and failure handling.
+
+## Teaching Comment Standard
+
+- Add real teaching comments, not labels.
+- Prefer file-level and type-level `///` comments that explain purpose, ownership, and design.
+- Add targeted inline comments for tricky lifecycle behavior, concurrency, cancellation, AX timing,
+  Core Foundation bridging, native pointer state, and macOS quirks.
+- Comments should explain why the code is written this way, which invariant it protects, or which
+  pitfall it avoids.
 - Avoid useless comments that merely restate the code.
-- If a piece of Swift syntax is likely to be unfamiliar, annotate it briefly the first time it appears.
+- If Swift syntax is likely to be unfamiliar, annotate it briefly the first time it appears in a new
+  concept-heavy area. Examples: `@Published`, `@ObservedObject`, `@StateObject`, `@MainActor`,
+  `Task`, async/await, actor isolation, closures, convenience initializers, `AXUIElement`,
+  `CFTypeRef`, and `unsafeBitCast`.
 
-## Response expectations
+## Change Strategy
 
-- In chat responses, explain new files and objects in a way that helps the user build a mental model of the system.
-- When making multi-file changes, include a short walkthrough of how the pieces connect.
-- If there are multiple reasonable approaches, explain why one was chosen and what the rejected alternatives cost.
-- If a bug reveals a broader lesson about architecture, ownership, concurrency, or API design, state that lesson explicitly.
-- Call out tradeoffs when there are multiple valid implementation choices.
+Prefer this order when changing behavior:
 
-## Current architecture intent
+1. Pure rules in `Support/`
+2. Domain models and contracts in `Models/`
+3. Service boundary behavior in `Services/`
+4. Coordinator orchestration in `App/`
+5. SwiftUI/AppKit presentation in `UI/`
 
-- `App/`: app entrypoint and lifecycle ownership.
-- `UI/`: menu bar views and presentation concerns.
-- `Services/`: side-effectful boundaries (permissions, process management, IO).
-- `Models/`: shared data/state contracts.
-- `Support/`: pure helper/resolution logic.
+This order reduces regression risk because deterministic code changes before stateful orchestration.
+It also creates better tests.
+
+## Validation
+
+Use the narrowest meaningful validation first, then broaden if the change touches shared behavior.
+Common commands:
+
+```bash
+xcodebuild -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' build
+xcodebuild -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' build-for-testing
+```
+
+Run targeted tests for changed pure logic when available. If `xcodebuild test` fails locally because
+of app-hosted test bundle signing or Team ID mismatch, report the exact failure and still provide the
+successful build/build-for-testing result.
+
+## Git And Worktree Safety
+
+- The worktree may already contain user edits. Never revert unrelated changes.
+- Before editing, inspect `git status -sb` and the relevant files.
+- Keep commits scoped. Do not silently include unrelated dirty files.
+- Avoid destructive commands such as `git reset --hard` or `git checkout --` unless the user
+  explicitly asks for that operation.

--- a/tabby.xcodeproj/project.pbxproj
+++ b/tabby.xcodeproj/project.pbxproj
@@ -41,8 +41,6 @@
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		1937414B2F81DE7000BEC04F /* tabby */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
 			path = tabby;
 			sourceTree = "<group>";
 		};
@@ -169,7 +167,7 @@
 			mainGroup = 193741402F81DE7000BEC04F;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				A1C3E0022F90000100AAA001 /* XCRemoteSwiftPackageReference "llama.swift" */,
+				A1C3E0022F90000100AAA001 /* XCRemoteSwiftPackageReference "llama" */,
 				A1C3E0122F90000100AAA001 /* XCRemoteSwiftPackageReference "Sparkle" */,
 			);
 			preferredProjectObjectVersion = 77;
@@ -500,7 +498,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		A1C3E0022F90000100AAA001 /* XCRemoteSwiftPackageReference "llama.swift" */ = {
+		A1C3E0022F90000100AAA001 /* XCRemoteSwiftPackageReference "llama" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mattt/llama.swift";
 			requirement = {
@@ -521,7 +519,7 @@
 /* Begin XCSwiftPackageProductDependency section */
 		A1C3E0002F90000100AAA001 /* LlamaSwift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A1C3E0022F90000100AAA001 /* XCRemoteSwiftPackageReference "llama.swift" */;
+			package = A1C3E0022F90000100AAA001 /* XCRemoteSwiftPackageReference "llama" */;
 			productName = LlamaSwift;
 		};
 		A1C3E0102F90000100AAA001 /* Sparkle */ = {

--- a/tabby.xcodeproj/xcshareddata/xcschemes/tabby.xcscheme
+++ b/tabby.xcodeproj/xcshareddata/xcschemes/tabby.xcscheme
@@ -64,16 +64,8 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "-tabby-show-focus-debug-overlay"
-            isEnabled = "NO">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "-tabby-debug-caret-overlay"
+            argument = "-tabby-debug"
             isEnabled = "YES">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "-tabby-log-focus-geometry"
-            isEnabled = "NO">
          </CommandLineArgument>
       </CommandLineArguments>
    </LaunchAction>

--- a/tabby/App/Coordinators/SuggestionCoordinator+Input.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator+Input.swift
@@ -13,6 +13,7 @@ extension SuggestionCoordinator {
             globallyEnabled: settingsSnapshot.isGloballyEnabled,
             disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
             inputMonitoringGranted: permissionManager.inputMonitoringGranted,
+            screenRecordingGranted: permissionManager.screenRecordingGranted,
             focusSnapshot: focusModel.snapshot
         ) {
             handleSupportedSnapshot(focusModel.snapshot)
@@ -20,13 +21,23 @@ extension SuggestionCoordinator {
     }
 
     func handleFocusSnapshotChange(_ snapshot: FocusSnapshot) {
+        // Start capturing visual context for a newly focused input even when predictions are
+        // temporarily disabled (e.g., "text is selected" or "secure field"). The OCR pipeline
+        // is field-scoped and should start as early as possible so context is ready by the
+        // time the user starts typing. Without this, switching between fields can leave the
+        // visual context coordinator dormant if the snapshot is transiently unsupported.
+        if let context = snapshot.context {
+            visualContextCoordinator.startSessionIfNeeded(for: context)
+        }
+
         if let disabledReason = SuggestionAvailabilityEvaluator.disabledReason(
             globallyEnabled: settingsSnapshot.isGloballyEnabled,
             disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
             inputMonitoringGranted: permissionManager.inputMonitoringGranted,
+            screenRecordingGranted: permissionManager.screenRecordingGranted,
             focusSnapshot: snapshot
         ) {
-            disablePredictions(reason: disabledReason)
+            disablePredictionsPreservingVisualContext(reason: disabledReason)
         } else {
             handleSupportedSnapshot(snapshot)
         }
@@ -38,10 +49,8 @@ extension SuggestionCoordinator {
             return
         }
 
-        // Legacy screenshot/OCR context capture is disabled for both prompt modes while we rebuild.
-        if visualContextStatus != .idle {
-            visualContextCoordinator.cancel(resetState: true)
-        }
+        // Start capturing visual context for newly focused input.
+        visualContextCoordinator.startSessionIfNeeded(for: focusedContext)
 
         if case .disabled = state {
             state = .idle
@@ -70,6 +79,7 @@ extension SuggestionCoordinator {
             globallyEnabled: settingsSnapshot.isGloballyEnabled,
             disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
             inputMonitoringGranted: permissionManager.inputMonitoringGranted,
+            screenRecordingGranted: permissionManager.screenRecordingGranted,
             focusSnapshot: focusModel.snapshot
         ) {
             disablePredictions(reason: disabledReason)

--- a/tabby/App/Coordinators/SuggestionCoordinator+Lifecycle.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator+Lifecycle.swift
@@ -58,21 +58,21 @@ extension SuggestionCoordinator {
             latestStageMessage = "Updated autocomplete engine to \(snapshot.selectedEngine.displayLabel)."
         } else if previousSnapshot.selectedWordCountPreset != snapshot.selectedWordCountPreset {
             latestStageMessage = "Updated suggestion length to \(snapshot.selectedWordCountPreset.displayLabel)."
-        } else if previousSnapshot.effectivePromptMode != snapshot.effectivePromptMode {
-            latestStageMessage = "Updated prompt mode to \(snapshot.effectivePromptMode.displayLabel)."
         } else {
             latestStageMessage = "Updated autocomplete settings."
         }
 
-        // Legacy screenshot/OCR context capture is disabled for both prompt modes while we rebuild.
-        if visualContextStatus != .idle {
-            visualContextCoordinator.cancel(resetState: true)
+        // Cancel any obsolete context, then restart it if focus is still active.
+        visualContextCoordinator.cancel(resetState: true)
+        if let focusedSnapshot = focusModel.snapshot.context {
+            visualContextCoordinator.startSessionIfNeeded(for: focusedSnapshot)
         }
 
         if SuggestionAvailabilityEvaluator.shouldSchedulePrediction(
             globallyEnabled: settingsSnapshot.isGloballyEnabled,
             disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
             inputMonitoringGranted: permissionManager.inputMonitoringGranted,
+            screenRecordingGranted: permissionManager.screenRecordingGranted,
             focusSnapshot: focusModel.snapshot
         )
         {

--- a/tabby/App/Coordinators/SuggestionCoordinator+Lifecycle.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator+Lifecycle.swift
@@ -74,8 +74,7 @@ extension SuggestionCoordinator {
             inputMonitoringGranted: permissionManager.inputMonitoringGranted,
             screenRecordingGranted: permissionManager.screenRecordingGranted,
             focusSnapshot: focusModel.snapshot
-        )
-        {
+        ) {
             schedulePrediction()
         }
     }

--- a/tabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
@@ -11,6 +11,7 @@ extension SuggestionCoordinator {
             globallyEnabled: settingsSnapshot.isGloballyEnabled,
             disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
             inputMonitoringGranted: permissionManager.inputMonitoringGranted,
+            screenRecordingGranted: permissionManager.screenRecordingGranted,
             focusSnapshot: focusModel.snapshot
         ) {
             disablePredictions(reason: disabledReason)
@@ -49,6 +50,7 @@ extension SuggestionCoordinator {
             globallyEnabled: settingsSnapshot.isGloballyEnabled,
             disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
             inputMonitoringGranted: permissionManager.inputMonitoringGranted,
+            screenRecordingGranted: permissionManager.screenRecordingGranted,
             focusSnapshot: snapshot
         ) {
             disablePredictions(reason: disabledReason)
@@ -68,10 +70,12 @@ extension SuggestionCoordinator {
         }
 
         let context = interactionState.materializeContext(from: rawContext)
+        let visualContextSummary = visualContextCoordinator.excerpt(for: context)
         let requestBuildResult = SuggestionRequestFactory.buildRequest(
             context: context,
             settings: settingsSnapshot,
-            configuration: configuration
+            configuration: configuration,
+            visualContextSummary: visualContextSummary
         )
         latestGenerationNumber = context.generation
         latestPromptPreview = requestBuildResult.promptPreview
@@ -126,6 +130,7 @@ extension SuggestionCoordinator {
             globallyEnabled: settingsSnapshot.isGloballyEnabled,
             disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
             inputMonitoringGranted: permissionManager.inputMonitoringGranted,
+            screenRecordingGranted: permissionManager.screenRecordingGranted,
             focusSnapshot: snapshot
         ) {
 
@@ -235,6 +240,7 @@ extension SuggestionCoordinator {
             globallyEnabled: settingsSnapshot.isGloballyEnabled,
             disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
             inputMonitoringGranted: permissionManager.inputMonitoringGranted,
+            screenRecordingGranted: permissionManager.screenRecordingGranted,
             focusSnapshot: focusModel.snapshot
         )
 
@@ -323,6 +329,22 @@ extension SuggestionCoordinator {
         latestStageMessage = "Disabled: \(reason)"
     }
 
+    /// Disables predictions without tearing down the visual context session.
+    ///
+    /// Transient disabled states — "text is selected", "secure field", brief "no focused element"
+    /// between field switches — should not cancel an in-progress OCR pipeline. The visual context
+    /// session is field-scoped and outlives individual prediction cycles; destroying it here would
+    /// force a redundant re-capture when the user starts typing again.
+    func disablePredictionsPreservingVisualContext(reason: String) {
+        cancelPredictionWork()
+        resetCachedGenerationContext()
+        interactionState.resetAll()
+        clearSuggestion(clearDiagnostics: true)
+        hideOverlay(reason: reason)
+        state = .disabled(reason)
+        latestStageMessage = "Disabled: \(reason)"
+    }
+
     /// Clears the active suggestion and optionally preserves or drops diagnostic breadcrumbs.
     func clearSuggestion(clearDiagnostics: Bool = false) {
         latestSuggestionPreview = nil
@@ -380,13 +402,13 @@ extension SuggestionCoordinator {
 
     /// Once screenshot context becomes ready, regenerate only if the user is still in the same
     /// field and there is enough typed text for a real inline completion request.
-    func schedulePredictionForCurrentFocusIfPossible(matching elementIdentifier: String) {
+    func schedulePredictionForCurrentFocusIfPossible(matching identity: FocusedInputIdentity) {
         focusModel.refreshNow()
         let snapshot = focusModel.snapshot
 
         guard SuggestionAvailabilityEvaluator.shouldSchedulePredictionWhenVisualContextBecomesReady(
             focusSnapshot: snapshot,
-            matching: elementIdentifier
+            matching: identity
         ) else {
             return
         }

--- a/tabby/App/Coordinators/SuggestionCoordinator.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator.swift
@@ -138,8 +138,8 @@ final class SuggestionCoordinator: ObservableObject {
             self?.latestVisualContextText = excerpt
         }
 
-        visualContextCoordinator.onInjectedContextReady = { [weak self] elementIdentifier in
-            self?.schedulePredictionForCurrentFocusIfPossible(matching: elementIdentifier)
+        visualContextCoordinator.onInjectedContextReady = { [weak self] identity in
+            self?.schedulePredictionForCurrentFocusIfPossible(matching: identity)
         }
 
         suggestionSettings.snapshotPublisher

--- a/tabby/App/Core/TabbyAppEnvironment.swift
+++ b/tabby/App/Core/TabbyAppEnvironment.swift
@@ -69,9 +69,8 @@ final class TabbyAppEnvironment {
         let suggestionInserter = SuggestionInserter(suppressionController: suppressionController)
         let overlayController = OverlayController(suggestionSettings: suggestionSettings)
         let activationIndicatorController = ActivationIndicatorController()
-        // DEPRECATED: This visual pipeline is intentionally left wired as legacy scaffolding while
-        // guided-mode context collection is rebuilt; live requests no longer consume OCR context.
-        let screenshotContextGenerator = ScreenshotContextGenerator()
+        let summarizer = LlamaVisualContextSummarizer(runtimeManager: runtimeManager)
+        let screenshotContextGenerator = ScreenshotContextGenerator(summarizer: summarizer)
         let visualContextCoordinator = VisualContextCoordinator(
             screenshotContextGenerator: screenshotContextGenerator,
             screenRecordingPermissionProvider: { permissionManager.screenRecordingGranted }

--- a/tabby/Models/FocusModels.swift
+++ b/tabby/Models/FocusModels.swift
@@ -5,6 +5,16 @@ import Foundation
 /// Pure data models for focused-input state, AX capability support, and stale-result signatures.
 /// These types let the rest of Tabby reason about focus without depending on raw Accessibility values.
 
+/// Immutable identity for one focused input observation.
+///
+/// `elementIdentifier` is still useful because it describes the AX node we resolved, but it is not
+/// globally unique over time: macOS can recycle `CFHash` values after AX elements are destroyed.
+/// Pairing it with `focusChangeSequence` gives async consumers a stable "same focus event" key.
+struct FocusedInputIdentity: Equatable, Sendable {
+    let elementIdentifier: String
+    let focusChangeSequence: UInt64
+}
+
 /// Describes how trustworthy the resolved caret rect is.
 ///
 /// This distinction matters because not every downstream feature should treat all caret geometry
@@ -135,6 +145,67 @@ struct FocusedInputSnapshot: Equatable {
     let trailingText: String
     let selection: NSRange
     let isSecure: Bool
+
+    /// Monotonic counter that increments every time a focus-changing AX notification fires
+    /// (`kAXFocusedUIElementChanged`, `kAXFocusedWindowChanged`, app activation, etc.).
+    ///
+    /// `elementIdentifier` is built from `CFHash`, which macOS can recycle when AX nodes are
+    /// destroyed and recreated. That makes `elementIdentifier` unreliable for detecting field
+    /// switches — two genuinely different text fields can produce the same identifier.
+    ///
+    /// This counter gives downstream consumers (especially `VisualContextCoordinator`) a
+    /// guaranteed-unique signal that focus actually changed, independent of hash collisions.
+    /// The initializer default of 0 keeps test and legacy call sites compiling without changes.
+    let focusChangeSequence: UInt64
+
+    /// Explicit initializer keeps `focusChangeSequence` immutable while preserving the old
+    /// memberwise-call ergonomics for tests that do not care about focus identity.
+    ///
+    /// Swift omits `let` properties with inline defaults from the synthesized memberwise
+    /// initializer. Writing the initializer ourselves gives production code a way to pass the real
+    /// focus sequence, and keeps existing call sites working through the default value.
+    init(
+        applicationName: String,
+        bundleIdentifier: String,
+        processIdentifier: Int32,
+        elementIdentifier: String,
+        role: String,
+        subrole: String?,
+        caretRect: CGRect,
+        inputFrameRect: CGRect?,
+        caretSource: String,
+        caretQuality: CaretGeometryQuality,
+        observedCharWidth: CGFloat?,
+        precedingText: String,
+        trailingText: String,
+        selection: NSRange,
+        isSecure: Bool,
+        focusChangeSequence: UInt64 = 0
+    ) {
+        self.applicationName = applicationName
+        self.bundleIdentifier = bundleIdentifier
+        self.processIdentifier = processIdentifier
+        self.elementIdentifier = elementIdentifier
+        self.role = role
+        self.subrole = subrole
+        self.caretRect = caretRect
+        self.inputFrameRect = inputFrameRect
+        self.caretSource = caretSource
+        self.caretQuality = caretQuality
+        self.observedCharWidth = observedCharWidth
+        self.precedingText = precedingText
+        self.trailingText = trailingText
+        self.selection = selection
+        self.isSecure = isSecure
+        self.focusChangeSequence = focusChangeSequence
+    }
+
+    var identity: FocusedInputIdentity {
+        FocusedInputIdentity(
+            elementIdentifier: elementIdentifier,
+            focusChangeSequence: focusChangeSequence
+        )
+    }
 
     /// The signature lets later pipeline stages detect whether a completion result is stale.
     /// This is the same idea you would use in a React app with a derived cache key.

--- a/tabby/Models/InputModels.swift
+++ b/tabby/Models/InputModels.swift
@@ -41,4 +41,3 @@ struct CapturedInputEvent: Equatable {
         }
     }
 }
-

--- a/tabby/Models/LlamaRuntimeModels.swift
+++ b/tabby/Models/LlamaRuntimeModels.swift
@@ -136,7 +136,7 @@ enum RuntimeModelCatalog {
             approximateSizeInGigabytes: 3.5,
             expectedSizeBytes: 4_539_054_208,
             sha256: "43b489bb77a81bda85180e7c490d40ad7f1d5c2ce654c9b05e15e104bd3c777e"
-        ),
+        )
     ]
 }
 
@@ -155,12 +155,38 @@ struct LlamaRuntimeConfiguration: Equatable, Sendable {
         preferredModelNames: [
             "gemma-3-1b-it-Q4_K_M.gguf",
             "Qwen3-0.6B-Q4_K_M.gguf",
-            "gemma-3n-E4B-it-Q4_K_M.gguf",
+            "gemma-3n-E4B-it-Q4_K_M.gguf"
         ],
         contextWindowTokens: 2048,
         batchSize: 512,
         gpuLayerCount: -1
     )
+}
+
+/// Sampling and length controls for one llama generation request.
+///
+/// These values travel together from the suggestion layer to the runtime. Modeling them as one
+/// value object keeps runtime APIs small and makes cache invalidation easier to reason about:
+/// changing any option means the request belongs to a different sampling configuration.
+struct LlamaGenerationOptions: Equatable, Sendable {
+    let maxPredictionTokens: Int
+    let temperature: Double
+    let topK: Int
+    let topP: Double
+    let minP: Double
+    let repetitionPenalty: Double
+    var seed: UInt32?
+
+    static func summary(maxPredictionTokens: Int, temperature: Double) -> LlamaGenerationOptions {
+        LlamaGenerationOptions(
+            maxPredictionTokens: maxPredictionTokens,
+            temperature: temperature,
+            topK: 40,
+            topP: 0.95,
+            minP: 0.05,
+            repetitionPenalty: 1.1
+        )
+    }
 }
 
 /// The concrete runtime assets selected during bootstrap after checking available model files.

--- a/tabby/Models/PermissionModels.swift
+++ b/tabby/Models/PermissionModels.swift
@@ -57,7 +57,7 @@ enum TabbyPermissionKind: String, CaseIterable, Identifiable, Sendable {
         case .inputMonitoring:
             "Detect typing and accept with Tab."
         case .screenRecording:
-            "Optional. Not required for autocomplete."
+            "Capture screen context for visual reasoning."
         }
     }
 
@@ -72,19 +72,15 @@ enum TabbyPermissionKind: String, CaseIterable, Identifiable, Sendable {
 
     var guidanceStyle: PermissionGuidanceStyle {
         switch self {
-        case .accessibility, .inputMonitoring:
+        case .accessibility, .inputMonitoring, .screenRecording:
             .guidedOverlay
-        case .screenRecording:
-            .settingsOnly
         }
     }
 
     var isRequiredForAutocomplete: Bool {
         switch self {
-        case .accessibility, .inputMonitoring:
+        case .accessibility, .inputMonitoring, .screenRecording:
             true
-        case .screenRecording:
-            false
         }
     }
 

--- a/tabby/Models/RuntimeBootstrapModel.swift
+++ b/tabby/Models/RuntimeBootstrapModel.swift
@@ -147,8 +147,7 @@ final class RuntimeBootstrapModel: ObservableObject {
         }
 
         if let persistedFilename,
-           availableModels.contains(where: { $0.filename == persistedFilename })
-        {
+           availableModels.contains(where: { $0.filename == persistedFilename }) {
             return persistedFilename
         }
 
@@ -186,14 +185,12 @@ final class RuntimeBootstrapModel: ObservableObject {
         }
 
         if let currentSelection,
-           availableModels.contains(where: { $0.filename == currentSelection })
-        {
+           availableModels.contains(where: { $0.filename == currentSelection }) {
             return currentSelection
         }
 
         if let persistedSelection,
-           availableModels.contains(where: { $0.filename == persistedSelection })
-        {
+           availableModels.contains(where: { $0.filename == persistedSelection }) {
             return persistedSelection
         }
 

--- a/tabby/Models/SuggestionEngineModels.swift
+++ b/tabby/Models/SuggestionEngineModels.swift
@@ -22,17 +22,6 @@ enum SuggestionEngineKind: String, CaseIterable, Equatable, Hashable, Sendable, 
         }
     }
 
-    /// These booleans let views render from capabilities instead of sprinkling engine-specific
-    /// branches throughout the codebase.
-    var supportsPromptModeSelection: Bool {
-        switch self {
-        case .appleIntelligence:
-            return false
-        case .llamaOpenSource:
-            return true
-        }
-    }
-
     var supportsLocalModelManagement: Bool {
         switch self {
         case .appleIntelligence:
@@ -40,19 +29,6 @@ enum SuggestionEngineKind: String, CaseIterable, Equatable, Hashable, Sendable, 
         case .llamaOpenSource:
             return true
         }
-    }
-
-    var supportedPromptModes: [SuggestionPromptMode] {
-        switch self {
-        case .appleIntelligence:
-            return [.prefixOnly]
-        case .llamaOpenSource:
-            return SuggestionPromptMode.allCases
-        }
-    }
-
-    var defaultPromptMode: SuggestionPromptMode {
-        .prefixOnly
     }
 }
 
@@ -75,8 +51,7 @@ struct SuggestionSettingsSnapshot: Equatable, Sendable {
     let disabledAppBundleIdentifiers: Set<String>
     let selectedEngine: SuggestionEngineKind
     let selectedWordCountPreset: SuggestionWordCountPreset
-    let effectivePromptMode: SuggestionPromptMode
-    /// Normalized user-authored guidance for the instructions-based completion style.
+    /// Normalized user-authored guidance for Tabby's instruction-rendered completion prompt.
     /// This travels in the snapshot so generation uses the same value the Settings UI shows.
     let customAIInstructions: String?
 }

--- a/tabby/Models/SuggestionModels.swift
+++ b/tabby/Models/SuggestionModels.swift
@@ -58,33 +58,6 @@ enum SuggestionWordCountPreset: String, CaseIterable, Equatable, Hashable, Senda
     }
 }
 
-/// Prompt construction strategy for inline completion.
-/// Both modes share the same generation pipeline; only the prompt wording changes.
-enum SuggestionPromptMode: String, CaseIterable, Equatable, Hashable, Sendable, Identifiable {
-    case guided
-    case prefixOnly
-
-    var id: String { rawValue }
-
-    var displayLabel: String {
-        switch self {
-        case .guided:
-            return "Use My Instructions"
-        case .prefixOnly:
-            return "Fast"
-        }
-    }
-
-    var compactLabel: String {
-        switch self {
-        case .guided:
-            return "Instructions"
-        case .prefixOnly:
-            return "Fast"
-        }
-    }
-}
-
 /// User-facing indicator display mode for supported text fields.
 /// This replaces the old caret-indicator boolean so Tabby can express multiple affordances
 /// without smuggling extra meaning through one toggle.
@@ -141,7 +114,6 @@ struct SuggestionConfiguration: Equatable, Sendable {
     /// the app's starting value for a fresh install.
     let defaultCustomAIInstructions: String?
     let defaultWordCountPreset: SuggestionWordCountPreset
-    let defaultPromptMode: SuggestionPromptMode
 
     /// The configuration shipped by the app today.
     /// These are product defaults, not temporary debug overrides.
@@ -168,8 +140,7 @@ struct SuggestionConfiguration: Equatable, Sendable {
             My name is Jacob Fu. I usually write in English.
             Write in a friendly, professional and empathetic voice.
             """,
-        defaultWordCountPreset: .sevenToTwelve,
-        defaultPromptMode: .prefixOnly
+        defaultWordCountPreset: .sevenToTwelve
     )
 }
 
@@ -192,6 +163,10 @@ struct FocusedInputContext: Equatable, Sendable {
     let trailingText: String
     let selection: NSRange
     let isSecure: Bool
+    /// Carries the immutable focus-observation identity across debounce/generation boundaries.
+    /// Without this, later visual-context lookups could fall back to `elementIdentifier` alone and
+    /// reintroduce the CFHash collision class this sequence is meant to avoid.
+    let focusChangeSequence: UInt64
     let generation: UInt64
 
     init(snapshot: FocusedInputSnapshot, generation: UInt64) {
@@ -209,7 +184,15 @@ struct FocusedInputContext: Equatable, Sendable {
         trailingText = snapshot.trailingText
         selection = snapshot.selection
         isSecure = snapshot.isSecure
+        focusChangeSequence = snapshot.focusChangeSequence
         self.generation = generation
+    }
+
+    var identity: FocusedInputIdentity {
+        FocusedInputIdentity(
+            elementIdentifier: elementIdentifier,
+            focusChangeSequence: focusChangeSequence
+        )
     }
 
     /// Content-only fingerprint — mirrors `FocusedInputSnapshot.contentSignature`.
@@ -253,6 +236,8 @@ struct SuggestionRequest: Equatable, Sendable {
     /// Optional user-provided style guidance. We keep this separate from base product behavior so
     /// future settings/personalization work can evolve independently from prompt safety rules.
     let customAIInstructions: String?
+    /// Ephemeral screen context summary injected only when available for the active text field.
+    let visualContextSummary: String?
 }
 
 /// The engine's normalized response, including raw model text for debugging.

--- a/tabby/Models/SuggestionModels.swift
+++ b/tabby/Models/SuggestionModels.swift
@@ -379,7 +379,9 @@ enum OverlayState: Equatable {
         case let .hidden(reason):
             return reason
         case let .visible(text, caretRect, caretQuality):
-            return "Showing \(text.count) characters near (\(Int(caretRect.minX)), \(Int(caretRect.minY))) using \(caretQuality.label) caret geometry."
+            return "Showing \(text.count) characters near " +
+                "(\(Int(caretRect.minX)), \(Int(caretRect.minY))) " +
+                "using \(caretQuality.label) caret geometry."
         }
     }
 

--- a/tabby/Models/SuggestionSettingsModel.swift
+++ b/tabby/Models/SuggestionSettingsModel.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// File overview:
 /// Owns the durable autocomplete preferences that are shared across the app:
-/// engine selection, completion length, indicator appearance, prompt strategy, and custom
+/// engine selection, completion length, indicator appearance, and custom
 /// writing guidance.
 ///
 /// This type is the right owner for these values because they are product settings, not
@@ -17,7 +17,6 @@ final class SuggestionSettingsModel: ObservableObject {
     @Published private(set) var customSuggestionTextColorHex: String?
     @Published private(set) var selectedEngine: SuggestionEngineKind
     @Published private(set) var selectedWordCountPreset: SuggestionWordCountPreset
-    @Published private(set) var selectedLocalPromptMode: SuggestionPromptMode
     @Published private(set) var customAIInstructions: String
 
     private let userDefaults: UserDefaults
@@ -30,7 +29,6 @@ final class SuggestionSettingsModel: ObservableObject {
     private static let customSuggestionTextColorHexDefaultsKey = "tabbyCustomSuggestionTextColorHex"
     private static let selectedEngineDefaultsKey = "selectedSuggestionEngine"
     private static let selectedWordCountPresetDefaultsKey = "selectedSuggestionWordCountPreset"
-    private static let selectedLocalPromptModeDefaultsKey = "selectedLocalSuggestionPromptMode"
     private static let customAIInstructionsDefaultsKey = "tabbyCustomAIInstructions"
 
     init(
@@ -57,10 +55,6 @@ final class SuggestionSettingsModel: ObservableObject {
             .string(forKey: Self.selectedWordCountPresetDefaultsKey)
             .flatMap(SuggestionWordCountPreset.init(rawValue:))
             ?? configuration.defaultWordCountPreset
-        let resolvedLocalPromptMode = userDefaults
-            .string(forKey: Self.selectedLocalPromptModeDefaultsKey)
-            .flatMap(SuggestionPromptMode.init(rawValue:))
-            ?? configuration.defaultPromptMode
         let resolvedCustomAIInstructions: String = if userDefaults.object(forKey: Self.customAIInstructionsDefaultsKey) == nil {
             configuration.defaultCustomAIInstructions ?? ""
         } else {
@@ -73,7 +67,6 @@ final class SuggestionSettingsModel: ObservableObject {
         customSuggestionTextColorHex = resolvedCustomSuggestionTextColorHex
         selectedEngine = resolvedEngine
         selectedWordCountPreset = resolvedWordCountPreset
-        selectedLocalPromptMode = resolvedLocalPromptMode
         customAIInstructions = resolvedCustomAIInstructions
 
         userDefaults.set(resolvedGloballyEnabled, forKey: Self.isGloballyEnabledDefaultsKey)
@@ -82,7 +75,6 @@ final class SuggestionSettingsModel: ObservableObject {
         persistCustomSuggestionTextColorHex(resolvedCustomSuggestionTextColorHex)
         persistSelectedEngine(resolvedEngine)
         persistSelectedWordCountPreset(resolvedWordCountPreset)
-        persistSelectedLocalPromptMode(resolvedLocalPromptMode)
         persistCustomAIInstructions(resolvedCustomAIInstructions)
     }
 
@@ -92,24 +84,12 @@ final class SuggestionSettingsModel: ObservableObject {
         selectedIndicatorMode != .hidden
     }
 
-    var availablePromptModes: [SuggestionPromptMode] {
-        selectedEngine.supportedPromptModes
-    }
-
-    var effectivePromptMode: SuggestionPromptMode {
-        Self.effectivePromptMode(
-            engine: selectedEngine,
-            localPromptMode: selectedLocalPromptMode
-        )
-    }
-
     var snapshot: SuggestionSettingsSnapshot {
         SuggestionSettingsSnapshot(
             isGloballyEnabled: isGloballyEnabled,
             disabledAppBundleIdentifiers: Set(disabledAppRules.map(\.bundleIdentifier)),
             selectedEngine: selectedEngine,
             selectedWordCountPreset: selectedWordCountPreset,
-            effectivePromptMode: effectivePromptMode,
             customAIInstructions: CustomAIInstructionFormatter.normalized(customAIInstructions)
         )
     }
@@ -130,15 +110,6 @@ final class SuggestionSettingsModel: ObservableObject {
 
         selectedWordCountPreset = preset
         persistSelectedWordCountPreset(preset)
-    }
-
-    func selectLocalPromptMode(_ mode: SuggestionPromptMode) {
-        guard selectedLocalPromptMode != mode else {
-            return
-        }
-
-        selectedLocalPromptMode = mode
-        persistSelectedLocalPromptMode(mode)
     }
 
     func setGloballyEnabled(_ enabled: Bool) {
@@ -262,27 +233,12 @@ final class SuggestionSettingsModel: ObservableObject {
         persistCustomAIInstructions(instructions)
     }
 
-    private static func effectivePromptMode(
-        engine: SuggestionEngineKind,
-        localPromptMode: SuggestionPromptMode
-    ) -> SuggestionPromptMode {
-        if engine.supportedPromptModes.contains(localPromptMode) {
-            return localPromptMode
-        }
-
-        return engine.defaultPromptMode
-    }
-
     private func persistSelectedEngine(_ engine: SuggestionEngineKind) {
         userDefaults.set(engine.rawValue, forKey: Self.selectedEngineDefaultsKey)
     }
 
     private func persistSelectedWordCountPreset(_ preset: SuggestionWordCountPreset) {
         userDefaults.set(preset.rawValue, forKey: Self.selectedWordCountPresetDefaultsKey)
-    }
-
-    private func persistSelectedLocalPromptMode(_ mode: SuggestionPromptMode) {
-        userDefaults.set(mode.rawValue, forKey: Self.selectedLocalPromptModeDefaultsKey)
     }
 
     private func persistSelectedIndicatorMode(_ mode: ActivationIndicatorMode) {
@@ -403,27 +359,20 @@ final class SuggestionSettingsModel: ObservableObject {
 
 extension SuggestionSettingsModel: SuggestionSettingsProviding {
     var snapshotPublisher: AnyPublisher<SuggestionSettingsSnapshot, Never> {
-        Publishers.CombineLatest3(
-            Publishers.CombineLatest4(
-                $isGloballyEnabled,
-                $disabledAppRules,
-                $selectedEngine,
-                $selectedWordCountPreset
-            ),
-            $selectedLocalPromptMode,
-            $customAIInstructions
+        Publishers.CombineLatest4(
+            $isGloballyEnabled,
+            $disabledAppRules,
+            $selectedEngine,
+            $selectedWordCountPreset
         )
-        .map { combinedSettings, localPromptMode, customAIInstructions in
+        .combineLatest($customAIInstructions)
+        .map { combinedSettings, customAIInstructions in
             let (globallyEnabled, disabledAppRules, engine, wordCountPreset) = combinedSettings
             return SuggestionSettingsSnapshot(
                 isGloballyEnabled: globallyEnabled,
                 disabledAppBundleIdentifiers: Set(disabledAppRules.map(\.bundleIdentifier)),
                 selectedEngine: engine,
                 selectedWordCountPreset: wordCountPreset,
-                effectivePromptMode: Self.effectivePromptMode(
-                    engine: engine,
-                    localPromptMode: localPromptMode
-                ),
                 customAIInstructions: CustomAIInstructionFormatter.normalized(customAIInstructions)
             )
         }

--- a/tabby/Models/SuggestionSubsystemContracts.swift
+++ b/tabby/Models/SuggestionSubsystemContracts.swift
@@ -71,7 +71,7 @@ protocol VisualContextCoordinating: AnyObject {
     var status: VisualContextStatus { get }
     var latestExcerpt: String? { get }
     var onStateChange: ((VisualContextStatus, String?) -> Void)? { get set }
-    var onInjectedContextReady: ((String) -> Void)? { get set }
+    var onInjectedContextReady: ((FocusedInputIdentity) -> Void)? { get set }
 
     func startSessionIfNeeded(for snapshotContext: FocusedInputSnapshot)
     func cancel(resetState: Bool)

--- a/tabby/Models/VisualContextModels.swift
+++ b/tabby/Models/VisualContextModels.swift
@@ -6,10 +6,6 @@ import Foundation
 ///
 /// The design goal is to model screenshot context as session state, just like suggestion state.
 /// That makes stale-result handling and UI diagnostics much easier to reason about.
-///
-/// DEPRECATED:
-/// As of the guided-mode rebuild, prompt construction no longer consumes screenshot/OCR context.
-/// Keep these types as legacy scaffolding while the replacement context pipeline is designed.
 
 /// Tunables for converting a focused-input screenshot into OCR text for prompt injection.
 /// These values are intentionally separate from `SuggestionConfiguration` because they govern
@@ -19,15 +15,17 @@ struct VisualContextConfiguration: Equatable, Sendable {
     let maxImageDimension: Int
     let minRecognizedCharacterCount: Int
     let maxRecognizedCharacters: Int
+    let maxSummaryCharacters: Int
 
     static let `default` = VisualContextConfiguration(
         // Capture a compact area around the focused field instead of an entire window.
-        snapshotDimension: 400,
+        snapshotDimension: 500,
         // Retina screenshots may still arrive at ~2x backing scale, so keep a small OCR ceiling.
         maxImageDimension: 900,
         minRecognizedCharacterCount: 12,
         // OCR text is injected directly into the completion prompt, so keep it intentionally short.
-        maxRecognizedCharacters: 320
+        maxRecognizedCharacters: 2000,
+        maxSummaryCharacters: 900
     )
 }
 
@@ -38,6 +36,7 @@ enum VisualContextStatus: Equatable, Sendable {
     case idle
     case capturing
     case extractingText
+    case summarizingText
     case ready
     case unavailable(String)
     case failed(String)
@@ -50,6 +49,8 @@ enum VisualContextStatus: Equatable, Sendable {
             return "Capturing nearby screen content."
         case .extractingText:
             return "Extracting visible text from the screenshot."
+        case .summarizingText:
+            return "Summarizing visible text for context."
         case .ready:
             return "Nearby visible text is ready."
         case let .unavailable(reason), let .failed(reason):
@@ -58,8 +59,9 @@ enum VisualContextStatus: Equatable, Sendable {
     }
 }
 
-/// The normalized OCR excerpt eventually injected into the completion prompt.
-/// This is intentionally plain text, not a model-generated summary.
+/// The final visual-context excerpt eventually injected into the completion prompt.
+/// This may be a model-generated summary when a summarizer is configured, or bounded normalized
+/// OCR text in tests/fallback wiring where no summarizer exists.
 struct VisualContextExcerpt: Equatable, Sendable {
     let text: String
 }
@@ -70,6 +72,9 @@ struct VisualContextExcerpt: Equatable, Sendable {
 struct FocusedInputAugmentationSession: Equatable, Sendable {
     let sessionID: UUID
     let elementIdentifier: String
+    /// Mirrors the monotonic counter from `FocusedInputSnapshot`. The coordinator compares this
+    /// alongside `elementIdentifier` to avoid CFHash-recycling false positives.
+    let focusChangeSequence: UInt64
     var status: VisualContextStatus
     var excerpt: VisualContextExcerpt?
 }

--- a/tabby/Services/Focus/AXTextGeometryResolver.swift
+++ b/tabby/Services/Focus/AXTextGeometryResolver.swift
@@ -61,8 +61,7 @@ struct AXTextGeometryResolver {
                 for: kAXBoundsForRangeParameterizedAttribute as CFString,
                 range: NSRange(location: selection.location, length: 0),
                 on: element
-            ), !rect.isEmpty
-        {
+            ), !rect.isEmpty {
             let cocoaRect = AXHelper.validatedCocoaTextRect(
                 fromAccessibilityRect: rect,
                 anchorFrame: cocoaAnchorFrame
@@ -94,8 +93,7 @@ struct AXTextGeometryResolver {
                 for: kAXBoundsForRangeParameterizedAttribute as CFString,
                 range: NSRange(location: selection.location - 1, length: 1),
                 on: element
-            ), !rect.isEmpty
-        {
+            ), !rect.isEmpty {
             let cocoaRect = AXHelper.validatedCocoaTextRect(
                 fromAccessibilityRect: rect,
                 anchorFrame: cocoaAnchorFrame
@@ -123,8 +121,7 @@ struct AXTextGeometryResolver {
 
         // Branch 3: AXFrame fallback — no text-range data available, estimate from element bounds.
         if supportsFrame,
-            let frame = AXHelper.rectValue(for: "AXFrame" as CFString, on: element), !frame.isEmpty
-        {
+            let frame = AXHelper.rectValue(for: "AXFrame" as CFString, on: element), !frame.isEmpty {
             let cocoaRect = AXHelper.cocoaRect(fromAccessibilityRect: frame)
             if cocoaRect.width > 10, let text = textValue {
                 let estimatedX = conservativeEstimatedCaretX(
@@ -267,8 +264,7 @@ struct AXTextGeometryResolver {
                 let text = AXHelper.stringValue(for: kAXValueAttribute as CFString, on: element),
                 !text.isEmpty,
                 let frame = AXHelper.rectValue(for: "AXFrame" as CFString, on: element),
-                !frame.isEmpty
-            {
+                !frame.isEmpty {
                 runs.append((text, frame))
             }
 

--- a/tabby/Services/Focus/FocusSnapshotResolver.swift
+++ b/tabby/Services/Focus/FocusSnapshotResolver.swift
@@ -12,7 +12,7 @@ struct FocusSnapshotResolver {
 
     // MARK: - Debug AX tree dump (temporary — remove after caret placement is fixed)
     /// Set to true to print the AX tree every time focus changes. Check Xcode console.
-    private static let dumpAXTree = true
+    private static let dumpAXTree = false
     private static var lastDumpedElementID: String?
 
     init(geometryResolver: AXTextGeometryResolver? = nil) {
@@ -20,9 +20,14 @@ struct FocusSnapshotResolver {
     }
 
     /// Resolves the best editable candidate around the focused AX node and materializes a focus snapshot.
+    ///
+    /// `focusChangeSequence` is a monotonic counter owned by `FocusTracker`. The resolver threads
+    /// it into the resulting `FocusedInputSnapshot` so downstream consumers can detect field
+    /// switches even when `CFHash`-based `elementIdentifier` collides across recycled AX nodes.
     func resolveSnapshot(
         focusedElement: AXUIElement,
-        application: NSRunningApplication
+        application: NSRunningApplication,
+        focusChangeSequence: UInt64 = 0
     ) -> FocusSnapshot {
         let applicationName = application.localizedName ?? "Unknown"
         let bundleIdentifier = application.bundleIdentifier ?? "unknown.bundle"
@@ -162,7 +167,8 @@ struct FocusSnapshotResolver {
             precedingText: nsValue.substring(to: safeSelectionLocation),
             trailingText: nsValue.substring(from: trailingStart),
             selection: selection,
-            isSecure: resolvedCandidate.isSecure
+            isSecure: resolvedCandidate.isSecure,
+            focusChangeSequence: focusChangeSequence
         )
 
         if resolvedCandidate.isSecure {
@@ -384,10 +390,38 @@ struct FocusSnapshotResolver {
             supportedAttributes.contains(kAXSelectedTextRangeAttribute as String)
             ? AXHelper.rangeValue(for: kAXSelectedTextRangeAttribute as CFString, on: element)
             : nil
-        let inputFrameRect =
+        var inputFrameRect =
             supportedAttributes.contains("AXFrame")
             ? geometryResolver.resolveInputFrameRect(for: element)
             : nil
+
+        if let currentFrame = inputFrameRect {
+            var finalWidth = currentFrame.width
+            var finalX = currentFrame.minX
+
+            // Optimization: grab the parent container's width if the active element is narrow
+            // so we capture the whole input bar context (e.g. Discord/Slack dynamically sized nodes).
+            if let parent = AXHelper.parentElement(of: element),
+               let parentFrame = AXHelper.rectValue(for: "AXFrame" as CFString, on: parent) {
+                let parentCocoa = AXHelper.cocoaRect(fromAccessibilityRect: parentFrame)
+                if parentCocoa.width > finalWidth {
+                    finalWidth = parentCocoa.width
+                    finalX = parentCocoa.minX
+                }
+            }
+
+            // Enforce a minimum width to ensure we get a decent horizontal slice.
+            if finalWidth < 500 {
+                finalWidth = max(finalWidth, 500)
+            }
+
+            inputFrameRect = CGRect(
+                x: finalX,
+                y: currentFrame.minY,
+                width: finalWidth,
+                height: currentFrame.height
+            )
+        }
         let caretResult = selection.flatMap {
             geometryResolver.resolveCaretRect(
                 for: element,

--- a/tabby/Services/Focus/FocusSnapshotResolver.swift
+++ b/tabby/Services/Focus/FocusSnapshotResolver.swift
@@ -119,8 +119,7 @@ struct FocusSnapshotResolver {
         let caretQuality: CaretGeometryQuality
         let observedCharWidth: CGFloat?
         if let primary = resolvedCandidate.caretRect,
-            resolvedCandidate.caretQuality == .exact || resolvedCandidate.caretQuality == .derived
-        {
+            resolvedCandidate.caretQuality == .exact || resolvedCandidate.caretQuality == .derived {
             caretRect = primary
             caretSource = "\(resolvedCandidate.caretQuality!.label) primary"
             caretQuality = resolvedCandidate.caretQuality!
@@ -371,8 +370,7 @@ struct FocusSnapshotResolver {
 
     /// Extracts the AX properties Tabby needs from one candidate element near the current focus.
     private func candidateSnapshot(for element: AXUIElement, bundleIdentifier: String)
-        -> AXFocusCandidate
-    {
+        -> AXFocusCandidate {
         let role = AXHelper.stringValue(for: kAXRoleAttribute as CFString, on: element) ?? "Unknown"
         let subrole = AXHelper.stringValue(for: kAXSubroleAttribute as CFString, on: element)
         let supportedAttributes = Set(AXHelper.attributeNames(on: element))
@@ -477,7 +475,7 @@ struct FocusSnapshotResolver {
             AXHelper.stringValue(for: kAXDescriptionAttribute as CFString, on: element)?
                 .lowercased() ?? "",
             AXHelper.stringValue(for: kAXTitleAttribute as CFString, on: element)?.lowercased()
-                ?? "",
+                ?? ""
         ]
 
         return secureMarkers.contains { marker in
@@ -493,15 +491,15 @@ struct FocusSnapshotResolver {
 
         out += "-- Focused + ancestors --\n"
         var ancestors: [AXUIElement] = [focusedElement]
-        var cur = focusedElement
+        var currentElement = focusedElement
         for _ in 0..<3 {
-            guard let p = AXHelper.parentElement(of: cur) else { break }
-            ancestors.append(p)
-            cur = p
+            guard let parent = AXHelper.parentElement(of: currentElement) else { break }
+            ancestors.append(parent)
+            currentElement = parent
         }
-        for (i, el) in ancestors.enumerated().reversed() {
-            let indent = String(repeating: "  ", count: ancestors.count - 1 - i)
-            out += describeNode(el, indent: indent)
+        for (offset, element) in ancestors.enumerated().reversed() {
+            let indent = String(repeating: "  ", count: ancestors.count - 1 - offset)
+            out += describeNode(element, indent: indent)
         }
 
         out += "\n-- Children (depth 6) --\n"
@@ -519,8 +517,8 @@ struct FocusSnapshotResolver {
     ) {
         guard depth < 6 else { return }
         let children = AXHelper.childElements(of: element)
-        for (i, child) in children.prefix(20).enumerated() {
-            out += describeNode(child, indent: "\(indent)[\(i)] ")
+        for (offset, child) in children.prefix(20).enumerated() {
+            out += describeNode(child, indent: "\(indent)[\(offset)] ")
             dumpChildrenRecursive(of: child, into: &out, indent: indent + "  ", depth: depth + 1)
         }
         if children.count > 20 {
@@ -528,62 +526,62 @@ struct FocusSnapshotResolver {
         }
     }
 
-    private func describeNode(_ el: AXUIElement, indent: String) -> String {
-        let role = AXHelper.stringValue(for: kAXRoleAttribute as CFString, on: el) ?? "?"
-        let subrole = AXHelper.stringValue(for: kAXSubroleAttribute as CFString, on: el)
-        let attrs = Set(AXHelper.attributeNames(on: el))
-        let paramAttrs = Set(AXHelper.parameterizedAttributeNames(on: el))
+    private func describeNode(_ element: AXUIElement, indent: String) -> String {
+        let role = AXHelper.stringValue(for: kAXRoleAttribute as CFString, on: element) ?? "?"
+        let subrole = AXHelper.stringValue(for: kAXSubroleAttribute as CFString, on: element)
+        let attributes = Set(AXHelper.attributeNames(on: element))
+        let parameterizedAttributes = Set(AXHelper.parameterizedAttributeNames(on: element))
 
-        var s = "\(indent)\(role)"
-        if let sr = subrole { s += " (\(sr))" }
-        s += "\n"
+        var summary = "\(indent)\(role)"
+        if let subrole { summary += " (\(subrole))" }
+        summary += "\n"
 
-        if let frame = AXHelper.rectValue(for: "AXFrame" as CFString, on: el) {
+        if let frame = AXHelper.rectValue(for: "AXFrame" as CFString, on: element) {
             let cocoa = AXHelper.cocoaRect(fromAccessibilityRect: frame)
-            s += "\(indent)  frame(AX): \(fmt(frame))  frame(cocoa): \(fmt(cocoa))\n"
+            summary += "\(indent)  frame(AX): \(fmt(frame))  frame(cocoa): \(fmt(cocoa))\n"
         }
 
-        if attrs.contains(kAXValueAttribute as String),
-            let text = AXHelper.stringValue(for: kAXValueAttribute as CFString, on: el)
-        {
-            let t = text.count > 80 ? String(text.prefix(80)) + "…" : text
-            s +=
-                "\(indent)  value: \"\(t.replacingOccurrences(of: "\n", with: "\\n"))\" (len=\(text.count))\n"
+        if attributes.contains(kAXValueAttribute as String),
+            let text = AXHelper.stringValue(for: kAXValueAttribute as CFString, on: element) {
+            let previewText = text.count > 80 ? String(text.prefix(80)) + "…" : text
+            summary += "\(indent)  value: " +
+                "\"\(previewText.replacingOccurrences(of: "\n", with: "\\n"))\" " +
+                "(len=\(text.count))\n"
         }
 
-        if let range = AXHelper.rangeValue(for: kAXSelectedTextRangeAttribute as CFString, on: el) {
-            s += "\(indent)  selection: loc=\(range.location) len=\(range.length)\n"
+        if let range = AXHelper.rangeValue(for: kAXSelectedTextRangeAttribute as CFString, on: element) {
+            summary += "\(indent)  selection: loc=\(range.location) len=\(range.length)\n"
 
-            if paramAttrs.contains(kAXBoundsForRangeParameterizedAttribute as String) {
-                let r = AXHelper.parameterizedRectValue(
+            if parameterizedAttributes.contains(kAXBoundsForRangeParameterizedAttribute as String) {
+                let boundsRect = AXHelper.parameterizedRectValue(
                     for: kAXBoundsForRangeParameterizedAttribute as CFString,
                     range: NSRange(location: range.location, length: 0),
-                    on: el
+                    on: element
                 )
-                if let r, !r.isEmpty {
-                    s += "\(indent)  BoundsForRange(loc,0): \(fmt(r))\n"
+                if let boundsRect, !boundsRect.isEmpty {
+                    summary += "\(indent)  BoundsForRange(loc,0): \(fmt(boundsRect))\n"
                 } else {
-                    s += "\(indent)  BoundsForRange(loc,0): FAILED\n"
+                    summary += "\(indent)  BoundsForRange(loc,0): FAILED\n"
                 }
             }
         }
 
-        if let mr = AXHelper.textMarkerCaretRect(on: el), !mr.isEmpty {
-            s += "\(indent)  TextMarkerCaret: \(fmt(mr))\n"
+        if let markerRect = AXHelper.textMarkerCaretRect(on: element), !markerRect.isEmpty {
+            summary += "\(indent)  TextMarkerCaret: \(fmt(markerRect))\n"
         }
 
-        if let ed = AXHelper.boolValue(for: "AXEditable" as CFString, on: el) {
-            s += "\(indent)  editable: \(ed)\n"
+        if let isEditable = AXHelper.boolValue(for: "AXEditable" as CFString, on: element) {
+            summary += "\(indent)  editable: \(isEditable)\n"
         }
 
-        let cc = AXHelper.childElements(of: el).count
-        if cc > 0 { s += "\(indent)  children: \(cc)\n" }
+        let childCount = AXHelper.childElements(of: element).count
+        if childCount > 0 { summary += "\(indent)  children: \(childCount)\n" }
 
-        return s
+        return summary
     }
 
-    private func fmt(_ r: CGRect) -> String {
-        String(format: "(%.0f, %.0f, %.0f×%.0f)", r.origin.x, r.origin.y, r.width, r.height)
+    private func fmt(_ rect: CGRect) -> String {
+        String(format: "(%.0f, %.0f, %.0f×%.0f)", rect.origin.x, rect.origin.y, rect.width, rect.height)
     }
 }
 

--- a/tabby/Services/Focus/FocusTracker.swift
+++ b/tabby/Services/Focus/FocusTracker.swift
@@ -27,13 +27,13 @@ final class FocusTracker {
         static let application: [CFString] = [
             kAXFocusedUIElementChangedNotification as CFString,
             kAXFocusedWindowChangedNotification as CFString,
-            kAXApplicationDeactivatedNotification as CFString,
+            kAXApplicationDeactivatedNotification as CFString
         ]
 
         static let focusedElement: [CFString] = [
             kAXValueChangedNotification as CFString,
             kAXSelectedTextChangedNotification as CFString,
-            kAXUIElementDestroyedNotification as CFString,
+            kAXUIElementDestroyedNotification as CFString
         ]
     }
 
@@ -142,7 +142,7 @@ final class FocusTracker {
         let focusChangingNotifications: Set<String> = [
             kAXFocusedUIElementChangedNotification as String,
             kAXFocusedWindowChangedNotification as String,
-            kAXApplicationDeactivatedNotification as String,
+            kAXApplicationDeactivatedNotification as String
         ]
         if focusChangingNotifications.contains(notificationName) {
             focusChangeSequence += 1
@@ -273,8 +273,7 @@ final class FocusTracker {
         }
 
         if let observedFocusedElement,
-           AXHelper.elementIdentity(for: observedFocusedElement) == AXHelper.elementIdentity(for: focusedElement)
-        {
+           AXHelper.elementIdentity(for: observedFocusedElement) == AXHelper.elementIdentity(for: focusedElement) {
             return
         }
 

--- a/tabby/Services/Focus/FocusTracker.swift
+++ b/tabby/Services/Focus/FocusTracker.swift
@@ -59,6 +59,15 @@ final class FocusTracker {
     private var workspaceActivationObserver: NSObjectProtocol?
     private var scheduledRefreshTask: Task<Void, Never>?
 
+    /// Monotonic counter that increments every time a focus-changing AX notification fires.
+    ///
+    /// AX element identity is based on `CFHash`, which macOS can recycle across unrelated
+    /// elements. This counter gives downstream consumers a guaranteed-unique signal that
+    /// focus actually changed, independent of hash collisions. It only increments on
+    /// notifications that signal a *new element or window* — value and selection changes
+    /// within the same field do not bump it.
+    private var focusChangeSequence: UInt64 = 0
+
     init(
         permissionProvider: @escaping @MainActor () -> Bool,
         ignoredBundleIdentifier: String?,
@@ -84,10 +93,15 @@ final class FocusTracker {
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor [weak self] in
+                // Switching apps is always a focus change.
+                self?.focusChangeSequence += 1
                 self?.refreshNow()
             }
         }
 
+        // The initial observation counts as a focus change so the first snapshot always
+        // carries a non-zero sequence, distinguishing it from the default 0.
+        focusChangeSequence += 1
         refreshNow()
     }
 
@@ -121,6 +135,18 @@ final class FocusTracker {
 
     fileprivate func handleAXNotification(named notificationName: String) {
         onAXNotification?(notificationName)
+
+        // Only focus-changing notifications bump the sequence. Value/selection changes within
+        // the same field should not, because the visual-context coordinator uses this counter
+        // to decide whether to start a new OCR session.
+        let focusChangingNotifications: Set<String> = [
+            kAXFocusedUIElementChangedNotification as String,
+            kAXFocusedWindowChangedNotification as String,
+            kAXApplicationDeactivatedNotification as String,
+        ]
+        if focusChangingNotifications.contains(notificationName) {
+            focusChangeSequence += 1
+        }
 
         if notificationName == kAXApplicationDeactivatedNotification as String {
             scheduleRefresh(after: 0)
@@ -207,7 +233,8 @@ final class FocusTracker {
         return FocusCaptureResult(
             snapshot: snapshotResolver.resolveSnapshot(
                 focusedElement: focusedElement,
-                application: application
+                application: application,
+                focusChangeSequence: focusChangeSequence
             ),
             focusedElement: focusedElement
         )

--- a/tabby/Services/Input/InputMonitor.swift
+++ b/tabby/Services/Input/InputMonitor.swift
@@ -139,7 +139,8 @@ final class InputMonitor {
         let characters = event.unicodeString
 
         // Key code 48 is the hardware Tab key on macOS keyboard events.
-        if keyCode == 48, flags.intersection([.maskCommand, .maskControl, .maskAlternate, .maskShift]).isEmpty {
+        if keyCode == 48,
+           flags.isDisjoint(with: [.maskCommand, .maskControl, .maskAlternate, .maskShift]) {
             return CapturedInputEvent(kind: .tab, keyCode: keyCode, characters: characters, flags: flags)
         }
 

--- a/tabby/Services/Permission/PermissionManager.swift
+++ b/tabby/Services/Permission/PermissionManager.swift
@@ -51,10 +51,10 @@ final class PermissionManager: ObservableObject {
         }
     }
 
-    /// Core autocomplete depends on Accessibility plus Input Monitoring.
+    /// Core autocomplete depends on Accessibility, Input Monitoring, and Screen Recording.
     ///
-    /// Screen Recording stays tracked here because legacy visual-context experiments still depend on
-    /// it, but it is not part of the required "Tabby basically works" definition.
+    /// Screen Recording was historically optional, but is now a core requirement for providing
+    /// visual context to the autocomplete engine.
     var requiredPermissionsGranted: Bool {
         TabbyPermissionKind.allCases
             .filter(\.isRequiredForAutocomplete)

--- a/tabby/Services/Permission/SystemSettingsWindowLocator.swift
+++ b/tabby/Services/Permission/SystemSettingsWindowLocator.swift
@@ -18,6 +18,12 @@ struct SystemSettingsWindowSnapshot: Equatable {
 enum SystemSettingsWindowLocator {
     static let bundleIdentifier = "com.apple.systempreferences"
 
+    private struct ScreenGeometry {
+        let frame: CGRect
+        let visibleFrame: CGRect
+        let displayBounds: CGRect
+    }
+
     static var isFrontmost: Bool {
         NSWorkspace.shared.frontmostApplication?.bundleIdentifier == bundleIdentifier
     }
@@ -81,12 +87,12 @@ enum SystemSettingsWindowLocator {
     }
 
     private static func appKitGeometry(from coreGraphicsFrame: CGRect) -> (frame: CGRect, visibleFrame: CGRect) {
-        let screens = NSScreen.screens.compactMap { screen -> (frame: CGRect, visibleFrame: CGRect, displayBounds: CGRect)? in
+        let screens = NSScreen.screens.compactMap { screen -> ScreenGeometry? in
             guard let number = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber else {
                 return nil
             }
             let displayID = CGDirectDisplayID(number.uint32Value)
-            return (
+            return ScreenGeometry(
                 frame: screen.frame,
                 visibleFrame: screen.visibleFrame,
                 displayBounds: CGDisplayBounds(displayID)
@@ -96,8 +102,8 @@ enum SystemSettingsWindowLocator {
         let matchedScreen = screens
             .filter { $0.displayBounds.intersects(coreGraphicsFrame) }
             .max { lhs, rhs in
-                lhs.displayBounds.intersection(coreGraphicsFrame).width * lhs.displayBounds.intersection(coreGraphicsFrame).height
-                    < rhs.displayBounds.intersection(coreGraphicsFrame).width * rhs.displayBounds.intersection(coreGraphicsFrame).height
+                intersectionArea(lhs.displayBounds, coreGraphicsFrame)
+                    < intersectionArea(rhs.displayBounds, coreGraphicsFrame)
             }
 
         guard let matchedScreen else {
@@ -115,5 +121,10 @@ enum SystemSettingsWindowLocator {
         )
 
         return (frame: frame, visibleFrame: matchedScreen.visibleFrame)
+    }
+
+    private static func intersectionArea(_ lhs: CGRect, _ rhs: CGRect) -> CGFloat {
+        let intersection = lhs.intersection(rhs)
+        return intersection.width * intersection.height
     }
 }

--- a/tabby/Services/Runtime/LlamaRuntimeCore.swift
+++ b/tabby/Services/Runtime/LlamaRuntimeCore.swift
@@ -48,6 +48,13 @@ actor LlamaRuntimeCore {
         var samplingFingerprint: SamplingFingerprint
     }
 
+    private struct PromptContextRequest {
+        let promptBytes: [UInt8]
+        let promptTokens: [llama_token]
+        let samplingFingerprint: SamplingFingerprint
+        let cachedPrefixBytes: Int?
+    }
+
     /// Generation knobs that intentionally break KV reuse when changed.
     /// The prompt KV itself is mostly independent from the sampler, but the product contract for
     /// this optimization is stricter: a different sampling configuration starts a clean context.
@@ -59,6 +66,16 @@ actor LlamaRuntimeCore {
         let minP: Double
         let repetitionPenalty: Double
         let seed: UInt32?
+
+        init(options: LlamaGenerationOptions) {
+            maxPredictionTokens = options.maxPredictionTokens
+            temperature = options.temperature
+            topK = options.topK
+            topP = options.topP
+            minP = options.minP
+            repetitionPenalty = options.repetitionPenalty
+            seed = options.seed
+        }
     }
 
     /// Loads the requested model once and records the runtime characteristics needed for diagnostics.
@@ -67,8 +84,7 @@ actor LlamaRuntimeCore {
         configuration: LlamaRuntimeConfiguration
     ) throws -> PreparedLlamaRuntime {
         if let preparedRuntime,
-           preparedRuntime.resolvedRuntime.modelFileURL == resolvedRuntime.modelFileURL
-        {
+           preparedRuntime.resolvedRuntime.modelFileURL == resolvedRuntime.modelFileURL {
             return preparedRuntime
         }
 
@@ -114,13 +130,7 @@ actor LlamaRuntimeCore {
     func generate(
         prompt: String,
         cachedPrefixBytes: Int? = nil,
-        maxPredictionTokens: Int,
-        temperature: Double,
-        topK: Int,
-        topP: Double,
-        minP: Double,
-        repetitionPenalty: Double,
-        seed: UInt32? = nil
+        options: LlamaGenerationOptions
     ) throws -> String {
         guard let preparedRuntime else {
             throw LlamaRuntimeError.unavailable("The llama model is not loaded.")
@@ -135,33 +145,19 @@ actor LlamaRuntimeCore {
         }
 
         let promptTokens = try tokenize(prompt, vocab: vocab)
-        let samplingFingerprint = SamplingFingerprint(
-            maxPredictionTokens: maxPredictionTokens,
-            temperature: temperature,
-            topK: topK,
-            topP: topP,
-            minP: minP,
-            repetitionPenalty: repetitionPenalty,
-            seed: seed
+        let contextRequest = PromptContextRequest(
+            promptBytes: Array(prompt.utf8),
+            promptTokens: promptTokens,
+            samplingFingerprint: SamplingFingerprint(options: options),
+            cachedPrefixBytes: cachedPrefixBytes
         )
-        let promptBytes = Array(prompt.utf8)
         let context = try preparePromptContext(
             model: model,
             preparedRuntime: preparedRuntime,
-            promptBytes: promptBytes,
-            promptTokens: promptTokens,
-            samplingFingerprint: samplingFingerprint,
-            cachedPrefixBytes: cachedPrefixBytes
+            request: contextRequest
         )
 
-        let sampler = try makeSampler(
-            temperature: temperature,
-            topK: topK,
-            topP: topP,
-            minP: minP,
-            repetitionPenalty: repetitionPenalty,
-            seed: seed
-        )
+        let sampler = try makeSampler(options: options)
         defer { llama_sampler_free(sampler) }
 
         var generatedText = ""
@@ -177,7 +173,7 @@ actor LlamaRuntimeCore {
         }
 
         do {
-            for _ in 0 ..< maxPredictionTokens {
+            for _ in 0 ..< options.maxPredictionTokens {
                 let nextToken = llama_sampler_sample(sampler, context, -1)
                 if nextToken == llama_vocab_eos(vocab) || llama_vocab_is_eog(vocab, nextToken) {
                     break
@@ -240,58 +236,55 @@ actor LlamaRuntimeCore {
     private func preparePromptContext(
         model: OpaquePointer,
         preparedRuntime: PreparedLlamaRuntime,
-        promptBytes: [UInt8],
-        promptTokens: [llama_token],
-        samplingFingerprint: SamplingFingerprint,
-        cachedPrefixBytes: Int?
+        request: PromptContextRequest
     ) throws -> OpaquePointer {
-        guard let cachedPrefixBytes,
+        guard let cachedPrefixBytes = request.cachedPrefixBytes,
               cachedPrefixBytes > 0,
               let cache = promptCache,
-              cache.samplingFingerprint == samplingFingerprint
+              cache.samplingFingerprint == request.samplingFingerprint
         else {
             return try rebuildPromptContext(
                 model: model,
                 preparedRuntime: preparedRuntime,
-                promptBytes: promptBytes,
-                promptTokens: promptTokens,
-                samplingFingerprint: samplingFingerprint
+                promptBytes: request.promptBytes,
+                promptTokens: request.promptTokens,
+                samplingFingerprint: request.samplingFingerprint
             )
         }
 
         let confirmedCommonBytes = min(
             cachedPrefixBytes,
-            Self.commonPrefixCount(cache.promptBytes, promptBytes)
+            Self.commonPrefixCount(cache.promptBytes, request.promptBytes)
         )
         guard confirmedCommonBytes > 0 else {
             return try rebuildPromptContext(
                 model: model,
                 preparedRuntime: preparedRuntime,
-                promptBytes: promptBytes,
-                promptTokens: promptTokens,
-                samplingFingerprint: samplingFingerprint
+                promptBytes: request.promptBytes,
+                promptTokens: request.promptTokens,
+                samplingFingerprint: request.samplingFingerprint
             )
         }
 
-        let commonTokenPrefix = Self.commonPrefixCount(cache.promptTokens, promptTokens)
+        let commonTokenPrefix = Self.commonPrefixCount(cache.promptTokens, request.promptTokens)
         let reusableTokenCount = Self.reusableTokenCount(
             commonTokenPrefix: commonTokenPrefix,
-            newPromptTokenCount: promptTokens.count
+            newPromptTokenCount: request.promptTokens.count
         )
 
         guard trimCachedTokens(from: reusableTokenCount, in: cache.context) else {
             return try rebuildPromptContext(
                 model: model,
                 preparedRuntime: preparedRuntime,
-                promptBytes: promptBytes,
-                promptTokens: promptTokens,
-                samplingFingerprint: samplingFingerprint
+                promptBytes: request.promptBytes,
+                promptTokens: request.promptTokens,
+                samplingFingerprint: request.samplingFingerprint
             )
         }
 
         do {
             try decodePrompt(
-                promptTokens,
+                request.promptTokens,
                 startingAt: reusableTokenCount,
                 in: cache.context,
                 batchCapacity: preparedRuntime.batchSize
@@ -303,9 +296,9 @@ actor LlamaRuntimeCore {
 
         promptCache = PromptCache(
             context: cache.context,
-            promptBytes: promptBytes,
-            promptTokens: promptTokens,
-            samplingFingerprint: samplingFingerprint
+            promptBytes: request.promptBytes,
+            promptTokens: request.promptTokens,
+            samplingFingerprint: request.samplingFingerprint
         )
         return cache.context
     }
@@ -488,66 +481,84 @@ actor LlamaRuntimeCore {
     }
 
     /// Assembles the sampler chain that controls temperature, nucleus sampling, and repetition behavior.
-    private func makeSampler(
-        temperature: Double,
-        topK: Int,
-        topP: Double,
-        minP: Double,
-        repetitionPenalty: Double,
-        seed: UInt32?
-    ) throws -> UnsafeMutablePointer<llama_sampler> {
+    private func makeSampler(options: LlamaGenerationOptions) throws -> UnsafeMutablePointer<llama_sampler> {
         let params = llama_sampler_chain_default_params()
         guard let sampler = llama_sampler_chain_init(params) else {
             throw LlamaRuntimeError.generationFailed("Unable to initialize the llama sampler chain.")
         }
 
-        if repetitionPenalty > 1.0 {
-            guard let penaltySampler = llama_sampler_init_penalties(64, Float(repetitionPenalty), 1.0, 1.0) else {
-                throw LlamaRuntimeError.generationFailed("Unable to initialize the repetition penalty sampler.")
-            }
-            llama_sampler_chain_add(sampler, penaltySampler)
-        }
+        try addPenaltySamplerIfNeeded(to: sampler, repetitionPenalty: options.repetitionPenalty)
 
-        if temperature > 0 {
-            guard let temperatureSampler = llama_sampler_init_temp(Float(temperature)) else {
-                throw LlamaRuntimeError.generationFailed("Unable to initialize the temperature sampler.")
-            }
-            llama_sampler_chain_add(sampler, temperatureSampler)
-
-            if topK > 0 {
-                guard let topKSampler = llama_sampler_init_top_k(Int32(topK)) else {
-                    throw LlamaRuntimeError.generationFailed("Unable to initialize the top-k sampler.")
-                }
-                llama_sampler_chain_add(sampler, topKSampler)
-            }
-
-            if minP > 0 && minP < 1 {
-                guard let minPSampler = llama_sampler_init_min_p(Float(minP), 1) else {
-                    throw LlamaRuntimeError.generationFailed("Unable to initialize the min-p sampler.")
-                }
-                llama_sampler_chain_add(sampler, minPSampler)
-            }
-
-            if topP > 0 && topP < 1 {
-                guard let topPSampler = llama_sampler_init_top_p(Float(topP), 1) else {
-                    throw LlamaRuntimeError.generationFailed("Unable to initialize the top-p sampler.")
-                }
-                llama_sampler_chain_add(sampler, topPSampler)
-            }
-
-            let resolvedSeed = seed ?? UInt32.random(in: UInt32.min ... UInt32.max)
-            guard let distributionSampler = llama_sampler_init_dist(resolvedSeed) else {
-                throw LlamaRuntimeError.generationFailed("Unable to initialize the distribution sampler.")
-            }
-            llama_sampler_chain_add(sampler, distributionSampler)
+        if options.temperature > 0 {
+            try addRandomSamplingChain(to: sampler, options: options)
         } else {
-            guard let greedySampler = llama_sampler_init_greedy() else {
-                throw LlamaRuntimeError.generationFailed("Unable to initialize the greedy sampler.")
-            }
-            llama_sampler_chain_add(sampler, greedySampler)
+            try addGreedySampler(to: sampler)
         }
 
         return sampler
+    }
+
+    private func addPenaltySamplerIfNeeded(
+        to sampler: UnsafeMutablePointer<llama_sampler>,
+        repetitionPenalty: Double
+    ) throws {
+        guard repetitionPenalty > 1.0 else {
+            return
+        }
+
+        guard let penaltySampler = llama_sampler_init_penalties(
+            64,
+            Float(repetitionPenalty),
+            1.0,
+            1.0
+        ) else {
+            throw LlamaRuntimeError.generationFailed("Unable to initialize the repetition penalty sampler.")
+        }
+        llama_sampler_chain_add(sampler, penaltySampler)
+    }
+
+    private func addRandomSamplingChain(
+        to sampler: UnsafeMutablePointer<llama_sampler>,
+        options: LlamaGenerationOptions
+    ) throws {
+        guard let temperatureSampler = llama_sampler_init_temp(Float(options.temperature)) else {
+            throw LlamaRuntimeError.generationFailed("Unable to initialize the temperature sampler.")
+        }
+        llama_sampler_chain_add(sampler, temperatureSampler)
+
+        if options.topK > 0 {
+            guard let topKSampler = llama_sampler_init_top_k(Int32(options.topK)) else {
+                throw LlamaRuntimeError.generationFailed("Unable to initialize the top-k sampler.")
+            }
+            llama_sampler_chain_add(sampler, topKSampler)
+        }
+
+        if options.minP > 0 && options.minP < 1 {
+            guard let minPSampler = llama_sampler_init_min_p(Float(options.minP), 1) else {
+                throw LlamaRuntimeError.generationFailed("Unable to initialize the min-p sampler.")
+            }
+            llama_sampler_chain_add(sampler, minPSampler)
+        }
+
+        if options.topP > 0 && options.topP < 1 {
+            guard let topPSampler = llama_sampler_init_top_p(Float(options.topP), 1) else {
+                throw LlamaRuntimeError.generationFailed("Unable to initialize the top-p sampler.")
+            }
+            llama_sampler_chain_add(sampler, topPSampler)
+        }
+
+        let resolvedSeed = options.seed ?? UInt32.random(in: UInt32.min ... UInt32.max)
+        guard let distributionSampler = llama_sampler_init_dist(resolvedSeed) else {
+            throw LlamaRuntimeError.generationFailed("Unable to initialize the distribution sampler.")
+        }
+        llama_sampler_chain_add(sampler, distributionSampler)
+    }
+
+    private func addGreedySampler(to sampler: UnsafeMutablePointer<llama_sampler>) throws {
+        guard let greedySampler = llama_sampler_init_greedy() else {
+            throw LlamaRuntimeError.generationFailed("Unable to initialize the greedy sampler.")
+        }
+        llama_sampler_chain_add(sampler, greedySampler)
     }
 
     /// Removes tokens at and after `position` from the prompt sequence.
@@ -612,7 +623,7 @@ actor LlamaRuntimeCore {
             }
 
             let bytes = buffer.prefix(Int(written)).map { UInt8(bitPattern: $0) }
-            return String(decoding: bytes, as: UTF8.self)
+            return String(bytes: bytes, encoding: .utf8) ?? ""
         }
     }
 }
@@ -621,8 +632,7 @@ extension LlamaRuntimeCore {
     /// Generates a summary without reading or modifying the global KV prompt cache.
     func summarize(
         prompt: String,
-        maxPredictionTokens: Int,
-        temperature: Double
+        options: LlamaGenerationOptions
     ) throws -> String {
         guard let preparedRuntime else {
             throw LlamaRuntimeError.unavailable("The llama model is not loaded.")
@@ -651,20 +661,13 @@ extension LlamaRuntimeCore {
             batchCapacity: preparedRuntime.batchSize
         )
 
-        let sampler = try makeSampler(
-            temperature: temperature,
-            topK: 40,
-            topP: 0.95,
-            minP: 0.05,
-            repetitionPenalty: 1.1,
-            seed: nil
-        )
+        let sampler = try makeSampler(options: options)
         defer { llama_sampler_free(sampler) }
 
         var generatedText = ""
         var position = Int32(promptTokens.count)
 
-        for _ in 0 ..< maxPredictionTokens {
+        for _ in 0 ..< options.maxPredictionTokens {
             let nextToken = llama_sampler_sample(sampler, context, -1)
             if nextToken == llama_vocab_eos(vocab) || llama_vocab_is_eog(vocab, nextToken) {
                 break

--- a/tabby/Services/Runtime/LlamaRuntimeCore.swift
+++ b/tabby/Services/Runtime/LlamaRuntimeCore.swift
@@ -616,3 +616,68 @@ actor LlamaRuntimeCore {
         }
     }
 }
+
+extension LlamaRuntimeCore {
+    /// Generates a summary without reading or modifying the global KV prompt cache.
+    func summarize(
+        prompt: String,
+        maxPredictionTokens: Int,
+        temperature: Double
+    ) throws -> String {
+        guard let preparedRuntime else {
+            throw LlamaRuntimeError.unavailable("The llama model is not loaded.")
+        }
+        guard let model else {
+            throw LlamaRuntimeError.unavailable("The llama model is not loaded.")
+        }
+        guard let vocab = llama_model_get_vocab(model) else {
+            throw LlamaRuntimeError.generationFailed("Unable to access the model vocabulary.")
+        }
+
+        let promptTokens = try tokenize(prompt, vocab: vocab)
+
+        let context = try makeContext(
+            model: model,
+            contextWindowTokens: preparedRuntime.contextWindowTokens,
+            batchSize: preparedRuntime.batchSize,
+            threadCount: preparedRuntime.threadCount
+        )
+        defer { llama_free(context) }
+
+        try decodePrompt(
+            promptTokens,
+            startingAt: 0,
+            in: context,
+            batchCapacity: preparedRuntime.batchSize
+        )
+
+        let sampler = try makeSampler(
+            temperature: temperature,
+            topK: 40,
+            topP: 0.95,
+            minP: 0.05,
+            repetitionPenalty: 1.1,
+            seed: nil
+        )
+        defer { llama_sampler_free(sampler) }
+
+        var generatedText = ""
+        var position = Int32(promptTokens.count)
+
+        for _ in 0 ..< maxPredictionTokens {
+            let nextToken = llama_sampler_sample(sampler, context, -1)
+            if nextToken == llama_vocab_eos(vocab) || llama_vocab_is_eog(vocab, nextToken) {
+                break
+            }
+
+            let piece = pieceString(for: nextToken, vocab: vocab)
+            generatedText += piece
+            llama_sampler_accept(sampler, nextToken)
+
+            try decodeToken(nextToken, position: position, in: context)
+            position += 1
+        }
+
+        return generatedText
+    }
+}

--- a/tabby/Services/Runtime/LlamaRuntimeManager.swift
+++ b/tabby/Services/Runtime/LlamaRuntimeManager.swift
@@ -87,13 +87,7 @@ final class LlamaRuntimeManager: ObservableObject {
     func generate(
         prompt: String,
         cachedPrefixBytes: Int? = nil,
-        maxPredictionTokens: Int,
-        temperature: Double,
-        topK: Int,
-        topP: Double,
-        minP: Double,
-        repetitionPenalty: Double,
-        seed: UInt32? = nil
+        options: LlamaGenerationOptions
     ) async throws -> String {
         _ = try await preparedRuntime()
 
@@ -101,13 +95,7 @@ final class LlamaRuntimeManager: ObservableObject {
             return try await core.generate(
                 prompt: prompt,
                 cachedPrefixBytes: cachedPrefixBytes,
-                maxPredictionTokens: maxPredictionTokens,
-                temperature: temperature,
-                topK: topK,
-                topP: topP,
-                minP: minP,
-                repetitionPenalty: repetitionPenalty,
-                seed: seed
+                options: options
             )
         } catch is CancellationError {
             throw LlamaRuntimeError.cancelled
@@ -136,8 +124,10 @@ final class LlamaRuntimeManager: ObservableObject {
         do {
             return try await core.summarize(
                 prompt: prompt,
-                maxPredictionTokens: maxPredictionTokens,
-                temperature: temperature
+                options: .summary(
+                    maxPredictionTokens: maxPredictionTokens,
+                    temperature: temperature
+                )
             )
         } catch is CancellationError {
             throw LlamaRuntimeError.cancelled
@@ -176,8 +166,7 @@ final class LlamaRuntimeManager: ObservableObject {
         let requestedModelFilename = resolvedRuntime.modelFileURL.lastPathComponent
 
         if let cachedRuntime,
-            cachedRuntime.resolvedRuntime.modelFileURL == resolvedRuntime.modelFileURL
-        {
+            cachedRuntime.resolvedRuntime.modelFileURL == resolvedRuntime.modelFileURL {
             return cachedRuntime
         }
 

--- a/tabby/Services/Runtime/LlamaRuntimeManager.swift
+++ b/tabby/Services/Runtime/LlamaRuntimeManager.swift
@@ -124,6 +124,33 @@ final class LlamaRuntimeManager: ObservableObject {
     /// Clears the native prompt KV cache without unloading the model.
     /// The manager exposes this as a lifecycle command because focus/settings resets originate in
     /// the app layer, while the actor still owns the raw llama pointers.
+
+    /// Generates a short summary using an ephemeral context so the autocomplete cache is unaffected.
+    func summarize(
+        prompt: String,
+        maxPredictionTokens: Int,
+        temperature: Double
+    ) async throws -> String {
+        _ = try await preparedRuntime()
+
+        do {
+            return try await core.summarize(
+                prompt: prompt,
+                maxPredictionTokens: maxPredictionTokens,
+                temperature: temperature
+            )
+        } catch is CancellationError {
+            throw LlamaRuntimeError.cancelled
+        } catch let error as LlamaRuntimeError {
+            diagnostics.lastError = error.localizedDescription
+            throw error
+        } catch {
+            let runtimeError = LlamaRuntimeError.generationFailed(error.localizedDescription)
+            diagnostics.lastError = runtimeError.localizedDescription
+            throw runtimeError
+        }
+    }
+
     func resetPromptCache() async {
         await core.resetPromptCache()
     }

--- a/tabby/Services/Runtime/LlamaSuggestionEngine.swift
+++ b/tabby/Services/Runtime/LlamaSuggestionEngine.swift
@@ -21,6 +21,10 @@ final class LlamaSuggestionEngine {
         do {
             let startTime = Date()
             let cachedPrefixBytes = promptCacheHintTracker.cachedPrefixBytes(for: request)
+            TabbyDebugOptions.log(
+                "[LlamaSuggestionEngine] starting prediction prompt_chars=\(request.prompt.count) "
+                    + "cached_prefix_bytes=\(cachedPrefixBytes ?? 0)"
+            )
             let rawSuggestion = try await runtimeManager.generate(
                 prompt: request.prompt,
                 cachedPrefixBytes: cachedPrefixBytes,

--- a/tabby/Services/Runtime/LlamaSuggestionEngine.swift
+++ b/tabby/Services/Runtime/LlamaSuggestionEngine.swift
@@ -28,13 +28,15 @@ final class LlamaSuggestionEngine {
             let rawSuggestion = try await runtimeManager.generate(
                 prompt: request.prompt,
                 cachedPrefixBytes: cachedPrefixBytes,
-                maxPredictionTokens: request.maxPredictionTokens,
-                temperature: request.temperature,
-                topK: request.topK,
-                topP: request.topP,
-                minP: request.minP,
-                repetitionPenalty: request.repetitionPenalty,
-                seed: request.randomSeed
+                options: LlamaGenerationOptions(
+                    maxPredictionTokens: request.maxPredictionTokens,
+                    temperature: request.temperature,
+                    topK: request.topK,
+                    topP: request.topP,
+                    minP: request.minP,
+                    repetitionPenalty: request.repetitionPenalty,
+                    seed: request.randomSeed
+                )
             )
             try Task.checkCancellation()
 

--- a/tabby/Services/Suggestion/SuggestionDebugLogger.swift
+++ b/tabby/Services/Suggestion/SuggestionDebugLogger.swift
@@ -1,9 +1,10 @@
 import Foundation
 
 /// File overview:
-/// Emits high-signal console logs for the suggestion pipeline. This logger owns the mechanics of
-/// compact summary lines, full prompt/output blocks, and duplicate suppression so the coordinator
-/// can focus on state transitions instead of string rendering.
+/// Emits high-signal console logs for the suggestion pipeline when `-tabby-debug` is enabled.
+/// This logger owns the mechanics of compact summary lines, full prompt/output blocks, and
+/// duplicate suppression so the coordinator can focus on state transitions instead of string
+/// rendering.
 ///
 /// Logging is intentionally stateful because duplicate suppression depends on the previously
 /// emitted line. Keeping that state here avoids scattering "did we already print this?" checks
@@ -40,6 +41,10 @@ final class SuggestionDebugLogger {
         rawOutput: String? = nil,
         normalizedOutput: String? = nil
     ) {
+        guard TabbyDebugOptions.isEnabled else {
+            return
+        }
+
         guard consoleStages.contains(stage) else {
             return
         }
@@ -164,7 +169,7 @@ final class SuggestionDebugLogger {
         }
 
         lastLoggedMessage = line
-        print(line)
+        TabbyDebugOptions.log(line)
     }
 
     /// Compact one-line logs are good for scanning, but prompt debugging requires the exact payload.
@@ -180,7 +185,7 @@ final class SuggestionDebugLogger {
         let renderedText = text.isEmpty ? "<empty>" : text
         // Multi-line log blocks are easier to inspect than escaped one-line strings when debugging
         // prompt construction or output normalization.
-        print(
+        TabbyDebugOptions.log(
             """
             [Suggestion \(kind)] stage=\(stage) work=\(workID) generation=\(generationSummary)
             ----- BEGIN \(kind.uppercased()) -----

--- a/tabby/Services/Suggestion/SuggestionDebugLogger.swift
+++ b/tabby/Services/Suggestion/SuggestionDebugLogger.swift
@@ -61,90 +61,148 @@ final class SuggestionDebugLogger {
 
         parts.append("message=\(message)")
 
-        if stage == "generating", let prompt {
-            parts.append("prompt=\(Self.debugPreview(prompt))")
-        }
-
-        if stage != "generating" {
-            switch (rawOutput, normalizedOutput) {
-            case let (raw?, normalized?):
-                // When generation and normalization diverge, surface both previews in the compact
-                // summary so we can immediately see whether the backend returned text that the
-                // cleanup layer later stripped away.
-                if raw == normalized {
-                    parts.append("output=\(Self.debugPreview(raw))")
-                } else {
-                    parts.append("rawOutput=\(Self.debugPreview(raw))")
-                    parts.append("normalizedOutput=\(Self.debugPreview(normalized))")
-                }
-            case let (raw?, nil):
-                parts.append("rawOutput=\(Self.debugPreview(raw))")
-            case let (nil, normalized?):
-                parts.append("normalizedOutput=\(Self.debugPreview(normalized))")
-            case (nil, nil):
-                break
-            }
-        }
+        appendPromptPreviewIfNeeded(stage: stage, prompt: prompt, to: &parts)
+        appendOutputPreviewIfNeeded(
+            stage: stage,
+            rawOutput: rawOutput,
+            normalizedOutput: normalizedOutput,
+            to: &parts
+        )
 
         let summaryLine = parts.joined(separator: " ")
         logLine(summaryLine)
 
-        if stage == "generating", let prompt {
-            logTextBlock(
-                kind: "prompt",
+        logPromptBlockIfNeeded(stage: stage, workID: workID, generation: generation, prompt: prompt)
+        logOutputBlocksIfNeeded(
+            stage: stage,
+            workID: workID,
+            generation: generation,
+            rawOutput: rawOutput,
+            normalizedOutput: normalizedOutput
+        )
+    }
+
+    private func appendPromptPreviewIfNeeded(
+        stage: String,
+        prompt: String?,
+        to parts: inout [String]
+    ) {
+        guard stage == "generating", let prompt else {
+            return
+        }
+
+        parts.append("prompt=\(Self.debugPreview(prompt))")
+    }
+
+    private func appendOutputPreviewIfNeeded(
+        stage: String,
+        rawOutput: String?,
+        normalizedOutput: String?,
+        to parts: inout [String]
+    ) {
+        guard stage != "generating" else {
+            return
+        }
+
+        switch (rawOutput, normalizedOutput) {
+        case let (raw?, normalized?):
+            appendPairedOutputPreview(raw: raw, normalized: normalized, to: &parts)
+        case let (raw?, nil):
+            parts.append("rawOutput=\(Self.debugPreview(raw))")
+        case let (nil, normalized?):
+            parts.append("normalizedOutput=\(Self.debugPreview(normalized))")
+        case (nil, nil):
+            break
+        }
+    }
+
+    private func appendPairedOutputPreview(
+        raw: String,
+        normalized: String,
+        to parts: inout [String]
+    ) {
+        // When generation and normalization diverge, surface both previews in the compact summary
+        // so we can immediately see whether cleanup stripped backend output away.
+        if raw == normalized {
+            parts.append("output=\(Self.debugPreview(raw))")
+        } else {
+            parts.append("rawOutput=\(Self.debugPreview(raw))")
+            parts.append("normalizedOutput=\(Self.debugPreview(normalized))")
+        }
+    }
+
+    private func logPromptBlockIfNeeded(
+        stage: String,
+        workID: UInt64,
+        generation: UInt64?,
+        prompt: String?
+    ) {
+        guard stage == "generating", let prompt else {
+            return
+        }
+
+        logTextBlock(
+            kind: "prompt",
+            stage: stage,
+            workID: workID,
+            generation: generation,
+            text: prompt
+        )
+    }
+
+    private func logOutputBlocksIfNeeded(
+        stage: String,
+        workID: UInt64,
+        generation: UInt64?,
+        rawOutput: String?,
+        normalizedOutput: String?
+    ) {
+        guard stage != "generating" else {
+            return
+        }
+
+        switch (rawOutput, normalizedOutput) {
+        case let (raw?, normalized?):
+            logPairedOutputBlocks(
                 stage: stage,
                 workID: workID,
                 generation: generation,
-                text: prompt
+                raw: raw,
+                normalized: normalized
             )
+        case let (raw?, nil):
+            logTextBlock(kind: "raw-output", stage: stage, workID: workID, generation: generation, text: raw)
+        case let (nil, normalized?):
+            logTextBlock(
+                kind: "normalized-output",
+                stage: stage,
+                workID: workID,
+                generation: generation,
+                text: normalized
+            )
+        case (nil, nil):
+            break
         }
+    }
 
-        if stage != "generating" {
-            switch (rawOutput, normalizedOutput) {
-            case let (raw?, normalized?):
-                if raw == normalized {
-                    logTextBlock(
-                        kind: "output",
-                        stage: stage,
-                        workID: workID,
-                        generation: generation,
-                        text: raw
-                    )
-                } else {
-                    logTextBlock(
-                        kind: "raw-output",
-                        stage: stage,
-                        workID: workID,
-                        generation: generation,
-                        text: raw
-                    )
-                    logTextBlock(
-                        kind: "normalized-output",
-                        stage: stage,
-                        workID: workID,
-                        generation: generation,
-                        text: normalized
-                    )
-                }
-            case let (raw?, nil):
-                logTextBlock(
-                    kind: "raw-output",
-                    stage: stage,
-                    workID: workID,
-                    generation: generation,
-                    text: raw
-                )
-            case let (nil, normalized?):
-                logTextBlock(
-                    kind: "normalized-output",
-                    stage: stage,
-                    workID: workID,
-                    generation: generation,
-                    text: normalized
-                )
-            case (nil, nil):
-                break
-            }
+    private func logPairedOutputBlocks(
+        stage: String,
+        workID: UInt64,
+        generation: UInt64?,
+        raw: String,
+        normalized: String
+    ) {
+        if raw == normalized {
+            logTextBlock(kind: "output", stage: stage, workID: workID, generation: generation, text: raw)
+        } else {
+            logTextBlock(kind: "raw-output", stage: stage, workID: workID, generation: generation, text: raw)
+            logTextBlock(
+                kind: "normalized-output",
+                stage: stage,
+                workID: workID,
+                generation: generation,
+                text: normalized
+            )
         }
     }
 

--- a/tabby/Services/UI/FocusDebugOverlayController.swift
+++ b/tabby/Services/UI/FocusDebugOverlayController.swift
@@ -2,15 +2,15 @@ import AppKit
 import Foundation
 import SwiftUI
 
-/// Gated behind `-tabby-debug-caret-overlay`. Shows a bright colored line at the resolved caret
+/// Gated behind `-tabby-debug`. Shows a bright colored line at the resolved caret
 /// position and a label indicating the geometry source and quality. This lets you visually verify
 /// that the caret rect aligns with the real blinking cursor in the host app.
 @MainActor
 final class FocusDebugOverlayController {
-    static let launchArgument = "-tabby-debug-caret-overlay"
+    static let launchArgument = TabbyDebugOptions.launchArgument
 
     static var isEnabled: Bool {
-        ProcessInfo.processInfo.arguments.contains(launchArgument)
+        TabbyDebugOptions.isEnabled
     }
 
     private lazy var caretPanel: NSPanel = makePanel()

--- a/tabby/Services/Utilities/LaunchAtLoginService.swift
+++ b/tabby/Services/Utilities/LaunchAtLoginService.swift
@@ -81,7 +81,7 @@ final class LaunchAtLoginService: ObservableObject {
         refresh()
     }
 
-    private static func     map(_ status: SMAppService.Status) -> LaunchAtLoginState {
+    private static func map(_ status: SMAppService.Status) -> LaunchAtLoginState {
         switch status {
         case .enabled:
             return .enabled

--- a/tabby/Services/Utilities/ModelDownloadManager.swift
+++ b/tabby/Services/Utilities/ModelDownloadManager.swift
@@ -382,8 +382,7 @@ private final class ModelDownloadSessionDelegate: NSObject, URLSessionDownloadDe
         response = downloadTask.response
     }
 
-    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?)
-    {
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         guard !hasCompleted else {
             return
         }

--- a/tabby/Services/Utilities/ModelFileValidator.swift
+++ b/tabby/Services/Utilities/ModelFileValidator.swift
@@ -33,7 +33,8 @@ enum ModelFileValidator {
             case let .checksumMismatch(expected, actual):
                 let expectedShort = String(expected.lowercased().prefix(16))
                 let actualShort = String(actual.lowercased().prefix(16))
-                return "Downloaded file's checksum (\(actualShort)…) doesn't match the expected (\(expectedShort)…). The file may be corrupt."
+                return "Downloaded file's checksum (\(actualShort)…) doesn't match the " +
+                    "expected (\(expectedShort)…). The file may be corrupt."
             case let .fileUnreadable(url):
                 return "Couldn't read \(url.lastPathComponent) for validation."
             }
@@ -95,7 +96,8 @@ enum ModelFileValidator {
         defer { try? handle.close() }
 
         var hasher = SHA256()
-        let chunkSize = 1024 * 1024  // 1 MB — small enough to stay out of large allocations, large enough to keep syscall overhead negligible.
+        // 1 MB keeps memory bounded while avoiding excessive read syscalls.
+        let chunkSize = 1024 * 1024
         while true {
             let chunk: Data
             do {

--- a/tabby/Services/Visual/LlamaVisualContextSummarizer.swift
+++ b/tabby/Services/Visual/LlamaVisualContextSummarizer.swift
@@ -27,20 +27,25 @@ final class LlamaVisualContextSummarizer: VisualContextSummarizing {
             "[LlamaVisualContextSummarizer] summarization-start "
                 + "app=\(applicationName) input_chars=\(text.count)"
         )
-        let prompt = """
-        You are an AI assistant analyzing what the user is currently looking at on their screen in the application \(applicationName).
-        The following text is an OCR extraction from a screenshot of the window where the user is currently typing.
-
-        Your task:
-        Summarize this on-screen text into 4-5 concise sentences. This summary will be used as background context for a code/text autocomplete engine to understand what the user might type next.
-        Focus on the main topics, the type of document/UI, and any relevant context that would help predict what the user is working on.
-        DO NOT reply to the text. DO NOT answer questions in the text. ONLY output the summary.
-
-        Screen text:
-        \(text)
-
-        Summary:
-        """
+        let prompt = [
+            "You are an AI assistant analyzing what the user is currently looking at on their " +
+                "screen in the application \(applicationName).",
+            "The following text is an OCR extraction from a screenshot of the window where the " +
+                "user is currently typing.",
+            "",
+            "Your task:",
+            "Summarize this on-screen text into 4-5 concise sentences. This summary will be " +
+                "used as background context for a code/text autocomplete engine to understand " +
+                "what the user might type next.",
+            "Focus on the main topics, the type of document/UI, and any relevant context that " +
+                "would help predict what the user is working on.",
+            "DO NOT reply to the text. DO NOT answer questions in the text. ONLY output the summary.",
+            "",
+            "Screen text:",
+            text,
+            "",
+            "Summary:"
+        ].joined(separator: "\n")
 
         let result = try await runtimeManager.summarize(
             prompt: prompt,

--- a/tabby/Services/Visual/LlamaVisualContextSummarizer.swift
+++ b/tabby/Services/Visual/LlamaVisualContextSummarizer.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Converts OCR text into a compact prompt-safe visual context summary.
+///
+/// The protocol keeps `ScreenshotContextGenerator` independent from the concrete llama runtime.
+/// That boundary matters because capture/OCR can be tested or reused without forcing a local model
+/// call in every environment.
+protocol VisualContextSummarizing: AnyObject, Sendable {
+    func summarize(text: String, applicationName: String) async throws -> String
+}
+
+/// Local-model implementation of visual-context summarization.
+///
+/// This type owns only the summarization prompt. Screenshot capture, OCR, prompt-injection limits,
+/// and stale-session checks remain in their own services so model prompting does not become a
+/// hidden owner of the visual-context lifecycle.
+@MainActor
+final class LlamaVisualContextSummarizer: VisualContextSummarizing {
+    private let runtimeManager: LlamaRuntimeManager
+
+    init(runtimeManager: LlamaRuntimeManager) {
+        self.runtimeManager = runtimeManager
+    }
+
+    func summarize(text: String, applicationName: String) async throws -> String {
+        TabbyDebugOptions.log(
+            "[LlamaVisualContextSummarizer] summarization-start "
+                + "app=\(applicationName) input_chars=\(text.count)"
+        )
+        let prompt = """
+        You are an AI assistant analyzing what the user is currently looking at on their screen in the application \(applicationName).
+        The following text is an OCR extraction from a screenshot of the window where the user is currently typing.
+
+        Your task:
+        Summarize this on-screen text into 4-5 concise sentences. This summary will be used as background context for a code/text autocomplete engine to understand what the user might type next.
+        Focus on the main topics, the type of document/UI, and any relevant context that would help predict what the user is working on.
+        DO NOT reply to the text. DO NOT answer questions in the text. ONLY output the summary.
+
+        Screen text:
+        \(text)
+
+        Summary:
+        """
+
+        let result = try await runtimeManager.summarize(
+            prompt: prompt,
+            maxPredictionTokens: 160,
+            temperature: 0
+        )
+        let trimmedResult = result.trimmingCharacters(in: .whitespacesAndNewlines)
+        TabbyDebugOptions.log(
+            "[LlamaVisualContextSummarizer] summarization-complete "
+                + "output_chars=\(trimmedResult.count)"
+        )
+        return trimmedResult
+    }
+}

--- a/tabby/Services/Visual/LlamaVisualContextSummarizer.swift
+++ b/tabby/Services/Visual/LlamaVisualContextSummarizer.swift
@@ -27,25 +27,21 @@ final class LlamaVisualContextSummarizer: VisualContextSummarizing {
             "[LlamaVisualContextSummarizer] summarization-start "
                 + "app=\(applicationName) input_chars=\(text.count)"
         )
-        let prompt = [
-            "You are an AI assistant analyzing what the user is currently looking at on their " +
-                "screen in the application \(applicationName).",
-            "The following text is an OCR extraction from a screenshot of the window where the " +
-                "user is currently typing.",
-            "",
-            "Your task:",
-            "Summarize this on-screen text into 4-5 concise sentences. This summary will be " +
-                "used as background context for a code/text autocomplete engine to understand " +
-                "what the user might type next.",
-            "Focus on the main topics, the type of document/UI, and any relevant context that " +
-                "would help predict what the user is working on.",
-            "DO NOT reply to the text. DO NOT answer questions in the text. ONLY output the summary.",
-            "",
-            "Screen text:",
-            text,
-            "",
-            "Summary:"
-        ].joined(separator: "\n")
+     let prompt = [
+    "Task: Write a concise, 4-sentence summary of what the provided text from the application '\(applicationName)' is about.",
+    "",
+    "Rules:",
+    "1. Output exactly and ONLY the summary text.",
+    "2. DO NOT add conversational filler (e.g., 'Here is the summary').",
+    "3. DO NOT add extra instructions or meta-commentary.",
+    "4. DO NOT repeat the prompt.",
+    "",
+    "--- START SCREEN TEXT ---",
+    text,
+    "--- END SCREEN TEXT ---",
+    "",
+    "Summary:"
+].joined(separator: "\n")
 
         let result = try await runtimeManager.summarize(
             prompt: prompt,

--- a/tabby/Services/Visual/ScreenshotContextGenerator.swift
+++ b/tabby/Services/Visual/ScreenshotContextGenerator.swift
@@ -1,17 +1,15 @@
 import CoreGraphics
 import Foundation
+import ImageIO
+import UniformTypeIdentifiers
 
 /// File overview:
 /// Converts a newly focused input's surrounding screenshot into OCR text for prompt injection.
-/// The pipeline is now intentionally direct: focused snapshot -> screenshot crop -> Apple OCR ->
-/// normalized visible-text excerpt.
+/// The pipeline is: focused snapshot -> screenshot crop -> Apple OCR -> optional local summary ->
+/// bounded visible-context excerpt.
 ///
-/// This keeps the visual-context subsystem fast and conceptually honest. If Tabby later gains
-/// true multimodal support, this file remains the seam where OCR can be replaced.
-///
-/// DEPRECATED:
-/// Suggestion requests no longer consume screenshot/OCR text. This generator is retained only as
-/// legacy scaffolding until the rebuilt context pipeline is implemented.
+/// Keeping capture/OCR/summarization at this boundary gives the suggestion coordinator a small
+/// plain-text value instead of exposing raw screenshots or OCR implementation details.
 
 enum ScreenshotContextGenerationError: LocalizedError {
     case unavailable(String)
@@ -29,11 +27,13 @@ enum ScreenshotContextGenerationError: LocalizedError {
 final class ScreenshotContextGenerator {
     private let screenshotService: WindowScreenshotService
     private let textExtractor: ScreenTextExtractor
+    private let summarizer: VisualContextSummarizing?
     private let configuration: VisualContextConfiguration
 
     init(
         screenshotService: WindowScreenshotService? = nil,
         textExtractor: ScreenTextExtractor? = nil,
+        summarizer: VisualContextSummarizing? = nil,
         configuration: VisualContextConfiguration? = nil
     ) {
         let actualConfig = configuration ?? .default
@@ -44,11 +44,12 @@ final class ScreenshotContextGenerator {
                 maxImageDimension: actualConfig.maxImageDimension,
                 maxRecognizedCharacters: actualConfig.maxRecognizedCharacters
             )
+        self.summarizer = summarizer
         self.configuration = actualConfig
     }
 
-    /// Captures a compact region around the focused input, runs OCR, and returns normalized visible
-    /// text that can be injected directly into the completion prompt.
+    /// Captures a compact region around the focused input and returns a bounded text excerpt that
+    /// can be injected into the completion prompt.
     func generateContext(
         for context: FocusedInputSnapshot,
         onStatusChange: (@Sendable (VisualContextStatus) async -> Void)? = nil
@@ -94,7 +95,7 @@ final class ScreenshotContextGenerator {
 
             let fallbackText = normalizeRecognizedText(windowTitle)
             log("context-ocr-empty using-window-title-fallback")
-            return VisualContextExcerpt(text: fallbackText)
+            return VisualContextExcerpt(text: boundedSummaryText(fallbackText))
         } catch let error as ScreenTextExtractionError {
             log("context-ocr-failed reason=\(error.localizedDescription)")
             throw ScreenshotContextGenerationError.unavailable(error.localizedDescription)
@@ -106,6 +107,14 @@ final class ScreenshotContextGenerator {
         let normalizedText = normalizeRecognizedText(extractedText)
         log("context-ocr-ready chars=\(normalizedText.count)")
 
+        if TabbyDebugOptions.isEnabled {
+            saveDebugScreenshot(
+                screenshot.image,
+                text: extractedText,
+                name: sanitizedDebugName(from: context.applicationName)
+            )
+        }
+
         guard hasMeaningfulSignal(normalizedText) else {
             log("context-unavailable weak-screenshot-signal")
             throw ScreenshotContextGenerationError.unavailable(
@@ -113,10 +122,29 @@ final class ScreenshotContextGenerator {
             )
         }
 
-        log("context-ready text=\(preview(normalizedText))")
+        let generatedContextText: String
+        if let summarizer = summarizer {
+            await onStatusChange?(.summarizingText)
+            do {
+                generatedContextText = try await summarizer.summarize(
+                    text: normalizedText,
+                    applicationName: context.applicationName
+                )
+            } catch {
+                log("context-summarization-failed reason=\(error.localizedDescription)")
+                throw ScreenshotContextGenerationError.failed(
+                    "Summarization failed: \(error.localizedDescription)"
+                )
+            }
+        } else {
+            generatedContextText = normalizedText
+        }
+
+        let finalContextText = boundedSummaryText(generatedContextText)
+        log("context-ready chars=\(finalContextText.count)")
 
         return VisualContextExcerpt(
-            text: normalizedText
+            text: finalContextText
         )
     }
 
@@ -138,6 +166,15 @@ final class ScreenshotContextGenerator {
             .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    /// Applies the final prompt-injection budget after optional summarization.
+    ///
+    /// `maxRecognizedCharacters` protects the OCR and summarizer input. This separate cap protects
+    /// the autocomplete prompt from a verbose model summary or from the raw-OCR fallback path.
+    private func boundedSummaryText(_ text: String) -> String {
+        String(text.prefix(configuration.maxSummaryCharacters))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     /// We reject OCR text that is mostly punctuation or numeric noise because that would hurt
     /// the completion prompt more than help it.
     private func hasMeaningfulSignal(_ text: String) -> Bool {
@@ -151,17 +188,51 @@ final class ScreenshotContextGenerator {
     }
 
     private func log(_ message: String) {
-        _ = message
+        TabbyDebugOptions.log("[ScreenshotContextGenerator] \(message)")
     }
 
-    private func preview(_ text: String) -> String {
-        let compact = text.replacingOccurrences(of: "\n", with: " ")
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        if compact.count <= 80 {
-            return compact
+    private func saveDebugScreenshot(_ image: CGImage, text: String, name: String) {
+        guard let desktopURL = FileManager.default.urls(
+            for: .desktopDirectory,
+            in: .userDomainMask
+        ).first else {
+            return
         }
 
-        let cut = compact.index(compact.startIndex, offsetBy: 80)
-        return "\(compact[..<cut])..."
+        let url = desktopURL.appendingPathComponent("tabby-debug-screenshots")
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd_HH-mm-ss-SSS"
+        let timestamp = formatter.string(from: Date())
+
+        let fileURL = url.appendingPathComponent("\(name)_\(timestamp).png")
+        let textURL = url.appendingPathComponent("\(name)_\(timestamp).txt")
+
+        if let dest = CGImageDestinationCreateWithURL(
+            fileURL as CFURL,
+            UTType.png.identifier as CFString,
+            1,
+            nil
+        ) {
+            CGImageDestinationAddImage(dest, image, nil)
+            CGImageDestinationFinalize(dest)
+            TabbyDebugOptions.log(
+                "[ScreenshotContextGenerator] saved-debug-screenshot path=\(fileURL.path)"
+            )
+
+            try? text.write(to: textURL, atomically: true, encoding: .utf8)
+        }
+    }
+
+    private func sanitizedDebugName(from rawName: String) -> String {
+        let allowedCharacters = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_"))
+        let replacement = UnicodeScalar("_")
+        let sanitizedScalars = rawName.unicodeScalars.map { scalar in
+            allowedCharacters.contains(scalar) ? scalar : replacement
+        }
+        let sanitizedName = String(String.UnicodeScalarView(sanitizedScalars))
+            .trimmingCharacters(in: CharacterSet(charactersIn: "_"))
+        return sanitizedName.isEmpty ? "unknown-app" : sanitizedName
     }
 }

--- a/tabby/Services/Visual/VisualContextCoordinator.swift
+++ b/tabby/Services/Visual/VisualContextCoordinator.swift
@@ -13,7 +13,7 @@ final class VisualContextCoordinator {
     /// The coordinator consumes these callbacks to mirror service state into published UI state
     /// without taking back ownership of the visual-context task lifecycle.
     var onStateChange: ((VisualContextStatus, String?) -> Void)?
-    var onInjectedContextReady: ((String) -> Void)?
+    var onInjectedContextReady: ((FocusedInputIdentity) -> Void)?
 
     private let screenshotContextGenerator: ScreenshotContextGenerator
     private let screenRecordingPermissionProvider: @MainActor () -> Bool
@@ -38,9 +38,15 @@ final class VisualContextCoordinator {
     /// Starts one screenshot-derived augmentation session per focused field.
     /// This is intentionally scoped to field identity rather than text generation number because
     /// the screenshot context should survive normal typing inside the same input.
+    ///
+    /// Field identity is checked using both `elementIdentifier` and `focusChangeSequence`.
+    /// `elementIdentifier` alone is unreliable because macOS can recycle `CFHash` values
+    /// across unrelated AX elements. The monotonic `focusChangeSequence` counter provides a
+    /// guaranteed-unique signal that the focus tracker actually observed a new element.
     func startSessionIfNeeded(for snapshotContext: FocusedInputSnapshot) {
         if let activeAugmentationSession,
-            activeAugmentationSession.elementIdentifier == snapshotContext.elementIdentifier
+            activeAugmentationSession.elementIdentifier == snapshotContext.elementIdentifier,
+            activeAugmentationSession.focusChangeSequence == snapshotContext.focusChangeSequence
         {
             if case .unavailable(let reason) = activeAugmentationSession.status,
                 reason.localizedCaseInsensitiveContains("Screen Recording"),
@@ -48,19 +54,22 @@ final class VisualContextCoordinator {
             {
                 cancel(resetState: true)
             } else {
+                log("session-dedup element=\(snapshotContext.elementIdentifier) seq=\(snapshotContext.focusChangeSequence) status=\(activeAugmentationSession.status)")
                 return
             }
         }
 
         cancel(resetState: false)
 
+        let hasPermission = screenRecordingPermissionProvider()
         let initialStatus: VisualContextStatus =
-            screenRecordingPermissionProvider()
+            hasPermission
             ? .capturing
             : .unavailable(Self.permissionMissingReason)
         let session = FocusedInputAugmentationSession(
             sessionID: UUID(),
             elementIdentifier: snapshotContext.elementIdentifier,
+            focusChangeSequence: snapshotContext.focusChangeSequence,
             status: initialStatus,
             excerpt: nil
         )
@@ -70,7 +79,10 @@ final class VisualContextCoordinator {
         status = initialStatus
         publishState()
 
-        guard screenRecordingPermissionProvider() else {
+        log("session-start element=\(snapshotContext.elementIdentifier) seq=\(snapshotContext.focusChangeSequence) permission=\(hasPermission)")
+
+        guard hasPermission else {
+            log("session-blocked missing-screen-recording-permission")
             return
         }
 
@@ -87,19 +99,23 @@ final class VisualContextCoordinator {
                     }
                 )
                 guard !Task.isCancelled else {
+                    log("session-cancelled-after-generate sessionID=\(session.sessionID)")
                     return
                 }
 
                 applyExcerpt(
                     excerpt,
                     for: session.sessionID,
-                    elementIdentifier: snapshotContext.elementIdentifier
+                    identity: snapshotContext.identity
                 )
             } catch is CancellationError {
+                log("session-cancellation sessionID=\(session.sessionID)")
                 return
             } catch let error as ScreenshotContextGenerationError {
+                log("session-error sessionID=\(session.sessionID) error=\(error.localizedDescription)")
                 setStatus(errorStatus(for: error), for: session.sessionID)
             } catch {
+                log("session-error sessionID=\(session.sessionID) error=\(error.localizedDescription)")
                 setStatus(.failed(error.localizedDescription), for: session.sessionID)
             }
         }
@@ -126,6 +142,7 @@ final class VisualContextCoordinator {
     func excerpt(for context: FocusedInputContext) -> String? {
         guard let activeAugmentationSession,
             activeAugmentationSession.elementIdentifier == context.elementIdentifier,
+            activeAugmentationSession.focusChangeSequence == context.focusChangeSequence,
             activeAugmentationSession.status == .ready
         else {
             return nil
@@ -150,10 +167,11 @@ final class VisualContextCoordinator {
     private func applyExcerpt(
         _ excerpt: VisualContextExcerpt,
         for sessionID: UUID,
-        elementIdentifier: String
+        identity: FocusedInputIdentity
     ) {
         guard activeAugmentationSession?.sessionID == sessionID,
-            activeAugmentationSession?.elementIdentifier == elementIdentifier
+            activeAugmentationSession?.elementIdentifier == identity.elementIdentifier,
+            activeAugmentationSession?.focusChangeSequence == identity.focusChangeSequence
         else {
             return
         }
@@ -163,7 +181,7 @@ final class VisualContextCoordinator {
         status = .ready
         latestExcerpt = excerpt.text
         publishState()
-        onInjectedContextReady?(elementIdentifier)
+        onInjectedContextReady?(identity)
     }
 
     private func errorStatus(for error: ScreenshotContextGenerationError) -> VisualContextStatus {
@@ -177,6 +195,10 @@ final class VisualContextCoordinator {
 
     private func publishState() {
         onStateChange?(status, latestExcerpt)
+    }
+
+    private func log(_ message: String) {
+        TabbyDebugOptions.log("[VisualContextCoordinator] \(message)")
     }
 }
 

--- a/tabby/Services/Visual/VisualContextCoordinator.swift
+++ b/tabby/Services/Visual/VisualContextCoordinator.swift
@@ -46,15 +46,17 @@ final class VisualContextCoordinator {
     func startSessionIfNeeded(for snapshotContext: FocusedInputSnapshot) {
         if let activeAugmentationSession,
             activeAugmentationSession.elementIdentifier == snapshotContext.elementIdentifier,
-            activeAugmentationSession.focusChangeSequence == snapshotContext.focusChangeSequence
-        {
+            activeAugmentationSession.focusChangeSequence == snapshotContext.focusChangeSequence {
             if case .unavailable(let reason) = activeAugmentationSession.status,
                 reason.localizedCaseInsensitiveContains("Screen Recording"),
-                screenRecordingPermissionProvider()
-            {
+                screenRecordingPermissionProvider() {
                 cancel(resetState: true)
             } else {
-                log("session-dedup element=\(snapshotContext.elementIdentifier) seq=\(snapshotContext.focusChangeSequence) status=\(activeAugmentationSession.status)")
+                log(
+                    "session-dedup element=\(snapshotContext.elementIdentifier) " +
+                        "seq=\(snapshotContext.focusChangeSequence) " +
+                        "status=\(activeAugmentationSession.status)"
+                )
                 return
             }
         }
@@ -79,7 +81,10 @@ final class VisualContextCoordinator {
         status = initialStatus
         publishState()
 
-        log("session-start element=\(snapshotContext.elementIdentifier) seq=\(snapshotContext.focusChangeSequence) permission=\(hasPermission)")
+        log(
+            "session-start element=\(snapshotContext.elementIdentifier) " +
+                "seq=\(snapshotContext.focusChangeSequence) permission=\(hasPermission)"
+        )
 
         guard hasPermission else {
             log("session-blocked missing-screen-recording-permission")

--- a/tabby/Services/Visual/WindowScreenshotService.swift
+++ b/tabby/Services/Visual/WindowScreenshotService.swift
@@ -10,10 +10,6 @@ import ScreenCaptureKit
 ///
 /// We use ScreenCaptureKit instead of deprecated Core Graphics screenshot APIs because the app
 /// targets a modern macOS SDK where `CGWindowListCreateImage` is no longer available.
-///
-/// DEPRECATED:
-/// Active autocomplete generation no longer consumes screenshot/OCR context.
-/// This service remains temporarily while the next-generation context system is rebuilt.
 
 struct CapturedWindowScreenshot {
     let image: CGImage
@@ -82,9 +78,17 @@ struct WindowScreenshotService {
 
         let filter = SCContentFilter(desktopIndependentWindow: matchingWindow)
         let configuration = SCStreamConfiguration()
-        configuration.sourceRect = sourceRect
-        configuration.width = max(Int((sourceRect.width * outputScale).rounded(.up)), 1)
-        configuration.height = max(Int((sourceRect.height * outputScale).rounded(.up)), 1)
+
+        let localSourceRect = CGRect(
+            x: sourceRect.minX - matchingWindow.frame.minX,
+            y: sourceRect.minY - matchingWindow.frame.minY,
+            width: sourceRect.width,
+            height: sourceRect.height
+        )
+
+        configuration.sourceRect = localSourceRect
+        configuration.width = max(Int((localSourceRect.width * outputScale).rounded(.up)), 1)
+        configuration.height = max(Int((localSourceRect.height * outputScale).rounded(.up)), 1)
         configuration.showsCursor = false
 
         let image = try await captureImage(filter: filter, configuration: configuration)
@@ -96,21 +100,30 @@ struct WindowScreenshotService {
         return CapturedWindowScreenshot(image: image, windowTitle: matchingWindow.title)
     }
 
-    /// Chooses the capture anchor. Small fields benefit from centering on the whole field, while
-    /// large editors are better anchored on the caret so the crop stays near the current work area.
     private func snapshotRect(
         around context: FocusedInputSnapshot,
         windowFrame: CGRect,
         snapshotDimension: CGFloat
     ) -> CGRect {
-        let anchorRect = preferredAnchorRect(for: context, snapshotDimension: snapshotDimension)
-        let targetWidth = min(snapshotDimension, windowFrame.width)
-        let targetHeight = min(snapshotDimension, windowFrame.height)
-        let halfWidth = targetWidth / 2
-        let halfHeight = targetHeight / 2
+        let targetHeight: CGFloat = 300
+        let targetWidth: CGFloat
+        let proposedX: CGFloat
+        let proposedY: CGFloat
 
-        let proposedX = anchorRect.midX - halfWidth
-        let proposedY = anchorRect.midY - halfHeight
+        if let inputFrameAppKit = context.inputFrameRect, !inputFrameAppKit.isEmpty {
+            let inputFrameCG = convertBetweenAppKitAndCG(rect: inputFrameAppKit)
+            targetWidth = min(inputFrameCG.width, windowFrame.width)
+            proposedX = inputFrameCG.minX
+            proposedY = inputFrameCG.minY - targetHeight
+        } else {
+            // Fall back to the caret if the input frame is completely unavailable.
+            let caretRectCG = convertBetweenAppKitAndCG(rect: context.caretRect)
+            targetWidth = min(snapshotDimension, windowFrame.width)
+            proposedX = caretRectCG.midX - (targetWidth / 2)
+            proposedY = caretRectCG.minY - targetHeight
+        }
+
+        // Clamp within the window frame bounds so SCK does not fail or crop incorrectly.
         let clampedX = min(max(proposedX, windowFrame.minX), windowFrame.maxX - targetWidth)
         let clampedY = min(max(proposedY, windowFrame.minY), windowFrame.maxY - targetHeight)
 
@@ -122,28 +135,28 @@ struct WindowScreenshotService {
         ).integral
     }
 
-    private func preferredAnchorRect(
-        for context: FocusedInputSnapshot,
-        snapshotDimension: CGFloat
-    ) -> CGRect {
-        if let inputFrameRect = context.inputFrameRect,
-           !inputFrameRect.isEmpty,
-           inputFrameRect.width <= snapshotDimension * 0.8,
-           inputFrameRect.height <= snapshotDimension * 0.8
-        {
-            return inputFrameRect
-        }
-
-        return context.caretRect
-    }
-
     private func backingScaleFactor(for rect: CGRect) -> CGFloat {
-        let midpoint = CGPoint(x: rect.midX, y: rect.midY)
+        let appKitRect = convertBetweenAppKitAndCG(rect: rect)
+        let midpoint = CGPoint(x: appKitRect.midX, y: appKitRect.midY)
+
         if let screen = NSScreen.screens.first(where: { $0.frame.contains(midpoint) }) {
             return screen.backingScaleFactor
         }
 
         return NSScreen.main?.backingScaleFactor ?? 2.0
+    }
+
+    private func convertBetweenAppKitAndCG(rect: CGRect) -> CGRect {
+        let desktopBounds = NSScreen.screens.map(\.frame).reduce(into: CGRect.null) {
+            $0 = $0.union($1)
+        }
+        guard !desktopBounds.isNull else { return rect }
+        return CGRect(
+            x: rect.origin.x,
+            y: desktopBounds.maxY - rect.origin.y - rect.height,
+            width: rect.width,
+            height: rect.height
+        )
     }
 
     /// Wraps ScreenCaptureKit's callback API so the rest of the app can use structured concurrency.
@@ -188,6 +201,6 @@ struct WindowScreenshotService {
     }
 
     private func log(_ message: String) {
-        _ = message
+        TabbyDebugOptions.log("[WindowScreenshotService] \(message)")
     }
 }

--- a/tabby/Support/AXHelper.swift
+++ b/tabby/Support/AXHelper.swift
@@ -14,7 +14,7 @@ enum AXHelper {
         kAXTextFieldRole as String,
         kAXTextAreaRole as String,
         "AXSearchField",
-        kAXComboBoxRole as String,
+        kAXComboBoxRole as String
     ]
 
     private static let knownReadOnlyRoles: Set<String> = [
@@ -22,7 +22,7 @@ enum AXHelper {
         kAXImageRole as String,
         kAXButtonRole as String,
         "AXLink",
-        kAXMenuItemRole as String,
+        kAXMenuItemRole as String
     ]
 
     // MARK: - Attribute Reading
@@ -77,16 +77,20 @@ enum AXHelper {
         return number.boolValue
     }
 
-    /// Reads an `AXValue`-backed range attribute such as the current selection.
-    static func rangeValue(for attribute: CFString, on element: AXUIElement) -> NSRange? {
-        guard let rawValue = copyAttributeValue(attribute, on: element),
-              CFGetTypeID(rawValue) == AXValueGetTypeID()
-        else {
+    /// Converts loosely typed Accessibility values into `AXValue` only after verifying the Core
+    /// Foundation type id. This keeps the unsafe CF boundary in one place and avoids force casts in
+    /// the higher-level helpers below.
+    private static func axValue(from value: AnyObject?) -> AXValue? {
+        guard let value, CFGetTypeID(value) == AXValueGetTypeID() else {
             return nil
         }
 
-        // Safe because we already checked the Core Foundation type id above.
-        let axValue = rawValue as! AXValue
+        return unsafeBitCast(value, to: AXValue.self)
+    }
+
+    /// Reads an `AXValue`-backed range attribute such as the current selection.
+    static func rangeValue(for attribute: CFString, on element: AXUIElement) -> NSRange? {
+        guard let axValue = axValue(from: copyAttributeValue(attribute, on: element)) else { return nil }
         guard AXValueGetType(axValue) == .cfRange else {
             return nil
         }
@@ -101,14 +105,7 @@ enum AXHelper {
 
     /// Reads an `AXValue`-backed rectangle attribute such as `AXFrame`.
     static func rectValue(for attribute: CFString, on element: AXUIElement) -> CGRect? {
-        guard let rawValue = copyAttributeValue(attribute, on: element),
-              CFGetTypeID(rawValue) == AXValueGetTypeID()
-        else {
-            return nil
-        }
-
-        // Safe because we already checked the Core Foundation type id above.
-        let axValue = rawValue as! AXValue
+        guard let axValue = axValue(from: copyAttributeValue(attribute, on: element)) else { return nil }
         guard AXValueGetType(axValue) == .cgRect else {
             return nil
         }
@@ -134,12 +131,7 @@ enum AXHelper {
 
         var value: CFTypeRef?
         let result = AXUIElementCopyParameterizedAttributeValue(element, attribute, parameter, &value)
-        guard result == .success, let value, CFGetTypeID(value) == AXValueGetTypeID() else {
-            return nil
-        }
-
-        // Safe because we already checked the Core Foundation type id above.
-        let axValue = value as! AXValue
+        guard result == .success, let axValue = axValue(from: value) else { return nil }
         guard AXValueGetType(axValue) == .cgRect else {
             return nil
         }
@@ -154,43 +146,38 @@ enum AXHelper {
 
     /// Some applications (like Chromium and WebKit browsers) do not properly support `AXBoundsForRange`
     /// using `NSRange`. Instead, they use a private, undocumented Accessibility object called `AXTextMarker`.
-    /// 
+    ///
     /// To get the caret rect from these apps, we must:
     /// 1. Ask for `AXSelectedTextMarkerRange` (which returns an opaque `AXTextMarkerRange`).
     /// 2. Pass that marker range back to the element using `AXBoundsForTextMarkerRange`.
-    /// 
+    ///
     /// This bypasses the need to translate `NSRange` manually and forces the browser to resolve
     /// the physical layout of its own internal selection object.
     static func textMarkerCaretRect(on element: AXUIElement) -> CGRect? {
         // 1. Get the opaque AXTextMarkerRange that represents the current selection/caret.
         let selectedMarkerRangeAttribute = "AXSelectedTextMarkerRange" as CFString
         var markerRangeValue: CFTypeRef?
-        
+
         var result = AXUIElementCopyAttributeValue(element, selectedMarkerRangeAttribute, &markerRangeValue)
         guard result == .success, let markerRange = markerRangeValue else {
             return nil
         }
-        
+
         // 2. Ask the element to compute the bounding box for that exact text marker range.
         let boundsForMarkerRangeAttribute = "AXBoundsForTextMarkerRange" as CFString
         var boundsValue: CFTypeRef?
-        
+
         result = AXUIElementCopyParameterizedAttributeValue(element, boundsForMarkerRangeAttribute, markerRange, &boundsValue)
-        guard result == .success, let bounds = boundsValue, CFGetTypeID(bounds) == AXValueGetTypeID() else {
-            return nil
-        }
-        
-        // Safe because we already checked the Core Foundation type id above.
-        let axBounds = bounds as! AXValue
+        guard result == .success, let axBounds = axValue(from: boundsValue) else { return nil }
         guard AXValueGetType(axBounds) == .cgRect else {
             return nil
         }
-        
+
         var rect = CGRect.zero
         guard AXValueGetValue(axBounds, .cgRect, &rect) else {
             return nil
         }
-        
+
         return rect
     }
 

--- a/tabby/Support/BundledRuntimeLocator.swift
+++ b/tabby/Support/BundledRuntimeLocator.swift
@@ -114,8 +114,7 @@ struct BundledRuntimeLocator {
                 candidate: candidate,
                 preferredModelNames: configuration.preferredModelNames
             ),
-                !modelOptions.isEmpty
-            {
+                !modelOptions.isEmpty {
                 return modelOptions
             }
         }
@@ -126,11 +125,9 @@ struct BundledRuntimeLocator {
     /// Enumerates runtime directories. By default we only load from the user-managed model directory.
     /// An explicit `runtimeDirectoryPath` can override this for tests or advanced local setups.
     private func runtimeCandidates(for configuration: LlamaRuntimeConfiguration)
-        -> [RuntimeCandidate]
-    {
+        -> [RuntimeCandidate] {
         if let runtimeDirectoryPath = configuration.runtimeDirectoryPath,
-            !runtimeDirectoryPath.isEmpty
-        {
+            !runtimeDirectoryPath.isEmpty {
             let runtimeDirectoryURL = URL(fileURLWithPath: runtimeDirectoryPath, isDirectory: true)
             return [
                 RuntimeCandidate(

--- a/tabby/Support/LlamaPromptRenderer.swift
+++ b/tabby/Support/LlamaPromptRenderer.swift
@@ -9,35 +9,17 @@ import Foundation
 /// prompt string. Keeping that composition isolated here prevents prompt policy from leaking into
 /// `SuggestionRequestFactory` or the runtime lifecycle layer.
 enum LlamaPromptRenderer {
+    /// Renders Tabby's local-model prompt.
+    ///
+    /// Tabby now always uses the instruction-rendered path. That makes custom user guidance the
+    /// default behavior and avoids keeping a second "fast" prompt contract that can drift from the
+    /// real product experience.
     static func prompt(
         prefixText: String,
         applicationName: String,
-        promptMode: SuggestionPromptMode,
         completionLengthInstruction: String,
-        customAIInstructions: String?
-    ) -> String {
-        switch promptMode {
-        case .prefixOnly:
-            // Fast mode is intentionally the low-overhead path: send only the user's local prefix
-            // text. This keeps latency down and minimizes extra steering for short completions.
-            return prefixText
-        case .guided:
-            return guidedPrompt(
-                prefixText: prefixText,
-                applicationName: applicationName,
-                completionLengthInstruction: completionLengthInstruction,
-                customAIInstructions: customAIInstructions
-            )
-        }
-    }
-
-    /// The instructions-based mode keeps a more explicit contract for local models that benefit
-    /// from stronger task framing, especially when testing how much user guidance the model follows.
-    private static func guidedPrompt(
-        prefixText: String,
-        applicationName: String,
-        completionLengthInstruction: String,
-        customAIInstructions: String?
+        customAIInstructions: String?,
+        visualContextSummary: String? = nil
     ) -> String {
         var sections = [
             "You are Tabby's inline autocomplete engine for a macOS text field.",
@@ -62,13 +44,17 @@ enum LlamaPromptRenderer {
             sections.append(contentsOf: customInstructionLines)
         }
 
-        sections.append(contentsOf: [
-            "",
-            "Context:",
-            "App: \(applicationName)",
-            "Text before caret:",
-            prefixText
-        ])
+        sections.append("")
+        sections.append("Context:")
+        sections.append("App: \(applicationName)")
+
+        if let summary = visualContextSummary, !summary.isEmpty {
+            sections.append("Screen content:")
+            sections.append(summary)
+        }
+
+        sections.append("Text before caret:")
+        sections.append(prefixText)
 
         return sections.joined(separator: "\n")
     }

--- a/tabby/Support/LlamaPromptRenderer.swift
+++ b/tabby/Support/LlamaPromptRenderer.swift
@@ -35,7 +35,7 @@ enum LlamaPromptRenderer {
             "Output contract:",
             "- Plain text only.",
             "- No labels, bullets, markdown, quotes, or explanation.",
-            "- Start immediately with the continuation text.",
+            "- Start immediately with the continuation text."
         ]
 
         let customInstructionLines = CustomAIInstructionFormatter.promptSectionLines(from: customAIInstructions)

--- a/tabby/Support/SuggestionAvailabilityEvaluator.swift
+++ b/tabby/Support/SuggestionAvailabilityEvaluator.swift
@@ -19,8 +19,7 @@ enum SuggestionAvailabilityEvaluator {
         }
 
         if let bundleIdentifier = focusSnapshot.bundleIdentifier,
-           disabledAppBundleIdentifiers.contains(bundleIdentifier)
-        {
+           disabledAppBundleIdentifiers.contains(bundleIdentifier) {
             return "Tabby is disabled in \(focusSnapshot.applicationName)."
         }
 

--- a/tabby/Support/SuggestionAvailabilityEvaluator.swift
+++ b/tabby/Support/SuggestionAvailabilityEvaluator.swift
@@ -11,6 +11,7 @@ enum SuggestionAvailabilityEvaluator {
         globallyEnabled: Bool = true,
         disabledAppBundleIdentifiers: Set<String> = [],
         inputMonitoringGranted: Bool,
+        screenRecordingGranted: Bool,
         focusSnapshot: FocusSnapshot
     ) -> String? {
         guard globallyEnabled else {
@@ -27,6 +28,11 @@ enum SuggestionAvailabilityEvaluator {
             return "Input Monitoring permission is required before Tabby can react to typing."
         }
 
+        guard screenRecordingGranted else {
+            return "Screen Recording permission is required before Tabby can build visual context "
+                + "for autocomplete."
+        }
+
         switch focusSnapshot.capability {
         case .supported:
             return nil
@@ -39,23 +45,25 @@ enum SuggestionAvailabilityEvaluator {
         globallyEnabled: Bool = true,
         disabledAppBundleIdentifiers: Set<String> = [],
         inputMonitoringGranted: Bool,
+        screenRecordingGranted: Bool,
         focusSnapshot: FocusSnapshot
     ) -> Bool {
         disabledReason(
             globallyEnabled: globallyEnabled,
             disabledAppBundleIdentifiers: disabledAppBundleIdentifiers,
             inputMonitoringGranted: inputMonitoringGranted,
+            screenRecordingGranted: screenRecordingGranted,
             focusSnapshot: focusSnapshot
         ) == nil
     }
 
     static func shouldSchedulePredictionWhenVisualContextBecomesReady(
         focusSnapshot: FocusSnapshot,
-        matching elementIdentifier: String
+        matching identity: FocusedInputIdentity
     ) -> Bool {
         guard case .supported = focusSnapshot.capability,
               let context = focusSnapshot.context,
-              context.elementIdentifier == elementIdentifier
+              context.identity == identity
         else {
             return false
         }

--- a/tabby/Support/SuggestionRequestFactory.swift
+++ b/tabby/Support/SuggestionRequestFactory.swift
@@ -29,7 +29,8 @@ enum SuggestionRequestFactory {
     static func buildRequest(
         context: FocusedInputContext,
         settings: SuggestionSettingsSnapshot,
-        configuration: SuggestionConfiguration
+        configuration: SuggestionConfiguration,
+        visualContextSummary: String? = nil
     ) -> SuggestionRequestBuildResult {
         let prefixText = truncatedPromptPrefix(
             from: context.precedingText,
@@ -40,9 +41,9 @@ enum SuggestionRequestFactory {
         let prompt = buildPrompt(
             context: context,
             prefixText: prefixText,
-            promptMode: settings.effectivePromptMode,
             completionLengthInstruction: completionLengthInstruction,
-            customAIInstructions: customAIInstructions
+            customAIInstructions: customAIInstructions,
+            visualContextSummary: visualContextSummary
         )
 
         let request = SuggestionRequest(
@@ -62,7 +63,8 @@ enum SuggestionRequestFactory {
             randomSeed: configuration.randomSeed,
             maxSuffixCharacters: configuration.maxSuffixCharacters,
             completionLengthInstruction: completionLengthInstruction,
-            customAIInstructions: customAIInstructions
+            customAIInstructions: customAIInstructions,
+            visualContextSummary: visualContextSummary
         )
 
         return SuggestionRequestBuildResult(
@@ -75,16 +77,16 @@ enum SuggestionRequestFactory {
     private static func buildPrompt(
         context: FocusedInputContext,
         prefixText: String,
-        promptMode: SuggestionPromptMode,
         completionLengthInstruction: String,
-        customAIInstructions: String?
+        customAIInstructions: String?,
+        visualContextSummary: String?
     ) -> String {
         LlamaPromptRenderer.prompt(
             prefixText: prefixText,
             applicationName: context.applicationName,
-            promptMode: promptMode,
             completionLengthInstruction: completionLengthInstruction,
-            customAIInstructions: customAIInstructions
+            customAIInstructions: customAIInstructions,
+            visualContextSummary: visualContextSummary
         )
     }
 
@@ -106,10 +108,6 @@ enum SuggestionRequestFactory {
     private static func activeCustomAIInstructions(
         settings: SuggestionSettingsSnapshot
     ) -> String? {
-        guard settings.effectivePromptMode == .guided else {
-            return nil
-        }
-
         return settings.customAIInstructions
     }
 

--- a/tabby/Support/SuggestionRequestFactory.swift
+++ b/tabby/Support/SuggestionRequestFactory.swift
@@ -108,7 +108,7 @@ enum SuggestionRequestFactory {
     private static func activeCustomAIInstructions(
         settings: SuggestionSettingsSnapshot
     ) -> String? {
-        return settings.customAIInstructions
+        settings.customAIInstructions
     }
 
     private static func activeMaxPredictionTokens(

--- a/tabby/Support/SuggestionSessionReconciler.swift
+++ b/tabby/Support/SuggestionSessionReconciler.swift
@@ -54,14 +54,6 @@ enum SuggestionSessionReconciler {
     ) -> SuggestionSessionReconciliation {
         let isAwaitingInsertedTextSync = pendingInsertionConsumedCount == session.consumedCharacterCount
 
-        func tolerateTransientPostInsertionLag() -> SuggestionSessionReconciliation {
-            .valid(
-                session: session,
-                advancement: nil,
-                nextPendingInsertionConsumedCount: pendingInsertionConsumedCount
-            )
-        }
-
         // Process-level identity check instead of AX element identity. Chrome recycles AX
         // node tokens between polls, making CFHash-based elementIdentifier unstable. The text
         // guards below catch intra-process field switches via content divergence.
@@ -73,53 +65,48 @@ enum SuggestionSessionReconciler {
             return .invalid("Overlay hidden because text is selected.")
         }
 
-        guard liveContext.trailingText == session.baseContext.trailingText else {
-            // Chromium editors can briefly publish a selection/caret update before their
-            // surrounding text snapshot catches up. Right after Tab insertion that makes the
-            // trailing-text slice look changed even though the active suggestion tail is still
-            // valid. We allow that transient mismatch only while the post-insertion sentinel is
-            // active and the prefix before the caret still anchors to the same field content.
-            if isAwaitingInsertedTextSync,
-               liveContext.precedingText.hasPrefix(session.baseContext.precedingText)
-            {
-                return tolerateTransientPostInsertionLag()
-            }
-            return .invalid("Overlay hidden because text after the caret changed.")
+        if let trailingTextReconciliation = reconcileTrailingText(
+            session: session,
+            liveContext: liveContext,
+            pendingInsertionConsumedCount: pendingInsertionConsumedCount,
+            isAwaitingInsertedTextSync: isAwaitingInsertedTextSync
+        ) {
+            return trailingTextReconciliation
         }
 
-        guard liveContext.precedingText.hasPrefix(session.baseContext.precedingText) else {
-            // The inverse Chromium race can also happen: the trailing text is already stable, but
-            // the prefix before the caret still reflects the pre-insertion snapshot. In that case
-            // we again prefer to wait for AX to settle instead of eagerly killing the session.
-            if isAwaitingInsertedTextSync {
-                return tolerateTransientPostInsertionLag()
-            }
-            return .invalid("Overlay hidden because text before the caret no longer matches the suggestion anchor.")
+        if let prefixReconciliation = reconcilePrefixAnchor(
+            session: session,
+            liveContext: liveContext,
+            pendingInsertionConsumedCount: pendingInsertionConsumedCount,
+            isAwaitingInsertedTextSync: isAwaitingInsertedTextSync
+        ) {
+            return prefixReconciliation
         }
 
         var nextPendingInsertionConsumedCount = pendingInsertionConsumedCount
         let consumedSuffix = String(liveContext.precedingText.dropFirst(session.baseContext.precedingText.count))
-        guard session.fullText.hasPrefix(consumedSuffix) else {
-            // If we just inserted via Tab, AX may still show stale text. Trust the sentinel
-            // for one reconciliation cycle instead of invalidating the whole session.
-            if isAwaitingInsertedTextSync {
-                return tolerateTransientPostInsertionLag()
-            }
-
-            return .invalid("Overlay hidden because typed text diverged from the active suggestion.")
+        if let consumedTextReconciliation = reconcileConsumedSuggestionText(
+            session: session,
+            consumedSuffix: consumedSuffix,
+            pendingInsertionConsumedCount: pendingInsertionConsumedCount,
+            isAwaitingInsertedTextSync: isAwaitingInsertedTextSync
+        ) {
+            return consumedTextReconciliation
         }
 
         // AX caught up (or never lagged) — clear the sentinel.
         if nextPendingInsertionConsumedCount != nil,
-           consumedSuffix.count >= session.consumedCharacterCount
-        {
+           consumedSuffix.count >= session.consumedCharacterCount {
             nextPendingInsertionConsumedCount = nil
         }
 
         guard consumedSuffix.count >= session.consumedCharacterCount else {
             // Same AX lag protection: if we just Tab-inserted, the preceding text hasn't updated yet.
             if isAwaitingInsertedTextSync {
-                return tolerateTransientPostInsertionLag()
+                return tolerateTransientPostInsertionLag(
+                    session: session,
+                    pendingInsertionConsumedCount: pendingInsertionConsumedCount
+                )
             }
 
             return .invalid("Overlay hidden because the active suggestion was partially undone.")
@@ -150,6 +137,86 @@ enum SuggestionSessionReconciler {
             advancement: advancement,
             nextPendingInsertionConsumedCount: nextPendingInsertionConsumedCount
         )
+    }
+
+    private static func tolerateTransientPostInsertionLag(
+        session: ActiveSuggestionSession,
+        pendingInsertionConsumedCount: Int?
+    ) -> SuggestionSessionReconciliation {
+        .valid(
+            session: session,
+            advancement: nil,
+            nextPendingInsertionConsumedCount: pendingInsertionConsumedCount
+        )
+    }
+
+    private static func reconcileTrailingText(
+        session: ActiveSuggestionSession,
+        liveContext: FocusedInputContext,
+        pendingInsertionConsumedCount: Int?,
+        isAwaitingInsertedTextSync: Bool
+    ) -> SuggestionSessionReconciliation? {
+        guard liveContext.trailingText != session.baseContext.trailingText else {
+            return nil
+        }
+
+        // Chromium editors can briefly publish a selection/caret update before their surrounding
+        // text snapshot catches up. Right after Tab insertion that makes the trailing-text slice
+        // look changed even though the active suggestion tail is still valid.
+        if isAwaitingInsertedTextSync,
+           liveContext.precedingText.hasPrefix(session.baseContext.precedingText) {
+            return tolerateTransientPostInsertionLag(
+                session: session,
+                pendingInsertionConsumedCount: pendingInsertionConsumedCount
+            )
+        }
+
+        return .invalid("Overlay hidden because text after the caret changed.")
+    }
+
+    private static func reconcilePrefixAnchor(
+        session: ActiveSuggestionSession,
+        liveContext: FocusedInputContext,
+        pendingInsertionConsumedCount: Int?,
+        isAwaitingInsertedTextSync: Bool
+    ) -> SuggestionSessionReconciliation? {
+        guard !liveContext.precedingText.hasPrefix(session.baseContext.precedingText) else {
+            return nil
+        }
+
+        // The inverse Chromium race can also happen: the trailing text is already stable, but the
+        // prefix before the caret still reflects the pre-insertion snapshot. In that case we wait
+        // for AX to settle instead of eagerly killing the session.
+        if isAwaitingInsertedTextSync {
+            return tolerateTransientPostInsertionLag(
+                session: session,
+                pendingInsertionConsumedCount: pendingInsertionConsumedCount
+            )
+        }
+
+        return .invalid("Overlay hidden because text before the caret no longer matches the suggestion anchor.")
+    }
+
+    private static func reconcileConsumedSuggestionText(
+        session: ActiveSuggestionSession,
+        consumedSuffix: String,
+        pendingInsertionConsumedCount: Int?,
+        isAwaitingInsertedTextSync: Bool
+    ) -> SuggestionSessionReconciliation? {
+        guard !session.fullText.hasPrefix(consumedSuffix) else {
+            return nil
+        }
+
+        // If we just inserted via Tab, AX may still show stale text. Trust the sentinel for one
+        // reconciliation cycle instead of invalidating the whole session.
+        if isAwaitingInsertedTextSync {
+            return tolerateTransientPostInsertionLag(
+                session: session,
+                pendingInsertionConsumedCount: pendingInsertionConsumedCount
+            )
+        }
+
+        return .invalid("Overlay hidden because typed text diverged from the active suggestion.")
     }
 
     /// Accepts optional leading whitespace plus the next visible token.

--- a/tabby/Support/SuggestionTextNormalizer.swift
+++ b/tabby/Support/SuggestionTextNormalizer.swift
@@ -46,8 +46,7 @@ enum SuggestionTextNormalizer {
         // suggestion as unusable. Showing only the remainder often produces confusing mid-word
         // ghosts, so the coordinator should regenerate instead.
         if !request.context.trailingText.isEmpty,
-            normalized.hasPrefix(request.context.trailingText)
-        {
+            normalized.hasPrefix(request.context.trailingText) {
             return ""
         }
 

--- a/tabby/Support/TabbyDebugOptions.swift
+++ b/tabby/Support/TabbyDebugOptions.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// File overview:
+/// Centralizes Tabby's developer-only runtime switches.
+///
+/// A single launch argument is easier to reason about than separate feature flags because every
+/// privacy-sensitive diagnostic path has one obvious gate. Passing `-tabby-debug` means the
+/// developer intentionally opted into local debugging artifacts such as overlays, detailed service
+/// logs, and screenshot/OCR captures.
+enum TabbyDebugOptions {
+    static let launchArgument = "-tabby-debug"
+
+    static var isEnabled: Bool {
+        ProcessInfo.processInfo.arguments.contains(launchArgument)
+    }
+
+    /// Writes a diagnostic line only when the explicit debug launch argument is present.
+    ///
+    /// Keep this for metadata, not raw user content. Full prompts, OCR text, and screenshots are
+    /// sensitive enough that call sites should make an intentional artifact decision instead of
+    /// accidentally leaking them through normal stdout.
+    static func log(_ message: @autoclosure () -> String) {
+        guard isEnabled else {
+            return
+        }
+
+        print(message())
+    }
+}

--- a/tabby/UI/SettingsView.swift
+++ b/tabby/UI/SettingsView.swift
@@ -500,8 +500,8 @@ struct SettingsView: View {
     }
 
     private var customAIInstructionsDescription: String {
-        return
-            "These instructions are active for autocomplete. Use them to tell Tabby about your tone, language, audience, or formatting preferences."
+        "These instructions are active for autocomplete. Use them to tell Tabby about your " +
+            "tone, language, audience, or formatting preferences."
     }
 
     private var localModelsDescription: String {

--- a/tabby/UI/SettingsView.swift
+++ b/tabby/UI/SettingsView.swift
@@ -165,19 +165,6 @@ struct SettingsView: View {
                         .tag(preset)
                 }
             }
-
-            if suggestionSettings.selectedEngine.supportsPromptModeSelection {
-                Picker("Completion Style", selection: selectedLocalPromptModeBinding) {
-                    ForEach(suggestionSettings.availablePromptModes) { mode in
-                        Text(mode.displayLabel)
-                            .tag(mode)
-                    }
-                }
-            } else {
-                Text("Completion Style and custom instructions apply to the Open Source engine.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
         }
     }
 
@@ -215,7 +202,7 @@ struct SettingsView: View {
     @ViewBuilder
     private var permissionsSection: some View {
         Section("Permissions") {
-            Text("Tabby needs Accessibility and Input Monitoring for autocomplete.")
+            Text("Tabby needs Accessibility, Input Monitoring, and Screen Recording for autocomplete.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
@@ -229,6 +216,12 @@ struct SettingsView: View {
                 title: "Input Monitoring",
                 granted: permissionManager.inputMonitoringGranted,
                 action: permissionManager.openInputMonitoringSettings
+            )
+
+            settingsPermissionRow(
+                title: "Screen Recording",
+                granted: permissionManager.screenRecordingGranted,
+                action: permissionManager.openScreenRecordingSettings
             )
         }
     }
@@ -468,15 +461,6 @@ struct SettingsView: View {
         )
     }
 
-    private var selectedLocalPromptModeBinding: Binding<SuggestionPromptMode> {
-        Binding(
-            get: { suggestionSettings.selectedLocalPromptMode },
-            set: { mode in
-                suggestionSettings.selectLocalPromptMode(mode)
-            }
-        )
-    }
-
     private var customAIInstructionsBinding: Binding<String> {
         Binding(
             get: { suggestionSettings.customAIInstructions },
@@ -516,20 +500,8 @@ struct SettingsView: View {
     }
 
     private var customAIInstructionsDescription: String {
-        if suggestionSettings.selectedEngine == .llamaOpenSource,
-            suggestionSettings.effectivePromptMode == .guided
-        {
-            return
-                "These instructions are active right now. Use them to tell Tabby about your tone, language, audience, or formatting preferences."
-        }
-
-        if suggestionSettings.selectedEngine == .llamaOpenSource {
-            return
-                "These instructions are saved for the Open Source engine. They take effect when Completion Style is set to Use My Instructions."
-        }
-
         return
-            "These instructions are saved for the Open Source engine. Apple Intelligence ignores this field."
+            "These instructions are active for autocomplete. Use them to tell Tabby about your tone, language, audience, or formatting preferences."
     }
 
     private var localModelsDescription: String {

--- a/tabby/UI/WelcomePermissionStepView.swift
+++ b/tabby/UI/WelcomePermissionStepView.swift
@@ -8,8 +8,8 @@ import SwiftUI
 /// an Allow button or Done state. The view stays subscribed to live permission state so cards
 /// update in real time as the user grants access through System Settings.
 ///
-/// Only the two required permissions (Accessibility, Input Monitoring) are shown during
-/// onboarding. Screen Recording is deprecated and intentionally omitted from the visible MVP flow.
+/// The onboarding list is derived from `TabbyPermissionKind.isRequiredForAutocomplete` so the
+/// product's permission model and first-run UI cannot drift apart.
 struct WelcomePermissionStepView: View {
     @ObservedObject var permissionManager: PermissionManager
 
@@ -17,8 +17,7 @@ struct WelcomePermissionStepView: View {
     let onBack: () -> Void
     let onContinue: () -> Void
 
-    /// Only show the permissions that matter for core autocomplete during onboarding.
-    /// Deprecated permissions stay out of the first-run UI so users see only what blocks setup.
+    /// Only show permissions that block core autocomplete.
     private var onboardingPermissions: [TabbyPermissionKind] {
         TabbyPermissionKind.allCases.filter(\.isRequiredForAutocomplete)
     }
@@ -29,7 +28,7 @@ struct WelcomePermissionStepView: View {
                 Text("Enable tabby")
                     .font(.system(size: 24, weight: .semibold, design: .rounded))
 
-                Text("Grant permissions so tabby can\nread your text and accept completions.")
+                Text("Grant permissions so tabby can\nread text, capture context, and accept completions.")
                     .font(.system(size: 14, design: .rounded))
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
@@ -48,7 +47,7 @@ struct WelcomePermissionStepView: View {
             WelcomeNavigation(
                 canGoBack: true,
                 canContinue: permissionManager.requiredPermissionsGranted,
-                disabledHint: "Grant both permissions to continue.",
+                disabledHint: "Grant all permissions to continue.",
                 onBack: onBack,
                 onContinue: onContinue
             )

--- a/tabby/UI/WelcomeView.swift
+++ b/tabby/UI/WelcomeView.swift
@@ -310,52 +310,55 @@ private struct EngineCard: View {
     let action: () -> Void
 
     var body: some View {
-        Button(action: {
-            if isAvailable {
-                action()
-            }
-        }) {
-            HStack(spacing: 14) {
-                EngineArtworkThumbnail(
-                    artworkName: artworkName,
-                    isSelected: isSelected,
-                    isAvailable: isAvailable
-                )
-
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(title)
-                        .font(.system(size: 14, weight: .medium))
-                        .foregroundStyle(isAvailable ? .primary : .tertiary)
-
-                    Text(subtitle)
-                        .font(.system(size: 12))
-                        .foregroundStyle(.secondary)
+        Button(
+            action: {
+                if isAvailable {
+                    action()
                 }
-
-                Spacer(minLength: 0)
-
-                if isSelected && isAvailable {
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(.system(size: 18))
-                        .foregroundColor(.accentColor)
-                }
-            }
-            .padding(18)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(
-                RoundedRectangle(cornerRadius: 16, style: .continuous)
-                    .fill(.regularMaterial)
-                    .shadow(color: .black.opacity(0.06), radius: 2, y: 1)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 16, style: .continuous)
-                    .stroke(
-                        isSelected && isAvailable
-                            ? Color.accentColor.opacity(0.4) : Color.white.opacity(0.08),
-                        lineWidth: isSelected && isAvailable ? 1.5 : 0.5
+            },
+            label: {
+                HStack(spacing: 14) {
+                    EngineArtworkThumbnail(
+                        artworkName: artworkName,
+                        isSelected: isSelected,
+                        isAvailable: isAvailable
                     )
-            )
-        }
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(title)
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundStyle(isAvailable ? .primary : .tertiary)
+
+                        Text(subtitle)
+                            .font(.system(size: 12))
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Spacer(minLength: 0)
+
+                    if isSelected && isAvailable {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.system(size: 18))
+                            .foregroundColor(.accentColor)
+                    }
+                }
+                .padding(18)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .fill(.regularMaterial)
+                        .shadow(color: .black.opacity(0.06), radius: 2, y: 1)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .stroke(
+                            isSelected && isAvailable
+                                ? Color.accentColor.opacity(0.4) : Color.white.opacity(0.08),
+                            lineWidth: isSelected && isAvailable ? 1.5 : 0.5
+                        )
+                )
+            }
+        )
         .buttonStyle(.plain)
         .disabled(!isAvailable)
     }
@@ -423,8 +426,8 @@ struct WelcomeButton: View {
 struct WelcomeNavigation: View {
     var canGoBack: Bool = false
     var canContinue: Bool = true
-    var disabledHint: String? = nil
-    var onBack: (() -> Void)? = nil
+    var disabledHint: String?
+    var onBack: (() -> Void)?
     let onContinue: () -> Void
 
     var body: some View {

--- a/tabby/UI/WelcomeView.swift
+++ b/tabby/UI/WelcomeView.swift
@@ -78,7 +78,7 @@ private enum WelcomeStep: Int, Comparable {
         case .welcome:
             return NSSize(width: 500, height: 320)
         case .permissions:
-            return NSSize(width: 540, height: 400)
+            return NSSize(width: 540, height: 480)
         case .chooseModel:
             if selectedEngine == .llamaOpenSource {
                 return NSSize(width: 540, height: 520)

--- a/tabbyTests/LlamaPromptRendererTests.swift
+++ b/tabbyTests/LlamaPromptRendererTests.swift
@@ -9,39 +9,6 @@ import XCTest
 /// same string, so every assertion here is deterministic.
 final class LlamaPromptRendererTests: XCTestCase {
 
-    // MARK: - prefixOnly mode
-
-    /// Fast path must return the prefix verbatim. If this ever breaks, base
-    /// models will see unexpected framing tokens and start hallucinating
-    /// "Sure," / "Here's" continuations.
-    func test_prefixOnly_returnsPrefixVerbatim() {
-        let prompt = LlamaPromptRenderer.prompt(
-            prefixText: "Hello, wor",
-            applicationName: "TestApp",
-            promptMode: .prefixOnly,
-            completionLengthInstruction: "Keep it short.",
-            customAIInstructions: nil
-        )
-
-        XCTAssertEqual(prompt, "Hello, wor")
-    }
-
-    /// prefixOnly deliberately ignores custom instructions — documented as the
-    /// "low-overhead path" in the renderer. If these ever leak in, base models
-    /// would suddenly see chat framing they don't know how to handle.
-    func test_prefixOnly_ignoresCustomInstructions() {
-        let prompt = LlamaPromptRenderer.prompt(
-            prefixText: "foo",
-            applicationName: "TestApp",
-            promptMode: .prefixOnly,
-            completionLengthInstruction: "Short.",
-            customAIInstructions: "UNIQUE_MARKER_SHOULD_NOT_APPEAR"
-        )
-
-        XCTAssertEqual(prompt, "foo")
-        XCTAssertFalse(prompt.contains("UNIQUE_MARKER_SHOULD_NOT_APPEAR"))
-    }
-
     // MARK: - cache hints
 
     func test_cacheHint_nilBeforeSuccessfulRequestIsRecorded() {
@@ -91,30 +58,31 @@ final class LlamaPromptRendererTests: XCTestCase {
         XCTAssertNil(tracker.cachedPrefixBytes(for: makeRequest(prompt: "hello!", topK: 40)))
     }
 
-    // MARK: - guided mode
+    // MARK: - instruction prompt
 
-    /// The structural contract of guided mode: three labelled sections the
+    /// The structural contract of the instruction prompt: three labelled sections the
     /// instruct model is trained to parse. Losing any of them would silently
     /// degrade output quality without throwing.
-    func test_guided_containsTaskAndOutputContract() {
+    func test_instructionPrompt_containsTaskAndOutputContract() {
         let prompt = LlamaPromptRenderer.prompt(
             prefixText: "Once upon",
             applicationName: "Messages",
-            promptMode: .guided,
             completionLengthInstruction: "Keep completion short.",
             customAIInstructions: nil
         )
 
-        XCTAssertTrue(prompt.contains("Task:"), "guided prompt should include Task section")
-        XCTAssertTrue(prompt.contains("Output contract:"), "guided prompt should include Output contract section")
-        XCTAssertTrue(prompt.contains("Context:"), "guided prompt should include Context section")
+        XCTAssertTrue(prompt.contains("Task:"), "instruction prompt should include Task section")
+        XCTAssertTrue(
+            prompt.contains("Output contract:"),
+            "instruction prompt should include Output contract section"
+        )
+        XCTAssertTrue(prompt.contains("Context:"), "instruction prompt should include Context section")
     }
 
-    func test_guided_includesApplicationNameAndPrefix() {
+    func test_instructionPrompt_includesApplicationNameAndPrefix() {
         let prompt = LlamaPromptRenderer.prompt(
             prefixText: "My prefix text here",
             applicationName: "Slack",
-            promptMode: .guided,
             completionLengthInstruction: "Short.",
             customAIInstructions: nil
         )
@@ -126,11 +94,10 @@ final class LlamaPromptRendererTests: XCTestCase {
     /// The completion-length instruction is chosen from the user's word-count
     /// preset. It must reach the prompt verbatim so the model sees the exact
     /// guidance the UI showed the user.
-    func test_guided_includesCompletionLengthInstruction() {
+    func test_instructionPrompt_includesCompletionLengthInstruction() {
         let prompt = LlamaPromptRenderer.prompt(
             prefixText: "x",
             applicationName: "App",
-            promptMode: .guided,
             completionLengthInstruction: "UNIQUE_LENGTH_MARKER_7_TO_12_WORDS",
             customAIInstructions: nil
         )
@@ -138,27 +105,25 @@ final class LlamaPromptRendererTests: XCTestCase {
         XCTAssertTrue(prompt.contains("UNIQUE_LENGTH_MARKER_7_TO_12_WORDS"))
     }
 
-    func test_guided_includesCustomInstructionsWhenProvided() {
+    func test_instructionPrompt_includesCustomInstructionsWhenProvided() {
         let prompt = LlamaPromptRenderer.prompt(
             prefixText: "x",
             applicationName: "App",
-            promptMode: .guided,
             completionLengthInstruction: "Short.",
             customAIInstructions: "UNIQUE_CUSTOM_MARKER_ZQRT"
         )
 
         XCTAssertTrue(prompt.contains("UNIQUE_CUSTOM_MARKER_ZQRT"),
-                      "guided prompt should carry user-provided custom instructions")
+                      "instruction prompt should carry user-provided custom instructions")
     }
 
-    /// The prefix is always the *last* section of guided mode — the model
+    /// The prefix is always the *last* section of the instruction prompt — the model
     /// continues from the last token, so the prefix has to come last.
     /// Tests the contract that prefix comes after Context:/App:/Text before caret:.
-    func test_guided_prefixAppearsAfterContextHeader() {
+    func test_instructionPrompt_prefixAppearsAfterContextHeader() {
         let prompt = LlamaPromptRenderer.prompt(
             prefixText: "PREFIX_BODY_XYZ",
             applicationName: "App",
-            promptMode: .guided,
             completionLengthInstruction: "Short.",
             customAIInstructions: nil
         )
@@ -171,6 +136,31 @@ final class LlamaPromptRendererTests: XCTestCase {
 
         XCTAssertLessThan(contextRange.lowerBound, prefixRange.lowerBound,
                           "prefix must appear after the Context: header")
+    }
+
+    func test_instructionPrompt_includesVisualContextSummaryWhenProvided() {
+        let prompt = LlamaPromptRenderer.prompt(
+            prefixText: "PREFIX",
+            applicationName: "App",
+            completionLengthInstruction: "Short.",
+            customAIInstructions: nil,
+            visualContextSummary: "A window describing a cat."
+        )
+
+        XCTAssertTrue(prompt.contains("Screen content:"))
+        XCTAssertTrue(prompt.contains("A window describing a cat."))
+    }
+
+    func test_instructionPrompt_omitsVisualContextSummaryWhenNil() {
+        let prompt = LlamaPromptRenderer.prompt(
+            prefixText: "PREFIX",
+            applicationName: "App",
+            completionLengthInstruction: "Short.",
+            customAIInstructions: nil,
+            visualContextSummary: nil
+        )
+
+        XCTAssertFalse(prompt.contains("Screen content:"))
     }
 
     private func makeRequest(
@@ -212,7 +202,8 @@ final class LlamaPromptRendererTests: XCTestCase {
             randomSeed: 42,
             maxSuffixCharacters: 192,
             completionLengthInstruction: "Return only the next few words.",
-            customAIInstructions: nil
+            customAIInstructions: nil,
+            visualContextSummary: nil
         )
     }
 }

--- a/tabbyTests/SuggestionAvailabilityEvaluatorTests.swift
+++ b/tabbyTests/SuggestionAvailabilityEvaluatorTests.swift
@@ -1,4 +1,5 @@
 import Combine
+import CoreGraphics
 import XCTest
 @testable import tabby
 
@@ -25,6 +26,39 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
         )
     }
 
+    private func makeSupportedSnapshotWithContext(
+        elementIdentifier: String = "field",
+        focusChangeSequence: UInt64 = 1,
+        precedingText: String = "hello"
+    ) -> FocusSnapshot {
+        let context = FocusedInputSnapshot(
+            applicationName: "TestApp",
+            bundleIdentifier: "app.test",
+            processIdentifier: 123,
+            elementIdentifier: elementIdentifier,
+            role: "AXTextField",
+            subrole: nil,
+            caretRect: .zero,
+            inputFrameRect: nil,
+            caretSource: "test",
+            caretQuality: .exact,
+            observedCharWidth: nil,
+            precedingText: precedingText,
+            trailingText: "",
+            selection: NSRange(location: precedingText.count, length: 0),
+            isSecure: false,
+            focusChangeSequence: focusChangeSequence
+        )
+
+        return FocusSnapshot(
+            applicationName: "TestApp",
+            bundleIdentifier: "app.test",
+            capability: .supported,
+            context: context,
+            inspection: nil
+        )
+    }
+
     // MARK: - disabledReason: exact-string contracts
 
     /// If this string ever changes, the menu-bar status copy will silently
@@ -33,6 +67,7 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
         let reason = SuggestionAvailabilityEvaluator.disabledReason(
             globallyEnabled: false,
             inputMonitoringGranted: true,
+            screenRecordingGranted: true,
             focusSnapshot: makeSnapshot(capability: .supported)
         )
 
@@ -43,12 +78,26 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
         let reason = SuggestionAvailabilityEvaluator.disabledReason(
             globallyEnabled: true,
             inputMonitoringGranted: false,
+            screenRecordingGranted: true,
             focusSnapshot: makeSnapshot(capability: .supported)
         )
 
         XCTAssertNotNil(reason)
         XCTAssertTrue(reason?.contains("Input Monitoring") ?? false,
                       "reason should point the user at the permission they need to grant")
+    }
+
+    func test_disabledReason_whenScreenRecordingDenied_mentionsPermission() {
+        let reason = SuggestionAvailabilityEvaluator.disabledReason(
+            globallyEnabled: true,
+            inputMonitoringGranted: true,
+            screenRecordingGranted: false,
+            focusSnapshot: makeSnapshot(capability: .supported)
+        )
+
+        XCTAssertNotNil(reason)
+        XCTAssertTrue(reason?.contains("Screen Recording") ?? false,
+                      "reason should point the user at the permission needed for visual context")
     }
 
     // MARK: - disabledReason: guard ordering
@@ -60,6 +109,7 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
         let reason = SuggestionAvailabilityEvaluator.disabledReason(
             globallyEnabled: false,
             inputMonitoringGranted: false,
+            screenRecordingGranted: false,
             focusSnapshot: makeSnapshot(capability: .supported)
         )
 
@@ -71,6 +121,7 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
             globallyEnabled: false,
             disabledAppBundleIdentifiers: ["app.test"],
             inputMonitoringGranted: true,
+            screenRecordingGranted: true,
             focusSnapshot: makeSnapshot(capability: .supported)
         )
 
@@ -82,6 +133,7 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
             globallyEnabled: true,
             disabledAppBundleIdentifiers: ["com.apple.Safari"],
             inputMonitoringGranted: true,
+            screenRecordingGranted: true,
             focusSnapshot: makeSnapshot(
                 applicationName: "Safari",
                 bundleIdentifier: "com.apple.Safari",
@@ -102,6 +154,7 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
         let reason = SuggestionAvailabilityEvaluator.disabledReason(
             globallyEnabled: true,
             inputMonitoringGranted: true,
+            screenRecordingGranted: true,
             focusSnapshot: makeSnapshot(capability: .blocked(blockReason))
         )
 
@@ -113,6 +166,7 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
         let reason = SuggestionAvailabilityEvaluator.disabledReason(
             globallyEnabled: true,
             inputMonitoringGranted: true,
+            screenRecordingGranted: true,
             focusSnapshot: makeSnapshot(capability: .unsupported(unsupportedReason))
         )
 
@@ -125,6 +179,7 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
         let reason = SuggestionAvailabilityEvaluator.disabledReason(
             globallyEnabled: true,
             inputMonitoringGranted: true,
+            screenRecordingGranted: true,
             focusSnapshot: makeSnapshot(capability: .supported)
         )
 
@@ -140,6 +195,7 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
         let ok = SuggestionAvailabilityEvaluator.shouldSchedulePrediction(
             globallyEnabled: true,
             inputMonitoringGranted: true,
+            screenRecordingGranted: true,
             focusSnapshot: makeSnapshot(capability: .supported)
         )
 
@@ -150,6 +206,7 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
         let ok = SuggestionAvailabilityEvaluator.shouldSchedulePrediction(
             globallyEnabled: false,
             inputMonitoringGranted: true,
+            screenRecordingGranted: true,
             focusSnapshot: makeSnapshot(capability: .supported)
         )
 
@@ -161,6 +218,7 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
             globallyEnabled: true,
             disabledAppBundleIdentifiers: ["app.test"],
             inputMonitoringGranted: true,
+            screenRecordingGranted: true,
             focusSnapshot: makeSnapshot(capability: .supported)
         )
 
@@ -172,6 +230,7 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
             globallyEnabled: true,
             disabledAppBundleIdentifiers: ["app.other"],
             inputMonitoringGranted: true,
+            screenRecordingGranted: true,
             focusSnapshot: makeSnapshot(capability: .supported)
         )
 
@@ -182,7 +241,47 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
         let ok = SuggestionAvailabilityEvaluator.shouldSchedulePrediction(
             globallyEnabled: true,
             inputMonitoringGranted: true,
+            screenRecordingGranted: true,
             focusSnapshot: makeSnapshot(capability: .unsupported("No focused text input"))
+        )
+
+        XCTAssertFalse(ok)
+    }
+
+    func test_shouldSchedulePrediction_falseWhenScreenRecordingDenied() {
+        let ok = SuggestionAvailabilityEvaluator.shouldSchedulePrediction(
+            globallyEnabled: true,
+            inputMonitoringGranted: true,
+            screenRecordingGranted: false,
+            focusSnapshot: makeSnapshot(capability: .supported)
+        )
+
+        XCTAssertFalse(ok)
+    }
+
+    func test_visualContextReadyScheduling_trueWhenElementAndFocusSequenceMatch() {
+        let snapshot = makeSupportedSnapshotWithContext(
+            elementIdentifier: "field",
+            focusChangeSequence: 42
+        )
+
+        let ok = SuggestionAvailabilityEvaluator.shouldSchedulePredictionWhenVisualContextBecomesReady(
+            focusSnapshot: snapshot,
+            matching: FocusedInputIdentity(elementIdentifier: "field", focusChangeSequence: 42)
+        )
+
+        XCTAssertTrue(ok)
+    }
+
+    func test_visualContextReadyScheduling_falseWhenFocusSequenceDiffers() {
+        let snapshot = makeSupportedSnapshotWithContext(
+            elementIdentifier: "field",
+            focusChangeSequence: 42
+        )
+
+        let ok = SuggestionAvailabilityEvaluator.shouldSchedulePredictionWhenVisualContextBecomesReady(
+            focusSnapshot: snapshot,
+            matching: FocusedInputIdentity(elementIdentifier: "field", focusChangeSequence: 41)
         )
 
         XCTAssertFalse(ok)


### PR DESCRIPTION
## Summary

Adds screenshot -> OCR -> local-summary visual context to Tabby's autocomplete pipeline and makes Screen Recording a first-class required permission for autocomplete. The coordinator now starts a field-scoped visual context session on focus changes, injects the ready summary into the local Llama prompt for the same focused input, and reschedules prediction once that context becomes available.

## What Changed

- Promoted Screen Recording into the required permission model across availability gating, Settings, onboarding copy, and guided System Settings flow.
- Added the visual context pipeline: focused-input screenshot capture, OCR extraction, optional local Llama summarization, bounded summary output, and prompt injection through the suggestion request factory.
- Added `LlamaVisualContextSummarizer` and an ephemeral `LlamaRuntimeManager.summarize` path so OCR summarization does not mutate or pollute the autocomplete KV prompt cache.
- Updated ScreenCaptureKit capture bounds to favor the focused input container width, apply a safer minimum width, and clamp crops inside the target window.
- Added field-scoped visual context session handling in `VisualContextCoordinator`, including capture/extract/summarize/ready states and prediction rescheduling when context becomes ready.
- Added `FocusedInputIdentity` with `elementIdentifier + focusChangeSequence`, then threaded that identity through snapshots, focused contexts, visual-context lookup, and ready callbacks to avoid CFHash reuse/collision bugs.
- Simplified local Llama prompting to one instruction-rendered contract so custom instructions and visual context use the same prompt path.
- Consolidated developer diagnostics under the single `-tabby-debug` launch flag, including the focus overlay, debug logs, and screenshot/OCR artifacts.
- Removed unconditional prompt/OCR stdout logging. Normal runs no longer dump full prompts, typed text, OCR text, or summaries to console.
- Added/updated tests for prompt rendering, permission gating, and visual-context identity matching.
- Cleaned up SwiftLint issues across the changed Swift files.

## Privacy and Debugging Notes

- Debug screenshots and OCR text are written to `~/Desktop/tabby-debug-screenshots` only when Tabby is launched with `-tabby-debug`.
- Prompt and visual-context diagnostics are gated behind `TabbyDebugOptions` instead of unconditional `print` calls.
- Visual summaries are capped with `VisualContextConfiguration.maxSummaryCharacters` before being injected into the autocomplete prompt.

## Reviewer Notes

- Visual context is intentionally tied to `FocusedInputIdentity`, not just `elementIdentifier`, because Accessibility element IDs are derived from `CFHash` and can be recycled by macOS.
- The summarization path uses a fresh llama context instead of the shared autocomplete context so background OCR summarization does not affect prefix-cache reuse for normal completions.
- The visual context session is preserved across transient disabled states like selected text or brief unsupported snapshots, because those states can happen while switching fields and should not force a redundant screenshot capture.

## Validation

- `swiftlint .`
- `git diff --check origin/main...HEAD`
- `xcodebuild build -scheme tabby -destination 'platform=macOS'`
