### PR TITLE
Update README: support button, permissions, features

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ Everything runs on-device. No hosted API, no cloud round-trip.
 
 ## Engines
 
-**Apple Intelligence** —> uses Apple's on-device `FoundationModels` runtime on macOS 26 or later. No download required. Availability depends on your Mac; tabby checks at runtime and explains when this engine is unavailable.
+**Apple Intelligence** — uses Apple's on-device `FoundationModels` runtime on macOS 26 or later. No download required. Availability depends on your Mac; tabby checks at runtime and explains when this engine is unavailable.
 
-**Open Source**: runs local GGUF models in-process through llama.cpp via `llama.swift`. Built-in downloadable models:
+**Open Source** — runs local GGUF models in-process through llama.cpp via `llama.swift`. Built-in downloadable models:
 
 | Model           | File                            | Size    |
 | --------------- | ------------------------------- | ------- |
@@ -77,7 +77,7 @@ You can also drop your own `.gguf` files into tabby's models folder and refresh 
 
 1. Download the latest `tabby.dmg` from GitHub Releases.
 2. Drag `tabby.app` into `Applications` and launch it.
-3. Grant **Accessibility** and **Input Monitoring** when prompted.
+3. Grant **Accessibility**, **Input Monitoring**, and **Screen Recording** when prompted.
 4. Pick an engine. Apple Intelligence if available, otherwise Open Source plus a model.
 5. Start typing in any supported editable field.
 
@@ -87,14 +87,18 @@ If macOS blocks first launch, right-click `tabby.app` → `Open`, or allow it in
 
 - **Accessibility**: read the focused text field's value and caret position.
 - **Input Monitoring**: detect global `Tab` presses for acceptance.
+- **Screen Recording**: capture a screenshot around the focused field for visual context (OCR).
 
 ## Features
 
 - Ghost text rendered live next to your caret
 - Partial `Tab` acceptance: take a chunk, keep the tail alive, press again to continue
-- Menu bar quick controls: enable, engine, model, indicator mode, completion length
-- Settings for launch at login, ghost text color, model downloads, and updates
-- Activity indicators that can be hidden, anchored to the caret, or shown as a field-edge icon
+- Visual context: screenshot OCR around the focused field gives the model awareness of what's on screen
+- Clipboard context: recent clipboard content helps inform suggestions
+- Per-app disable rules and automatic terminal detection
+- Menu bar quick controls: enable/disable, engine, model, completion length
+- Settings for launch at login, ghost text color, suggestion delay, model downloads, and updates
+- Field-edge activity indicator (can be hidden)
 - Accepted-word counter
 
 **Requires macOS 15.0 or later.** Apple Intelligence suggestions require macOS 26 or later; on earlier supported systems, use the Open Source engine. Behavior depends on what each host app exposes through the Accessibility APIs — some fields only provide coarse caret geometry, so tabby falls back to more conservative placement.
@@ -114,6 +118,12 @@ If you want to understand the runtime and suggestion pipeline before contributin
 ## Contributing
 
 Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, build, and PR guidelines, and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for community expectations. For a tour of the runtime and suggestion pipeline, read [ARCHITECTURE.md](ARCHITECTURE.md).
+
+## Support
+
+If tabby is useful to you, consider buying us a coffee:
+
+<a href="https://buymeacoffee.com/tabbyapp" target="_blank"><img src="https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png" alt="Buy Me A Coffee" style="height: 41px !important;width: 174px !important;box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;-webkit-box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;" ></a>
 
 ## Creators
 


### PR DESCRIPTION
## Summary
- Add Buy Me A Coffee donate button (https://buymeacoffee.com/tabbyapp) in new Support section
- Add Screen Recording to install steps and permissions section (required for visual context OCR)
- Refresh features list: visual context, clipboard context, per-app disable rules, terminal auto-detection, configurable suggestion delay
- Fix activity indicator description (caret anchor mode was removed)
- Minor copy fix (arrow typo in Engines section)

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a documentation-only update to `README.md`. It corrects em-dash formatting in the Engines section, adds Screen Recording to the install and permissions sections, refreshes the Features list with new capabilities, and appends a Support section with a Buy Me A Coffee donation button.

- **Permissions**: Screen Recording is now correctly documented alongside Accessibility and Input Monitoring, consistent with the app's use of screenshot OCR for visual context.
- **Features**: The list now reflects visual context, clipboard context, per-app disable rules, terminal detection, and configurable suggestion delay; the outdated caret-anchor indicator description is replaced with the current field-edge-only description.
- **Support section**: A Buy Me A Coffee HTML button is added; GitHub's sanitizer will strip `style` and `target` attributes, so the rendered image will use its natural dimensions and the link will open in the same tab.

<h3>Confidence Score: 5/5</h3>

README-only change with no effect on application code — safe to merge.

All changes are confined to README.md. The feature descriptions align with live capabilities documented in AGENTS.md (Screen Recording, visual context OCR, clipboard context, per-app rules). The only minor point is the Buy Me A Coffee HTML button using attributes GitHub will strip, which does not break anything functional.

No files require special attention; the single changed file is README.md.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Documentation-only update: adds Screen Recording permission, refreshes feature list, fixes em-dash typos, and adds a Buy Me A Coffee support section. The HTML button uses inline styles and target="_blank" that GitHub strips. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Download tabby.dmg] --> B[Drag to Applications & Launch]
    B --> C{Grant Permissions}
    C --> D[Accessibility\nread focused field + caret]
    C --> E[Input Monitoring\ndetect global Tab presses]
    C --> F[Screen Recording\nscreenshot OCR for visual context]
    D & E & F --> G[Pick Engine]
    G --> H{Apple Intelligence\nmacOS 26+?}
    H -- Available --> I[Use Apple Intelligence]
    H -- Not Available --> J[Use Open Source + GGUF Model]
    I & J --> K[Start typing in any supported field]
    K --> L[tabby renders ghost text]
    L --> M{User action}
    M -- Tab --> N[Accept chunk, tail stays alive]
    M -- Keep typing --> O[Diverge from suggestion]
    N --> M
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22update%2Freadme-refresh%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22update%2Freadme-refresh%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AREADME.md%3A126%0AGitHub's%20HTML%20sanitizer%20strips%20%60style%60%20and%20%60target%60%20attributes%20from%20inline%20HTML%20in%20README%20files.%20The%20%60box-shadow%60%20styling%20and%20forced%20%60height%60%2F%60width%60%20dimensions%20won't%20apply%2C%20and%20the%20link%20will%20open%20in%20the%20same%20tab%20rather%20than%20a%20new%20one.%20The%20image%20will%20still%20render%20at%20its%20natural%20dimensions%20and%20the%20link%20will%20work%2C%20but%20if%20the%20intended%20presentation%20matters%2C%20a%20plain%20Markdown%20image%20link%20renders%20more%20predictably.%0A%0A%60%60%60suggestion%0A%5B!%5BBuy%20Me%20A%20Coffee%5D%28https%3A%2F%2Fwww.buymeacoffee.com%2Fassets%2Fimg%2Fcustom_images%2Forange_img.png%29%5D%28https%3A%2F%2Fbuymeacoffee.com%2Ftabbyapp%29%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AREADME.md%3A126%0AGitHub's%20HTML%20sanitizer%20strips%20%60style%60%20and%20%60target%60%20attributes%20from%20inline%20HTML%20in%20README%20files.%20The%20%60box-shadow%60%20styling%20and%20forced%20%60height%60%2F%60width%60%20dimensions%20won't%20apply%2C%20and%20the%20link%20will%20open%20in%20the%20same%20tab%20rather%20than%20a%20new%20one.%20The%20image%20will%20still%20render%20at%20its%20natural%20dimensions%20and%20the%20link%20will%20work%2C%20but%20if%20the%20intended%20presentation%20matters%2C%20a%20plain%20Markdown%20image%20link%20renders%20more%20predictably.%0A%0A%60%60%60suggestion%0A%5B!%5BBuy%20Me%20A%20Coffee%5D%28https%3A%2F%2Fwww.buymeacoffee.com%2Fassets%2Fimg%2Fcustom_images%2Forange_img.png%29%5D%28https%3A%2F%2Fbuymeacoffee.com%2Ftabbyapp%29%0A%60%60%60%0A%0A&repo=fujacob%2Ftabby&pr=144&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Update README: add support button, fix p..."](https://github.com/fujacob/tabby/commit/77fc52fefde011b2f4e40da9f734162e4d9a279a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33190673)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->