### PR TITLE
Fix main actor isolation error in FocusTracker

### DIFF
--- a/tabby/Services/Focus/FocusTracker.swift
+++ b/tabby/Services/Focus/FocusTracker.swift
@@ -240,7 +240,7 @@ private extension FocusedInputPollingSignature {
         let fallbackElementIdentifier: String?
 
         init(inputFrame: CGRect?, fallbackElementIdentifier: String) {
-            roundedInputFrame = inputFrame.map(RoundedRect.init(rect:))
+            roundedInputFrame = inputFrame.map { RoundedRect(rect: $0) }
             self.fallbackElementIdentifier = roundedInputFrame == nil ? fallbackElementIdentifier : nil
         }
     }


### PR DESCRIPTION
## Summary
- Fixes `Call to main actor-isolated initializer 'init(rect:)' in a synchronous nonisolated context` at `FocusTracker.swift:243`
- Point-free `RoundedRect.init(rect:)` inherits `@MainActor` isolation from the file's `FocusTracker` class; replaced with a closure to avoid the mismatch

## Test plan
- [x] `xcodebuild build` passes
- [ ] CI passes (SwiftLint, xcodebuild, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a Swift concurrency build error in `FocusTracker.swift` by replacing a point-free initializer reference with an equivalent closure, preventing the compiler from inheriting `@MainActor` isolation in a nonisolated `Optional.map` call.

- The single changed line swaps `inputFrame.map(RoundedRect.init(rect:))` for `inputFrame.map { RoundedRect(rect: $0) }` — semantically identical, but the closure form avoids carrying the `@MainActor` annotation that the point-free reference inherits from the surrounding `FocusTracker` file scope.
- No behavioral change; the `RoundedRect` value produced is the same regardless of which form is used.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is a one-line, semantically equivalent substitution that unblocks a build error with no runtime behavior change.

The fix is correct and minimal. The only open item is a missing inline comment explaining why the closure form is used, which is worth adding given that AGENTS.md explicitly asks for actor isolation nuances to be annotated — a future contributor could easily revert this to the more concise point-free syntax without understanding the compilation constraint.

No files require special attention beyond the suggestion to add a teaching comment at line 243.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tabby/Services/Focus/FocusTracker.swift | Single-line actor isolation fix: replaces point-free RoundedRect.init(rect:) reference with an explicit closure to avoid the @MainActor-isolation mismatch in Optional.map. Change is semantically equivalent but lacks a teaching comment explaining the actor isolation nuance, which AGENTS.md explicitly calls for. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["FocusedInputPollingSignature.init(context:)"] --> B["FieldAnchor.init(inputFrame:fallbackElementIdentifier:)"]
    B --> C{"inputFrame is nil?"}
    C -- "nil" --> D["roundedInputFrame = nil\nfallbackElementIdentifier kept"]
    C -- "CGRect" --> E["closure: RoundedRect(rect: $0)\nno @MainActor inheritance"]
    E --> F["roundedInputFrame = RoundedRect\nfallbackElementIdentifier = nil"]
    D --> G["FieldAnchor"]
    F --> G
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22fix%2Ffocus-tracker-isolation%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Ffocus-tracker-isolation%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atabby%2FServices%2FFocus%2FFocusTracker.swift%3A243%0AAGENTS.md%20calls%20for%20targeted%20inline%20comments%20on%20actor%20isolation%20nuances%20%E2%80%94%20this%20is%20a%20good%20spot%20for%20one.%20A%20future%20reader%20unfamiliar%20with%20Swift's%20point-free%20reference%20semantics%20will%20see%20a%20closure%20where%20they%20might%20expect%20the%20more%20concise%20%60RoundedRect.init%28rect%3A%29%60%20and%20not%20understand%20why.%20A%20short%20comment%20explaining%20the%20reason%20prevents%20the%20pattern%20from%20being%20%22helpfully%22%20reverted.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Use%20a%20closure%20instead%20of%20a%20point-free%20reference%20%28RoundedRect.init%28rect%3A%29%29%20to%20avoid%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20inheriting%20%40MainActor%20isolation%20from%20the%20surrounding%20FocusTracker%20context.%20The%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20point-free%20form%20captures%20the%20initializer's%20actor%20annotation%2C%20which%20the%20compiler%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20rejects%20in%20a%20synchronous%20nonisolated%20position%20like%20Optional.map.%0A%20%20%20%20%20%20%20%20%20%20%20%20roundedInputFrame%20%3D%20inputFrame.map%20%7B%20RoundedRect%28rect%3A%20%240%29%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atabby%2FServices%2FFocus%2FFocusTracker.swift%3A243%0AAGENTS.md%20calls%20for%20targeted%20inline%20comments%20on%20actor%20isolation%20nuances%20%E2%80%94%20this%20is%20a%20good%20spot%20for%20one.%20A%20future%20reader%20unfamiliar%20with%20Swift's%20point-free%20reference%20semantics%20will%20see%20a%20closure%20where%20they%20might%20expect%20the%20more%20concise%20%60RoundedRect.init%28rect%3A%29%60%20and%20not%20understand%20why.%20A%20short%20comment%20explaining%20the%20reason%20prevents%20the%20pattern%20from%20being%20%22helpfully%22%20reverted.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Use%20a%20closure%20instead%20of%20a%20point-free%20reference%20%28RoundedRect.init%28rect%3A%29%29%20to%20avoid%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20inheriting%20%40MainActor%20isolation%20from%20the%20surrounding%20FocusTracker%20context.%20The%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20point-free%20form%20captures%20the%20initializer's%20actor%20annotation%2C%20which%20the%20compiler%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20rejects%20in%20a%20synchronous%20nonisolated%20position%20like%20Optional.map.%0A%20%20%20%20%20%20%20%20%20%20%20%20roundedInputFrame%20%3D%20inputFrame.map%20%7B%20RoundedRect%28rect%3A%20%240%29%20%7D%0A%60%60%60%0A%0A&repo=fujacob%2Ftabby&pr=132&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Fix main actor isolation error in FocusT..."](https://github.com/fujacob/tabby/commit/9028d56379adc3e93b41bbf13cea285b7bbbab0a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33186361)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=45fae5fd-3007-4631-a2b0-92b2beb3df2a))

<!-- /greptile_comment -->