### PR TITLE
Fix README support layout: button then creators with hr separators

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,15 @@
   <img alt="Visitors" src="https://visitor-badge.laobi.icu/badge?page_id=FuJacob.tabby" />
 </p>
 
+---
+
 <p align="center">
-  Built by <a href="https://github.com/FuJacob">@FuJacob</a> and <a href="https://github.com/jam-cai">@jam-cai</a>
-  <br /><br />
   <a href="https://buymeacoffee.com/tabbyapp" target="_blank"><img src="https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png" alt="Buy Me A Coffee" style="height: 41px !important;width: 174px !important;box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;-webkit-box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;" ></a>
+  <br />
+  Built by <a href="https://github.com/FuJacob">@FuJacob</a> and <a href="https://github.com/jam-cai">@jam-cai</a>
 </p>
+
+---
 
 ## Demo
 


### PR DESCRIPTION
## Summary
- Coffee button first, "Built by" line underneath
- Horizontal rules above and below for clean separation from badges and content

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adjusts the README's support section layout by promoting the "Buy Me a Coffee" button above the "Built by" credits line and wrapping the block with `---` horizontal rules for cleaner visual separation.

- The coffee button now appears first inside the centered `<p>` block, with the "Built by" attribution on the line below it, replacing the previous reversed order.
- Two `---` dividers are added — one above the support block (after the badges) and one below it (before the Demo section).

<h3>Confidence Score: 5/5</h3>

This is a documentation-only change with no logic or runtime impact — safe to merge as-is.

The change touches only README.md, reordering two HTML elements inside a `<p align="center">` block and inserting two markdown `---` dividers. There is no application code, no config, and no behavior change involved.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Reorders support section (coffee button before "Built by" line) and wraps it with `---` horizontal rules for visual separation from badges and content. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix README: button first, then creators,..."](https://github.com/fujacob/tabby/commit/59ff9e400b3a5ce0add3b71047ff44a9f80d006d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33191325)</sub>

<!-- /greptile_comment -->