### PR TITLE
Update CLAUDE.md to reflect production open-source project

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,10 +1,13 @@
 # Claude Instructions for Tabby
 
-Tabby is a macOS menu bar app that provides on-device inline autocomplete in the
-text field the user is already editing. It watches Accessibility focus, monitors
-global input, generates a local continuation through Apple Intelligence or
-llama.cpp, renders ghost text near the caret, and inserts accepted text when the
-user presses `Tab`.
+Tabby is a community-driven open-source macOS menu bar app that provides
+on-device inline autocomplete in any text field. It watches Accessibility focus,
+monitors global input, generates a local continuation through Apple Intelligence
+or llama.cpp, renders ghost text near the caret, and inserts accepted text when
+the user presses `Tab`.
+
+This is a production app with real users and external contributors. Treat every
+change as shipping to end users, not as an exercise.
 
 ## How To Work In This Repo
 
@@ -49,15 +52,25 @@ user presses `Tab`.
   `FoundationModelSuggestionEngine`, `LlamaSuggestionEngine`,
   `LlamaRuntimeManager`, and the serialized `LlamaRuntimeCore` actor.
 
-## Teaching Comments
+## Comments
 
-- Comments should teach, not narrate. Explain why a design exists, which invariant
-  it protects, or which macOS/Swift pitfall it avoids.
+- Comments should explain why, not what. Explain which invariant a design
+  protects or which macOS/Swift pitfall it avoids.
 - Prefer file-level and type-level `///` comments for new important files/types.
 - Add targeted inline comments for tricky lifecycle, `@MainActor`, `Task`,
   cancellation, Accessibility/Core Foundation bridging, unsafe pointer work, and
   llama.cpp runtime state.
 - Avoid comments that merely restate the next line of code.
+
+## Contributing Workflow
+
+- External contributors open PRs against `main`. Greptile reviews automatically.
+- New test files in `tabbyTests/` must be manually registered in
+  `tabby.xcodeproj/project.pbxproj` (the `tabby/` source group auto-discovers
+  files, but `tabbyTests/` uses manual PBXGroup entries).
+- Run SwiftLint before pushing: `swiftlint lint --quiet`. The project config is
+  in `.swiftlint.yml` (line length 140/200, trailing commas disallowed).
+- Wiki lives at https://github.com/FuJacob/tabby/wiki for contributor onboarding.
 
 ## Swift And macOS Expectations
 


### PR DESCRIPTION
## Summary
- Reframes intro from teaching-oriented to community-driven production app
- Renames "Teaching Comments" to "Comments" with production-appropriate guidance
- Adds "Contributing Workflow" section covering Greptile reviews, pbxproj test file registration, SwiftLint config, and wiki link

## Test plan
- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Confirm no existing guidance was lost, only reframed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates `.claude/CLAUDE.md` to align with `AGENTS.md` (repo root), reframing the project description from a teaching context to a community-driven production app and adding a new Contributing Workflow section.

- Intro paragraph updated to emphasize "production app with real users," matching the language already in `AGENTS.md`.
- "Teaching Comments" section renamed to "Comments" with slightly tightened guidance (same rules, cleaner phrasing).
- New Contributing Workflow section documents the `tabbyTests/` pbxproj registration requirement, SwiftLint pre-push step, and wiki link — previously undocumented in `CLAUDE.md`.

<h3>Confidence Score: 5/5</h3>

Documentation-only change with no code execution path affected; safe to merge.

The change touches only `.claude/CLAUDE.md` and brings it into sync with the existing `AGENTS.md` at the repo root. No logic, APIs, or configuration is modified. The new Contributing Workflow section accurately reflects the repo's build tooling (SwiftLint, pbxproj manual registration) based on the surrounding codebase context.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .claude/CLAUDE.md | Documentation-only update: reframes intro to production/community framing, renames "Teaching Comments" to "Comments", and adds a new Contributing Workflow section. Content aligns with existing AGENTS.md at the repo root. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[External Contributor] --> B[Fork & Branch]
    B --> C[Make Changes]
    C --> D{New test file\nin tabbyTests/?}
    D -- Yes --> E[Manually register in\nproject.pbxproj]
    D -- No --> F[Run SwiftLint\nswiftlint lint --quiet]
    E --> F
    F --> G{Lint passes?}
    G -- No --> C
    G -- Yes --> H[Open PR against main]
    H --> I[Greptile auto-review]
    I --> J[Human review & merge]
```

<sub>Reviews (1): Last reviewed commit: ["Update CLAUDE.md to reflect production o..."](https://github.com/fujacob/tabby/commit/92060e3c40b03feafb60b884dc60b958d70f450f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33187342)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=45fae5fd-3007-4631-a2b0-92b2beb3df2a))

<!-- /greptile_comment -->