### PR TITLE
Simplify activation indicator + add local DMG build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,11 @@ build/
 .LSOverride
 ._*
 
+# Python virtual environments
+.venv/
+.venv-*/
+venv/
+
 # Large model files — keep out of git
 *.gguf
 *.bin

--- a/scripts/build_test_dmg.sh
+++ b/scripts/build_test_dmg.sh
@@ -12,7 +12,7 @@ BACKGROUND="$REPO_ROOT/assets/release/dmg_background.png"
 # Ensure dmgbuild is available.
 if ! python3 -c "import dmgbuild" 2>/dev/null; then
     echo "Installing dmgbuild..."
-    python3 -m pip install "dmgbuild[badge_icons]==1.6.7"
+    python3 -m pip install --user "dmgbuild[badge_icons]==1.6.7"
 fi
 
 # Build the app if the bundle is missing.

--- a/scripts/build_test_dmg.sh
+++ b/scripts/build_test_dmg.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Build a local test DMG from the Debug app bundle.
+# Usage: bash scripts/build_test_dmg.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DERIVED_DATA="/tmp/TabbyDerivedData"
+APP_PATH="$DERIVED_DATA/Build/Products/Debug/Tabby.app"
+OUTPUT_PATH="/tmp/Tabby-test.dmg"
+BACKGROUND="$REPO_ROOT/assets/release/dmg_background.png"
+
+# Ensure dmgbuild is available.
+if ! python3 -c "import dmgbuild" 2>/dev/null; then
+    echo "Installing dmgbuild..."
+    python3 -m pip install "dmgbuild[badge_icons]==1.6.7"
+fi
+
+# Build the app if the bundle is missing.
+if [ ! -d "$APP_PATH" ]; then
+    echo "Tabby.app not found — building..."
+    xcodebuild \
+        -project "$REPO_ROOT/tabby.xcodeproj" \
+        -scheme tabby \
+        -configuration Debug \
+        -derivedDataPath "$DERIVED_DATA" \
+        build
+fi
+
+echo "Building DMG..."
+python3 "$REPO_ROOT/scripts/build_release_dmg.py" \
+    --app-path "$APP_PATH" \
+    --output-path "$OUTPUT_PATH" \
+    --background-path "$BACKGROUND" \
+    --volume-name "Tabby"
+
+echo "Opening $OUTPUT_PATH"
+open "$OUTPUT_PATH"

--- a/tabby/App/Core/AppDelegate.swift
+++ b/tabby/App/Core/AppDelegate.swift
@@ -139,9 +139,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         activationIndicatorController.show(
-            mode: suggestionSettings.selectedIndicatorMode,
-            caretRect: context.caretRect,
-            inputFrameRect: context.inputFrameRect
+            enabled: suggestionSettings.showCaretIndicator,
+            caretRect: context.caretRect
         )
     }
 

--- a/tabby/Services/Runtime/LlamaRuntimeCore.swift
+++ b/tabby/Services/Runtime/LlamaRuntimeCore.swift
@@ -446,18 +446,18 @@ actor LlamaRuntimeCore {
 
             batch.n_tokens = Int32(chunkSize)
 
-            for i in 0 ..< chunkSize {
-                let tokenIndex = cursor + i
-                batch.token[i] = promptTokens[tokenIndex]
-                batch.pos[i] = Int32(tokenIndex)
-                batch.n_seq_id[i] = 1
+            for offset in 0 ..< chunkSize {
+                let tokenIndex = cursor + offset
+                batch.token[offset] = promptTokens[tokenIndex]
+                batch.pos[offset] = Int32(tokenIndex)
+                batch.n_seq_id[offset] = 1
 
-                if let seqIDs = batch.seq_id, let seqID = seqIDs[i] {
+                if let seqIDs = batch.seq_id, let seqID = seqIDs[offset] {
                     seqID[0] = Self.promptSequenceID
                 }
 
                 // Only request logits for the very last token of the entire prompt.
-                batch.logits[i] = (chunkEnd == endIndex && i == chunkSize - 1) ? 1 : 0
+                batch.logits[offset] = (chunkEnd == endIndex && offset == chunkSize - 1) ? 1 : 0
             }
 
             guard llama_decode(context, batch) == 0 else {

--- a/tabby/Services/UI/ActivationIndicatorController.swift
+++ b/tabby/Services/UI/ActivationIndicatorController.swift
@@ -3,18 +3,14 @@ import Foundation
 import SwiftUI
 
 /// File overview:
-/// Owns the tiny non-activating panel that marks supported inputs with a subtle affordance.
-/// Unlike the ghost-text overlay, this controller is focus-driven and can anchor either to the
-/// caret itself or to the left edge of the active text area.
+/// Owns the tiny non-activating panel that marks supported inputs with a subtle caret pointer.
+/// Unlike the ghost-text overlay, this controller is focus-driven and toggled by a simple boolean.
 ///
 /// Keeping this as a separate controller preserves the architectural split between:
 /// supported-field affordances and suggestion-specific UI.
 @MainActor
 final class ActivationIndicatorController {
     private let verticalGap: CGFloat = 2
-    /// Field-edge mode should visually touch the input's outside edge. A gap reads as accidental
-    /// padding because the icon is an affordance for the field itself, not for the surrounding UI.
-    private let fieldEdgeGap: CGFloat = 0
     private let screenInset: CGFloat = 2
 
     private lazy var contentView: NSHostingView<AnyView> = {
@@ -40,20 +36,15 @@ final class ActivationIndicatorController {
         return panel
     }()
 
-    private var lastMode: ActivationIndicatorMode?
+    private var isVisible = false
 
-    /// Sizes and positions the chosen activation affordance for the current field.
-    ///
-    /// `caretAnchor` points directly at the insertion point, while `fieldEdgeIcon` places Tabby's
-    /// icon outside the text area's left edge so the signal stays visible even when caret geometry
-    /// is jittery.
+    /// Shows or hides the caret-anchored indicator based on a simple boolean toggle.
     func show(
-        mode: ActivationIndicatorMode,
-        caretRect: CGRect,
-        inputFrameRect: CGRect?
+        enabled: Bool,
+        caretRect: CGRect
     ) {
-        guard mode != .hidden else {
-            hide(reason: "Activation indicator hidden because the chosen mode is Hidden.")
+        guard enabled else {
+            hide(reason: "Activation indicator hidden because it is disabled.")
             return
         }
 
@@ -62,51 +53,25 @@ final class ActivationIndicatorController {
             return
         }
 
-        contentView.rootView = AnyView(view(for: mode))
+        contentView.rootView = AnyView(CaretAnchorIndicatorView())
         contentView.layoutSubtreeIfNeeded()
         let contentSize = contentView.fittingSize
-
-        let origin: CGPoint
-        switch mode {
-        case .hidden:
-            hide(reason: "Activation indicator hidden because the chosen mode is Hidden.")
-            return
-        case .caretAnchor:
-            origin = caretAnchorOrigin(for: caretRect, contentSize: contentSize)
-        case .fieldEdgeIcon:
-            origin = fieldEdgeIconOrigin(
-                caretRect: caretRect,
-                inputFrameRect: inputFrameRect,
-                contentSize: contentSize
-            )
-        }
+        let origin = caretAnchorOrigin(for: caretRect, contentSize: contentSize)
 
         let frame = CGRect(origin: origin, size: contentSize).integral
-        if lastMode == mode, panel.frame == frame, panel.isVisible {
+        if isVisible, panel.frame == frame, panel.isVisible {
             return
         }
 
         panel.setFrame(frame, display: true)
         panel.orderFrontRegardless()
-        lastMode = mode
+        isVisible = true
     }
 
     /// Hides the indicator when Tabby is not actively supporting the current field.
     func hide(reason _: String) {
         panel.orderOut(nil)
-        lastMode = nil
-    }
-
-    @ViewBuilder
-    private func view(for mode: ActivationIndicatorMode) -> some View {
-        switch mode {
-        case .hidden:
-            EmptyView()
-        case .caretAnchor:
-            CaretAnchorIndicatorView()
-        case .fieldEdgeIcon:
-            FieldEdgeIconIndicatorView(icon: NSApp.applicationIconImage)
-        }
+        isVisible = false
     }
 
     /// Centers the caret pointer horizontally on the caret and prefers placing it just below the
@@ -132,42 +97,6 @@ final class ActivationIndicatorController {
         )
         let clampedY = min(
             max(preferredY, visibleFrame.minY + screenInset),
-            visibleFrame.maxY - contentSize.height - screenInset
-        )
-
-        return CGPoint(x: clampedX, y: clampedY)
-    }
-
-    /// Places Tabby's icon just outside the text area's left edge. When the field is flush against
-    /// the screen edge we fall back to the right side so the icon stays fully visible.
-    private func fieldEdgeIconOrigin(
-        caretRect: CGRect,
-        inputFrameRect: CGRect?,
-        contentSize: CGSize
-    ) -> CGPoint {
-        let anchorRect = if let inputFrameRect, !inputFrameRect.isEmpty {
-            inputFrameRect
-        } else {
-            caretRect
-        }
-        let preferredLeftX = anchorRect.minX - contentSize.width - fieldEdgeGap
-        let fallbackRightX = anchorRect.maxX + fieldEdgeGap
-        let centeredY = anchorRect.midY - (contentSize.height / 2)
-
-        guard let screen = screen(for: anchorRect) else {
-            return CGPoint(x: preferredLeftX, y: centeredY)
-        }
-
-        let visibleFrame = screen.visibleFrame
-        let preferredX = preferredLeftX >= visibleFrame.minX + screenInset
-            ? preferredLeftX
-            : fallbackRightX
-        let clampedX = min(
-            max(preferredX, visibleFrame.minX + screenInset),
-            visibleFrame.maxX - contentSize.width - screenInset
-        )
-        let clampedY = min(
-            max(centeredY, visibleFrame.minY + screenInset),
             visibleFrame.maxY - contentSize.height - screenInset
         )
 
@@ -205,22 +134,6 @@ private struct CaretAnchorIndicatorView: View {
             .fill(bgColor)
             .frame(width: 8, height: 5)
             .shadow(color: .black.opacity(0.16), radius: 1, y: 1)
-            .fixedSize()
-    }
-}
-
-private struct FieldEdgeIconIndicatorView: View {
-    let icon: NSImage
-
-    var body: some View {
-        Image(nsImage: icon)
-            .resizable()
-            .interpolation(.high)
-            .scaledToFit()
-            .frame(width: 20, height: 20)
-            .brightness(0.16)
-            .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
-            .shadow(color: .black.opacity(0.10), radius: 2, y: 1)
             .fixedSize()
     }
 }

--- a/tabby/UI/MenuBarView.swift
+++ b/tabby/UI/MenuBarView.swift
@@ -78,7 +78,7 @@ struct MenuBarView: View {
                 .toggleStyle(.switch)
                 .controlSize(.small)
 
-            Toggle("Clipboard Context", isOn: clipboardContextEnabledBinding)
+            Toggle("Include Clipboard Context", isOn: clipboardContextEnabledBinding)
                 .toggleStyle(.switch)
                 .controlSize(.small)
 

--- a/tabby/UI/MenuBarView.swift
+++ b/tabby/UI/MenuBarView.swift
@@ -88,16 +88,9 @@ struct MenuBarView: View {
                     .controlSize(.small)
             }
 
-            MenuBarPickerRow(title: "Indicator") {
-                Picker("Indicator", selection: selectedIndicatorModeBinding) {
-                    ForEach(ActivationIndicatorMode.allCases) { mode in
-                        Text(mode.compactLabel)
-                            .tag(mode)
-                    }
-                }
-                .labelsHidden()
-                .pickerStyle(.menu)
-            }
+            Toggle("Indicator", isOn: showCaretIndicatorBinding)
+                .toggleStyle(.switch)
+                .controlSize(.small)
 
             MenuBarPickerRow(title: "Engine") {
                 Picker("Engine", selection: selectedEngineBinding) {
@@ -248,10 +241,10 @@ struct MenuBarView: View {
         )
     }
 
-    private var selectedIndicatorModeBinding: Binding<ActivationIndicatorMode> {
+    private var showCaretIndicatorBinding: Binding<Bool> {
         Binding(
-            get: { suggestionSettings.selectedIndicatorMode },
-            set: { suggestionSettings.selectIndicatorMode($0) }
+            get: { suggestionSettings.showCaretIndicator },
+            set: { suggestionSettings.setShowCaretIndicator($0) }
         )
     }
 

--- a/tabby/UI/SettingsView.swift
+++ b/tabby/UI/SettingsView.swift
@@ -117,25 +117,26 @@ struct SettingsView: View {
 
             Toggle("Show Indicator", isOn: showCaretIndicatorBinding)
 
-            LabeledContent("Ghost Text Color") {
-                HStack(spacing: 8) {
-                    ColorPicker(
-                        "Ghost Text Color",
-                        selection: customSuggestionTextColorBinding,
-                        supportsOpacity: false
-                    )
-                    .labelsHidden()
-
-                    Button("Use Automatic") {
-                        suggestionSettings.setCustomSuggestionTextColorHex(nil)
-                    }
-                    .disabled(suggestionSettings.customSuggestionTextColorHex == nil)
-                }
-            }
-
-            Text(ghostTextColorDescription)
-                .font(.caption)
-                .foregroundStyle(.secondary)
+            // TODO: Re-enable ghost text color customization once the inline overlay is stable.
+            // LabeledContent("Ghost Text Color") {
+            //     HStack(spacing: 8) {
+            //         ColorPicker(
+            //             "Ghost Text Color",
+            //             selection: customSuggestionTextColorBinding,
+            //             supportsOpacity: false
+            //         )
+            //         .labelsHidden()
+            //
+            //         Button("Use Automatic") {
+            //             suggestionSettings.setCustomSuggestionTextColorHex(nil)
+            //         }
+            //         .disabled(suggestionSettings.customSuggestionTextColorHex == nil)
+            //     }
+            // }
+            //
+            // Text(ghostTextColorDescription)
+            //     .font(.caption)
+            //     .foregroundStyle(.secondary)
 
             Picker("Engine", selection: selectedEngineBinding) {
                 ForEach(SuggestionEngineKind.allCases) { engine in

--- a/tabby/UI/SettingsView.swift
+++ b/tabby/UI/SettingsView.swift
@@ -115,12 +115,7 @@ struct SettingsView: View {
 
             Toggle("Include Clipboard Context", isOn: clipboardContextEnabledBinding)
 
-            Picker("Indicator", selection: selectedIndicatorModeBinding) {
-                ForEach(ActivationIndicatorMode.allCases) { mode in
-                    Text(mode.displayLabel)
-                        .tag(mode)
-                }
-            }
+            Toggle("Show Indicator", isOn: showCaretIndicatorBinding)
 
             LabeledContent("Ghost Text Color") {
                 HStack(spacing: 8) {
@@ -442,12 +437,10 @@ struct SettingsView: View {
         )
     }
 
-    private var selectedIndicatorModeBinding: Binding<ActivationIndicatorMode> {
+    private var showCaretIndicatorBinding: Binding<Bool> {
         Binding(
-            get: { suggestionSettings.selectedIndicatorMode },
-            set: { mode in
-                suggestionSettings.selectIndicatorMode(mode)
-            }
+            get: { suggestionSettings.showCaretIndicator },
+            set: { suggestionSettings.setShowCaretIndicator($0) }
         )
     }
 


### PR DESCRIPTION
## Summary
- **Indicator simplified**: Replace 3-mode picker (None / Caret / Tabby Icon) with a simple on/off toggle in settings and menu bar
- **Clipboard toggle renamed**: "Clipboard Context" → "Include Clipboard Context" in both menu bar and settings
- **Ghost Text Color disabled**: Commented out the color picker and description — only relevant for the inline overlay which isn't stable yet
- **Local DMG build script**: Added `scripts/build_test_dmg.sh` for quick local QA builds
- **SwiftLint fix**: Renamed `i` → `offset` in chunked decode loop to satisfy `identifier_name` min_length rule
- Removed `FieldEdgeIconIndicatorView` and field-edge positioning logic (~100 lines deleted)
- `ActivationIndicatorController.show()` simplified to `enabled: Bool` + `caretRect`

## Test plan
- [x] Build succeeds
- [x] SwiftLint passes (0 serious violations)
- [ ] Settings: "Show Indicator" toggle, no Ghost Text Color, "Include Clipboard Context"
- [ ] Menu bar: "Include Clipboard Context" and "Indicator" toggles
- [ ] Toggle on → caret pointer appears; toggle off → no indicator
- [ ] `bash scripts/build_test_dmg.sh` produces a working DMG

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR simplifies the activation indicator from a three-way mode picker (`hidden` / `caretAnchor` / `fieldEdgeIcon`) to a plain boolean toggle, removes the `FieldEdgeIconIndicatorView` rendering path, and adds a local `scripts/build_test_dmg.sh` helper for testing DMG builds.

- **Indicator simplification**: `ActivationIndicatorController.show()` now takes `enabled: Bool` instead of a mode enum; the `fieldEdgeIcon` view and its positioning logic are deleted. `SuggestionSettingsModel` retains the underlying `ActivationIndicatorMode` enum and the legacy UserDefaults key for migration compatibility, exposing `showCaretIndicator`/`setShowCaretIndicator` shims to the new boolean UI.
- **UI updates**: Both `MenuBarView` and `SettingsView` replace the `Picker` with a `Toggle`, and the clipboard menu item is renamed to "Include Clipboard Context".
- **Build script**: `scripts/build_test_dmg.sh` installs `dmgbuild` with `--user`, optionally runs `xcodebuild`, then invokes `build_release_dmg.py` and opens the result; `.gitignore` gains venv patterns to match.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a straightforward deletion of unused rendering paths, and existing migration shims keep UserDefaults backward-compatible

All changed paths are well-scoped: the controller drops a rendering branch that no longer has a caller, the settings model retains the enum for legacy key migration, and the UI updates are one-for-one toggle replacements. No new state is introduced and no existing persistence contract is broken.

No files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tabby/Services/UI/ActivationIndicatorController.swift | Removes fieldEdgeIcon mode and FieldEdgeIconIndicatorView; simplifies show() to a bool+caretRect signature; replaces lastMode tracking with an isVisible flag |
| tabby/UI/MenuBarView.swift | Replaces the Indicator mode picker with a Toggle backed by showCaretIndicator; renames Clipboard Context to Include Clipboard Context |
| tabby/UI/SettingsView.swift | Replaces Indicator picker with Show Indicator toggle; comments out ghost text color section with a TODO |
| tabby/App/Core/AppDelegate.swift | Updates activationIndicatorController.show() call site to use the new bool+caretRect signature, dropping inputFrameRect |
| scripts/build_test_dmg.sh | New developer helper script that installs dmgbuild with --user, optionally builds the Debug bundle via xcodebuild, invokes build_release_dmg.py, then opens the resulting DMG |
| tabby/Services/Runtime/LlamaRuntimeCore.swift | Renames loop variable i to offset for clarity in the batch-token preparation loop, pure readability change with no behavioural impact |
| .gitignore | Adds Python venv directory patterns to keep virtual environments out of git |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["AppDelegate.updateActivationIndicator()"] -->|"show(enabled:caretRect:)"| B["ActivationIndicatorController"]
    B --> C{enabled AND not caretRect.isEmpty}
    C -->|No| D["hide()"]
    C -->|Yes| E["Compute caretAnchorOrigin"]
    E --> F{frame unchanged and panel.isVisible}
    F -->|Yes| G["Early return no-op"]
    F -->|No| H["panel.setFrame + orderFrontRegardless"]
    H --> I["CaretAnchorIndicatorView shown"]
    J["MenuBarView or SettingsView Toggle"] -->|"setShowCaretIndicator(Bool)"| K["SuggestionSettingsModel"]
    K -->|"selectIndicatorMode(.caretAnchor or .hidden)"| L["UserDefaults persisted"]
    K -->|"showCaretIndicator = selectedIndicatorMode != .hidden"| A
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22ui%2Fsimplify-indicator%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ui%2Fsimplify-indicator%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atabby%2FServices%2FUI%2FActivationIndicatorController.swift%3A39-41%0AThe%20%60isVisible%60%20flag%20is%20always%20in%20lockstep%20with%20%60panel.isVisible%60%20%E2%80%94%20both%20are%20set%2Fcleared%20together%20%E2%80%94%20so%20checking%20both%20in%20the%20early-return%20guard%20is%20redundant.%20The%20flag%20can%20be%20removed%20and%20the%20condition%20simplified%20to%20just%20%60panel.frame%20%3D%3D%20frame%2C%20panel.isVisible%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Shows%20or%20hides%20the%20caret-anchored%20indicator%20based%20on%20a%20simple%20boolean%20toggle.%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Atabby%2FServices%2FUI%2FActivationIndicatorController.swift%3A61-75%0AWith%20%60isVisible%60%20removed%2C%20the%20early-return%20guard%20and%20the%20post-show%20assignment%20can%20be%20simplified%20to%20rely%20on%20%60panel.isVisible%60%20alone.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20frame%20%3D%20CGRect%28origin%3A%20origin%2C%20size%3A%20contentSize%29.integral%0A%20%20%20%20%20%20%20%20if%20panel.frame%20%3D%3D%20frame%2C%20panel.isVisible%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20panel.setFrame%28frame%2C%20display%3A%20true%29%0A%20%20%20%20%20%20%20%20panel.orderFrontRegardless%28%29%0A%20%20%20%20%7D%0A%0A%20%20%20%20%2F%2F%2F%20Hides%20the%20indicator%20when%20Tabby%20is%20not%20actively%20supporting%20the%20current%20field.%0A%20%20%20%20func%20hide%28reason%20_%3A%20String%29%20%7B%0A%20%20%20%20%20%20%20%20panel.orderOut%28nil%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atabby%2FServices%2FUI%2FActivationIndicatorController.swift%3A39-41%0AThe%20%60isVisible%60%20flag%20is%20always%20in%20lockstep%20with%20%60panel.isVisible%60%20%E2%80%94%20both%20are%20set%2Fcleared%20together%20%E2%80%94%20so%20checking%20both%20in%20the%20early-return%20guard%20is%20redundant.%20The%20flag%20can%20be%20removed%20and%20the%20condition%20simplified%20to%20just%20%60panel.frame%20%3D%3D%20frame%2C%20panel.isVisible%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Shows%20or%20hides%20the%20caret-anchored%20indicator%20based%20on%20a%20simple%20boolean%20toggle.%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Atabby%2FServices%2FUI%2FActivationIndicatorController.swift%3A61-75%0AWith%20%60isVisible%60%20removed%2C%20the%20early-return%20guard%20and%20the%20post-show%20assignment%20can%20be%20simplified%20to%20rely%20on%20%60panel.isVisible%60%20alone.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20frame%20%3D%20CGRect%28origin%3A%20origin%2C%20size%3A%20contentSize%29.integral%0A%20%20%20%20%20%20%20%20if%20panel.frame%20%3D%3D%20frame%2C%20panel.isVisible%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20panel.setFrame%28frame%2C%20display%3A%20true%29%0A%20%20%20%20%20%20%20%20panel.orderFrontRegardless%28%29%0A%20%20%20%20%7D%0A%0A%20%20%20%20%2F%2F%2F%20Hides%20the%20indicator%20when%20Tabby%20is%20not%20actively%20supporting%20the%20current%20field.%0A%20%20%20%20func%20hide%28reason%20_%3A%20String%29%20%7B%0A%20%20%20%20%20%20%20%20panel.orderOut%28nil%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=fujacob%2Ftabby&pr=117&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["Fix SwiftLint violation and UI polish"](https://github.com/fujacob/tabby/commit/ddcff7e53b62ec5855f9d4f62b1aa40bf6c54078) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33166380)</sub>

<!-- /greptile_comment -->