### PR TITLE
Prompt optimization

### DIFF
--- a/tabby/Support/LlamaPromptRenderer.swift
+++ b/tabby/Support/LlamaPromptRenderer.swift
@@ -22,20 +22,11 @@ enum LlamaPromptRenderer {
         visualContextSummary: String? = nil
     ) -> String {
         var sections = [
-            "You are Tabby's inline autocomplete engine for a macOS text field.",
-            "",
             "Task:",
             "- Continue the user's existing text exactly at the caret position.",
             "- This is autocomplete, not chat. Do not answer the user or start a conversation.",
-            "- Return exactly one continuation fragment.",
             "- Never repeat, restate, or quote the text before the caret.",
-            "- \(completionLengthInstruction)",
-            "- Match the surrounding language, tone, casing, punctuation, and formatting.",
-            "",
-            "Output contract:",
-            "- Plain text only.",
-            "- No labels, bullets, markdown, quotes, or explanation.",
-            "- Start immediately with the continuation text."
+            "- Return plain text only with no labels, bullets, markdown, quotes, or explanation."
         ]
 
         var profileSections: [String] = []
@@ -51,18 +42,23 @@ enum LlamaPromptRenderer {
             sections.append("")
             sections.append("User Profile Context:")
             sections.append(contentsOf: profileSections)
-            sections.append("- Use this context only when it fits naturally into the continuation.")
         }
 
         sections.append("")
-        sections.append("Context:")
+        sections.append("Screen context:")
         sections.append("App: \(applicationName)")
-
         if let summary = visualContextSummary, !summary.isEmpty {
             sections.append("Screen content:")
             sections.append(summary)
         }
 
+        // The final task cue sits immediately before the prefix so small instruct models see the
+        // current length policy right before the text they must continue, while the prefix itself
+        // still remains the last payload in the prompt.
+        sections.append("")
+        sections.append("Final instruction:")
+        sections.append("- \(completionLengthInstruction)")
+        sections.append("- The next line must begin directly with the continuation text.")
         sections.append("Text before caret:")
         sections.append(prefixText)
 

--- a/tabbyTests/LlamaPromptRendererTests.swift
+++ b/tabbyTests/LlamaPromptRendererTests.swift
@@ -60,10 +60,10 @@ final class LlamaPromptRendererTests: XCTestCase {
 
     // MARK: - instruction prompt
 
-    /// The structural contract of the instruction prompt: three labelled sections the
-    /// instruct model is trained to parse. Losing any of them would silently
-    /// degrade output quality without throwing.
-    func test_instructionPrompt_containsTaskAndOutputContract() {
+    /// The structural contract for local instruct models: stable task rules first, supporting
+    /// context in the middle, then a late length cue right before the prefix the model must
+    /// continue. Losing one of these sections tends to degrade prompt-following without throwing.
+    func test_instructionPrompt_containsTaskScreenContextAndFinalInstruction() {
         let prompt = LlamaPromptRenderer.prompt(
             prefixText: "Once upon",
             applicationName: "Messages",
@@ -74,10 +74,14 @@ final class LlamaPromptRendererTests: XCTestCase {
 
         XCTAssertTrue(prompt.contains("Task:"), "instruction prompt should include Task section")
         XCTAssertTrue(
-            prompt.contains("Output contract:"),
-            "instruction prompt should include Output contract section"
+            prompt.contains("Screen context:"),
+            "instruction prompt should include Screen context section"
         )
-        XCTAssertTrue(prompt.contains("Context:"), "instruction prompt should include Context section")
+        XCTAssertTrue(
+            prompt.contains("Final instruction:"),
+            "instruction prompt should include a late final instruction section"
+        )
+        XCTAssertTrue(prompt.contains("Text before caret:"), "instruction prompt should include the prefix header")
     }
 
     func test_instructionPrompt_includesApplicationNameAndPrefix() {
@@ -96,9 +100,9 @@ final class LlamaPromptRendererTests: XCTestCase {
     /// The completion-length instruction is chosen from the user's word-count
     /// preset. It must reach the prompt verbatim so the model sees the exact
     /// guidance the UI showed the user.
-    func test_instructionPrompt_includesCompletionLengthInstruction() {
+    func test_instructionPrompt_includesCompletionLengthInstructionNearPrefix() {
         let prompt = LlamaPromptRenderer.prompt(
-            prefixText: "x",
+            prefixText: "PREFIX_BODY_XYZ",
             applicationName: "App",
             completionLengthInstruction: "UNIQUE_LENGTH_MARKER_7_TO_12_WORDS",
             userName: nil,
@@ -106,6 +110,16 @@ final class LlamaPromptRendererTests: XCTestCase {
         )
 
         XCTAssertTrue(prompt.contains("UNIQUE_LENGTH_MARKER_7_TO_12_WORDS"))
+
+        guard let finalInstructionRange = prompt.range(of: "Final instruction:"),
+              let lengthRange = prompt.range(of: "UNIQUE_LENGTH_MARKER_7_TO_12_WORDS"),
+              let prefixRange = prompt.range(of: "PREFIX_BODY_XYZ") else {
+            XCTFail("Expected final instruction header, length marker, and prefix in the prompt")
+            return
+        }
+
+        XCTAssertLessThan(finalInstructionRange.lowerBound, lengthRange.lowerBound)
+        XCTAssertLessThan(lengthRange.lowerBound, prefixRange.lowerBound)
     }
 
     func test_instructionPrompt_includesProfileContextWhenProvided() {
@@ -123,10 +137,9 @@ final class LlamaPromptRendererTests: XCTestCase {
                       "instruction prompt should carry user-provided profile tags")
     }
 
-    /// The prefix is always the *last* section of the instruction prompt — the model
-    /// continues from the last token, so the prefix has to come last.
-    /// Tests the contract that prefix comes after Context:/App:/Text before caret:.
-    func test_instructionPrompt_prefixAppearsAfterContextHeader() {
+    /// The prefix remains the last payload in the prompt so the model still ends on the actual
+    /// text it must continue, even though the length cue is moved later in the prompt.
+    func test_instructionPrompt_prefixAppearsAfterScreenContextAndEndsPrompt() {
         let prompt = LlamaPromptRenderer.prompt(
             prefixText: "PREFIX_BODY_XYZ",
             applicationName: "App",
@@ -135,14 +148,15 @@ final class LlamaPromptRendererTests: XCTestCase {
             userTags: nil
         )
 
-        guard let contextRange = prompt.range(of: "Context:"),
+        guard let contextRange = prompt.range(of: "Screen context:"),
               let prefixRange = prompt.range(of: "PREFIX_BODY_XYZ") else {
-            XCTFail("Expected both Context: and PREFIX_BODY_XYZ in the prompt")
+            XCTFail("Expected both Screen context: and PREFIX_BODY_XYZ in the prompt")
             return
         }
 
         XCTAssertLessThan(contextRange.lowerBound, prefixRange.lowerBound,
-                          "prefix must appear after the Context: header")
+                          "prefix must appear after the Screen context header")
+        XCTAssertTrue(prompt.hasSuffix("PREFIX_BODY_XYZ"))
     }
 
     func test_instructionPrompt_includesVisualContextSummaryWhenProvided() {


### PR DESCRIPTION
## Summary

<!--
One or two sentences: what changed and why. Skip the play-by-play.
The diff already shows what; this section should explain why.
-->

improves LLM prompt because suggested word count was being ignored by LLM 

## Validation

<!--
What you actually ran and what you actually saw — not what you intended to run.
Examples:

  xcodebuild test -project tabby.xcodeproj -scheme tabby \
    -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO
  # ** TEST SUCCEEDED **  N tests, 0 failures

  swiftlint lint --config .swiftlint.yml --quiet
  # exit 0

For UI changes, attach a screenshot or short screen recording.
For changes that can't be verified end-to-end yet, say so explicitly.
-->

## Linked issues

<!--
Use `Fixes #N` to auto-close on merge, `Refs #N` to link without closing.
-->

## Risk / rollout notes

<!--
Anything reviewers should know that isn't visible from the diff:
- Schema, settings, or pbxproj migrations
- Behavior changes that touch existing user flows
- Performance characteristics worth flagging
- Follow-up issues filed (link them)

Skip this section entirely if there's nothing to flag.
-->
