### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Summary

<!--
One or two sentences: what changed and why. Skip the play-by-play.
The diff already shows what; this section should explain why.
-->

## Validation

<!--
What you actually ran and what you actually saw — not what you intended to run.
Examples:

  xcodebuild test -project tabby.xcodeproj -scheme tabby \
    -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO
  # ** TEST SUCCEEDED **  N tests, 0 failures

  swiftlint lint --config .swiftlint.yml --quiet
  # exit 0

For UI changes, attach a screenshot or short screen recording.
For changes that can't be verified end-to-end yet, say so explicitly.
-->

## Linked issues

<!--
Use `Fixes #N` to auto-close on merge, `Refs #N` to link without closing.
-->

## Risk / rollout notes

<!--
Anything reviewers should know that isn't visible from the diff:
- Schema, settings, or pbxproj migrations
- Behavior changes that touch existing user flows
- Performance characteristics worth flagging
- Follow-up issues filed (link them)

Skip this section entirely if there's nothing to flag.
-->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `.github/dependabot.yml` to automate dependency update PRs for the GitHub Actions workflows on a weekly schedule.

- Configures Dependabot for the `github-actions` ecosystem, which will open PRs when action versions in `.github/workflows/` are outdated.
- The project also has two Swift Package Manager dependencies (`llama.swift` and `Sparkle`) that are not covered by this config; a `swift` ecosystem entry would extend the same automated coverage to those packages.

<h3>Confidence Score: 4/5</h3>

Safe to merge — this is a purely additive config file with no runtime impact.

The change is a straightforward Dependabot config that only monitors GitHub Actions. The Swift packages used by the project are not included, so automated update PRs for those dependencies won't be generated, but that's a gap in coverage rather than a correctness problem.

.github/dependabot.yml — worth considering whether the `swift` ecosystem should be added to cover the existing SPM dependencies.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/dependabot.yml | Adds Dependabot configuration for the `github-actions` ecosystem with a weekly schedule; does not cover the project's Swift Package Manager dependencies (llama.swift, Sparkle) |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Dependabot weekly schedule] --> B{Ecosystems monitored}
    B --> C[github-actions ✅
.github/workflows/*.yml]
    B --> D[swift ❌ not configured
llama.swift, Sparkle]
    C --> E[Opens PRs for
Actions version bumps]
    D --> F[No automated PRs
for Swift packages]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22james%2Fdependabot%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22james%2Fdependabot%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fdependabot.yml%3A1-6%0AThe%20project%20has%20two%20Swift%20Package%20Manager%20dependencies%20%28%60llama.swift%60%20and%20%60Sparkle%60%29%20pinned%20in%20%60tabby.xcodeproj%2Fproject.xcworkspace%2Fxcshareddata%2Fswiftpm%2FPackage.resolved%60.%20Adding%20a%20%60swift%60%20ecosystem%20entry%20would%20let%20Dependabot%20open%20PRs%20when%20new%20versions%20of%20those%20packages%20are%20released%2C%20keeping%20security%20and%20feature%20updates%20automated%20alongside%20Actions.%0A%0A%60%60%60suggestion%0Aversion%3A%202%0Aupdates%3A%0A%20%20-%20package-ecosystem%3A%20github-actions%0A%20%20%20%20directory%3A%20%2F%0A%20%20%20%20schedule%3A%0A%20%20%20%20%20%20interval%3A%20weekly%0A%20%20-%20package-ecosystem%3A%20swift%0A%20%20%20%20directory%3A%20%2F%0A%20%20%20%20schedule%3A%0A%20%20%20%20%20%20interval%3A%20weekly%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fdependabot.yml%3A1-6%0AThe%20project%20has%20two%20Swift%20Package%20Manager%20dependencies%20%28%60llama.swift%60%20and%20%60Sparkle%60%29%20pinned%20in%20%60tabby.xcodeproj%2Fproject.xcworkspace%2Fxcshareddata%2Fswiftpm%2FPackage.resolved%60.%20Adding%20a%20%60swift%60%20ecosystem%20entry%20would%20let%20Dependabot%20open%20PRs%20when%20new%20versions%20of%20those%20packages%20are%20released%2C%20keeping%20security%20and%20feature%20updates%20automated%20alongside%20Actions.%0A%0A%60%60%60suggestion%0Aversion%3A%202%0Aupdates%3A%0A%20%20-%20package-ecosystem%3A%20github-actions%0A%20%20%20%20directory%3A%20%2F%0A%20%20%20%20schedule%3A%0A%20%20%20%20%20%20interval%3A%20weekly%0A%20%20-%20package-ecosystem%3A%20swift%0A%20%20%20%20directory%3A%20%2F%0A%20%20%20%20schedule%3A%0A%20%20%20%20%20%20interval%3A%20weekly%0A%60%60%60%0A%0A&repo=fujacob%2Ftabby&pr=136&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add dependabot"](https://github.com/fujacob/tabby/commit/225b5b833e2e061a2817e1931b1d2932a90c3334) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33188275)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->