### PR TITLE
Add ghost text wrapping for inline suggestions

### DIFF
--- a/tabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
@@ -98,7 +98,9 @@ extension SuggestionCoordinator {
             presentOverlay(
                 text: advancedSession.remainingText,
                 at: predictedCaret,
-                caretQuality: liveContext.caretQuality
+                inputFrameRect: liveContext.inputFrameRect,
+                caretQuality: liveContext.caretQuality,
+                observedCharWidth: liveContext.observedCharWidth
             )
             // Force an early AX refresh so the real caret position corrects any prediction
             // error faster than the normal 250ms poll interval.
@@ -159,7 +161,9 @@ extension SuggestionCoordinator {
         presentOverlay(
             text: advancedSession.remainingText,
             at: session.baseContext.caretRect,
-            caretQuality: session.baseContext.caretQuality
+            inputFrameRect: session.baseContext.inputFrameRect,
+            caretQuality: session.baseContext.caretQuality,
+            observedCharWidth: session.baseContext.observedCharWidth
         )
         logStage(
             "typed-match-advanced",
@@ -297,12 +301,19 @@ extension SuggestionCoordinator {
     func presentOverlay(
         text: String,
         at caretRect: CGRect,
-        caretQuality: CaretGeometryQuality
+        inputFrameRect: CGRect?,
+        caretQuality: CaretGeometryQuality,
+        observedCharWidth: CGFloat?
     ) {
+        let geometry = SuggestionOverlayGeometry(
+            caretRect: caretRect,
+            inputFrameRect: inputFrameRect,
+            caretQuality: caretQuality,
+            observedCharWidth: observedCharWidth
+        )
         if let message = overlayPresenter.present(
             text: text,
-            at: caretRect,
-            caretQuality: caretQuality,
+            geometry: geometry,
             previousState: overlayState
         ) {
             latestOverlayMessage = message

--- a/tabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
@@ -208,7 +208,9 @@ extension SuggestionCoordinator {
         presentOverlay(
             text: session.remainingText,
             at: liveContext.caretRect,
-            caretQuality: liveContext.caretQuality
+            inputFrameRect: liveContext.inputFrameRect,
+            caretQuality: liveContext.caretQuality,
+            observedCharWidth: liveContext.observedCharWidth
         )
         logStage(
             "ready",
@@ -300,7 +302,9 @@ extension SuggestionCoordinator {
             presentOverlay(
                 text: reconciledSession.remainingText,
                 at: liveContext.caretRect,
-                caretQuality: liveContext.caretQuality
+                inputFrameRect: liveContext.inputFrameRect,
+                caretQuality: liveContext.caretQuality,
+                observedCharWidth: liveContext.observedCharWidth
             )
             if let advancement {
                 logStage(

--- a/tabby/Models/SuggestionModels.swift
+++ b/tabby/Models/SuggestionModels.swift
@@ -359,11 +359,25 @@ enum SuggestionDebugState: Equatable {
     }
 }
 
+/// Geometry needed to render ghost text in the same visual line box as the host editor.
+///
+/// `caretRect` tells Tabby where the current insertion point is. `inputFrameRect` gives the
+/// broader editor bounds, which lets the overlay wrap overflow text back to the field's left edge
+/// instead of drawing past the right edge of the text container.
+struct SuggestionOverlayGeometry: Equatable, Sendable {
+    let caretRect: CGRect
+    let inputFrameRect: CGRect?
+    let caretQuality: CaretGeometryQuality
+    /// Average character width from AX child-frame sampling when available. Layout uses this as a
+    /// cheap approximation for host-editor text width before falling back to local font metrics.
+    let observedCharWidth: CGFloat?
+}
+
 /// The overlay is intentionally modeled as data so diagnostics can reason about visibility
 /// without poking into AppKit window objects directly.
 enum OverlayState: Equatable {
     case hidden(reason: String)
-    case visible(text: String, caretRect: CGRect, caretQuality: CaretGeometryQuality)
+    case visible(text: String, geometry: SuggestionOverlayGeometry)
 
     var shortLabel: String {
         switch self {
@@ -378,10 +392,10 @@ enum OverlayState: Equatable {
         switch self {
         case let .hidden(reason):
             return reason
-        case let .visible(text, caretRect, caretQuality):
+        case let .visible(text, geometry):
             return "Showing \(text.count) characters near " +
-                "(\(Int(caretRect.minX)), \(Int(caretRect.minY))) " +
-                "using \(caretQuality.label) caret geometry."
+                "(\(Int(geometry.caretRect.minX)), \(Int(geometry.caretRect.minY))) " +
+                "using \(geometry.caretQuality.label) caret geometry."
         }
     }
 
@@ -394,7 +408,7 @@ enum OverlayState: Equatable {
     }
 
     var visibleText: String? {
-        guard case let .visible(text, _, _) = self else {
+        guard case let .visible(text, _) = self else {
             return nil
         }
 

--- a/tabby/Models/SuggestionSubsystemContracts.swift
+++ b/tabby/Models/SuggestionSubsystemContracts.swift
@@ -62,7 +62,7 @@ protocol SuggestionOverlayControlling: AnyObject {
     var state: OverlayState { get }
     var onStateChange: ((OverlayState) -> Void)? { get set }
 
-    func showSuggestion(_ text: String, at caretRect: CGRect, caretQuality: CaretGeometryQuality)
+    func showSuggestion(_ text: String, geometry: SuggestionOverlayGeometry)
     func hide(reason: String)
 }
 

--- a/tabby/Services/Suggestion/SuggestionOverlayPresenter.swift
+++ b/tabby/Services/Suggestion/SuggestionOverlayPresenter.swift
@@ -20,8 +20,7 @@ struct SuggestionOverlayPresenter {
     /// Shows or repositions ghost text while preserving the previous overlay message when nothing changed.
     func present(
         text: String,
-        at caretRect: CGRect,
-        caretQuality: CaretGeometryQuality,
+        geometry: SuggestionOverlayGeometry,
         previousState: OverlayState
     ) -> String? {
         let displayText = text.trimmingCharacters(in: .whitespaces).isEmpty ? "" : text
@@ -31,24 +30,27 @@ struct SuggestionOverlayPresenter {
 
         guard previousState != .visible(
             text: displayText,
-            caretRect: caretRect,
-            caretQuality: caretQuality
+            geometry: geometry
         ) else {
             return nil
         }
 
-        overlayController.showSuggestion(displayText, at: caretRect, caretQuality: caretQuality)
+        overlayController.showSuggestion(displayText, geometry: geometry)
 
         switch previousState {
-        case .visible(let previousText, let previousCaretRect, let previousCaretQuality)
+        case .visible(let previousText, let previousGeometry)
         where previousText == displayText
-            && previousCaretRect == caretRect
-            && previousCaretQuality != caretQuality:
+            && previousGeometry.caretRect == geometry.caretRect
+            && previousGeometry.caretQuality != geometry.caretQuality:
             return "Updated ghost text styling for the latest caret quality."
 
-        case .visible(let previousText, let previousCaretRect, _)
-        where previousText == displayText && previousCaretRect != caretRect:
+        case .visible(let previousText, let previousGeometry)
+        where previousText == displayText && previousGeometry.caretRect != geometry.caretRect:
             return "Moved ghost text to the latest caret position."
+
+        case .visible(let previousText, _)
+        where previousText == displayText:
+            return "Updated ghost text layout for the latest input bounds."
 
         default:
             return "Displayed ghost text near the caret."

--- a/tabby/Services/UI/OverlayController.swift
+++ b/tabby/Services/UI/OverlayController.swift
@@ -60,20 +60,29 @@ final class OverlayController: SuggestionOverlayControlling {
     }()
 
     /// Sizes and positions the overlay next to the reported caret bounds for the current field.
-    func showSuggestion(_ text: String, at caretRect: CGRect, caretQuality: CaretGeometryQuality) {
+    func showSuggestion(_ text: String, geometry: SuggestionOverlayGeometry) {
         guard !text.isEmpty else {
             hide(reason: "Overlay not shown because the suggestion was empty.")
             return
         }
 
-        let fontSize = resolvedGhostFontSize(for: caretRect, caretQuality: caretQuality)
+        let fontSize = resolvedGhostFontSize(
+            for: geometry.caretRect,
+            caretQuality: geometry.caretQuality
+        )
+        let layout = GhostSuggestionLayout.make(
+            text: text,
+            geometry: geometry,
+            fontSize: fontSize,
+            visibleFrame: targetScreenVisibleFrame(for: geometry.caretRect)
+        )
         let customGhostColor = SuggestionTextColorCodec.color(
             fromHex: suggestionSettings.customSuggestionTextColorHex
         )
         let contentView: NSHostingView<GhostSuggestionView>
         if let existing = hostingView {
             existing.rootView = GhostSuggestionView(
-                text: text,
+                layout: layout,
                 fontSize: fontSize,
                 customColor: customGhostColor
             )
@@ -81,7 +90,7 @@ final class OverlayController: SuggestionOverlayControlling {
         } else {
             let fresh = NSHostingView(
                 rootView: GhostSuggestionView(
-                    text: text,
+                    layout: layout,
                     fontSize: fontSize,
                     customColor: customGhostColor
                 )
@@ -93,19 +102,11 @@ final class OverlayController: SuggestionOverlayControlling {
         contentView.layoutSubtreeIfNeeded()
         let contentSize = contentView.fittingSize
 
-        // Vertically center the ghost text within the caret rect. When the caret rect is a
-        // tight line-height box this looks identical to top-alignment, but when it's oversized
-        // (e.g. AXFrame fallback returning the full text area) the text lands at the visual
-        // midpoint instead of floating at the top edge.
-        let origin = CGPoint(
-            x: caretRect.maxX + 6,
-            y: caretRect.midY - contentSize.height / 2
-        )
-        let frame = CGRect(origin: origin, size: contentSize)
+        let frame = layout.panelFrame(for: contentSize, caretRect: geometry.caretRect)
 
         panel.setFrame(frame.integral, display: true)
         panel.orderFrontRegardless()
-        state = .visible(text: text, caretRect: caretRect, caretQuality: caretQuality)
+        state = .visible(text: text, geometry: geometry)
     }
 
     /// Hides the floating panel and records why the overlay is no longer visible.
@@ -132,6 +133,14 @@ final class OverlayController: SuggestionOverlayControlling {
 
         return min(proposedSize, qualityCap)
     }
+
+    private func targetScreenVisibleFrame(for caretRect: CGRect) -> CGRect {
+        if let screen = NSScreen.screens.first(where: { $0.frame.intersects(caretRect) }) {
+            return screen.visibleFrame
+        }
+
+        return NSScreen.main?.visibleFrame ?? CGRect(x: 0, y: 0, width: 800, height: 600)
+    }
 }
 
 private final class OverlayPanel: NSPanel {
@@ -144,7 +153,7 @@ private final class OverlayPanel: NSPanel {
 /// without touching the AppKit positioning code.
 private struct GhostSuggestionView: View {
     @Environment(\.colorScheme) var colorScheme
-    let text: String
+    let layout: GhostSuggestionLayout
     let fontSize: CGFloat
     let customColor: Color?
 
@@ -158,14 +167,22 @@ private struct GhostSuggestionView: View {
     }
 
     var body: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 6) {
-            Text(text)
-                .font(.system(size: fontSize))
-                .foregroundStyle(ghostColor)
-                .lineLimit(1)
-                .fixedSize(horizontal: true, vertical: true)
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(layout.lines) { line in
+                HStack(alignment: .firstTextBaseline, spacing: line.showsKeycap ? 6 : 0) {
+                    Text(line.text)
+                        .font(.system(size: fontSize))
+                        .foregroundStyle(ghostColor)
+                        .lineLimit(1)
+                        .fixedSize(horizontal: true, vertical: true)
 
-            GhostTabKeycap()
+                    if line.showsKeycap {
+                        GhostTabKeycap()
+                    }
+                }
+                .padding(.leading, line.leadingIndent)
+                .fixedSize(horizontal: true, vertical: true)
+            }
         }
         .fixedSize(horizontal: true, vertical: true)
     }

--- a/tabby/Support/GhostSuggestionLayout.swift
+++ b/tabby/Support/GhostSuggestionLayout.swift
@@ -1,0 +1,255 @@
+import AppKit
+import CoreGraphics
+import Foundation
+
+/// Computes the visual line layout for ghost text before `OverlayController` renders it.
+///
+/// Keeping this as a pure value helper gives us a clear boundary: the helper answers "where should
+/// the text lines go?", while `OverlayController` answers "how do we place the non-activating
+/// AppKit panel?". That split matters because wrapping bugs are layout bugs, not window lifecycle
+/// bugs.
+struct GhostSuggestionLayout: Equatable {
+    struct Line: Equatable, Identifiable {
+        let index: Int
+        let text: String
+        let leadingIndent: CGFloat
+        let showsKeycap: Bool
+
+        var id: Int { index }
+    }
+
+    let lines: [Line]
+    let panelOriginX: CGFloat
+    let lineHeight: CGFloat
+    let topLineCenterOffsetFromCaret: CGFloat
+
+    private enum Metrics {
+        static let caretGap: CGFloat = 6
+        static let inputHorizontalPadding: CGFloat = 8
+        static let fallbackScreenMargin: CGFloat = 16
+        static let minimumLineWidth: CGFloat = 48
+        static let estimatedKeycapAndSpacingWidth: CGFloat = 36
+        static let lineHeightMultiplier: CGFloat = 1.25
+    }
+
+    static func make(
+        text: String,
+        geometry: SuggestionOverlayGeometry,
+        fontSize: CGFloat,
+        visibleFrame: CGRect
+    ) -> GhostSuggestionLayout {
+        let normalizedText = normalizedDisplayText(text)
+        let lineHeight = ceil(fontSize * Metrics.lineHeightMultiplier)
+        let usableFrame = usableTextFrame(
+            geometry: geometry,
+            visibleFrame: visibleFrame
+        )
+        let firstLineX = min(
+            max(geometry.caretRect.maxX + Metrics.caretGap, usableFrame.minX),
+            usableFrame.maxX
+        )
+        let firstLineBudget = max(
+            0,
+            usableFrame.maxX - firstLineX - Metrics.estimatedKeycapAndSpacingWidth
+        )
+        let overflowBudget = max(
+            Metrics.minimumLineWidth,
+            usableFrame.width - Metrics.estimatedKeycapAndSpacingWidth
+        )
+
+        let singleLineFits = measuredWidth(
+            of: normalizedText,
+            fontSize: fontSize,
+            observedCharWidth: geometry.observedCharWidth
+        ) <= firstLineBudget
+
+        if singleLineFits {
+            return GhostSuggestionLayout(
+                lines: [
+                    Line(index: 0, text: normalizedText, leadingIndent: 0, showsKeycap: true)
+                ],
+                panelOriginX: firstLineX,
+                lineHeight: lineHeight,
+                topLineCenterOffsetFromCaret: 0
+            )
+        }
+
+        let panelOriginX = usableFrame.minX
+        var remainingText = normalizedText
+        var rawLines: [(text: String, leadingIndent: CGFloat)] = []
+        var startsBelowCaret = false
+
+        if firstLineBudget >= Metrics.minimumLineWidth {
+            let split = splitPrefix(
+                from: remainingText,
+                maxWidth: firstLineBudget,
+                fontSize: fontSize,
+                observedCharWidth: geometry.observedCharWidth
+            )
+            if !split.line.isEmpty {
+                rawLines.append((split.line, firstLineX - panelOriginX))
+                remainingText = split.remainder
+            } else {
+                startsBelowCaret = true
+            }
+        } else {
+            startsBelowCaret = true
+        }
+
+        while !remainingText.isEmpty {
+            let split = splitPrefix(
+                from: remainingText,
+                maxWidth: overflowBudget,
+                fontSize: fontSize,
+                observedCharWidth: geometry.observedCharWidth
+            )
+            guard !split.line.isEmpty else {
+                break
+            }
+
+            rawLines.append((split.line, 0))
+            remainingText = split.remainder
+        }
+
+        if rawLines.isEmpty {
+            rawLines.append((normalizedText, 0))
+            startsBelowCaret = true
+        }
+
+        let finalLines = rawLines.enumerated().map { offset, rawLine in
+            Line(
+                index: offset,
+                text: rawLine.text,
+                leadingIndent: rawLine.leadingIndent,
+                showsKeycap: offset == rawLines.count - 1
+            )
+        }
+
+        return GhostSuggestionLayout(
+            lines: finalLines,
+            panelOriginX: panelOriginX,
+            lineHeight: lineHeight,
+            topLineCenterOffsetFromCaret: startsBelowCaret ? -lineHeight : 0
+        )
+    }
+
+    func panelFrame(for contentSize: CGSize, caretRect: CGRect) -> CGRect {
+        let topLineCenterY = caretRect.midY + topLineCenterOffsetFromCaret
+        let originY = topLineCenterY - contentSize.height + (lineHeight / 2)
+
+        return CGRect(
+            origin: CGPoint(x: panelOriginX, y: originY),
+            size: contentSize
+        )
+    }
+
+    private static func usableTextFrame(
+        geometry: SuggestionOverlayGeometry,
+        visibleFrame: CGRect
+    ) -> CGRect {
+        let fallbackMinX = geometry.caretRect.maxX + Metrics.caretGap
+        let fallbackMaxX = visibleFrame.maxX - Metrics.fallbackScreenMargin
+        let fallbackFrame = CGRect(
+            x: fallbackMinX,
+            y: geometry.caretRect.minY,
+            width: max(Metrics.minimumLineWidth, fallbackMaxX - fallbackMinX),
+            height: geometry.caretRect.height
+        )
+
+        guard let inputFrame = geometry.inputFrameRect?.standardized,
+              inputFrame.width > Metrics.minimumLineWidth
+        else {
+            return fallbackFrame
+        }
+
+        let minX = max(
+            inputFrame.minX + Metrics.inputHorizontalPadding,
+            visibleFrame.minX + Metrics.fallbackScreenMargin
+        )
+        let maxX = min(
+            inputFrame.maxX - Metrics.inputHorizontalPadding,
+            visibleFrame.maxX - Metrics.fallbackScreenMargin
+        )
+
+        guard maxX - minX > Metrics.minimumLineWidth else {
+            return fallbackFrame
+        }
+
+        return CGRect(
+            x: minX,
+            y: inputFrame.minY,
+            width: maxX - minX,
+            height: inputFrame.height
+        )
+    }
+
+    private static func normalizedDisplayText(_ text: String) -> String {
+        let words = text.split(whereSeparator: \.isWhitespace).map(String.init)
+        guard !words.isEmpty else {
+            return text
+        }
+
+        let joined = words.joined(separator: " ")
+        return text.first?.isWhitespace == true ? " \(joined)" : joined
+    }
+
+    private static func splitPrefix(
+        from text: String,
+        maxWidth: CGFloat,
+        fontSize: CGFloat,
+        observedCharWidth: CGFloat?
+    ) -> (line: String, remainder: String) {
+        let source = text.trimmingCharacters(in: .whitespaces)
+        guard !source.isEmpty else {
+            return ("", "")
+        }
+
+        let safeMaxWidth = max(maxWidth, Metrics.minimumLineWidth)
+        if measuredWidth(of: source, fontSize: fontSize, observedCharWidth: observedCharWidth) <= safeMaxWidth {
+            return (source, "")
+        }
+
+        let characters = Array(source)
+        var lastWhitespaceBreak: Int?
+
+        for endIndex in characters.indices {
+            let prefix = String(characters[...endIndex])
+            if characters[endIndex].isWhitespace {
+                lastWhitespaceBreak = endIndex + 1
+            }
+
+            if measuredWidth(of: prefix, fontSize: fontSize, observedCharWidth: observedCharWidth) > safeMaxWidth {
+                if let breakIndex = lastWhitespaceBreak, breakIndex > 0 {
+                    let line = String(characters[..<breakIndex])
+                        .trimmingCharacters(in: .whitespaces)
+                    let remainder = String(characters[breakIndex...])
+                        .trimmingCharacters(in: .whitespaces)
+                    return (line, remainder)
+                }
+
+                let splitIndex = max(endIndex, 1)
+                let line = String(characters[..<splitIndex])
+                    .trimmingCharacters(in: .whitespaces)
+                let remainder = String(characters[splitIndex...])
+                    .trimmingCharacters(in: .whitespaces)
+                return (line, remainder)
+            }
+        }
+
+        return (text.trimmingCharacters(in: .whitespaces), "")
+    }
+
+    private static func measuredWidth(
+        of text: String,
+        fontSize: CGFloat,
+        observedCharWidth: CGFloat?
+    ) -> CGFloat {
+        if let observedCharWidth, observedCharWidth > 0 {
+            return CGFloat((text as NSString).length) * observedCharWidth
+        }
+
+        return (text as NSString).size(withAttributes: [
+            .font: NSFont.systemFont(ofSize: fontSize)
+        ]).width
+    }
+}

--- a/tabby/Support/SuggestionSessionReconciler.swift
+++ b/tabby/Support/SuggestionSessionReconciler.swift
@@ -264,7 +264,7 @@ enum SuggestionSessionReconciler {
     /// The overlay may be hidden briefly while waiting for the host app to publish an updated
     /// caret position, so hidden does not automatically mean "reject Tab."
     static func overlayAllowsAcceptance(of text: String, overlayState: OverlayState) -> Bool {
-        guard case let .visible(visibleText, _, _) = overlayState else {
+        guard case let .visible(visibleText, _) = overlayState else {
             return true
         }
 

--- a/tabbyTests/ModelAndPresentationValueTests.swift
+++ b/tabbyTests/ModelAndPresentationValueTests.swift
@@ -66,8 +66,10 @@ final class SuggestionModelValueTests: XCTestCase {
     func test_overlayStateDetailIncludesTextCountCaretPositionAndQuality() {
         let state = OverlayState.visible(
             text: "hello",
-            caretRect: CGRect(x: 12.9, y: 40.1, width: 2, height: 18),
-            caretQuality: .derived
+            geometry: TabbyTestFixtures.overlayGeometry(
+                caretRect: CGRect(x: 12.9, y: 40.1, width: 2, height: 18),
+                caretQuality: .derived
+            )
         )
 
         XCTAssertEqual(state.shortLabel, "Visible")
@@ -76,6 +78,44 @@ final class SuggestionModelValueTests: XCTestCase {
             "Showing 5 characters near (12, 40) using derived caret geometry."
         )
         XCTAssertEqual(state.visibleText, "hello")
+    }
+
+    func test_ghostSuggestionLayoutWrapsOverflowToInputLeftEdge() {
+        let geometry = TabbyTestFixtures.overlayGeometry(
+            caretRect: CGRect(x: 190, y: 80, width: 2, height: 18),
+            inputFrameRect: CGRect(x: 100, y: 70, width: 140, height: 30),
+            observedCharWidth: 7
+        )
+
+        let layout = GhostSuggestionLayout.make(
+            text: " alpha beta gamma delta",
+            geometry: geometry,
+            fontSize: 14,
+            visibleFrame: CGRect(x: 0, y: 0, width: 500, height: 300)
+        )
+
+        XCTAssertGreaterThan(layout.lines.count, 1)
+        XCTAssertEqual(layout.panelOriginX, 108)
+        XCTAssertEqual(layout.lines.last?.leadingIndent, 0)
+        XCTAssertEqual(layout.lines.last?.showsKeycap, true)
+    }
+
+    func test_ghostSuggestionLayoutUsesNextLineWhenCaretHasNoUsefulSpace() {
+        let geometry = TabbyTestFixtures.overlayGeometry(
+            caretRect: CGRect(x: 232, y: 80, width: 2, height: 18),
+            inputFrameRect: CGRect(x: 100, y: 70, width: 140, height: 30),
+            observedCharWidth: 7
+        )
+
+        let layout = GhostSuggestionLayout.make(
+            text: " next words",
+            geometry: geometry,
+            fontSize: 14,
+            visibleFrame: CGRect(x: 0, y: 0, width: 500, height: 300)
+        )
+
+        XCTAssertEqual(layout.lines.first?.leadingIndent, 0)
+        XCTAssertLessThan(layout.topLineCenterOffsetFromCaret, 0)
     }
 
     func test_suggestionDebugStateLabelsAndDetailsAreStable() {

--- a/tabbyTests/SuggestionSessionReconcilerTests.swift
+++ b/tabbyTests/SuggestionSessionReconcilerTests.swift
@@ -82,13 +82,19 @@ final class SuggestionSessionReconcilerTests: XCTestCase {
         XCTAssertTrue(
             SuggestionSessionReconciler.overlayAllowsAcceptance(
                 of: " world",
-                overlayState: .visible(text: " world", caretRect: caretRect, caretQuality: .exact)
+                overlayState: .visible(
+                    text: " world",
+                    geometry: TabbyTestFixtures.overlayGeometry(caretRect: caretRect)
+                )
             )
         )
         XCTAssertFalse(
             SuggestionSessionReconciler.overlayAllowsAcceptance(
                 of: " world",
-                overlayState: .visible(text: " there", caretRect: caretRect, caretQuality: .exact)
+                overlayState: .visible(
+                    text: " there",
+                    geometry: TabbyTestFixtures.overlayGeometry(caretRect: caretRect)
+                )
             )
         )
     }

--- a/tabbyTests/SuggestionStateHelperTests.swift
+++ b/tabbyTests/SuggestionStateHelperTests.swift
@@ -125,8 +125,7 @@ final class SuggestionInteractionStateTests: XCTestCase {
                 from: snapshot,
                 overlayState: .visible(
                     text: " world again",
-                    caretRect: context.caretRect,
-                    caretQuality: .exact
+                    geometry: TabbyTestFixtures.overlayGeometry(caretRect: context.caretRect)
                 )
             )
 
@@ -150,8 +149,7 @@ final class SuggestionInteractionStateTests: XCTestCase {
                 from: TabbyTestFixtures.focusedInputSnapshot(precedingText: "Hello"),
                 overlayState: .visible(
                     text: " different",
-                    caretRect: context.caretRect,
-                    caretQuality: .exact
+                    geometry: TabbyTestFixtures.overlayGeometry(caretRect: context.caretRect)
                 )
             )
 
@@ -395,8 +393,7 @@ final class SuggestionOverlayPresenterTests: XCTestCase {
 
             let message = presenter.present(
                 text: "   ",
-                at: .zero,
-                caretQuality: .exact,
+                geometry: TabbyTestFixtures.overlayGeometry(caretRect: .zero),
                 previousState: overlayController.state
             )
 
@@ -414,8 +411,7 @@ final class SuggestionOverlayPresenterTests: XCTestCase {
 
             let message = presenter.present(
                 text: " world",
-                at: caretRect,
-                caretQuality: .exact,
+                geometry: TabbyTestFixtures.overlayGeometry(caretRect: caretRect),
                 previousState: overlayController.state
             )
 
@@ -429,15 +425,15 @@ final class SuggestionOverlayPresenterTests: XCTestCase {
     func test_presentIdenticalVisibleStateDoesNotCallOverlayAgain() {
         runOnMainActor {
             let caretRect = CGRect(x: 10, y: 20, width: 2, height: 18)
+            let geometry = TabbyTestFixtures.overlayGeometry(caretRect: caretRect)
             let overlayController = FakeOverlayController(
-                initialState: .visible(text: " world", caretRect: caretRect, caretQuality: .exact)
+                initialState: .visible(text: " world", geometry: geometry)
             )
             let presenter = SuggestionOverlayPresenter(overlayController: overlayController)
 
             let message = presenter.present(
                 text: " world",
-                at: caretRect,
-                caretQuality: .exact,
+                geometry: geometry,
                 previousState: overlayController.state
             )
 
@@ -455,9 +451,11 @@ final class SuggestionOverlayPresenterTests: XCTestCase {
 
             let message = presenter.present(
                 text: " world",
-                at: nextRect,
-                caretQuality: .exact,
-                previousState: .visible(text: " world", caretRect: previousRect, caretQuality: .exact)
+                geometry: TabbyTestFixtures.overlayGeometry(caretRect: nextRect),
+                previousState: .visible(
+                    text: " world",
+                    geometry: TabbyTestFixtures.overlayGeometry(caretRect: previousRect)
+                )
             )
 
             XCTAssertEqual(message, "Moved ghost text to the latest caret position.")
@@ -472,9 +470,14 @@ final class SuggestionOverlayPresenterTests: XCTestCase {
 
             let message = presenter.present(
                 text: " world",
-                at: caretRect,
-                caretQuality: .derived,
-                previousState: .visible(text: " world", caretRect: caretRect, caretQuality: .exact)
+                geometry: TabbyTestFixtures.overlayGeometry(
+                    caretRect: caretRect,
+                    caretQuality: .derived
+                ),
+                previousState: .visible(
+                    text: " world",
+                    geometry: TabbyTestFixtures.overlayGeometry(caretRect: caretRect)
+                )
             )
 
             XCTAssertEqual(message, "Updated ghost text styling for the latest caret quality.")
@@ -537,6 +540,7 @@ private final class FakeOverlayController: SuggestionOverlayControlling {
     private(set) var showCallCount = 0
     private(set) var lastShownText: String?
     private(set) var lastShownCaretRect: CGRect?
+    private(set) var lastShownGeometry: SuggestionOverlayGeometry?
     private(set) var hideReasons: [String] = []
 
     init(initialState: OverlayState = .hidden(reason: "Overlay idle.")) {
@@ -545,13 +549,13 @@ private final class FakeOverlayController: SuggestionOverlayControlling {
 
     func showSuggestion(
         _ text: String,
-        at caretRect: CGRect,
-        caretQuality: CaretGeometryQuality
+        geometry: SuggestionOverlayGeometry
     ) {
         showCallCount += 1
         lastShownText = text
-        lastShownCaretRect = caretRect
-        state = .visible(text: text, caretRect: caretRect, caretQuality: caretQuality)
+        lastShownCaretRect = geometry.caretRect
+        lastShownGeometry = geometry
+        state = .visible(text: text, geometry: geometry)
         onStateChange?(state)
     }
 

--- a/tabbyTests/TabbyTestFixtures.swift
+++ b/tabbyTests/TabbyTestFixtures.swift
@@ -143,6 +143,20 @@ enum TabbyTestFixtures {
         )
     }
 
+    static func overlayGeometry(
+        caretRect: CGRect = CGRect(x: 10, y: 20, width: 2, height: 18),
+        inputFrameRect: CGRect? = CGRect(x: 0, y: 0, width: 240, height: 32),
+        caretQuality: CaretGeometryQuality = .exact,
+        observedCharWidth: CGFloat? = nil
+    ) -> SuggestionOverlayGeometry {
+        SuggestionOverlayGeometry(
+            caretRect: caretRect,
+            inputFrameRect: inputFrameRect,
+            caretQuality: caretQuality,
+            observedCharWidth: observedCharWidth
+        )
+    }
+
     static func focusCapabilityCandidate(
         elementIdentifier: String = "candidate",
         role: String = "AXTextField",


### PR DESCRIPTION
## Summary

- Adds a dedicated ghost suggestion layout helper that wraps overflowing suggestion text onto additional overlay lines instead of letting it run past the focused input frame.
- Threads overlay geometry through coordinator, presenter, overlay state, and controller so the first line can start at the caret while wrapped lines align to the input frame's left edge.
- Updates presentation and session tests to cover wrapped layout, overlay geometry, and acceptance behavior with the new state shape.

## Validation

- `swiftlint .`
  - Found 0 violations, 0 serious in 78 files.
- `git diff --check origin/main...HEAD`
  - Exit 0.
- `xcodebuild test -scheme tabby -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO`
  - **TEST SUCCEEDED**; 151 tests, 0 failures.

## Linked issues

Refs #94

## Risk / rollout notes

- This is an approximate visual wrapping pass based on available caret/input geometry and observed character width. It improves overflow behavior, but it does not fully solve the follow-up bug where some host editors reflow accepted text before AX exposes the refreshed caret/text-node geometry.
- The unsigned test run still prints the existing llama/Metal shutdown assert after XCTest finishes, but `xcodebuild` exits successfully and reports `TEST SUCCEEDED`.
