### PR TITLE
Move creators and donate button into README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@
   <img alt="Visitors" src="https://visitor-badge.laobi.icu/badge?page_id=FuJacob.tabby" />
 </p>
 
+<p align="center">
+  Built by <a href="https://github.com/FuJacob">@FuJacob</a> and <a href="https://github.com/jam-cai">@jam-cai</a>
+  <br /><br />
+  <a href="https://buymeacoffee.com/tabbyapp" target="_blank"><img src="https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png" alt="Buy Me A Coffee" style="height: 41px !important;width: 174px !important;box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;-webkit-box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;" ></a>
+</p>
+
 ## Demo
 
 <p align="center">
@@ -118,16 +124,6 @@ If you want to understand the runtime and suggestion pipeline before contributin
 ## Contributing
 
 Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, build, and PR guidelines, and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for community expectations. For a tour of the runtime and suggestion pipeline, read [ARCHITECTURE.md](ARCHITECTURE.md).
-
-## Support
-
-If tabby is useful to you, consider buying us a coffee:
-
-<a href="https://buymeacoffee.com/tabbyapp" target="_blank"><img src="https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png" alt="Buy Me A Coffee" style="height: 41px !important;width: 174px !important;box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;-webkit-box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;" ></a>
-
-## Creators
-
-tabby is built by [@FuJacob](https://github.com/FuJacob) and [@jam-cai](https://github.com/jam-cai).
 
 ## Acknowledgments
 


### PR DESCRIPTION
## Summary
- Moves creators line and Buy Me A Coffee button right below the badge row in the centered header
- Removes the separate **Support** and **Creators** sections for a cleaner layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restructures the README header by consolidating the creators attribution and Buy Me A Coffee donation button into a single centered block immediately below the badge row, removing the separate **Support** and **Creators** sections that previously appeared near the end of the document.

- The \"Built by\" line and the donation button are now grouped together in a new `<p align=\"center\">` block right after the badges, making attribution and support more prominent without requiring readers to scroll to the bottom.
- The `## Support` and `## Creators` sections at the bottom of the file are removed; no content is lost, and all links remain intact.

<h3>Confidence Score: 5/5</h3>

This PR only modifies README.md layout — no code, logic, or configuration is touched.

All content from the removed sections (creators attribution and donation link) is preserved in the new header block. The change is a straightforward copy-up with no information loss, no broken links, and no effect on the application itself.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Moves creators attribution and Buy Me A Coffee button from bottom-of-file sections into the centered header block; removes the separate Support and Creators sections. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Move creators + donate button to header,..."](https://github.com/fujacob/tabby/commit/2d32274527c3c6a7fb2bc156aab2f253cc5b9748) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33191096)</sub>

<!-- /greptile_comment -->