### PR TITLE
Disable Tabby in terminal applications

### DIFF
--- a/tabby.xcodeproj/project.pbxproj
+++ b/tabby.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		AF0F4C853CCA8B86BB5E28CD /* ModelFileValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9D35DB9E86506B9FAE1CFE9 /* ModelFileValidatorTests.swift */; };
 		B053492719F6106E48290C32 /* SuggestionAvailabilityEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A39EC1A44E9160E13E2AE77 /* SuggestionAvailabilityEvaluatorTests.swift */; };
 		B5788B37B93AFEC10EFD3108 /* DownloadFileRescuerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAAEE25772008D75883F2655 /* DownloadFileRescuerTests.swift */; };
+		D10000012F92000100CCC001 /* TerminalAppDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000112F92000100CCC011 /* TerminalAppDetectorTests.swift */; };
 		C10000012F91000100BBB001 /* TabbyTestFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10000112F91000100BBB011 /* TabbyTestFixtures.swift */; };
 		C10000022F91000100BBB002 /* SuggestionTextNormalizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10000122F91000100BBB012 /* SuggestionTextNormalizerTests.swift */; };
 		C10000032F91000100BBB003 /* SuggestionSessionReconcilerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10000132F91000100BBB013 /* SuggestionSessionReconcilerTests.swift */; };
@@ -42,6 +43,7 @@
 		8B1121FFDAD30C7F62E15289 /* SuggestionRequestFactoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SuggestionRequestFactoryTests.swift; sourceTree = "<group>"; };
 		BAAEE25772008D75883F2655 /* DownloadFileRescuerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DownloadFileRescuerTests.swift; sourceTree = "<group>"; };
 		C10000112F91000100BBB011 /* TabbyTestFixtures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TabbyTestFixtures.swift; sourceTree = "<group>"; };
+		D10000112F92000100CCC011 /* TerminalAppDetectorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TerminalAppDetectorTests.swift; sourceTree = "<group>"; };
 		C10000122F91000100BBB012 /* SuggestionTextNormalizerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SuggestionTextNormalizerTests.swift; sourceTree = "<group>"; };
 		C10000132F91000100BBB013 /* SuggestionSessionReconcilerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SuggestionSessionReconcilerTests.swift; sourceTree = "<group>"; };
 		C10000142F91000100BBB014 /* FocusCapabilityResolverTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FocusCapabilityResolverTests.swift; sourceTree = "<group>"; };
@@ -114,6 +116,7 @@
 				562F89255AF340C15A0554BE /* DownloadOutcomeClassifierTests.swift */,
 				F9D35DB9E86506B9FAE1CFE9 /* ModelFileValidatorTests.swift */,
 				BAAEE25772008D75883F2655 /* DownloadFileRescuerTests.swift */,
+			D10000112F92000100CCC011 /* TerminalAppDetectorTests.swift */,
 			);
 			path = tabbyTests;
 			sourceTree = "<group>";
@@ -244,6 +247,7 @@
 				8B6282F0C1CCA0746D96B914 /* DownloadOutcomeClassifierTests.swift in Sources */,
 				AF0F4C853CCA8B86BB5E28CD /* ModelFileValidatorTests.swift in Sources */,
 				B5788B37B93AFEC10EFD3108 /* DownloadFileRescuerTests.swift in Sources */,
+				D10000012F92000100CCC001 /* TerminalAppDetectorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/tabby/Support/SuggestionAvailabilityEvaluator.swift
+++ b/tabby/Support/SuggestionAvailabilityEvaluator.swift
@@ -23,6 +23,10 @@ enum SuggestionAvailabilityEvaluator {
             return "Tabby is disabled in \(focusSnapshot.applicationName)."
         }
 
+        if TerminalAppDetector.isTerminal(bundleIdentifier: focusSnapshot.bundleIdentifier) {
+            return "Tabby is not available in terminal apps."
+        }
+
         guard inputMonitoringGranted else {
             return "Input Monitoring permission is required before Tabby can react to typing."
         }

--- a/tabby/Support/TerminalAppDetector.swift
+++ b/tabby/Support/TerminalAppDetector.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Identifies terminal emulator applications by bundle identifier.
+///
+/// Terminal apps have their own completion, history, and shell integrations that conflict with
+/// ghost-text autocomplete. Tabby stays out of the way automatically so the user doesn't have to
+/// manually disable each terminal they use.
+enum TerminalAppDetector {
+    /// Bundle identifiers of well-known macOS terminal emulators.
+    private static let terminalBundleIdentifiers: Set<String> = [
+        "com.apple.Terminal",
+        "com.googlecode.iterm2",
+        "net.kovidgoyal.kitty",
+        "io.alacritty",
+        "co.zeit.hyper",
+        "com.mitchellh.ghostty",
+        "dev.warp.Warp-Stable",
+        "com.github.wez.wezterm",
+        "com.colliderli.iina-terminal",
+        "io.rio.terminal",
+    ]
+
+    static func isTerminal(bundleIdentifier: String?) -> Bool {
+        guard let bundleIdentifier else { return false }
+        return terminalBundleIdentifiers.contains(bundleIdentifier)
+    }
+}

--- a/tabby/Support/TerminalAppDetector.swift
+++ b/tabby/Support/TerminalAppDetector.swift
@@ -16,8 +16,7 @@ enum TerminalAppDetector {
         "com.mitchellh.ghostty",
         "dev.warp.Warp-Stable",
         "com.github.wez.wezterm",
-        "com.colliderli.iina-terminal",
-        "io.rio.terminal",
+        "io.rio.terminal"
     ]
 
     static func isTerminal(bundleIdentifier: String?) -> Bool {

--- a/tabby/UI/MenuBarView.swift
+++ b/tabby/UI/MenuBarView.swift
@@ -82,7 +82,8 @@ struct MenuBarView: View {
                 .toggleStyle(.switch)
                 .controlSize(.small)
 
-            if let application = focusModel.latestExternalApplication {
+            if let application = focusModel.latestExternalApplication,
+               !TerminalAppDetector.isTerminal(bundleIdentifier: application.bundleIdentifier) {
                 Toggle("Enable in \(application.applicationName)", isOn: appEnabledBinding(for: application))
                     .toggleStyle(.switch)
                     .controlSize(.small)

--- a/tabbyTests/TerminalAppDetectorTests.swift
+++ b/tabbyTests/TerminalAppDetectorTests.swift
@@ -1,0 +1,132 @@
+import XCTest
+@testable import tabby
+
+final class TerminalAppDetectorTests: XCTestCase {
+
+    // MARK: - Known terminals
+
+    func test_isTerminal_appleTerminal() {
+        XCTAssertTrue(TerminalAppDetector.isTerminal(bundleIdentifier: "com.apple.Terminal"))
+    }
+
+    func test_isTerminal_iTerm2() {
+        XCTAssertTrue(TerminalAppDetector.isTerminal(bundleIdentifier: "com.googlecode.iterm2"))
+    }
+
+    func test_isTerminal_kitty() {
+        XCTAssertTrue(TerminalAppDetector.isTerminal(bundleIdentifier: "net.kovidgoyal.kitty"))
+    }
+
+    func test_isTerminal_alacritty() {
+        XCTAssertTrue(TerminalAppDetector.isTerminal(bundleIdentifier: "io.alacritty"))
+    }
+
+    func test_isTerminal_hyper() {
+        XCTAssertTrue(TerminalAppDetector.isTerminal(bundleIdentifier: "co.zeit.hyper"))
+    }
+
+    func test_isTerminal_ghostty() {
+        XCTAssertTrue(TerminalAppDetector.isTerminal(bundleIdentifier: "com.mitchellh.ghostty"))
+    }
+
+    func test_isTerminal_warp() {
+        XCTAssertTrue(TerminalAppDetector.isTerminal(bundleIdentifier: "dev.warp.Warp-Stable"))
+    }
+
+    func test_isTerminal_wezterm() {
+        XCTAssertTrue(TerminalAppDetector.isTerminal(bundleIdentifier: "com.github.wez.wezterm"))
+    }
+
+    // MARK: - Non-terminals
+
+    func test_isTerminal_safari() {
+        XCTAssertFalse(TerminalAppDetector.isTerminal(bundleIdentifier: "com.apple.Safari"))
+    }
+
+    func test_isTerminal_vscode() {
+        XCTAssertFalse(TerminalAppDetector.isTerminal(bundleIdentifier: "com.microsoft.VSCode"))
+    }
+
+    func test_isTerminal_nil() {
+        XCTAssertFalse(TerminalAppDetector.isTerminal(bundleIdentifier: nil))
+    }
+
+    // MARK: - Evaluator integration
+
+    func test_evaluator_blocksTerminalApp() {
+        let snapshot = FocusSnapshot(
+            applicationName: "Terminal",
+            bundleIdentifier: "com.apple.Terminal",
+            capability: .supported,
+            context: nil,
+            inspection: nil
+        )
+
+        let reason = SuggestionAvailabilityEvaluator.disabledReason(
+            globallyEnabled: true,
+            inputMonitoringGranted: true,
+            screenRecordingGranted: true,
+            focusSnapshot: snapshot
+        )
+
+        XCTAssertEqual(reason, "Tabby is not available in terminal apps.")
+    }
+
+    func test_evaluator_doesNotBlockNonTerminalApp() {
+        let snapshot = FocusSnapshot(
+            applicationName: "Safari",
+            bundleIdentifier: "com.apple.Safari",
+            capability: .supported,
+            context: nil,
+            inspection: nil
+        )
+
+        let reason = SuggestionAvailabilityEvaluator.disabledReason(
+            globallyEnabled: true,
+            inputMonitoringGranted: true,
+            screenRecordingGranted: true,
+            focusSnapshot: snapshot
+        )
+
+        XCTAssertNil(reason)
+    }
+
+    func test_shouldSchedulePrediction_falseForTerminal() {
+        let snapshot = FocusSnapshot(
+            applicationName: "iTerm2",
+            bundleIdentifier: "com.googlecode.iterm2",
+            capability: .supported,
+            context: nil,
+            inspection: nil
+        )
+
+        XCTAssertFalse(
+            SuggestionAvailabilityEvaluator.shouldSchedulePrediction(
+                globallyEnabled: true,
+                inputMonitoringGranted: true,
+                screenRecordingGranted: true,
+                focusSnapshot: snapshot
+            )
+        )
+    }
+
+    func test_globalDisabled_winsOverTerminalCheck() {
+        let snapshot = FocusSnapshot(
+            applicationName: "Terminal",
+            bundleIdentifier: "com.apple.Terminal",
+            capability: .supported,
+            context: nil,
+            inspection: nil
+        )
+
+        let reason = SuggestionAvailabilityEvaluator.disabledReason(
+            globallyEnabled: false,
+            inputMonitoringGranted: true,
+            screenRecordingGranted: true,
+            focusSnapshot: snapshot
+        )
+
+        XCTAssertEqual(reason, "Tabby is turned off.",
+                       "Global-off should take precedence over the terminal check")
+    }
+}

--- a/tabbyTests/TerminalAppDetectorTests.swift
+++ b/tabbyTests/TerminalAppDetectorTests.swift
@@ -37,6 +37,10 @@ final class TerminalAppDetectorTests: XCTestCase {
         XCTAssertTrue(TerminalAppDetector.isTerminal(bundleIdentifier: "com.github.wez.wezterm"))
     }
 
+    func test_isTerminal_rio() {
+        XCTAssertTrue(TerminalAppDetector.isTerminal(bundleIdentifier: "io.rio.terminal"))
+    }
+
     // MARK: - Non-terminals
 
     func test_isTerminal_safari() {


### PR DESCRIPTION
## Summary
- Adds built-in detection of terminal emulator apps (Terminal, iTerm2, Kitty, Alacritty, Ghostty, Warp, WezTerm, Hyper, Rio) via `TerminalAppDetector`
- Blocks suggestions automatically when a terminal is focused — terminals have their own completion/history that conflicts with ghost-text autocomplete
- Hides the per-app "Enable in …" menu bar toggle when the focused app is a terminal (since the built-in block can't be overridden)

Closes #126

## Test plan
- [ ] Build succeeds (`xcodebuild build`)
- [ ] Test build succeeds (`xcodebuild build-for-testing`)
- [ ] Focus Apple Terminal — menu bar shows "Tabby is not available in terminal apps." and no per-app toggle
- [ ] Focus iTerm2 or other listed terminal — same behavior
- [ ] Focus a non-terminal app (Safari, VS Code) — Tabby works normally, per-app toggle visible
- [ ] User-disabled app check still takes precedence (disable Safari via menu bar, verify it stays disabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds automatic terminal-app detection to block Tabby suggestions when a terminal emulator is focused, and hides the per-app "Enable in …" toggle for those apps. The implementation is clean and well-tested, following the existing `SuggestionAvailabilityEvaluator` gating pattern.

- `TerminalAppDetector` holds a hard-coded `Set` of 9 terminal bundle identifiers and is called in both the evaluator and the menu bar view, keeping the two gating layers in sync.
- The Alacritty entry uses `io.alacritty` but Alacritty's official `Info.plist` registers `org.alacritty`; the detector will never fire for Alacritty, and the corresponding test asserts the same wrong ID so it gives a false green.
- All other bundle IDs and the integration tests look correct; the ordering in the evaluator (per-app disable → terminal block → permissions) is consistent with the PR's stated precedence rules.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the Alacritty bundle ID; all other terminals and the evaluator/menu-bar logic are correct.

The Alacritty bundle identifier `io.alacritty` does not match Alacritty's actual registered ID (`org.alacritty`), so the terminal block silently does nothing for Alacritty users. The companion test uses the same wrong value and passes, masking the gap. Everything else — other bundle IDs, evaluator ordering, menu bar gating, and the broader test suite — looks correct.

tabby/Support/TerminalAppDetector.swift (wrong Alacritty bundle ID) and tabbyTests/TerminalAppDetectorTests.swift (test mirrors the same incorrect value).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tabby/Support/TerminalAppDetector.swift | New detector using a hard-coded Set of bundle identifiers; the Alacritty entry uses the wrong bundle ID (`io.alacritty` instead of `org.alacritty`), so Alacritty is never blocked. |
| tabby/Support/SuggestionAvailabilityEvaluator.swift | Terminal check inserted correctly between per-app disable check and permissions checks; ordering and message strings look correct. |
| tabby/UI/MenuBarView.swift | Per-app toggle correctly hidden for terminal apps using the same TerminalAppDetector call; logic is consistent with the evaluator. |
| tabbyTests/TerminalAppDetectorTests.swift | Good coverage of all 9 terminals and integration paths, but test_isTerminal_alacritty asserts the wrong bundle ID and needs to be updated alongside the detector fix. |
| tabby.xcodeproj/project.pbxproj | Correctly registers TerminalAppDetectorTests.swift as a build source; minor indentation inconsistency in the file-reference group entry. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[App Focused] --> B{Globally Enabled?}
    B -- No --> C[Return: Tabby is turned off.]
    B -- Yes --> D{App in disabledAppBundleIdentifiers?}
    D -- Yes --> E[Return: Tabby is disabled in app.]
    D -- No --> F{TerminalAppDetector.isTerminal?}
    F -- Yes --> G[Return: Tabby is not available in terminal apps.]
    F -- No --> H{Input Monitoring granted?}
    H -- No --> I[Return: Permission required.]
    H -- Yes --> J{Screen Recording granted?}
    J -- No --> K[Return: Permission required.]
    J -- Yes --> L{focusSnapshot.capability?}
    L -- .supported --> M[Return nil — suggestions enabled]
    L -- .blocked / .unsupported --> N[Return reason string]

    subgraph MenuBarView
        O[latestExternalApplication set?] --> P{isTerminal?}
        P -- Yes --> Q[Hide per-app toggle]
        P -- No --> R[Show Enable in App toggle]
    end
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22disable-tabby-in-terminals%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22disable-tabby-in-terminals%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atabby%2FSupport%2FTerminalAppDetector.swift%3A14%0AAlacritty's%20actual%20%60CFBundleIdentifier%60%20is%20%60org.alacritty%60%2C%20not%20%60io.alacritty%60.%20The%20official%20%60Info.plist%60%20in%20the%20Alacritty%20repository%20%28confirmed%20from%20crash%20reports%20and%20source%29%20shows%20%60%3Cstring%3Eorg.alacritty%3C%2Fstring%3E%60.%20With%20%60io.alacritty%60%20registered%20here%2C%20the%20detector%20will%20never%20match%20a%20real%20Alacritty%20install%2C%20so%20Tabby's%20suggestions%20will%20continue%20to%20appear%20inside%20Alacritty.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%22org.alacritty%22%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0AtabbyTests%2FTerminalAppDetectorTests.swift%3A20-22%0AThe%20test%20uses%20the%20same%20incorrect%20%60io.alacritty%60%20identifier%20as%20the%20detector%2C%20so%20it%20always%20passes%20%E2%80%94%20but%20it%20proves%20nothing%20about%20real%20Alacritty%20installs.%20Update%20to%20%60org.alacritty%60%20to%20match%20the%20fix%20to%20%60TerminalAppDetector%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20func%20test_isTerminal_alacritty%28%29%20%7B%0A%20%20%20%20%20%20%20%20XCTAssertTrue%28TerminalAppDetector.isTerminal%28bundleIdentifier%3A%20%22org.alacritty%22%29%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atabby%2FSupport%2FTerminalAppDetector.swift%3A14%0AAlacritty's%20actual%20%60CFBundleIdentifier%60%20is%20%60org.alacritty%60%2C%20not%20%60io.alacritty%60.%20The%20official%20%60Info.plist%60%20in%20the%20Alacritty%20repository%20%28confirmed%20from%20crash%20reports%20and%20source%29%20shows%20%60%3Cstring%3Eorg.alacritty%3C%2Fstring%3E%60.%20With%20%60io.alacritty%60%20registered%20here%2C%20the%20detector%20will%20never%20match%20a%20real%20Alacritty%20install%2C%20so%20Tabby's%20suggestions%20will%20continue%20to%20appear%20inside%20Alacritty.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%22org.alacritty%22%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0AtabbyTests%2FTerminalAppDetectorTests.swift%3A20-22%0AThe%20test%20uses%20the%20same%20incorrect%20%60io.alacritty%60%20identifier%20as%20the%20detector%2C%20so%20it%20always%20passes%20%E2%80%94%20but%20it%20proves%20nothing%20about%20real%20Alacritty%20installs.%20Update%20to%20%60org.alacritty%60%20to%20match%20the%20fix%20to%20%60TerminalAppDetector%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20func%20test_isTerminal_alacritty%28%29%20%7B%0A%20%20%20%20%20%20%20%20XCTAssertTrue%28TerminalAppDetector.isTerminal%28bundleIdentifier%3A%20%22org.alacritty%22%29%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=fujacob%2Ftabby&pr=127&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["Remove bogus IINA bundle ID, add missing..."](https://github.com/fujacob/tabby/commit/e0b57d6ea4c1d0fa5e91c2602efca6bb456440dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33176117)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->