### PR TITLE
Add missing autocomplete test coverage

### DIFF
--- a/tabby.xcodeproj/project.pbxproj
+++ b/tabby.xcodeproj/project.pbxproj
@@ -15,6 +15,13 @@
 		AF0F4C853CCA8B86BB5E28CD /* ModelFileValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9D35DB9E86506B9FAE1CFE9 /* ModelFileValidatorTests.swift */; };
 		B053492719F6106E48290C32 /* SuggestionAvailabilityEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A39EC1A44E9160E13E2AE77 /* SuggestionAvailabilityEvaluatorTests.swift */; };
 		B5788B37B93AFEC10EFD3108 /* DownloadFileRescuerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAAEE25772008D75883F2655 /* DownloadFileRescuerTests.swift */; };
+		C10000012F91000100BBB001 /* TabbyTestFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10000112F91000100BBB011 /* TabbyTestFixtures.swift */; };
+		C10000022F91000100BBB002 /* SuggestionTextNormalizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10000122F91000100BBB012 /* SuggestionTextNormalizerTests.swift */; };
+		C10000032F91000100BBB003 /* SuggestionSessionReconcilerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10000132F91000100BBB013 /* SuggestionSessionReconcilerTests.swift */; };
+		C10000042F91000100BBB004 /* FocusCapabilityResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10000142F91000100BBB014 /* FocusCapabilityResolverTests.swift */; };
+		C10000052F91000100BBB005 /* PromptPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10000152F91000100BBB015 /* PromptPolicyTests.swift */; };
+		C10000062F91000100BBB006 /* ModelAndPresentationValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10000162F91000100BBB016 /* ModelAndPresentationValueTests.swift */; };
+		C10000072F91000100BBB007 /* SuggestionStateHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10000172F91000100BBB017 /* SuggestionStateHelperTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -34,6 +41,13 @@
 		5A39EC1A44E9160E13E2AE77 /* SuggestionAvailabilityEvaluatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SuggestionAvailabilityEvaluatorTests.swift; sourceTree = "<group>"; };
 		8B1121FFDAD30C7F62E15289 /* SuggestionRequestFactoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SuggestionRequestFactoryTests.swift; sourceTree = "<group>"; };
 		BAAEE25772008D75883F2655 /* DownloadFileRescuerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DownloadFileRescuerTests.swift; sourceTree = "<group>"; };
+		C10000112F91000100BBB011 /* TabbyTestFixtures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TabbyTestFixtures.swift; sourceTree = "<group>"; };
+		C10000122F91000100BBB012 /* SuggestionTextNormalizerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SuggestionTextNormalizerTests.swift; sourceTree = "<group>"; };
+		C10000132F91000100BBB013 /* SuggestionSessionReconcilerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SuggestionSessionReconcilerTests.swift; sourceTree = "<group>"; };
+		C10000142F91000100BBB014 /* FocusCapabilityResolverTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FocusCapabilityResolverTests.swift; sourceTree = "<group>"; };
+		C10000152F91000100BBB015 /* PromptPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PromptPolicyTests.swift; sourceTree = "<group>"; };
+		C10000162F91000100BBB016 /* ModelAndPresentationValueTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ModelAndPresentationValueTests.swift; sourceTree = "<group>"; };
+		C10000172F91000100BBB017 /* SuggestionStateHelperTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SuggestionStateHelperTests.swift; sourceTree = "<group>"; };
 		F29623C5C0A67B992D383A3C /* LlamaPromptRendererTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LlamaPromptRendererTests.swift; sourceTree = "<group>"; };
 		F9D35DB9E86506B9FAE1CFE9 /* ModelFileValidatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ModelFileValidatorTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -87,9 +101,16 @@
 		38079AF58386B5C2E9373742 /* tabbyTests */ = {
 			isa = PBXGroup;
 			children = (
+				C10000112F91000100BBB011 /* TabbyTestFixtures.swift */,
 				F29623C5C0A67B992D383A3C /* LlamaPromptRendererTests.swift */,
+				C10000152F91000100BBB015 /* PromptPolicyTests.swift */,
 				5A39EC1A44E9160E13E2AE77 /* SuggestionAvailabilityEvaluatorTests.swift */,
 				8B1121FFDAD30C7F62E15289 /* SuggestionRequestFactoryTests.swift */,
+				C10000122F91000100BBB012 /* SuggestionTextNormalizerTests.swift */,
+				C10000132F91000100BBB013 /* SuggestionSessionReconcilerTests.swift */,
+				C10000172F91000100BBB017 /* SuggestionStateHelperTests.swift */,
+				C10000142F91000100BBB014 /* FocusCapabilityResolverTests.swift */,
+				C10000162F91000100BBB016 /* ModelAndPresentationValueTests.swift */,
 				562F89255AF340C15A0554BE /* DownloadOutcomeClassifierTests.swift */,
 				F9D35DB9E86506B9FAE1CFE9 /* ModelFileValidatorTests.swift */,
 				BAAEE25772008D75883F2655 /* DownloadFileRescuerTests.swift */,
@@ -213,6 +234,13 @@
 				A404828463CADB2ECDAE7AF3 /* LlamaPromptRendererTests.swift in Sources */,
 				B053492719F6106E48290C32 /* SuggestionAvailabilityEvaluatorTests.swift in Sources */,
 				ADEFEE12C197DB6C990E3812 /* SuggestionRequestFactoryTests.swift in Sources */,
+				C10000022F91000100BBB002 /* SuggestionTextNormalizerTests.swift in Sources */,
+				C10000032F91000100BBB003 /* SuggestionSessionReconcilerTests.swift in Sources */,
+				C10000072F91000100BBB007 /* SuggestionStateHelperTests.swift in Sources */,
+				C10000042F91000100BBB004 /* FocusCapabilityResolverTests.swift in Sources */,
+				C10000052F91000100BBB005 /* PromptPolicyTests.swift in Sources */,
+				C10000062F91000100BBB006 /* ModelAndPresentationValueTests.swift in Sources */,
+				C10000012F91000100BBB001 /* TabbyTestFixtures.swift in Sources */,
 				8B6282F0C1CCA0746D96B914 /* DownloadOutcomeClassifierTests.swift in Sources */,
 				AF0F4C853CCA8B86BB5E28CD /* ModelFileValidatorTests.swift in Sources */,
 				B5788B37B93AFEC10EFD3108 /* DownloadFileRescuerTests.swift in Sources */,

--- a/tabby/Support/SuggestionTextColorCodec.swift
+++ b/tabby/Support/SuggestionTextColorCodec.swift
@@ -22,8 +22,16 @@ enum SuggestionTextColorCodec {
             return nil
         }
 
+        let normalizedHex = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        let validCharacters = CharacterSet(charactersIn: "0123456789ABCDEFabcdef")
+        guard normalizedHex.count == 6,
+              normalizedHex.unicodeScalars.allSatisfy(validCharacters.contains(_:))
+        else {
+            return nil
+        }
+
         var value: UInt64 = 0
-        guard Scanner(string: hex).scanHexInt64(&value) else {
+        guard Scanner(string: normalizedHex).scanHexInt64(&value) else {
             return nil
         }
 

--- a/tabbyTests/FocusCapabilityResolverTests.swift
+++ b/tabbyTests/FocusCapabilityResolverTests.swift
@@ -1,0 +1,121 @@
+import XCTest
+@testable import tabby
+
+/// Tests for choosing the best Accessibility candidate around the focused element.
+///
+/// These tests stay below real AX APIs. The resolver's job is to score already-observed candidate
+/// facts, so pure value tests give us deterministic coverage of the heuristic policy.
+final class FocusCapabilityResolverTests: XCTestCase {
+    func test_resolve_selectsFirstCandidateWithFullCapabilities() {
+        let partial = TabbyTestFixtures.focusCapabilityCandidate(
+            elementIdentifier: "partial",
+            hasCaretBounds: false
+        )
+        let full = TabbyTestFixtures.focusCapabilityCandidate(
+            elementIdentifier: "full",
+            editableHintScore: 20
+        )
+
+        let resolution = FocusCapabilityResolver.resolve(candidates: [partial, full])
+
+        XCTAssertEqual(resolution.resolvedCandidate?.elementIdentifier, "full")
+        XCTAssertEqual(resolution.inspectedCandidateCount, 2)
+        XCTAssertTrue(resolution.missingCapabilities.isEmpty)
+    }
+
+    func test_resolve_stopsAtFirstFullCandidateBecauseSearchOrderCarriesMeaning() {
+        let firstFull = TabbyTestFixtures.focusCapabilityCandidate(
+            elementIdentifier: "first",
+            editableHintScore: 0
+        )
+        let laterFull = TabbyTestFixtures.focusCapabilityCandidate(
+            elementIdentifier: "later",
+            editableHintScore: 50
+        )
+
+        let resolution = FocusCapabilityResolver.resolve(candidates: [firstFull, laterFull])
+
+        XCTAssertEqual(resolution.resolvedCandidate?.elementIdentifier, "first")
+        XCTAssertEqual(resolution.inspectedCandidateCount, 1)
+    }
+
+    func test_evaluate_reportsMissingCapabilitiesInStableRequirementOrder() {
+        let candidate = TabbyTestFixtures.focusCapabilityCandidate(
+            hasStrongEditabilitySignal: false,
+            isKnownReadOnlyRole: true,
+            hasTextValue: false,
+            hasSelectionRange: true,
+            hasCaretBounds: false
+        )
+
+        let evaluation = FocusCapabilityResolver.evaluate(candidate)
+
+        XCTAssertEqual(
+            evaluation.missingCapabilities,
+            [.textValue, .caretBounds, .editableTarget]
+        )
+        XCTAssertFalse(evaluation.hasFullCapabilities)
+    }
+
+    func test_evaluate_scoresAvailableCapabilitiesBeforeEditableHint() {
+        let candidate = TabbyTestFixtures.focusCapabilityCandidate(
+            editableHintScore: 7,
+            hasStrongEditabilitySignal: true,
+            hasTextValue: true,
+            hasSelectionRange: true,
+            hasCaretBounds: false
+        )
+
+        let evaluation = FocusCapabilityResolver.evaluate(candidate)
+
+        XCTAssertEqual(evaluation.score, 307)
+    }
+
+    func test_resolve_returnsBestPartialCandidateForDiagnostics() {
+        let weakerPartial = TabbyTestFixtures.focusCapabilityCandidate(
+            elementIdentifier: "weaker",
+            hasSelectionRange: false,
+            hasCaretBounds: false
+        )
+        let strongerPartial = TabbyTestFixtures.focusCapabilityCandidate(
+            elementIdentifier: "stronger",
+            hasStrongEditabilitySignal: false
+        )
+
+        let resolution = FocusCapabilityResolver.resolve(
+            candidates: [weakerPartial, strongerPartial]
+        )
+
+        XCTAssertNil(resolution.resolvedCandidate)
+        XCTAssertEqual(resolution.bestDiagnosticCandidate?.elementIdentifier, "stronger")
+        XCTAssertEqual(resolution.unsupportedReason, "Missing editable target.")
+    }
+
+    func test_resolve_emptyCandidateListReportsGenericUnsupportedReason() {
+        let resolution = FocusCapabilityResolver.resolve(candidates: [])
+
+        XCTAssertNil(resolution.resolvedCandidate)
+        XCTAssertNil(resolution.bestDiagnosticCandidate)
+        XCTAssertEqual(resolution.missingCapabilities, FocusCapabilityRequirement.allCases)
+        XCTAssertEqual(
+            resolution.unsupportedReason,
+            "No nearby text target exposed the required Accessibility capabilities."
+        )
+    }
+
+    func test_evaluate_readOnlyRoleCannotBecomeEditableTarget() {
+        let candidate = TabbyTestFixtures.focusCapabilityCandidate(
+            role: "AXStaticText",
+            hasStrongEditabilitySignal: true,
+            isKnownReadOnlyRole: true,
+            hasTextValue: true,
+            hasSelectionRange: true,
+            hasCaretBounds: true
+        )
+
+        let evaluation = FocusCapabilityResolver.evaluate(candidate)
+
+        XCTAssertEqual(evaluation.missingCapabilities, [.editableTarget])
+        XCTAssertFalse(evaluation.hasFullCapabilities)
+    }
+}

--- a/tabbyTests/ModelAndPresentationValueTests.swift
+++ b/tabbyTests/ModelAndPresentationValueTests.swift
@@ -1,0 +1,126 @@
+import AppKit
+import XCTest
+@testable import tabby
+
+/// Tests for compact value-model behavior used directly by menu and overlay UI.
+///
+/// These are intentionally small, but they protect user-facing copy and normalization rules that
+/// would otherwise regress quietly during UI refactors.
+final class SuggestionTextColorCodecTests: XCTestCase {
+    func test_nsColorFromHex_decodesSixDigitRGB() {
+        let color = SuggestionTextColorCodec.nsColor(fromHex: "336699")?.usingColorSpace(.sRGB)
+
+        XCTAssertNotNil(color)
+        XCTAssertEqual(color?.redComponent ?? 0, CGFloat(0x33) / 255, accuracy: 0.001)
+        XCTAssertEqual(color?.greenComponent ?? 0, CGFloat(0x66) / 255, accuracy: 0.001)
+        XCTAssertEqual(color?.blueComponent ?? 0, CGFloat(0x99) / 255, accuracy: 0.001)
+        XCTAssertEqual(color?.alphaComponent ?? 0, 1, accuracy: 0.001)
+    }
+
+    func test_nsColorFromHex_rejectsMalformedValues() {
+        XCTAssertNil(SuggestionTextColorCodec.nsColor(fromHex: nil))
+        XCTAssertNil(SuggestionTextColorCodec.nsColor(fromHex: "12345"))
+        XCTAssertNil(SuggestionTextColorCodec.nsColor(fromHex: "1234567"))
+        XCTAssertNil(SuggestionTextColorCodec.nsColor(fromHex: "#336699"))
+        XCTAssertNil(SuggestionTextColorCodec.nsColor(fromHex: "GG6699"))
+    }
+
+    func test_hexStringFromNSColor_roundsToUppercaseSixDigitRGB() {
+        let color = NSColor(
+            srgbRed: CGFloat(0x12) / 255,
+            green: CGFloat(0xAB) / 255,
+            blue: CGFloat(0xF0) / 255,
+            alpha: 0.5
+        )
+
+        XCTAssertEqual(SuggestionTextColorCodec.hexString(from: color), "12ABF0")
+    }
+}
+
+final class SuggestionModelValueTests: XCTestCase {
+    func test_wordCountPresetsExposeMatchingPromptInstructionsAndTokenBudgets() {
+        XCTAssertEqual(SuggestionWordCountPreset.oneToThree.promptInstruction, "Return only the next 1 to 3 words.")
+        XCTAssertEqual(SuggestionWordCountPreset.oneToThree.suggestedPredictionTokenBudget, 5)
+
+        XCTAssertEqual(SuggestionWordCountPreset.threeToSeven.promptInstruction, "Return only the next 3 to 7 words.")
+        XCTAssertEqual(SuggestionWordCountPreset.threeToSeven.suggestedPredictionTokenBudget, 11)
+
+        XCTAssertEqual(SuggestionWordCountPreset.sevenToTwelve.promptInstruction, "Return only the next 7 to 12 words.")
+        XCTAssertEqual(SuggestionWordCountPreset.sevenToTwelve.suggestedPredictionTokenBudget, 18)
+
+        XCTAssertEqual(SuggestionWordCountPreset.twelveToTwenty.promptInstruction, "Return only the next 12 to 20 words.")
+        XCTAssertEqual(SuggestionWordCountPreset.twelveToTwenty.suggestedPredictionTokenBudget, 30)
+    }
+
+    func test_activeSuggestionSession_clampsConsumedCountAndSlicesByCharacters() {
+        let session = TabbyTestFixtures.activeSession(
+            fullText: "hello",
+            consumedCharacterCount: 99
+        )
+
+        XCTAssertEqual(session.acceptedText, "hello")
+        XCTAssertEqual(session.remainingText, "")
+        XCTAssertTrue(session.isExhausted)
+    }
+
+    func test_overlayStateDetailIncludesTextCountCaretPositionAndQuality() {
+        let state = OverlayState.visible(
+            text: "hello",
+            caretRect: CGRect(x: 12.9, y: 40.1, width: 2, height: 18),
+            caretQuality: .derived
+        )
+
+        XCTAssertEqual(state.shortLabel, "Visible")
+        XCTAssertEqual(
+            state.detail,
+            "Showing 5 characters near (12, 40) using derived caret geometry."
+        )
+        XCTAssertEqual(state.visibleText, "hello")
+    }
+
+    func test_suggestionDebugStateLabelsAndDetailsAreStable() {
+        XCTAssertEqual(SuggestionDebugState.idle.shortLabel, "Idle")
+        XCTAssertEqual(SuggestionDebugState.disabled("No permission").shortLabel, "Disabled")
+        XCTAssertEqual(SuggestionDebugState.failed("Runtime failed").detail, "Runtime failed")
+        XCTAssertEqual(SuggestionDebugState.ready(text: "hello", latency: 0.2).shortLabel, "Ready")
+    }
+}
+
+final class RuntimeAndInputModelValueTests: XCTestCase {
+    func test_modelDownloadStateProgressFractionIsClamped() {
+        XCTAssertEqual(ModelDownloadState.downloading(progress: -0.5).progressFraction, 0)
+        XCTAssertEqual(ModelDownloadState.downloading(progress: 0.42).progressFraction, 0.42)
+        XCTAssertEqual(ModelDownloadState.downloading(progress: 1.5).progressFraction, 1)
+        XCTAssertNil(ModelDownloadState.downloading(progress: nil).progressFraction)
+        XCTAssertNil(ModelDownloadState.idle.progressFraction)
+    }
+
+    func test_modelDownloadStateStatusTextUsesRoundedPercent() {
+        XCTAssertEqual(ModelDownloadState.idle.statusText, "Not installed")
+        XCTAssertEqual(ModelDownloadState.downloading(progress: nil).statusText, "Downloading")
+        XCTAssertEqual(ModelDownloadState.downloading(progress: 0.426).statusText, "Downloading 43%")
+        XCTAssertEqual(ModelDownloadState.downloaded.statusText, "Installed")
+        XCTAssertEqual(ModelDownloadState.failed("Network failed").statusText, "Network failed")
+    }
+
+    func test_runtimeModelCatalogMapsKnownNamesAndLeavesCustomNamesAlone() {
+        XCTAssertEqual(
+            RuntimeModelCatalog.displayName(for: "Qwen3-0.6B-Q4_K_M.gguf"),
+            "tabby-fast-1"
+        )
+        XCTAssertEqual(
+            RuntimeModelCatalog.displayName(for: "custom-local-model.gguf"),
+            "custom-local-model.gguf"
+        )
+    }
+
+    func test_capturedInputEventComputedPropertiesReflectSchedulingPolicy() {
+        XCTAssertTrue(TabbyTestFixtures.inputEvent(kind: .textMutation).shouldSchedulePrediction)
+        XCTAssertTrue(TabbyTestFixtures.inputEvent(kind: .shortcutMutation).shouldSchedulePrediction)
+        XCTAssertFalse(TabbyTestFixtures.inputEvent(kind: .navigation).shouldSchedulePrediction)
+
+        XCTAssertTrue(TabbyTestFixtures.inputEvent(kind: .dismissal).shouldClearSuggestion)
+        XCTAssertFalse(TabbyTestFixtures.inputEvent(kind: .tab).shouldClearSuggestion)
+        XCTAssertFalse(TabbyTestFixtures.inputEvent(kind: .other).shouldClearSuggestion)
+    }
+}

--- a/tabbyTests/PromptPolicyTests.swift
+++ b/tabbyTests/PromptPolicyTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+@testable import tabby
+
+/// Tests for prompt-policy helpers shared by llama.cpp and Foundation Models.
+///
+/// The important contract is separation of concerns: base autocomplete rules stay stable, while
+/// optional user writing preferences are normalized once and inserted consistently.
+final class CustomAIInstructionFormatterTests: XCTestCase {
+    func test_normalized_returnsNilForMissingOrWhitespaceInstructions() {
+        XCTAssertNil(CustomAIInstructionFormatter.normalized(nil))
+        XCTAssertNil(CustomAIInstructionFormatter.normalized(" \n\t "))
+    }
+
+    func test_normalized_trimsMeaningfulInstructions() {
+        XCTAssertEqual(
+            CustomAIInstructionFormatter.normalized("  Prefer concise replies. \n"),
+            "Prefer concise replies."
+        )
+    }
+
+    func test_promptSectionLines_splitsAndFiltersInstructionLines() {
+        let lines = CustomAIInstructionFormatter.promptSectionLines(
+            from: " Prefer concise replies. \n\n Match my tone. "
+        )
+
+        XCTAssertEqual(
+            lines,
+            [
+                "Custom AI writing preferences:",
+                "- Prefer concise replies.",
+                "- Match my tone.",
+                "Apply this guidance only when it fits the surrounding text.",
+                "Do not mention or explain these preferences."
+            ]
+        )
+    }
+}
+
+/// Tests for the Apple Intelligence prompt adapter.
+///
+/// Foundation Models gives Tabby an instructions channel, so these tests lock down which rules go
+/// into high-priority instructions and which field-specific text remains in the short prompt.
+final class FoundationModelPromptRendererTests: XCTestCase {
+    func test_sessionInstructions_includeAutocompleteContractAndRequestPolicies() {
+        let request = TabbyTestFixtures.suggestionRequest(
+            completionLengthInstruction: "UNIQUE_LENGTH_POLICY",
+            customAIInstructions: "UNIQUE_CUSTOM_POLICY"
+        )
+
+        let instructions = FoundationModelPromptRenderer.sessionInstructions(for: request)
+
+        XCTAssertTrue(instructions.contains("inline autocomplete engine"))
+        XCTAssertTrue(instructions.contains("UNIQUE_LENGTH_POLICY"))
+        XCTAssertTrue(instructions.contains("UNIQUE_CUSTOM_POLICY"))
+        XCTAssertTrue(instructions.contains("Do not repeat or quote the existing text."))
+    }
+
+    func test_prompt_includesApplicationNameAndTrimmedPrefixText() {
+        let request = TabbyTestFixtures.suggestionRequest(
+            prefixText: "  Hello from the field  ",
+            precedingText: "  Hello from the field  "
+        )
+
+        let prompt = FoundationModelPromptRenderer.prompt(for: request)
+
+        XCTAssertTrue(prompt.contains("App: TestApp"))
+        XCTAssertTrue(prompt.contains("Hello from the field"))
+        XCTAssertFalse(prompt.contains("  Hello from the field  "))
+    }
+
+    func test_prompt_returnsFallbackWhenPrefixIsEmptyAfterTrimming() {
+        let request = TabbyTestFixtures.suggestionRequest(
+            prefixText: " \n ",
+            precedingText: " \n "
+        )
+
+        let prompt = FoundationModelPromptRenderer.prompt(for: request)
+
+        XCTAssertEqual(
+            prompt,
+            "Continue the text at the caret using a short inline completion."
+        )
+    }
+}

--- a/tabbyTests/SuggestionRequestFactoryTests.swift
+++ b/tabbyTests/SuggestionRequestFactoryTests.swift
@@ -52,4 +52,93 @@ final class SuggestionRequestFactoryTests: XCTestCase {
     func test_shouldGenerate_trueWhenContentPrecedesTrailingWhitespace() {
         XCTAssertTrue(SuggestionRequestFactory.shouldGenerateSuggestion(for: "hello  "))
     }
+
+    // MARK: - buildRequest
+
+    /// Request construction is the boundary between live editor state and runtime-specific prompt
+    /// work. This test locks down the "small local context" rule: keep the recent character window,
+    /// then trim that window down to the configured number of trailing words.
+    func test_buildRequest_truncatesPrefixByCharacterAndWordBudgets() {
+        let context = TabbyTestFixtures.focusedInputContext(
+            precedingText: "alpha beta gamma delta epsilon zeta eta theta"
+        )
+        let configuration = SuggestionConfiguration(
+            maxPredictionTokens: 8,
+            debounceMilliseconds: 0,
+            temperature: 0.1,
+            topK: 20,
+            topP: 0.7,
+            minP: 0.08,
+            repetitionPenalty: 1.05,
+            randomSeed: 42,
+            maxPrefixWords: 3,
+            maxPrefixCharacters: 32,
+            maxSuffixCharacters: 192,
+            defaultCustomAIInstructions: nil,
+            defaultWordCountPreset: .sevenToTwelve
+        )
+
+        let result = SuggestionRequestFactory.buildRequest(
+            context: context,
+            settings: TabbyTestFixtures.settingsSnapshot(),
+            configuration: configuration
+        )
+
+        XCTAssertEqual(result.request.prefixText, "zeta eta theta")
+        XCTAssertTrue(result.promptPreview.contains("zeta eta theta"))
+        XCTAssertFalse(result.promptPreview.contains("alpha beta"))
+    }
+
+    func test_buildRequest_usesWordCountPresetForInstructionAndTokenBudget() {
+        let context = TabbyTestFixtures.focusedInputContext(precedingText: "Hello world")
+        let configuration = SuggestionConfiguration(
+            maxPredictionTokens: 1,
+            debounceMilliseconds: 0,
+            temperature: 0.1,
+            topK: 20,
+            topP: 0.7,
+            minP: 0.08,
+            repetitionPenalty: 1.05,
+            randomSeed: 42,
+            maxPrefixWords: 50,
+            maxPrefixCharacters: 1000,
+            maxSuffixCharacters: 192,
+            defaultCustomAIInstructions: nil,
+            defaultWordCountPreset: .sevenToTwelve
+        )
+
+        let result = SuggestionRequestFactory.buildRequest(
+            context: context,
+            settings: TabbyTestFixtures.settingsSnapshot(selectedWordCountPreset: .twelveToTwenty),
+            configuration: configuration
+        )
+
+        XCTAssertEqual(
+            result.request.completionLengthInstruction,
+            "Return only the next 12 to 20 words."
+        )
+        XCTAssertEqual(result.request.maxPredictionTokens, 30)
+        XCTAssertEqual(result.promptPreview, result.request.prompt)
+    }
+
+    func test_buildRequest_carriesCustomInstructionsAndVisualContextSummary() {
+        let context = TabbyTestFixtures.focusedInputContext(precedingText: "Hello")
+
+        let result = SuggestionRequestFactory.buildRequest(
+            context: context,
+            settings: TabbyTestFixtures.settingsSnapshot(
+                customAIInstructions: "Prefer direct wording."
+            ),
+            configuration: .standard,
+            visualContextSummary: "Calendar window says project review at 3 PM."
+        )
+
+        XCTAssertEqual(result.request.customAIInstructions, "Prefer direct wording.")
+        XCTAssertEqual(
+            result.request.visualContextSummary,
+            "Calendar window says project review at 3 PM."
+        )
+        XCTAssertTrue(result.promptPreview.contains("Prefer direct wording."))
+        XCTAssertTrue(result.promptPreview.contains("Calendar window says project review at 3 PM."))
+    }
 }

--- a/tabbyTests/SuggestionSessionReconcilerTests.swift
+++ b/tabbyTests/SuggestionSessionReconcilerTests.swift
@@ -1,0 +1,321 @@
+import CoreGraphics
+import XCTest
+@testable import tabby
+
+/// Tests for the pure state-machine rules behind partial acceptance.
+///
+/// This is the highest-risk autocomplete logic because it decides whether a live editor change is
+/// still consistent with the active ghost-text tail or whether Tabby must invalidate the session.
+final class SuggestionSessionReconcilerTests: XCTestCase {
+    func test_advanceIfTypedCharactersMatch_advancesMatchingDirectText() {
+        let session = TabbyTestFixtures.activeSession(fullText: " world again")
+
+        let advanced = SuggestionSessionReconciler.advanceIfTypedCharactersMatch(
+            " world",
+            session: session
+        )
+
+        XCTAssertEqual(advanced?.acceptedText, " world")
+        XCTAssertEqual(advanced?.remainingText, " again")
+    }
+
+    func test_advanceIfTypedCharactersMatch_returnsNilForDivergentText() {
+        let session = TabbyTestFixtures.activeSession(fullText: " world again")
+
+        let advanced = SuggestionSessionReconciler.advanceIfTypedCharactersMatch(
+            " there",
+            session: session
+        )
+
+        XCTAssertNil(advanced)
+    }
+
+    func test_advanceIfTypedCharactersMatch_returnsNilForControlCharacters() {
+        let session = TabbyTestFixtures.activeSession(fullText: " world again")
+
+        let advanced = SuggestionSessionReconciler.advanceIfTypedCharactersMatch(
+            "\n",
+            session: session
+        )
+
+        XCTAssertNil(advanced)
+    }
+
+    func test_nextAcceptanceChunk_includesLeadingWhitespaceAndNextVisibleToken() {
+        XCTAssertEqual(
+            SuggestionSessionReconciler.nextAcceptanceChunk(from: "  world again"),
+            "  world"
+        )
+    }
+
+    func test_nextAcceptanceChunk_returnsSingleTokenWhenNoLeadingWhitespace() {
+        XCTAssertEqual(
+            SuggestionSessionReconciler.nextAcceptanceChunk(from: "world again"),
+            "world"
+        )
+    }
+
+    func test_nextAcceptanceChunk_returnsEmptyForEmptyTail() {
+        XCTAssertEqual(SuggestionSessionReconciler.nextAcceptanceChunk(from: ""), "")
+    }
+
+    func test_acceptedWordCount_countsOnlyTokensWithAlphanumerics() {
+        let count = SuggestionSessionReconciler.acceptedWordCount(
+            in: "hello, !!! world 123 --"
+        )
+
+        XCTAssertEqual(count, 3)
+    }
+
+    func test_overlayAllowsAcceptance_trueWhenOverlayHidden() {
+        XCTAssertTrue(
+            SuggestionSessionReconciler.overlayAllowsAcceptance(
+                of: " world",
+                overlayState: .hidden(reason: "waiting for AX")
+            )
+        )
+    }
+
+    func test_overlayAllowsAcceptance_trueOnlyWhenVisibleTextMatches() {
+        let caretRect = CGRect(x: 10, y: 20, width: 2, height: 18)
+
+        XCTAssertTrue(
+            SuggestionSessionReconciler.overlayAllowsAcceptance(
+                of: " world",
+                overlayState: .visible(text: " world", caretRect: caretRect, caretQuality: .exact)
+            )
+        )
+        XCTAssertFalse(
+            SuggestionSessionReconciler.overlayAllowsAcceptance(
+                of: " world",
+                overlayState: .visible(text: " there", caretRect: caretRect, caretQuality: .exact)
+            )
+        )
+    }
+
+    func test_overlayHideReason_mapsSemanticInputEventsToUserVisibleReasons() {
+        XCTAssertEqual(
+            SuggestionSessionReconciler.overlayHideReason(
+                for: TabbyTestFixtures.inputEvent(kind: .textMutation)
+            ),
+            "Overlay hidden because typing invalidated the current suggestion."
+        )
+        XCTAssertEqual(
+            SuggestionSessionReconciler.overlayHideReason(
+                for: TabbyTestFixtures.inputEvent(kind: .navigation)
+            ),
+            "Overlay hidden because caret navigation invalidated the current suggestion."
+        )
+        XCTAssertEqual(
+            SuggestionSessionReconciler.overlayHideReason(
+                for: TabbyTestFixtures.inputEvent(kind: .dismissal)
+            ),
+            "Overlay hidden because a dismissal key was pressed."
+        )
+    }
+
+    func test_reconcile_validWhenLiveContextStillMatchesBaseContext() {
+        let session = TabbyTestFixtures.activeSession(
+            fullText: " world again",
+            basePrecedingText: "Hello",
+            baseTrailingText: " tail"
+        )
+        let liveContext = TabbyTestFixtures.focusedInputContext(
+            precedingText: "Hello",
+            trailingText: " tail"
+        )
+
+        let reconciliation = SuggestionSessionReconciler.reconcile(
+            session: session,
+            with: liveContext,
+            pendingInsertionConsumedCount: nil
+        )
+
+        guard case let .valid(reconciledSession, advancement, nextPending) = reconciliation else {
+            XCTFail("Expected valid reconciliation")
+            return
+        }
+        XCTAssertEqual(reconciledSession.acceptedText, session.acceptedText)
+        XCTAssertEqual(reconciledSession.remainingText, session.remainingText)
+        XCTAssertNil(advancement)
+        XCTAssertNil(nextPending)
+    }
+
+    func test_reconcile_invalidWhenProcessChanges() {
+        let session = TabbyTestFixtures.activeSession(processIdentifier: 123)
+        let liveContext = TabbyTestFixtures.focusedInputContext(processIdentifier: 456)
+
+        let reconciliation = SuggestionSessionReconciler.reconcile(
+            session: session,
+            with: liveContext,
+            pendingInsertionConsumedCount: nil
+        )
+
+        assertInvalid(
+            reconciliation,
+            reason: "Overlay hidden because the focused field changed."
+        )
+    }
+
+    func test_reconcile_invalidWhenTextIsSelected() {
+        let session = TabbyTestFixtures.activeSession()
+        let liveContext = TabbyTestFixtures.focusedInputContext(
+            selection: NSRange(location: 1, length: 2)
+        )
+
+        let reconciliation = SuggestionSessionReconciler.reconcile(
+            session: session,
+            with: liveContext,
+            pendingInsertionConsumedCount: nil
+        )
+
+        assertInvalid(reconciliation, reason: "Overlay hidden because text is selected.")
+    }
+
+    func test_reconcile_invalidWhenTrailingTextChangesOutsideInsertionSyncWindow() {
+        let session = TabbyTestFixtures.activeSession(
+            fullText: " world again",
+            basePrecedingText: "Hello",
+            baseTrailingText: " tail"
+        )
+        let liveContext = TabbyTestFixtures.focusedInputContext(
+            precedingText: "Hello",
+            trailingText: " changed"
+        )
+
+        let reconciliation = SuggestionSessionReconciler.reconcile(
+            session: session,
+            with: liveContext,
+            pendingInsertionConsumedCount: nil
+        )
+
+        assertInvalid(
+            reconciliation,
+            reason: "Overlay hidden because text after the caret changed."
+        )
+    }
+
+    func test_reconcile_toleratesTrailingTextRaceAfterAcceptedInsertion() {
+        let session = TabbyTestFixtures.activeSession(
+            fullText: " world again",
+            consumedCharacterCount: 6,
+            basePrecedingText: "Hello",
+            baseTrailingText: " tail"
+        )
+        let liveContext = TabbyTestFixtures.focusedInputContext(
+            precedingText: "Hello",
+            trailingText: " changed"
+        )
+
+        let reconciliation = SuggestionSessionReconciler.reconcile(
+            session: session,
+            with: liveContext,
+            pendingInsertionConsumedCount: 6
+        )
+
+        guard case let .valid(reconciledSession, advancement, nextPending) = reconciliation else {
+            XCTFail("Expected transient insertion lag to be tolerated")
+            return
+        }
+        XCTAssertEqual(reconciledSession.acceptedText, session.acceptedText)
+        XCTAssertEqual(reconciledSession.remainingText, session.remainingText)
+        XCTAssertNil(advancement)
+        XCTAssertEqual(nextPending, 6)
+    }
+
+    func test_reconcile_invalidWhenPrefixAnchorChangesOutsideInsertionSyncWindow() {
+        let session = TabbyTestFixtures.activeSession(
+            fullText: " world again",
+            basePrecedingText: "Hello"
+        )
+        let liveContext = TabbyTestFixtures.focusedInputContext(precedingText: "Goodbye")
+
+        let reconciliation = SuggestionSessionReconciler.reconcile(
+            session: session,
+            with: liveContext,
+            pendingInsertionConsumedCount: nil
+        )
+
+        assertInvalid(
+            reconciliation,
+            reason: "Overlay hidden because text before the caret no longer matches the suggestion anchor."
+        )
+    }
+
+    func test_reconcile_invalidWhenConsumedSuffixDivergesFromSuggestion() {
+        let session = TabbyTestFixtures.activeSession(
+            fullText: " world again",
+            basePrecedingText: "Hello"
+        )
+        let liveContext = TabbyTestFixtures.focusedInputContext(precedingText: "Hello there")
+
+        let reconciliation = SuggestionSessionReconciler.reconcile(
+            session: session,
+            with: liveContext,
+            pendingInsertionConsumedCount: nil
+        )
+
+        assertInvalid(
+            reconciliation,
+            reason: "Overlay hidden because typed text diverged from the active suggestion."
+        )
+    }
+
+    func test_reconcile_advancesSessionWhenLiveTextConsumedSuggestionPrefix() {
+        let session = TabbyTestFixtures.activeSession(
+            fullText: " world again",
+            basePrecedingText: "Hello"
+        )
+        let liveContext = TabbyTestFixtures.focusedInputContext(precedingText: "Hello world")
+
+        let reconciliation = SuggestionSessionReconciler.reconcile(
+            session: session,
+            with: liveContext,
+            pendingInsertionConsumedCount: nil
+        )
+
+        guard case let .valid(reconciledSession, advancement, nextPending) = reconciliation else {
+            XCTFail("Expected consumed suggestion text to advance the session")
+            return
+        }
+        XCTAssertEqual(reconciledSession.acceptedText, " world")
+        XCTAssertEqual(reconciledSession.remainingText, " again")
+        XCTAssertEqual(advancement?.stage, "session-reconciled")
+        XCTAssertNil(nextPending)
+    }
+
+    func test_reconcile_clearsPendingInsertionSentinelWhenAXCatchesUp() {
+        let session = TabbyTestFixtures.activeSession(
+            fullText: " world again",
+            consumedCharacterCount: 6,
+            basePrecedingText: "Hello"
+        )
+        let liveContext = TabbyTestFixtures.focusedInputContext(precedingText: "Hello world")
+
+        let reconciliation = SuggestionSessionReconciler.reconcile(
+            session: session,
+            with: liveContext,
+            pendingInsertionConsumedCount: 6
+        )
+
+        guard case let .valid(_, _, nextPending) = reconciliation else {
+            XCTFail("Expected caught-up AX state to remain valid")
+            return
+        }
+        XCTAssertNil(nextPending)
+    }
+
+    private func assertInvalid(
+        _ reconciliation: SuggestionSessionReconciliation,
+        reason expectedReason: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard case let .invalid(reason) = reconciliation else {
+            XCTFail("Expected invalid reconciliation", file: file, line: line)
+            return
+        }
+
+        XCTAssertEqual(reason, expectedReason, file: file, line: line)
+    }
+}

--- a/tabbyTests/SuggestionStateHelperTests.swift
+++ b/tabbyTests/SuggestionStateHelperTests.swift
@@ -1,0 +1,584 @@
+import CoreGraphics
+import XCTest
+@testable import tabby
+
+/// Tests for the focused-context generation buffer.
+///
+/// `ContextBuffer` is a small type, but it protects a major async invariant: old model results
+/// must not be applied after the user changes fields or text.
+final class ContextBufferTests: XCTestCase {
+    /// App-hosted macOS tests have shown deallocation crashes for short-lived main-actor objects.
+    /// Retaining these helpers for the process lifetime mirrors the existing settings-model tests.
+    private static var retainedBuffers: [ContextBuffer] = []
+
+    func test_materialize_assignsFirstGenerationAndStoresCurrentContext() {
+        runOnMainActor {
+            let buffer = makeBuffer()
+            let snapshot = TabbyTestFixtures.focusedInputSnapshot(precedingText: "Hello")
+
+            let context = buffer.materialize(from: snapshot)
+
+            XCTAssertEqual(context.generation, 1)
+            XCTAssertEqual(buffer.currentContext, context)
+        }
+    }
+
+    func test_materialize_keepsGenerationForIdenticalProcessAndContent() {
+        runOnMainActor {
+            let buffer = makeBuffer()
+            let first = buffer.materialize(
+                from: TabbyTestFixtures.focusedInputSnapshot(
+                    processIdentifier: 123,
+                    elementIdentifier: "field-a",
+                    precedingText: "Hello"
+                )
+            )
+            let second = buffer.materialize(
+                from: TabbyTestFixtures.focusedInputSnapshot(
+                    processIdentifier: 123,
+                    elementIdentifier: "field-b",
+                    precedingText: "Hello"
+                )
+            )
+
+            XCTAssertEqual(second.generation, first.generation)
+        }
+    }
+
+    func test_materialize_incrementsGenerationWhenContentChanges() {
+        runOnMainActor {
+            let buffer = makeBuffer()
+            let first = buffer.materialize(from: TabbyTestFixtures.focusedInputSnapshot(precedingText: "Hello"))
+            let second = buffer.materialize(from: TabbyTestFixtures.focusedInputSnapshot(precedingText: "Hello!"))
+
+            XCTAssertEqual(second.generation, first.generation + 1)
+        }
+    }
+
+    func test_materialize_incrementsGenerationWhenProcessChanges() {
+        runOnMainActor {
+            let buffer = makeBuffer()
+            let first = buffer.materialize(
+                from: TabbyTestFixtures.focusedInputSnapshot(processIdentifier: 123)
+            )
+            let second = buffer.materialize(
+                from: TabbyTestFixtures.focusedInputSnapshot(processIdentifier: 456)
+            )
+
+            XCTAssertEqual(second.generation, first.generation + 1)
+        }
+    }
+
+    func test_clearDropsCurrentContextAndAdvancesFutureGeneration() {
+        runOnMainActor {
+            let buffer = makeBuffer()
+            let first = buffer.materialize(from: TabbyTestFixtures.focusedInputSnapshot(precedingText: "Hello"))
+
+            buffer.clear()
+
+            XCTAssertNil(buffer.currentContext)
+            let second = buffer.materialize(from: TabbyTestFixtures.focusedInputSnapshot(precedingText: "Hello"))
+            XCTAssertGreaterThan(second.generation, first.generation)
+        }
+    }
+
+    @MainActor
+    private func makeBuffer() -> ContextBuffer {
+        let buffer = ContextBuffer()
+        Self.retainedBuffers.append(buffer)
+        return buffer
+    }
+}
+
+/// Tests for the storage wrapper around active suggestion session state.
+///
+/// The coordinator owns the user-facing state machine, while this helper owns the mutable details:
+/// current context, active tail, and the AX-lag sentinel after Tab insertion.
+final class SuggestionInteractionStateTests: XCTestCase {
+    private static var retainedStates: [SuggestionInteractionState] = []
+
+    func test_startSessionStoresActiveSessionAndClearsPendingInsertionSentinel() {
+        runOnMainActor {
+            let state = makeState()
+            let context = TabbyTestFixtures.focusedInputContext(precedingText: "Hello")
+
+            let session = state.startSession(
+                fullText: " world",
+                liveContext: context,
+                latency: 0.2
+            )
+
+            XCTAssertEqual(state.activeSession, session)
+            XCTAssertNil(state.pendingInsertionConsumedCount)
+            XCTAssertFalse(state.isAwaitingPostInsertionSync)
+        }
+    }
+
+    func test_prepareAcceptance_returnsReadyForVisibleMatchingOverlay() {
+        runOnMainActor {
+            let state = makeState()
+            let context = TabbyTestFixtures.focusedInputContext(precedingText: "Hello")
+            _ = state.startSession(fullText: " world again", liveContext: context, latency: 0.1)
+            let snapshot = TabbyTestFixtures.focusedInputSnapshot(precedingText: "Hello")
+
+            let preparation = state.prepareAcceptance(
+                from: snapshot,
+                overlayState: .visible(
+                    text: " world again",
+                    caretRect: context.caretRect,
+                    caretQuality: .exact
+                )
+            )
+
+            guard case let .ready(liveContext, session, acceptedChunk) = preparation else {
+                XCTFail("Expected acceptance to be ready")
+                return
+            }
+            XCTAssertEqual(liveContext.precedingText, "Hello")
+            XCTAssertEqual(session.remainingText, " world again")
+            XCTAssertEqual(acceptedChunk, " world")
+        }
+    }
+
+    func test_prepareAcceptance_rejectsVisibleOverlayTextMismatch() {
+        runOnMainActor {
+            let state = makeState()
+            let context = TabbyTestFixtures.focusedInputContext(precedingText: "Hello")
+            _ = state.startSession(fullText: " world again", liveContext: context, latency: 0.1)
+
+            let preparation = state.prepareAcceptance(
+                from: TabbyTestFixtures.focusedInputSnapshot(precedingText: "Hello"),
+                overlayState: .visible(
+                    text: " different",
+                    caretRect: context.caretRect,
+                    caretQuality: .exact
+                )
+            )
+
+            guard case let .invalid(reason) = preparation else {
+                XCTFail("Expected overlay mismatch to reject acceptance")
+                return
+            }
+            XCTAssertEqual(
+                reason,
+                "Tab passed through because no visible ghost text matched the ready suggestion."
+            )
+        }
+    }
+
+    func test_prepareAcceptance_allowsHiddenOverlayWhenProcessStillMatches() {
+        runOnMainActor {
+            let state = makeState()
+            let context = TabbyTestFixtures.focusedInputContext(
+                processIdentifier: 123,
+                precedingText: "Hello"
+            )
+            _ = state.startSession(fullText: " world again", liveContext: context, latency: 0.1)
+
+            let preparation = state.prepareAcceptance(
+                from: TabbyTestFixtures.focusedInputSnapshot(
+                    processIdentifier: 123,
+                    precedingText: "Different live text"
+                ),
+                overlayState: .hidden(reason: "waiting for caret sync")
+            )
+
+            guard case let .ready(_, _, acceptedChunk) = preparation else {
+                XCTFail("Expected hidden overlay to allow acceptance during sync")
+                return
+            }
+            XCTAssertEqual(acceptedChunk, " world")
+        }
+    }
+
+    func test_commitAcceptedChunkAdvancesSessionAndSetsPendingInsertionSentinel() {
+        runOnMainActor {
+            let state = makeState()
+            let context = TabbyTestFixtures.focusedInputContext(precedingText: "Hello", generation: 7)
+            let session = state.startSession(fullText: " world again", liveContext: context, latency: 0.1)
+
+            let progress = state.commitAcceptedChunk(
+                " world",
+                liveContext: context,
+                session: session
+            )
+
+            guard case let .advanced(advancedSession, generation) = progress else {
+                XCTFail("Expected partial acceptance to keep the session alive")
+                return
+            }
+            XCTAssertEqual(generation, 7)
+            XCTAssertEqual(advancedSession.acceptedText, " world")
+            XCTAssertEqual(advancedSession.remainingText, " again")
+            XCTAssertEqual(state.activeSession, advancedSession)
+            XCTAssertEqual(state.pendingInsertionConsumedCount, 6)
+            XCTAssertTrue(state.isAwaitingPostInsertionSync)
+        }
+    }
+
+    func test_commitAcceptedChunkClearsSessionWhenTailIsExhausted() {
+        runOnMainActor {
+            let state = makeState()
+            let context = TabbyTestFixtures.focusedInputContext(precedingText: "Hello", generation: 4)
+            let session = state.startSession(fullText: " world", liveContext: context, latency: 0.1)
+
+            let progress = state.commitAcceptedChunk(
+                " world",
+                liveContext: context,
+                session: session
+            )
+
+            guard case let .exhausted(generation) = progress else {
+                XCTFail("Expected final chunk to exhaust the session")
+                return
+            }
+            XCTAssertEqual(generation, 4)
+            XCTAssertNil(state.activeSession)
+            XCTAssertNil(state.pendingInsertionConsumedCount)
+        }
+    }
+
+    func test_reconcileActiveSessionStoresAdvancedSession() {
+        runOnMainActor {
+            let state = makeState()
+            let context = TabbyTestFixtures.focusedInputContext(precedingText: "Hello")
+            _ = state.startSession(fullText: " world again", liveContext: context, latency: 0.1)
+
+            let reconciliation = state.reconcileActiveSession(
+                with: TabbyTestFixtures.focusedInputSnapshot(precedingText: "Hello world")
+            )
+
+            guard case let .valid(_, session, advancement) = reconciliation else {
+                XCTFail("Expected live consumed text to advance stored session")
+                return
+            }
+            XCTAssertEqual(session.remainingText, " again")
+            XCTAssertEqual(state.activeSession?.remainingText, " again")
+            XCTAssertEqual(advancement?.actionSummary, "Suggestion tail advanced from live editor state.")
+        }
+    }
+
+    func test_advanceIfTypedCharactersMatchRequiresExpectedStoredSession() {
+        runOnMainActor {
+            let state = makeState()
+            let context = TabbyTestFixtures.focusedInputContext(precedingText: "Hello")
+            let storedSession = state.startSession(fullText: " world again", liveContext: context, latency: 0.1)
+            let differentExpectedSession = storedSession.advancing(by: 1)
+
+            XCTAssertNil(
+                state.advanceIfTypedCharactersMatch(
+                    " world",
+                    expectedSession: differentExpectedSession
+                )
+            )
+
+            let advanced = state.advanceIfTypedCharactersMatch(
+                " world",
+                expectedSession: storedSession
+            )
+            XCTAssertEqual(advanced?.remainingText, " again")
+            XCTAssertEqual(state.activeSession?.remainingText, " again")
+        }
+    }
+
+    @MainActor
+    private func makeState() -> SuggestionInteractionState {
+        let state = SuggestionInteractionState()
+        Self.retainedStates.append(state)
+        return state
+    }
+}
+
+/// Tests for async work identity and cancellation.
+///
+/// The controller gives the coordinator "latest request wins" semantics. That is the protection
+/// against older debounce or generation tasks writing stale results after the user keeps typing.
+final class SuggestionWorkControllerTests: XCTestCase {
+    private var retainedControllers: [SuggestionWorkController] = []
+
+    override func tearDown() {
+        runOnMainActor {
+            retainedControllers.forEach { $0.cancelAll() }
+            retainedControllers.removeAll()
+        }
+        super.tearDown()
+    }
+
+    func test_replaceDebouncedWorkRunsOnlyLatestOperation() {
+        let operationRan = expectation(description: "latest debounce runs")
+        let recorder = runOnMainActor { WorkRecorder() }
+        var firstID: UInt64 = 0
+        var secondID: UInt64 = 0
+
+        runOnMainActor {
+            let controller = makeController()
+            firstID = controller.replaceDebouncedWork(delayMilliseconds: 20) { workID in
+                recorder.record(workID)
+            }
+            secondID = controller.replaceDebouncedWork(delayMilliseconds: 1) { workID in
+                recorder.record(workID)
+                operationRan.fulfill()
+            }
+        }
+
+        wait(for: [operationRan], timeout: 1.0)
+
+        runOnMainActor {
+            XCTAssertEqual(firstID, 1)
+            XCTAssertEqual(secondID, 2)
+            XCTAssertEqual(recorder.workIDs, [2])
+        }
+    }
+
+    func test_cancelAllPreventsPendingDebouncedOperation() {
+        let operationRan = expectation(description: "cancelled debounce should not run")
+        operationRan.isInverted = true
+        var currentWorkID: UInt64 = 0
+
+        runOnMainActor {
+            let controller = makeController()
+            _ = controller.replaceDebouncedWork(delayMilliseconds: 1) { _ in
+                operationRan.fulfill()
+            }
+            controller.cancelAll()
+            currentWorkID = controller.currentWorkID
+        }
+
+        wait(for: [operationRan], timeout: 0.1)
+        XCTAssertEqual(currentWorkID, 2)
+    }
+
+    func test_replaceGenerationWorkRunsForCurrentWorkID() {
+        let generationRan = expectation(description: "current generation runs")
+
+        runOnMainActor {
+            let controller = makeController()
+            let workID = controller.replaceDebouncedWork(delayMilliseconds: 1_000) { _ in }
+            controller.replaceGenerationWork(for: workID) {
+                generationRan.fulfill()
+            }
+        }
+
+        wait(for: [generationRan], timeout: 1.0)
+    }
+
+    func test_replaceGenerationWorkRejectsStaleWorkID() {
+        let generationRan = expectation(description: "stale generation should not run")
+        generationRan.isInverted = true
+
+        runOnMainActor {
+            let controller = makeController()
+            let staleWorkID = controller.replaceDebouncedWork(delayMilliseconds: 1_000) { _ in }
+            controller.cancelAll()
+            controller.replaceGenerationWork(for: staleWorkID) {
+                generationRan.fulfill()
+            }
+        }
+
+        wait(for: [generationRan], timeout: 0.1)
+    }
+
+    @MainActor
+    private func makeController() -> SuggestionWorkController {
+        let controller = SuggestionWorkController()
+        retainedControllers.append(controller)
+        return controller
+    }
+}
+
+/// Tests for the small adapter between coordinator intent and overlay-controller calls.
+final class SuggestionOverlayPresenterTests: XCTestCase {
+    func test_presentEmptyTextHidesOverlay() {
+        runOnMainActor {
+            let overlayController = FakeOverlayController()
+            let presenter = SuggestionOverlayPresenter(overlayController: overlayController)
+
+            let message = presenter.present(
+                text: "   ",
+                at: .zero,
+                caretQuality: .exact,
+                previousState: overlayController.state
+            )
+
+            XCTAssertEqual(message, "Overlay hidden because the suggestion text was empty.")
+            XCTAssertEqual(overlayController.hideReasons, ["Overlay hidden because the suggestion text was empty."])
+            XCTAssertEqual(overlayController.showCallCount, 0)
+        }
+    }
+
+    func test_presentNewTextShowsOverlayAndReturnsDisplayedMessage() {
+        runOnMainActor {
+            let overlayController = FakeOverlayController()
+            let presenter = SuggestionOverlayPresenter(overlayController: overlayController)
+            let caretRect = CGRect(x: 10, y: 20, width: 2, height: 18)
+
+            let message = presenter.present(
+                text: " world",
+                at: caretRect,
+                caretQuality: .exact,
+                previousState: overlayController.state
+            )
+
+            XCTAssertEqual(message, "Displayed ghost text near the caret.")
+            XCTAssertEqual(overlayController.lastShownText, " world")
+            XCTAssertEqual(overlayController.lastShownCaretRect, caretRect)
+            XCTAssertEqual(overlayController.showCallCount, 1)
+        }
+    }
+
+    func test_presentIdenticalVisibleStateDoesNotCallOverlayAgain() {
+        runOnMainActor {
+            let caretRect = CGRect(x: 10, y: 20, width: 2, height: 18)
+            let overlayController = FakeOverlayController(
+                initialState: .visible(text: " world", caretRect: caretRect, caretQuality: .exact)
+            )
+            let presenter = SuggestionOverlayPresenter(overlayController: overlayController)
+
+            let message = presenter.present(
+                text: " world",
+                at: caretRect,
+                caretQuality: .exact,
+                previousState: overlayController.state
+            )
+
+            XCTAssertNil(message)
+            XCTAssertEqual(overlayController.showCallCount, 0)
+        }
+    }
+
+    func test_presentSameTextAtNewCaretReturnsMovedMessage() {
+        runOnMainActor {
+            let previousRect = CGRect(x: 10, y: 20, width: 2, height: 18)
+            let nextRect = CGRect(x: 30, y: 20, width: 2, height: 18)
+            let overlayController = FakeOverlayController()
+            let presenter = SuggestionOverlayPresenter(overlayController: overlayController)
+
+            let message = presenter.present(
+                text: " world",
+                at: nextRect,
+                caretQuality: .exact,
+                previousState: .visible(text: " world", caretRect: previousRect, caretQuality: .exact)
+            )
+
+            XCTAssertEqual(message, "Moved ghost text to the latest caret position.")
+        }
+    }
+
+    func test_presentSameTextAndCaretWithNewQualityReturnsStylingMessage() {
+        runOnMainActor {
+            let caretRect = CGRect(x: 10, y: 20, width: 2, height: 18)
+            let overlayController = FakeOverlayController()
+            let presenter = SuggestionOverlayPresenter(overlayController: overlayController)
+
+            let message = presenter.present(
+                text: " world",
+                at: caretRect,
+                caretQuality: .derived,
+                previousState: .visible(text: " world", caretRect: caretRect, caretQuality: .exact)
+            )
+
+            XCTAssertEqual(message, "Updated ghost text styling for the latest caret quality.")
+        }
+    }
+
+    func test_hideForwardsReasonToOverlayController() {
+        runOnMainActor {
+            let overlayController = FakeOverlayController()
+            let presenter = SuggestionOverlayPresenter(overlayController: overlayController)
+
+            let message = presenter.hide(reason: "Overlay hidden for test.")
+
+            XCTAssertEqual(message, "Overlay hidden for test.")
+            XCTAssertEqual(overlayController.hideReasons, ["Overlay hidden for test."])
+        }
+    }
+}
+
+final class SuggestionCaretPredictionTests: XCTestCase {
+    func test_predictedCaretRectUsesObservedCharacterWidthForTrustedGeometry() {
+        runOnMainActor {
+            let oldRect = CGRect(x: 10, y: 20, width: 2, height: 18)
+
+            let predicted = SuggestionCoordinator.predictedCaretRect(
+                after: "abcd",
+                oldCaretRect: oldRect,
+                caretQuality: .exact,
+                observedCharWidth: 7
+            )
+
+            XCTAssertEqual(predicted.origin.x, 38)
+            XCTAssertEqual(predicted.origin.y, oldRect.origin.y)
+            XCTAssertEqual(predicted.size, oldRect.size)
+        }
+    }
+
+    func test_predictedCaretRectStillMovesForwardForEstimatedGeometry() {
+        runOnMainActor {
+            let oldRect = CGRect(x: 10, y: 20, width: 2, height: 18)
+
+            let predicted = SuggestionCoordinator.predictedCaretRect(
+                after: "abcd",
+                oldCaretRect: oldRect,
+                caretQuality: .estimated,
+                observedCharWidth: 7
+            )
+
+            XCTAssertGreaterThan(predicted.origin.x, oldRect.origin.x)
+            XCTAssertEqual(predicted.origin.y, oldRect.origin.y)
+        }
+    }
+}
+
+@MainActor
+private final class FakeOverlayController: SuggestionOverlayControlling {
+    var state: OverlayState
+    var onStateChange: ((OverlayState) -> Void)?
+
+    private(set) var showCallCount = 0
+    private(set) var lastShownText: String?
+    private(set) var lastShownCaretRect: CGRect?
+    private(set) var hideReasons: [String] = []
+
+    init(initialState: OverlayState = .hidden(reason: "Overlay idle.")) {
+        state = initialState
+    }
+
+    func showSuggestion(
+        _ text: String,
+        at caretRect: CGRect,
+        caretQuality: CaretGeometryQuality
+    ) {
+        showCallCount += 1
+        lastShownText = text
+        lastShownCaretRect = caretRect
+        state = .visible(text: text, caretRect: caretRect, caretQuality: caretQuality)
+        onStateChange?(state)
+    }
+
+    func hide(reason: String) {
+        hideReasons.append(reason)
+        state = .hidden(reason: reason)
+        onStateChange?(state)
+    }
+}
+
+@MainActor
+private final class WorkRecorder {
+    private(set) var workIDs: [UInt64] = []
+
+    func record(_ workID: UInt64) {
+        workIDs.append(workID)
+    }
+}
+
+private func runOnMainActor<Result>(
+    _ body: @MainActor () throws -> Result
+) rethrows -> Result {
+    if Thread.isMainThread {
+        return try MainActor.assumeIsolated(body)
+    }
+
+    return try DispatchQueue.main.sync {
+        try MainActor.assumeIsolated(body)
+    }
+}

--- a/tabbyTests/SuggestionTextNormalizerTests.swift
+++ b/tabbyTests/SuggestionTextNormalizerTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+@testable import tabby
+
+/// Tests for the final cleanup layer shared by every suggestion backend.
+///
+/// The normalizer is deliberately backend-agnostic: llama.cpp and Foundation Models can both echo
+/// prompt text, add template markers, or return multi-line completions. These tests lock down the
+/// UI-facing contract that only one usable inline continuation reaches the overlay.
+final class SuggestionTextNormalizerTests: XCTestCase {
+    func test_normalize_removesChatTemplateMarkersAndPromptEcho() {
+        let request = TabbyTestFixtures.suggestionRequest(
+            prefixText: "Hello",
+            prompt: "PROMPT_PAYLOAD",
+            precedingText: "Hello"
+        )
+
+        let normalized = SuggestionTextNormalizer.normalize(
+            "PROMPT_PAYLOAD<|im_start|> useful continuation<|im_end|>",
+            for: request
+        )
+
+        XCTAssertEqual(normalized, " useful continuation")
+    }
+
+    func test_normalize_removesPrefixEchoWhenPromptWasNotEchoed() {
+        let request = TabbyTestFixtures.suggestionRequest(
+            prefixText: "Hello world",
+            prompt: "SHORT_APPLE_PROMPT",
+            precedingText: "Hello world"
+        )
+
+        let normalized = SuggestionTextNormalizer.normalize(
+            "Hello world, with a small addition",
+            for: request
+        )
+
+        XCTAssertEqual(normalized, ", with a small addition")
+    }
+
+    func test_normalize_trimsLeadingFormattingNewlinesBeforeTakingFirstLine() {
+        let request = TabbyTestFixtures.suggestionRequest(precedingText: "Hello")
+
+        let normalized = SuggestionTextNormalizer.normalize(
+            "\n\nnext words only\nsecond paragraph should be dropped",
+            for: request
+        )
+
+        XCTAssertEqual(normalized, "next words only")
+    }
+
+    func test_normalize_dropsSuggestionThatRepeatsTrailingTextAfterCaret() {
+        let request = TabbyTestFixtures.suggestionRequest(
+            precedingText: "Hello",
+            trailingText: " existing suffix"
+        )
+
+        let normalized = SuggestionTextNormalizer.normalize(
+            " existing suffix and extra generated text",
+            for: request
+        )
+
+        XCTAssertEqual(normalized, "")
+    }
+
+    func test_normalize_stripsModelLeadingWhitespaceWhenPrecedingTextAlreadyEndsWithWhitespace() {
+        let request = TabbyTestFixtures.suggestionRequest(precedingText: "Hello ")
+
+        let normalized = SuggestionTextNormalizer.normalize(" world", for: request)
+
+        XCTAssertEqual(normalized, "world")
+    }
+
+    func test_normalize_preservesModelLeadingWhitespaceWhenPrecedingTextNeedsWordBoundary() {
+        let request = TabbyTestFixtures.suggestionRequest(precedingText: "Hello")
+
+        let normalized = SuggestionTextNormalizer.normalize(" world", for: request)
+
+        XCTAssertEqual(normalized, " world")
+    }
+
+    func test_normalize_stripsRepeatedPrecedingTailAcrossMultipleWords() {
+        let request = TabbyTestFixtures.suggestionRequest(precedingText: "hi i like")
+
+        let normalized = SuggestionTextNormalizer.normalize(
+            "I like matcha in the morning",
+            for: request
+        )
+
+        XCTAssertEqual(normalized, "matcha in the morning")
+    }
+
+    func test_normalize_returnsEmptyWhenSuggestionIsOnlyAnEchoedTailWord() {
+        let request = TabbyTestFixtures.suggestionRequest(precedingText: "hello world")
+
+        let normalized = SuggestionTextNormalizer.normalize("world", for: request)
+
+        XCTAssertEqual(normalized, "")
+    }
+}

--- a/tabbyTests/TabbyTestFixtures.swift
+++ b/tabbyTests/TabbyTestFixtures.swift
@@ -1,0 +1,201 @@
+import ApplicationServices
+import CoreGraphics
+import Foundation
+@testable import tabby
+
+/// Shared constructors for tests that exercise Tabby's pure autocomplete domain.
+///
+/// These helpers keep each test focused on the rule it is locking down. The production types are
+/// intentionally explicit value objects, so building them inline in every test would bury the
+/// meaningful input under repeated boilerplate.
+enum TabbyTestFixtures {
+    static func focusedInputSnapshot(
+        applicationName: String = "TestApp",
+        bundleIdentifier: String = "com.example.TestApp",
+        processIdentifier: Int32 = 123,
+        elementIdentifier: String = "field",
+        role: String = "AXTextField",
+        subrole: String? = nil,
+        caretRect: CGRect = CGRect(x: 10, y: 20, width: 2, height: 18),
+        inputFrameRect: CGRect? = CGRect(x: 0, y: 0, width: 240, height: 32),
+        caretSource: String = "test",
+        caretQuality: CaretGeometryQuality = .exact,
+        observedCharWidth: CGFloat? = nil,
+        precedingText: String = "Hello",
+        trailingText: String = "",
+        selection: NSRange? = nil,
+        isSecure: Bool = false,
+        focusChangeSequence: UInt64 = 1
+    ) -> FocusedInputSnapshot {
+        let resolvedSelection = selection
+            ?? NSRange(location: (precedingText as NSString).length, length: 0)
+
+        return FocusedInputSnapshot(
+            applicationName: applicationName,
+            bundleIdentifier: bundleIdentifier,
+            processIdentifier: processIdentifier,
+            elementIdentifier: elementIdentifier,
+            role: role,
+            subrole: subrole,
+            caretRect: caretRect,
+            inputFrameRect: inputFrameRect,
+            caretSource: caretSource,
+            caretQuality: caretQuality,
+            observedCharWidth: observedCharWidth,
+            precedingText: precedingText,
+            trailingText: trailingText,
+            selection: resolvedSelection,
+            isSecure: isSecure,
+            focusChangeSequence: focusChangeSequence
+        )
+    }
+
+    static func focusedInputContext(
+        applicationName: String = "TestApp",
+        bundleIdentifier: String = "com.example.TestApp",
+        processIdentifier: Int32 = 123,
+        elementIdentifier: String = "field",
+        caretRect: CGRect = CGRect(x: 10, y: 20, width: 2, height: 18),
+        inputFrameRect: CGRect? = CGRect(x: 0, y: 0, width: 240, height: 32),
+        caretQuality: CaretGeometryQuality = .exact,
+        observedCharWidth: CGFloat? = nil,
+        precedingText: String = "Hello",
+        trailingText: String = "",
+        selection: NSRange? = nil,
+        isSecure: Bool = false,
+        focusChangeSequence: UInt64 = 1,
+        generation: UInt64 = 1
+    ) -> FocusedInputContext {
+        FocusedInputContext(
+            snapshot: focusedInputSnapshot(
+                applicationName: applicationName,
+                bundleIdentifier: bundleIdentifier,
+                processIdentifier: processIdentifier,
+                elementIdentifier: elementIdentifier,
+                caretRect: caretRect,
+                inputFrameRect: inputFrameRect,
+                caretQuality: caretQuality,
+                observedCharWidth: observedCharWidth,
+                precedingText: precedingText,
+                trailingText: trailingText,
+                selection: selection,
+                isSecure: isSecure,
+                focusChangeSequence: focusChangeSequence
+            ),
+            generation: generation
+        )
+    }
+
+    static func suggestionRequest(
+        prefixText: String = "Hello",
+        prompt: String = "PROMPT",
+        precedingText: String? = nil,
+        trailingText: String = "",
+        generation: UInt64 = 1,
+        maxPredictionTokens: Int = 8,
+        completionLengthInstruction: String = "Return only the next few words.",
+        customAIInstructions: String? = nil,
+        visualContextSummary: String? = nil
+    ) -> SuggestionRequest {
+        let resolvedPrecedingText = precedingText ?? prefixText
+        let context = focusedInputContext(
+            precedingText: resolvedPrecedingText,
+            trailingText: trailingText,
+            generation: generation
+        )
+
+        return SuggestionRequest(
+            context: context,
+            prefixText: prefixText,
+            prompt: prompt,
+            generation: generation,
+            maxPredictionTokens: maxPredictionTokens,
+            temperature: 0.1,
+            topK: 20,
+            topP: 0.7,
+            minP: 0.08,
+            repetitionPenalty: 1.05,
+            randomSeed: 42,
+            maxSuffixCharacters: 192,
+            completionLengthInstruction: completionLengthInstruction,
+            customAIInstructions: customAIInstructions,
+            visualContextSummary: visualContextSummary
+        )
+    }
+
+    static func activeSession(
+        fullText: String = " world again",
+        consumedCharacterCount: Int = 0,
+        basePrecedingText: String = "Hello",
+        baseTrailingText: String = "",
+        processIdentifier: Int32 = 123,
+        latency: TimeInterval = 0.1
+    ) -> ActiveSuggestionSession {
+        ActiveSuggestionSession(
+            baseContext: focusedInputContext(
+                processIdentifier: processIdentifier,
+                precedingText: basePrecedingText,
+                trailingText: baseTrailingText
+            ),
+            fullText: fullText,
+            consumedCharacterCount: consumedCharacterCount,
+            latency: latency
+        )
+    }
+
+    static func focusCapabilityCandidate(
+        elementIdentifier: String = "candidate",
+        role: String = "AXTextField",
+        subrole: String? = nil,
+        editableHintScore: Int = 0,
+        hasStrongEditabilitySignal: Bool = true,
+        isKnownReadOnlyRole: Bool = false,
+        hasTextValue: Bool = true,
+        hasSelectionRange: Bool = true,
+        hasCaretBounds: Bool = true,
+        isSecure: Bool = false
+    ) -> FocusCapabilityCandidate {
+        FocusCapabilityCandidate(
+            elementIdentifier: elementIdentifier,
+            role: role,
+            subrole: subrole,
+            editableHintScore: editableHintScore,
+            hasStrongEditabilitySignal: hasStrongEditabilitySignal,
+            isKnownReadOnlyRole: isKnownReadOnlyRole,
+            hasTextValue: hasTextValue,
+            hasSelectionRange: hasSelectionRange,
+            hasCaretBounds: hasCaretBounds,
+            isSecure: isSecure
+        )
+    }
+
+    static func inputEvent(
+        kind: CapturedInputEvent.Kind,
+        keyCode: CGKeyCode = 0,
+        characters: String = "",
+        flags: CGEventFlags = []
+    ) -> CapturedInputEvent {
+        CapturedInputEvent(
+            kind: kind,
+            keyCode: keyCode,
+            characters: characters,
+            flags: flags
+        )
+    }
+
+    static func settingsSnapshot(
+        isGloballyEnabled: Bool = true,
+        disabledAppBundleIdentifiers: Set<String> = [],
+        selectedEngine: SuggestionEngineKind = .llamaOpenSource,
+        selectedWordCountPreset: SuggestionWordCountPreset = .sevenToTwelve,
+        customAIInstructions: String? = nil
+    ) -> SuggestionSettingsSnapshot {
+        SuggestionSettingsSnapshot(
+            isGloballyEnabled: isGloballyEnabled,
+            disabledAppBundleIdentifiers: disabledAppBundleIdentifiers,
+            selectedEngine: selectedEngine,
+            selectedWordCountPreset: selectedWordCountPreset,
+            customAIInstructions: customAIInstructions
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Adds broad unit coverage for Tabby's autocomplete support logic so request construction, prompt policy, normalization, reconciliation, focus capability scoring, overlay presentation, and async work cancellation are protected by tests. Also tightens ghost-text color hex parsing after the new value-model tests exposed that malformed strings could be accepted too loosely.

## Validation

```bash
xcodebuild -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

xcodebuild -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' build-for-testing
# ** TEST BUILD SUCCEEDED **

xcodebuild -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' -derivedDataPath .context/DerivedData test CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=-
# ** TEST SUCCEEDED **; 149 tests, 0 failures
```

I also ran the normal signed `xcodebuild test`; it still fails before executing tests because the app-hosted test bundle and host app have different Team IDs locally: `mapping process and mapped file (non-platform) have different Team IDs`.

## Linked issues

None.

## Risk / rollout notes

Most of this PR is test-only. The only runtime behavior change is stricter six-digit RGB validation in `SuggestionTextColorCodec.nsColor(fromHex:)`, which rejects malformed persisted or user-provided color strings instead of partially scanning them.
