### PR TITLE
Reuse guided permission flow from menu

### DIFF
--- a/tabby/App/Core/AppDelegate.swift
+++ b/tabby/App/Core/AppDelegate.swift
@@ -20,6 +20,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let inputMonitor: InputMonitor
     let appUpdateManager: AppUpdateManager
     let launchAtLoginService: LaunchAtLoginService
+    let permissionGuidanceController: PermissionGuidanceController
     let suggestionSettings: SuggestionSettingsModel
     let foundationModelAvailabilityService: FoundationModelAvailabilityService
     let suggestionCoordinator: SuggestionCoordinator
@@ -42,6 +43,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         inputMonitor = environment.inputMonitor
         appUpdateManager = environment.appUpdateManager
         launchAtLoginService = environment.launchAtLoginService
+        permissionGuidanceController = environment.permissionGuidanceController
         suggestionSettings = environment.suggestionSettings
         foundationModelAvailabilityService = environment.foundationModelAvailabilityService
         suggestionCoordinator = environment.suggestionCoordinator

--- a/tabby/App/Core/TabbyApp.swift
+++ b/tabby/App/Core/TabbyApp.swift
@@ -18,6 +18,7 @@ struct TabbyApp: App {
                 runtimeModel: appDelegate.runtimeModel,
                 modelDownloadManager: appDelegate.modelDownloadManager,
                 focusModel: appDelegate.focusModel,
+                permissionGuidanceController: appDelegate.permissionGuidanceController,
                 suggestionSettings: appDelegate.suggestionSettings,
                 foundationModelAvailabilityService: appDelegate.foundationModelAvailabilityService,
                 suggestionCoordinator: appDelegate.suggestionCoordinator,

--- a/tabby/App/Core/TabbyAppEnvironment.swift
+++ b/tabby/App/Core/TabbyAppEnvironment.swift
@@ -16,6 +16,7 @@ final class TabbyAppEnvironment {
     let inputMonitor: InputMonitor
     let appUpdateManager: AppUpdateManager
     let launchAtLoginService: LaunchAtLoginService
+    let permissionGuidanceController: PermissionGuidanceController
     let suggestionSettings: SuggestionSettingsModel
     let foundationModelAvailabilityService: FoundationModelAvailabilityService
     let suggestionCoordinator: SuggestionCoordinator
@@ -107,6 +108,7 @@ final class TabbyAppEnvironment {
         self.inputMonitor = inputMonitor
         self.appUpdateManager = appUpdateManager
         self.launchAtLoginService = launchAtLoginService
+        self.permissionGuidanceController = permissionGuidanceController
         self.suggestionSettings = suggestionSettings
         self.foundationModelAvailabilityService = foundationModelAvailabilityService
         self.suggestionCoordinator = suggestionCoordinator

--- a/tabby/Services/Permission/PermissionDragSourceView.swift
+++ b/tabby/Services/Permission/PermissionDragSourceView.swift
@@ -7,7 +7,7 @@ import Foundation
 /// This lives in AppKit instead of SwiftUI because the flow depends on `NSDraggingSession`,
 /// pasteboard item providers, and a view snapshot used as the drag image. Those APIs are far more
 /// natural at the AppKit boundary.
-final class PermissionDragSourceView: NSView, NSPasteboardItemDataProvider, NSDraggingSource {
+final class PermissionDragSourceView: NSView, NSDraggingSource {
     private let hostApp: PermissionHostApp
     private let rowView = NSView()
     private let iconChrome = NSView()
@@ -31,10 +31,10 @@ final class PermissionDragSourceView: NSView, NSPasteboardItemDataProvider, NSDr
     }
 
     override func mouseDown(with event: NSEvent) {
-        let pasteboardItem = NSPasteboardItem()
-        pasteboardItem.setDataProvider(self, forTypes: [.fileURL])
-
-        let draggingItem = NSDraggingItem(pasteboardWriter: pasteboardItem)
+        // Use NSURL as the pasteboard writer so System Settings receives AppKit's native file-URL
+        // representations for the current app bundle. Hand-encoding `.fileURL` data is easy to get
+        // subtly wrong and can make TCC grant a different identity than the running process.
+        let draggingItem = NSDraggingItem(pasteboardWriter: hostApp.bundleURL as NSURL)
         draggingItem.setDraggingFrame(draggingFrame(), contents: draggingImage())
 
         let session = beginDraggingSession(with: [draggingItem], event: event, source: self)
@@ -44,18 +44,6 @@ final class PermissionDragSourceView: NSView, NSPasteboardItemDataProvider, NSDr
     override func viewDidChangeEffectiveAppearance() {
         super.viewDidChangeEffectiveAppearance()
         updateAppearance()
-    }
-
-    func pasteboard(
-        _ pasteboard: NSPasteboard?,
-        item: NSPasteboardItem,
-        provideDataForType type: NSPasteboard.PasteboardType
-    ) {
-        guard type == .fileURL else {
-            return
-        }
-
-        item.setData(hostApp.bundleURL.dataRepresentation, forType: .fileURL)
     }
 
     func draggingSession(_ session: NSDraggingSession, willBeginAt screenPoint: NSPoint) {

--- a/tabby/Services/Permission/PermissionGuidanceController.swift
+++ b/tabby/Services/Permission/PermissionGuidanceController.swift
@@ -34,7 +34,7 @@ final class PermissionGuidanceController {
         }
     }
 
-    /// Public entry point used by onboarding buttons.
+    /// Public entry point used by onboarding and menu-bar permission buttons.
     ///
     /// The controller chooses the appropriate experience based on the permission's metadata. That
     /// keeps the view layer simple: onboarding asks for help with a permission, and this type

--- a/tabby/Services/Permission/PermissionGuidanceController.swift
+++ b/tabby/Services/Permission/PermissionGuidanceController.swift
@@ -40,6 +40,16 @@ final class PermissionGuidanceController {
     /// keeps the view layer simple: onboarding asks for help with a permission, and this type
     /// decides whether that means a rich guided overlay or a plain Settings deep link.
     func requestAccess(for permission: TabbyPermissionKind, sourceFrameInScreen: CGRect? = nil) {
+        permissionManager.refresh()
+        guard !permissionManager.isGranted(permission) else {
+            return
+        }
+
+        permissionManager.requestSystemAccess(for: permission)
+        guard !permissionManager.isGranted(permission) else {
+            return
+        }
+
         switch permission.guidanceStyle {
         case .guidedOverlay:
             presentGuidance(for: permission, sourceFrameInScreen: sourceFrameInScreen)

--- a/tabby/Services/Permission/PermissionManager.swift
+++ b/tabby/Services/Permission/PermissionManager.swift
@@ -20,9 +20,14 @@ final class PermissionManager: ObservableObject {
     /// Polling keeps UI state aligned with system settings changes performed outside the app.
     init() {
         refresh()
-        pollTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] _ in
+        let pollTimer = Timer(timeInterval: 2.0, repeats: true) { [weak self] _ in
             DispatchQueue.main.async { self?.refresh() }
         }
+        // Menu panels and drag sessions can move the main run loop out of its default mode.
+        // Common modes keep the permission cache from freezing during exactly the flows that
+        // change permissions.
+        RunLoop.main.add(pollTimer, forMode: .common)
+        self.pollTimer = pollTimer
     }
 
     deinit {
@@ -31,9 +36,23 @@ final class PermissionManager: ObservableObject {
 
     /// Re-reads the current system permission state and republishes any changes to observers.
     func refresh() {
-        accessibilityGranted = AXIsProcessTrusted()
-        inputMonitoringGranted = CGPreflightListenEventAccess()
-        screenRecordingGranted = CGPreflightScreenCaptureAccess()
+        let latestAccessibilityGranted = AXIsProcessTrusted()
+        let latestInputMonitoringGranted = CGPreflightListenEventAccess()
+        let latestScreenRecordingGranted = CGPreflightScreenCaptureAccess()
+
+        // `@Published` notifies on assignment, even when the value is unchanged. Compare first so
+        // the 2-second poll does not redraw SwiftUI surfaces that already have the right state.
+        if accessibilityGranted != latestAccessibilityGranted {
+            accessibilityGranted = latestAccessibilityGranted
+        }
+
+        if inputMonitoringGranted != latestInputMonitoringGranted {
+            inputMonitoringGranted = latestInputMonitoringGranted
+        }
+
+        if screenRecordingGranted != latestScreenRecordingGranted {
+            screenRecordingGranted = latestScreenRecordingGranted
+        }
     }
 
     /// Returns the latest cached grant state for a specific permission kind.

--- a/tabby/Services/Permission/PermissionManager.swift
+++ b/tabby/Services/Permission/PermissionManager.swift
@@ -55,6 +55,34 @@ final class PermissionManager: ObservableObject {
         }
     }
 
+    /// Asks macOS to register or prompt for the current process before showing manual guidance.
+    ///
+    /// The drag helper is useful once the user is in System Settings, but TCC permissions are
+    /// ultimately granted to the current app's code identity. Calling the native request API first
+    /// makes macOS resolve that identity itself instead of relying only on a file dragged into the
+    /// Settings table.
+    @discardableResult
+    func requestSystemAccess(for permission: TabbyPermissionKind) -> Bool {
+        let granted: Bool
+
+        switch permission {
+        case .accessibility:
+            let options = [
+                kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true
+            ] as CFDictionary
+            granted = AXIsProcessTrustedWithOptions(options)
+
+        case .inputMonitoring:
+            granted = CGRequestListenEventAccess()
+
+        case .screenRecording:
+            granted = CGRequestScreenCaptureAccess()
+        }
+
+        refresh()
+        return granted
+    }
+
     /// Returns the latest cached grant state for a specific permission kind.
     ///
     /// Keeping this switch here means higher-level UI can reason in terms of `TabbyPermissionKind`

--- a/tabby/UI/MenuBarPresentationObserver.swift
+++ b/tabby/UI/MenuBarPresentationObserver.swift
@@ -1,0 +1,88 @@
+import AppKit
+import SwiftUI
+
+/// Observes the AppKit window that backs SwiftUI's menu-bar panel.
+///
+/// `MenuBarExtra` may keep its SwiftUI content alive between openings, which means `onAppear` is
+/// not a perfect "the user opened the menu" signal. This tiny bridge watches the real `NSWindow`
+/// instead and calls `onPresent` whenever the panel becomes key or visible again.
+struct MenuBarPresentationObserver: NSViewRepresentable {
+    let onPresent: () -> Void
+
+    func makeNSView(context: Context) -> MenuBarPresentationTrackingView {
+        let view = MenuBarPresentationTrackingView()
+        view.onPresent = onPresent
+        return view
+    }
+
+    func updateNSView(_ nsView: MenuBarPresentationTrackingView, context: Context) {
+        nsView.onPresent = onPresent
+    }
+}
+
+/// Invisible AppKit view that attaches window notifications to a SwiftUI menu-bar panel.
+///
+/// The view deliberately reports only visibility/key-window transitions. The permission manager
+/// already owns periodic polling; this bridge only covers the UI lifecycle edge where reopening
+/// the menu should force one immediate permission read.
+final class MenuBarPresentationTrackingView: NSView {
+    var onPresent: (() -> Void)?
+
+    private weak var observedWindow: NSWindow?
+    private var observers: [NSObjectProtocol] = []
+
+    deinit {
+        removeObservers()
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        observeCurrentWindow()
+        refreshIfVisible()
+    }
+
+    func refreshIfVisible() {
+        guard let window, window.isVisible || window.occlusionState.contains(.visible) else {
+            return
+        }
+
+        onPresent?()
+    }
+
+    private func observeCurrentWindow() {
+        guard observedWindow !== window else {
+            return
+        }
+
+        removeObservers()
+        observedWindow = window
+
+        guard let window else {
+            return
+        }
+
+        let center = NotificationCenter.default
+        observers = [
+            center.addObserver(
+                forName: NSWindow.didBecomeKeyNotification,
+                object: window,
+                queue: .main
+            ) { [weak self] _ in
+                self?.refreshIfVisible()
+            },
+            center.addObserver(
+                forName: NSWindow.didChangeOcclusionStateNotification,
+                object: window,
+                queue: .main
+            ) { [weak self] _ in
+                self?.refreshIfVisible()
+            }
+        ]
+    }
+
+    private func removeObservers() {
+        observers.forEach(NotificationCenter.default.removeObserver(_:))
+        observers.removeAll()
+        observedWindow = nil
+    }
+}

--- a/tabby/UI/MenuBarSections.swift
+++ b/tabby/UI/MenuBarSections.swift
@@ -50,13 +50,17 @@ struct MenuBarPickerRow<Content: View>: View {
     }
 }
 
-/// A single permission row with a checkmark/x indicator and an inline "Grant" button
-/// when the permission is missing. The button calls directly into PermissionManager's
-/// existing System Settings openers.
+/// A single permission row with a checkmark/x indicator and an inline "Grant" button.
+///
+/// The row measures the Grant button in screen coordinates so callers can anchor AppKit overlays
+/// to the exact clicked control. That keeps the menu row presentational while still giving the
+/// permission-guidance service the geometry it needs for its cross-window animation.
 struct PermissionRow: View {
     let title: String
     let granted: Bool
-    let action: () -> Void
+    let action: (CGRect?) -> Void
+
+    @State private var actionButtonFrame = CGRect.zero
 
     var body: some View {
         HStack(spacing: 8) {
@@ -71,11 +75,12 @@ struct PermissionRow: View {
 
             if !granted {
                 Button("Grant") {
-                    action()
+                    action(actionButtonFrame.isEmpty ? nil : actionButtonFrame)
                 }
                 .font(.caption)
                 .buttonStyle(.borderless)
                 .foregroundStyle(.tint)
+                .background(ScreenFrameReader(frameInScreen: $actionButtonFrame))
             }
         }
     }

--- a/tabby/UI/MenuBarView.swift
+++ b/tabby/UI/MenuBarView.swift
@@ -34,6 +34,10 @@ struct MenuBarView: View {
         .padding(16)
         .frame(width: 340)
         .onAppear {
+            // The menu is a status surface, so re-read system permissions whenever it opens.
+            // The background poll eventually catches changes too, but this avoids showing stale
+            // "Grant" rows after the user just updated System Settings.
+            permissionManager.refresh()
             refreshAppleIntelligenceAvailabilityIfNeeded()
         }
         .onChange(of: suggestionSettings.selectedEngine) { _, _ in

--- a/tabby/UI/MenuBarView.swift
+++ b/tabby/UI/MenuBarView.swift
@@ -33,6 +33,11 @@ struct MenuBarView: View {
         }
         .padding(16)
         .frame(width: 340)
+        .background(
+            MenuBarPresentationObserver {
+                permissionManager.refresh()
+            }
+        )
         .onAppear {
             // The menu is a status surface, so re-read system permissions whenever it opens.
             // The background poll eventually catches changes too, but this avoids showing stale

--- a/tabby/UI/MenuBarView.swift
+++ b/tabby/UI/MenuBarView.swift
@@ -17,6 +17,7 @@ struct MenuBarView: View {
     @ObservedObject var runtimeModel: RuntimeBootstrapModel
     @ObservedObject var modelDownloadManager: ModelDownloadManager
     @ObservedObject var focusModel: FocusTrackingModel
+    let permissionGuidanceController: PermissionGuidanceController
     @ObservedObject var suggestionSettings: SuggestionSettingsModel
     @ObservedObject var foundationModelAvailabilityService: FoundationModelAvailabilityService
     @ObservedObject var suggestionCoordinator: SuggestionCoordinator
@@ -163,7 +164,12 @@ struct MenuBarView: View {
                     PermissionRow(
                         title: permission.title,
                         granted: permissionManager.isGranted(permission),
-                        action: { permissionManager.openSettings(for: permission) }
+                        action: { sourceFrameInScreen in
+                            permissionGuidanceController.requestAccess(
+                                for: permission,
+                                sourceFrameInScreen: sourceFrameInScreen
+                            )
+                        }
                     )
                 }
             }

--- a/tabby/UI/ScreenFrameReader.swift
+++ b/tabby/UI/ScreenFrameReader.swift
@@ -1,0 +1,62 @@
+import AppKit
+import SwiftUI
+
+/// Bridges SwiftUI layout into AppKit screen coordinates for cross-window UI.
+///
+/// SwiftUI's `GeometryReader` is excellent for local layout, but Tabby's permission guidance
+/// overlay is an `NSPanel` positioned outside the SwiftUI hierarchy. This representable installs a
+/// tiny AppKit view behind a SwiftUI control and reports that control's bounds in global screen
+/// coordinates, which gives AppKit an anchor rect without coupling the view to window management.
+struct ScreenFrameReader: NSViewRepresentable {
+    @Binding var frameInScreen: CGRect
+
+    func makeNSView(context: Context) -> ScreenFrameTrackingView {
+        let view = ScreenFrameTrackingView()
+        view.onFrameChange = { frame in
+            frameInScreen = frame
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: ScreenFrameTrackingView, context: Context) {
+        nsView.onFrameChange = { frame in
+            frameInScreen = frame
+        }
+        nsView.reportFrame()
+    }
+}
+
+/// Invisible AppKit measuring view used by `ScreenFrameReader`.
+///
+/// The view reports after window attachment and layout because menu-bar popovers and onboarding
+/// windows can move independently. Re-reading the rect protects the overlay animation from stale
+/// geometry when the parent window is repositioned before the user clicks.
+final class ScreenFrameTrackingView: NSView {
+    var onFrameChange: ((CGRect) -> Void)?
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        reportFrame()
+    }
+
+    override func layout() {
+        super.layout()
+        reportFrame()
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        reportFrame()
+    }
+
+    func reportFrame() {
+        guard let window else {
+            return
+        }
+
+        let frame = window.convertToScreen(convert(bounds, to: nil))
+        DispatchQueue.main.async { [onFrameChange] in
+            onFrameChange?(frame)
+        }
+    }
+}

--- a/tabby/UI/WelcomePermissionStepView.swift
+++ b/tabby/UI/WelcomePermissionStepView.swift
@@ -1,4 +1,3 @@
-import AppKit
 import SwiftUI
 
 /// File overview:
@@ -149,58 +148,5 @@ private struct PermissionDoneBadge: View {
                 .font(.system(size: 12, weight: .medium))
         }
         .foregroundStyle(.green)
-    }
-}
-
-/// SwiftUI wrapper around a tiny AppKit view that reports its bounds in screen coordinates.
-///
-/// The permission guidance animation needs a global screen rect to anchor the drag helper overlay
-/// on a separate NSPanel. GeometryReader only knows local layout, so we bridge through AppKit.
-private struct ScreenFrameReader: NSViewRepresentable {
-    @Binding var frameInScreen: CGRect
-
-    func makeNSView(context: Context) -> ScreenFrameTrackingView {
-        let view = ScreenFrameTrackingView()
-        view.onFrameChange = { frame in
-            frameInScreen = frame
-        }
-        return view
-    }
-
-    func updateNSView(_ nsView: ScreenFrameTrackingView, context: Context) {
-        nsView.onFrameChange = { frame in
-            frameInScreen = frame
-        }
-        nsView.reportFrame()
-    }
-}
-
-private final class ScreenFrameTrackingView: NSView {
-    var onFrameChange: ((CGRect) -> Void)?
-
-    override func viewDidMoveToWindow() {
-        super.viewDidMoveToWindow()
-        reportFrame()
-    }
-
-    override func layout() {
-        super.layout()
-        reportFrame()
-    }
-
-    override func updateTrackingAreas() {
-        super.updateTrackingAreas()
-        reportFrame()
-    }
-
-    func reportFrame() {
-        guard let window else {
-            return
-        }
-
-        let frame = window.convertToScreen(convert(bounds, to: nil))
-        DispatchQueue.main.async { [onFrameChange] in
-            onFrameChange?(frame)
-        }
     }
 }


### PR DESCRIPTION
## Summary

Menu-bar permission Grant actions now reuse the same guided permission controller as onboarding, including the System Settings drag-helper overlay. The menu also refreshes permission state from the AppKit window presentation signal, so reopening the menu no longer depends on SwiftUI `onAppear` firing again.

The permission flow now asks macOS through the native current-process request APIs before falling back to the manual drag overlay. The drag helper also uses `NSURL` as the drag pasteboard writer so System Settings receives AppKit's native file-URL representation for the running app bundle.

The screen-frame reader was extracted into a shared UI helper so both onboarding cards and compact menu rows can provide AppKit anchor geometry without duplicating bridge code. Permission polling now runs in common run-loop modes and only publishes when grant values actually change.

## Validation

- `xcodebuild -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' build`
  - `** BUILD SUCCEEDED **`
- `xcodebuild -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' build-for-testing`
  - `** TEST BUILD SUCCEEDED **`

No screenshot attached; the changed behavior launches macOS System Settings and depends on local TCC state. I also tried to inspect the local TCC database directly, but macOS denied DB access without Full Disk Access, so validation is compile/test-build plus code-path inspection.

## Linked issues

None.

## Risk / rollout notes

Screen Recording remains required for autocomplete. This PR does not weaken permission gating; it changes how Tabby requests and refreshes permissions so TCC sees the current running process instead of relying only on a manual drag into System Settings.

The permission menu now has a small AppKit bridge because `MenuBarExtra` can keep SwiftUI content alive between openings. That bridge observes only the menu window visibility/key transitions and delegates the actual permission read back to `PermissionManager`.
