### PR TITLE
feat: First-token logit gating to suppress chat-residue openers

### DIFF
--- a/tabby/Models/SuggestionEngineModels.swift
+++ b/tabby/Models/SuggestionEngineModels.swift
@@ -79,4 +79,8 @@ struct SuggestionSettingsSnapshot: Equatable, Sendable {
     /// Normalized user-authored guidance for the instructions-based completion style.
     /// This travels in the snapshot so generation uses the same value the Settings UI shows.
     let customAIInstructions: String?
+    /// When true, the llama runtime applies `-inf` logit bias to known chat-residue tokens
+    /// on the first generated token, preventing conversational openers from appearing in
+    /// inline autocomplete suggestions.
+    let isFirstTokenGatingEnabled: Bool
 }

--- a/tabby/Models/SuggestionModels.swift
+++ b/tabby/Models/SuggestionModels.swift
@@ -253,6 +253,10 @@ struct SuggestionRequest: Equatable, Sendable {
     /// Optional user-provided style guidance. We keep this separate from base product behavior so
     /// future settings/personalization work can evolve independently from prompt safety rules.
     let customAIInstructions: String?
+    /// When true, the llama runtime should apply `-inf` logit bias to known chat-residue tokens
+    /// on the very first sampled token. This is a llama-only feature — Apple Intelligence does
+    /// not expose logit-level control.
+    let isFirstTokenGatingEnabled: Bool
 }
 
 /// The engine's normalized response, including raw model text for debugging.

--- a/tabby/Models/SuggestionSettingsModel.swift
+++ b/tabby/Models/SuggestionSettingsModel.swift
@@ -19,6 +19,11 @@ final class SuggestionSettingsModel: ObservableObject {
     @Published private(set) var selectedWordCountPreset: SuggestionWordCountPreset
     @Published private(set) var selectedLocalPromptMode: SuggestionPromptMode
     @Published private(set) var customAIInstructions: String
+    /// When enabled, the llama runtime applies a `-inf` logit bias to known chat-residue tokens
+    /// (e.g. "Sure,", "Here's", "I ") on the first generated token only.
+    /// This prevents instruction-tuned models from starting suggestions with conversational
+    /// openers that belong in a chat reply, not in inline autocomplete.
+    @Published private(set) var isFirstTokenGatingEnabled: Bool
 
     private let userDefaults: UserDefaults
 
@@ -32,6 +37,7 @@ final class SuggestionSettingsModel: ObservableObject {
     private static let selectedWordCountPresetDefaultsKey = "selectedSuggestionWordCountPreset"
     private static let selectedLocalPromptModeDefaultsKey = "selectedLocalSuggestionPromptMode"
     private static let customAIInstructionsDefaultsKey = "tabbyCustomAIInstructions"
+    private static let isFirstTokenGatingEnabledDefaultsKey = "tabbyFirstTokenGatingEnabled"
 
     init(
         configuration: SuggestionConfiguration,
@@ -66,6 +72,8 @@ final class SuggestionSettingsModel: ObservableObject {
         } else {
             userDefaults.string(forKey: Self.customAIInstructionsDefaultsKey) ?? ""
         }
+        // Default to enabled — first-token gating is a net positive for all known instruct models.
+        let resolvedFirstTokenGatingEnabled = userDefaults.object(forKey: Self.isFirstTokenGatingEnabledDefaultsKey) as? Bool ?? true
 
         isGloballyEnabled = resolvedGloballyEnabled
         disabledAppRules = resolvedDisabledAppRules
@@ -75,6 +83,7 @@ final class SuggestionSettingsModel: ObservableObject {
         selectedWordCountPreset = resolvedWordCountPreset
         selectedLocalPromptMode = resolvedLocalPromptMode
         customAIInstructions = resolvedCustomAIInstructions
+        isFirstTokenGatingEnabled = resolvedFirstTokenGatingEnabled
 
         userDefaults.set(resolvedGloballyEnabled, forKey: Self.isGloballyEnabledDefaultsKey)
         persistDisabledAppRules(resolvedDisabledAppRules)
@@ -84,6 +93,7 @@ final class SuggestionSettingsModel: ObservableObject {
         persistSelectedWordCountPreset(resolvedWordCountPreset)
         persistSelectedLocalPromptMode(resolvedLocalPromptMode)
         persistCustomAIInstructions(resolvedCustomAIInstructions)
+        userDefaults.set(resolvedFirstTokenGatingEnabled, forKey: Self.isFirstTokenGatingEnabledDefaultsKey)
     }
 
     /// Compatibility shim for legacy call sites while the UI migrates from the old toggle to the
@@ -110,7 +120,8 @@ final class SuggestionSettingsModel: ObservableObject {
             selectedEngine: selectedEngine,
             selectedWordCountPreset: selectedWordCountPreset,
             effectivePromptMode: effectivePromptMode,
-            customAIInstructions: CustomAIInstructionFormatter.normalized(customAIInstructions)
+            customAIInstructions: CustomAIInstructionFormatter.normalized(customAIInstructions),
+            isFirstTokenGatingEnabled: isFirstTokenGatingEnabled
         )
     }
 
@@ -262,6 +273,15 @@ final class SuggestionSettingsModel: ObservableObject {
         persistCustomAIInstructions(instructions)
     }
 
+    func setFirstTokenGatingEnabled(_ enabled: Bool) {
+        guard isFirstTokenGatingEnabled != enabled else {
+            return
+        }
+
+        isFirstTokenGatingEnabled = enabled
+        userDefaults.set(enabled, forKey: Self.isFirstTokenGatingEnabledDefaultsKey)
+    }
+
     private static func effectivePromptMode(
         engine: SuggestionEngineKind,
         localPromptMode: SuggestionPromptMode
@@ -403,7 +423,7 @@ final class SuggestionSettingsModel: ObservableObject {
 
 extension SuggestionSettingsModel: SuggestionSettingsProviding {
     var snapshotPublisher: AnyPublisher<SuggestionSettingsSnapshot, Never> {
-        Publishers.CombineLatest3(
+        Publishers.CombineLatest4(
             Publishers.CombineLatest4(
                 $isGloballyEnabled,
                 $disabledAppRules,
@@ -411,9 +431,10 @@ extension SuggestionSettingsModel: SuggestionSettingsProviding {
                 $selectedWordCountPreset
             ),
             $selectedLocalPromptMode,
-            $customAIInstructions
+            $customAIInstructions,
+            $isFirstTokenGatingEnabled
         )
-        .map { combinedSettings, localPromptMode, customAIInstructions in
+        .map { combinedSettings, localPromptMode, customAIInstructions, firstTokenGatingEnabled in
             let (globallyEnabled, disabledAppRules, engine, wordCountPreset) = combinedSettings
             return SuggestionSettingsSnapshot(
                 isGloballyEnabled: globallyEnabled,
@@ -424,7 +445,8 @@ extension SuggestionSettingsModel: SuggestionSettingsProviding {
                     engine: engine,
                     localPromptMode: localPromptMode
                 ),
-                customAIInstructions: CustomAIInstructionFormatter.normalized(customAIInstructions)
+                customAIInstructions: CustomAIInstructionFormatter.normalized(customAIInstructions),
+                isFirstTokenGatingEnabled: firstTokenGatingEnabled
             )
         }
         .removeDuplicates()

--- a/tabby/Services/Runtime/LlamaRuntimeCore.swift
+++ b/tabby/Services/Runtime/LlamaRuntimeCore.swift
@@ -1,5 +1,6 @@
 import Foundation
 import LlamaSwift
+import os
 
 /// File overview:
 /// Owns the raw llama.cpp lifecycle behind one serialized actor. This file is the lowest-level
@@ -32,10 +33,24 @@ actor LlamaRuntimeCore {
     private static var isNativeLoggingSilenced = false
     private static let promptSequenceID: llama_seq_id = 0
 
+    /// Filterable signal for first-token gating activity. Visible via:
+    ///   log stream --predicate 'subsystem == "app.tabby" AND category == "first-token-gate"'
+    /// Use `.debug` so production builds don't pay the cost unless someone explicitly streams it.
+    private static let firstTokenGateLogger = Logger(
+        subsystem: "app.tabby",
+        category: "first-token-gate"
+    )
+
     private var backendInitialized = false
     private var model: OpaquePointer?
     private var preparedRuntime: PreparedLlamaRuntime?
     private var promptCache: PromptCache?
+
+    /// Token IDs resolved from `FirstTokenDenyList` for the currently loaded model.
+    /// These are computed once per model load in `prepare()` because tokenization requires the
+    /// model's vocabulary. The list is intentionally small (typically <20 token IDs) so the
+    /// logit-bias sampler adds negligible overhead.
+    private var resolvedFirstTokenDenyList: [llama_logit_bias] = []
 
     /// Native prompt-cache state tied to one llama context.
     /// `promptTokens` records the tokens represented in KV memory; each new request still
@@ -98,6 +113,32 @@ actor LlamaRuntimeCore {
 
         model = loadedModel
 
+        // Resolve the first-token deny list now that we have a loaded vocabulary.
+        // This turns human-readable strings ("Sure", "Here", "I ") into concrete token IDs
+        // that the logit-bias sampler can mask at `-inf` during generation.
+        let modelFilename = resolvedRuntime.modelFileURL.lastPathComponent
+        resolvedFirstTokenDenyList = resolveFirstTokenDenyList(
+            for: modelFilename,
+            model: loadedModel
+        )
+
+        // Log the resolved deny list so debug builds can verify which token IDs
+        // got masked for this model. Useful when a chat opener still slips
+        // through and you need to confirm whether it was on the list at all
+        // versus the tokenizer producing a different leading token.
+        if let vocab = llama_model_get_vocab(loadedModel) {
+            let resolvedSummaries: [String] = resolvedFirstTokenDenyList.map { bias in
+                let piece = pieceString(for: bias.token, vocab: vocab)
+                let escaped = piece
+                    .replacingOccurrences(of: "\n", with: "\\n")
+                    .replacingOccurrences(of: "\t", with: "\\t")
+                return "\(bias.token):\"\(escaped)\""
+            }
+            Self.firstTokenGateLogger.debug(
+                "resolved deny list for \(modelFilename, privacy: .public): [\(resolvedSummaries.joined(separator: ", "), privacy: .public)]"
+            )
+        }
+
         let preparedRuntime = PreparedLlamaRuntime(
             resolvedRuntime: resolvedRuntime,
             contextWindowTokens: Int(configuration.contextWindowTokens),
@@ -120,7 +161,8 @@ actor LlamaRuntimeCore {
         topP: Double,
         minP: Double,
         repetitionPenalty: Double,
-        seed: UInt32? = nil
+        seed: UInt32? = nil,
+        firstTokenGatingEnabled: Bool = true
     ) throws -> String {
         guard let preparedRuntime else {
             throw LlamaRuntimeError.unavailable("The llama model is not loaded.")
@@ -164,6 +206,26 @@ actor LlamaRuntimeCore {
         )
         defer { llama_sampler_free(sampler) }
 
+        // Build a separate sampler with the first-token logit gate prepended.
+        // We use two samplers instead of mutating one mid-generation because it's more legible
+        // and the cost of initializing a second chain is negligible next to model decode.
+        let useFirstTokenGating = firstTokenGatingEnabled && !resolvedFirstTokenDenyList.isEmpty
+        let firstTokenSampler: UnsafeMutablePointer<llama_sampler>?
+        if useFirstTokenGating {
+            firstTokenSampler = try makeFirstTokenGatedSampler(
+                vocab: vocab,
+                temperature: temperature,
+                topK: topK,
+                topP: topP,
+                minP: minP,
+                repetitionPenalty: repetitionPenalty,
+                seed: seed
+            )
+        } else {
+            firstTokenSampler = nil
+        }
+        defer { firstTokenSampler.map { llama_sampler_free($0) } }
+
         var generatedText = ""
         var position = Int32(promptTokens.count)
         var hasVisibleContent = false
@@ -177,8 +239,25 @@ actor LlamaRuntimeCore {
         }
 
         do {
-            for _ in 0 ..< maxPredictionTokens {
-                let nextToken = llama_sampler_sample(sampler, context, -1)
+            for tokenIndex in 0 ..< maxPredictionTokens {
+                // Use the gated sampler only for the very first token (position 0).
+                // After that, switch to the standard sampler so deny-listed tokens can appear
+                // naturally in the middle of a continuation (e.g. "I" is fine as a second word).
+                let activeSampler = (tokenIndex == 0 && firstTokenSampler != nil)
+                    ? firstTokenSampler!
+                    : sampler
+
+                // Before sampling the first token through the gated chain, inspect the raw
+                // logits to detect when the model's top choice would have been a deny-listed
+                // token. This is the "gate fired" signal — the un-gated argmax check is a
+                // sharper indicator than the actual sampled token (which could differ from
+                // argmax under temperature/top-p), and it answers the practical question:
+                // "did the gate prevent a chat-residue opener from being chosen?"
+                if tokenIndex == 0 && firstTokenSampler != nil {
+                    logFirstTokenGateFireIfNeeded(context: context, vocab: vocab)
+                }
+
+                let nextToken = llama_sampler_sample(activeSampler, context, -1)
                 if nextToken == llama_vocab_eos(vocab) || llama_vocab_is_eog(vocab, nextToken) {
                     break
                 }
@@ -226,6 +305,7 @@ actor LlamaRuntimeCore {
         }
 
         preparedRuntime = nil
+        resolvedFirstTokenDenyList = []
 
         if backendInitialized {
             llama_backend_free()
@@ -548,6 +628,207 @@ actor LlamaRuntimeCore {
         }
 
         return sampler
+    }
+
+    /// Builds a sampler chain with a logit-bias gate prepended that applies `-inf` to all
+    /// resolved first-token deny-list entries. This chain is used only for the very first
+    /// sampled token; subsequent tokens use the standard (ungated) sampler.
+    ///
+    /// The chain is otherwise identical to `makeSampler()` — same temperature, top-k, top-p,
+    /// min-p, repetition penalty, and seed. We build a separate chain instead of mutating one
+    /// mid-generation because it's easier to reason about and the init cost is negligible.
+    private func makeFirstTokenGatedSampler(
+        vocab: OpaquePointer,
+        temperature: Double,
+        topK: Int,
+        topP: Double,
+        minP: Double,
+        repetitionPenalty: Double,
+        seed: UInt32?
+    ) throws -> UnsafeMutablePointer<llama_sampler> {
+        let params = llama_sampler_chain_default_params()
+        guard let sampler = llama_sampler_chain_init(params) else {
+            throw LlamaRuntimeError.generationFailed("Unable to initialize the first-token gated sampler chain.")
+        }
+
+        // Prepend the logit-bias stage so it runs before any other sampling transforms.
+        // Each entry applies `-inf` bias, making the token impossible to sample.
+        let nVocab = llama_vocab_n_tokens(vocab)
+        var biases = resolvedFirstTokenDenyList
+        guard let biasSampler = llama_sampler_init_logit_bias(
+            nVocab,
+            Int32(biases.count),
+            &biases
+        ) else {
+            llama_sampler_free(sampler)
+            throw LlamaRuntimeError.generationFailed("Unable to initialize the logit bias sampler for first-token gating.")
+        }
+        llama_sampler_chain_add(sampler, biasSampler)
+
+        // The remaining stages mirror makeSampler() exactly.
+        if repetitionPenalty > 1.0 {
+            guard let penaltySampler = llama_sampler_init_penalties(64, Float(repetitionPenalty), 1.0, 1.0) else {
+                llama_sampler_free(sampler)
+                throw LlamaRuntimeError.generationFailed("Unable to initialize the repetition penalty sampler.")
+            }
+            llama_sampler_chain_add(sampler, penaltySampler)
+        }
+
+        if temperature > 0 {
+            guard let temperatureSampler = llama_sampler_init_temp(Float(temperature)) else {
+                llama_sampler_free(sampler)
+                throw LlamaRuntimeError.generationFailed("Unable to initialize the temperature sampler.")
+            }
+            llama_sampler_chain_add(sampler, temperatureSampler)
+
+            if topK > 0 {
+                guard let topKSampler = llama_sampler_init_top_k(Int32(topK)) else {
+                    llama_sampler_free(sampler)
+                    throw LlamaRuntimeError.generationFailed("Unable to initialize the top-k sampler.")
+                }
+                llama_sampler_chain_add(sampler, topKSampler)
+            }
+
+            if minP > 0 && minP < 1 {
+                guard let minPSampler = llama_sampler_init_min_p(Float(minP), 1) else {
+                    llama_sampler_free(sampler)
+                    throw LlamaRuntimeError.generationFailed("Unable to initialize the min-p sampler.")
+                }
+                llama_sampler_chain_add(sampler, minPSampler)
+            }
+
+            if topP > 0 && topP < 1 {
+                guard let topPSampler = llama_sampler_init_top_p(Float(topP), 1) else {
+                    llama_sampler_free(sampler)
+                    throw LlamaRuntimeError.generationFailed("Unable to initialize the top-p sampler.")
+                }
+                llama_sampler_chain_add(sampler, topPSampler)
+            }
+
+            let resolvedSeed = seed ?? UInt32.random(in: UInt32.min ... UInt32.max)
+            guard let distributionSampler = llama_sampler_init_dist(resolvedSeed) else {
+                llama_sampler_free(sampler)
+                throw LlamaRuntimeError.generationFailed("Unable to initialize the distribution sampler.")
+            }
+            llama_sampler_chain_add(sampler, distributionSampler)
+        } else {
+            guard let greedySampler = llama_sampler_init_greedy() else {
+                llama_sampler_free(sampler)
+                throw LlamaRuntimeError.generationFailed("Unable to initialize the greedy sampler.")
+            }
+            llama_sampler_chain_add(sampler, greedySampler)
+        }
+
+        return sampler
+    }
+
+    /// Converts the human-readable deny strings from `FirstTokenDenyList` into concrete
+    /// `llama_logit_bias` entries using the loaded model's vocabulary.
+    ///
+    /// For each deny string, we tokenize it and take only the **first** token. This is correct
+    /// because we only gate position 0 — whether "Sure," tokenizes as one token `["Sure,"]` or
+    /// two tokens `["Sure", ","]`, we want to block the leading token `"Sure"` (or `"Sure,"`)
+    /// at position 0.
+    ///
+    /// Duplicate token IDs are deduplicated so each token appears at most once in the bias array.
+    private func resolveFirstTokenDenyList(
+        for modelFilename: String,
+        model: OpaquePointer
+    ) -> [llama_logit_bias] {
+        guard let vocab = llama_model_get_vocab(model) else {
+            return []
+        }
+
+        let denyStrings = FirstTokenDenyList.denyStrings(for: modelFilename)
+        var seenTokenIDs: Set<llama_token> = []
+        var biases: [llama_logit_bias] = []
+
+        for denyString in denyStrings {
+            // Tokenize without adding BOS — we want the raw token for the string fragment,
+            // not a sequence that starts with the model's beginning-of-sequence marker.
+            guard let firstToken = tokenizeFirstToken(denyString, vocab: vocab) else {
+                continue
+            }
+
+            // Deduplicate: different deny strings may resolve to the same leading token
+            // (e.g. "Sure" and "Sure," might both start with token ID 12345).
+            guard seenTokenIDs.insert(firstToken).inserted else {
+                continue
+            }
+
+            biases.append(llama_logit_bias(token: firstToken, bias: -.infinity))
+        }
+
+        return biases
+    }
+
+    /// Detects when the gate is about to suppress the model's top-of-distribution choice and logs
+    /// a debug-level signal naming the suppressed token. We compute the un-gated argmax over the
+    /// raw logits at the last context position; if that argmax token sits in the resolved deny
+    /// set, the gate fired meaningfully on this generation.
+    ///
+    /// We check argmax (greedy) rather than the actual sampled token because the sampled token
+    /// passes through temperature/top-p/min-p stochastic stages — argmax is the precise answer
+    /// to "what was the model's strongest preference?" which is what the gate is defending
+    /// against. Cost is one O(nVocab) scan, only on the first token, only when gating is on.
+    private func logFirstTokenGateFireIfNeeded(
+        context: OpaquePointer,
+        vocab: OpaquePointer
+    ) {
+        guard !resolvedFirstTokenDenyList.isEmpty,
+              let logits = llama_get_logits_ith(context, -1)
+        else { return }
+
+        let nVocab = Int(llama_vocab_n_tokens(vocab))
+        guard nVocab > 0 else { return }
+
+        var bestTokenID: llama_token = 0
+        var bestLogit: Float = -.infinity
+        for tokenID in 0 ..< nVocab {
+            let value = logits[tokenID]
+            if value > bestLogit {
+                bestLogit = value
+                bestTokenID = llama_token(tokenID)
+            }
+        }
+
+        guard resolvedFirstTokenDenyList.contains(where: { $0.token == bestTokenID }) else {
+            return
+        }
+
+        let piece = pieceString(for: bestTokenID, vocab: vocab)
+        let escaped = piece
+            .replacingOccurrences(of: "\n", with: "\\n")
+            .replacingOccurrences(of: "\t", with: "\\t")
+        Self.firstTokenGateLogger.debug(
+            "gate suppressed token \(bestTokenID, privacy: .public) (\"\(escaped, privacy: .public)\", logit=\(bestLogit, privacy: .public))"
+        )
+    }
+
+    /// Tokenizes a short string and returns just the first token, without BOS.
+    /// Returns nil if tokenization fails or produces no tokens.
+    private func tokenizeFirstToken(_ text: String, vocab: OpaquePointer) -> llama_token? {
+        let utf8Count = max(text.utf8.count, 1)
+        let capacity = utf8Count + 8
+        var tokens = [llama_token](repeating: 0, count: capacity)
+
+        let tokenCount = text.withCString { cString in
+            llama_tokenize(
+                vocab,
+                cString,
+                Int32(text.utf8.count),
+                &tokens,
+                Int32(tokens.count),
+                false,  // add_special = false: no BOS, we want the raw fragment token
+                false
+            )
+        }
+
+        guard tokenCount > 0 else {
+            return nil
+        }
+
+        return tokens[0]
     }
 
     /// Removes tokens at and after `position` from the prompt sequence.

--- a/tabby/Services/Runtime/LlamaRuntimeManager.swift
+++ b/tabby/Services/Runtime/LlamaRuntimeManager.swift
@@ -93,7 +93,8 @@ final class LlamaRuntimeManager: ObservableObject {
         topP: Double,
         minP: Double,
         repetitionPenalty: Double,
-        seed: UInt32? = nil
+        seed: UInt32? = nil,
+        firstTokenGatingEnabled: Bool = true
     ) async throws -> String {
         _ = try await preparedRuntime()
 
@@ -107,7 +108,8 @@ final class LlamaRuntimeManager: ObservableObject {
                 topP: topP,
                 minP: minP,
                 repetitionPenalty: repetitionPenalty,
-                seed: seed
+                seed: seed,
+                firstTokenGatingEnabled: firstTokenGatingEnabled
             )
         } catch is CancellationError {
             throw LlamaRuntimeError.cancelled

--- a/tabby/Services/Runtime/LlamaSuggestionEngine.swift
+++ b/tabby/Services/Runtime/LlamaSuggestionEngine.swift
@@ -30,7 +30,8 @@ final class LlamaSuggestionEngine {
                 topP: request.topP,
                 minP: request.minP,
                 repetitionPenalty: request.repetitionPenalty,
-                seed: request.randomSeed
+                seed: request.randomSeed,
+                firstTokenGatingEnabled: request.isFirstTokenGatingEnabled
             )
             try Task.checkCancellation()
 

--- a/tabby/Support/FirstTokenDenyList.swift
+++ b/tabby/Support/FirstTokenDenyList.swift
@@ -6,82 +6,69 @@ import Foundation
 /// When instruction-tuned models (Gemma-instruct, Qwen3, etc.) are used for inline autocomplete,
 /// they sometimes begin their response with conversational tokens that belong to a "helpful
 /// assistant" reply rather than the user's text continuation — phrases like "Sure,", "Here's",
-/// "I ", or leading newlines.
+/// "Of course", or a leading newline.
 ///
-/// This file defines the human-readable deny strings per model. The strings are resolved to
-/// concrete token IDs at model-load time inside `LlamaRuntimeCore`, since tokenization depends
-/// on the loaded model's vocabulary.
+/// This file defines the human-readable deny strings. The strings are resolved to concrete token
+/// IDs at model-load time inside `LlamaRuntimeCore`, since tokenization depends on the loaded
+/// model's vocabulary.
+///
+/// Why this list is small and conservative:
+/// the gate is a hard `-inf` mask — every entry is a permanent block at position 0 with no
+/// soft-bias fallback. False positives matter. The list intentionally only contains tokens that
+/// are *almost never* the right continuation of arbitrary typed text:
+///   - "Sure", "Of course", "Certainly" — pure politeness openers, no prose use case at position 0
+///   - "Here"   — chat residue ("Here's…", "Here is…"); rarely starts a continuation otherwise
+///   - "\n"     — leading-newline reflex from instruct prompting; usually noise, not signal
+///
+/// Notably *not* on the list (despite being suggestive in the issue):
+///   - "I " — high false-positive rate in real prose ("I went to…", "I think…")
+///   - "Let me" / "Let" — "Let's" and similar legitimate continuations would also collide
+///   - Language-specific openers ("好的", "当然") — no measurement yet to back them
+///
+/// The debug log under subsystem=app.tabby category=first-token-gate fires whenever the un-gated
+/// argmax of the raw logits at position 0 is in this list. That's the data we need to grow this
+/// list deliberately rather than by intuition.
 ///
 /// Architectural placement: `Support/` because this is pure, deterministic data with no side
 /// effects, runtime dependencies, or OS interactions. It changes at a different rate than
 /// the runtime code that consumes it.
 
-/// Provides per-model deny lists of strings that should never appear as the first generated token
-/// during inline autocomplete. Each string represents a common chat-residue opener that
-/// instruction-tuned models tend to emit.
-///
-/// The deny list is intentionally small and conservative. False positives (blocking a legitimate
-/// continuation) are possible but unlikely in inline autocomplete contexts, where starting a
-/// suggestion with "Sure" or "Here's" is almost never the right continuation of typed text.
+/// Provides deny lists of strings that should never appear as the first generated token during
+/// inline autocomplete. Each string represents a chat-residue opener that instruction-tuned
+/// models commonly emit when the prompt looks conversational.
 enum FirstTokenDenyList {
 
     /// Returns the deny strings for the given model filename.
     ///
-    /// Known built-in models get curated lists based on observed chat-residue patterns.
-    /// Unknown models (user-provided custom GGUFs) get a conservative default list that
-    /// covers the most common English-language chat openers without being overly aggressive.
+    /// Today every known and unknown model gets the same conservative list. The per-model
+    /// switch is kept as the extension point: once the debug log gives us evidence that a
+    /// specific model has a different residue profile (e.g. Qwen3 emitting Chinese openers
+    /// frequently in this code path), we add a model-specific case here without changing
+    /// the runtime resolution path.
     ///
     /// - Parameter modelFilename: The basename of the loaded GGUF file (e.g. "gemma-3-1b-it-Q4_K_M.gguf").
     /// - Returns: An array of strings whose leading token(s) should be denied at generation position 0.
     static func denyStrings(for modelFilename: String) -> [String] {
         switch modelFilename {
-
-        // Gemma instruct models are instruction-tuned on conversational data and frequently
-        // emit politeness openers and first-person narration before the actual continuation.
         case "gemma-3-1b-it-Q4_K_M.gguf",
-             "gemma-3n-E4B-it-Q4_K_M.gguf":
-            return Self.gemmaInstructDenyStrings
-
-        // Qwen3 is multilingual and sometimes emits Chinese-language chat openers
-        // in addition to the standard English ones.
-        case "Qwen3-0.6B-Q4_K_M.gguf":
-            return Self.qwen3DenyStrings
-
-        // Conservative fallback for user-provided custom models.
-        // Only blocks the most universally problematic chat-residue tokens.
+             "gemma-3n-E4B-it-Q4_K_M.gguf",
+             "Qwen3-0.6B-Q4_K_M.gguf":
+            return Self.conservativeDenyStrings
         default:
-            return Self.defaultDenyStrings
+            return Self.conservativeDenyStrings
         }
     }
 
-    // MARK: - Per-Model Deny String Lists
+    // MARK: - Deny Lists
 
-    /// Gemma-instruct models: broad English chat-residue coverage.
-    private static let gemmaInstructDenyStrings: [String] = [
+    /// The starting list. Every entry is an opener that has essentially no legitimate use as the
+    /// *first* token of an inline-autocomplete continuation. Grow this only with evidence from the
+    /// gate-fire debug log, not from intuition.
+    private static let conservativeDenyStrings: [String] = [
         "Sure",
         "Here",
-        "I ",
-        "Let me",
         "Of course",
         "Certainly",
-    ]
-
-    /// Qwen3 models: English chat residue plus common Chinese-language openers.
-    /// "好的" (hǎo de, "okay") and "当然" (dāng rán, "of course") are frequent Qwen chat starters.
-    private static let qwen3DenyStrings: [String] = [
-        "Sure",
-        "Here",
-        "I ",
-        "Let",
-        "好的",
-        "当然",
-    ]
-
-    /// Conservative default for unknown/custom models.
-    /// Keeps the list minimal to avoid false positives on models we haven't profiled.
-    private static let defaultDenyStrings: [String] = [
-        "Sure",
-        "Here",
-        "I ",
+        "\n"
     ]
 }

--- a/tabby/Support/FirstTokenDenyList.swift
+++ b/tabby/Support/FirstTokenDenyList.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// File overview:
+/// Declarative first-token deny lists for suppressing chat residue from instruction-tuned models.
+///
+/// When instruction-tuned models (Gemma-instruct, Qwen3, etc.) are used for inline autocomplete,
+/// they sometimes begin their response with conversational tokens that belong to a "helpful
+/// assistant" reply rather than the user's text continuation — phrases like "Sure,", "Here's",
+/// "I ", or leading newlines.
+///
+/// This file defines the human-readable deny strings per model. The strings are resolved to
+/// concrete token IDs at model-load time inside `LlamaRuntimeCore`, since tokenization depends
+/// on the loaded model's vocabulary.
+///
+/// Architectural placement: `Support/` because this is pure, deterministic data with no side
+/// effects, runtime dependencies, or OS interactions. It changes at a different rate than
+/// the runtime code that consumes it.
+
+/// Provides per-model deny lists of strings that should never appear as the first generated token
+/// during inline autocomplete. Each string represents a common chat-residue opener that
+/// instruction-tuned models tend to emit.
+///
+/// The deny list is intentionally small and conservative. False positives (blocking a legitimate
+/// continuation) are possible but unlikely in inline autocomplete contexts, where starting a
+/// suggestion with "Sure" or "Here's" is almost never the right continuation of typed text.
+enum FirstTokenDenyList {
+
+    /// Returns the deny strings for the given model filename.
+    ///
+    /// Known built-in models get curated lists based on observed chat-residue patterns.
+    /// Unknown models (user-provided custom GGUFs) get a conservative default list that
+    /// covers the most common English-language chat openers without being overly aggressive.
+    ///
+    /// - Parameter modelFilename: The basename of the loaded GGUF file (e.g. "gemma-3-1b-it-Q4_K_M.gguf").
+    /// - Returns: An array of strings whose leading token(s) should be denied at generation position 0.
+    static func denyStrings(for modelFilename: String) -> [String] {
+        switch modelFilename {
+
+        // Gemma instruct models are instruction-tuned on conversational data and frequently
+        // emit politeness openers and first-person narration before the actual continuation.
+        case "gemma-3-1b-it-Q4_K_M.gguf",
+             "gemma-3n-E4B-it-Q4_K_M.gguf":
+            return Self.gemmaInstructDenyStrings
+
+        // Qwen3 is multilingual and sometimes emits Chinese-language chat openers
+        // in addition to the standard English ones.
+        case "Qwen3-0.6B-Q4_K_M.gguf":
+            return Self.qwen3DenyStrings
+
+        // Conservative fallback for user-provided custom models.
+        // Only blocks the most universally problematic chat-residue tokens.
+        default:
+            return Self.defaultDenyStrings
+        }
+    }
+
+    // MARK: - Per-Model Deny String Lists
+
+    /// Gemma-instruct models: broad English chat-residue coverage.
+    private static let gemmaInstructDenyStrings: [String] = [
+        "Sure",
+        "Here",
+        "I ",
+        "Let me",
+        "Of course",
+        "Certainly",
+    ]
+
+    /// Qwen3 models: English chat residue plus common Chinese-language openers.
+    /// "好的" (hǎo de, "okay") and "当然" (dāng rán, "of course") are frequent Qwen chat starters.
+    private static let qwen3DenyStrings: [String] = [
+        "Sure",
+        "Here",
+        "I ",
+        "Let",
+        "好的",
+        "当然",
+    ]
+
+    /// Conservative default for unknown/custom models.
+    /// Keeps the list minimal to avoid false positives on models we haven't profiled.
+    private static let defaultDenyStrings: [String] = [
+        "Sure",
+        "Here",
+        "I ",
+    ]
+}

--- a/tabby/Support/SuggestionRequestFactory.swift
+++ b/tabby/Support/SuggestionRequestFactory.swift
@@ -62,7 +62,8 @@ enum SuggestionRequestFactory {
             randomSeed: configuration.randomSeed,
             maxSuffixCharacters: configuration.maxSuffixCharacters,
             completionLengthInstruction: completionLengthInstruction,
-            customAIInstructions: customAIInstructions
+            customAIInstructions: customAIInstructions,
+            isFirstTokenGatingEnabled: settings.isFirstTokenGatingEnabled
         )
 
         return SuggestionRequestBuildResult(

--- a/tabby/UI/SettingsView.swift
+++ b/tabby/UI/SettingsView.swift
@@ -176,7 +176,10 @@ struct SettingsView: View {
 
                 Toggle("Suppress Chat Openers", isOn: firstTokenGatingBinding)
 
-                Text("Blocks instruction-tuned models from starting suggestions with conversational openers like \"Sure,\" or \"Here's\". Open Source engine only.")
+                Text(
+                    "Blocks instruction-tuned models from starting suggestions with "
+                    + "conversational openers like \"Sure,\" or \"Here's\". Open Source engine only."
+                )
                     .font(.caption)
                     .foregroundStyle(.secondary)
             } else {

--- a/tabby/UI/SettingsView.swift
+++ b/tabby/UI/SettingsView.swift
@@ -173,6 +173,12 @@ struct SettingsView: View {
                             .tag(mode)
                     }
                 }
+
+                Toggle("Suppress Chat Openers", isOn: firstTokenGatingBinding)
+
+                Text("Blocks instruction-tuned models from starting suggestions with conversational openers like \"Sure,\" or \"Here's\". Open Source engine only.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             } else {
                 Text("Completion Style and custom instructions apply to the Open Source engine.")
                     .font(.caption)
@@ -473,6 +479,15 @@ struct SettingsView: View {
             get: { suggestionSettings.selectedLocalPromptMode },
             set: { mode in
                 suggestionSettings.selectLocalPromptMode(mode)
+            }
+        )
+    }
+
+    private var firstTokenGatingBinding: Binding<Bool> {
+        Binding(
+            get: { suggestionSettings.isFirstTokenGatingEnabled },
+            set: { enabled in
+                suggestionSettings.setFirstTokenGatingEnabled(enabled)
             }
         )
     }

--- a/tabbyTests/LlamaPromptRendererTests.swift
+++ b/tabbyTests/LlamaPromptRendererTests.swift
@@ -212,7 +212,8 @@ final class LlamaPromptRendererTests: XCTestCase {
             randomSeed: 42,
             maxSuffixCharacters: 192,
             completionLengthInstruction: "Return only the next few words.",
-            customAIInstructions: nil
+            customAIInstructions: nil,
+            isFirstTokenGatingEnabled: true
         )
     }
 }


### PR DESCRIPTION
<!-- Summary: 1-3 sentences on what changed and why. -->

Implements issue #24. Instruction-tuned models routinely begin inline-autocomplete suggestions with conversational openers ("Sure,", "Here's", "Of course", a leading newline) — chat-reply behavior leaking into a continuation context. This adds a per-tokenizer deny list applied as a `-inf` logit mask on the first sampled token only, eliminating the residue deterministically without prompt engineering.

## What's in here

**Mechanism**
- `tabby/Support/FirstTokenDenyList.swift` — declarative deny strings. Pure data; no runtime deps.
- `LlamaRuntimeCore` resolves strings to token IDs once per model load against the loaded vocabulary, deduplicating leading-token collisions.
- A second sampler chain prepends `llama_sampler_init_logit_bias` with `-inf` entries and is used **only at `tokenIndex == 0`**; subsequent tokens use the standard sampler so deny-listed tokens can still appear naturally mid-suggestion (e.g. "I" as a second word).

**Conservative starting list**
`"Sure"`, `"Here"`, `"Of course"`, `"Certainly"`, `"\n"`. Every entry is a token that has essentially no legitimate use as the *first* token of a continuation. Notably **not** included despite being suggestive in the issue: `"I "` (high false-positive rate in real prose), `"Let me"` / `"Let"` (too broad), language-specific openers — none of these have measurement to back them. The per-model switch is kept as the extension point so the list can grow from gate-fire log evidence rather than intuition.

**Settings toggle**
"Suppress Chat Openers", default on, persisted under `tabbyFirstTokenGatingEnabled`. Apple Intelligence does not expose logit-level control, so the toggle only renders for the Open Source engine.

**Debug logging** (acceptance criterion)
Subsystem `app.tabby`, category `first-token-gate`. Logs the resolved deny list at model load, plus a per-fire signal whenever the **un-gated argmax** of the raw logits at position 0 is in the deny set. Argmax is checked rather than the sampled token because the sampled token passes through stochastic top-p / min-p stages — argmax precisely answers "did the gate prevent the model's strongest preference from being chosen?".

```
log stream --predicate 'subsystem == "app.tabby" AND category == "first-token-gate"' --level debug
```

<!-- Validation: what you actually ran and saw, not what you intended to run. -->

## Validation

Ran locally:
- `swiftlint --reporter github-actions-logging` — no new warnings on changed files
- `xcodebuild ... build CODE_SIGNING_ALLOWED=NO` — **BUILD SUCCEEDED**
- `xcodebuild test ... CODE_SIGNING_ALLOWED=NO` — **TEST SUCCEEDED**

`LlamaPromptRendererTests` updated to pass the new `isFirstTokenGatingEnabled` argument to its `SuggestionRequest` constructor.

**Screenshot of the new Settings toggle:** TODO — local build couldn't capture due to Screen Recording permissions; will attach when running on a machine with the permission, or happy to ship without if you'd prefer to verify in your build.

## Linked issues

Closes #24.

## Risk / rollout notes

- Default-on is intentional: the gate only applies a `-inf` mask to a small set of tokens whose argmax-occurrence rate at position 0 is exactly the misbehavior we want to fix. False-positive cost on the conservative starting list should be near zero.
- The gate is a pure sampling-time addition; if it ever needs to be turned off in the field, the toggle disables the second sampler chain and falls back to today's behavior.
- Resolution is per-model-load, so adding entries to the deny list later is a no-op until the next model load.