### PR TITLE
Remove userTags feature to fix recurring CI failures

### DIFF
--- a/tabby/Models/SuggestionEngineModels.swift
+++ b/tabby/Models/SuggestionEngineModels.swift
@@ -55,7 +55,6 @@ struct SuggestionSettingsSnapshot: Equatable, Sendable {
     /// User-authored profile data for Tabby's single instruction-rendered completion prompt.
     /// This travels in the snapshot so generation uses the same value the Settings UI shows.
     let userName: String
-    let userTags: [String]
     let debounceMilliseconds: Int
     let focusPollIntervalMilliseconds: Int
 }

--- a/tabby/Models/SuggestionModels.swift
+++ b/tabby/Models/SuggestionModels.swift
@@ -82,7 +82,6 @@ struct SuggestionConfiguration: Equatable, Sendable {
     /// `SuggestionSettingsModel` persists the user's real preference; configuration only provides
     /// the app's starting value for a fresh install.
     let defaultUserName: String?
-    let defaultUserTags: [String]?
     let defaultWordCountPreset: SuggestionWordCountPreset
     let focusPollIntervalMilliseconds: Int
 
@@ -108,7 +107,6 @@ struct SuggestionConfiguration: Equatable, Sendable {
         maxSuffixCharacters: 192,
         // Seed the profile settings with lightweight defaults on first launch.
         defaultUserName: "Jacob",
-        defaultUserTags: [],
         defaultWordCountPreset: .sevenToTwelve,
         focusPollIntervalMilliseconds: 50
     )
@@ -206,7 +204,6 @@ struct SuggestionRequest: Equatable, Sendable {
     /// Optional user-provided profile context. We keep this separate from base product behavior so
     /// future settings/personalization work can evolve independently from prompt safety rules.
     let userName: String?
-    let userTags: [String]?
     /// Ephemeral clipboard context captured only when the user has enabled clipboard prompting.
     let clipboardContext: String?
     /// Ephemeral screen context summary injected only when available for the active text field.

--- a/tabby/Models/SuggestionSettingsModel.swift
+++ b/tabby/Models/SuggestionSettingsModel.swift
@@ -19,7 +19,6 @@ final class SuggestionSettingsModel: ObservableObject {
     @Published private(set) var selectedWordCountPreset: SuggestionWordCountPreset
     @Published private(set) var isClipboardContextEnabled: Bool
     @Published private(set) var userName: String
-    @Published private(set) var userTags: [String]
     @Published private(set) var debounceMilliseconds: Int
     @Published private(set) var focusPollIntervalMilliseconds: Int
     private let userDefaults: UserDefaults
@@ -34,7 +33,6 @@ final class SuggestionSettingsModel: ObservableObject {
     private static let selectedWordCountPresetDefaultsKey = "selectedSuggestionWordCountPreset"
     private static let clipboardContextEnabledDefaultsKey = "tabbyClipboardContextEnabled"
     private static let userNameDefaultsKey = "tabbyUserName"
-    private static let userTagsDefaultsKey = "tabbyUserTags"
     private static let debounceMillisecondsDefaultsKey = "tabbyDebounceMilliseconds"
     private static let focusPollIntervalMillisecondsDefaultsKey = "tabbyFocusPollIntervalMilliseconds"
 
@@ -72,12 +70,6 @@ final class SuggestionSettingsModel: ObservableObject {
             userDefaults.string(forKey: Self.userNameDefaultsKey) ?? ""
         }
 
-        let resolvedUserTags: [String] = if userDefaults.object(forKey: Self.userTagsDefaultsKey) == nil {
-            configuration.defaultUserTags ?? []
-        } else {
-            userDefaults.stringArray(forKey: Self.userTagsDefaultsKey) ?? []
-        }
-
         let resolvedDebounceMilliseconds: Int = {
             let raw = userDefaults.object(forKey: Self.debounceMillisecondsDefaultsKey) as? Int
                 ?? configuration.debounceMilliseconds
@@ -97,7 +89,6 @@ final class SuggestionSettingsModel: ObservableObject {
         selectedWordCountPreset = resolvedWordCountPreset
         isClipboardContextEnabled = resolvedClipboardContextEnabled
         userName = resolvedUserName
-        userTags = resolvedUserTags
         debounceMilliseconds = resolvedDebounceMilliseconds
         focusPollIntervalMilliseconds = resolvedFocusPollIntervalMilliseconds
 
@@ -109,7 +100,6 @@ final class SuggestionSettingsModel: ObservableObject {
         persistSelectedWordCountPreset(resolvedWordCountPreset)
         persistClipboardContextEnabled(resolvedClipboardContextEnabled)
         persistUserName(resolvedUserName)
-        persistUserTags(resolvedUserTags)
         userDefaults.set(resolvedDebounceMilliseconds, forKey: Self.debounceMillisecondsDefaultsKey)
         userDefaults.set(resolvedFocusPollIntervalMilliseconds, forKey: Self.focusPollIntervalMillisecondsDefaultsKey)
     }
@@ -127,7 +117,6 @@ final class SuggestionSettingsModel: ObservableObject {
             selectedWordCountPreset: selectedWordCountPreset,
             isClipboardContextEnabled: isClipboardContextEnabled,
             userName: userName,
-            userTags: userTags,
             debounceMilliseconds: debounceMilliseconds,
             focusPollIntervalMilliseconds: focusPollIntervalMilliseconds
         )
@@ -295,15 +284,6 @@ final class SuggestionSettingsModel: ObservableObject {
         persistUserName(name)
     }
 
-    func setUserTags(_ tags: [String]) {
-        guard userTags != tags else {
-            return
-        }
-
-        userTags = tags
-        persistUserTags(tags)
-    }
-
     private func persistSelectedEngine(_ engine: SuggestionEngineKind) {
         userDefaults.set(engine.rawValue, forKey: Self.selectedEngineDefaultsKey)
     }
@@ -415,10 +395,6 @@ final class SuggestionSettingsModel: ObservableObject {
         userDefaults.set(name, forKey: Self.userNameDefaultsKey)
     }
 
-    private func persistUserTags(_ tags: [String]) {
-        userDefaults.set(tags, forKey: Self.userTagsDefaultsKey)
-    }
-
     private func persistDisabledAppRules(_ rules: [DisabledApplicationRule]) {
         guard !rules.isEmpty else {
             userDefaults.removeObject(forKey: Self.disabledAppRulesDefaultsKey)
@@ -441,12 +417,11 @@ extension SuggestionSettingsModel: SuggestionSettingsProviding {
                 $selectedWordCountPreset
             ),
             $isClipboardContextEnabled,
-            Publishers.CombineLatest($userName, $userTags),
+            $userName,
             Publishers.CombineLatest($debounceMilliseconds, $focusPollIntervalMilliseconds)
         )
-        .map { combinedSettings, clipboardContextEnabled, profile, timing in
+        .map { combinedSettings, clipboardContextEnabled, userName, timing in
             let (globallyEnabled, disabledAppRules, engine, wordCountPreset) = combinedSettings
-            let (userName, userTags) = profile
             let (debounce, focusPoll) = timing
             return SuggestionSettingsSnapshot(
                 isGloballyEnabled: globallyEnabled,
@@ -455,7 +430,6 @@ extension SuggestionSettingsModel: SuggestionSettingsProviding {
                 selectedWordCountPreset: wordCountPreset,
                 isClipboardContextEnabled: clipboardContextEnabled,
                 userName: userName,
-                userTags: userTags,
                 debounceMilliseconds: debounce,
                 focusPollIntervalMilliseconds: focusPoll
             )

--- a/tabby/Support/FoundationModelPromptRenderer.swift
+++ b/tabby/Support/FoundationModelPromptRenderer.swift
@@ -32,12 +32,6 @@ enum FoundationModelPromptRenderer {
         if let name = request.userName, !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             profileSections.append("The user's name is \(name).")
         }
-        // TODO: Re-enable userTags in the prompt once we validate the feature's value.
-        // if let tags = request.userTags, !tags.isEmpty {
-        //     let tagsString = tags.joined(separator: ", ")
-        //     profileSections.append("Things the user types often include: \(tagsString).")
-        // }
-
         if !profileSections.isEmpty {
             lines.append("User Profile Context:")
             lines.append(contentsOf: profileSections)

--- a/tabby/Support/LlamaPromptRenderer.swift
+++ b/tabby/Support/LlamaPromptRenderer.swift
@@ -18,7 +18,6 @@ enum LlamaPromptRenderer {
         applicationName: String,
         completionLengthInstruction: String,
         userName: String?,
-        userTags: [String]?,
         clipboardContext: String? = nil,
         visualContextSummary: String? = nil
     ) -> String {
@@ -35,12 +34,6 @@ enum LlamaPromptRenderer {
         if let name = userName, !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             profileSections.append("- The user's name is \(name).")
         }
-        // TODO: Re-enable userTags in the prompt once we validate the feature's value.
-        // if let tags = userTags, !tags.isEmpty {
-        //     let tagsString = tags.joined(separator: ", ")
-        //     profileSections.append("- Things the user types often include: \(tagsString).")
-        // }
-
         if !profileSections.isEmpty {
             sections.append("")
             sections.append("User Profile Context:")

--- a/tabby/Support/SuggestionRequestFactory.swift
+++ b/tabby/Support/SuggestionRequestFactory.swift
@@ -42,7 +42,6 @@ enum SuggestionRequestFactory {
         )
         let completionLengthInstruction = settings.selectedWordCountPreset.promptInstruction
         let userName = activeUserName(settings: settings)
-        let userTags = activeUserTags(settings: settings)
         let boundedClipboardContext = activeClipboardContext(
             rawContext: clipboardContext,
             settings: settings
@@ -55,7 +54,6 @@ enum SuggestionRequestFactory {
             applicationName: context.applicationName,
             completionLengthInstruction: completionLengthInstruction,
             userName: userName,
-            userTags: userTags,
             clipboardContext: boundedClipboardContext,
             visualContextSummary: boundedVisualContextSummary
         )
@@ -78,7 +76,6 @@ enum SuggestionRequestFactory {
             maxSuffixCharacters: configuration.maxSuffixCharacters,
             completionLengthInstruction: completionLengthInstruction,
             userName: userName,
-            userTags: userTags,
             clipboardContext: boundedClipboardContext,
             visualContextSummary: boundedVisualContextSummary
         )
@@ -108,13 +105,6 @@ enum SuggestionRequestFactory {
         settings: SuggestionSettingsSnapshot
     ) -> String? {
         settings.userName
-    }
-
-    private static func activeUserTags(
-        settings: SuggestionSettingsSnapshot
-    ) -> [String]? {
-        // TODO: Re-enable userTags once we validate the feature's value.
-        nil
     }
 
     private static func activeClipboardContext(

--- a/tabby/UI/SettingsView.swift
+++ b/tabby/UI/SettingsView.swift
@@ -254,19 +254,6 @@ struct SettingsView: View {
                     .textFieldStyle(.roundedBorder)
                 }
 
-                // TODO: Re-enable "Things you type often" once we validate the feature's value.
-                // VStack(alignment: .leading, spacing: 6) {
-                //     Text("Things you type often")
-                //         .font(.system(size: 13, weight: .medium))
-                //
-                //     TagsInputView(
-                //         tags: Binding(
-                //             get: { suggestionSettings.userTags },
-                //             set: { suggestionSettings.setUserTags($0) }
-                //         ),
-                //         placeholder: "Add tags (press Enter to add)"
-                //     )
-                // }
             }
             .padding(.vertical, 4)
         }

--- a/tabby/UI/WelcomeProfileStepView.swift
+++ b/tabby/UI/WelcomeProfileStepView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 /// File overview:
-/// A dedicated step in the onboarding flow to collect the user's name and common tags.
+/// A dedicated step in the onboarding flow to collect the user's name.
 struct WelcomeProfileStepView: View {
     @ObservedObject var suggestionSettings: SuggestionSettingsModel
 
@@ -33,23 +33,6 @@ struct WelcomeProfileStepView: View {
                     .controlSize(.large)
                 }
 
-                // TODO: Re-enable "Things you type often" once we validate the feature's value.
-                // VStack(alignment: .leading, spacing: 6) {
-                //     Text("Things you type often")
-                //         .font(.system(size: 13, weight: .medium))
-                //
-                //     Text("Optional. Tabby will self-learn, but feel free to add common phrases, email sign-offs, or jargon.")
-                //         .font(.system(size: 11))
-                //         .foregroundStyle(.secondary)
-                //
-                //     TagsInputView(
-                //         tags: Binding(
-                //             get: { suggestionSettings.userTags },
-                //             set: { suggestionSettings.setUserTags($0) }
-                //         ),
-                //         placeholder: "e.g., 'Best regards, Jacob', 'PR approved', 'LGTM'"
-                //     )
-                // }
             }
             .padding(.horizontal, 8)
             .padding(.vertical, 4)

--- a/tabbyTests/LlamaPromptRendererTests.swift
+++ b/tabbyTests/LlamaPromptRendererTests.swift
@@ -68,8 +68,7 @@ final class LlamaPromptRendererTests: XCTestCase {
             prefixText: "Once upon",
             applicationName: "Messages",
             completionLengthInstruction: "Keep completion short.",
-            userName: nil,
-            userTags: nil
+            userName: nil
         )
 
         XCTAssertTrue(prompt.contains("Task:"), "instruction prompt should include Task section")
@@ -89,8 +88,7 @@ final class LlamaPromptRendererTests: XCTestCase {
             prefixText: "My prefix text here",
             applicationName: "Slack",
             completionLengthInstruction: "Short.",
-            userName: nil,
-            userTags: nil
+            userName: nil
         )
 
         XCTAssertTrue(prompt.contains("App: Slack"))
@@ -105,8 +103,7 @@ final class LlamaPromptRendererTests: XCTestCase {
             prefixText: "PREFIX_BODY_XYZ",
             applicationName: "App",
             completionLengthInstruction: "UNIQUE_LENGTH_MARKER_7_TO_12_WORDS",
-            userName: nil,
-            userTags: nil
+            userName: nil
         )
 
         XCTAssertTrue(prompt.contains("UNIQUE_LENGTH_MARKER_7_TO_12_WORDS"))
@@ -127,16 +124,11 @@ final class LlamaPromptRendererTests: XCTestCase {
             prefixText: "x",
             applicationName: "App",
             completionLengthInstruction: "Short.",
-            userName: "UNIQUE_NAME_MARKER_ZQRT",
-            userTags: ["UNIQUE_TAG_MARKER"]
+            userName: "UNIQUE_NAME_MARKER_ZQRT"
         )
 
         XCTAssertTrue(prompt.contains("UNIQUE_NAME_MARKER_ZQRT"),
                       "instruction prompt should carry user-provided profile name")
-        // userTags emission is intentionally disabled in LlamaPromptRenderer
-        // (see TODO in that file); the tag string must not leak into the prompt today.
-        XCTAssertFalse(prompt.contains("UNIQUE_TAG_MARKER"),
-                       "instruction prompt should not carry user-provided profile tags while the feature is gated off")
     }
 
     /// The prefix remains the last payload in the prompt so the model still ends on the actual
@@ -146,8 +138,7 @@ final class LlamaPromptRendererTests: XCTestCase {
             prefixText: "PREFIX_BODY_XYZ",
             applicationName: "App",
             completionLengthInstruction: "Short.",
-            userName: nil,
-            userTags: nil
+            userName: nil
         )
 
         guard let contextRange = prompt.range(of: "Screen context:"),
@@ -167,7 +158,6 @@ final class LlamaPromptRendererTests: XCTestCase {
             applicationName: "App",
             completionLengthInstruction: "Short.",
             userName: nil,
-            userTags: nil,
             visualContextSummary: "A window describing a cat."
         )
 
@@ -181,7 +171,6 @@ final class LlamaPromptRendererTests: XCTestCase {
             applicationName: "App",
             completionLengthInstruction: "Short.",
             userName: nil,
-            userTags: nil,
             clipboardContext: "UNIQUE_CLIPBOARD_MARKER"
         )
 
@@ -195,7 +184,6 @@ final class LlamaPromptRendererTests: XCTestCase {
             applicationName: "App",
             completionLengthInstruction: "Short.",
             userName: nil,
-            userTags: nil,
             visualContextSummary: nil
         )
 
@@ -242,7 +230,6 @@ final class LlamaPromptRendererTests: XCTestCase {
             maxSuffixCharacters: 192,
             completionLengthInstruction: "Return only the next few words.",
             userName: nil,
-            userTags: nil,
             clipboardContext: nil,
             visualContextSummary: nil
         )

--- a/tabbyTests/PromptPolicyTests.swift
+++ b/tabbyTests/PromptPolicyTests.swift
@@ -9,8 +9,7 @@ final class FoundationModelPromptRendererTests: XCTestCase {
     func test_sessionInstructions_includeAutocompleteContractAndRequestPolicies() {
         let request = TabbyTestFixtures.suggestionRequest(
             completionLengthInstruction: "UNIQUE_LENGTH_POLICY",
-            userName: "UNIQUE_PROFILE_NAME",
-            userTags: ["UNIQUE_PROFILE_TAG"]
+            userName: "UNIQUE_PROFILE_NAME"
         )
 
         let instructions = FoundationModelPromptRenderer.sessionInstructions(for: request)
@@ -18,9 +17,6 @@ final class FoundationModelPromptRendererTests: XCTestCase {
         XCTAssertTrue(instructions.contains("inline autocomplete engine"))
         XCTAssertTrue(instructions.contains("UNIQUE_LENGTH_POLICY"))
         XCTAssertTrue(instructions.contains("UNIQUE_PROFILE_NAME"))
-        // userTags emission is intentionally disabled in FoundationModelPromptRenderer
-        // (see TODO in that file); the tag string must not leak into instructions today.
-        XCTAssertFalse(instructions.contains("UNIQUE_PROFILE_TAG"))
         XCTAssertTrue(instructions.contains("Do not repeat or quote the existing text."))
     }
 

--- a/tabbyTests/SuggestionRequestFactoryTests.swift
+++ b/tabbyTests/SuggestionRequestFactoryTests.swift
@@ -75,7 +75,6 @@ final class SuggestionRequestFactoryTests: XCTestCase {
             maxPrefixCharacters: 32,
             maxSuffixCharacters: 192,
             defaultUserName: nil,
-            defaultUserTags: nil,
             defaultWordCountPreset: .sevenToTwelve,
             focusPollIntervalMilliseconds: 50
         )
@@ -106,7 +105,6 @@ final class SuggestionRequestFactoryTests: XCTestCase {
             maxPrefixCharacters: 1000,
             maxSuffixCharacters: 192,
             defaultUserName: nil,
-            defaultUserTags: nil,
             defaultWordCountPreset: .sevenToTwelve,
             focusPollIntervalMilliseconds: 50
         )
@@ -131,25 +129,18 @@ final class SuggestionRequestFactoryTests: XCTestCase {
         let result = SuggestionRequestFactory.buildRequest(
             context: context,
             settings: TabbyTestFixtures.settingsSnapshot(
-                userName: "Casey",
-                userTags: ["Prefer direct wording."]
+                userName: "Casey"
             ),
             configuration: .standard,
             visualContextSummary: "Calendar window says project review at 3 PM."
         )
 
         XCTAssertEqual(result.request.userName, "Casey")
-        // userTags disabled — re-enable when the feature is validated.
-        XCTAssertNil(result.request.userTags)
         XCTAssertEqual(
             result.request.visualContextSummary,
             "Calendar window says project review at 3 PM."
         )
         XCTAssertTrue(result.promptPreview.contains("Casey"))
-        // userTags emission is intentionally disabled in the prompt renderers
-        // (see TODO in LlamaPromptRenderer/FoundationModelPromptRenderer); the tag string
-        // is plumbed through the request but must not appear in the rendered prompt today.
-        XCTAssertFalse(result.promptPreview.contains("Prefer direct wording."))
         XCTAssertTrue(result.promptPreview.contains("Calendar window says project review at 3 PM."))
     }
 

--- a/tabbyTests/TabbyTestFixtures.swift
+++ b/tabbyTests/TabbyTestFixtures.swift
@@ -95,7 +95,6 @@ enum TabbyTestFixtures {
         maxPredictionTokens: Int = 8,
         completionLengthInstruction: String = "Return only the next few words.",
         userName: String? = nil,
-        userTags: [String]? = nil,
         clipboardContext: String? = nil,
         visualContextSummary: String? = nil
     ) -> SuggestionRequest {
@@ -121,7 +120,6 @@ enum TabbyTestFixtures {
             maxSuffixCharacters: 192,
             completionLengthInstruction: completionLengthInstruction,
             userName: userName,
-            userTags: userTags,
             clipboardContext: clipboardContext,
             visualContextSummary: visualContextSummary
         )
@@ -208,7 +206,6 @@ enum TabbyTestFixtures {
         selectedWordCountPreset: SuggestionWordCountPreset = .sevenToTwelve,
         isClipboardContextEnabled: Bool = true,
         userName: String = "",
-        userTags: [String] = [],
         debounceMilliseconds: Int = 50,
         focusPollIntervalMilliseconds: Int = 50
     ) -> SuggestionSettingsSnapshot {
@@ -219,7 +216,6 @@ enum TabbyTestFixtures {
             selectedWordCountPreset: selectedWordCountPreset,
             isClipboardContextEnabled: isClipboardContextEnabled,
             userName: userName,
-            userTags: userTags,
             debounceMilliseconds: debounceMilliseconds,
             focusPollIntervalMilliseconds: focusPollIntervalMilliseconds
         )


### PR DESCRIPTION
## Summary
- Completely removes the `userTags` feature which was gated off behind TODO comments but kept breaking CI whenever squash merges accidentally re-enabled the commented-out code
- Removes all traces across 12 files: model fields, settings persistence/defaults keys, prompt renderer params, request factory, UI sections (Settings + Onboarding), and test assertions
- **Net: -123 lines, +10 lines** (pure deletion)

## Revert plan
This PR can be reverted wholesale when the userTags feature is ready to ship.

## Test plan
- [x] `xcodebuild build` passes
- [x] `xcodebuild build-for-testing` passes
- [x] SwiftLint clean (no new warnings)
- [x] No remaining `userTags` references in `.swift` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the `userTags` feature entirely across 12 files to eliminate recurring CI failures caused by commented-out code being accidentally re-enabled on squash merges. The deletion is complete and consistent: models, settings persistence, prompt renderers, the request factory, UI sections, and all test fixtures/assertions are cleaned up in lock-step.

- Removes `userTags` from `SuggestionSettingsSnapshot`, `SuggestionRequest`, and `SuggestionConfiguration`; the Combine publisher chain in `SuggestionSettingsModel` is correctly rebounded from a `CombineLatest($userName, $userTags)` tuple to a bare `$userName` publisher.
- Deletes the `activeUserTags` helper in `SuggestionRequestFactory` (which always returned `nil` anyway) and its two call sites, along with all commented-out TODO blocks in both prompt renderers and UI views.
- Test fixtures and gated-off assertions are removed consistently; no `userTags` references remain in Swift source.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a pure deletion of dead/gated-off code with no behavioral impact on the running app.

Every changed file is a consistent removal of a feature that was already fully suppressed at runtime (the activeUserTags helper returned nil, both prompt renderers had the emission commented out). The Combine publisher chain in SuggestionSettingsModel is correctly updated from a CombineLatest tuple to a bare publisher, and all test fixtures and call sites are updated in lock-step. There are no dangling references and no behavioral changes to shipping code paths.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tabby/Models/SuggestionSettingsModel.swift | Removes userTags @Published property, UserDefaults key, persistence helpers, and the Combine publisher chain entry; the map closure is correctly rebounded from a CombineLatest tuple to a bare $userName publisher. |
| tabby/Models/SuggestionEngineModels.swift | Removes userTags field from SuggestionSettingsSnapshot struct; no other changes. |
| tabby/Models/SuggestionModels.swift | Removes defaultUserTags from SuggestionConfiguration and userTags from SuggestionRequest; default static value updated consistently. |
| tabby/Support/SuggestionRequestFactory.swift | Removes activeUserTags helper (which always returned nil) and its two call sites; both buildRequest overloads updated symmetrically. |
| tabby/Support/LlamaPromptRenderer.swift | Removes userTags parameter from renderInstructionPrompt and deletes the commented-out TODO block; clean deletion. |
| tabby/Support/FoundationModelPromptRenderer.swift | Removes commented-out TODO block for userTags in sessionInstructions; no behavioral change. |
| tabby/UI/SettingsView.swift | Removes commented-out 'Things you type often' VStack section; UI unchanged from user perspective since it was already gated off. |
| tabby/UI/WelcomeProfileStepView.swift | Removes commented-out tags VStack from onboarding and updates file-level doc comment; clean deletion. |
| tabbyTests/TabbyTestFixtures.swift | Removes userTags parameter from both suggestionRequest and settingsSnapshot fixture helpers; all downstream test call sites updated. |
| tabbyTests/LlamaPromptRendererTests.swift | Removes userTags arguments across all call sites and deletes the gated-off assertion that confirmed tags were suppressed from the rendered prompt. |
| tabbyTests/PromptPolicyTests.swift | Removes userTags from test request and the assertion that confirmed tags were absent from rendered instructions. |
| tabbyTests/SuggestionRequestFactoryTests.swift | Removes defaultUserTags and userTags from test configurations and deletes the XCTAssertNil(result.request.userTags) assertion; consistent with model changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SuggestionSettingsModel] -->|publishes snapshot| B[SuggestionSettingsSnapshot]
    B -->|consumed by| C[SuggestionRequestFactory]
    C -->|builds| D[SuggestionRequest]
    D -->|rendered by| E[LlamaPromptRenderer]
    D -->|rendered by| F[FoundationModelPromptRenderer]

    subgraph REMOVED
        R1[userTags property - SuggestionSettingsModel]
        R2[userTags field - SuggestionSettingsSnapshot]
        R3[userTags field - SuggestionRequest]
        R4[activeUserTags helper - SuggestionRequestFactory]
        R5[userTags param - LlamaPromptRenderer]
        R6[TODO commented block - FoundationModelPromptRenderer]
    end

    A -.->|removed| R1
    B -.->|removed| R2
    D -.->|removed| R3
    C -.->|removed| R4
    E -.->|removed| R5
    F -.->|removed| R6
```

<sub>Reviews (1): Last reviewed commit: ["Remove userTags feature entirely to fix ..."](https://github.com/fujacob/tabby/commit/abe8729f7133367ab83388f9b94ea739a728a0dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33187590)</sub>

<!-- /greptile_comment -->