### PR TITLE
Align Apple Intelligence suggestions

### DIFF
--- a/tabby/Models/SuggestionModels.swift
+++ b/tabby/Models/SuggestionModels.swift
@@ -421,12 +421,15 @@ enum OverlayState: Equatable {
 /// Errors specific to suggestion generation and normalization.
 enum SuggestionClientError: LocalizedError {
     case unavailable(String)
+    case unsupportedLanguageOrLocale(String)
     case generationFailed(String)
     case cancelled
 
     var errorDescription: String? {
         switch self {
-        case let .unavailable(message), let .generationFailed(message):
+        case let .unavailable(message),
+            let .unsupportedLanguageOrLocale(message),
+            let .generationFailed(message):
             return message
         case .cancelled:
             return "Generation was cancelled."

--- a/tabby/Services/Runtime/FoundationModelSuggestionEngine.swift
+++ b/tabby/Services/Runtime/FoundationModelSuggestionEngine.swift
@@ -30,12 +30,13 @@ final class FoundationModelSuggestionEngine {
 
         do {
             let startTime = Date()
+            let prompt = FoundationModelPromptRenderer.prompt(for: request)
             let session = LanguageModelSession(
                 model: availabilityService.model,
                 instructions: FoundationModelPromptRenderer.sessionInstructions(for: request)
             )
             let response = try await session.respond(
-                to: FoundationModelPromptRenderer.prompt(for: request),
+                to: prompt,
                 options: generationOptions(for: request)
             )
             try Task.checkCancellation()
@@ -43,7 +44,8 @@ final class FoundationModelSuggestionEngine {
             let rawSuggestion = response.content
             let normalizedSuggestion = SuggestionTextNormalizer.normalize(
                 rawSuggestion,
-                for: request
+                for: request,
+                promptEchoCandidates: [prompt]
             )
 
             return SuggestionResult(
@@ -94,7 +96,9 @@ final class FoundationModelSuggestionEngine {
         case .assetsUnavailable:
             return .unavailable("Apple Intelligence assets are unavailable right now.")
         case .unsupportedLanguageOrLocale:
-            return .unavailable("Apple Intelligence does not support the current language or locale.")
+            return .unsupportedLanguageOrLocale(
+                "Apple Intelligence does not support the current language or locale for this request."
+            )
         case .exceededContextWindowSize:
             return .generationFailed("The Apple on-device model rejected the prompt because it was too large.")
         case .guardrailViolation:

--- a/tabby/Services/Runtime/SuggestionEngineRouter.swift
+++ b/tabby/Services/Runtime/SuggestionEngineRouter.swift
@@ -7,13 +7,13 @@ import Foundation
 @MainActor
 final class SuggestionEngineRouter {
     private let suggestionSettings: SuggestionSettingsModel
-    private let foundationModelEngine: FoundationModelSuggestionEngine
-    private let llamaEngine: LlamaSuggestionEngine
+    private let foundationModelEngine: any SuggestionGenerating
+    private let llamaEngine: any SuggestionGenerating
 
     init(
         suggestionSettings: SuggestionSettingsModel,
-        foundationModelEngine: FoundationModelSuggestionEngine,
-        llamaEngine: LlamaSuggestionEngine
+        foundationModelEngine: any SuggestionGenerating,
+        llamaEngine: any SuggestionGenerating
     ) {
         self.suggestionSettings = suggestionSettings
         self.foundationModelEngine = foundationModelEngine
@@ -23,7 +23,14 @@ final class SuggestionEngineRouter {
     func generateSuggestion(for request: SuggestionRequest) async throws -> SuggestionResult {
         switch suggestionSettings.selectedEngine {
         case .appleIntelligence:
-            return try await foundationModelEngine.generateSuggestion(for: request)
+            do {
+                return try await foundationModelEngine.generateSuggestion(for: request)
+            } catch SuggestionClientError.unsupportedLanguageOrLocale(let message) {
+                return try await generateOpenSourceFallback(
+                    for: request,
+                    appleFailureMessage: message
+                )
+            }
         case .llamaOpenSource:
             return try await llamaEngine.generateSuggestion(for: request)
         }
@@ -35,6 +42,24 @@ final class SuggestionEngineRouter {
     func resetCachedGenerationContext() async {
         await foundationModelEngine.resetCachedGenerationContext()
         await llamaEngine.resetCachedGenerationContext()
+    }
+
+    /// Apple Intelligence can reject a request after global availability reports success because
+    /// language support is checked against the active request/locale. Falling back here keeps the
+    /// coordinator backend-agnostic while giving local models a chance to handle that text.
+    private func generateOpenSourceFallback(
+        for request: SuggestionRequest,
+        appleFailureMessage: String
+    ) async throws -> SuggestionResult {
+        do {
+            return try await llamaEngine.generateSuggestion(for: request)
+        } catch SuggestionClientError.cancelled {
+            throw SuggestionClientError.cancelled
+        } catch {
+            throw SuggestionClientError.unavailable(
+                "\(appleFailureMessage) Open Source fallback also failed: \(error.localizedDescription)"
+            )
+        }
     }
 }
 

--- a/tabby/Support/FoundationModelPromptRenderer.swift
+++ b/tabby/Support/FoundationModelPromptRenderer.swift
@@ -50,17 +50,24 @@ enum FoundationModelPromptRenderer {
     /// Foundation Models tends to behave more reliably when the prompt describes the immediate task
     /// and the stable rules live in session instructions instead of being mixed together.
     static func prompt(for request: SuggestionRequest) -> String {
-        let prefixText = request.prefixText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let prefixText = request.prefixText
 
-        if prefixText.isEmpty {
+        if prefixText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             // This should be rare because upstream generation is already gated on meaningful text.
             // Returning a small fallback prompt is safer than crashing or sending an empty string.
             return "Continue the text at the caret using a short inline completion."
         }
 
         var sections = [
-            "App: \(request.context.applicationName)",
+            "Screen context:",
+            "App: \(request.context.applicationName)"
         ]
+
+        if let summary = request.visualContextSummary,
+           !summary.isEmpty {
+            sections.append("Screen content:")
+            sections.append(summary)
+        }
 
         if let clipboardContext = request.clipboardContext,
            !clipboardContext.isEmpty {
@@ -78,5 +85,18 @@ enum FoundationModelPromptRenderer {
         ])
 
         return sections.joined(separator: "\n")
+    }
+
+    /// Diagnostics need to show both payloads Apple receives: the high-priority instructions and
+    /// the shorter request prompt. Keeping this renderer-owned prevents the menu/debug preview from
+    /// accidentally showing the llama prompt while Apple Intelligence is the selected engine.
+    static func promptPreview(for request: SuggestionRequest) -> String {
+        [
+            "Instructions:",
+            sessionInstructions(for: request),
+            "",
+            "Prompt:",
+            prompt(for: request)
+        ].joined(separator: "\n")
     }
 }

--- a/tabby/Support/SuggestionRequestFactory.swift
+++ b/tabby/Support/SuggestionRequestFactory.swift
@@ -2,14 +2,15 @@ import Foundation
 
 /// File overview:
 /// Owns the pure rules for deciding whether Tabby should generate and, when it should, how the
-/// request payload and prompt preview are constructed. This keeps prompt policy out of the coordinator.
+/// request payload and backend-specific prompt preview are constructed.
+/// This keeps prompt policy out of the coordinator.
 ///
 /// Architectural role:
 /// `SuggestionCoordinator` decides when a generation attempt should happen. This factory decides
 /// what the request should contain once that decision has already been made.
 struct SuggestionRequestBuildResult: Equatable, Sendable {
-    /// The engine-facing request plus the exact prompt preview shown in the menu UI.
-    /// Keeping these together prevents preview text from drifting away from the real request.
+    /// The engine-facing request plus the selected backend's prompt preview shown in diagnostics.
+    /// Keeping these together prevents preview text from drifting away from the chosen engine.
     let request: SuggestionRequest
     let promptPreview: String
 }
@@ -81,7 +82,7 @@ enum SuggestionRequestFactory {
 
         return SuggestionRequestBuildResult(
             request: request,
-            promptPreview: prompt
+            promptPreview: promptPreview(for: request, selectedEngine: settings.selectedEngine)
         )
     }
 
@@ -146,5 +147,17 @@ enum SuggestionRequestFactory {
         wordCountPreset: SuggestionWordCountPreset
     ) -> Int {
         max(configuration.maxPredictionTokens, wordCountPreset.suggestedPredictionTokenBudget)
+    }
+
+    private static func promptPreview(
+        for request: SuggestionRequest,
+        selectedEngine: SuggestionEngineKind
+    ) -> String {
+        switch selectedEngine {
+        case .appleIntelligence:
+            return FoundationModelPromptRenderer.promptPreview(for: request)
+        case .llamaOpenSource:
+            return request.prompt
+        }
     }
 }

--- a/tabby/Support/SuggestionTextNormalizer.swift
+++ b/tabby/Support/SuggestionTextNormalizer.swift
@@ -8,7 +8,11 @@ import Foundation
 /// This type is intentionally pure. Given the same request and raw output, it always returns the
 /// same normalized suggestion. That makes it safe to share across backends and easy to test later.
 enum SuggestionTextNormalizer {
-    static func normalize(_ rawSuggestion: String, for request: SuggestionRequest) -> String {
+    static func normalize(
+        _ rawSuggestion: String,
+        for request: SuggestionRequest,
+        promptEchoCandidates: [String] = []
+    ) -> String {
         var normalized = rawSuggestion.replacingOccurrences(of: "\r", with: "")
 
         // Some runtimes echo the prompt or include chat-template control markers in the response.
@@ -16,8 +20,11 @@ enum SuggestionTextNormalizer {
         normalized = normalized.replacingOccurrences(of: "<|im_end|>", with: "")
         normalized = normalized.replacingOccurrences(of: "<|im_start|>", with: "")
 
-        if !request.prompt.isEmpty, normalized.hasPrefix(request.prompt) {
-            normalized.removeFirst(request.prompt.count)
+        for prompt in [request.prompt] + promptEchoCandidates {
+            if !prompt.isEmpty, normalized.hasPrefix(prompt) {
+                normalized.removeFirst(prompt.count)
+                normalized = normalized.trimmingCharacters(in: .controlCharacters.union(.newlines))
+            }
         }
 
         // Apple Intelligence uses a separate instructions channel and a short task prompt, so the

--- a/tabbyTests/PromptPolicyTests.swift
+++ b/tabbyTests/PromptPolicyTests.swift
@@ -22,7 +22,7 @@ final class FoundationModelPromptRendererTests: XCTestCase {
         XCTAssertTrue(instructions.contains("Do not repeat or quote the existing text."))
     }
 
-    func test_prompt_includesApplicationNameAndTrimmedPrefixText() {
+    func test_prompt_includesApplicationNameAndPreservesPrefixText() {
         let request = TabbyTestFixtures.suggestionRequest(
             prefixText: "  Hello from the field  ",
             precedingText: "  Hello from the field  "
@@ -31,8 +31,19 @@ final class FoundationModelPromptRendererTests: XCTestCase {
         let prompt = FoundationModelPromptRenderer.prompt(for: request)
 
         XCTAssertTrue(prompt.contains("App: TestApp"))
-        XCTAssertTrue(prompt.contains("Hello from the field"))
-        XCTAssertFalse(prompt.contains("  Hello from the field  "))
+        XCTAssertTrue(prompt.contains("  Hello from the field  "))
+    }
+
+    func test_prompt_includesVisualContextWhenProvided() {
+        let request = TabbyTestFixtures.suggestionRequest(
+            prefixText: "Continue this",
+            visualContextSummary: "UNIQUE_APPLE_SCREEN_CONTEXT"
+        )
+
+        let prompt = FoundationModelPromptRenderer.prompt(for: request)
+
+        XCTAssertTrue(prompt.contains("Screen content:"))
+        XCTAssertTrue(prompt.contains("UNIQUE_APPLE_SCREEN_CONTEXT"))
     }
 
     func test_prompt_includesClipboardContextWhenProvided() {
@@ -60,4 +71,93 @@ final class FoundationModelPromptRendererTests: XCTestCase {
             "Continue the text at the caret using a short inline completion."
         )
     }
+
+    func test_promptPreview_includesInstructionsAndPromptPayload() {
+        let request = TabbyTestFixtures.suggestionRequest(
+            prefixText: "Continue this",
+            completionLengthInstruction: "UNIQUE_LENGTH_POLICY",
+            visualContextSummary: "UNIQUE_APPLE_SCREEN_CONTEXT"
+        )
+
+        let preview = FoundationModelPromptRenderer.promptPreview(for: request)
+
+        XCTAssertTrue(preview.contains("Instructions:\n"))
+        XCTAssertTrue(preview.contains("UNIQUE_LENGTH_POLICY"))
+        XCTAssertTrue(preview.contains("Prompt:\n"))
+        XCTAssertTrue(preview.contains("UNIQUE_APPLE_SCREEN_CONTEXT"))
+    }
+}
+
+@MainActor
+final class SuggestionEngineRouterTests: XCTestCase {
+    func test_generateSuggestion_fallsBackToOpenSourceWhenAppleRejectsLanguageOrLocale() async throws {
+        let settings = SuggestionSettingsModel(
+            configuration: .standard,
+            userDefaults: makeUserDefaults()
+        )
+        settings.selectEngine(.appleIntelligence)
+        let request = TabbyTestFixtures.suggestionRequest()
+        let fallbackResult = SuggestionResult(
+            generation: request.generation,
+            rawText: "fallback raw",
+            text: "fallback text",
+            latency: 0.1
+        )
+        let appleEngine = StubSuggestionEngine(
+            behavior: .failure(
+                SuggestionClientError.unsupportedLanguageOrLocale("Apple language failure.")
+            )
+        )
+        let openSourceEngine = StubSuggestionEngine(behavior: .success(fallbackResult))
+        let router = SuggestionEngineRouter(
+            suggestionSettings: settings,
+            foundationModelEngine: appleEngine,
+            llamaEngine: openSourceEngine
+        )
+
+        let result = try await router.generateSuggestion(for: request)
+
+        XCTAssertEqual(result, fallbackResult)
+        XCTAssertEqual(appleEngine.generateCallCount, 1)
+        XCTAssertEqual(openSourceEngine.generateCallCount, 1)
+    }
+
+    private func makeUserDefaults() -> UserDefaults {
+        let suiteName = "SuggestionEngineRouterTests-\(UUID().uuidString)"
+        guard let userDefaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Expected an isolated UserDefaults suite")
+            return .standard
+        }
+
+        userDefaults.removePersistentDomain(forName: suiteName)
+        return userDefaults
+    }
+}
+
+@MainActor
+private final class StubSuggestionEngine: SuggestionGenerating {
+    enum Behavior {
+        case success(SuggestionResult)
+        case failure(Error)
+    }
+
+    private let behavior: Behavior
+    private(set) var generateCallCount = 0
+
+    init(behavior: Behavior) {
+        self.behavior = behavior
+    }
+
+    func generateSuggestion(for request: SuggestionRequest) async throws -> SuggestionResult {
+        generateCallCount += 1
+
+        switch behavior {
+        case .success(let result):
+            return result
+        case .failure(let error):
+            throw error
+        }
+    }
+
+    func resetCachedGenerationContext() async {}
 }

--- a/tabbyTests/SuggestionRequestFactoryTests.swift
+++ b/tabbyTests/SuggestionRequestFactoryTests.swift
@@ -147,6 +147,24 @@ final class SuggestionRequestFactoryTests: XCTestCase {
         XCTAssertTrue(result.promptPreview.contains("Calendar window says project review at 3 PM."))
     }
 
+    func test_buildRequest_usesApplePromptPreviewWhenAppleEngineSelected() {
+        let context = TabbyTestFixtures.focusedInputContext(precedingText: "Hello")
+
+        let result = SuggestionRequestFactory.buildRequest(
+            context: context,
+            settings: TabbyTestFixtures.settingsSnapshot(selectedEngine: .appleIntelligence),
+            configuration: .standard,
+            visualContextSummary: "Calendar window says project review at 3 PM."
+        )
+
+        XCTAssertEqual(
+            result.promptPreview,
+            FoundationModelPromptRenderer.promptPreview(for: result.request)
+        )
+        XCTAssertNotEqual(result.promptPreview, result.request.prompt)
+        XCTAssertTrue(result.promptPreview.contains("Calendar window says project review at 3 PM."))
+    }
+
     func test_buildRequest_carriesClipboardContextWhenEnabled() {
         let context = TabbyTestFixtures.focusedInputContext(precedingText: "Hello")
 

--- a/tabbyTests/SuggestionTextNormalizerTests.swift
+++ b/tabbyTests/SuggestionTextNormalizerTests.swift
@@ -37,6 +37,22 @@ final class SuggestionTextNormalizerTests: XCTestCase {
         XCTAssertEqual(normalized, ", with a small addition")
     }
 
+    func test_normalize_removesBackendSpecificPromptEchoCandidate() {
+        let request = TabbyTestFixtures.suggestionRequest(
+            prefixText: "Hello world",
+            prompt: "LLAMA_PROMPT",
+            precedingText: "Hello world"
+        )
+
+        let normalized = SuggestionTextNormalizer.normalize(
+            "APPLE_PROMPT\n useful continuation",
+            for: request,
+            promptEchoCandidates: ["APPLE_PROMPT"]
+        )
+
+        XCTAssertEqual(normalized, " useful continuation")
+    }
+
     func test_normalize_trimsLeadingFormattingNewlinesBeforeTakingFirstLine() {
         let request = TabbyTestFixtures.suggestionRequest(precedingText: "Hello")
 


### PR DESCRIPTION
## Summary
- Pass visual context through the Apple Intelligence prompt and preserve the same prefix text the shared request carries.
- Make prompt diagnostics backend-aware so Apple mode shows its instructions plus prompt instead of the llama prompt.
- Normalize Apple prompt echoes and fall back to Open Source generation when Apple rejects a request for unsupported language or locale.

## Testing
- `xcodebuild -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' build-for-testing`
- `xcodebuild -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' build`
- Targeted `xcodebuild ... test -only-testing:...` compiled the changed test target, but execution is blocked locally by the hosted test bundle Team ID signing mismatch.