### PR TITLE
fix: show screen recording in menu permissions

### DIFF
--- a/tabby/UI/MenuBarView.swift
+++ b/tabby/UI/MenuBarView.swift
@@ -159,17 +159,13 @@ struct MenuBarView: View {
                     .font(.subheadline.weight(.medium))
                     .padding(.bottom, 2)
 
-                PermissionRow(
-                    title: "Accessibility",
-                    granted: permissionManager.accessibilityGranted,
-                    action: permissionManager.openAccessibilitySettings
-                )
-
-                PermissionRow(
-                    title: "Input Monitoring",
-                    granted: permissionManager.inputMonitoringGranted,
-                    action: permissionManager.openInputMonitoringSettings
-                )
+                ForEach(TabbyPermissionKind.allCases.filter(\.isRequiredForAutocomplete)) { permission in
+                    PermissionRow(
+                        title: permission.title,
+                        granted: permissionManager.isGranted(permission),
+                        action: { permissionManager.openSettings(for: permission) }
+                    )
+                }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(12)
@@ -278,8 +274,7 @@ struct MenuBarView: View {
     // MARK: - Derived state
 
     private var allPermissionsGranted: Bool {
-        permissionManager.accessibilityGranted
-            && permissionManager.inputMonitoringGranted
+        permissionManager.requiredPermissionsGranted
     }
 
     private func refreshAppleIntelligenceAvailabilityIfNeeded() {


### PR DESCRIPTION
## Summary

Show Screen Recording in the menu-bar permissions card by deriving the menu rows from `TabbyPermissionKind` instead of hard-coding Accessibility and Input Monitoring.

This keeps the menu popup aligned with the app's central required-permission model, so the card remains visible until Accessibility, Input Monitoring, and Screen Recording are all granted.

## Validation

```sh
xcodebuild -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **
```

## Linked issues

None.

## Risk / rollout notes

Low-risk UI state fix. The menu now uses the same `PermissionManager.requiredPermissionsGranted` and `TabbyPermissionKind.isRequiredForAutocomplete` rules already used elsewhere.
