### PR TITLE
Simplify indicator to on/off toggle

### DIFF
--- a/tabby/App/Core/AppDelegate.swift
+++ b/tabby/App/Core/AppDelegate.swift
@@ -139,9 +139,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         activationIndicatorController.show(
-            mode: suggestionSettings.selectedIndicatorMode,
-            caretRect: context.caretRect,
-            inputFrameRect: context.inputFrameRect
+            enabled: suggestionSettings.showCaretIndicator,
+            caretRect: context.caretRect
         )
     }
 

--- a/tabby/Services/UI/ActivationIndicatorController.swift
+++ b/tabby/Services/UI/ActivationIndicatorController.swift
@@ -3,18 +3,14 @@ import Foundation
 import SwiftUI
 
 /// File overview:
-/// Owns the tiny non-activating panel that marks supported inputs with a subtle affordance.
-/// Unlike the ghost-text overlay, this controller is focus-driven and can anchor either to the
-/// caret itself or to the left edge of the active text area.
+/// Owns the tiny non-activating panel that marks supported inputs with a subtle caret pointer.
+/// Unlike the ghost-text overlay, this controller is focus-driven and toggled by a simple boolean.
 ///
 /// Keeping this as a separate controller preserves the architectural split between:
 /// supported-field affordances and suggestion-specific UI.
 @MainActor
 final class ActivationIndicatorController {
     private let verticalGap: CGFloat = 2
-    /// Field-edge mode should visually touch the input's outside edge. A gap reads as accidental
-    /// padding because the icon is an affordance for the field itself, not for the surrounding UI.
-    private let fieldEdgeGap: CGFloat = 0
     private let screenInset: CGFloat = 2
 
     private lazy var contentView: NSHostingView<AnyView> = {
@@ -40,20 +36,15 @@ final class ActivationIndicatorController {
         return panel
     }()
 
-    private var lastMode: ActivationIndicatorMode?
+    private var isVisible = false
 
-    /// Sizes and positions the chosen activation affordance for the current field.
-    ///
-    /// `caretAnchor` points directly at the insertion point, while `fieldEdgeIcon` places Tabby's
-    /// icon outside the text area's left edge so the signal stays visible even when caret geometry
-    /// is jittery.
+    /// Shows or hides the caret-anchored indicator based on a simple boolean toggle.
     func show(
-        mode: ActivationIndicatorMode,
-        caretRect: CGRect,
-        inputFrameRect: CGRect?
+        enabled: Bool,
+        caretRect: CGRect
     ) {
-        guard mode != .hidden else {
-            hide(reason: "Activation indicator hidden because the chosen mode is Hidden.")
+        guard enabled else {
+            hide(reason: "Activation indicator hidden because it is disabled.")
             return
         }
 
@@ -62,51 +53,25 @@ final class ActivationIndicatorController {
             return
         }
 
-        contentView.rootView = AnyView(view(for: mode))
+        contentView.rootView = AnyView(CaretAnchorIndicatorView())
         contentView.layoutSubtreeIfNeeded()
         let contentSize = contentView.fittingSize
-
-        let origin: CGPoint
-        switch mode {
-        case .hidden:
-            hide(reason: "Activation indicator hidden because the chosen mode is Hidden.")
-            return
-        case .caretAnchor:
-            origin = caretAnchorOrigin(for: caretRect, contentSize: contentSize)
-        case .fieldEdgeIcon:
-            origin = fieldEdgeIconOrigin(
-                caretRect: caretRect,
-                inputFrameRect: inputFrameRect,
-                contentSize: contentSize
-            )
-        }
+        let origin = caretAnchorOrigin(for: caretRect, contentSize: contentSize)
 
         let frame = CGRect(origin: origin, size: contentSize).integral
-        if lastMode == mode, panel.frame == frame, panel.isVisible {
+        if isVisible, panel.frame == frame, panel.isVisible {
             return
         }
 
         panel.setFrame(frame, display: true)
         panel.orderFrontRegardless()
-        lastMode = mode
+        isVisible = true
     }
 
     /// Hides the indicator when Tabby is not actively supporting the current field.
     func hide(reason _: String) {
         panel.orderOut(nil)
-        lastMode = nil
-    }
-
-    @ViewBuilder
-    private func view(for mode: ActivationIndicatorMode) -> some View {
-        switch mode {
-        case .hidden:
-            EmptyView()
-        case .caretAnchor:
-            CaretAnchorIndicatorView()
-        case .fieldEdgeIcon:
-            FieldEdgeIconIndicatorView(icon: NSApp.applicationIconImage)
-        }
+        isVisible = false
     }
 
     /// Centers the caret pointer horizontally on the caret and prefers placing it just below the
@@ -132,42 +97,6 @@ final class ActivationIndicatorController {
         )
         let clampedY = min(
             max(preferredY, visibleFrame.minY + screenInset),
-            visibleFrame.maxY - contentSize.height - screenInset
-        )
-
-        return CGPoint(x: clampedX, y: clampedY)
-    }
-
-    /// Places Tabby's icon just outside the text area's left edge. When the field is flush against
-    /// the screen edge we fall back to the right side so the icon stays fully visible.
-    private func fieldEdgeIconOrigin(
-        caretRect: CGRect,
-        inputFrameRect: CGRect?,
-        contentSize: CGSize
-    ) -> CGPoint {
-        let anchorRect = if let inputFrameRect, !inputFrameRect.isEmpty {
-            inputFrameRect
-        } else {
-            caretRect
-        }
-        let preferredLeftX = anchorRect.minX - contentSize.width - fieldEdgeGap
-        let fallbackRightX = anchorRect.maxX + fieldEdgeGap
-        let centeredY = anchorRect.midY - (contentSize.height / 2)
-
-        guard let screen = screen(for: anchorRect) else {
-            return CGPoint(x: preferredLeftX, y: centeredY)
-        }
-
-        let visibleFrame = screen.visibleFrame
-        let preferredX = preferredLeftX >= visibleFrame.minX + screenInset
-            ? preferredLeftX
-            : fallbackRightX
-        let clampedX = min(
-            max(preferredX, visibleFrame.minX + screenInset),
-            visibleFrame.maxX - contentSize.width - screenInset
-        )
-        let clampedY = min(
-            max(centeredY, visibleFrame.minY + screenInset),
             visibleFrame.maxY - contentSize.height - screenInset
         )
 
@@ -205,22 +134,6 @@ private struct CaretAnchorIndicatorView: View {
             .fill(bgColor)
             .frame(width: 8, height: 5)
             .shadow(color: .black.opacity(0.16), radius: 1, y: 1)
-            .fixedSize()
-    }
-}
-
-private struct FieldEdgeIconIndicatorView: View {
-    let icon: NSImage
-
-    var body: some View {
-        Image(nsImage: icon)
-            .resizable()
-            .interpolation(.high)
-            .scaledToFit()
-            .frame(width: 20, height: 20)
-            .brightness(0.16)
-            .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
-            .shadow(color: .black.opacity(0.10), radius: 2, y: 1)
             .fixedSize()
     }
 }

--- a/tabby/UI/MenuBarView.swift
+++ b/tabby/UI/MenuBarView.swift
@@ -78,7 +78,7 @@ struct MenuBarView: View {
                 .toggleStyle(.switch)
                 .controlSize(.small)
 
-            Toggle("Clipboard Context", isOn: clipboardContextEnabledBinding)
+            Toggle("Include Clipboard Context", isOn: clipboardContextEnabledBinding)
                 .toggleStyle(.switch)
                 .controlSize(.small)
 

--- a/tabby/UI/MenuBarView.swift
+++ b/tabby/UI/MenuBarView.swift
@@ -88,16 +88,9 @@ struct MenuBarView: View {
                     .controlSize(.small)
             }
 
-            MenuBarPickerRow(title: "Indicator") {
-                Picker("Indicator", selection: selectedIndicatorModeBinding) {
-                    ForEach(ActivationIndicatorMode.allCases) { mode in
-                        Text(mode.compactLabel)
-                            .tag(mode)
-                    }
-                }
-                .labelsHidden()
-                .pickerStyle(.menu)
-            }
+            Toggle("Indicator", isOn: showCaretIndicatorBinding)
+                .toggleStyle(.switch)
+                .controlSize(.small)
 
             MenuBarPickerRow(title: "Engine") {
                 Picker("Engine", selection: selectedEngineBinding) {
@@ -248,10 +241,10 @@ struct MenuBarView: View {
         )
     }
 
-    private var selectedIndicatorModeBinding: Binding<ActivationIndicatorMode> {
+    private var showCaretIndicatorBinding: Binding<Bool> {
         Binding(
-            get: { suggestionSettings.selectedIndicatorMode },
-            set: { suggestionSettings.selectIndicatorMode($0) }
+            get: { suggestionSettings.showCaretIndicator },
+            set: { suggestionSettings.setShowCaretIndicator($0) }
         )
     }
 

--- a/tabby/UI/SettingsView.swift
+++ b/tabby/UI/SettingsView.swift
@@ -117,25 +117,26 @@ struct SettingsView: View {
 
             Toggle("Show Indicator", isOn: showCaretIndicatorBinding)
 
-            LabeledContent("Ghost Text Color") {
-                HStack(spacing: 8) {
-                    ColorPicker(
-                        "Ghost Text Color",
-                        selection: customSuggestionTextColorBinding,
-                        supportsOpacity: false
-                    )
-                    .labelsHidden()
-
-                    Button("Use Automatic") {
-                        suggestionSettings.setCustomSuggestionTextColorHex(nil)
-                    }
-                    .disabled(suggestionSettings.customSuggestionTextColorHex == nil)
-                }
-            }
-
-            Text(ghostTextColorDescription)
-                .font(.caption)
-                .foregroundStyle(.secondary)
+            // TODO: Re-enable ghost text color customization once the inline overlay is stable.
+            // LabeledContent("Ghost Text Color") {
+            //     HStack(spacing: 8) {
+            //         ColorPicker(
+            //             "Ghost Text Color",
+            //             selection: customSuggestionTextColorBinding,
+            //             supportsOpacity: false
+            //         )
+            //         .labelsHidden()
+            //
+            //         Button("Use Automatic") {
+            //             suggestionSettings.setCustomSuggestionTextColorHex(nil)
+            //         }
+            //         .disabled(suggestionSettings.customSuggestionTextColorHex == nil)
+            //     }
+            // }
+            //
+            // Text(ghostTextColorDescription)
+            //     .font(.caption)
+            //     .foregroundStyle(.secondary)
 
             Picker("Engine", selection: selectedEngineBinding) {
                 ForEach(SuggestionEngineKind.allCases) { engine in

--- a/tabby/UI/SettingsView.swift
+++ b/tabby/UI/SettingsView.swift
@@ -115,12 +115,7 @@ struct SettingsView: View {
 
             Toggle("Include Clipboard Context", isOn: clipboardContextEnabledBinding)
 
-            Picker("Indicator", selection: selectedIndicatorModeBinding) {
-                ForEach(ActivationIndicatorMode.allCases) { mode in
-                    Text(mode.displayLabel)
-                        .tag(mode)
-                }
-            }
+            Toggle("Show Indicator", isOn: showCaretIndicatorBinding)
 
             LabeledContent("Ghost Text Color") {
                 HStack(spacing: 8) {
@@ -442,12 +437,10 @@ struct SettingsView: View {
         )
     }
 
-    private var selectedIndicatorModeBinding: Binding<ActivationIndicatorMode> {
+    private var showCaretIndicatorBinding: Binding<Bool> {
         Binding(
-            get: { suggestionSettings.selectedIndicatorMode },
-            set: { mode in
-                suggestionSettings.selectIndicatorMode(mode)
-            }
+            get: { suggestionSettings.showCaretIndicator },
+            set: { suggestionSettings.setShowCaretIndicator($0) }
         )
     }
 


### PR DESCRIPTION
## Summary
- Replace 3-mode indicator picker (None / Caret / Tabby Icon) with a simple on/off toggle in both settings and menu bar
- Rename "Clipboard Context" → "Include Clipboard Context" in menu bar (matches settings)
- Comment out Ghost Text Color picker — only relevant for inline overlay which isn't stable yet
- Remove `FieldEdgeIconIndicatorView` and field-edge positioning logic (~100 lines deleted)
- `ActivationIndicatorController.show()` simplified to `enabled: Bool` + `caretRect`
- `ActivationIndicatorMode` enum kept for backward-compatible deserialization

## Test plan
- [x] Build succeeds
- [ ] Settings: "Show Indicator" toggle, no Ghost Text Color row
- [ ] Menu bar: "Include Clipboard Context" and "Indicator" toggles
- [ ] Toggle on → caret pointer appears; toggle off → no indicator
- [ ] Users with prior "Tabby Icon" preference gracefully fall back

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the three-mode activation indicator picker (None / Caret / Tabby Icon) with a simple on/off toggle across Settings and the menu bar, removing `FieldEdgeIconIndicatorView` and its field-edge positioning logic (~100 lines). The `ActivationIndicatorMode` enum is kept for backward-compatible deserialization of persisted preferences, and users who had \"Tabby Icon\" selected gracefully fall back to the caret indicator.

- `ActivationIndicatorController.show()` API simplified from `(mode:caretRect:inputFrameRect:)` to `(enabled:caretRect:)`, eliminating the unused field-edge code path.
- Both `SettingsView` and `MenuBarView` now use a `Toggle` backed by `showCaretIndicator` / `setShowCaretIndicator` on `SuggestionSettingsModel`.
- The ghost-text color customization UI is commented out with a TODO pending overlay stability.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the simplification is well-scoped, the backward-compat path for persisted fieldEdgeIcon users is correctly handled, and no logic regressions were found.

The code changes are clean and the reduction in surface area is a net positive. The two stale doc comments in SuggestionSettingsModel and SuggestionModels now describe the opposite of the current design intent, which could mislead a future contributor into treating the boolean-based API as a deprecated shim scheduled for removal.

The doc comments on showCaretIndicator/setShowCaretIndicator in SuggestionSettingsModel.swift and the enum-level comment in SuggestionModels.swift should be updated to reflect that the boolean toggle is now the primary interface, not a transitional shim.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tabby/App/Core/AppDelegate.swift | Drops `mode` and `inputFrameRect` from the `activationIndicatorController.show()` call-site; now passes `enabled: Bool` and `caretRect` only. Simple, correct change. |
| tabby/Services/UI/ActivationIndicatorController.swift | Removed `FieldEdgeIconIndicatorView` and all field-edge positioning logic (~100 lines); `show()` now takes `enabled: Bool` + `caretRect`, always displays `CaretAnchorIndicatorView`. No regressions found; early-return optimization is preserved. |
| tabby/UI/MenuBarView.swift | Replaces `MenuBarPickerRow` + `Picker` for indicator with a simple `Toggle("Indicator")`; also renames "Clipboard Context" label to "Include Clipboard Context" for consistency with SettingsView. Clean change. |
| tabby/UI/SettingsView.swift | Replaces `Picker("Indicator")` with `Toggle("Show Indicator")` and comments out the ghost-text color section with a TODO. The commented-out block is well-scoped and the TODO is clear. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant SettingsView/MenuBarView
    participant SuggestionSettingsModel
    participant AppDelegate
    participant ActivationIndicatorController

    User->>SettingsView/MenuBarView: Toggle "Show Indicator" (on/off)
    SettingsView/MenuBarView->>SuggestionSettingsModel: setShowCaretIndicator(Bool)
    SuggestionSettingsModel->>SuggestionSettingsModel: selectIndicatorMode(.caretAnchor / .hidden)
    SuggestionSettingsModel->>SuggestionSettingsModel: persist to UserDefaults

    AppDelegate->>SuggestionSettingsModel: read showCaretIndicator
    AppDelegate->>ActivationIndicatorController: show(enabled: Bool, caretRect: CGRect)
    alt "enabled == true && caretRect non-empty"
        ActivationIndicatorController->>ActivationIndicatorController: render CaretAnchorIndicatorView
        ActivationIndicatorController->>ActivationIndicatorController: panel.orderFrontRegardless()
    else
        ActivationIndicatorController->>ActivationIndicatorController: panel.orderOut (hide)
    end
```

<sub>Reviews (1): Last reviewed commit: ["Rename clipboard toggle in menu bar, dis..."](https://github.com/fujacob/tabby/commit/28cb21d80e50355c677d6a47ef1f63db2edd484e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33164853)</sub>

<!-- /greptile_comment -->