### PR TITLE
Replace AXObserver focus tracking with polling

### DIFF
--- a/tabby/App/Core/AppDelegate.swift
+++ b/tabby/App/Core/AppDelegate.swift
@@ -84,12 +84,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
             .store(in: &cancellables)
 
-        focusModel.$latestObserverEvent
-            .compactMap { $0 }
-            .sink { [weak self] event in
-                self?.focusDebugOverlayController?.flashAXObserverHit(event: event)
-            }
-            .store(in: &cancellables)
+        if let focusDebugOverlayController {
+            focusModel.$latestPollEvent
+                .compactMap { $0 }
+                .sink { [weak focusDebugOverlayController] pollEvent in
+                    focusDebugOverlayController?.updateFocusPolling(event: pollEvent)
+                }
+                .store(in: &cancellables)
+        }
 
         suggestionCoordinator.$visualContextStatus
             .combineLatest(suggestionCoordinator.$latestVisualContextText)
@@ -103,7 +105,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     }
 
-    /// Starts runtime and observer services once AppKit reports that app launch finished.
+    /// Starts runtime and polling services once AppKit reports that app launch finished.
     func applicationDidFinishLaunching(_ notification: Notification) {
         startRuntimeIfPreferredEngineRequiresIt()
         focusModel.start()
@@ -113,7 +115,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         welcomeCoordinator.presentIfNeeded()
     }
 
-    /// Stops long-lived services before process exit so observers and runtime resources detach cleanly.
+    /// Stops long-lived services before process exit so timers and runtime resources detach cleanly.
     func applicationWillTerminate(_ notification: Notification) {
         activationIndicatorController.hide(reason: "Activation indicator hidden because Tabby is terminating.")
         focusDebugOverlayController?.hide()

--- a/tabby/App/Core/TabbyAppEnvironment.swift
+++ b/tabby/App/Core/TabbyAppEnvironment.swift
@@ -42,7 +42,8 @@ final class TabbyAppEnvironment {
         )
         let focusModel = FocusTrackingModel(
             permissionProvider: { permissionManager.accessibilityGranted },
-            ignoredBundleIdentifier: Bundle.main.bundleIdentifier
+            ignoredBundleIdentifier: Bundle.main.bundleIdentifier,
+            publishesPollingEvents: FocusDebugOverlayController.isEnabled
         )
         let appUpdateManager = AppUpdateManager()
         let launchAtLoginService = LaunchAtLoginService()

--- a/tabby/Models/FocusModels.swift
+++ b/tabby/Models/FocusModels.swift
@@ -146,8 +146,8 @@ struct FocusedInputSnapshot: Equatable {
     let selection: NSRange
     let isSecure: Bool
 
-    /// Monotonic counter that increments every time a focus-changing AX notification fires
-    /// (`kAXFocusedUIElementChanged`, `kAXFocusedWindowChanged`, app activation, etc.).
+    /// Monotonic counter that increments every time polling observes a focused-input identity
+    /// change.
     ///
     /// `elementIdentifier` is built from `CFHash`, which macOS can recycle when AX nodes are
     /// destroyed and recreated. That makes `elementIdentifier` unreliable for detecting field
@@ -270,18 +270,21 @@ struct FocusSnapshot: Equatable {
     }
 }
 
-/// Debug-only signal that an `AXObserver` notification reached Tabby.
+/// Debug-only signal that one focus polling pass completed.
 ///
-/// This intentionally stays separate from `FocusSnapshot`: a notification can be useful diagnostic
+/// This intentionally stays separate from `FocusSnapshot`: a poll can be useful diagnostic
 /// information even when the resolved focus snapshot does not change. The sequence number gives
-/// Combine/SwiftUI consumers an always-unique value for repeated identical notifications.
-struct FocusObserverEvent: Equatable {
+/// Combine/SwiftUI consumers an always-unique value for repeated identical polls.
+struct FocusPollingEvent: Equatable {
     let sequence: Int
-    let notificationName: String
+    let focusChangeSequence: UInt64
+    let didChangeFocusedInput: Bool
+    let applicationName: String
+    let capabilitySummary: String
     let occurredAt: Date
 
-    var displayName: String {
-        notificationName.replacingOccurrences(of: "AX", with: "")
+    var changeSummary: String {
+        didChangeFocusedInput ? "changed" : "unchanged"
     }
 }
 

--- a/tabby/Models/FocusTrackingModel.swift
+++ b/tabby/Models/FocusTrackingModel.swift
@@ -3,24 +3,24 @@ import Foundation
 
 /// File overview:
 /// Publishes focused-input snapshots to SwiftUI and other main-actor consumers. It keeps
-/// AX observation details hidden behind a small observable interface.
+/// Accessibility polling details hidden behind a small observable interface.
 ///
-/// Bridges the event-driven focus tracker into SwiftUI-facing published state.
+/// Bridges the polling-based focus tracker into SwiftUI-facing published state.
 @MainActor
 final class FocusTrackingModel: ObservableObject {
     @Published private(set) var snapshot: FocusSnapshot
     @Published private(set) var latestExternalApplication: FocusedApplicationIdentity?
-    /// Debug-only pulse source for the caret overlay; not used by suggestion generation.
-    @Published private(set) var latestObserverEvent: FocusObserverEvent?
+    /// Debug-only polling diagnostics for the bottom-edge overlay; not used by suggestion generation.
+    @Published private(set) var latestPollEvent: FocusPollingEvent?
 
     private let tracker: FocusTracker
     private let ignoredBundleIdentifier: String?
     private var isStarted = false
-    private var observerEventSequence = 0
 
     init(
         permissionProvider: @escaping @MainActor () -> Bool,
-        ignoredBundleIdentifier: String?
+        ignoredBundleIdentifier: String?,
+        publishesPollingEvents: Bool = false
     ) {
         self.ignoredBundleIdentifier = ignoredBundleIdentifier
         tracker = FocusTracker(
@@ -37,8 +37,10 @@ final class FocusTrackingModel: ObservableObject {
             self?.updateLatestExternalApplication(from: snapshot)
         }
 
-        tracker.onAXNotification = { [weak self] notificationName in
-            self?.publishObserverEvent(named: notificationName)
+        if publishesPollingEvents {
+            tracker.onPoll = { [weak self] event in
+                self?.latestPollEvent = event
+            }
         }
     }
 
@@ -59,8 +61,8 @@ final class FocusTrackingModel: ObservableObject {
         tracker.stop()
     }
 
-    /// A manual refresh is useful when another subsystem already knows "input just changed"
-    /// and wants the latest AX snapshot immediately instead of waiting for an AX notification.
+    /// A manual refresh is useful when another subsystem already knows "input just changed" and
+    /// wants the latest AX snapshot immediately instead of waiting for the next timer tick.
     func refreshNow() {
         tracker.refreshNow()
     }
@@ -89,15 +91,6 @@ final class FocusTrackingModel: ObservableObject {
         }
 
         latestExternalApplication = application
-    }
-
-    private func publishObserverEvent(named notificationName: String) {
-        observerEventSequence += 1
-        latestObserverEvent = FocusObserverEvent(
-            sequence: observerEventSequence,
-            notificationName: notificationName,
-            occurredAt: Date()
-        )
     }
 }
 

--- a/tabby/Services/Focus/FocusSnapshotResolver.swift
+++ b/tabby/Services/Focus/FocusSnapshotResolver.swift
@@ -5,7 +5,7 @@ import Foundation
 /// File overview:
 /// Resolves the most usable editable candidate around the current AX focus and materializes a
 /// stable `FocusSnapshot`. This keeps AX candidate search and snapshot assembly separate from the
-/// event-observation shell in `FocusTracker`.
+/// polling shell in `FocusTracker`.
 @MainActor
 struct FocusSnapshotResolver {
     private let geometryResolver: AXTextGeometryResolver

--- a/tabby/Services/Focus/FocusTracker.swift
+++ b/tabby/Services/Focus/FocusTracker.swift
@@ -1,46 +1,17 @@
 import AppKit
-import ApplicationServices
 import Foundation
 
 /// File overview:
-/// Observes Accessibility focus notifications and publishes the latest `FocusSnapshot`.
+/// Polls the Accessibility tree on a fixed timer and publishes the latest `FocusSnapshot`.
 ///
-/// This experimental version removes the polling timer entirely. `FocusTracker` owns observer
-/// lifecycle, permission/frontmost-app guards, and the final `snapshot` publication contract.
-/// AX candidate resolution lives in `FocusSnapshotResolver`, and caret/frame heuristics live in
-/// `AXTextGeometryResolver`.
-nonisolated private let focusTrackerObserverCallback: AXObserverCallback = { _, _, notification, refcon in
-    guard let refcon else {
-        return
-    }
-
-    let notificationName = notification as String
-    let tracker = Unmanaged<FocusTracker>.fromOpaque(refcon).takeUnretainedValue()
-    Task { @MainActor in
-        tracker.handleAXNotification(named: notificationName)
-    }
-}
-
+/// Polling is intentionally the only focus-change source. AXObserver delivery is inconsistent in
+/// several host apps, and a hybrid push/poll design creates ordering ambiguity. A single polling
+/// loop gives Tabby predictable eventual consistency: every tick re-reads the current frontmost
+/// focused element and repairs stale state within one poll interval.
 @MainActor
 final class FocusTracker {
-    private enum AXNotificationSet {
-        static let application: [CFString] = [
-            kAXFocusedUIElementChangedNotification as CFString,
-            kAXFocusedWindowChangedNotification as CFString,
-            kAXApplicationDeactivatedNotification as CFString
-        ]
-
-        static let focusedElement: [CFString] = [
-            kAXValueChangedNotification as CFString,
-            kAXSelectedTextChangedNotification as CFString,
-            kAXUIElementDestroyedNotification as CFString
-        ]
-    }
-
     var onSnapshotChange: ((FocusSnapshot) -> Void)?
-    /// Debug hook for raw AX notification hits. The tracker still publishes snapshots separately
-    /// because several notifications can collapse into the same resolved focus state.
-    var onAXNotification: ((String) -> Void)?
+    var onPoll: ((FocusPollingEvent) -> Void)?
 
     private(set) var snapshot: FocusSnapshot = .inactive {
         didSet {
@@ -48,31 +19,23 @@ final class FocusTracker {
         }
     }
 
+    private let pollInterval: TimeInterval
     private let permissionProvider: @MainActor () -> Bool
     private let ignoredBundleIdentifier: String?
     private let snapshotResolver: FocusSnapshotResolver
 
-    private var observer: AXObserver?
-    private var observedApplicationElement: AXUIElement?
-    private var observedFocusedElement: AXUIElement?
-    private var observedApplicationPID: pid_t?
-    private var workspaceActivationObserver: NSObjectProtocol?
-    private var scheduledRefreshTask: Task<Void, Never>?
-
-    /// Monotonic counter that increments every time a focus-changing AX notification fires.
-    ///
-    /// AX element identity is based on `CFHash`, which macOS can recycle across unrelated
-    /// elements. This counter gives downstream consumers a guaranteed-unique signal that
-    /// focus actually changed, independent of hash collisions. It only increments on
-    /// notifications that signal a *new element or window* — value and selection changes
-    /// within the same field do not bump it.
+    private var timer: Timer?
+    private var pollSequence = 0
     private var focusChangeSequence: UInt64 = 0
+    private var lastFocusedInputSignature: FocusedInputPollingSignature?
 
     init(
+        pollInterval: TimeInterval = 0.25,
         permissionProvider: @escaping @MainActor () -> Bool,
         ignoredBundleIdentifier: String?,
         snapshotResolver: FocusSnapshotResolver? = nil
     ) {
+        self.pollInterval = pollInterval
         self.permissionProvider = permissionProvider
         self.ignoredBundleIdentifier = ignoredBundleIdentifier
         // Default resolver construction must happen inside the actor-isolated initializer body.
@@ -80,258 +43,202 @@ final class FocusTracker {
         self.snapshotResolver = snapshotResolver ?? FocusSnapshotResolver()
     }
 
-    /// Starts event-driven AX observation and immediately captures an initial snapshot.
+    /// Starts periodic AX polling and immediately captures an initial snapshot.
     func start() {
-        guard workspaceActivationObserver == nil else {
+        guard timer == nil else {
             refreshNow()
             return
         }
 
-        workspaceActivationObserver = NSWorkspace.shared.notificationCenter.addObserver(
-            forName: NSWorkspace.didActivateApplicationNotification,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor [weak self] in
-                // Switching apps is always a focus change.
-                self?.focusChangeSequence += 1
-                self?.refreshNow()
-            }
-        }
-
-        // The initial observation counts as a focus change so the first snapshot always
-        // carries a non-zero sequence, distinguishing it from the default 0.
-        focusChangeSequence += 1
         refreshNow()
-    }
 
-    /// Stops event observation while leaving the most recent snapshot available to callers.
-    func stop() {
-        scheduledRefreshTask?.cancel()
-        scheduledRefreshTask = nil
-
-        if let workspaceActivationObserver {
-            NSWorkspace.shared.notificationCenter.removeObserver(workspaceActivationObserver)
-            self.workspaceActivationObserver = nil
-        }
-
-        clearAXObserver()
-    }
-
-    /// Performs a synchronous snapshot capture outside the normal notification cadence.
-    func refreshNow() {
-        scheduledRefreshTask?.cancel()
-        scheduledRefreshTask = nil
-
-        let capture = captureSnapshot()
-        snapshot = capture.snapshot
-
-        if let focusedElement = capture.focusedElement {
-            registerFocusedElementNotifications(on: focusedElement)
-        } else {
-            clearFocusedElementNotifications()
-        }
-    }
-
-    fileprivate func handleAXNotification(named notificationName: String) {
-        onAXNotification?(notificationName)
-
-        // Only focus-changing notifications bump the sequence. Value/selection changes within
-        // the same field should not, because the visual-context coordinator uses this counter
-        // to decide whether to start a new OCR session.
-        let focusChangingNotifications: Set<String> = [
-            kAXFocusedUIElementChangedNotification as String,
-            kAXFocusedWindowChangedNotification as String,
-            kAXApplicationDeactivatedNotification as String
-        ]
-        if focusChangingNotifications.contains(notificationName) {
-            focusChangeSequence += 1
-        }
-
-        if notificationName == kAXApplicationDeactivatedNotification as String {
-            scheduleRefresh(after: 0)
-            return
-        }
-
-        // AX notifications can fire before the app has updated value/selection attributes.
-        // A tiny coalescing delay avoids reading the old state while still feeling immediate.
-        scheduleRefresh(after: 0.005)
-    }
-
-    private func scheduleRefresh(after delay: TimeInterval) {
-        scheduledRefreshTask?.cancel()
-        scheduledRefreshTask = Task { [weak self] in
-            guard delay > 0 else {
+        let timer = Timer(timeInterval: pollInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
                 self?.refreshNow()
-                return
             }
-
-            try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
-            guard !Task.isCancelled else {
-                return
-            }
-
-            self?.refreshNow()
         }
+        self.timer = timer
+        RunLoop.main.add(timer, forMode: .common)
+    }
+
+    /// Stops polling while leaving the most recent snapshot available to callers.
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    /// Performs a synchronous snapshot capture outside the normal polling cadence.
+    ///
+    /// Other subsystems still call this after input or acceptance events because they know a read is
+    /// useful immediately. The implementation is still polling-style: no event is trusted as state;
+    /// it only triggers another full AX read.
+    func refreshNow() {
+        pollSequence += 1
+        let capture = captureSnapshot()
+
+        if capture.snapshot != snapshot {
+            snapshot = capture.snapshot
+        }
+
+        onPoll?(
+            FocusPollingEvent(
+                sequence: pollSequence,
+                focusChangeSequence: focusChangeSequence,
+                didChangeFocusedInput: capture.didChangeFocusedInput,
+                applicationName: capture.snapshot.applicationName,
+                capabilitySummary: capture.snapshot.capability.shortLabel,
+                occurredAt: Date()
+            )
+        )
     }
 
     /// Captures the current frontmost application's focused element and reduces it into a snapshot.
     private func captureSnapshot() -> FocusCaptureResult {
         guard permissionProvider() else {
-            clearAXObserver()
-            return FocusCaptureResult(
-                snapshot: FocusSnapshot(
-                    applicationName: "Accessibility permission missing",
-                    bundleIdentifier: nil,
-                    capability: .blocked("Accessibility permission is required."),
-                    context: nil,
-                    inspection: nil
-                )
+            return inactiveCapture(
+                applicationName: "Accessibility permission missing",
+                bundleIdentifier: nil,
+                capability: .blocked("Accessibility permission is required.")
             )
         }
 
         guard let application = NSWorkspace.shared.frontmostApplication else {
-            clearAXObserver()
-            return FocusCaptureResult(
-                snapshot: FocusSnapshot(
-                    applicationName: "No active application",
-                    bundleIdentifier: nil,
-                    capability: .unsupported("No active application."),
-                    context: nil,
-                    inspection: nil
-                )
+            return inactiveCapture(
+                applicationName: "No active application",
+                bundleIdentifier: nil,
+                capability: .unsupported("No active application.")
             )
         }
 
         if application.bundleIdentifier == ignoredBundleIdentifier {
-            clearAXObserver()
-            return FocusCaptureResult(
-                snapshot: FocusSnapshot(
-                    applicationName: application.localizedName ?? "Tabby",
-                    bundleIdentifier: application.bundleIdentifier,
-                    capability: .blocked("Tabby is focused."),
-                    context: nil,
-                    inspection: nil
-                )
+            return inactiveCapture(
+                applicationName: application.localizedName ?? "Tabby",
+                bundleIdentifier: application.bundleIdentifier,
+                capability: .blocked("Tabby is focused.")
             )
         }
-
-        configureAXObserver(for: application)
 
         guard let focusedElement = AXHelper.focusedElement() else {
-            return FocusCaptureResult(
-                snapshot: FocusSnapshot(
-                    applicationName: application.localizedName ?? "Unknown",
-                    bundleIdentifier: application.bundleIdentifier,
-                    capability: .unsupported("No focused Accessibility element."),
-                    context: nil,
-                    inspection: nil
-                )
+            return inactiveCapture(
+                applicationName: application.localizedName ?? "Unknown",
+                bundleIdentifier: application.bundleIdentifier,
+                capability: .unsupported("No focused Accessibility element.")
             )
         }
 
-        return FocusCaptureResult(
-            snapshot: snapshotResolver.resolveSnapshot(
-                focusedElement: focusedElement,
-                application: application,
-                focusChangeSequence: focusChangeSequence
+        let firstPassSnapshot = snapshotResolver.resolveSnapshot(
+            focusedElement: focusedElement,
+            application: application,
+            focusChangeSequence: focusChangeSequence
+        )
+
+        guard let context = firstPassSnapshot.context else {
+            return FocusCaptureResult(
+                snapshot: firstPassSnapshot,
+                didChangeFocusedInput: clearFocusedInputSignatureIfNeeded()
+            )
+        }
+
+        let nextSignature = FocusedInputPollingSignature(context: context)
+        guard nextSignature != lastFocusedInputSignature else {
+            return FocusCaptureResult(snapshot: firstPassSnapshot, didChangeFocusedInput: false)
+        }
+
+        lastFocusedInputSignature = nextSignature
+        focusChangeSequence += 1
+
+        let finalSnapshot = snapshotResolver.resolveSnapshot(
+            focusedElement: focusedElement,
+            application: application,
+            focusChangeSequence: focusChangeSequence
+        )
+        return FocusCaptureResult(snapshot: finalSnapshot, didChangeFocusedInput: true)
+    }
+
+    private func inactiveCapture(
+        applicationName: String,
+        bundleIdentifier: String?,
+        capability: FocusCapability
+    ) -> FocusCaptureResult {
+        FocusCaptureResult(
+            snapshot: FocusSnapshot(
+                applicationName: applicationName,
+                bundleIdentifier: bundleIdentifier,
+                capability: capability,
+                context: nil,
+                inspection: nil
             ),
-            focusedElement: focusedElement
+            didChangeFocusedInput: clearFocusedInputSignatureIfNeeded()
         )
     }
 
-    private func configureAXObserver(for application: NSRunningApplication) {
-        let pid = application.processIdentifier
-        guard observer == nil || observedApplicationPID != pid else {
-            return
-        }
-
-        clearAXObserver()
-
-        var newObserver: AXObserver?
-        let result = AXObserverCreate(pid, focusTrackerObserverCallback, &newObserver)
-        guard result == .success, let newObserver else {
-            return
-        }
-
-        let applicationElement = AXUIElementCreateApplication(pid)
-        observer = newObserver
-        observedApplicationElement = applicationElement
-        observedApplicationPID = pid
-
-        let source = AXObserverGetRunLoopSource(newObserver)
-        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
-
-        for notification in AXNotificationSet.application {
-            addNotification(notification, to: applicationElement)
-        }
-    }
-
-    private func registerFocusedElementNotifications(on focusedElement: AXUIElement) {
-        guard observer != nil else {
-            return
-        }
-
-        if let observedFocusedElement,
-           AXHelper.elementIdentity(for: observedFocusedElement) == AXHelper.elementIdentity(for: focusedElement) {
-            return
-        }
-
-        clearFocusedElementNotifications()
-        observedFocusedElement = focusedElement
-
-        for notification in AXNotificationSet.focusedElement {
-            addNotification(notification, to: focusedElement)
-        }
-    }
-
-    private func clearFocusedElementNotifications() {
-        guard let observer, let observedFocusedElement else {
-            self.observedFocusedElement = nil
-            return
-        }
-
-        for notification in AXNotificationSet.focusedElement {
-            AXObserverRemoveNotification(observer, observedFocusedElement, notification)
-        }
-
-        self.observedFocusedElement = nil
-    }
-
-    private func clearAXObserver() {
-        scheduledRefreshTask?.cancel()
-        scheduledRefreshTask = nil
-
-        clearFocusedElementNotifications()
-
-        if let observer {
-            let source = AXObserverGetRunLoopSource(observer)
-            CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
-        }
-
-        observer = nil
-        observedApplicationElement = nil
-        observedApplicationPID = nil
-    }
-
-    @discardableResult
-    private func addNotification(_ notification: CFString, to element: AXUIElement) -> Bool {
-        guard let observer else {
+    /// Clears the last field signature when polling no longer finds a usable focused input.
+    ///
+    /// This matters for a later return to the same AX element. Leaving and re-entering a field is a
+    /// new focus session for visual context even if the host app reuses the same AX object.
+    private func clearFocusedInputSignatureIfNeeded() -> Bool {
+        guard lastFocusedInputSignature != nil else {
             return false
         }
 
-        let refcon = Unmanaged.passUnretained(self).toOpaque()
-        let result = AXObserverAddNotification(observer, element, notification, refcon)
-        return result == .success || result == .notificationAlreadyRegistered
+        lastFocusedInputSignature = nil
+        focusChangeSequence += 1
+        return true
     }
 }
 
 private struct FocusCaptureResult {
     let snapshot: FocusSnapshot
-    let focusedElement: AXUIElement?
+    let didChangeFocusedInput: Bool
+}
 
-    init(snapshot: FocusSnapshot, focusedElement: AXUIElement? = nil) {
-        self.snapshot = snapshot
-        self.focusedElement = focusedElement
+/// Stable-enough identity for one focused input as observed by polling.
+///
+/// Text, selection, and caret position are deliberately excluded. Those can change inside the same
+/// field and should not restart the visual-context session. The input frame is preferred over the
+/// AX element id because AX identifiers are derived from Core Foundation object identity, which can
+/// be recycled by macOS.
+private struct FocusedInputPollingSignature: Equatable {
+    let bundleIdentifier: String
+    let processIdentifier: Int32
+    let role: String
+    let subrole: String?
+    let fieldAnchor: FieldAnchor
+
+    init(context: FocusedInputSnapshot) {
+        bundleIdentifier = context.bundleIdentifier
+        processIdentifier = context.processIdentifier
+        role = context.role
+        subrole = context.subrole
+        fieldAnchor = FieldAnchor(
+            inputFrame: context.inputFrameRect,
+            fallbackElementIdentifier: context.elementIdentifier
+        )
+    }
+}
+
+private extension FocusedInputPollingSignature {
+    struct FieldAnchor: Equatable {
+        let roundedInputFrame: RoundedRect?
+        let fallbackElementIdentifier: String?
+
+        init(inputFrame: CGRect?, fallbackElementIdentifier: String) {
+            roundedInputFrame = inputFrame.map(RoundedRect.init(rect:))
+            self.fallbackElementIdentifier = roundedInputFrame == nil ? fallbackElementIdentifier : nil
+        }
+    }
+
+    struct RoundedRect: Equatable {
+        let minX: Int
+        let minY: Int
+        let width: Int
+        let height: Int
+
+        init(rect: CGRect) {
+            minX = Int(rect.minX.rounded())
+            minY = Int(rect.minY.rounded())
+            width = Int(rect.width.rounded())
+            height = Int(rect.height.rounded())
+        }
     }
 }

--- a/tabby/Services/UI/FocusDebugOverlayController.swift
+++ b/tabby/Services/UI/FocusDebugOverlayController.swift
@@ -3,8 +3,8 @@ import Foundation
 import SwiftUI
 
 /// Gated behind `-tabby-debug`. Shows focused-input geometry near the caret and renders a
-/// bottom-edge status panel for async debug signals such as AX observer notifications and the
-/// screenshot/OCR visual-context pipeline.
+/// bottom-edge status panel for focus polling diagnostics and the screenshot/OCR visual-context
+/// pipeline.
 ///
 /// The controller is UI-only. It observes already-published app state instead of asking
 /// `FocusTracker` or `VisualContextCoordinator` for data directly, which keeps the service layer
@@ -24,8 +24,7 @@ final class FocusDebugOverlayController {
     private var latestCaretRect: CGRect?
     private var latestVisualContextStatus: VisualContextStatus = .idle
     private var latestVisualContextExcerptCharacterCount: Int?
-    private var latestObserverEvent: FocusObserverEvent?
-    private var observerEventClearTask: Task<Void, Never>?
+    private var latestPollEvent: FocusPollingEvent?
 
     func update(for snapshot: FocusSnapshot) {
         guard let context = snapshot.context else {
@@ -48,32 +47,18 @@ final class FocusDebugOverlayController {
         renderBottomStatusPanel()
     }
 
-    /// Records an AX observer notification in the bottom status panel.
+    /// Mirrors focus polling diagnostics into the bottom status panel.
     ///
-    /// The old implementation flashed this near the caret. Moving it to the bottom edge keeps
-    /// caret geometry debugging visually separate from event-stream debugging.
-    func flashAXObserverHit(event: FocusObserverEvent) {
-        observerEventClearTask?.cancel()
-        latestObserverEvent = event
+    /// Polling diagnostics replace the old AXObserver pulse. This keeps focus debugging tied to
+    /// the single source of truth that now drives snapshots.
+    func updateFocusPolling(event: FocusPollingEvent) {
+        latestPollEvent = event
         renderBottomStatusPanel()
-
-        observerEventClearTask = Task { @MainActor [weak self] in
-            try? await Task.sleep(nanoseconds: 1_500_000_000)
-            guard !Task.isCancelled else {
-                return
-            }
-
-            self?.latestObserverEvent = nil
-            self?.observerEventClearTask = nil
-            self?.renderBottomStatusPanel()
-        }
     }
 
     func hide() {
         hideFocusGeometry()
-        observerEventClearTask?.cancel()
-        observerEventClearTask = nil
-        latestObserverEvent = nil
+        latestPollEvent = nil
         latestVisualContextStatus = .idle
         latestVisualContextExcerptCharacterCount = nil
         bottomStatusPanel.orderOut(nil)
@@ -138,7 +123,7 @@ final class FocusDebugOverlayController {
         let contentView = NSHostingView(rootView: BottomDebugStatusView(
             visualContextStatus: latestVisualContextStatus,
             excerptCharacterCount: latestVisualContextExcerptCharacterCount,
-            observerEvent: latestObserverEvent,
+            pollEvent: latestPollEvent,
             maxWidth: maxWidth
         ))
         contentView.layoutSubtreeIfNeeded()
@@ -158,7 +143,7 @@ final class FocusDebugOverlayController {
     }
 
     private var shouldShowBottomStatusPanel: Bool {
-        latestVisualContextStatus != .idle || latestObserverEvent != nil
+        latestVisualContextStatus != .idle || latestPollEvent != nil
     }
 
     // MARK: - Helpers
@@ -234,7 +219,7 @@ private struct CaretDebugView: View {
 private struct BottomDebugStatusView: View {
     let visualContextStatus: VisualContextStatus
     let excerptCharacterCount: Int?
-    let observerEvent: FocusObserverEvent?
+    let pollEvent: FocusPollingEvent?
     let maxWidth: CGFloat
 
     private var stages: [VisualContextDebugStage] {
@@ -279,20 +264,30 @@ private struct BottomDebugStatusView: View {
                 }
             }
 
-            if let observerEvent {
+            if let pollEvent {
                 Divider()
                     .overlay(Color.white.opacity(0.16))
 
                 HStack(spacing: 7) {
                     Circle()
-                        .fill(Color.cyan)
+                        .fill(pollEvent.didChangeFocusedInput ? Color.green : Color.cyan)
                         .frame(width: 7, height: 7)
 
-                    Text("AX \(observerEvent.sequence)")
+                    Text("Poll \(pollEvent.sequence)")
                         .font(.system(size: 10, weight: .bold, design: .monospaced))
                         .foregroundStyle(.cyan)
 
-                    Text(observerEvent.displayName)
+                    Text(pollEvent.changeSummary)
+                        .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(pollEvent.didChangeFocusedInput ? .green : .white.opacity(0.72))
+                        .lineLimit(1)
+
+                    Text("focusSeq \(pollEvent.focusChangeSequence)")
+                        .font(.system(size: 10, weight: .medium, design: .monospaced))
+                        .foregroundStyle(.white.opacity(0.62))
+                        .lineLimit(1)
+
+                    Text("\(pollEvent.applicationName) / \(pollEvent.capabilitySummary)")
                         .font(.system(size: 10, weight: .medium, design: .monospaced))
                         .foregroundStyle(.white.opacity(0.82))
                         .lineLimit(1)


### PR DESCRIPTION
## Summary

Replaces event-driven AXObserver focus tracking with a single timer-driven polling loop. Focus changes now come from polling the current AX focus and comparing focused-input identity, with polling diagnostics exposed only when `-tabby-debug` is enabled.

## Validation

- `swiftlint .` — 0 violations, 0 serious in 77 files.
- `git diff --check` — exit 0.
- `xcodebuild build -scheme tabby -destination 'platform=macOS'` — **BUILD SUCCEEDED**.

## Linked issues

Refs #76

## Risk / rollout notes

This is a stacked PR against `jafu/debug-observability`. Focus updates now use eventual consistency at the 0.25s poll interval instead of AX notification delivery. The tradeoff is a small polling cadence delay in exchange for one focus source of truth and no observer lifecycle ordering bugs.
