### PR TITLE
Change default models

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,10 @@ Everything runs on-device. No hosted API, no cloud round-trip.
 
 **Open Source** — runs local GGUF models in-process through llama.cpp via `llama.swift`. Built-in downloadable models:
 
-| Model              | File                            | Size    |
-| ------------------ | ------------------------------- | ------- |
-| `tabby-fast-1`     | `Qwen3-0.6B-Q4_K_M.gguf`        | ~0.4 GB |
-| `tabby-balanced-1` | `gemma-3-1b-it-Q4_K_M.gguf`     | ~0.8 GB |
-| `tabby-depth-1`    | `gemma-3n-E4B-it-Q4_K_M.gguf`   | ~3.5 GB |
+| Model           | File                            | Size    |
+| --------------- | ------------------------------- | ------- |
+| `tabby-fast`    | `Qwen3.5-0.8B-Q4_K_M.gguf`     | ~0.5 GB |
+| `tabby-quality` | `gemma-4-E2B-it-Q4_K_M.gguf`   | ~3.1 GB |
 
 You can also drop your own `.gguf` files into Tabby's models folder and refresh the model list.
 

--- a/tabby/Models/LlamaRuntimeModels.swift
+++ b/tabby/Models/LlamaRuntimeModels.swift
@@ -102,30 +102,30 @@ enum RuntimeModelCatalog {
     ///
     ///   curl -sIL "<URL>" | grep -iE "^(x-linked-size|x-linked-etag):"
     static let downloadableModels: [DownloadableRuntimeModel] = [
-            DownloadableRuntimeModel(
-                filename: "Qwen3.5-0.8B-Q4_K_M.gguf",
-                displayName: displayName(for: "Qwen3.5-0.8B-Q4_K_M.gguf"),
-                downloadURL: URL(
-                    string:
-                        "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/Qwen3.5-0.8B-Q4_K_M.gguf?download=true"
-                )!,
-                approximateSizeInGigabytes: 0.5,
-                expectedSizeBytes: 532517120,
-                sha256: "bd258782e35f7f458f8aced1adc053e6e92e89bc735ba3be89d38a06121dc517"
-            ),
-            DownloadableRuntimeModel(
-                filename: "gemma-4-E2B-it-Q4_K_M.gguf",
-                displayName: displayName(for: "gemma-4-E2B-it-Q4_K_M.gguf"),
-                downloadURL: URL(
-                    string:
-                        "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/gemma-4-E2B-it-Q4_K_M.gguf?download=true"
-                )!,
-                approximateSizeInGigabytes: 3.1,
-                expectedSizeBytes: 3106736256,
-                sha256: "9378bc471710229ef165709b62e34bfb62231420ddaf6d729e727305b5b8672d"
-            )
-        ]
-    }
+        DownloadableRuntimeModel(
+            filename: "Qwen3.5-0.8B-Q4_K_M.gguf",
+            displayName: displayName(for: "Qwen3.5-0.8B-Q4_K_M.gguf"),
+            downloadURL: URL(
+                string:
+                    "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/Qwen3.5-0.8B-Q4_K_M.gguf?download=true"
+            )!,
+            approximateSizeInGigabytes: 0.5,
+            expectedSizeBytes: 532_517_120,
+            sha256: "bd258782e35f7f458f8aced1adc053e6e92e89bc735ba3be89d38a06121dc517"
+        ),
+        DownloadableRuntimeModel(
+            filename: "gemma-4-E2B-it-Q4_K_M.gguf",
+            displayName: displayName(for: "gemma-4-E2B-it-Q4_K_M.gguf"),
+            downloadURL: URL(
+                string:
+                    "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/gemma-4-E2B-it-Q4_K_M.gguf?download=true"
+            )!,
+            approximateSizeInGigabytes: 3.1,
+            expectedSizeBytes: 3_106_736_256,
+            sha256: "9378bc471710229ef165709b62e34bfb62231420ddaf6d729e727305b5b8672d"
+        )
+    ]
+}
 
 /// Startup configuration that controls which GGUF model to load and how large the runtime should be.
 struct LlamaRuntimeConfiguration: Equatable, Sendable {

--- a/tabby/Models/LlamaRuntimeModels.swift
+++ b/tabby/Models/LlamaRuntimeModels.swift
@@ -123,7 +123,7 @@ enum RuntimeModelCatalog {
                 approximateSizeInGigabytes: 3.1,
                 expectedSizeBytes: 3106736256,
                 sha256: "9378bc471710229ef165709b62e34bfb62231420ddaf6d729e727305b5b8672d"
-            ),
+            )
         ]
     }
 
@@ -141,9 +141,9 @@ struct LlamaRuntimeConfiguration: Equatable, Sendable {
         runtimeDirectoryPath: nil,
         preferredModelNames: [
             "gemma-4-E2B-it-Q4_K_M.gguf",
-            "Qwen3.5-0.8B-Q4_K_M.gguf",
+            "Qwen3.5-0.8B-Q4_K_M.gguf"
         ],
-        contextWindowTokens: 4096,
+        contextWindowTokens: 2048,
         batchSize: 512,
         gpuLayerCount: -1
     )

--- a/tabby/Models/LlamaRuntimeModels.swift
+++ b/tabby/Models/LlamaRuntimeModels.swift
@@ -85,12 +85,10 @@ struct DownloadableRuntimeModel: Equatable, Hashable, Sendable, Identifiable {
 enum RuntimeModelCatalog {
     static func displayName(for filename: String) -> String {
         switch filename {
-        case "Qwen3-0.6B-Q4_K_M.gguf":
-            return "tabby-fast-1"
-        case "gemma-3-1b-it-Q4_K_M.gguf":
-            return "tabby-balanced-1"
-        case "gemma-3n-E4B-it-Q4_K_M.gguf":
-            return "tabby-depth-1"
+        case "Qwen3.5-0.8B-Q4_K_M.gguf":
+            return "tabby-fast"
+        case "gemma-4-E2B-it-Q4_K_M.gguf":
+            return "tabby-quality"
         default:
             return filename
         }
@@ -104,41 +102,30 @@ enum RuntimeModelCatalog {
     ///
     ///   curl -sIL "<URL>" | grep -iE "^(x-linked-size|x-linked-etag):"
     static let downloadableModels: [DownloadableRuntimeModel] = [
-        DownloadableRuntimeModel(
-            filename: "gemma-3-1b-it-Q4_K_M.gguf",
-            displayName: displayName(for: "gemma-3-1b-it-Q4_K_M.gguf"),
-            downloadURL: URL(
-                string:
-                    "https://huggingface.co/unsloth/gemma-3-1b-it-GGUF/resolve/main/gemma-3-1b-it-Q4_K_M.gguf?download=true"
-            )!,
-            approximateSizeInGigabytes: 0.8,
-            expectedSizeBytes: 806_058_272,
-            sha256: "8270790f3ab69fdfe860b7b64008d9a19986d8df7e407bb018184caa08798ebd"
-        ),
-        DownloadableRuntimeModel(
-            filename: "Qwen3-0.6B-Q4_K_M.gguf",
-            displayName: displayName(for: "Qwen3-0.6B-Q4_K_M.gguf"),
-            downloadURL: URL(
-                string:
-                    "https://huggingface.co/unsloth/Qwen3-0.6B-GGUF/resolve/main/Qwen3-0.6B-Q4_K_M.gguf?download=true"
-            )!,
-            approximateSizeInGigabytes: 0.4,
-            expectedSizeBytes: 396_705_472,
-            sha256: "ac2d97712095a558e31573f62f466a3f9d93990898b0ec79d7c974c1780d524a"
-        ),
-        DownloadableRuntimeModel(
-            filename: "gemma-3n-E4B-it-Q4_K_M.gguf",
-            displayName: displayName(for: "gemma-3n-E4B-it-Q4_K_M.gguf"),
-            downloadURL: URL(
-                string:
-                    "https://huggingface.co/unsloth/gemma-3n-E4B-it-GGUF/resolve/main/gemma-3n-E4B-it-Q4_K_M.gguf?download=true"
-            )!,
-            approximateSizeInGigabytes: 3.5,
-            expectedSizeBytes: 4_539_054_208,
-            sha256: "43b489bb77a81bda85180e7c490d40ad7f1d5c2ce654c9b05e15e104bd3c777e"
-        )
-    ]
-}
+            DownloadableRuntimeModel(
+                filename: "Qwen3.5-0.8B-Q4_K_M.gguf",
+                displayName: displayName(for: "Qwen3.5-0.8B-Q4_K_M.gguf"),
+                downloadURL: URL(
+                    string:
+                        "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/Qwen3.5-0.8B-Q4_K_M.gguf?download=true"
+                )!,
+                approximateSizeInGigabytes: 0.5,
+                expectedSizeBytes: 532517120,
+                sha256: "bd258782e35f7f458f8aced1adc053e6e92e89bc735ba3be89d38a06121dc517"
+            ),
+            DownloadableRuntimeModel(
+                filename: "gemma-4-E2B-it-Q4_K_M.gguf",
+                displayName: displayName(for: "gemma-4-E2B-it-Q4_K_M.gguf"),
+                downloadURL: URL(
+                    string:
+                        "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/gemma-4-E2B-it-Q4_K_M.gguf?download=true"
+                )!,
+                approximateSizeInGigabytes: 3.1,
+                expectedSizeBytes: 3106736256,
+                sha256: "9378bc471710229ef165709b62e34bfb62231420ddaf6d729e727305b5b8672d"
+            ),
+        ]
+    }
 
 /// Startup configuration that controls which GGUF model to load and how large the runtime should be.
 struct LlamaRuntimeConfiguration: Equatable, Sendable {
@@ -153,11 +140,10 @@ struct LlamaRuntimeConfiguration: Equatable, Sendable {
     static let `default` = LlamaRuntimeConfiguration(
         runtimeDirectoryPath: nil,
         preferredModelNames: [
-            "gemma-3-1b-it-Q4_K_M.gguf",
-            "Qwen3-0.6B-Q4_K_M.gguf",
-            "gemma-3n-E4B-it-Q4_K_M.gguf"
+            "gemma-4-E2B-it-Q4_K_M.gguf",
+            "Qwen3.5-0.8B-Q4_K_M.gguf",
         ],
-        contextWindowTokens: 2048,
+        contextWindowTokens: 4096,
         batchSize: 512,
         gpuLayerCount: -1
     )

--- a/tabby/Support/LlamaPromptRenderer.swift
+++ b/tabby/Support/LlamaPromptRenderer.swift
@@ -28,7 +28,7 @@ enum LlamaPromptRenderer {
             "- This is autocomplete, not chat. Do not answer the user or start a conversation.",
             "- Never repeat, restate, or quote the text before the caret.",
             "- Use clipboard context only when it directly helps the inline continuation.",
-            "- Return plain text only with no labels, bullets, markdown, quotes, or explanation."
+            "- Return plain text only with no thinking, labels, bullets, markdown, quotes, or explanation."
         ]
 
         var profileSections: [String] = []

--- a/tabbyTests/ModelAndPresentationValueTests.swift
+++ b/tabbyTests/ModelAndPresentationValueTests.swift
@@ -145,8 +145,8 @@ final class RuntimeAndInputModelValueTests: XCTestCase {
 
     func test_runtimeModelCatalogMapsKnownNamesAndLeavesCustomNamesAlone() {
         XCTAssertEqual(
-            RuntimeModelCatalog.displayName(for: "Qwen3-0.6B-Q4_K_M.gguf"),
-            "tabby-fast-1"
+            RuntimeModelCatalog.displayName(for: "Qwen3.5-0.8B-Q4_K_M.gguf"),
+            "tabby-fast"
         )
         XCTAssertEqual(
             RuntimeModelCatalog.displayName(for: "custom-local-model.gguf"),

--- a/tabbyTests/ModelAndPresentationValueTests.swift
+++ b/tabbyTests/ModelAndPresentationValueTests.swift
@@ -149,6 +149,10 @@ final class RuntimeAndInputModelValueTests: XCTestCase {
             "tabby-fast"
         )
         XCTAssertEqual(
+            RuntimeModelCatalog.displayName(for: "gemma-4-E2B-it-Q4_K_M.gguf"),
+            "tabby-quality"
+        )
+        XCTAssertEqual(
             RuntimeModelCatalog.displayName(for: "custom-local-model.gguf"),
             "custom-local-model.gguf"
         )


### PR DESCRIPTION
## Summary
- change out oss models for better ones

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR swaps the three built-in GGUF models (`tabby-fast-1`, `tabby-balanced-1`, `tabby-depth-1`) for two updated ones (`tabby-fast` → Qwen3.5-0.8B, `tabby-quality` → gemma-4-E2B), updating download URLs, byte counts, and SHA-256 hashes throughout.

- **`LlamaRuntimeModels.swift`**: Catalog, display-name switch, and `preferredModelNames` all updated; the larger `gemma-4` model is now first in the priority list, so it loads by default when both are installed.
- **`LlamaPromptRenderer.swift`**: Adds `\"no thinking\"` to the system-prompt rules to suppress Qwen3.5's chain-of-thought output from appearing in completions.
- **Tests**: Both new model → display-name mappings are now explicitly asserted, closing the gap noted in the prior review.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are mechanical model-metadata swaps with consistent updates across catalog, tests, README, and the system prompt.

Every touch point (catalog entries, display-name switch, preferred-model list, README table, system-prompt rule, and tests) is updated consistently. The "no thinking" system-prompt addition is correct for Qwen3.5's thinking mode and is benign for other models. The test now covers both new model→name mappings.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tabby/Models/LlamaRuntimeModels.swift | Replaces three-model catalog (tabby-fast-1/balanced-1/depth-1) with two new models (tabby-fast/tabby-quality); updates filenames, download URLs, byte sizes, SHA-256 hashes, and preferred-model priority order. |
| tabby/Support/LlamaPromptRenderer.swift | Adds "no thinking" to the system-prompt rule list to suppress chain-of-thought output from Qwen3.5, which supports a thinking mode; harmless to other models. |
| tabbyTests/ModelAndPresentationValueTests.swift | Updates the catalog display-name test to cover both new model filenames (Qwen3.5 → tabby-fast and gemma-4 → tabby-quality) plus the existing custom-name passthrough assertion. |
| README.md | Updates the built-in model table to reflect the two new models and their sizes; removes the now-dropped balanced/depth tiers. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[App startup] --> B[LlamaRuntimeConfiguration.default]
    B --> C{preferredModelNames priority}
    C -->|1st - 3.1 GB| D[gemma-4-E2B-it-Q4_K_M.gguf]
    C -->|2nd - 0.5 GB| E[Qwen3.5-0.8B-Q4_K_M.gguf]
    D --> F[RuntimeModelCatalog.displayName]
    E --> F
    F -->|gemma-4-E2B-it-Q4_K_M.gguf| G[tabby-quality]
    F -->|Qwen3.5-0.8B-Q4_K_M.gguf| H[tabby-fast]
    F -->|anything else| I[raw filename]
    D -->|not found on disk| E
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tabbyTests/ModelAndPresentationValueTests.swift`, line 146-155 ([link](https://github.com/fujacob/tabby/blob/19cb0f2d2fb56239ba225feaf0c0012652995672/tabbyTests/ModelAndPresentationValueTests.swift#L146-L155)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> The test verifies the `Qwen3.5` → `"tabby-fast"` mapping but has no assertion for `gemma-4-E2B-it-Q4_K_M.gguf` → `"tabby-quality"`. The test name says "known names" (plural), so a silent typo in the new switch case would fall through to the `default` branch and return the raw filename without any test failure.

   

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22james%2Fupdate-models%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22james%2Fupdate-models%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tabbyTests%2FModelAndPresentationValueTests.swift%0ALine%3A%20146-155%0A%0AComment%3A%0AThe%20test%20verifies%20the%20%60Qwen3.5%60%20%E2%86%92%20%60%22tabby-fast%22%60%20mapping%20but%20has%20no%20assertion%20for%20%60gemma-4-E2B-it-Q4_K_M.gguf%60%20%E2%86%92%20%60%22tabby-quality%22%60.%20The%20test%20name%20says%20%22known%20names%22%20%28plural%29%2C%20so%20a%20silent%20typo%20in%20the%20new%20switch%20case%20would%20fall%20through%20to%20the%20%60default%60%20branch%20and%20return%20the%20raw%20filename%20without%20any%20test%20failure.%0A%0A%60%60%60suggestion%0A%20%20%20%20func%20test_runtimeModelCatalogMapsKnownNamesAndLeavesCustomNamesAlone%28%29%20%7B%0A%20%20%20%20%20%20%20%20XCTAssertEqual%28%0A%20%20%20%20%20%20%20%20%20%20%20%20RuntimeModelCatalog.displayName%28for%3A%20%22Qwen3.5-0.8B-Q4_K_M.gguf%22%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22tabby-fast%22%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20XCTAssertEqual%28%0A%20%20%20%20%20%20%20%20%20%20%20%20RuntimeModelCatalog.displayName%28for%3A%20%22gemma-4-E2B-it-Q4_K_M.gguf%22%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22tabby-quality%22%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20XCTAssertEqual%28%0A%20%20%20%20%20%20%20%20%20%20%20%20RuntimeModelCatalog.displayName%28for%3A%20%22custom-local-model.gguf%22%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22custom-local-model.gguf%22%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tabbyTests%2FModelAndPresentationValueTests.swift%0ALine%3A%20146-155%0A%0AComment%3A%0AThe%20test%20verifies%20the%20%60Qwen3.5%60%20%E2%86%92%20%60%22tabby-fast%22%60%20mapping%20but%20has%20no%20assertion%20for%20%60gemma-4-E2B-it-Q4_K_M.gguf%60%20%E2%86%92%20%60%22tabby-quality%22%60.%20The%20test%20name%20says%20%22known%20names%22%20%28plural%29%2C%20so%20a%20silent%20typo%20in%20the%20new%20switch%20case%20would%20fall%20through%20to%20the%20%60default%60%20branch%20and%20return%20the%20raw%20filename%20without%20any%20test%20failure.%0A%0A%60%60%60suggestion%0A%20%20%20%20func%20test_runtimeModelCatalogMapsKnownNamesAndLeavesCustomNamesAlone%28%29%20%7B%0A%20%20%20%20%20%20%20%20XCTAssertEqual%28%0A%20%20%20%20%20%20%20%20%20%20%20%20RuntimeModelCatalog.displayName%28for%3A%20%22Qwen3.5-0.8B-Q4_K_M.gguf%22%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22tabby-fast%22%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20XCTAssertEqual%28%0A%20%20%20%20%20%20%20%20%20%20%20%20RuntimeModelCatalog.displayName%28for%3A%20%22gemma-4-E2B-it-Q4_K_M.gguf%22%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22tabby-quality%22%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20XCTAssertEqual%28%0A%20%20%20%20%20%20%20%20%20%20%20%20RuntimeModelCatalog.displayName%28for%3A%20%22custom-local-model.gguf%22%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22custom-local-model.gguf%22%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Ftabby&pr=124&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Update README model table for new Qwen3...."](https://github.com/fujacob/tabby/commit/c9beecb4d2e8eff443e1e4ba6ca40c5e26db4b35) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33173863)</sub>

<!-- /greptile_comment -->