### PR TITLE
Fix ghost text overflow by wrapping text

### DIFF
--- a/tabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
@@ -98,7 +98,8 @@ extension SuggestionCoordinator {
             presentOverlay(
                 text: advancedSession.remainingText,
                 at: predictedCaret,
-                caretQuality: liveContext.caretQuality
+                caretQuality: liveContext.caretQuality,
+                inputFrameRect: liveContext.inputFrameRect
             )
             // Force an early AX refresh so the real caret position corrects any prediction
             // error faster than the normal 250ms poll interval.
@@ -159,7 +160,8 @@ extension SuggestionCoordinator {
         presentOverlay(
             text: advancedSession.remainingText,
             at: session.baseContext.caretRect,
-            caretQuality: session.baseContext.caretQuality
+            caretQuality: session.baseContext.caretQuality,
+            inputFrameRect: session.baseContext.inputFrameRect
         )
         logStage(
             "typed-match-advanced",
@@ -297,12 +299,14 @@ extension SuggestionCoordinator {
     func presentOverlay(
         text: String,
         at caretRect: CGRect,
-        caretQuality: CaretGeometryQuality
+        caretQuality: CaretGeometryQuality,
+        inputFrameRect: CGRect?
     ) {
         if let message = overlayPresenter.present(
             text: text,
             at: caretRect,
             caretQuality: caretQuality,
+            inputFrameRect: inputFrameRect,
             previousState: overlayState
         ) {
             latestOverlayMessage = message

--- a/tabby/App/Coordinators/SuggestionCoordinator+Lifecycle.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator+Lifecycle.swift
@@ -74,8 +74,7 @@ extension SuggestionCoordinator {
             disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
             inputMonitoringGranted: permissionManager.inputMonitoringGranted,
             focusSnapshot: focusModel.snapshot
-        )
-        {
+        ) {
             schedulePrediction()
         }
     }

--- a/tabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
@@ -203,7 +203,8 @@ extension SuggestionCoordinator {
         presentOverlay(
             text: session.remainingText,
             at: liveContext.caretRect,
-            caretQuality: liveContext.caretQuality
+            caretQuality: liveContext.caretQuality,
+            inputFrameRect: liveContext.inputFrameRect
         )
         logStage(
             "ready",
@@ -294,7 +295,8 @@ extension SuggestionCoordinator {
             presentOverlay(
                 text: reconciledSession.remainingText,
                 at: liveContext.caretRect,
-                caretQuality: liveContext.caretQuality
+                caretQuality: liveContext.caretQuality,
+                inputFrameRect: liveContext.inputFrameRect
             )
             if let advancement {
                 logStage(

--- a/tabby/Models/InputModels.swift
+++ b/tabby/Models/InputModels.swift
@@ -41,4 +41,3 @@ struct CapturedInputEvent: Equatable {
         }
     }
 }
-

--- a/tabby/Models/LlamaRuntimeModels.swift
+++ b/tabby/Models/LlamaRuntimeModels.swift
@@ -136,7 +136,7 @@ enum RuntimeModelCatalog {
             approximateSizeInGigabytes: 3.5,
             expectedSizeBytes: 4_539_054_208,
             sha256: "43b489bb77a81bda85180e7c490d40ad7f1d5c2ce654c9b05e15e104bd3c777e"
-        ),
+        )
     ]
 }
 
@@ -155,7 +155,7 @@ struct LlamaRuntimeConfiguration: Equatable, Sendable {
         preferredModelNames: [
             "gemma-3-1b-it-Q4_K_M.gguf",
             "Qwen3-0.6B-Q4_K_M.gguf",
-            "gemma-3n-E4B-it-Q4_K_M.gguf",
+            "gemma-3n-E4B-it-Q4_K_M.gguf"
         ],
         contextWindowTokens: 2048,
         batchSize: 512,

--- a/tabby/Models/RuntimeBootstrapModel.swift
+++ b/tabby/Models/RuntimeBootstrapModel.swift
@@ -147,8 +147,7 @@ final class RuntimeBootstrapModel: ObservableObject {
         }
 
         if let persistedFilename,
-           availableModels.contains(where: { $0.filename == persistedFilename })
-        {
+           availableModels.contains(where: { $0.filename == persistedFilename }) {
             return persistedFilename
         }
 
@@ -186,14 +185,12 @@ final class RuntimeBootstrapModel: ObservableObject {
         }
 
         if let currentSelection,
-           availableModels.contains(where: { $0.filename == currentSelection })
-        {
+           availableModels.contains(where: { $0.filename == currentSelection }) {
             return currentSelection
         }
 
         if let persistedSelection,
-           availableModels.contains(where: { $0.filename == persistedSelection })
-        {
+           availableModels.contains(where: { $0.filename == persistedSelection }) {
             return persistedSelection
         }
 

--- a/tabby/Models/SuggestionModels.swift
+++ b/tabby/Models/SuggestionModels.swift
@@ -394,7 +394,8 @@ enum OverlayState: Equatable {
         case let .hidden(reason):
             return reason
         case let .visible(text, caretRect, caretQuality, _):
-            return "Showing \(text.count) characters near (\(Int(caretRect.minX)), \(Int(caretRect.minY))) using \(caretQuality.label) caret geometry."
+            let coords = "(\(Int(caretRect.minX)), \(Int(caretRect.minY)))"
+            return "Showing \(text.count) characters near \(coords) using \(caretQuality.label) caret geometry."
         }
     }
 

--- a/tabby/Models/SuggestionModels.swift
+++ b/tabby/Models/SuggestionModels.swift
@@ -378,7 +378,7 @@ enum SuggestionDebugState: Equatable {
 /// without poking into AppKit window objects directly.
 enum OverlayState: Equatable {
     case hidden(reason: String)
-    case visible(text: String, caretRect: CGRect, caretQuality: CaretGeometryQuality)
+    case visible(text: String, caretRect: CGRect, caretQuality: CaretGeometryQuality, inputFrameRect: CGRect?)
 
     var shortLabel: String {
         switch self {
@@ -393,7 +393,7 @@ enum OverlayState: Equatable {
         switch self {
         case let .hidden(reason):
             return reason
-        case let .visible(text, caretRect, caretQuality):
+        case let .visible(text, caretRect, caretQuality, _):
             return "Showing \(text.count) characters near (\(Int(caretRect.minX)), \(Int(caretRect.minY))) using \(caretQuality.label) caret geometry."
         }
     }
@@ -407,7 +407,7 @@ enum OverlayState: Equatable {
     }
 
     var visibleText: String? {
-        guard case let .visible(text, _, _) = self else {
+        guard case let .visible(text, _, _, _) = self else {
             return nil
         }
 

--- a/tabby/Models/SuggestionSubsystemContracts.swift
+++ b/tabby/Models/SuggestionSubsystemContracts.swift
@@ -62,7 +62,7 @@ protocol SuggestionOverlayControlling: AnyObject {
     var state: OverlayState { get }
     var onStateChange: ((OverlayState) -> Void)? { get set }
 
-    func showSuggestion(_ text: String, at caretRect: CGRect, caretQuality: CaretGeometryQuality)
+    func showSuggestion(_ text: String, at caretRect: CGRect, caretQuality: CaretGeometryQuality, inputFrameRect: CGRect?)
     func hide(reason: String)
 }
 

--- a/tabby/Services/Focus/AXTextGeometryResolver.swift
+++ b/tabby/Services/Focus/AXTextGeometryResolver.swift
@@ -61,8 +61,7 @@ struct AXTextGeometryResolver {
                 for: kAXBoundsForRangeParameterizedAttribute as CFString,
                 range: NSRange(location: selection.location, length: 0),
                 on: element
-            ), !rect.isEmpty
-        {
+            ), !rect.isEmpty {
             let cocoaRect = AXHelper.validatedCocoaTextRect(
                 fromAccessibilityRect: rect,
                 anchorFrame: cocoaAnchorFrame
@@ -94,8 +93,7 @@ struct AXTextGeometryResolver {
                 for: kAXBoundsForRangeParameterizedAttribute as CFString,
                 range: NSRange(location: selection.location - 1, length: 1),
                 on: element
-            ), !rect.isEmpty
-        {
+            ), !rect.isEmpty {
             let cocoaRect = AXHelper.validatedCocoaTextRect(
                 fromAccessibilityRect: rect,
                 anchorFrame: cocoaAnchorFrame
@@ -123,8 +121,7 @@ struct AXTextGeometryResolver {
 
         // Branch 3: AXFrame fallback — no text-range data available, estimate from element bounds.
         if supportsFrame,
-            let frame = AXHelper.rectValue(for: "AXFrame" as CFString, on: element), !frame.isEmpty
-        {
+            let frame = AXHelper.rectValue(for: "AXFrame" as CFString, on: element), !frame.isEmpty {
             let cocoaRect = AXHelper.cocoaRect(fromAccessibilityRect: frame)
             if cocoaRect.width > 10, let text = textValue {
                 let estimatedX = conservativeEstimatedCaretX(
@@ -267,8 +264,7 @@ struct AXTextGeometryResolver {
                 let text = AXHelper.stringValue(for: kAXValueAttribute as CFString, on: element),
                 !text.isEmpty,
                 let frame = AXHelper.rectValue(for: "AXFrame" as CFString, on: element),
-                !frame.isEmpty
-            {
+                !frame.isEmpty {
                 runs.append((text, frame))
             }
 

--- a/tabby/Services/Focus/FocusSnapshotResolver.swift
+++ b/tabby/Services/Focus/FocusSnapshotResolver.swift
@@ -114,8 +114,7 @@ struct FocusSnapshotResolver {
         let caretQuality: CaretGeometryQuality
         let observedCharWidth: CGFloat?
         if let primary = resolvedCandidate.caretRect,
-            resolvedCandidate.caretQuality == .exact || resolvedCandidate.caretQuality == .derived
-        {
+            resolvedCandidate.caretQuality == .exact || resolvedCandidate.caretQuality == .derived {
             caretRect = primary
             caretSource = "\(resolvedCandidate.caretQuality!.label) primary"
             caretQuality = resolvedCandidate.caretQuality!
@@ -365,8 +364,7 @@ struct FocusSnapshotResolver {
 
     /// Extracts the AX properties Tabby needs from one candidate element near the current focus.
     private func candidateSnapshot(for element: AXUIElement, bundleIdentifier: String)
-        -> AXFocusCandidate
-    {
+        -> AXFocusCandidate {
         let role = AXHelper.stringValue(for: kAXRoleAttribute as CFString, on: element) ?? "Unknown"
         let subrole = AXHelper.stringValue(for: kAXSubroleAttribute as CFString, on: element)
         let supportedAttributes = Set(AXHelper.attributeNames(on: element))
@@ -443,7 +441,7 @@ struct FocusSnapshotResolver {
             AXHelper.stringValue(for: kAXDescriptionAttribute as CFString, on: element)?
                 .lowercased() ?? "",
             AXHelper.stringValue(for: kAXTitleAttribute as CFString, on: element)?.lowercased()
-                ?? "",
+                ?? ""
         ]
 
         return secureMarkers.contains { marker in
@@ -461,12 +459,12 @@ struct FocusSnapshotResolver {
         var ancestors: [AXUIElement] = [focusedElement]
         var cur = focusedElement
         for _ in 0..<3 {
-            guard let p = AXHelper.parentElement(of: cur) else { break }
-            ancestors.append(p)
-            cur = p
+            guard let parent = AXHelper.parentElement(of: cur) else { break }
+            ancestors.append(parent)
+            cur = parent
         }
-        for (i, el) in ancestors.enumerated().reversed() {
-            let indent = String(repeating: "  ", count: ancestors.count - 1 - i)
+        for (idx, el) in ancestors.enumerated().reversed() {
+            let indent = String(repeating: "  ", count: ancestors.count - 1 - idx)
             out += describeNode(el, indent: indent)
         }
 
@@ -485,8 +483,8 @@ struct FocusSnapshotResolver {
     ) {
         guard depth < 6 else { return }
         let children = AXHelper.childElements(of: element)
-        for (i, child) in children.prefix(20).enumerated() {
-            out += describeNode(child, indent: "\(indent)[\(i)] ")
+        for (idx, child) in children.prefix(20).enumerated() {
+            out += describeNode(child, indent: "\(indent)[\(idx)] ")
             dumpChildrenRecursive(of: child, into: &out, indent: indent + "  ", depth: depth + 1)
         }
         if children.count > 20 {
@@ -500,56 +498,55 @@ struct FocusSnapshotResolver {
         let attrs = Set(AXHelper.attributeNames(on: el))
         let paramAttrs = Set(AXHelper.parameterizedAttributeNames(on: el))
 
-        var s = "\(indent)\(role)"
-        if let sr = subrole { s += " (\(sr))" }
-        s += "\n"
+        var line = "\(indent)\(role)"
+        if let sr = subrole { line += " (\(sr))" }
+        line += "\n"
 
         if let frame = AXHelper.rectValue(for: "AXFrame" as CFString, on: el) {
             let cocoa = AXHelper.cocoaRect(fromAccessibilityRect: frame)
-            s += "\(indent)  frame(AX): \(fmt(frame))  frame(cocoa): \(fmt(cocoa))\n"
+            line += "\(indent)  frame(AX): \(fmt(frame))  frame(cocoa): \(fmt(cocoa))\n"
         }
 
         if attrs.contains(kAXValueAttribute as String),
-            let text = AXHelper.stringValue(for: kAXValueAttribute as CFString, on: el)
-        {
-            let t = text.count > 80 ? String(text.prefix(80)) + "…" : text
-            s +=
-                "\(indent)  value: \"\(t.replacingOccurrences(of: "\n", with: "\\n"))\" (len=\(text.count))\n"
+            let text = AXHelper.stringValue(for: kAXValueAttribute as CFString, on: el) {
+            let truncated = text.count > 80 ? String(text.prefix(80)) + "…" : text
+            line +=
+                "\(indent)  value: \"\(truncated.replacingOccurrences(of: "\n", with: "\\n"))\" (len=\(text.count))\n"
         }
 
         if let range = AXHelper.rangeValue(for: kAXSelectedTextRangeAttribute as CFString, on: el) {
-            s += "\(indent)  selection: loc=\(range.location) len=\(range.length)\n"
+            line += "\(indent)  selection: loc=\(range.location) len=\(range.length)\n"
 
             if paramAttrs.contains(kAXBoundsForRangeParameterizedAttribute as String) {
-                let r = AXHelper.parameterizedRectValue(
+                let rect = AXHelper.parameterizedRectValue(
                     for: kAXBoundsForRangeParameterizedAttribute as CFString,
                     range: NSRange(location: range.location, length: 0),
                     on: el
                 )
-                if let r, !r.isEmpty {
-                    s += "\(indent)  BoundsForRange(loc,0): \(fmt(r))\n"
+                if let rect, !rect.isEmpty {
+                    line += "\(indent)  BoundsForRange(loc,0): \(fmt(rect))\n"
                 } else {
-                    s += "\(indent)  BoundsForRange(loc,0): FAILED\n"
+                    line += "\(indent)  BoundsForRange(loc,0): FAILED\n"
                 }
             }
         }
 
         if let mr = AXHelper.textMarkerCaretRect(on: el), !mr.isEmpty {
-            s += "\(indent)  TextMarkerCaret: \(fmt(mr))\n"
+            line += "\(indent)  TextMarkerCaret: \(fmt(mr))\n"
         }
 
         if let ed = AXHelper.boolValue(for: "AXEditable" as CFString, on: el) {
-            s += "\(indent)  editable: \(ed)\n"
+            line += "\(indent)  editable: \(ed)\n"
         }
 
         let cc = AXHelper.childElements(of: el).count
-        if cc > 0 { s += "\(indent)  children: \(cc)\n" }
+        if cc > 0 { line += "\(indent)  children: \(cc)\n" }
 
-        return s
+        return line
     }
 
-    private func fmt(_ r: CGRect) -> String {
-        String(format: "(%.0f, %.0f, %.0f×%.0f)", r.origin.x, r.origin.y, r.width, r.height)
+    private func fmt(_ rect: CGRect) -> String {
+        String(format: "(%.0f, %.0f, %.0f×%.0f)", rect.origin.x, rect.origin.y, rect.width, rect.height)
     }
 }
 

--- a/tabby/Services/Focus/FocusTracker.swift
+++ b/tabby/Services/Focus/FocusTracker.swift
@@ -27,13 +27,13 @@ final class FocusTracker {
         static let application: [CFString] = [
             kAXFocusedUIElementChangedNotification as CFString,
             kAXFocusedWindowChangedNotification as CFString,
-            kAXApplicationDeactivatedNotification as CFString,
+            kAXApplicationDeactivatedNotification as CFString
         ]
 
         static let focusedElement: [CFString] = [
             kAXValueChangedNotification as CFString,
             kAXSelectedTextChangedNotification as CFString,
-            kAXUIElementDestroyedNotification as CFString,
+            kAXUIElementDestroyedNotification as CFString
         ]
     }
 
@@ -246,8 +246,7 @@ final class FocusTracker {
         }
 
         if let observedFocusedElement,
-           AXHelper.elementIdentity(for: observedFocusedElement) == AXHelper.elementIdentity(for: focusedElement)
-        {
+           AXHelper.elementIdentity(for: observedFocusedElement) == AXHelper.elementIdentity(for: focusedElement) {
             return
         }
 

--- a/tabby/Services/Input/InputMonitor.swift
+++ b/tabby/Services/Input/InputMonitor.swift
@@ -139,7 +139,7 @@ final class InputMonitor {
         let characters = event.unicodeString
 
         // Key code 48 is the hardware Tab key on macOS keyboard events.
-        if keyCode == 48, flags.intersection([.maskCommand, .maskControl, .maskAlternate, .maskShift]).isEmpty {
+        if keyCode == 48, flags.isDisjoint(with: [.maskCommand, .maskControl, .maskAlternate, .maskShift]) {
             return CapturedInputEvent(kind: .tab, keyCode: keyCode, characters: characters, flags: flags)
         }
 

--- a/tabby/Services/Permission/SystemSettingsWindowLocator.swift
+++ b/tabby/Services/Permission/SystemSettingsWindowLocator.swift
@@ -80,13 +80,21 @@ enum SystemSettingsWindowLocator {
         rect.width * rect.height
     }
 
+    /// Named container for per-screen AppKit and CoreGraphics geometry.
+    /// Replaces a 3-member tuple so compactMap closures can name members explicitly.
+    private struct ScreenGeometry {
+        let frame: CGRect
+        let visibleFrame: CGRect
+        let displayBounds: CGRect
+    }
+
     private static func appKitGeometry(from coreGraphicsFrame: CGRect) -> (frame: CGRect, visibleFrame: CGRect) {
-        let screens = NSScreen.screens.compactMap { screen -> (frame: CGRect, visibleFrame: CGRect, displayBounds: CGRect)? in
+        let screens = NSScreen.screens.compactMap { screen -> ScreenGeometry? in
             guard let number = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber else {
                 return nil
             }
             let displayID = CGDirectDisplayID(number.uint32Value)
-            return (
+            return ScreenGeometry(
                 frame: screen.frame,
                 visibleFrame: screen.visibleFrame,
                 displayBounds: CGDisplayBounds(displayID)
@@ -96,8 +104,10 @@ enum SystemSettingsWindowLocator {
         let matchedScreen = screens
             .filter { $0.displayBounds.intersects(coreGraphicsFrame) }
             .max { lhs, rhs in
-                lhs.displayBounds.intersection(coreGraphicsFrame).width * lhs.displayBounds.intersection(coreGraphicsFrame).height
-                    < rhs.displayBounds.intersection(coreGraphicsFrame).width * rhs.displayBounds.intersection(coreGraphicsFrame).height
+                lhs.displayBounds.intersection(coreGraphicsFrame).width
+                    * lhs.displayBounds.intersection(coreGraphicsFrame).height
+                    < rhs.displayBounds.intersection(coreGraphicsFrame).width
+                    * rhs.displayBounds.intersection(coreGraphicsFrame).height
             }
 
         guard let matchedScreen else {

--- a/tabby/Services/Runtime/LlamaRuntimeCore.swift
+++ b/tabby/Services/Runtime/LlamaRuntimeCore.swift
@@ -24,6 +24,19 @@ struct PreparedLlamaRuntime: Sendable {
     let backendName: String
 }
 
+/// Sampling knobs forwarded from the suggestion request into the runtime actor.
+/// Bundling these removes the long parameter list from `generate` and `makeSampler`
+/// and gives callers a single value to pass rather than six positional arguments.
+struct LlamaSamplingParameters: Sendable {
+    let maxPredictionTokens: Int
+    let temperature: Double
+    let topK: Int
+    let topP: Double
+    let minP: Double
+    let repetitionPenalty: Double
+    let seed: UInt32?
+}
+
 /// Owns the long-lived model and hides the raw llama.cpp lifecycle behind one serialized actor.
 /// The actor owns one reusable prompt context so consecutive autocomplete requests can reuse the
 /// already-decoded KV cache for their common token prefix. Keeping that state here matters because
@@ -48,6 +61,15 @@ actor LlamaRuntimeCore {
         var samplingFingerprint: SamplingFingerprint
     }
 
+    /// Bundles the three per-request content fields passed from `generate` into `preparePromptContext`
+    /// and `rebuildPromptContext`. This keeps those functions under the parameter-count lint limit
+    /// while keeping the relationship between bytes, tokens, and the sampling fingerprint explicit.
+    private struct PromptPayload {
+        let promptBytes: [UInt8]
+        let promptTokens: [llama_token]
+        let samplingFingerprint: SamplingFingerprint
+    }
+
     /// Generation knobs that intentionally break KV reuse when changed.
     /// The prompt KV itself is mostly independent from the sampler, but the product contract for
     /// this optimization is stricter: a different sampling configuration starts a clean context.
@@ -59,6 +81,17 @@ actor LlamaRuntimeCore {
         let minP: Double
         let repetitionPenalty: Double
         let seed: UInt32?
+
+        /// Derive a fingerprint from the public parameter bundle.
+        init(from params: LlamaSamplingParameters) {
+            maxPredictionTokens = params.maxPredictionTokens
+            temperature = params.temperature
+            topK = params.topK
+            topP = params.topP
+            minP = params.minP
+            repetitionPenalty = params.repetitionPenalty
+            seed = params.seed
+        }
     }
 
     /// Loads the requested model once and records the runtime characteristics needed for diagnostics.
@@ -113,13 +146,7 @@ actor LlamaRuntimeCore {
     func generate(
         prompt: String,
         cachedPrefixBytes: Int? = nil,
-        maxPredictionTokens: Int,
-        temperature: Double,
-        topK: Int,
-        topP: Double,
-        minP: Double,
-        repetitionPenalty: Double,
-        seed: UInt32? = nil
+        sampling: LlamaSamplingParameters
     ) throws -> String {
         guard let preparedRuntime else {
             throw LlamaRuntimeError.unavailable("The llama model is not loaded.")
@@ -134,33 +161,19 @@ actor LlamaRuntimeCore {
         }
 
         let promptTokens = try tokenize(prompt, vocab: vocab)
-        let samplingFingerprint = SamplingFingerprint(
-            maxPredictionTokens: maxPredictionTokens,
-            temperature: temperature,
-            topK: topK,
-            topP: topP,
-            minP: minP,
-            repetitionPenalty: repetitionPenalty,
-            seed: seed
+        let payload = PromptPayload(
+            promptBytes: Array(prompt.utf8),
+            promptTokens: promptTokens,
+            samplingFingerprint: SamplingFingerprint(from: sampling)
         )
-        let promptBytes = Array(prompt.utf8)
         let context = try preparePromptContext(
             model: model,
             preparedRuntime: preparedRuntime,
-            promptBytes: promptBytes,
-            promptTokens: promptTokens,
-            samplingFingerprint: samplingFingerprint,
+            payload: payload,
             cachedPrefixBytes: cachedPrefixBytes
         )
 
-        let sampler = try makeSampler(
-            temperature: temperature,
-            topK: topK,
-            topP: topP,
-            minP: minP,
-            repetitionPenalty: repetitionPenalty,
-            seed: seed
-        )
+        let sampler = try makeSampler(sampling: sampling)
         defer { llama_sampler_free(sampler) }
 
         var generatedText = ""
@@ -176,7 +189,7 @@ actor LlamaRuntimeCore {
         }
 
         do {
-            for _ in 0 ..< maxPredictionTokens {
+            for _ in 0 ..< sampling.maxPredictionTokens {
                 let nextToken = llama_sampler_sample(sampler, context, -1)
                 if nextToken == llama_vocab_eos(vocab) || llama_vocab_is_eog(vocab, nextToken) {
                     break
@@ -239,58 +252,38 @@ actor LlamaRuntimeCore {
     private func preparePromptContext(
         model: OpaquePointer,
         preparedRuntime: PreparedLlamaRuntime,
-        promptBytes: [UInt8],
-        promptTokens: [llama_token],
-        samplingFingerprint: SamplingFingerprint,
+        payload: PromptPayload,
         cachedPrefixBytes: Int?
     ) throws -> OpaquePointer {
         guard let cachedPrefixBytes,
               cachedPrefixBytes > 0,
               let cache = promptCache,
-              cache.samplingFingerprint == samplingFingerprint
+              cache.samplingFingerprint == payload.samplingFingerprint
         else {
-            return try rebuildPromptContext(
-                model: model,
-                preparedRuntime: preparedRuntime,
-                promptBytes: promptBytes,
-                promptTokens: promptTokens,
-                samplingFingerprint: samplingFingerprint
-            )
+            return try rebuildPromptContext(model: model, preparedRuntime: preparedRuntime, payload: payload)
         }
 
         let confirmedCommonBytes = min(
             cachedPrefixBytes,
-            Self.commonPrefixCount(cache.promptBytes, promptBytes)
+            Self.commonPrefixCount(cache.promptBytes, payload.promptBytes)
         )
         guard confirmedCommonBytes > 0 else {
-            return try rebuildPromptContext(
-                model: model,
-                preparedRuntime: preparedRuntime,
-                promptBytes: promptBytes,
-                promptTokens: promptTokens,
-                samplingFingerprint: samplingFingerprint
-            )
+            return try rebuildPromptContext(model: model, preparedRuntime: preparedRuntime, payload: payload)
         }
 
-        let commonTokenPrefix = Self.commonPrefixCount(cache.promptTokens, promptTokens)
+        let commonTokenPrefix = Self.commonPrefixCount(cache.promptTokens, payload.promptTokens)
         let reusableTokenCount = Self.reusableTokenCount(
             commonTokenPrefix: commonTokenPrefix,
-            newPromptTokenCount: promptTokens.count
+            newPromptTokenCount: payload.promptTokens.count
         )
 
         guard trimCachedTokens(from: reusableTokenCount, in: cache.context) else {
-            return try rebuildPromptContext(
-                model: model,
-                preparedRuntime: preparedRuntime,
-                promptBytes: promptBytes,
-                promptTokens: promptTokens,
-                samplingFingerprint: samplingFingerprint
-            )
+            return try rebuildPromptContext(model: model, preparedRuntime: preparedRuntime, payload: payload)
         }
 
         do {
             try decodePrompt(
-                promptTokens,
+                payload.promptTokens,
                 startingAt: reusableTokenCount,
                 in: cache.context,
                 batchCapacity: preparedRuntime.batchSize
@@ -302,9 +295,9 @@ actor LlamaRuntimeCore {
 
         promptCache = PromptCache(
             context: cache.context,
-            promptBytes: promptBytes,
-            promptTokens: promptTokens,
-            samplingFingerprint: samplingFingerprint
+            promptBytes: payload.promptBytes,
+            promptTokens: payload.promptTokens,
+            samplingFingerprint: payload.samplingFingerprint
         )
         return cache.context
     }
@@ -314,9 +307,7 @@ actor LlamaRuntimeCore {
     private func rebuildPromptContext(
         model: OpaquePointer,
         preparedRuntime: PreparedLlamaRuntime,
-        promptBytes: [UInt8],
-        promptTokens: [llama_token],
-        samplingFingerprint: SamplingFingerprint
+        payload: PromptPayload
     ) throws -> OpaquePointer {
         clearPromptCache()
 
@@ -329,7 +320,7 @@ actor LlamaRuntimeCore {
 
         do {
             try decodePrompt(
-                promptTokens,
+                payload.promptTokens,
                 startingAt: 0,
                 in: context,
                 batchCapacity: preparedRuntime.batchSize
@@ -341,9 +332,9 @@ actor LlamaRuntimeCore {
 
         promptCache = PromptCache(
             context: context,
-            promptBytes: promptBytes,
-            promptTokens: promptTokens,
-            samplingFingerprint: samplingFingerprint
+            promptBytes: payload.promptBytes,
+            promptTokens: payload.promptTokens,
+            samplingFingerprint: payload.samplingFingerprint
         )
         return context
     }
@@ -488,57 +479,24 @@ actor LlamaRuntimeCore {
 
     /// Assembles the sampler chain that controls temperature, nucleus sampling, and repetition behavior.
     private func makeSampler(
-        temperature: Double,
-        topK: Int,
-        topP: Double,
-        minP: Double,
-        repetitionPenalty: Double,
-        seed: UInt32?
+        sampling: LlamaSamplingParameters
     ) throws -> UnsafeMutablePointer<llama_sampler> {
         let params = llama_sampler_chain_default_params()
         guard let sampler = llama_sampler_chain_init(params) else {
             throw LlamaRuntimeError.generationFailed("Unable to initialize the llama sampler chain.")
         }
 
-        if repetitionPenalty > 1.0 {
-            guard let penaltySampler = llama_sampler_init_penalties(64, Float(repetitionPenalty), 1.0, 1.0) else {
+        if sampling.repetitionPenalty > 1.0 {
+            guard let penaltySampler = llama_sampler_init_penalties(
+                64, Float(sampling.repetitionPenalty), 1.0, 1.0
+            ) else {
                 throw LlamaRuntimeError.generationFailed("Unable to initialize the repetition penalty sampler.")
             }
             llama_sampler_chain_add(sampler, penaltySampler)
         }
 
-        if temperature > 0 {
-            guard let temperatureSampler = llama_sampler_init_temp(Float(temperature)) else {
-                throw LlamaRuntimeError.generationFailed("Unable to initialize the temperature sampler.")
-            }
-            llama_sampler_chain_add(sampler, temperatureSampler)
-
-            if topK > 0 {
-                guard let topKSampler = llama_sampler_init_top_k(Int32(topK)) else {
-                    throw LlamaRuntimeError.generationFailed("Unable to initialize the top-k sampler.")
-                }
-                llama_sampler_chain_add(sampler, topKSampler)
-            }
-
-            if minP > 0 && minP < 1 {
-                guard let minPSampler = llama_sampler_init_min_p(Float(minP), 1) else {
-                    throw LlamaRuntimeError.generationFailed("Unable to initialize the min-p sampler.")
-                }
-                llama_sampler_chain_add(sampler, minPSampler)
-            }
-
-            if topP > 0 && topP < 1 {
-                guard let topPSampler = llama_sampler_init_top_p(Float(topP), 1) else {
-                    throw LlamaRuntimeError.generationFailed("Unable to initialize the top-p sampler.")
-                }
-                llama_sampler_chain_add(sampler, topPSampler)
-            }
-
-            let resolvedSeed = seed ?? UInt32.random(in: UInt32.min ... UInt32.max)
-            guard let distributionSampler = llama_sampler_init_dist(resolvedSeed) else {
-                throw LlamaRuntimeError.generationFailed("Unable to initialize the distribution sampler.")
-            }
-            llama_sampler_chain_add(sampler, distributionSampler)
+        if sampling.temperature > 0 {
+            try addTemperatureSamplers(to: sampler, sampling: sampling)
         } else {
             guard let greedySampler = llama_sampler_init_greedy() else {
                 throw LlamaRuntimeError.generationFailed("Unable to initialize the greedy sampler.")
@@ -547,6 +505,45 @@ actor LlamaRuntimeCore {
         }
 
         return sampler
+    }
+
+    /// Adds temperature, top-k, min-p, top-p, and distribution samplers to an existing chain.
+    /// Extracted from makeSampler to keep its cyclomatic complexity within the configured limit.
+    private func addTemperatureSamplers(
+        to sampler: UnsafeMutablePointer<llama_sampler>,
+        sampling: LlamaSamplingParameters
+    ) throws {
+        guard let temperatureSampler = llama_sampler_init_temp(Float(sampling.temperature)) else {
+            throw LlamaRuntimeError.generationFailed("Unable to initialize the temperature sampler.")
+        }
+        llama_sampler_chain_add(sampler, temperatureSampler)
+
+        if sampling.topK > 0 {
+            guard let topKSampler = llama_sampler_init_top_k(Int32(sampling.topK)) else {
+                throw LlamaRuntimeError.generationFailed("Unable to initialize the top-k sampler.")
+            }
+            llama_sampler_chain_add(sampler, topKSampler)
+        }
+
+        if sampling.minP > 0 && sampling.minP < 1 {
+            guard let minPSampler = llama_sampler_init_min_p(Float(sampling.minP), 1) else {
+                throw LlamaRuntimeError.generationFailed("Unable to initialize the min-p sampler.")
+            }
+            llama_sampler_chain_add(sampler, minPSampler)
+        }
+
+        if sampling.topP > 0 && sampling.topP < 1 {
+            guard let topPSampler = llama_sampler_init_top_p(Float(sampling.topP), 1) else {
+                throw LlamaRuntimeError.generationFailed("Unable to initialize the top-p sampler.")
+            }
+            llama_sampler_chain_add(sampler, topPSampler)
+        }
+
+        let resolvedSeed = sampling.seed ?? UInt32.random(in: UInt32.min ... UInt32.max)
+        guard let distributionSampler = llama_sampler_init_dist(resolvedSeed) else {
+            throw LlamaRuntimeError.generationFailed("Unable to initialize the distribution sampler.")
+        }
+        llama_sampler_chain_add(sampler, distributionSampler)
     }
 
     /// Removes tokens at and after `position` from the prompt sequence.

--- a/tabby/Services/Runtime/LlamaRuntimeCore.swift
+++ b/tabby/Services/Runtime/LlamaRuntimeCore.swift
@@ -67,8 +67,7 @@ actor LlamaRuntimeCore {
         configuration: LlamaRuntimeConfiguration
     ) throws -> PreparedLlamaRuntime {
         if let preparedRuntime,
-           preparedRuntime.resolvedRuntime.modelFileURL == resolvedRuntime.modelFileURL
-        {
+           preparedRuntime.resolvedRuntime.modelFileURL == resolvedRuntime.modelFileURL {
             return preparedRuntime
         }
 
@@ -611,8 +610,8 @@ actor LlamaRuntimeCore {
                 continue
             }
 
-            let bytes = buffer.prefix(Int(written)).map { UInt8(bitPattern: $0) }
-            return String(decoding: bytes, as: UTF8.self)
+            let data = Data(bytes: buffer.prefix(Int(written)).map { UInt8(bitPattern: $0) })
+            return String(bytes: data, encoding: .utf8) ?? ""
         }
     }
 }

--- a/tabby/Services/Runtime/LlamaRuntimeManager.swift
+++ b/tabby/Services/Runtime/LlamaRuntimeManager.swift
@@ -87,13 +87,7 @@ final class LlamaRuntimeManager: ObservableObject {
     func generate(
         prompt: String,
         cachedPrefixBytes: Int? = nil,
-        maxPredictionTokens: Int,
-        temperature: Double,
-        topK: Int,
-        topP: Double,
-        minP: Double,
-        repetitionPenalty: Double,
-        seed: UInt32? = nil
+        sampling: LlamaSamplingParameters
     ) async throws -> String {
         _ = try await preparedRuntime()
 
@@ -101,13 +95,7 @@ final class LlamaRuntimeManager: ObservableObject {
             return try await core.generate(
                 prompt: prompt,
                 cachedPrefixBytes: cachedPrefixBytes,
-                maxPredictionTokens: maxPredictionTokens,
-                temperature: temperature,
-                topK: topK,
-                topP: topP,
-                minP: minP,
-                repetitionPenalty: repetitionPenalty,
-                seed: seed
+                sampling: sampling
             )
         } catch is CancellationError {
             throw LlamaRuntimeError.cancelled

--- a/tabby/Services/Runtime/LlamaRuntimeManager.swift
+++ b/tabby/Services/Runtime/LlamaRuntimeManager.swift
@@ -149,8 +149,7 @@ final class LlamaRuntimeManager: ObservableObject {
         let requestedModelFilename = resolvedRuntime.modelFileURL.lastPathComponent
 
         if let cachedRuntime,
-            cachedRuntime.resolvedRuntime.modelFileURL == resolvedRuntime.modelFileURL
-        {
+            cachedRuntime.resolvedRuntime.modelFileURL == resolvedRuntime.modelFileURL {
             return cachedRuntime
         }
 

--- a/tabby/Services/Runtime/LlamaSuggestionEngine.swift
+++ b/tabby/Services/Runtime/LlamaSuggestionEngine.swift
@@ -21,9 +21,7 @@ final class LlamaSuggestionEngine {
         do {
             let startTime = Date()
             let cachedPrefixBytes = promptCacheHintTracker.cachedPrefixBytes(for: request)
-            let rawSuggestion = try await runtimeManager.generate(
-                prompt: request.prompt,
-                cachedPrefixBytes: cachedPrefixBytes,
+            let sampling = LlamaSamplingParameters(
                 maxPredictionTokens: request.maxPredictionTokens,
                 temperature: request.temperature,
                 topK: request.topK,
@@ -31,6 +29,11 @@ final class LlamaSuggestionEngine {
                 minP: request.minP,
                 repetitionPenalty: request.repetitionPenalty,
                 seed: request.randomSeed
+            )
+            let rawSuggestion = try await runtimeManager.generate(
+                prompt: request.prompt,
+                cachedPrefixBytes: cachedPrefixBytes,
+                sampling: sampling
             )
             try Task.checkCancellation()
 

--- a/tabby/Services/Suggestion/SuggestionDebugLogger.swift
+++ b/tabby/Services/Suggestion/SuggestionDebugLogger.swift
@@ -61,85 +61,80 @@ final class SuggestionDebugLogger {
         }
 
         if stage != "generating" {
-            switch (rawOutput, normalizedOutput) {
-            case let (raw?, normalized?):
-                // When generation and normalization diverge, surface both previews in the compact
-                // summary so we can immediately see whether the backend returned text that the
-                // cleanup layer later stripped away.
-                if raw == normalized {
-                    parts.append("output=\(Self.debugPreview(raw))")
-                } else {
-                    parts.append("rawOutput=\(Self.debugPreview(raw))")
-                    parts.append("normalizedOutput=\(Self.debugPreview(normalized))")
-                }
-            case let (raw?, nil):
-                parts.append("rawOutput=\(Self.debugPreview(raw))")
-            case let (nil, normalized?):
-                parts.append("normalizedOutput=\(Self.debugPreview(normalized))")
-            case (nil, nil):
-                break
-            }
-        }
-
-        let summaryLine = parts.joined(separator: " ")
-        logLine(summaryLine)
-
-        if stage == "generating", let prompt {
-            logTextBlock(
-                kind: "prompt",
-                stage: stage,
-                workID: workID,
-                generation: generation,
-                text: prompt
+            appendOutputSummaryParts(
+                to: &parts,
+                rawOutput: rawOutput,
+                normalizedOutput: normalizedOutput
             )
         }
 
+        logLine(parts.joined(separator: " "))
+
+        if stage == "generating", let prompt {
+            logTextBlock(kind: "prompt", stage: stage, workID: workID, generation: generation, text: prompt)
+        }
+
         if stage != "generating" {
-            switch (rawOutput, normalizedOutput) {
-            case let (raw?, normalized?):
-                if raw == normalized {
-                    logTextBlock(
-                        kind: "output",
-                        stage: stage,
-                        workID: workID,
-                        generation: generation,
-                        text: raw
-                    )
-                } else {
-                    logTextBlock(
-                        kind: "raw-output",
-                        stage: stage,
-                        workID: workID,
-                        generation: generation,
-                        text: raw
-                    )
-                    logTextBlock(
-                        kind: "normalized-output",
-                        stage: stage,
-                        workID: workID,
-                        generation: generation,
-                        text: normalized
-                    )
-                }
-            case let (raw?, nil):
-                logTextBlock(
-                    kind: "raw-output",
-                    stage: stage,
-                    workID: workID,
-                    generation: generation,
-                    text: raw
-                )
-            case let (nil, normalized?):
-                logTextBlock(
-                    kind: "normalized-output",
-                    stage: stage,
-                    workID: workID,
-                    generation: generation,
-                    text: normalized
-                )
-            case (nil, nil):
-                break
+            logOutputBlocks(
+                stage: stage,
+                workID: workID,
+                generation: generation,
+                rawOutput: rawOutput,
+                normalizedOutput: normalizedOutput
+            )
+        }
+    }
+
+    /// Appends compact output preview tokens to the running summary parts array.
+    /// Extracted to keep `logStage` cyclomatic complexity within the configured limit.
+    private func appendOutputSummaryParts(
+        to parts: inout [String],
+        rawOutput: String?,
+        normalizedOutput: String?
+    ) {
+        switch (rawOutput, normalizedOutput) {
+        case let (raw?, normalized?):
+            // When generation and normalization diverge, surface both previews in the compact
+            // summary so we can immediately see whether the backend returned text that the
+            // cleanup layer later stripped away.
+            if raw == normalized {
+                parts.append("output=\(Self.debugPreview(raw))")
+            } else {
+                parts.append("rawOutput=\(Self.debugPreview(raw))")
+                parts.append("normalizedOutput=\(Self.debugPreview(normalized))")
             }
+        case let (raw?, nil):
+            parts.append("rawOutput=\(Self.debugPreview(raw))")
+        case let (nil, normalized?):
+            parts.append("normalizedOutput=\(Self.debugPreview(normalized))")
+        case (nil, nil):
+            break
+        }
+    }
+
+    /// Emits full multi-line output blocks for a non-generating stage.
+    /// Extracted to keep `logStage` cyclomatic complexity within the configured limit.
+    private func logOutputBlocks(
+        stage: String,
+        workID: UInt64,
+        generation: UInt64?,
+        rawOutput: String?,
+        normalizedOutput: String?
+    ) {
+        switch (rawOutput, normalizedOutput) {
+        case let (raw?, normalized?):
+            if raw == normalized {
+                logTextBlock(kind: "output", stage: stage, workID: workID, generation: generation, text: raw)
+            } else {
+                logTextBlock(kind: "raw-output", stage: stage, workID: workID, generation: generation, text: raw)
+                logTextBlock(kind: "normalized-output", stage: stage, workID: workID, generation: generation, text: normalized)
+            }
+        case let (raw?, nil):
+            logTextBlock(kind: "raw-output", stage: stage, workID: workID, generation: generation, text: raw)
+        case let (nil, normalized?):
+            logTextBlock(kind: "normalized-output", stage: stage, workID: workID, generation: generation, text: normalized)
+        case (nil, nil):
+            break
         }
     }
 

--- a/tabby/Services/Suggestion/SuggestionOverlayPresenter.swift
+++ b/tabby/Services/Suggestion/SuggestionOverlayPresenter.swift
@@ -22,6 +22,7 @@ struct SuggestionOverlayPresenter {
         text: String,
         at caretRect: CGRect,
         caretQuality: CaretGeometryQuality,
+        inputFrameRect: CGRect?,
         previousState: OverlayState
     ) -> String? {
         let displayText = text.trimmingCharacters(in: .whitespaces).isEmpty ? "" : text
@@ -32,21 +33,22 @@ struct SuggestionOverlayPresenter {
         guard previousState != .visible(
             text: displayText,
             caretRect: caretRect,
-            caretQuality: caretQuality
+            caretQuality: caretQuality,
+            inputFrameRect: inputFrameRect
         ) else {
             return nil
         }
 
-        overlayController.showSuggestion(displayText, at: caretRect, caretQuality: caretQuality)
+        overlayController.showSuggestion(displayText, at: caretRect, caretQuality: caretQuality, inputFrameRect: inputFrameRect)
 
         switch previousState {
-        case .visible(let previousText, let previousCaretRect, let previousCaretQuality)
+        case .visible(let previousText, let previousCaretRect, let previousCaretQuality, _)
         where previousText == displayText
             && previousCaretRect == caretRect
             && previousCaretQuality != caretQuality:
             return "Updated ghost text styling for the latest caret quality."
 
-        case .visible(let previousText, let previousCaretRect, _)
+        case .visible(let previousText, let previousCaretRect, _, _)
         where previousText == displayText && previousCaretRect != caretRect:
             return "Moved ghost text to the latest caret position."
 

--- a/tabby/Services/UI/OverlayController.swift
+++ b/tabby/Services/UI/OverlayController.swift
@@ -80,7 +80,7 @@ final class OverlayController: SuggestionOverlayControlling {
         let viewIndent: CGFloat
         let panelOriginX: CGFloat
         let containerWidth: CGFloat?
-        
+
         if overflowText != nil, let frameRect = inputFrameRect {
             panelOriginX = frameRect.minX
             viewIndent = max(0, caretRect.maxX + 6 - frameRect.minX)
@@ -178,19 +178,19 @@ final class OverlayController: SuggestionOverlayControlling {
         guard let inputFrameRect = inputFrameRect else {
             return (text, nil)
         }
-        
+
         // Tab keycap takes ~40 points; we reserve 10 points for safe margin.
         let availableWidth = max(0, inputFrameRect.maxX - (caretRect.maxX + 6) - 10)
-        
+
         let attrs: [NSAttributedString.Key: Any] = [
             .font: NSFont.systemFont(ofSize: fontSize)
         ]
-        
+
         let fullWidth = (text as NSString).size(withAttributes: attrs).width
         if fullWidth <= availableWidth {
             return (text, nil)
         }
-        
+
         var lastFitIndex = text.startIndex
         for index in text.indices {
             let substring = text[text.startIndex..<index]
@@ -202,7 +202,7 @@ final class OverlayController: SuggestionOverlayControlling {
                 lastFitIndex = index
             }
         }
-        
+
         // If not even the first word fits, break at the first space or take the whole text.
         if lastFitIndex == text.startIndex {
             if let firstSpace = text.firstIndex(where: { $0.isWhitespace }) {
@@ -211,15 +211,15 @@ final class OverlayController: SuggestionOverlayControlling {
                 lastFitIndex = text.endIndex
             }
         }
-        
+
         let inlineText = String(text[text.startIndex..<lastFitIndex])
         var overflowTextStr = String(text[lastFitIndex..<text.endIndex])
-        
+
         // Trim leading spaces from the overflow text so the wrapped line is flush to the edge
         while overflowTextStr.first?.isWhitespace == true {
             overflowTextStr.removeFirst()
         }
-        
+
         let overflowText = overflowTextStr.isEmpty ? nil : overflowTextStr
         return (inlineText.isEmpty ? text : inlineText, overflowText)
     }
@@ -259,14 +259,14 @@ private struct GhostSuggestionView: View {
                     .foregroundStyle(ghostColor)
                     .lineLimit(1)
                     .padding(.leading, viewIndent)
-                
+
                 HStack(alignment: .lastTextBaseline, spacing: 6) {
                     Text(overflow)
                         .font(.system(size: fontSize))
                         .foregroundStyle(ghostColor)
                         .lineLimit(nil)
                         .fixedSize(horizontal: false, vertical: true)
-                    
+
                     GhostTabKeycap()
                 }
             }

--- a/tabby/Services/UI/OverlayController.swift
+++ b/tabby/Services/UI/OverlayController.swift
@@ -60,7 +60,7 @@ final class OverlayController: SuggestionOverlayControlling {
     }()
 
     /// Sizes and positions the overlay next to the reported caret bounds for the current field.
-    func showSuggestion(_ text: String, at caretRect: CGRect, caretQuality: CaretGeometryQuality) {
+    func showSuggestion(_ text: String, at caretRect: CGRect, caretQuality: CaretGeometryQuality, inputFrameRect: CGRect?) {
         guard !text.isEmpty else {
             hide(reason: "Overlay not shown because the suggestion was empty.")
             return
@@ -70,19 +70,46 @@ final class OverlayController: SuggestionOverlayControlling {
         let customGhostColor = SuggestionTextColorCodec.color(
             fromHex: suggestionSettings.customSuggestionTextColorHex
         )
+        let (inlineText, overflowText) = splitTextForWrapping(
+            text: text,
+            caretRect: caretRect,
+            inputFrameRect: inputFrameRect,
+            fontSize: fontSize
+        )
+
+        let viewIndent: CGFloat
+        let panelOriginX: CGFloat
+        let containerWidth: CGFloat?
+        
+        if overflowText != nil, let frameRect = inputFrameRect {
+            panelOriginX = frameRect.minX
+            viewIndent = max(0, caretRect.maxX + 6 - frameRect.minX)
+            containerWidth = frameRect.width
+        } else {
+            panelOriginX = caretRect.maxX + 6
+            viewIndent = 0
+            containerWidth = nil
+        }
+
         let contentView: NSHostingView<GhostSuggestionView>
         if let existing = hostingView {
             existing.rootView = GhostSuggestionView(
-                text: text,
+                inlineText: inlineText,
+                overflowText: overflowText,
                 fontSize: fontSize,
+                viewIndent: viewIndent,
+                containerWidth: containerWidth,
                 customColor: customGhostColor
             )
             contentView = existing
         } else {
             let fresh = NSHostingView(
                 rootView: GhostSuggestionView(
-                    text: text,
+                    inlineText: inlineText,
+                    overflowText: overflowText,
                     fontSize: fontSize,
+                    viewIndent: viewIndent,
+                    containerWidth: containerWidth,
                     customColor: customGhostColor
                 )
             )
@@ -93,19 +120,27 @@ final class OverlayController: SuggestionOverlayControlling {
         contentView.layoutSubtreeIfNeeded()
         let contentSize = contentView.fittingSize
 
-        // Vertically center the ghost text within the caret rect. When the caret rect is a
-        // tight line-height box this looks identical to top-alignment, but when it's oversized
-        // (e.g. AXFrame fallback returning the full text area) the text lands at the visual
-        // midpoint instead of floating at the top edge.
+        // Vertically center the ghost text within the caret rect. 
+        // When there are multiple lines, we want the FIRST line to center around the caret's midY.
+        let originY: CGFloat
+        if overflowText != nil {
+            // In AppKit (bottom-up), the top Y is `origin.y + height`.
+            // We want the top of the first line to be `caretRect.midY + caretRect.height / 2`.
+            let topY = caretRect.midY + caretRect.height / 2
+            originY = topY - contentSize.height
+        } else {
+            originY = caretRect.midY - contentSize.height / 2
+        }
+
         let origin = CGPoint(
-            x: caretRect.maxX + 6,
-            y: caretRect.midY - contentSize.height / 2
+            x: panelOriginX,
+            y: originY
         )
         let frame = CGRect(origin: origin, size: contentSize)
 
         panel.setFrame(frame.integral, display: true)
         panel.orderFrontRegardless()
-        state = .visible(text: text, caretRect: caretRect, caretQuality: caretQuality)
+        state = .visible(text: text, caretRect: caretRect, caretQuality: caretQuality, inputFrameRect: inputFrameRect)
     }
 
     /// Hides the floating panel and records why the overlay is no longer visible.
@@ -132,6 +167,62 @@ final class OverlayController: SuggestionOverlayControlling {
 
         return min(proposedSize, qualityCap)
     }
+
+    /// Splits text into the portion that fits on the same line as the caret, and the overflow.
+    private func splitTextForWrapping(
+        text: String,
+        caretRect: CGRect,
+        inputFrameRect: CGRect?,
+        fontSize: CGFloat
+    ) -> (inlineText: String, overflowText: String?) {
+        guard let inputFrameRect = inputFrameRect else {
+            return (text, nil)
+        }
+        
+        // Tab keycap takes ~40 points; we reserve 10 points for safe margin.
+        let availableWidth = max(0, inputFrameRect.maxX - (caretRect.maxX + 6) - 10)
+        
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: fontSize)
+        ]
+        
+        let fullWidth = (text as NSString).size(withAttributes: attrs).width
+        if fullWidth <= availableWidth {
+            return (text, nil)
+        }
+        
+        var lastFitIndex = text.startIndex
+        for index in text.indices {
+            let substring = text[text.startIndex..<index]
+            let width = (String(substring) as NSString).size(withAttributes: attrs).width
+            if width > availableWidth {
+                break
+            }
+            if substring.last?.isWhitespace == true {
+                lastFitIndex = index
+            }
+        }
+        
+        // If not even the first word fits, break at the first space or take the whole text.
+        if lastFitIndex == text.startIndex {
+            if let firstSpace = text.firstIndex(where: { $0.isWhitespace }) {
+                lastFitIndex = firstSpace
+            } else {
+                lastFitIndex = text.endIndex
+            }
+        }
+        
+        let inlineText = String(text[text.startIndex..<lastFitIndex])
+        var overflowTextStr = String(text[lastFitIndex..<text.endIndex])
+        
+        // Trim leading spaces from the overflow text so the wrapped line is flush to the edge
+        while overflowTextStr.first?.isWhitespace == true {
+            overflowTextStr.removeFirst()
+        }
+        
+        let overflowText = overflowTextStr.isEmpty ? nil : overflowTextStr
+        return (inlineText.isEmpty ? text : inlineText, overflowText)
+    }
 }
 
 private final class OverlayPanel: NSPanel {
@@ -144,8 +235,11 @@ private final class OverlayPanel: NSPanel {
 /// without touching the AppKit positioning code.
 private struct GhostSuggestionView: View {
     @Environment(\.colorScheme) var colorScheme
-    let text: String
+    let inlineText: String
+    let overflowText: String?
     let fontSize: CGFloat
+    let viewIndent: CGFloat
+    let containerWidth: CGFloat?
     let customColor: Color?
 
     var ghostColor: Color {
@@ -158,16 +252,38 @@ private struct GhostSuggestionView: View {
     }
 
     var body: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 6) {
-            Text(text)
-                .font(.system(size: fontSize))
-                .foregroundStyle(ghostColor)
-                .lineLimit(1)
-                .fixedSize(horizontal: true, vertical: true)
+        if let overflow = overflowText {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(inlineText)
+                    .font(.system(size: fontSize))
+                    .foregroundStyle(ghostColor)
+                    .lineLimit(1)
+                    .padding(.leading, viewIndent)
+                
+                HStack(alignment: .lastTextBaseline, spacing: 6) {
+                    Text(overflow)
+                        .font(.system(size: fontSize))
+                        .foregroundStyle(ghostColor)
+                        .lineLimit(nil)
+                        .fixedSize(horizontal: false, vertical: true)
+                    
+                    GhostTabKeycap()
+                }
+            }
+            .frame(maxWidth: containerWidth, alignment: .leading)
+            .fixedSize(horizontal: true, vertical: true)
+        } else {
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                Text(inlineText)
+                    .font(.system(size: fontSize))
+                    .foregroundStyle(ghostColor)
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: true)
 
-            GhostTabKeycap()
+                GhostTabKeycap()
+            }
+            .fixedSize(horizontal: true, vertical: true)
         }
-        .fixedSize(horizontal: true, vertical: true)
     }
 }
 

--- a/tabby/Services/Utilities/LaunchAtLoginService.swift
+++ b/tabby/Services/Utilities/LaunchAtLoginService.swift
@@ -81,7 +81,7 @@ final class LaunchAtLoginService: ObservableObject {
         refresh()
     }
 
-    private static func     map(_ status: SMAppService.Status) -> LaunchAtLoginState {
+    private static func map(_ status: SMAppService.Status) -> LaunchAtLoginState {
         switch status {
         case .enabled:
             return .enabled

--- a/tabby/Services/Utilities/ModelDownloadManager.swift
+++ b/tabby/Services/Utilities/ModelDownloadManager.swift
@@ -382,8 +382,7 @@ private final class ModelDownloadSessionDelegate: NSObject, URLSessionDownloadDe
         response = downloadTask.response
     }
 
-    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?)
-    {
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         guard !hasCompleted else {
             return
         }

--- a/tabby/Services/Utilities/ModelFileValidator.swift
+++ b/tabby/Services/Utilities/ModelFileValidator.swift
@@ -33,7 +33,8 @@ enum ModelFileValidator {
             case let .checksumMismatch(expected, actual):
                 let expectedShort = String(expected.lowercased().prefix(16))
                 let actualShort = String(actual.lowercased().prefix(16))
-                return "Downloaded file's checksum (\(actualShort)…) doesn't match the expected (\(expectedShort)…). The file may be corrupt."
+                return "Downloaded file's checksum (\(actualShort)…) doesn't match " +
+                    "the expected (\(expectedShort)…). The file may be corrupt."
             case let .fileUnreadable(url):
                 return "Couldn't read \(url.lastPathComponent) for validation."
             }
@@ -95,7 +96,8 @@ enum ModelFileValidator {
         defer { try? handle.close() }
 
         var hasher = SHA256()
-        let chunkSize = 1024 * 1024  // 1 MB — small enough to stay out of large allocations, large enough to keep syscall overhead negligible.
+        let chunkSize = 1024 * 1024  // 1 MB — small enough to stay out of large allocations,
+        // large enough to keep syscall overhead negligible.
         while true {
             let chunk: Data
             do {

--- a/tabby/Services/Visual/VisualContextCoordinator.swift
+++ b/tabby/Services/Visual/VisualContextCoordinator.swift
@@ -40,12 +40,10 @@ final class VisualContextCoordinator {
     /// the screenshot context should survive normal typing inside the same input.
     func startSessionIfNeeded(for snapshotContext: FocusedInputSnapshot) {
         if let activeAugmentationSession,
-            activeAugmentationSession.elementIdentifier == snapshotContext.elementIdentifier
-        {
+            activeAugmentationSession.elementIdentifier == snapshotContext.elementIdentifier {
             if case .unavailable(let reason) = activeAugmentationSession.status,
                 reason.localizedCaseInsensitiveContains("Screen Recording"),
-                screenRecordingPermissionProvider()
-            {
+                screenRecordingPermissionProvider() {
                 cancel(resetState: true)
             } else {
                 return

--- a/tabby/Services/Visual/WindowScreenshotService.swift
+++ b/tabby/Services/Visual/WindowScreenshotService.swift
@@ -129,8 +129,7 @@ struct WindowScreenshotService {
         if let inputFrameRect = context.inputFrameRect,
            !inputFrameRect.isEmpty,
            inputFrameRect.width <= snapshotDimension * 0.8,
-           inputFrameRect.height <= snapshotDimension * 0.8
-        {
+           inputFrameRect.height <= snapshotDimension * 0.8 {
             return inputFrameRect
         }
 

--- a/tabby/Support/AXHelper.swift
+++ b/tabby/Support/AXHelper.swift
@@ -14,7 +14,7 @@ enum AXHelper {
         kAXTextFieldRole as String,
         kAXTextAreaRole as String,
         "AXSearchField",
-        kAXComboBoxRole as String,
+        kAXComboBoxRole as String
     ]
 
     private static let knownReadOnlyRoles: Set<String> = [
@@ -22,7 +22,7 @@ enum AXHelper {
         kAXImageRole as String,
         kAXButtonRole as String,
         "AXLink",
-        kAXMenuItemRole as String,
+        kAXMenuItemRole as String
     ]
 
     // MARK: - Attribute Reading
@@ -165,32 +165,32 @@ enum AXHelper {
         // 1. Get the opaque AXTextMarkerRange that represents the current selection/caret.
         let selectedMarkerRangeAttribute = "AXSelectedTextMarkerRange" as CFString
         var markerRangeValue: CFTypeRef?
-        
+
         var result = AXUIElementCopyAttributeValue(element, selectedMarkerRangeAttribute, &markerRangeValue)
         guard result == .success, let markerRange = markerRangeValue else {
             return nil
         }
-        
+
         // 2. Ask the element to compute the bounding box for that exact text marker range.
         let boundsForMarkerRangeAttribute = "AXBoundsForTextMarkerRange" as CFString
         var boundsValue: CFTypeRef?
-        
+
         result = AXUIElementCopyParameterizedAttributeValue(element, boundsForMarkerRangeAttribute, markerRange, &boundsValue)
         guard result == .success, let bounds = boundsValue, CFGetTypeID(bounds) == AXValueGetTypeID() else {
             return nil
         }
-        
+
         // Safe because we already checked the Core Foundation type id above.
         let axBounds = bounds as! AXValue
         guard AXValueGetType(axBounds) == .cgRect else {
             return nil
         }
-        
+
         var rect = CGRect.zero
         guard AXValueGetValue(axBounds, .cgRect, &rect) else {
             return nil
         }
-        
+
         return rect
     }
 

--- a/tabby/Support/AXHelper.swift
+++ b/tabby/Support/AXHelper.swift
@@ -85,8 +85,10 @@ enum AXHelper {
             return nil
         }
 
-        // Safe because we already checked the Core Foundation type id above.
-        let axValue = rawValue as! AXValue
+        // We verified the CF type ID above, so the bit-cast is guaranteed safe.
+        // unsafeBitCast is the correct idiomatic pattern for CF types that bridge
+        // as AnyObject but need a more specific opaque CF wrapper type.
+        let axValue = unsafeBitCast(rawValue, to: AXValue.self)
         guard AXValueGetType(axValue) == .cfRange else {
             return nil
         }
@@ -107,8 +109,8 @@ enum AXHelper {
             return nil
         }
 
-        // Safe because we already checked the Core Foundation type id above.
-        let axValue = rawValue as! AXValue
+        // We verified the CF type ID above, so the bit-cast is guaranteed safe.
+        let axValue = unsafeBitCast(rawValue, to: AXValue.self)
         guard AXValueGetType(axValue) == .cgRect else {
             return nil
         }
@@ -138,8 +140,8 @@ enum AXHelper {
             return nil
         }
 
-        // Safe because we already checked the Core Foundation type id above.
-        let axValue = value as! AXValue
+        // We verified the CF type ID above, so the bit-cast is guaranteed safe.
+        let axValue = unsafeBitCast(value, to: AXValue.self)
         guard AXValueGetType(axValue) == .cgRect else {
             return nil
         }
@@ -180,8 +182,8 @@ enum AXHelper {
             return nil
         }
 
-        // Safe because we already checked the Core Foundation type id above.
-        let axBounds = bounds as! AXValue
+        // We verified the CF type ID above, so the bit-cast is guaranteed safe.
+        let axBounds = unsafeBitCast(bounds, to: AXValue.self)
         guard AXValueGetType(axBounds) == .cgRect else {
             return nil
         }

--- a/tabby/Support/BundledRuntimeLocator.swift
+++ b/tabby/Support/BundledRuntimeLocator.swift
@@ -114,8 +114,7 @@ struct BundledRuntimeLocator {
                 candidate: candidate,
                 preferredModelNames: configuration.preferredModelNames
             ),
-                !modelOptions.isEmpty
-            {
+                !modelOptions.isEmpty {
                 return modelOptions
             }
         }
@@ -126,11 +125,9 @@ struct BundledRuntimeLocator {
     /// Enumerates runtime directories. By default we only load from the user-managed model directory.
     /// An explicit `runtimeDirectoryPath` can override this for tests or advanced local setups.
     private func runtimeCandidates(for configuration: LlamaRuntimeConfiguration)
-        -> [RuntimeCandidate]
-    {
+        -> [RuntimeCandidate] {
         if let runtimeDirectoryPath = configuration.runtimeDirectoryPath,
-            !runtimeDirectoryPath.isEmpty
-        {
+            !runtimeDirectoryPath.isEmpty {
             let runtimeDirectoryURL = URL(fileURLWithPath: runtimeDirectoryPath, isDirectory: true)
             return [
                 RuntimeCandidate(

--- a/tabby/Support/LlamaPromptRenderer.swift
+++ b/tabby/Support/LlamaPromptRenderer.swift
@@ -53,7 +53,7 @@ enum LlamaPromptRenderer {
             "Output contract:",
             "- Plain text only.",
             "- No labels, bullets, markdown, quotes, or explanation.",
-            "- Start immediately with the continuation text.",
+            "- Start immediately with the continuation text."
         ]
 
         let customInstructionLines = CustomAIInstructionFormatter.promptSectionLines(from: customAIInstructions)

--- a/tabby/Support/SuggestionAvailabilityEvaluator.swift
+++ b/tabby/Support/SuggestionAvailabilityEvaluator.swift
@@ -18,8 +18,7 @@ enum SuggestionAvailabilityEvaluator {
         }
 
         if let bundleIdentifier = focusSnapshot.bundleIdentifier,
-           disabledAppBundleIdentifiers.contains(bundleIdentifier)
-        {
+           disabledAppBundleIdentifiers.contains(bundleIdentifier) {
             return "Tabby is disabled in \(focusSnapshot.applicationName)."
         }
 

--- a/tabby/Support/SuggestionSessionReconciler.swift
+++ b/tabby/Support/SuggestionSessionReconciler.swift
@@ -54,12 +54,17 @@ enum SuggestionSessionReconciler {
     ) -> SuggestionSessionReconciliation {
         let isAwaitingInsertedTextSync = pendingInsertionConsumedCount == session.consumedCharacterCount
 
-        func tolerateTransientPostInsertionLag() -> SuggestionSessionReconciliation {
-            .valid(
-                session: session,
-                advancement: nil,
-                nextPendingInsertionConsumedCount: pendingInsertionConsumedCount
-            )
+        // Inline helper: when the AX lag sentinel is active, tolerate the mismatch for one cycle.
+        // Otherwise the guard produced a genuine divergence, so the session is invalid.
+        func axLagOrInvalid(_ reason: String) -> SuggestionSessionReconciliation {
+            if isAwaitingInsertedTextSync {
+                return .valid(
+                    session: session,
+                    advancement: nil,
+                    nextPendingInsertionConsumedCount: pendingInsertionConsumedCount
+                )
+            }
+            return .invalid(reason)
         }
 
         // Process-level identity check instead of AX element identity. Chrome recycles AX
@@ -81,19 +86,17 @@ enum SuggestionSessionReconciler {
             // active and the prefix before the caret still anchors to the same field content.
             if isAwaitingInsertedTextSync,
                liveContext.precedingText.hasPrefix(session.baseContext.precedingText) {
-                return tolerateTransientPostInsertionLag()
+                return axLagOrInvalid("")  // hasPrefix guard already validated above
             }
             return .invalid("Overlay hidden because text after the caret changed.")
         }
 
         guard liveContext.precedingText.hasPrefix(session.baseContext.precedingText) else {
-            // The inverse Chromium race can also happen: the trailing text is already stable, but
-            // the prefix before the caret still reflects the pre-insertion snapshot. In that case
-            // we again prefer to wait for AX to settle instead of eagerly killing the session.
-            if isAwaitingInsertedTextSync {
-                return tolerateTransientPostInsertionLag()
-            }
-            return .invalid("Overlay hidden because text before the caret no longer matches the suggestion anchor.")
+            // The inverse Chromium race: trailing text is stable but the prefix still reflects
+            // the pre-insertion snapshot. Wait for AX to settle.
+            return axLagOrInvalid(
+                "Overlay hidden because text before the caret no longer matches the suggestion anchor."
+            )
         }
 
         var nextPendingInsertionConsumedCount = pendingInsertionConsumedCount
@@ -101,11 +104,7 @@ enum SuggestionSessionReconciler {
         guard session.fullText.hasPrefix(consumedSuffix) else {
             // If we just inserted via Tab, AX may still show stale text. Trust the sentinel
             // for one reconciliation cycle instead of invalidating the whole session.
-            if isAwaitingInsertedTextSync {
-                return tolerateTransientPostInsertionLag()
-            }
-
-            return .invalid("Overlay hidden because typed text diverged from the active suggestion.")
+            return axLagOrInvalid("Overlay hidden because typed text diverged from the active suggestion.")
         }
 
         // AX caught up (or never lagged) — clear the sentinel.
@@ -116,11 +115,7 @@ enum SuggestionSessionReconciler {
 
         guard consumedSuffix.count >= session.consumedCharacterCount else {
             // Same AX lag protection: if we just Tab-inserted, the preceding text hasn't updated yet.
-            if isAwaitingInsertedTextSync {
-                return tolerateTransientPostInsertionLag()
-            }
-
-            return .invalid("Overlay hidden because the active suggestion was partially undone.")
+            return axLagOrInvalid("Overlay hidden because the active suggestion was partially undone.")
         }
 
         let reconciledSession = session.withConsumedCharacters(consumedSuffix.count)

--- a/tabby/Support/SuggestionSessionReconciler.swift
+++ b/tabby/Support/SuggestionSessionReconciler.swift
@@ -80,8 +80,7 @@ enum SuggestionSessionReconciler {
             // valid. We allow that transient mismatch only while the post-insertion sentinel is
             // active and the prefix before the caret still anchors to the same field content.
             if isAwaitingInsertedTextSync,
-               liveContext.precedingText.hasPrefix(session.baseContext.precedingText)
-            {
+               liveContext.precedingText.hasPrefix(session.baseContext.precedingText) {
                 return tolerateTransientPostInsertionLag()
             }
             return .invalid("Overlay hidden because text after the caret changed.")
@@ -111,8 +110,7 @@ enum SuggestionSessionReconciler {
 
         // AX caught up (or never lagged) — clear the sentinel.
         if nextPendingInsertionConsumedCount != nil,
-           consumedSuffix.count >= session.consumedCharacterCount
-        {
+           consumedSuffix.count >= session.consumedCharacterCount {
             nextPendingInsertionConsumedCount = nil
         }
 

--- a/tabby/Support/SuggestionSessionReconciler.swift
+++ b/tabby/Support/SuggestionSessionReconciler.swift
@@ -197,7 +197,7 @@ enum SuggestionSessionReconciler {
     /// The overlay may be hidden briefly while waiting for the host app to publish an updated
     /// caret position, so hidden does not automatically mean "reject Tab."
     static func overlayAllowsAcceptance(of text: String, overlayState: OverlayState) -> Bool {
-        guard case let .visible(visibleText, _, _) = overlayState else {
+        guard case let .visible(visibleText, _, _, _) = overlayState else {
             return true
         }
 

--- a/tabby/Support/SuggestionTextNormalizer.swift
+++ b/tabby/Support/SuggestionTextNormalizer.swift
@@ -46,8 +46,7 @@ enum SuggestionTextNormalizer {
         // suggestion as unusable. Showing only the remainder often produces confusing mid-word
         // ghosts, so the coordinator should regenerate instead.
         if !request.context.trailingText.isEmpty,
-            normalized.hasPrefix(request.context.trailingText)
-        {
+            normalized.hasPrefix(request.context.trailingText) {
             return ""
         }
 

--- a/tabby/UI/SettingsView.swift
+++ b/tabby/UI/SettingsView.swift
@@ -517,15 +517,14 @@ struct SettingsView: View {
 
     private var customAIInstructionsDescription: String {
         if suggestionSettings.selectedEngine == .llamaOpenSource,
-            suggestionSettings.effectivePromptMode == .guided
-        {
-            return
-                "These instructions are active right now. Use them to tell Tabby about your tone, language, audience, or formatting preferences."
+            suggestionSettings.effectivePromptMode == .guided {
+            return "These instructions are active right now. " +
+                "Use them to tell Tabby about your tone, language, audience, or formatting preferences."
         }
 
         if suggestionSettings.selectedEngine == .llamaOpenSource {
-            return
-                "These instructions are saved for the Open Source engine. They take effect when Completion Style is set to Use My Instructions."
+            return "These instructions are saved for the Open Source engine. " +
+                "They take effect when Completion Style is set to Use My Instructions."
         }
 
         return

--- a/tabby/UI/WelcomeView.swift
+++ b/tabby/UI/WelcomeView.swift
@@ -314,7 +314,7 @@ private struct EngineCard: View {
             if isAvailable {
                 action()
             }
-        }) {
+        }, label: {
             HStack(spacing: 14) {
                 EngineArtworkThumbnail(
                     artworkName: artworkName,
@@ -355,7 +355,7 @@ private struct EngineCard: View {
                         lineWidth: isSelected && isAvailable ? 1.5 : 0.5
                     )
             )
-        }
+        })
         .buttonStyle(.plain)
         .disabled(!isAvailable)
     }
@@ -423,8 +423,8 @@ struct WelcomeButton: View {
 struct WelcomeNavigation: View {
     var canGoBack: Bool = false
     var canContinue: Bool = true
-    var disabledHint: String? = nil
-    var onBack: (() -> Void)? = nil
+    var disabledHint: String?
+    var onBack: (() -> Void)?
     let onContinue: () -> Void
 
     var body: some View {


### PR DESCRIPTION
## Summary

Fixes the issue where long ghost text suggestions overflowed the right edge of the window or input field frame.
The `OverlayState.visible` was updated to include the bounding `inputFrameRect`. The UI layer `OverlayController` now manually measures string fragments and splits the text into `inlineText` and `overflowText` if it exceeds the available space. The `GhostSuggestionView` was restructured into a `VStack` to layout the overflow text, dropping it to a new line that aligns flush left to the `inputFrameRect`, and places the tab keycap properly at the end of the final wrapped text line.

## Validation

- Verified the build succeeds (`xcodebuild -scheme tabby build`).
- Ensure no pattern matching errors remain in the reconciler logic.
- Tested by manual code inspection of multiline string splitting against AppKit font attribute measurement logic.

## Linked issues

N/A

## Risk / rollout notes

- The `inputFrameRect` relies on AppKit/Accessibility frames. If the editor publishes an inaccurate frame, the wrap boundary may be imprecise, but in most cases, this provides a massive visual layout improvement over infinite 1-line truncation.
