### PR TITLE
Fix local DMG build script

### DIFF
--- a/scripts/build_test_dmg.sh
+++ b/scripts/build_test_dmg.sh
@@ -5,14 +5,14 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DERIVED_DATA="/tmp/TabbyDerivedData"
-APP_PATH="$DERIVED_DATA/Build/Products/Debug/Tabby.app"
+APP_PATH="$DERIVED_DATA/Build/Products/Debug/tabby.app"
 OUTPUT_PATH="/tmp/Tabby-test.dmg"
 BACKGROUND="$REPO_ROOT/assets/release/dmg_background.png"
 
 # Ensure dmgbuild is available.
 if ! python3 -c "import dmgbuild" 2>/dev/null; then
     echo "Installing dmgbuild..."
-    python3 -m pip install --user "dmgbuild[badge_icons]==1.6.7"
+    python3 -m pip install --user "dmgbuild[badge_icons]>=1.6.0"
 fi
 
 # Build the app if the bundle is missing.


### PR DESCRIPTION
## Summary
- Fix app bundle path: `Tabby.app` → `tabby.app` (target name is lowercase)
- Relax dmgbuild version pin: `==1.6.7` → `>=1.6.0` (1.6.7 requires Python >=3.10, macOS system Python is 3.9)

## Context
The script was failing with either "not found" (wrong app path) or pip version errors. Both issues are now fixed and the script has been tested end-to-end producing a valid 7.9MB DMG.

## Test plan
- [x] `bash scripts/build_test_dmg.sh` builds and opens DMG successfully
- [x] DMG contains the app with vertical background layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two issues in the local DMG build script that were preventing it from running successfully. Both changes are minimal and targeted.

- **App bundle path casing**: Corrects `Tabby.app` → `tabby.app` to match the actual Xcode target name, resolving \"not found\" errors.
- **Version pin relaxation**: Changes `dmgbuild[badge_icons]==1.6.7` → `>=1.6.0` so the install step works with macOS system Python 3.9, which cannot satisfy the `==1.6.7` pin.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the two changes are minimal, targeted, and directly address the described failures without touching any application logic.

Both changes fix real, reproducible failures in the dev build script: a wrong path casing and a Python version incompatibility in the pip constraint. The rest of the script is unchanged and was already working. No regressions are introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/build_test_dmg.sh | Two targeted fixes: corrects the app bundle path casing (Tabby.app → tabby.app) and relaxes the dmgbuild version pin to support Python 3.9. No logic errors introduced. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix local DMG build script"](https://github.com/fujacob/tabby/commit/158b494d697d94de8ecde22afe90af7f6172387b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33168002)</sub>

<!-- /greptile_comment -->