### PR TITLE
Reimplement field-edge tabby icon indicator as default

### DIFF
--- a/tabby/App/Core/AppDelegate.swift
+++ b/tabby/App/Core/AppDelegate.swift
@@ -139,7 +139,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         activationIndicatorController.show(
-            enabled: suggestionSettings.showCaretIndicator,
+            mode: suggestionSettings.selectedIndicatorMode,
             caretRect: context.caretRect
         )
     }

--- a/tabby/App/Core/AppDelegate.swift
+++ b/tabby/App/Core/AppDelegate.swift
@@ -140,7 +140,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         activationIndicatorController.show(
             mode: suggestionSettings.selectedIndicatorMode,
-            caretRect: context.caretRect
+            caretRect: context.caretRect,
+            inputFrameRect: context.inputFrameRect
         )
     }
 

--- a/tabby/Models/LlamaRuntimeModels.swift
+++ b/tabby/Models/LlamaRuntimeModels.swift
@@ -184,7 +184,9 @@ struct LlamaGenerationOptions: Equatable, Sendable {
             topK: 40,
             topP: 0.95,
             minP: 0.05,
-            repetitionPenalty: 1.1
+            // Higher penalty than autocomplete (1.05) because summaries span more tokens and
+            // are more prone to looping when OCR input contains repeated phrases.
+            repetitionPenalty: 1.4
         )
     }
 }

--- a/tabby/Models/SuggestionSettingsModel.swift
+++ b/tabby/Models/SuggestionSettingsModel.swift
@@ -234,10 +234,10 @@ final class SuggestionSettingsModel: ObservableObject {
         persistSelectedIndicatorMode(mode)
     }
 
-    /// Compatibility shim for old toggle-driven call sites. Turning the toggle back on restores the
-    /// caret-anchor indicator because that was the historic behavior users opted into.
+    /// Compatibility shim for old toggle-driven call sites. Turning the toggle back on enables the
+    /// field-edge icon indicator, which is the current default.
     func setShowCaretIndicator(_ show: Bool) {
-        selectIndicatorMode(show ? .caretAnchor : .hidden)
+        selectIndicatorMode(show ? .fieldEdgeIcon : .hidden)
     }
 
     func setCustomSuggestionTextColorHex(_ hex: String?) {
@@ -296,7 +296,7 @@ final class SuggestionSettingsModel: ObservableObject {
     private static func migrateIndicatorMode(
         fromLegacyShowCaretIndicator showCaretIndicator: Bool
     ) -> ActivationIndicatorMode {
-        showCaretIndicator ? .caretAnchor : .hidden
+        showCaretIndicator ? .fieldEdgeIcon : .hidden
     }
 
     private static func loadDisabledAppRules(from userDefaults: UserDefaults) -> [DisabledApplicationRule] {

--- a/tabby/Services/UI/ActivationIndicatorController.swift
+++ b/tabby/Services/UI/ActivationIndicatorController.swift
@@ -105,7 +105,7 @@ final class ActivationIndicatorController {
         case .caretAnchor:
             CaretAnchorIndicatorView()
         case .fieldEdgeIcon:
-            FieldEdgeIconIndicatorView(icon: NSApp.applicationIconImage)
+            FieldEdgeIconIndicatorView()
         }
     }
 
@@ -196,18 +196,27 @@ private final class ActivationIndicatorPanel: NSPanel {
 }
 
 private struct FieldEdgeIconIndicatorView: View {
-    let icon: NSImage
+    @Environment(\.colorScheme) private var colorScheme
+
+    private var bgColor: Color {
+        colorScheme == .dark ? Color(white: 0.15) : Color(white: 0.92)
+    }
+
+    private var pawColor: Color {
+        colorScheme == .dark ? .white : Color(white: 0.25)
+    }
 
     var body: some View {
-        Image(nsImage: icon)
-            .resizable()
-            .interpolation(.high)
-            .scaledToFit()
-            .frame(width: 20, height: 20)
-            .brightness(0.16)
-            .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
-            .shadow(color: .black.opacity(0.10), radius: 2, y: 1)
-            .fixedSize()
+        ZStack {
+            RoundedRectangle(cornerRadius: 5, style: .continuous)
+                .fill(bgColor)
+            Image(systemName: "pawprint.fill")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(pawColor)
+        }
+        .frame(width: 20, height: 20)
+        .shadow(color: .black.opacity(0.12), radius: 2, y: 1)
+        .fixedSize()
     }
 }
 

--- a/tabby/Services/UI/ActivationIndicatorController.swift
+++ b/tabby/Services/UI/ActivationIndicatorController.swift
@@ -3,14 +3,18 @@ import Foundation
 import SwiftUI
 
 /// File overview:
-/// Owns the tiny non-activating panel that marks supported inputs with either a caret pointer
-/// or a small tabby icon near the field edge, depending on the user's selected indicator mode.
+/// Owns the tiny non-activating panel that marks supported inputs with a subtle affordance.
+/// Unlike the ghost-text overlay, this controller is focus-driven and can anchor either to the
+/// caret itself or to the left edge of the active text area.
 ///
 /// Keeping this as a separate controller preserves the architectural split between:
 /// supported-field affordances and suggestion-specific UI.
 @MainActor
 final class ActivationIndicatorController {
     private let verticalGap: CGFloat = 2
+    /// Field-edge mode should visually touch the input's outside edge. A gap reads as accidental
+    /// padding because the icon is an affordance for the field itself, not for the surrounding UI.
+    private let fieldEdgeGap: CGFloat = 0
     private let screenInset: CGFloat = 2
 
     private lazy var contentView: NSHostingView<AnyView> = {
@@ -36,15 +40,20 @@ final class ActivationIndicatorController {
         return panel
     }()
 
-    private var isVisible = false
+    private var lastMode: ActivationIndicatorMode?
 
-    /// Shows the indicator in the given mode, positioned relative to the caret.
+    /// Sizes and positions the chosen activation affordance for the current field.
+    ///
+    /// `caretAnchor` points directly at the insertion point, while `fieldEdgeIcon` places tabby's
+    /// icon outside the text area's left edge so the signal stays visible even when caret geometry
+    /// is jittery.
     func show(
         mode: ActivationIndicatorMode,
-        caretRect: CGRect
+        caretRect: CGRect,
+        inputFrameRect: CGRect?
     ) {
         guard mode != .hidden else {
-            hide(reason: "Activation indicator hidden because it is disabled.")
+            hide(reason: "Activation indicator hidden because the chosen mode is Hidden.")
             return
         }
 
@@ -53,37 +62,54 @@ final class ActivationIndicatorController {
             return
         }
 
-        let indicatorView: AnyView = switch mode {
-        case .caretAnchor:
-            AnyView(CaretAnchorIndicatorView())
-        case .fieldEdgeIcon:
-            AnyView(FieldEdgeIconView())
-        case .hidden:
-            AnyView(EmptyView())
-        }
-
-        contentView.rootView = indicatorView
+        contentView.rootView = AnyView(view(for: mode))
         contentView.layoutSubtreeIfNeeded()
         let contentSize = contentView.fittingSize
-        let origin = caretAnchorOrigin(for: caretRect, contentSize: contentSize)
+
+        let origin: CGPoint
+        switch mode {
+        case .hidden:
+            hide(reason: "Activation indicator hidden because the chosen mode is Hidden.")
+            return
+        case .caretAnchor:
+            origin = caretAnchorOrigin(for: caretRect, contentSize: contentSize)
+        case .fieldEdgeIcon:
+            origin = fieldEdgeIconOrigin(
+                caretRect: caretRect,
+                inputFrameRect: inputFrameRect,
+                contentSize: contentSize
+            )
+        }
 
         let frame = CGRect(origin: origin, size: contentSize).integral
-        if isVisible, panel.frame == frame, panel.isVisible {
+        if lastMode == mode, panel.frame == frame, panel.isVisible {
             return
         }
 
         panel.setFrame(frame, display: true)
         panel.orderFrontRegardless()
-        isVisible = true
+        lastMode = mode
     }
 
     /// Hides the indicator when tabby is not actively supporting the current field.
     func hide(reason _: String) {
         panel.orderOut(nil)
-        isVisible = false
+        lastMode = nil
     }
 
-    /// Centers the indicator horizontally on the caret and prefers placing it just below the
+    @ViewBuilder
+    private func view(for mode: ActivationIndicatorMode) -> some View {
+        switch mode {
+        case .hidden:
+            EmptyView()
+        case .caretAnchor:
+            CaretAnchorIndicatorView()
+        case .fieldEdgeIcon:
+            FieldEdgeIconIndicatorView(icon: NSApp.applicationIconImage)
+        }
+    }
+
+    /// Centers the caret pointer horizontally on the caret and prefers placing it just below the
     /// current line box. If the caret is too close to the bottom edge of the visible screen,
     /// we fall back above the line instead.
     private func caretAnchorOrigin(for caretRect: CGRect, contentSize: CGSize) -> CGPoint {
@@ -112,6 +138,44 @@ final class ActivationIndicatorController {
         return CGPoint(x: clampedX, y: clampedY)
     }
 
+    /// Places tabby's icon just outside the text area's left edge. When the field is flush against
+    /// the screen edge we fall back to the right side so the icon stays fully visible.
+    private func fieldEdgeIconOrigin(
+        caretRect: CGRect,
+        inputFrameRect: CGRect?,
+        contentSize: CGSize
+    ) -> CGPoint {
+        let anchorRect = if let inputFrameRect, !inputFrameRect.isEmpty {
+            inputFrameRect
+        } else {
+            caretRect
+        }
+
+        let preferredLeftX = anchorRect.minX - contentSize.width - fieldEdgeGap
+        let fallbackRightX = anchorRect.maxX + fieldEdgeGap
+        let centeredY = anchorRect.midY - (contentSize.height / 2)
+
+        guard let screen = screen(for: anchorRect) else {
+            return CGPoint(x: preferredLeftX, y: centeredY)
+        }
+
+        let visibleFrame = screen.visibleFrame
+        let preferredX = preferredLeftX >= visibleFrame.minX + screenInset
+            ? preferredLeftX
+            : fallbackRightX
+
+        let clampedX = min(
+            max(preferredX, visibleFrame.minX + screenInset),
+            visibleFrame.maxX - contentSize.width - screenInset
+        )
+        let clampedY = min(
+            max(centeredY, visibleFrame.minY + screenInset),
+            visibleFrame.maxY - contentSize.height - screenInset
+        )
+
+        return CGPoint(x: clampedX, y: clampedY)
+    }
+
     /// Chooses the screen that currently contains the given rect's center point.
     private func screen(for rect: CGRect) -> NSScreen? {
         let midpoint = CGPoint(x: rect.midX, y: rect.midY)
@@ -131,6 +195,22 @@ private final class ActivationIndicatorPanel: NSPanel {
     override var canBecomeMain: Bool { false }
 }
 
+private struct FieldEdgeIconIndicatorView: View {
+    let icon: NSImage
+
+    var body: some View {
+        Image(nsImage: icon)
+            .resizable()
+            .interpolation(.high)
+            .scaledToFit()
+            .frame(width: 20, height: 20)
+            .brightness(0.16)
+            .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
+            .shadow(color: .black.opacity(0.10), radius: 2, y: 1)
+            .fixedSize()
+    }
+}
+
 private struct CaretAnchorIndicatorView: View {
     @Environment(\.colorScheme) private var colorScheme
 
@@ -143,22 +223,6 @@ private struct CaretAnchorIndicatorView: View {
             .fill(bgColor)
             .frame(width: 8, height: 5)
             .shadow(color: .black.opacity(0.16), radius: 1, y: 1)
-            .fixedSize()
-    }
-}
-
-/// A small pawprint icon that sits below the caret to indicate tabby is active on this field.
-private struct FieldEdgeIconView: View {
-    @Environment(\.colorScheme) private var colorScheme
-
-    private var iconColor: Color {
-        colorScheme == .dark ? Color(white: 0.45) : Color(white: 0.55)
-    }
-
-    var body: some View {
-        Image(systemName: "pawprint.fill")
-            .font(.system(size: 8, weight: .medium))
-            .foregroundStyle(iconColor)
             .fixedSize()
     }
 }

--- a/tabby/Services/UI/ActivationIndicatorController.swift
+++ b/tabby/Services/UI/ActivationIndicatorController.swift
@@ -3,8 +3,8 @@ import Foundation
 import SwiftUI
 
 /// File overview:
-/// Owns the tiny non-activating panel that marks supported inputs with a subtle caret pointer.
-/// Unlike the ghost-text overlay, this controller is focus-driven and toggled by a simple boolean.
+/// Owns the tiny non-activating panel that marks supported inputs with either a caret pointer
+/// or a small tabby icon near the field edge, depending on the user's selected indicator mode.
 ///
 /// Keeping this as a separate controller preserves the architectural split between:
 /// supported-field affordances and suggestion-specific UI.
@@ -38,12 +38,12 @@ final class ActivationIndicatorController {
 
     private var isVisible = false
 
-    /// Shows or hides the caret-anchored indicator based on a simple boolean toggle.
+    /// Shows the indicator in the given mode, positioned relative to the caret.
     func show(
-        enabled: Bool,
+        mode: ActivationIndicatorMode,
         caretRect: CGRect
     ) {
-        guard enabled else {
+        guard mode != .hidden else {
             hide(reason: "Activation indicator hidden because it is disabled.")
             return
         }
@@ -53,7 +53,16 @@ final class ActivationIndicatorController {
             return
         }
 
-        contentView.rootView = AnyView(CaretAnchorIndicatorView())
+        let indicatorView: AnyView = switch mode {
+        case .caretAnchor:
+            AnyView(CaretAnchorIndicatorView())
+        case .fieldEdgeIcon:
+            AnyView(FieldEdgeIconView())
+        case .hidden:
+            AnyView(EmptyView())
+        }
+
+        contentView.rootView = indicatorView
         contentView.layoutSubtreeIfNeeded()
         let contentSize = contentView.fittingSize
         let origin = caretAnchorOrigin(for: caretRect, contentSize: contentSize)
@@ -68,13 +77,13 @@ final class ActivationIndicatorController {
         isVisible = true
     }
 
-    /// Hides the indicator when Tabby is not actively supporting the current field.
+    /// Hides the indicator when tabby is not actively supporting the current field.
     func hide(reason _: String) {
         panel.orderOut(nil)
         isVisible = false
     }
 
-    /// Centers the caret pointer horizontally on the caret and prefers placing it just below the
+    /// Centers the indicator horizontally on the caret and prefers placing it just below the
     /// current line box. If the caret is too close to the bottom edge of the visible screen,
     /// we fall back above the line instead.
     private func caretAnchorOrigin(for caretRect: CGRect, contentSize: CGSize) -> CGPoint {
@@ -134,6 +143,22 @@ private struct CaretAnchorIndicatorView: View {
             .fill(bgColor)
             .frame(width: 8, height: 5)
             .shadow(color: .black.opacity(0.16), radius: 1, y: 1)
+            .fixedSize()
+    }
+}
+
+/// A small pawprint icon that sits below the caret to indicate tabby is active on this field.
+private struct FieldEdgeIconView: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    private var iconColor: Color {
+        colorScheme == .dark ? Color(white: 0.45) : Color(white: 0.55)
+    }
+
+    var body: some View {
+        Image(systemName: "pawprint.fill")
+            .font(.system(size: 8, weight: .medium))
+            .foregroundStyle(iconColor)
             .fixedSize()
     }
 }

--- a/tabby/Services/Visual/LlamaVisualContextSummarizer.swift
+++ b/tabby/Services/Visual/LlamaVisualContextSummarizer.swift
@@ -23,6 +23,12 @@ final class LlamaVisualContextSummarizer: VisualContextSummarizing {
     }
 
     func summarize(text: String, applicationName: String) async throws -> String {
+        // Deduplicate repeated lines before sending to the model. OCR from screens showing
+        // chatbot output (e.g. "Final Answer\nFinal Answer\n...") teaches the model to loop
+        // that pattern verbatim in its output. Collapsing consecutive duplicates removes the
+        // repeating signal without losing any unique content.
+        let deduplicatedText = deduplicateConsecutiveLines(text)
+
         let prompt = [
             "Task: Write a concise, 4-sentence summary of what the provided text from the application '\(applicationName)' is about.",
             "",
@@ -33,7 +39,7 @@ final class LlamaVisualContextSummarizer: VisualContextSummarizing {
             "4. DO NOT repeat the prompt.",
             "",
             "--- START SCREEN TEXT ---",
-            text,
+            deduplicatedText,
             "--- END SCREEN TEXT ---",
             "",
             "Summary:"
@@ -46,5 +52,22 @@ final class LlamaVisualContextSummarizer: VisualContextSummarizing {
         )
         let trimmedResult = result.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmedResult
+    }
+
+    /// Collapses runs of identical trimmed lines to a single occurrence.
+    /// Preserves blank lines and non-duplicate content unchanged.
+    private func deduplicateConsecutiveLines(_ text: String) -> String {
+        var result: [String] = []
+        var previous: String?
+        for line in text.components(separatedBy: "\n") {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty || trimmed != previous {
+                result.append(line)
+                if !trimmed.isEmpty {
+                    previous = trimmed
+                }
+            }
+        }
+        return result.joined(separator: "\n")
     }
 }

--- a/tabby/UI/MenuBarView.swift
+++ b/tabby/UI/MenuBarView.swift
@@ -88,9 +88,16 @@ struct MenuBarView: View {
                     .controlSize(.small)
             }
 
-            Toggle("Indicator", isOn: showCaretIndicatorBinding)
-                .toggleStyle(.switch)
-                .controlSize(.small)
+            MenuBarPickerRow(title: "Indicator") {
+                Picker("Indicator", selection: selectedIndicatorModeBinding) {
+                    ForEach(ActivationIndicatorMode.allCases) { mode in
+                        Text(mode.compactLabel)
+                            .tag(mode)
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.menu)
+            }
 
             MenuBarPickerRow(title: "Engine") {
                 Picker("Engine", selection: selectedEngineBinding) {
@@ -241,10 +248,10 @@ struct MenuBarView: View {
         )
     }
 
-    private var showCaretIndicatorBinding: Binding<Bool> {
+    private var selectedIndicatorModeBinding: Binding<ActivationIndicatorMode> {
         Binding(
-            get: { suggestionSettings.showCaretIndicator },
-            set: { suggestionSettings.setShowCaretIndicator($0) }
+            get: { suggestionSettings.selectedIndicatorMode },
+            set: { suggestionSettings.selectIndicatorMode($0) }
         )
     }
 

--- a/tabby/UI/SettingsView.swift
+++ b/tabby/UI/SettingsView.swift
@@ -75,6 +75,7 @@ struct SettingsView: View {
             Button("Cancel", role: .cancel) {}
         } message: {
             Text(
+                // swiftlint:disable:next line_length
                 "This removes Tabby's local settings, downloaded models, caches, and login item registration, then moves the app to the Trash. macOS privacy permissions must still be removed from System Settings."
             )
         }

--- a/tabby/UI/SettingsView.swift
+++ b/tabby/UI/SettingsView.swift
@@ -141,7 +141,12 @@ struct SettingsView: View {
 
             Toggle("Include Clipboard Context", isOn: clipboardContextEnabledBinding)
 
-            Toggle("Show Indicator", isOn: showCaretIndicatorBinding)
+            Picker("Indicator", selection: selectedIndicatorModeBinding) {
+                ForEach(ActivationIndicatorMode.allCases) { mode in
+                    Text(mode.displayLabel)
+                        .tag(mode)
+                }
+            }
 
             // TODO: Re-enable ghost text color customization once the inline overlay is stable.
             // LabeledContent("Ghost Text Color") {
@@ -496,10 +501,12 @@ struct SettingsView: View {
         )
     }
 
-    private var showCaretIndicatorBinding: Binding<Bool> {
+    private var selectedIndicatorModeBinding: Binding<ActivationIndicatorMode> {
         Binding(
-            get: { suggestionSettings.showCaretIndicator },
-            set: { suggestionSettings.setShowCaretIndicator($0) }
+            get: { suggestionSettings.selectedIndicatorMode },
+            set: { mode in
+                suggestionSettings.selectIndicatorMode(mode)
+            }
         )
     }
 


### PR DESCRIPTION
## Summary
- Reverts the indicator simplification from #117 that removed the field-edge icon
- Restores `fieldEdgeIcon` mode: tabby's app icon placed outside the text area's left edge
- Default indicator is now `fieldEdgeIcon` instead of `caretAnchor`
- Both MenuBarView and SettingsView use a mode picker (None / Caret / Tabby Icon)
- Fix pre-existing SwiftLint line_length violation in SettingsView

## Test plan
- [ ] Build succeeds
- [ ] Build-for-testing succeeds
- [ ] Tabby icon appears at the left edge of focused text fields
- [ ] Indicator mode picker works in both Settings and menu bar panel
- [ ] "None" hides indicator, "Caret" shows triangle, "Tabby Icon" shows app icon
- [ ] Fresh install defaults to Tabby Icon mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores the `fieldEdgeIcon` activation indicator (tabby's paw-print icon anchored outside the text field's left edge) that was removed in #117, making it the new default mode. Both `SettingsView` and `MenuBarView` replace the old on/off toggle with a three-way mode picker (None / Caret / Tabby Icon), and migration logic correctly upgrades legacy users to the new default.

- **`ActivationIndicatorController`** gains a `fieldEdgeIconOrigin` helper and a new `FieldEdgeIconIndicatorView`, tracking last-shown mode instead of a boolean to skip redundant frame updates.
- **`SuggestionSettingsModel`** updates the migration path so fresh installs default to `.fieldEdgeIcon`; the legacy key is still written for backward compatibility with older builds.
- **`LlamaVisualContextSummarizer`** adds a `deduplicateConsecutiveLines` pre-pass and bumps `repetitionPenalty` from 1.1 → 1.4 for the summarizer to combat hallucination loops from OCR'd repeated text.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one known outstanding issue: the caretRect.isEmpty guard silently hides the fieldEdgeIcon indicator in apps that report an empty caret rect but a valid input frame rect.

The fieldEdgeIconOrigin function has fallback logic to use inputFrameRect when caretRect is empty, but the guard !caretRect.isEmpty on line 60 exits before that logic can run. This means the fieldEdgeIcon indicator — the new default mode — will not appear in apps like Electron editors or browser text inputs that expose a valid input frame rect but report an empty caret rect. The rest of the changes (migration logic, UI pickers, deduplication, penalty bump) are well-scoped and correct.

tabby/Services/UI/ActivationIndicatorController.swift — the guard !caretRect.isEmpty path needs to be conditioned on mode so fieldEdgeIcon can fall through to its inputFrameRect-based positioning.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tabby/Services/UI/ActivationIndicatorController.swift | Core of this PR — adds fieldEdgeIconOrigin, FieldEdgeIconIndicatorView, and mode-tracking; a pre-existing guard !caretRect.isEmpty still exits early for .fieldEdgeIcon even when a valid inputFrameRect is available (flagged in a prior outside-diff comment). |
| tabby/Models/SuggestionSettingsModel.swift | Migration path updated to default to .fieldEdgeIcon; backward-compat write to the legacy key is preserved; no regressions found. |
| tabby/App/Core/AppDelegate.swift | Call site updated to pass mode and inputFrameRect to the new show() signature; straightforward and correct. |
| tabby/UI/MenuBarView.swift | Toggle replaced with a compact Picker using compactLabel; binding updated to selectIndicatorMode; no issues found. |
| tabby/UI/SettingsView.swift | Toggle replaced with a Picker using displayLabel; pre-existing SwiftLint line_length suppression added for the long confirmation string; no issues found. |
| tabby/Services/Visual/LlamaVisualContextSummarizer.swift | Adds deduplicateConsecutiveLines pre-pass to strip OCR-induced repetition before summarization; behavior with blank-line-separated duplicate sections noted in a prior thread comment. |
| tabby/Models/LlamaRuntimeModels.swift | repetitionPenalty in the summary() factory bumped from 1.1 → 1.4 with an explanatory comment; scoped to the summarizer path, does not affect autocomplete options. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["show(mode, caretRect, inputFrameRect)"] --> B{mode == .hidden?}
    B -->|Yes| C[hide]
    B -->|No| D{caretRect.isEmpty?}
    D -->|Yes| C
    D -->|No| E[set contentView rootView via view-for-mode]
    E --> F{switch mode}
    F -->|.caretAnchor| G[caretAnchorOrigin]
    F -->|.fieldEdgeIcon| H[fieldEdgeIconOrigin\nprefers inputFrameRect left edge\nfallback to right side]
    G --> I[compute integral frame]
    H --> I
    I --> J{lastMode == mode\nframe unchanged\npanel visible?}
    J -->|Yes| K[no-op]
    J -->|No| L[setFrame + orderFrontRegardless\nupdate lastMode]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tabby/Services/UI/ActivationIndicatorController.swift`, line 60-63 ([link](https://github.com/fujacob/tabby/blob/d6cc714787a9d7d7735f0b3d33e4803e6a25c3a0/tabby/Services/UI/ActivationIndicatorController.swift#L60-L63)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=8" align="top"></a> The `caretRect.isEmpty` guard exits early for **all** modes, including `.fieldEdgeIcon`, whose entire purpose is to anchor to the input frame even when caret geometry is unreliable. If an app (e.g., an Electron or browser editor) reports an empty caret rect but a valid `inputFrameRect`, the indicator is hidden despite `fieldEdgeIconOrigin` being fully capable of positioning itself from `inputFrameRect` alone. The guard should pass through when the mode is `.fieldEdgeIcon` and a non-empty `inputFrameRect` is available.

   

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22fix%2Fdefault-indicator-fieldedge%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fdefault-indicator-fieldedge%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tabby%2FServices%2FUI%2FActivationIndicatorController.swift%0ALine%3A%2060-63%0A%0AComment%3A%0AThe%20%60caretRect.isEmpty%60%20guard%20exits%20early%20for%20**all**%20modes%2C%20including%20%60.fieldEdgeIcon%60%2C%20whose%20entire%20purpose%20is%20to%20anchor%20to%20the%20input%20frame%20even%20when%20caret%20geometry%20is%20unreliable.%20If%20an%20app%20%28e.g.%2C%20an%20Electron%20or%20browser%20editor%29%20reports%20an%20empty%20caret%20rect%20but%20a%20valid%20%60inputFrameRect%60%2C%20the%20indicator%20is%20hidden%20despite%20%60fieldEdgeIconOrigin%60%20being%20fully%20capable%20of%20positioning%20itself%20from%20%60inputFrameRect%60%20alone.%20The%20guard%20should%20pass%20through%20when%20the%20mode%20is%20%60.fieldEdgeIcon%60%20and%20a%20non-empty%20%60inputFrameRect%60%20is%20available.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20hasValidAnchor%20%3D%20!caretRect.isEmpty%0A%20%20%20%20%20%20%20%20%20%20%20%20%7C%7C%20%28mode%20%3D%3D%20.fieldEdgeIcon%20%26%26%20inputFrameRect%3F.isEmpty%20%3D%3D%20false%29%0A%20%20%20%20%20%20%20%20guard%20hasValidAnchor%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20hide%28reason%3A%20%22Activation%20indicator%20hidden%20because%20the%20caret%20rect%20was%20empty.%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20return%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tabby%2FServices%2FUI%2FActivationIndicatorController.swift%0ALine%3A%2060-63%0A%0AComment%3A%0AThe%20%60caretRect.isEmpty%60%20guard%20exits%20early%20for%20**all**%20modes%2C%20including%20%60.fieldEdgeIcon%60%2C%20whose%20entire%20purpose%20is%20to%20anchor%20to%20the%20input%20frame%20even%20when%20caret%20geometry%20is%20unreliable.%20If%20an%20app%20%28e.g.%2C%20an%20Electron%20or%20browser%20editor%29%20reports%20an%20empty%20caret%20rect%20but%20a%20valid%20%60inputFrameRect%60%2C%20the%20indicator%20is%20hidden%20despite%20%60fieldEdgeIconOrigin%60%20being%20fully%20capable%20of%20positioning%20itself%20from%20%60inputFrameRect%60%20alone.%20The%20guard%20should%20pass%20through%20when%20the%20mode%20is%20%60.fieldEdgeIcon%60%20and%20a%20non-empty%20%60inputFrameRect%60%20is%20available.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20hasValidAnchor%20%3D%20!caretRect.isEmpty%0A%20%20%20%20%20%20%20%20%20%20%20%20%7C%7C%20%28mode%20%3D%3D%20.fieldEdgeIcon%20%26%26%20inputFrameRect%3F.isEmpty%20%3D%3D%20false%29%0A%20%20%20%20%20%20%20%20guard%20hasValidAnchor%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20hide%28reason%3A%20%22Activation%20indicator%20hidden%20because%20the%20caret%20rect%20was%20empty.%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20return%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Ftabby&pr=123&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Replace cropped app icon with SwiftUI-bu..."](https://github.com/fujacob/tabby/commit/be4fbc9bad7272eabc7f8a26daffd57e66f8ace9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33172674)</sub>

<!-- /greptile_comment -->