### PR TITLE
Polish settings UI and disable user tags

### DIFF
--- a/tabby/Support/FoundationModelPromptRenderer.swift
+++ b/tabby/Support/FoundationModelPromptRenderer.swift
@@ -32,10 +32,11 @@ enum FoundationModelPromptRenderer {
         if let name = request.userName, !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             profileSections.append("The user's name is \(name).")
         }
-        if let tags = request.userTags, !tags.isEmpty {
-            let tagsString = tags.joined(separator: ", ")
-            profileSections.append("Things the user types often include: \(tagsString).")
-        }
+        // TODO: Re-enable userTags in the prompt once we validate the feature's value.
+        // if let tags = request.userTags, !tags.isEmpty {
+        //     let tagsString = tags.joined(separator: ", ")
+        //     profileSections.append("Things the user types often include: \(tagsString).")
+        // }
 
         if !profileSections.isEmpty {
             lines.append("User Profile Context:")

--- a/tabby/Support/LlamaPromptRenderer.swift
+++ b/tabby/Support/LlamaPromptRenderer.swift
@@ -35,10 +35,11 @@ enum LlamaPromptRenderer {
         if let name = userName, !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             profileSections.append("- The user's name is \(name).")
         }
-        if let tags = userTags, !tags.isEmpty {
-            let tagsString = tags.joined(separator: ", ")
-            profileSections.append("- Things the user types often include: \(tagsString).")
-        }
+        // TODO: Re-enable userTags in the prompt once we validate the feature's value.
+        // if let tags = userTags, !tags.isEmpty {
+        //     let tagsString = tags.joined(separator: ", ")
+        //     profileSections.append("- Things the user types often include: \(tagsString).")
+        // }
 
         if !profileSections.isEmpty {
             sections.append("")

--- a/tabby/UI/SettingsView.swift
+++ b/tabby/UI/SettingsView.swift
@@ -28,13 +28,13 @@ struct SettingsView: View {
     var body: some View {
         Form {
             settingsHeader
+            updatesSection
             generalSection
             autocompleteSection
             disabledAppsSection
             profileSection
             permissionsSection
             localModelsSection
-            updatesSection
         }
         .formStyle(.grouped)
         .frame(minWidth: 620, minHeight: 560)
@@ -113,7 +113,7 @@ struct SettingsView: View {
         Section("Autocomplete") {
             Toggle("Enable Globally", isOn: globallyEnabledBinding)
 
-            Toggle("Clipboard Context", isOn: clipboardContextEnabledBinding)
+            Toggle("Include Clipboard Context", isOn: clipboardContextEnabledBinding)
 
             Picker("Indicator", selection: selectedIndicatorModeBinding) {
                 ForEach(ActivationIndicatorMode.allCases) { mode in
@@ -204,18 +204,19 @@ struct SettingsView: View {
                     .textFieldStyle(.roundedBorder)
                 }
 
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("Things you type often")
-                        .font(.system(size: 13, weight: .medium))
-
-                    TagsInputView(
-                        tags: Binding(
-                            get: { suggestionSettings.userTags },
-                            set: { suggestionSettings.setUserTags($0) }
-                        ),
-                        placeholder: "Add tags (press Enter to add)"
-                    )
-                }
+                // TODO: Re-enable "Things you type often" once we validate the feature's value.
+                // VStack(alignment: .leading, spacing: 6) {
+                //     Text("Things you type often")
+                //         .font(.system(size: 13, weight: .medium))
+                //
+                //     TagsInputView(
+                //         tags: Binding(
+                //             get: { suggestionSettings.userTags },
+                //             set: { suggestionSettings.setUserTags($0) }
+                //         ),
+                //         placeholder: "Add tags (press Enter to add)"
+                //     )
+                // }
             }
             .padding(.vertical, 4)
         }

--- a/tabby/UI/WelcomeProfileStepView.swift
+++ b/tabby/UI/WelcomeProfileStepView.swift
@@ -33,23 +33,23 @@ struct WelcomeProfileStepView: View {
                     .controlSize(.large)
                 }
 
-                // Tags
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("Things you type often")
-                        .font(.system(size: 13, weight: .medium))
-
-                    Text("Optional. Tabby will self-learn, but feel free to add common phrases, email sign-offs, or jargon.")
-                        .font(.system(size: 11))
-                        .foregroundStyle(.secondary)
-
-                    TagsInputView(
-                        tags: Binding(
-                            get: { suggestionSettings.userTags },
-                            set: { suggestionSettings.setUserTags($0) }
-                        ),
-                        placeholder: "e.g., 'Best regards, Jacob', 'PR approved', 'LGTM'"
-                    )
-                }
+                // TODO: Re-enable "Things you type often" once we validate the feature's value.
+                // VStack(alignment: .leading, spacing: 6) {
+                //     Text("Things you type often")
+                //         .font(.system(size: 13, weight: .medium))
+                //
+                //     Text("Optional. Tabby will self-learn, but feel free to add common phrases, email sign-offs, or jargon.")
+                //         .font(.system(size: 11))
+                //         .foregroundStyle(.secondary)
+                //
+                //     TagsInputView(
+                //         tags: Binding(
+                //             get: { suggestionSettings.userTags },
+                //             set: { suggestionSettings.setUserTags($0) }
+                //         ),
+                //         placeholder: "e.g., 'Best regards, Jacob', 'PR approved', 'LGTM'"
+                //     )
+                // }
             }
             .padding(.horizontal, 8)
             .padding(.vertical, 4)


### PR DESCRIPTION
## Summary
- Move **Updates** section to top of settings (most immediately useful)
- Rename toggle from "Clipboard Context" → "Include Clipboard Context"
- Comment out "Things you type often" (user tags) everywhere: settings profile section, onboarding step, and both prompt renderers (Llama + Foundation Model). The plumbing and storage remain intact for easy re-enablement.

## Context
Tabby is still rough around the edges — no point shipping a feature we haven't validated yet. User tags add prompt tokens for unclear value. Disabling them now keeps the surface area small while we focus on core autocomplete quality.

## Test plan
- [x] Build succeeds
- [x] Test build succeeds
- [ ] Settings window shows Updates at the top
- [ ] Toggle reads "Include Clipboard Context"
- [ ] Profile section in settings only shows Name (no tags)
- [ ] Onboarding profile step only shows Name (no tags)
- [ ] Generated prompts do not include user tags even if previously saved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR polishes the settings UI and intentionally disables the user-tags feature across all surfaces while preserving the underlying storage for easy re-enablement later.

- The Updates section is moved above General in `SettingsView`, the clipboard toggle is renamed to "Include Clipboard Context", and the "Things you type often" block is commented out (with a TODO) in both the settings profile section and the onboarding step.
- Both prompt renderers (`LlamaPromptRenderer` and `FoundationModelPromptRenderer`) have their `userTags` injection commented out in parallel, so previously saved tags are never sent to a model even if they exist in storage.

<h3>Confidence Score: 4/5</h3>

Safe to merge — all user-tag surfaces are consistently disabled and the underlying storage is untouched.

The changes are narrow and consistent: both prompt renderers and both UI surfaces disable tags in lockstep, and the toggle rename and section reorder are straightforward. The only thing worth a second look is the stale doc comment in WelcomeProfileStepView that still describes collecting "common tags".

WelcomeProfileStepView.swift — its file-level doc comment still references tags collection.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tabby/Support/FoundationModelPromptRenderer.swift | User tags block commented out with TODO; no logic changes to the active prompt path |
| tabby/Support/LlamaPromptRenderer.swift | Mirror of FoundationModelPromptRenderer change — user tags block commented out with matching TODO |
| tabby/UI/SettingsView.swift | Updates section moved to top, toggle renamed to "Include Clipboard Context", profile tags commented out with TODO |
| tabby/UI/WelcomeProfileStepView.swift | Tags section commented out; file-level doc comment still references collecting "common tags" which is now disabled |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SuggestionSettingsModel\nuserTags stored ✓] -->|was read by| B[LlamaPromptRenderer\nuserTags block]
    A -->|was read by| C[FoundationModelPromptRenderer\nuserTags block]
    A -->|was shown in| D[SettingsView\nprofileSection]
    A -->|was shown in| E[WelcomeProfileStepView\nTags UI]
    B -->|now commented out 🚫| F[Llama Prompt\nno tags injected]
    C -->|now commented out 🚫| G[Foundation Model Prompt\nno tags injected]
    D -->|now commented out 🚫| H[Settings UI\nname only]
    E -->|now commented out 🚫| I[Onboarding UI\nname only]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tabby/UI/WelcomeProfileStepView.swift`, line 3-4 ([link](https://github.com/fujacob/tabby/blob/bf1b825ea7b4d9410e06841aa59313f50540d65a/tabby/UI/WelcomeProfileStepView.swift#L3-L4)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> The file-level doc comment still says "to collect the user's name and common tags," but the tags UI is now commented out. Per the AGENTS.md teaching comment standard, doc comments should accurately describe purpose and design — a stale description here will mislead anyone who reads it before re-enabling the feature.

   **Context Used:** AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=45fae5fd-3007-4631-a2b0-92b2beb3df2a))
   
   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22ui%2Fsettings-cleanup%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ui%2Fsettings-cleanup%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tabby%2FUI%2FWelcomeProfileStepView.swift%0ALine%3A%203-4%0A%0AComment%3A%0AThe%20file-level%20doc%20comment%20still%20says%20%22to%20collect%20the%20user's%20name%20and%20common%20tags%2C%22%20but%20the%20tags%20UI%20is%20now%20commented%20out.%20Per%20the%20AGENTS.md%20teaching%20comment%20standard%2C%20doc%20comments%20should%20accurately%20describe%20purpose%20and%20design%20%E2%80%94%20a%20stale%20description%20here%20will%20mislead%20anyone%20who%20reads%20it%20before%20re-enabling%20the%20feature.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20File%20overview%3A%0A%2F%2F%2F%20A%20dedicated%20step%20in%20the%20onboarding%20flow%20to%20collect%20the%20user's%20name.%0A%2F%2F%2F%20Tags%20%28%22Things%20you%20type%20often%22%29%20are%20temporarily%20disabled%20%E2%80%94%20see%20the%20TODO%20below%20for%20re-enablement.%0A%60%60%60%0A%0A**Context%20Used%3A**%20AGENTS.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D45fae5fd-3007-4631-a2b0-92b2beb3df2a%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tabby%2FUI%2FWelcomeProfileStepView.swift%0ALine%3A%203-4%0A%0AComment%3A%0AThe%20file-level%20doc%20comment%20still%20says%20%22to%20collect%20the%20user's%20name%20and%20common%20tags%2C%22%20but%20the%20tags%20UI%20is%20now%20commented%20out.%20Per%20the%20AGENTS.md%20teaching%20comment%20standard%2C%20doc%20comments%20should%20accurately%20describe%20purpose%20and%20design%20%E2%80%94%20a%20stale%20description%20here%20will%20mislead%20anyone%20who%20reads%20it%20before%20re-enabling%20the%20feature.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20File%20overview%3A%0A%2F%2F%2F%20A%20dedicated%20step%20in%20the%20onboarding%20flow%20to%20collect%20the%20user's%20name.%0A%2F%2F%2F%20Tags%20%28%22Things%20you%20type%20often%22%29%20are%20temporarily%20disabled%20%E2%80%94%20see%20the%20TODO%20below%20for%20re-enablement.%0A%60%60%60%0A%0A**Context%20Used%3A**%20AGENTS.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D45fae5fd-3007-4631-a2b0-92b2beb3df2a%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Ftabby&pr=115&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22ui%2Fsettings-cleanup%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ui%2Fsettings-cleanup%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atabby%2FUI%2FWelcomeProfileStepView.swift%3A3-4%0AThe%20file-level%20doc%20comment%20still%20says%20%22to%20collect%20the%20user's%20name%20and%20common%20tags%2C%22%20but%20the%20tags%20UI%20is%20now%20commented%20out.%20Per%20the%20AGENTS.md%20teaching%20comment%20standard%2C%20doc%20comments%20should%20accurately%20describe%20purpose%20and%20design%20%E2%80%94%20a%20stale%20description%20here%20will%20mislead%20anyone%20who%20reads%20it%20before%20re-enabling%20the%20feature.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20File%20overview%3A%0A%2F%2F%2F%20A%20dedicated%20step%20in%20the%20onboarding%20flow%20to%20collect%20the%20user's%20name.%0A%2F%2F%2F%20Tags%20%28%22Things%20you%20type%20often%22%29%20are%20temporarily%20disabled%20%E2%80%94%20see%20the%20TODO%20below%20for%20re-enablement.%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atabby%2FUI%2FWelcomeProfileStepView.swift%3A3-4%0AThe%20file-level%20doc%20comment%20still%20says%20%22to%20collect%20the%20user's%20name%20and%20common%20tags%2C%22%20but%20the%20tags%20UI%20is%20now%20commented%20out.%20Per%20the%20AGENTS.md%20teaching%20comment%20standard%2C%20doc%20comments%20should%20accurately%20describe%20purpose%20and%20design%20%E2%80%94%20a%20stale%20description%20here%20will%20mislead%20anyone%20who%20reads%20it%20before%20re-enabling%20the%20feature.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20File%20overview%3A%0A%2F%2F%2F%20A%20dedicated%20step%20in%20the%20onboarding%20flow%20to%20collect%20the%20user's%20name.%0A%2F%2F%2F%20Tags%20%28%22Things%20you%20type%20often%22%29%20are%20temporarily%20disabled%20%E2%80%94%20see%20the%20TODO%20below%20for%20re-enablement.%0A%60%60%60%0A%0A&repo=fujacob%2Ftabby&pr=115&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Polish settings UI and disable user tags..."](https://github.com/fujacob/tabby/commit/bf1b825ea7b4d9410e06841aa59313f50540d65a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33163747)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=45fae5fd-3007-4631-a2b0-92b2beb3df2a))

<!-- /greptile_comment -->