### PR TITLE
Re-disable userTags in prompt renderers (fixes CI)

### DIFF
--- a/tabby/Support/FoundationModelPromptRenderer.swift
+++ b/tabby/Support/FoundationModelPromptRenderer.swift
@@ -32,10 +32,11 @@ enum FoundationModelPromptRenderer {
         if let name = request.userName, !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             profileSections.append("The user's name is \(name).")
         }
-        if let tags = request.userTags, !tags.isEmpty {
-            let tagsString = tags.joined(separator: ", ")
-            profileSections.append("Things the user types often include: \(tagsString).")
-        }
+        // TODO: Re-enable userTags in the prompt once we validate the feature's value.
+        // if let tags = request.userTags, !tags.isEmpty {
+        //     let tagsString = tags.joined(separator: ", ")
+        //     profileSections.append("Things the user types often include: \(tagsString).")
+        // }
 
         if !profileSections.isEmpty {
             lines.append("User Profile Context:")

--- a/tabby/Support/LlamaPromptRenderer.swift
+++ b/tabby/Support/LlamaPromptRenderer.swift
@@ -35,10 +35,11 @@ enum LlamaPromptRenderer {
         if let name = userName, !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             profileSections.append("- The user's name is \(name).")
         }
-        if let tags = userTags, !tags.isEmpty {
-            let tagsString = tags.joined(separator: ", ")
-            profileSections.append("- Things the user types often include: \(tagsString).")
-        }
+        // TODO: Re-enable userTags in the prompt once we validate the feature's value.
+        // if let tags = userTags, !tags.isEmpty {
+        //     let tagsString = tags.joined(separator: ", ")
+        //     profileSections.append("- Things the user types often include: \(tagsString).")
+        // }
 
         if !profileSections.isEmpty {
             sections.append("")


### PR DESCRIPTION
## Summary
- PR #122's squash merge accidentally un-commented the userTags emission in both `FoundationModelPromptRenderer` and `LlamaPromptRenderer`
- Restores the `// TODO` gating comments to match the test expectations that assert tags must not appear in prompts

## Test plan
- [x] `xcodebuild build` passes
- [x] `xcodebuild build-for-testing` passes
- [x] SwiftLint clean (no new warnings)
- [ ] CI: `FoundationModelPromptRendererTests` and `LlamaPromptRendererTests` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR re-comments the `userTags` emission block in both `FoundationModelPromptRenderer` and `LlamaPromptRenderer`, restoring the `// TODO` gating that was accidentally removed during PR #122's squash merge.

- In `FoundationModelPromptRenderer.sessionInstructions`, the four-line `userTags` block is re-commented with a `TODO` explaining it will be re-enabled after feature validation.
- In `LlamaPromptRenderer.prompt`, the same block is re-commented; the `userTags: [String]?` parameter is intentionally kept in the function signature so call sites require no changes when the feature is eventually re-enabled.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change reverts an accidental uncomment, restoring the exact commented-out state the tests expect.

Both files receive a surgical re-comment of the userTags block. No logic is altered, no new paths are introduced, and the userTags parameter is deliberately preserved in LlamaPromptRenderer's signature so call sites stay unchanged. The change is a direct fix for a known CI regression with clear test coverage validating the correct state.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tabby/Support/FoundationModelPromptRenderer.swift | Re-comments the userTags block in sessionInstructions, restoring the TODO-gated state that CI tests expect. |
| tabby/Support/LlamaPromptRenderer.swift | Re-comments the userTags block in prompt; the userTags parameter remains in the function signature for forward-compatibility when the feature is re-enabled. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SuggestionRequest] --> B{Engine}
    B -->|Apple Intelligence| C[FoundationModelPromptRenderer]
    B -->|Local llama.cpp| D[LlamaPromptRenderer]
    C --> E[sessionInstructions]
    E --> F{userName present?}
    F -->|Yes| G[Append name to profileSections]
    F -->|No| H[Skip]
    G --> I[userTags block — commented out TODO]
    H --> I
    I --> J{profileSections empty?}
    J -->|No| K[Append User Profile Context]
    J -->|Yes| L[Skip profile block]
    D --> M[prompt]
    M --> N{userName present?}
    N -->|Yes| O[Append name to profileSections]
    N -->|No| P[Skip]
    O --> Q[userTags block — commented out TODO]
    P --> Q
    Q --> R{profileSections empty?}
    R -->|No| S[Append User Profile Context]
    R -->|Yes| T[Skip profile block]
```

<sub>Reviews (1): Last reviewed commit: ["Re-disable userTags in prompt renderers ..."](https://github.com/fujacob/tabby/commit/16ad91408474a208e8f54f7107f1b413ea8197ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33186901)</sub>

<!-- /greptile_comment -->