### PR TITLE
Align and enlarge activation indicator

### DIFF
--- a/tabby/Services/UI/ActivationIndicatorController.swift
+++ b/tabby/Services/UI/ActivationIndicatorController.swift
@@ -12,7 +12,9 @@ import SwiftUI
 @MainActor
 final class ActivationIndicatorController {
     private let verticalGap: CGFloat = 2
-    private let horizontalGap: CGFloat = 6
+    /// Field-edge mode should visually touch the input's outside edge. A gap reads as accidental
+    /// padding because the icon is an affordance for the field itself, not for the surrounding UI.
+    private let fieldEdgeGap: CGFloat = 0
     private let screenInset: CGFloat = 2
 
     private lazy var contentView: NSHostingView<AnyView> = {
@@ -148,8 +150,8 @@ final class ActivationIndicatorController {
         } else {
             caretRect
         }
-        let preferredLeftX = anchorRect.minX - contentSize.width - horizontalGap
-        let fallbackRightX = anchorRect.maxX + horizontalGap
+        let preferredLeftX = anchorRect.minX - contentSize.width - fieldEdgeGap
+        let fallbackRightX = anchorRect.maxX + fieldEdgeGap
         let centeredY = anchorRect.midY - (contentSize.height / 2)
 
         guard let screen = screen(for: anchorRect) else {
@@ -215,9 +217,10 @@ private struct FieldEdgeIconIndicatorView: View {
             .resizable()
             .interpolation(.high)
             .scaledToFit()
-            .frame(width: 16, height: 16)
-            .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
-            .shadow(color: .black.opacity(0.12), radius: 2, y: 1)
+            .frame(width: 20, height: 20)
+            .brightness(0.16)
+            .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
+            .shadow(color: .black.opacity(0.10), radius: 2, y: 1)
             .fixedSize()
     }
 }


### PR DESCRIPTION
## Summary

Makes the field-edge Tabby activation indicator larger, visually flush with the focused input edge, and slightly lighter so the black app icon reads less heavy against text fields.

This keeps the change inside `ActivationIndicatorController`: the positioning gap is now zero for field-edge mode, the icon renders at 20pt instead of 16pt, and a small SwiftUI brightness adjustment softens the black without adding a new asset pipeline.

## Validation

- `git diff --check` -> exit 0
- `xcodebuild -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' build` -> **BUILD SUCCEEDED**

## Linked issues

None.

## Risk / rollout notes

The indicator now touches the input frame edge exactly in field-edge mode. If a host app reports a slightly oversized AX input frame, the icon will align to that reported frame because Tabby intentionally treats Accessibility geometry as the source of truth.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR polishes the `fieldEdgeIcon` activation indicator: the positioning gap is reduced from 6 pt to 0 so the icon sits flush with the focused input's edge, the icon grows from 16 pt to 20 pt, a `brightness(0.16)` modifier lightens the black app icon, and the corner radius / shadow are nudged to match.

- `horizontalGap` (6) is replaced by `fieldEdgeGap` (0), affecting both the preferred-left and fallback-right computations in `fieldEdgeIconOrigin`, making the indicator flush on both sides.
- `FieldEdgeIconIndicatorView` gains `.brightness(0.16)` between `.frame()` and `.clipShape()`, which uniformly raises every color channel — safe for the current dark icon but worth keeping in mind if the icon gains colorful regions in the future.

<h3>Confidence Score: 4/5</h3>

Safe to merge — all changes are confined to visual presentation with no impact on logic, state, or Accessibility geometry handling.

The diff touches only layout constants and SwiftUI view modifiers inside a single private view. There are no data-flow changes, no new async paths, and the positioning arithmetic is identical apart from substituting 0 for the old 6-pt gap. The two observations are style-level: the right-side fallback silently inherits the zero gap without documentation, and the `.brightness` modifier sits after `.frame()` rather than closer to the image declaration — neither affects runtime correctness.

No files require special attention beyond a quick visual sanity-check of the right-side fallback rendering in `ActivationIndicatorController.swift`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tabby/Services/UI/ActivationIndicatorController.swift | Visual-only polish: renames horizontalGap→fieldEdgeGap (value 0), grows icon from 16→20pt, adds brightness(0.16) lightening, and adjusts corner-radius/shadow. No logic changes outside positioning arithmetic. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["show(mode:caretRect:inputFrameRect:)"] --> B{mode?}
    B -- hidden --> C[hide]
    B -- caretAnchor --> D[caretAnchorOrigin]
    B -- fieldEdgeIcon --> E[fieldEdgeIconOrigin]

    E --> F{"inputFrameRect\navailable & non-empty?"}
    F -- yes --> G[anchorRect = inputFrameRect]
    F -- no --> H[anchorRect = caretRect]

    G & H --> I["preferredLeftX =\nanchorRect.minX − contentSize.width\n− fieldEdgeGap (0)"]
    I --> J["fallbackRightX =\nanchorRect.maxX\n+ fieldEdgeGap (0)"]
    J --> K{preferredLeftX ≥\nvisibleFrame.minX + screenInset?}
    K -- yes --> L[use preferredLeftX]
    K -- no --> M[use fallbackRightX]
    L & M --> N[clamp X & Y to screen bounds]
    N --> O[set panel frame & order front]

    D --> P[center on caret X, prefer below line]
    P --> N
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tabby/Services/UI/ActivationIndicatorController.swift`, line 216-222 ([link](https://github.com/fujacob/tabby/blob/3144485e1eb12b6a6a7b8f8fdddbd988329e0d03/tabby/Services/UI/ActivationIndicatorController.swift#L216-L222)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> `.brightness(0.16)` adds 0.16 to every color channel before clipping. Placing it before `.clipShape()` means the brightened pixels outside the rounded rectangle are computed but then discarded by the clip, which is harmless. However, inserting it between `.frame()` and `.clipShape()` rather than right after `Image(nsImage:)` is slightly non-idiomatic — typically image-level color adjustments come before layout modifiers so the intent (modify the image, not the layout box) is clear at a glance.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22codex%2Falign-tabby-indicator%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Falign-tabby-indicator%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tabby%2FServices%2FUI%2FActivationIndicatorController.swift%0ALine%3A%20216-222%0A%0AComment%3A%0A%60.brightness%280.16%29%60%20adds%200.16%20to%20every%20color%20channel%20before%20clipping.%20Placing%20it%20before%20%60.clipShape%28%29%60%20means%20the%20brightened%20pixels%20outside%20the%20rounded%20rectangle%20are%20computed%20but%20then%20discarded%20by%20the%20clip%2C%20which%20is%20harmless.%20However%2C%20inserting%20it%20between%20%60.frame%28%29%60%20and%20%60.clipShape%28%29%60%20rather%20than%20right%20after%20%60Image%28nsImage%3A%29%60%20is%20slightly%20non-idiomatic%20%E2%80%94%20typically%20image-level%20color%20adjustments%20come%20before%20layout%20modifiers%20so%20the%20intent%20%28modify%20the%20image%2C%20not%20the%20layout%20box%29%20is%20clear%20at%20a%20glance.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20Image%28nsImage%3A%20icon%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.resizable%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.interpolation%28.high%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.scaledToFit%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.brightness%280.16%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.frame%28width%3A%2020%2C%20height%3A%2020%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.clipShape%28RoundedRectangle%28cornerRadius%3A%205%2C%20style%3A%20.continuous%29%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tabby%2FServices%2FUI%2FActivationIndicatorController.swift%0ALine%3A%20216-222%0A%0AComment%3A%0A%60.brightness%280.16%29%60%20adds%200.16%20to%20every%20color%20channel%20before%20clipping.%20Placing%20it%20before%20%60.clipShape%28%29%60%20means%20the%20brightened%20pixels%20outside%20the%20rounded%20rectangle%20are%20computed%20but%20then%20discarded%20by%20the%20clip%2C%20which%20is%20harmless.%20However%2C%20inserting%20it%20between%20%60.frame%28%29%60%20and%20%60.clipShape%28%29%60%20rather%20than%20right%20after%20%60Image%28nsImage%3A%29%60%20is%20slightly%20non-idiomatic%20%E2%80%94%20typically%20image-level%20color%20adjustments%20come%20before%20layout%20modifiers%20so%20the%20intent%20%28modify%20the%20image%2C%20not%20the%20layout%20box%29%20is%20clear%20at%20a%20glance.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20Image%28nsImage%3A%20icon%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.resizable%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.interpolation%28.high%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.scaledToFit%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.brightness%280.16%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.frame%28width%3A%2020%2C%20height%3A%2020%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.clipShape%28RoundedRectangle%28cornerRadius%3A%205%2C%20style%3A%20.continuous%29%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Ftabby&pr=112&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22codex%2Falign-tabby-indicator%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Falign-tabby-indicator%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atabby%2FServices%2FUI%2FActivationIndicatorController.swift%3A15-17%0AWith%20%60fieldEdgeGap%20%3D%200%60%2C%20the%20fallback-right%20path%20now%20also%20places%20the%20icon%20flush%20against%20the%20field's%20right%20edge.%20The%20intent%20for%20the%20preferred-left%20case%20%28flush%20with%20the%20left%20edge%29%20is%20clearly%20documented%2C%20but%20the%20symmetry%20on%20the%20right%20side%20is%20not.%20If%20a%20right-side%20fallback%20with%20zero%20gap%20ever%20looks%20visually%20abrupt%20%E2%80%94%20e.g.%20the%20icon%20immediately%20abutting%20text%20that%20overflows%20the%20field%20boundary%20%E2%80%94%20a%20dedicated%20%60fieldEdgeFallbackGap%60%20constant%20would%20make%20the%20asymmetric%20intent%20explicit%20and%20easy%20to%20adjust.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Field-edge%20mode%20should%20visually%20touch%20the%20input's%20outside%20edge.%20A%20gap%20reads%20as%20accidental%0A%20%20%20%20%2F%2F%2F%20padding%20because%20the%20icon%20is%20an%20affordance%20for%20the%20field%20itself%2C%20not%20for%20the%20surrounding%20UI.%0A%20%20%20%20private%20let%20fieldEdgeGap%3A%20CGFloat%20%3D%200%0A%20%20%20%20%2F%2F%2F%20When%20the%20indicator%20must%20fall%20back%20to%20the%20right%20side%20of%20the%20field%20%28left-edge-hugging%20inputs%29%2C%0A%20%20%20%20%2F%2F%2F%20a%20small%20gap%20avoids%20abutting%20text%20that%20overflows%20the%20field%20boundary.%20Set%20to%200%20to%20match%20the%0A%20%20%20%20%2F%2F%2F%20flush-edge%20intent%2C%20or%20raise%20to%20a%20small%20value%20%28e.g.%204%29%20if%20right-side%20fallback%20looks%20crowded.%0A%20%20%20%20private%20let%20fieldEdgeFallbackGap%3A%20CGFloat%20%3D%200%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Atabby%2FServices%2FUI%2FActivationIndicatorController.swift%3A216-222%0A%60.brightness%280.16%29%60%20adds%200.16%20to%20every%20color%20channel%20before%20clipping.%20Placing%20it%20before%20%60.clipShape%28%29%60%20means%20the%20brightened%20pixels%20outside%20the%20rounded%20rectangle%20are%20computed%20but%20then%20discarded%20by%20the%20clip%2C%20which%20is%20harmless.%20However%2C%20inserting%20it%20between%20%60.frame%28%29%60%20and%20%60.clipShape%28%29%60%20rather%20than%20right%20after%20%60Image%28nsImage%3A%29%60%20is%20slightly%20non-idiomatic%20%E2%80%94%20typically%20image-level%20color%20adjustments%20come%20before%20layout%20modifiers%20so%20the%20intent%20%28modify%20the%20image%2C%20not%20the%20layout%20box%29%20is%20clear%20at%20a%20glance.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20Image%28nsImage%3A%20icon%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.resizable%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.interpolation%28.high%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.scaledToFit%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.brightness%280.16%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.frame%28width%3A%2020%2C%20height%3A%2020%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.clipShape%28RoundedRectangle%28cornerRadius%3A%205%2C%20style%3A%20.continuous%29%29%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atabby%2FServices%2FUI%2FActivationIndicatorController.swift%3A15-17%0AWith%20%60fieldEdgeGap%20%3D%200%60%2C%20the%20fallback-right%20path%20now%20also%20places%20the%20icon%20flush%20against%20the%20field's%20right%20edge.%20The%20intent%20for%20the%20preferred-left%20case%20%28flush%20with%20the%20left%20edge%29%20is%20clearly%20documented%2C%20but%20the%20symmetry%20on%20the%20right%20side%20is%20not.%20If%20a%20right-side%20fallback%20with%20zero%20gap%20ever%20looks%20visually%20abrupt%20%E2%80%94%20e.g.%20the%20icon%20immediately%20abutting%20text%20that%20overflows%20the%20field%20boundary%20%E2%80%94%20a%20dedicated%20%60fieldEdgeFallbackGap%60%20constant%20would%20make%20the%20asymmetric%20intent%20explicit%20and%20easy%20to%20adjust.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Field-edge%20mode%20should%20visually%20touch%20the%20input's%20outside%20edge.%20A%20gap%20reads%20as%20accidental%0A%20%20%20%20%2F%2F%2F%20padding%20because%20the%20icon%20is%20an%20affordance%20for%20the%20field%20itself%2C%20not%20for%20the%20surrounding%20UI.%0A%20%20%20%20private%20let%20fieldEdgeGap%3A%20CGFloat%20%3D%200%0A%20%20%20%20%2F%2F%2F%20When%20the%20indicator%20must%20fall%20back%20to%20the%20right%20side%20of%20the%20field%20%28left-edge-hugging%20inputs%29%2C%0A%20%20%20%20%2F%2F%2F%20a%20small%20gap%20avoids%20abutting%20text%20that%20overflows%20the%20field%20boundary.%20Set%20to%200%20to%20match%20the%0A%20%20%20%20%2F%2F%2F%20flush-edge%20intent%2C%20or%20raise%20to%20a%20small%20value%20%28e.g.%204%29%20if%20right-side%20fallback%20looks%20crowded.%0A%20%20%20%20private%20let%20fieldEdgeFallbackGap%3A%20CGFloat%20%3D%200%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Atabby%2FServices%2FUI%2FActivationIndicatorController.swift%3A216-222%0A%60.brightness%280.16%29%60%20adds%200.16%20to%20every%20color%20channel%20before%20clipping.%20Placing%20it%20before%20%60.clipShape%28%29%60%20means%20the%20brightened%20pixels%20outside%20the%20rounded%20rectangle%20are%20computed%20but%20then%20discarded%20by%20the%20clip%2C%20which%20is%20harmless.%20However%2C%20inserting%20it%20between%20%60.frame%28%29%60%20and%20%60.clipShape%28%29%60%20rather%20than%20right%20after%20%60Image%28nsImage%3A%29%60%20is%20slightly%20non-idiomatic%20%E2%80%94%20typically%20image-level%20color%20adjustments%20come%20before%20layout%20modifiers%20so%20the%20intent%20%28modify%20the%20image%2C%20not%20the%20layout%20box%29%20is%20clear%20at%20a%20glance.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20Image%28nsImage%3A%20icon%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.resizable%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.interpolation%28.high%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.scaledToFit%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.brightness%280.16%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.frame%28width%3A%2020%2C%20height%3A%2020%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.clipShape%28RoundedRectangle%28cornerRadius%3A%205%2C%20style%3A%20.continuous%29%29%0A%60%60%60%0A%0A&repo=fujacob%2Ftabby&pr=112&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Align activation indicator with field ed..."](https://github.com/fujacob/tabby/commit/3144485e1eb12b6a6a7b8f8fdddbd988329e0d03) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33160580)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->