### PR TITLE
Fix summarizer repetition loop by widening penalty window

### DIFF
--- a/tabby/Models/LlamaRuntimeModels.swift
+++ b/tabby/Models/LlamaRuntimeModels.swift
@@ -175,6 +175,10 @@ struct LlamaGenerationOptions: Equatable, Sendable {
     let topP: Double
     let minP: Double
     let repetitionPenalty: Double
+    /// How many recent tokens the repetition penalty examines. A cycle longer than this window
+    /// escapes the penalty entirely. Defaults to 64 for autocomplete (short outputs); summaries
+    /// set this to `maxPredictionTokens` so the penalty covers the entire generation.
+    let repetitionPenaltyWindow: Int
     var seed: UInt32?
 
     static func summary(maxPredictionTokens: Int, temperature: Double) -> LlamaGenerationOptions {
@@ -186,7 +190,9 @@ struct LlamaGenerationOptions: Equatable, Sendable {
             minP: 0.05,
             // Higher penalty than autocomplete (1.05) because summaries span more tokens and
             // are more prone to looping when OCR input contains repeated phrases.
-            repetitionPenalty: 1.4
+            repetitionPenalty: 1.4,
+            // Cover the entire generation so multi-sentence cycles can't escape the window.
+            repetitionPenaltyWindow: maxPredictionTokens
         )
     }
 }

--- a/tabby/Services/Runtime/LlamaRuntimeCore.swift
+++ b/tabby/Services/Runtime/LlamaRuntimeCore.swift
@@ -511,7 +511,11 @@ actor LlamaRuntimeCore {
             throw LlamaRuntimeError.generationFailed("Unable to initialize the llama sampler chain.")
         }
 
-        try addPenaltySamplerIfNeeded(to: sampler, repetitionPenalty: options.repetitionPenalty)
+        try addPenaltySamplerIfNeeded(
+            to: sampler,
+            repetitionPenalty: options.repetitionPenalty,
+            window: options.repetitionPenaltyWindow
+        )
 
         if options.temperature > 0 {
             try addRandomSamplingChain(to: sampler, options: options)
@@ -524,14 +528,15 @@ actor LlamaRuntimeCore {
 
     private func addPenaltySamplerIfNeeded(
         to sampler: UnsafeMutablePointer<llama_sampler>,
-        repetitionPenalty: Double
+        repetitionPenalty: Double,
+        window: Int
     ) throws {
         guard repetitionPenalty > 1.0 else {
             return
         }
 
         guard let penaltySampler = llama_sampler_init_penalties(
-            64,
+            Int32(window),
             Float(repetitionPenalty),
             1.0,
             1.0

--- a/tabby/Services/Runtime/LlamaSuggestionEngine.swift
+++ b/tabby/Services/Runtime/LlamaSuggestionEngine.swift
@@ -31,6 +31,7 @@ final class LlamaSuggestionEngine {
                     topP: request.topP,
                     minP: request.minP,
                     repetitionPenalty: request.repetitionPenalty,
+                    repetitionPenaltyWindow: 64,
                     seed: request.randomSeed
                 )
             )

--- a/tabby/Services/Visual/LlamaVisualContextSummarizer.swift
+++ b/tabby/Services/Visual/LlamaVisualContextSummarizer.swift
@@ -51,7 +51,7 @@ final class LlamaVisualContextSummarizer: VisualContextSummarizing {
             temperature: 0
         )
         let trimmedResult = result.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmedResult
+        return truncateAtRepeatedBlock(trimmedResult)
     }
 
     /// Collapses runs of identical trimmed lines to a single occurrence.
@@ -69,5 +69,30 @@ final class LlamaVisualContextSummarizer: VisualContextSummarizing {
             }
         }
         return result.joined(separator: "\n")
+    }
+
+    /// Detects repeated multi-line blocks in the model output and truncates at the first repeat.
+    /// Small models under greedy decoding can still loop even with a full-window repetition penalty
+    /// if the cycle length is long enough. This catches any remaining loops post-generation.
+    private func truncateAtRepeatedBlock(_ text: String) -> String {
+        let lines = text.components(separatedBy: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        guard lines.count >= 4 else { return text }
+
+        // Try block sizes from 1 line up to half the output.
+        for blockSize in 1 ... lines.count / 2 {
+            let block = Array(lines[0 ..< blockSize])
+            let nextStart = blockSize
+            let nextEnd = nextStart + blockSize
+            guard nextEnd <= lines.count else { continue }
+            let nextBlock = Array(lines[nextStart ..< nextEnd])
+            if block == nextBlock {
+                // Keep only the first occurrence of the block.
+                return block.joined(separator: "\n")
+            }
+        }
+
+        return text
     }
 }

--- a/tabby/Services/Visual/ScreenshotContextGenerator.swift
+++ b/tabby/Services/Visual/ScreenshotContextGenerator.swift
@@ -55,6 +55,7 @@ final class ScreenshotContextGenerator {
         onStatusChange: (@Sendable (VisualContextStatus) async -> Void)? = nil
     ) async throws -> VisualContextExcerpt {
         await onStatusChange?(.capturing)
+        let pipelineStart = Date()
 
         let screenshot: CapturedWindowScreenshot
         do {
@@ -68,7 +69,15 @@ final class ScreenshotContextGenerator {
             throw ScreenshotContextGenerationError.failed(error.localizedDescription)
         }
 
+        if TabbyDebugOptions.isEnabled {
+            let captureElapsed = Date().timeIntervalSince(pipelineStart)
+            TabbyDebugOptions.log(
+                "[Visual context] capture done — \(String(format: "%.1f", captureElapsed))s"
+            )
+        }
+
         await onStatusChange?(.extractingText)
+        let ocrStart = Date()
 
         let extractedText: String
         do {
@@ -94,6 +103,13 @@ final class ScreenshotContextGenerator {
         let normalizedText = normalizeRecognizedText(extractedText)
 
         if TabbyDebugOptions.isEnabled {
+            let ocrElapsed = Date().timeIntervalSince(ocrStart)
+            TabbyDebugOptions.log(
+                "[Visual context] OCR done — \(String(format: "%.1f", ocrElapsed))s, \(extractedText.count) chars extracted"
+            )
+        }
+
+        if TabbyDebugOptions.isEnabled {
             saveDebugScreenshot(
                 screenshot.image,
                 text: extractedText,
@@ -110,14 +126,39 @@ final class ScreenshotContextGenerator {
         let generatedContextText: String
         if let summarizer = summarizer {
             await onStatusChange?(.summarizingText)
+            let inputCharCount = normalizedText.count
+            let summarizeStart = Date()
+            if TabbyDebugOptions.isEnabled {
+                TabbyDebugOptions.log(
+                    "[Visual context] summarize start — input \(inputCharCount) chars, app=\(context.applicationName)"
+                )
+            }
             do {
                 generatedContextText = try await summarizer.summarize(
                     text: normalizedText,
                     applicationName: context.applicationName
                 )
             } catch {
+                if TabbyDebugOptions.isEnabled {
+                    let elapsed = Date().timeIntervalSince(summarizeStart)
+                    TabbyDebugOptions.log(
+                        "[Visual context] summarize FAILED after \(String(format: "%.1f", elapsed))s — \(error.localizedDescription)"
+                    )
+                }
                 throw ScreenshotContextGenerationError.failed(
                     "Summarization failed: \(error.localizedDescription)"
+                )
+            }
+            if TabbyDebugOptions.isEnabled {
+                let elapsed = Date().timeIntervalSince(summarizeStart)
+                TabbyDebugOptions.log(
+                    "[Visual context] summarize done — \(String(format: "%.1f", elapsed))s, output \(generatedContextText.count) chars"
+                )
+                TabbyDebugOptions.log(
+                    "[Visual context] summarize input:\n\(normalizedText.prefix(500))"
+                )
+                TabbyDebugOptions.log(
+                    "[Visual context] summarize output:\n\(generatedContextText)"
                 )
             }
         } else {


### PR DESCRIPTION
## Summary
- The repetition penalty sampler used a hardcoded 64-token lookback window. A typical summary cycle (~35 tokens) escaped the window by its second repetition, letting greedy decoding loop indefinitely. This became visible after the screenshot crop expansion (251ad31) doubled OCR input length.
- Made the penalty window configurable via `LlamaGenerationOptions`. Summaries now use `maxPredictionTokens` (160) as the window so the penalty covers the entire generation. Autocomplete keeps the original 64.
- Added post-generation loop detection in `LlamaVisualContextSummarizer` that truncates at the first repeated block as a safety net.

## Test plan
- [ ] Build succeeds (`xcodebuild build` + `build-for-testing`)
- [ ] Open Tabby while viewing a chatbot conversation (e.g. Claude Code) — verify the visual context summary in the debug output no longer repeats
- [ ] Verify autocomplete suggestion quality is unaffected (penalty window unchanged at 64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a summarizer repetition loop caused by the repetition-penalty sampler's 64-token lookback window being shorter than a typical summary cycle (~35 tokens), allowing greedy decoding to loop indefinitely after the screenshot crop expansion doubled OCR input length. The fix makes the penalty window configurable per generation type and adds a post-generation line-repetition safety net.

- **`LlamaRuntimeModels` / `LlamaRuntimeCore`**: adds `repetitionPenaltyWindow` to `LlamaGenerationOptions`; the `summary()` factory sets it to `maxPredictionTokens` (160), while autocomplete retains 64.
- **`LlamaVisualContextSummarizer`**: new `truncateAtRepeatedBlock` helper scans the model output for back-to-back identical line blocks and truncates at the first repeat.
- **`ScreenshotContextGenerator`**: adds gated `TabbyDebugOptions` timing/content logs for each pipeline stage (capture, OCR, summarize).

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted fix that narrows the scope of a known looping bug without touching the autocomplete path.

The penalty-window widening is mechanically simple and well-scoped: it adds one Int field to a value type, wires it through one function call, and lets each caller opt in. Autocomplete behavior is unchanged. The post-generation safety net in truncateAtRepeatedBlock has known limitations (anchored at output start) but is explicitly documented as a secondary defense, and its weaknesses were already captured in previous review threads. Debug logging is entirely gated and has no production side effects.

No files require special attention. LlamaVisualContextSummarizer.swift carries the acknowledged loop-detection limitations but the primary fix lives upstream in the sampler configuration.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tabby/Models/LlamaRuntimeModels.swift | Adds `repetitionPenaltyWindow: Int` to `LlamaGenerationOptions`; `summary()` factory sets it to `maxPredictionTokens`, ensuring the full generation is covered by the penalty. |
| tabby/Services/Runtime/LlamaRuntimeCore.swift | Threads the new `window` parameter down to `llama_sampler_init_penalties`; replaces the hardcoded 64 with the caller-supplied value. No behavioral change for autocomplete (still 64). |
| tabby/Services/Runtime/LlamaSuggestionEngine.swift | Explicitly passes `repetitionPenaltyWindow: 64` to preserve the original autocomplete penalty window; no logic change. |
| tabby/Services/Visual/LlamaVisualContextSummarizer.swift | Adds `truncateAtRepeatedBlock` safety net; the helper is anchored at index 0 so mid-text cycles are missed (already flagged in review thread). Primary defense is the widened penalty window. |
| tabby/Services/Visual/ScreenshotContextGenerator.swift | Adds `TabbyDebugOptions`-gated timing logs for capture, OCR, and summarize stages; purely observational, no logic changes. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Add visual context pipeline timing logs ..."](https://github.com/fujacob/tabby/commit/913872a216d3f50b3418796abf916aedfe9321d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33174617)</sub>

<!-- /greptile_comment -->