### PR TITLE
Sanitize auxiliary prompt context

### DIFF
--- a/tabby/Services/Utilities/ClipboardContextProvider.swift
+++ b/tabby/Services/Utilities/ClipboardContextProvider.swift
@@ -28,14 +28,12 @@ final class ClipboardContextProvider: ClipboardContextProviding {
             return nil
         }
 
-        let sanitizedText = PromptContextSanitizer.sanitize(text)
-        guard !sanitizedText.isEmpty,
-              PromptContextSanitizer.containsAlphanumericSignal(sanitizedText)
-        else {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
             return nil
         }
 
-        return sanitizedText
+        return trimmed
     }
 
     private func imageContext() -> String? {

--- a/tabby/Services/Visual/ScreenshotContextGenerator.swift
+++ b/tabby/Services/Visual/ScreenshotContextGenerator.swift
@@ -82,14 +82,9 @@ final class ScreenshotContextGenerator {
                 )
             }
 
-            let fallbackText = normalizeRecognizedText(windowTitle)
-            guard hasMeaningfulSignal(fallbackText) else {
-                throw ScreenshotContextGenerationError.unavailable(
-                    "The screenshot did not contain enough visible text to build prompt context."
-                )
-            }
-
-            return VisualContextExcerpt(text: boundedSummaryText(fallbackText))
+            return VisualContextExcerpt(
+                text: boundedSummaryText(normalizeRecognizedText(windowTitle))
+            )
         } catch let error as ScreenTextExtractionError {
             throw ScreenshotContextGenerationError.unavailable(error.localizedDescription)
         } catch {


### PR DESCRIPTION
## Summary
- Introduces `PromptContextSanitizer` to strip ANSI escapes, replace non-standard Unicode scalars, and collapse whitespace from auxiliary prompt context (clipboard, visual/OCR)
- Applies sanitization + alphanumeric signal gate in `SuggestionRequestFactory` for both clipboard and visual context inputs
- Adds `activeVisualContextSummary` to the factory so visual context gets the same sanitization as clipboard
- Removes redundant double-sanitization in `ClipboardContextProvider` — the factory owns the sanitization boundary
- Removes unreachable `hasMeaningfulSignal` guard in `ScreenshotContextGenerator` fallback path

## Review feedback addressed
- **P2 — Redundant sanitization layer**: Removed `PromptContextSanitizer` from `ClipboardContextProvider.normalizedText`; the provider returns trimmed text and the factory handles sanitization per the documented ownership boundary.
- **P2 — Dead guard in fallback path**: Removed second `hasMeaningfulSignal(fallbackText)` check after `normalizeRecognizedText` — the sanitizer preserves letter scalars so if the pre-sanitization check passed, the post-sanitization check cannot fail.

## Test plan
- [x] Build succeeds
- [x] Test build succeeds
- [ ] Clipboard context with ANSI escapes / special Unicode is cleaned before reaching the prompt
- [ ] Visual context fallback (window title only) still works when OCR finds no text

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a shared `PromptContextSanitizer` helper and wires it into the clipboard, OCR, and request-construction layers to strip ANSI escapes, Markdown fences, shell punctuation, and separator tokens from auxiliary prompt context before injection.

- **`PromptContextSanitizer.swift`** (new): pure `enum` that replaces disallowed Unicode scalars with spaces (preserving word boundaries), collapses inline whitespace per line, and optionally applies a character budget via `prefix(_:)`.
- **`ScreenshotContextGenerator`**: `normalizeRecognizedText` and `boundedSummaryText` both delegate to the sanitizer; a new `hasMeaningfulSignal` guard after `boundedSummaryText` catches low-signal summarizer output.
- **`SuggestionRequestFactory`**: adds `activeVisualContextSummary` to sanitize visual context at the factory boundary, mirroring the existing clipboard path; `ClipboardContextProvider` is a style-only refactor with no behavior change.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the sanitizer is idempotent and all production paths bound visual context before it reaches the factory.

All changed paths produce correct, sanitized output. The only asymmetry is that activeVisualContextSummary omits the character cap that activeClipboardContext enforces, but in every current production call site the text is already bounded by ScreenshotContextGenerator.boundedSummaryText before reaching the factory.

tabby/Support/SuggestionRequestFactory.swift — the missing character cap in activeVisualContextSummary is worth closing before new call sites are added.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tabby/Support/PromptContextSanitizer.swift | New pure helper: strips ANSI escapes, replaces non-alphanumeric/whitespace/@/. scalars with spaces, collapses inline whitespace per line, filters empty lines, then applies an optional character budget via prefix(_:). Logic is correct and idempotent. |
| tabby/Support/SuggestionRequestFactory.swift | Adds activeVisualContextSummary helper that sanitizes the visual context before prompt injection, mirroring the existing clipboard path. However, unlike activeClipboardContext which enforces maxClipboardContextCharacters, the new helper applies no character cap, leaving the factory's own "final prompt clipping policy" unenforceable for callers that bypass ScreenshotContextGenerator. |
| tabby/Services/Visual/ScreenshotContextGenerator.swift | normalizeRecognizedText and boundedSummaryText both delegate to PromptContextSanitizer.sanitize; adds a hasMeaningfulSignal guard after boundedSummaryText to catch low-signal summarizer output; fallback path simplified by inlining the normalise+bound call. |
| tabby/Services/Utilities/ClipboardContextProvider.swift | Style-only refactor of the early-return in normalizedText; no behavior change. Sanitization ownership stays correctly in SuggestionRequestFactory. |
| tabbyTests/SuggestionRequestFactoryTests.swift | Two new tests cover ANSI escapes, Markdown fences, shell punctuation, and separator stripping for both the visual context and clipboard paths; assertions are precise and verify both the stored request value and the prompt preview. |

</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22codex%2Fsanitize-context-symbols%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fsanitize-context-symbols%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atabby%2FSupport%2FSuggestionRequestFactory.swift%3A139-152%0AUnlike%20%60activeClipboardContext%60%20%E2%80%94%20which%20enforces%20a%20hard%20%60maxClipboardContextCharacters%60%20cap%20before%20the%20sanitized%20string%20reaches%20the%20prompt%20%E2%80%94%20%60activeVisualContextSummary%60%20returns%20the%20full%20sanitized%20string%20with%20no%20character%20limit.%20In%20production%20the%20value%20always%20arrives%20pre-bounded%20from%20%60ScreenshotContextGenerator.boundedSummaryText%60%2C%20but%20%60buildRequest%60%20accepts%20any%20raw%20string%20as%20%60visualContextSummary%3A%60%20and%20the%20factory's%20own%20doc%20comment%20says%20it%20%22owns%20the%20final%20prompt%20clipping%20policy.%22%20A%20caller%20that%20bypasses%20the%20generator%20%28or%20a%20future%20caller%29%20can%20inject%20an%20arbitrarily%20long%20visual%20summary.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20static%20let%20maxVisualContextCharacters%20%3D%201_200%0A%0A%20%20%20%20private%20static%20func%20activeVisualContextSummary%28rawSummary%3A%20String%3F%29%20-%3E%20String%3F%20%7B%0A%20%20%20%20%20%20%20%20guard%20let%20rawSummary%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20nil%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20let%20sanitizedSummary%20%3D%20PromptContextSanitizer.sanitize%28rawSummary%29%0A%20%20%20%20%20%20%20%20guard%20!sanitizedSummary.isEmpty%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20PromptContextSanitizer.containsAlphanumericSignal%28sanitizedSummary%29%0A%20%20%20%20%20%20%20%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20nil%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20return%20clippedText%28sanitizedSummary%2C%20maxCharacters%3A%20maxVisualContextCharacters%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atabby%2FSupport%2FSuggestionRequestFactory.swift%3A139-152%0AUnlike%20%60activeClipboardContext%60%20%E2%80%94%20which%20enforces%20a%20hard%20%60maxClipboardContextCharacters%60%20cap%20before%20the%20sanitized%20string%20reaches%20the%20prompt%20%E2%80%94%20%60activeVisualContextSummary%60%20returns%20the%20full%20sanitized%20string%20with%20no%20character%20limit.%20In%20production%20the%20value%20always%20arrives%20pre-bounded%20from%20%60ScreenshotContextGenerator.boundedSummaryText%60%2C%20but%20%60buildRequest%60%20accepts%20any%20raw%20string%20as%20%60visualContextSummary%3A%60%20and%20the%20factory's%20own%20doc%20comment%20says%20it%20%22owns%20the%20final%20prompt%20clipping%20policy.%22%20A%20caller%20that%20bypasses%20the%20generator%20%28or%20a%20future%20caller%29%20can%20inject%20an%20arbitrarily%20long%20visual%20summary.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20static%20let%20maxVisualContextCharacters%20%3D%201_200%0A%0A%20%20%20%20private%20static%20func%20activeVisualContextSummary%28rawSummary%3A%20String%3F%29%20-%3E%20String%3F%20%7B%0A%20%20%20%20%20%20%20%20guard%20let%20rawSummary%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20nil%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20let%20sanitizedSummary%20%3D%20PromptContextSanitizer.sanitize%28rawSummary%29%0A%20%20%20%20%20%20%20%20guard%20!sanitizedSummary.isEmpty%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20PromptContextSanitizer.containsAlphanumericSignal%28sanitizedSummary%29%0A%20%20%20%20%20%20%20%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20nil%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20return%20clippedText%28sanitizedSummary%2C%20maxCharacters%3A%20maxVisualContextCharacters%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=fujacob%2Ftabby&pr=111&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Address Greptile review feedback"](https://github.com/fujacob/tabby/commit/85478812334c1d24c45af8916cb4af2c84f83651) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33159425)</sub>

<!-- /greptile_comment -->