### PR TITLE
Add clipboard context to suggestions

### DIFF
--- a/tabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
@@ -71,10 +71,14 @@ extension SuggestionCoordinator {
 
         let context = interactionState.materializeContext(from: rawContext)
         let visualContextSummary = visualContextCoordinator.excerpt(for: context)
+        let clipboardContext = settingsSnapshot.isClipboardContextEnabled
+            ? clipboardContextProvider.currentContext()
+            : nil
         let requestBuildResult = SuggestionRequestFactory.buildRequest(
             context: context,
             settings: settingsSnapshot,
             configuration: configuration,
+            clipboardContext: clipboardContext,
             visualContextSummary: visualContextSummary
         )
         latestGenerationNumber = context.generation

--- a/tabby/App/Coordinators/SuggestionCoordinator.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator.swift
@@ -41,6 +41,7 @@ final class SuggestionCoordinator: ObservableObject {
     let suggestionInserter: any SuggestionInserting
     let suggestionEngine: any SuggestionGenerating
     let suggestionSettings: any SuggestionSettingsProviding
+    let clipboardContextProvider: any ClipboardContextProviding
     let visualContextCoordinator: any VisualContextCoordinating
     let interactionState: SuggestionInteractionState
     let workController: SuggestionWorkController
@@ -68,6 +69,7 @@ final class SuggestionCoordinator: ObservableObject {
         suggestionInserter: any SuggestionInserting,
         suggestionEngine: any SuggestionGenerating,
         suggestionSettings: any SuggestionSettingsProviding,
+        clipboardContextProvider: any ClipboardContextProviding,
         visualContextCoordinator: any VisualContextCoordinating,
         interactionState: SuggestionInteractionState,
         workController: SuggestionWorkController,
@@ -84,6 +86,7 @@ final class SuggestionCoordinator: ObservableObject {
         self.suggestionInserter = suggestionInserter
         self.suggestionEngine = suggestionEngine
         self.suggestionSettings = suggestionSettings
+        self.clipboardContextProvider = clipboardContextProvider
         self.visualContextCoordinator = visualContextCoordinator
         self.interactionState = interactionState
         self.workController = workController

--- a/tabby/App/Core/TabbyAppEnvironment.swift
+++ b/tabby/App/Core/TabbyAppEnvironment.swift
@@ -19,6 +19,7 @@ final class TabbyAppEnvironment {
     let permissionGuidanceController: PermissionGuidanceController
     let suggestionSettings: SuggestionSettingsModel
     let foundationModelAvailabilityService: FoundationModelAvailabilityService
+    let clipboardContextProvider: ClipboardContextProvider
     let suggestionCoordinator: SuggestionCoordinator
     let welcomeCoordinator: WelcomeCoordinator
     let settingsCoordinator: SettingsCoordinator
@@ -71,6 +72,7 @@ final class TabbyAppEnvironment {
         let suggestionInserter = SuggestionInserter(suppressionController: suppressionController)
         let overlayController = OverlayController(suggestionSettings: suggestionSettings)
         let activationIndicatorController = ActivationIndicatorController()
+        let clipboardContextProvider = ClipboardContextProvider()
         let summarizer = LlamaVisualContextSummarizer(runtimeManager: runtimeManager)
         let screenshotContextGenerator = ScreenshotContextGenerator(summarizer: summarizer)
         let visualContextCoordinator = VisualContextCoordinator(
@@ -95,6 +97,7 @@ final class TabbyAppEnvironment {
             suggestionInserter: suggestionInserter,
             suggestionEngine: suggestionEngine,
             suggestionSettings: suggestionSettings,
+            clipboardContextProvider: clipboardContextProvider,
             visualContextCoordinator: visualContextCoordinator,
             interactionState: interactionState,
             workController: workController,
@@ -111,6 +114,7 @@ final class TabbyAppEnvironment {
         self.permissionGuidanceController = permissionGuidanceController
         self.suggestionSettings = suggestionSettings
         self.foundationModelAvailabilityService = foundationModelAvailabilityService
+        self.clipboardContextProvider = clipboardContextProvider
         self.suggestionCoordinator = suggestionCoordinator
         self.welcomeCoordinator = welcomeCoordinator
         self.settingsCoordinator = settingsCoordinator

--- a/tabby/Models/SuggestionEngineModels.swift
+++ b/tabby/Models/SuggestionEngineModels.swift
@@ -51,6 +51,7 @@ struct SuggestionSettingsSnapshot: Equatable, Sendable {
     let disabledAppBundleIdentifiers: Set<String>
     let selectedEngine: SuggestionEngineKind
     let selectedWordCountPreset: SuggestionWordCountPreset
+    let isClipboardContextEnabled: Bool
     /// User-authored profile data for Tabby's single instruction-rendered completion prompt.
     /// This travels in the snapshot so generation uses the same value the Settings UI shows.
     let userName: String

--- a/tabby/Models/SuggestionModels.swift
+++ b/tabby/Models/SuggestionModels.swift
@@ -236,6 +236,8 @@ struct SuggestionRequest: Equatable, Sendable {
     /// future settings/personalization work can evolve independently from prompt safety rules.
     let userName: String?
     let userTags: [String]?
+    /// Ephemeral clipboard context captured only when the user has enabled clipboard prompting.
+    let clipboardContext: String?
     /// Ephemeral screen context summary injected only when available for the active text field.
     let visualContextSummary: String?
 }

--- a/tabby/Models/SuggestionSettingsModel.swift
+++ b/tabby/Models/SuggestionSettingsModel.swift
@@ -17,6 +17,7 @@ final class SuggestionSettingsModel: ObservableObject {
     @Published private(set) var customSuggestionTextColorHex: String?
     @Published private(set) var selectedEngine: SuggestionEngineKind
     @Published private(set) var selectedWordCountPreset: SuggestionWordCountPreset
+    @Published private(set) var isClipboardContextEnabled: Bool
     @Published private(set) var userName: String
     @Published private(set) var userTags: [String]
     private let userDefaults: UserDefaults
@@ -29,6 +30,7 @@ final class SuggestionSettingsModel: ObservableObject {
     private static let customSuggestionTextColorHexDefaultsKey = "tabbyCustomSuggestionTextColorHex"
     private static let selectedEngineDefaultsKey = "selectedSuggestionEngine"
     private static let selectedWordCountPresetDefaultsKey = "selectedSuggestionWordCountPreset"
+    private static let clipboardContextEnabledDefaultsKey = "tabbyClipboardContextEnabled"
     private static let userNameDefaultsKey = "tabbyUserName"
     private static let userTagsDefaultsKey = "tabbyUserTags"
 
@@ -56,6 +58,8 @@ final class SuggestionSettingsModel: ObservableObject {
             .string(forKey: Self.selectedWordCountPresetDefaultsKey)
             .flatMap(SuggestionWordCountPreset.init(rawValue:))
             ?? configuration.defaultWordCountPreset
+        let resolvedClipboardContextEnabled =
+            userDefaults.object(forKey: Self.clipboardContextEnabledDefaultsKey) as? Bool ?? true
         let resolvedUserName: String = if userDefaults.object(forKey: Self.userNameDefaultsKey) == nil {
             configuration.defaultUserName ?? ""
         } else {
@@ -74,6 +78,7 @@ final class SuggestionSettingsModel: ObservableObject {
         customSuggestionTextColorHex = resolvedCustomSuggestionTextColorHex
         selectedEngine = resolvedEngine
         selectedWordCountPreset = resolvedWordCountPreset
+        isClipboardContextEnabled = resolvedClipboardContextEnabled
         userName = resolvedUserName
         userTags = resolvedUserTags
 
@@ -83,6 +88,7 @@ final class SuggestionSettingsModel: ObservableObject {
         persistCustomSuggestionTextColorHex(resolvedCustomSuggestionTextColorHex)
         persistSelectedEngine(resolvedEngine)
         persistSelectedWordCountPreset(resolvedWordCountPreset)
+        persistClipboardContextEnabled(resolvedClipboardContextEnabled)
         persistUserName(resolvedUserName)
         persistUserTags(resolvedUserTags)
     }
@@ -99,6 +105,7 @@ final class SuggestionSettingsModel: ObservableObject {
             disabledAppBundleIdentifiers: Set(disabledAppRules.map(\.bundleIdentifier)),
             selectedEngine: selectedEngine,
             selectedWordCountPreset: selectedWordCountPreset,
+            isClipboardContextEnabled: isClipboardContextEnabled,
             userName: userName,
             userTags: userTags
         )
@@ -120,6 +127,15 @@ final class SuggestionSettingsModel: ObservableObject {
 
         selectedWordCountPreset = preset
         persistSelectedWordCountPreset(preset)
+    }
+
+    func setClipboardContextEnabled(_ enabled: Bool) {
+        guard isClipboardContextEnabled != enabled else {
+            return
+        }
+
+        isClipboardContextEnabled = enabled
+        persistClipboardContextEnabled(enabled)
     }
 
     func setGloballyEnabled(_ enabled: Bool) {
@@ -260,6 +276,10 @@ final class SuggestionSettingsModel: ObservableObject {
         userDefaults.set(preset.rawValue, forKey: Self.selectedWordCountPresetDefaultsKey)
     }
 
+    private func persistClipboardContextEnabled(_ enabled: Bool) {
+        userDefaults.set(enabled, forKey: Self.clipboardContextEnabledDefaultsKey)
+    }
+
     private func persistSelectedIndicatorMode(_ mode: ActivationIndicatorMode) {
         userDefaults.set(mode.rawValue, forKey: Self.selectedIndicatorModeDefaultsKey)
         userDefaults.set(mode != .hidden, forKey: Self.showCaretIndicatorDefaultsKey)
@@ -389,16 +409,18 @@ extension SuggestionSettingsModel: SuggestionSettingsProviding {
                 $selectedEngine,
                 $selectedWordCountPreset
             ),
-            $userName,
-            $userTags
+            $isClipboardContextEnabled,
+            Publishers.CombineLatest($userName, $userTags)
         )
-        .map { combinedSettings, userName, userTags in
+        .map { combinedSettings, clipboardContextEnabled, profile in
             let (globallyEnabled, disabledAppRules, engine, wordCountPreset) = combinedSettings
+            let (userName, userTags) = profile
             return SuggestionSettingsSnapshot(
                 isGloballyEnabled: globallyEnabled,
                 disabledAppBundleIdentifiers: Set(disabledAppRules.map(\.bundleIdentifier)),
                 selectedEngine: engine,
                 selectedWordCountPreset: wordCountPreset,
+                isClipboardContextEnabled: clipboardContextEnabled,
                 userName: userName,
                 userTags: userTags
             )

--- a/tabby/Models/SuggestionSubsystemContracts.swift
+++ b/tabby/Models/SuggestionSubsystemContracts.swift
@@ -51,6 +51,11 @@ protocol SuggestionSettingsProviding: AnyObject {
 }
 
 @MainActor
+protocol ClipboardContextProviding: AnyObject {
+    func currentContext() -> String?
+}
+
+@MainActor
 protocol SuggestionInserting: AnyObject {
     var lastErrorMessage: String? { get }
 

--- a/tabby/Services/Utilities/ClipboardContextProvider.swift
+++ b/tabby/Services/Utilities/ClipboardContextProvider.swift
@@ -1,0 +1,124 @@
+import AppKit
+import Foundation
+import UniformTypeIdentifiers
+
+/// Reads the current pasteboard only when Tabby is about to build a prompt.
+///
+/// Clipboard contents are highly sensitive and change outside Tabby's control, so this service does
+/// not cache or publish them. The coordinator asks for a fresh, bounded description at generation
+/// time, and `SuggestionRequestFactory` still owns the final prompt clipping policy.
+@MainActor
+final class ClipboardContextProvider: ClipboardContextProviding {
+    private let pasteboard: NSPasteboard
+
+    init(pasteboard: NSPasteboard = .general) {
+        self.pasteboard = pasteboard
+    }
+
+    func currentContext() -> String? {
+        if let text = normalizedText(pasteboard.string(forType: .string)) {
+            return text
+        }
+
+        return imageContext()
+    }
+
+    private func normalizedText(_ text: String?) -> String? {
+        guard let text else {
+            return nil
+        }
+
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func imageContext() -> String? {
+        if let image = NSImage(pasteboard: pasteboard) {
+            return imageSummary(for: image, format: preferredImageFormat())
+        }
+
+        return imageFileContext()
+    }
+
+    private func imageFileContext() -> String? {
+        guard let urls = pasteboard.readObjects(
+            forClasses: [NSURL.self],
+            options: [.urlReadingFileURLsOnly: true]
+        ) as? [URL] else {
+            return nil
+        }
+
+        guard let imageURL = urls.first(where: isImageFile) else {
+            return nil
+        }
+
+        let format = imageURL.pathExtension.isEmpty ? nil : imageURL.pathExtension.uppercased()
+        let image = NSImage(contentsOf: imageURL)
+        let imageDescription = image.map { imageSummary(for: $0, format: format) }
+            ?? "Image file"
+
+        return "\(imageDescription): \(imageURL.lastPathComponent)"
+    }
+
+    private func imageSummary(for image: NSImage, format: String?) -> String {
+        let details = [
+            format,
+            pixelDimensions(for: image)
+        ].compactMap { $0 }
+
+        guard !details.isEmpty else {
+            return "Image"
+        }
+
+        return "Image (\(details.joined(separator: ", ")))"
+    }
+
+    private func preferredImageFormat() -> String? {
+        let knownTypes: [(UTType, String)] = [
+            (.png, "PNG"),
+            (.jpeg, "JPEG"),
+            (.tiff, "TIFF"),
+            (.gif, "GIF"),
+            (.heic, "HEIC")
+        ]
+
+        let pasteboardTypes = Set(pasteboard.types ?? [])
+        for (type, label) in knownTypes {
+            if pasteboardTypes.contains(NSPasteboard.PasteboardType(type.identifier)) {
+                return label
+            }
+        }
+
+        return nil
+    }
+
+    private func pixelDimensions(for image: NSImage) -> String? {
+        let bestRepresentation = image.representations
+            .filter { $0.pixelsWide > 0 && $0.pixelsHigh > 0 }
+            .max { lhs, rhs in
+                lhs.pixelsWide * lhs.pixelsHigh < rhs.pixelsWide * rhs.pixelsHigh
+            }
+
+        if let bestRepresentation {
+            return "\(bestRepresentation.pixelsWide)x\(bestRepresentation.pixelsHigh) px"
+        }
+
+        let pointWidth = Int(image.size.width.rounded())
+        let pointHeight = Int(image.size.height.rounded())
+        guard pointWidth > 0, pointHeight > 0 else {
+            return nil
+        }
+
+        return "\(pointWidth)x\(pointHeight) pt"
+    }
+
+    private func isImageFile(_ url: URL) -> Bool {
+        guard url.isFileURL,
+              let type = UTType(filenameExtension: url.pathExtension)
+        else {
+            return false
+        }
+
+        return type.conforms(to: .image)
+    }
+}

--- a/tabby/Support/FoundationModelPromptRenderer.swift
+++ b/tabby/Support/FoundationModelPromptRenderer.swift
@@ -24,6 +24,7 @@ enum FoundationModelPromptRenderer {
             request.completionLengthInstruction,
             "Do not repeat or quote the existing text.",
             "Match the existing tone, language, casing, and punctuation.",
+            "Use clipboard context only when it directly helps the inline continuation.",
             "Use plain text only with no labels, bullets, markdown, or explanation."
         ]
 
@@ -57,14 +58,25 @@ enum FoundationModelPromptRenderer {
             return "Continue the text at the caret using a short inline completion."
         }
 
-        return [
+        var sections = [
             "App: \(request.context.applicationName)",
+        ]
+
+        if let clipboardContext = request.clipboardContext,
+           !clipboardContext.isEmpty {
+            sections.append("")
+            sections.append("User's clipboard:")
+            sections.append(clipboardContext)
+        }
+
+        sections.append(contentsOf: [
             "",
             "Text before the caret:",
             prefixText,
             "",
             "Write only the next continuation fragment."
-        ]
-        .joined(separator: "\n")
+        ])
+
+        return sections.joined(separator: "\n")
     }
 }

--- a/tabby/Support/LlamaPromptRenderer.swift
+++ b/tabby/Support/LlamaPromptRenderer.swift
@@ -19,6 +19,7 @@ enum LlamaPromptRenderer {
         completionLengthInstruction: String,
         userName: String?,
         userTags: [String]?,
+        clipboardContext: String? = nil,
         visualContextSummary: String? = nil
     ) -> String {
         var sections = [
@@ -26,6 +27,7 @@ enum LlamaPromptRenderer {
             "- Continue the user's existing text exactly at the caret position.",
             "- This is autocomplete, not chat. Do not answer the user or start a conversation.",
             "- Never repeat, restate, or quote the text before the caret.",
+            "- Use clipboard context only when it directly helps the inline continuation.",
             "- Return plain text only with no labels, bullets, markdown, quotes, or explanation."
         ]
 
@@ -50,6 +52,10 @@ enum LlamaPromptRenderer {
         if let summary = visualContextSummary, !summary.isEmpty {
             sections.append("Screen content:")
             sections.append(summary)
+        }
+        if let clipboardContext, !clipboardContext.isEmpty {
+            sections.append("User's clipboard:")
+            sections.append(clipboardContext)
         }
 
         // The final task cue sits immediately before the prefix so small instruct models see the

--- a/tabby/Support/SuggestionRequestFactory.swift
+++ b/tabby/Support/SuggestionRequestFactory.swift
@@ -17,6 +17,8 @@ struct SuggestionRequestBuildResult: Equatable, Sendable {
 /// Pure prompt-policy surface for the autocomplete pipeline.
 /// This type has no access to UserDefaults, tasks, overlays, or runtime services.
 enum SuggestionRequestFactory {
+    private static let maxClipboardContextCharacters = 1_200
+
     /// Require at least one non-whitespace character so we don't suggest on a blank field.
     /// No trailing-space gate — the debounce handles rapid keystroke settling, and
     /// `SuggestionTextNormalizer` applies deterministic space management on the output side.
@@ -30,6 +32,7 @@ enum SuggestionRequestFactory {
         context: FocusedInputContext,
         settings: SuggestionSettingsSnapshot,
         configuration: SuggestionConfiguration,
+        clipboardContext: String? = nil,
         visualContextSummary: String? = nil
     ) -> SuggestionRequestBuildResult {
         let prefixText = truncatedPromptPrefix(
@@ -39,12 +42,17 @@ enum SuggestionRequestFactory {
         let completionLengthInstruction = settings.selectedWordCountPreset.promptInstruction
         let userName = activeUserName(settings: settings)
         let userTags = activeUserTags(settings: settings)
+        let boundedClipboardContext = activeClipboardContext(
+            rawContext: clipboardContext,
+            settings: settings
+        )
         let prompt = LlamaPromptRenderer.prompt(
             prefixText: prefixText,
             applicationName: context.applicationName,
             completionLengthInstruction: completionLengthInstruction,
             userName: userName,
             userTags: userTags,
+            clipboardContext: boundedClipboardContext,
             visualContextSummary: visualContextSummary
         )
 
@@ -67,6 +75,7 @@ enum SuggestionRequestFactory {
             completionLengthInstruction: completionLengthInstruction,
             userName: userName,
             userTags: userTags,
+            clipboardContext: boundedClipboardContext,
             visualContextSummary: visualContextSummary
         )
 
@@ -101,6 +110,35 @@ enum SuggestionRequestFactory {
         settings: SuggestionSettingsSnapshot
     ) -> [String]? {
         settings.userTags
+    }
+
+    private static func activeClipboardContext(
+        rawContext: String?,
+        settings: SuggestionSettingsSnapshot
+    ) -> String? {
+        guard settings.isClipboardContextEnabled,
+              let rawContext
+        else {
+            return nil
+        }
+
+        let trimmed = rawContext.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return nil
+        }
+
+        return clippedText(trimmed, maxCharacters: maxClipboardContextCharacters)
+    }
+
+    private static func clippedText(_ text: String, maxCharacters: Int) -> String {
+        guard text.count > maxCharacters else {
+            return text
+        }
+
+        let suffix = "..."
+        let allowedPrefixCount = max(maxCharacters - suffix.count, 0)
+        return String(text.prefix(allowedPrefixCount))
+            .trimmingCharacters(in: .whitespacesAndNewlines) + suffix
     }
 
     private static func activeMaxPredictionTokens(

--- a/tabby/UI/MenuBarView.swift
+++ b/tabby/UI/MenuBarView.swift
@@ -78,6 +78,10 @@ struct MenuBarView: View {
                 .toggleStyle(.switch)
                 .controlSize(.small)
 
+            Toggle("Clipboard Context", isOn: clipboardContextEnabledBinding)
+                .toggleStyle(.switch)
+                .controlSize(.small)
+
             if let application = focusModel.latestExternalApplication {
                 Toggle("Enable in \(application.applicationName)", isOn: appEnabledBinding(for: application))
                     .toggleStyle(.switch)
@@ -217,6 +221,13 @@ struct MenuBarView: View {
         Binding(
             get: { suggestionSettings.isGloballyEnabled },
             set: { suggestionSettings.setGloballyEnabled($0) }
+        )
+    }
+
+    private var clipboardContextEnabledBinding: Binding<Bool> {
+        Binding(
+            get: { suggestionSettings.isClipboardContextEnabled },
+            set: { suggestionSettings.setClipboardContextEnabled($0) }
         )
     }
 

--- a/tabby/UI/SettingsView.swift
+++ b/tabby/UI/SettingsView.swift
@@ -113,6 +113,8 @@ struct SettingsView: View {
         Section("Autocomplete") {
             Toggle("Enable Globally", isOn: globallyEnabledBinding)
 
+            Toggle("Clipboard Context", isOn: clipboardContextEnabledBinding)
+
             Picker("Indicator", selection: selectedIndicatorModeBinding) {
                 ForEach(ActivationIndicatorMode.allCases) { mode in
                     Text(mode.displayLabel)
@@ -429,6 +431,13 @@ struct SettingsView: View {
         Binding(
             get: { suggestionSettings.isGloballyEnabled },
             set: { suggestionSettings.setGloballyEnabled($0) }
+        )
+    }
+
+    private var clipboardContextEnabledBinding: Binding<Bool> {
+        Binding(
+            get: { suggestionSettings.isClipboardContextEnabled },
+            set: { suggestionSettings.setClipboardContextEnabled($0) }
         )
     }
 

--- a/tabbyTests/LlamaPromptRendererTests.swift
+++ b/tabbyTests/LlamaPromptRendererTests.swift
@@ -173,6 +173,20 @@ final class LlamaPromptRendererTests: XCTestCase {
         XCTAssertTrue(prompt.contains("A window describing a cat."))
     }
 
+    func test_instructionPrompt_includesClipboardContextWhenProvided() {
+        let prompt = LlamaPromptRenderer.prompt(
+            prefixText: "PREFIX",
+            applicationName: "App",
+            completionLengthInstruction: "Short.",
+            userName: nil,
+            userTags: nil,
+            clipboardContext: "UNIQUE_CLIPBOARD_MARKER"
+        )
+
+        XCTAssertTrue(prompt.contains("User's clipboard:"))
+        XCTAssertTrue(prompt.contains("UNIQUE_CLIPBOARD_MARKER"))
+    }
+
     func test_instructionPrompt_omitsVisualContextSummaryWhenNil() {
         let prompt = LlamaPromptRenderer.prompt(
             prefixText: "PREFIX",
@@ -227,6 +241,7 @@ final class LlamaPromptRendererTests: XCTestCase {
             completionLengthInstruction: "Return only the next few words.",
             userName: nil,
             userTags: nil,
+            clipboardContext: nil,
             visualContextSummary: nil
         )
     }

--- a/tabbyTests/PromptPolicyTests.swift
+++ b/tabbyTests/PromptPolicyTests.swift
@@ -35,6 +35,18 @@ final class FoundationModelPromptRendererTests: XCTestCase {
         XCTAssertFalse(prompt.contains("  Hello from the field  "))
     }
 
+    func test_prompt_includesClipboardContextWhenProvided() {
+        let request = TabbyTestFixtures.suggestionRequest(
+            prefixText: "Continue this",
+            clipboardContext: "UNIQUE_APPLE_CLIPBOARD_MARKER"
+        )
+
+        let prompt = FoundationModelPromptRenderer.prompt(for: request)
+
+        XCTAssertTrue(prompt.contains("User's clipboard:"))
+        XCTAssertTrue(prompt.contains("UNIQUE_APPLE_CLIPBOARD_MARKER"))
+    }
+
     func test_prompt_returnsFallbackWhenPrefixIsEmptyAfterTrimming() {
         let request = TabbyTestFixtures.suggestionRequest(
             prefixText: " \n ",

--- a/tabbyTests/SuggestionAvailabilityEvaluatorTests.swift
+++ b/tabbyTests/SuggestionAvailabilityEvaluatorTests.swift
@@ -459,6 +459,44 @@ final class SuggestionSettingsModelDisabledAppsTests: XCTestCase {
         _ = cancellables
     }
 
+    func test_clipboardContextEnabled_defaultsToTrueAndPersists() {
+        runOnMainActor {
+            let userDefaults = makeUserDefaults()
+            let model = makeModel(userDefaults: userDefaults)
+
+            XCTAssertTrue(model.isClipboardContextEnabled)
+            XCTAssertTrue(model.snapshot.isClipboardContextEnabled)
+
+            model.setClipboardContextEnabled(false)
+            let reloadedModel = makeModel(userDefaults: userDefaults)
+
+            XCTAssertFalse(reloadedModel.isClipboardContextEnabled)
+            XCTAssertFalse(reloadedModel.snapshot.isClipboardContextEnabled)
+        }
+    }
+
+    func test_snapshotPublisher_emitsWhenClipboardContextSettingChanges() {
+        let expectation = expectation(description: "snapshot emits after clipboard setting changes")
+        var cancellables = Set<AnyCancellable>()
+
+        runOnMainActor {
+            let model = makeModel()
+
+            model.snapshotPublisher
+                .dropFirst()
+                .sink { snapshot in
+                    XCTAssertFalse(snapshot.isClipboardContextEnabled)
+                    expectation.fulfill()
+                }
+                .store(in: &cancellables)
+
+            model.setClipboardContextEnabled(false)
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+        _ = cancellables
+    }
+
     @MainActor
     private func makeModel(
         userDefaults: UserDefaults? = nil

--- a/tabbyTests/SuggestionRequestFactoryTests.swift
+++ b/tabbyTests/SuggestionRequestFactoryTests.swift
@@ -146,4 +146,50 @@ final class SuggestionRequestFactoryTests: XCTestCase {
         XCTAssertTrue(result.promptPreview.contains("Prefer direct wording."))
         XCTAssertTrue(result.promptPreview.contains("Calendar window says project review at 3 PM."))
     }
+
+    func test_buildRequest_carriesClipboardContextWhenEnabled() {
+        let context = TabbyTestFixtures.focusedInputContext(precedingText: "Hello")
+
+        let result = SuggestionRequestFactory.buildRequest(
+            context: context,
+            settings: TabbyTestFixtures.settingsSnapshot(isClipboardContextEnabled: true),
+            configuration: .standard,
+            clipboardContext: "  Copied project notes.  "
+        )
+
+        XCTAssertEqual(result.request.clipboardContext, "Copied project notes.")
+        XCTAssertTrue(result.promptPreview.contains("User's clipboard:"))
+        XCTAssertTrue(result.promptPreview.contains("Copied project notes."))
+    }
+
+    func test_buildRequest_omitsClipboardContextWhenDisabled() {
+        let context = TabbyTestFixtures.focusedInputContext(precedingText: "Hello")
+
+        let result = SuggestionRequestFactory.buildRequest(
+            context: context,
+            settings: TabbyTestFixtures.settingsSnapshot(isClipboardContextEnabled: false),
+            configuration: .standard,
+            clipboardContext: "Copied project notes."
+        )
+
+        XCTAssertNil(result.request.clipboardContext)
+        XCTAssertFalse(result.promptPreview.contains("User's clipboard:"))
+        XCTAssertFalse(result.promptPreview.contains("Copied project notes."))
+    }
+
+    func test_buildRequest_clipsLongClipboardContext() throws {
+        let context = TabbyTestFixtures.focusedInputContext(precedingText: "Hello")
+        let longClipboard = String(repeating: "a", count: 1_500)
+
+        let result = SuggestionRequestFactory.buildRequest(
+            context: context,
+            settings: TabbyTestFixtures.settingsSnapshot(isClipboardContextEnabled: true),
+            configuration: .standard,
+            clipboardContext: longClipboard
+        )
+
+        let clipboardContext = try XCTUnwrap(result.request.clipboardContext)
+        XCTAssertEqual(clipboardContext.count, 1_200)
+        XCTAssertTrue(clipboardContext.hasSuffix("..."))
+    }
 }

--- a/tabbyTests/TabbyTestFixtures.swift
+++ b/tabbyTests/TabbyTestFixtures.swift
@@ -96,6 +96,7 @@ enum TabbyTestFixtures {
         completionLengthInstruction: String = "Return only the next few words.",
         userName: String? = nil,
         userTags: [String]? = nil,
+        clipboardContext: String? = nil,
         visualContextSummary: String? = nil
     ) -> SuggestionRequest {
         let resolvedPrecedingText = precedingText ?? prefixText
@@ -121,6 +122,7 @@ enum TabbyTestFixtures {
             completionLengthInstruction: completionLengthInstruction,
             userName: userName,
             userTags: userTags,
+            clipboardContext: clipboardContext,
             visualContextSummary: visualContextSummary
         )
     }
@@ -204,6 +206,7 @@ enum TabbyTestFixtures {
         disabledAppBundleIdentifiers: Set<String> = [],
         selectedEngine: SuggestionEngineKind = .llamaOpenSource,
         selectedWordCountPreset: SuggestionWordCountPreset = .sevenToTwelve,
+        isClipboardContextEnabled: Bool = true,
         userName: String = "",
         userTags: [String] = []
     ) -> SuggestionSettingsSnapshot {
@@ -212,6 +215,7 @@ enum TabbyTestFixtures {
             disabledAppBundleIdentifiers: disabledAppBundleIdentifiers,
             selectedEngine: selectedEngine,
             selectedWordCountPreset: selectedWordCountPreset,
+            isClipboardContextEnabled: isClipboardContextEnabled,
             userName: userName,
             userTags: userTags
         )


### PR DESCRIPTION
## Summary

Adds opt-out clipboard context to autocomplete prompts, defaulting enabled so Tabby can use recently copied text or lightweight image metadata when generating inline suggestions. Clipboard reading is isolated to a pasteboard provider, while prompt clipping and enablement gates stay in the pure request factory so both Llama and Foundation Model paths share the same bounded behavior.

## Validation

- `git diff --check origin/main...HEAD` passed.
- `xcodebuild -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' build` passed with `** BUILD SUCCEEDED **`.
- `xcodebuild -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' build-for-testing` passed with `** TEST BUILD SUCCEEDED **`.
- `xcodebuild test -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' -only-testing:tabbyTests/SuggestionRequestFactoryTests -only-testing:tabbyTests/LlamaPromptRendererTests -only-testing:tabbyTests/FoundationModelPromptRendererTests -only-testing:tabbyTests/SuggestionSettingsModelDisabledAppsTests` was attempted, but local execution failed before running assertions because the app-hosted test bundle could not load: `mapping process and mapped file (non-platform) have different Team IDs`.

## Linked issues

None.

## Risk / rollout notes

Clipboard context is on by default per product direction, so the PR adds explicit toggles in Settings and the menu bar popup. Image clipboard support intentionally sends metadata only, not OCR or raw image content, to keep prompt size and privacy exposure bounded.