### PR TITLE
Fix onboarding lost after permission-prompted restart

### DIFF
--- a/tabby/App/Coordinators/WelcomeCoordinator.swift
+++ b/tabby/App/Coordinators/WelcomeCoordinator.swift
@@ -24,8 +24,13 @@ final class WelcomeCoordinator: NSObject, NSWindowDelegate {
     private let userDefaults: UserDefaults
 
     private var welcomeWindowController: NSWindowController?
+    private var permissionReminderWindowController: NSWindowController?
 
-    private static let hasShownWelcomeDefaultsKey = "hasShownWelcomeWindow"
+    private static let onboardingCompletedDefaultsKey = "onboardingCompleted"
+
+    /// Legacy key from when the flag was set at presentation time rather than completion.
+    /// Migrated once so existing users who finished onboarding aren't forced through it again.
+    private static let legacyHasShownWelcomeDefaultsKey = "hasShownWelcomeWindow"
 
     init(
         permissionManager: PermissionManager,
@@ -45,16 +50,48 @@ final class WelcomeCoordinator: NSObject, NSWindowDelegate {
         self.userDefaults = userDefaults
     }
 
-    /// Presents the welcome UI once for the lifetime of this installation.
-    /// The "shown" bit is persisted at presentation time so first-run onboarding stays one-time
-    /// even if the user simply closes the window instead of pressing the button.
+    /// Whether the user completed the full onboarding wizard (reached "done" and dismissed).
+    private var isOnboardingCompleted: Bool {
+        if userDefaults.bool(forKey: Self.onboardingCompletedDefaultsKey) {
+            return true
+        }
+
+        // Migrate from the legacy key: existing users who saw onboarding before this change
+        // should not be forced through the wizard again.
+        if userDefaults.bool(forKey: Self.legacyHasShownWelcomeDefaultsKey) {
+            userDefaults.set(true, forKey: Self.onboardingCompletedDefaultsKey)
+            return true
+        }
+
+        return false
+    }
+
+    /// Presents the welcome wizard if the user has never completed onboarding.
+    ///
+    /// Unlike the previous approach, the completion flag is set when the user finishes the wizard
+    /// (taps "Start Using tabby"), not when the window first appears. If the user closes the
+    /// window mid-flow or macOS prompts a restart for permissions, the wizard will reappear on
+    /// next launch so they don't lose their place.
     func presentIfNeeded() {
-        guard !userDefaults.bool(forKey: Self.hasShownWelcomeDefaultsKey) else {
+        guard !isOnboardingCompleted else {
             return
         }
 
-        userDefaults.set(true, forKey: Self.hasShownWelcomeDefaultsKey)
         showWelcome()
+    }
+
+    /// Shows just the permission step when the user completed onboarding previously but one or
+    /// more required permissions are now missing (e.g., after a permission-prompted restart, or
+    /// if the user later revoked a permission in System Settings).
+    func presentPermissionReminderIfNeeded() {
+        guard isOnboardingCompleted,
+              !permissionManager.requiredPermissionsGranted,
+              permissionReminderWindowController == nil
+        else {
+            return
+        }
+
+        showPermissionReminder()
     }
 
     /// Manual entry point for reopening the welcome screen later from the menu.
@@ -77,7 +114,7 @@ final class WelcomeCoordinator: NSObject, NSWindowDelegate {
                     self?.resizeWelcomeWindow(to: size)
                 },
                 onDismiss: { [weak self] in
-                    self?.dismissWelcome()
+                    self?.completeOnboarding()
                 }
             )
         )
@@ -115,12 +152,59 @@ final class WelcomeCoordinator: NSObject, NSWindowDelegate {
         if closingWindow == welcomeWindowController?.window {
             permissionGuidanceController.dismiss()
             welcomeWindowController = nil
+        } else if closingWindow == permissionReminderWindowController?.window {
+            permissionGuidanceController.dismiss()
+            permissionReminderWindowController = nil
         }
     }
 
-    private func dismissWelcome() {
+    /// Called when the user completes the full onboarding wizard ("Start Using tabby").
+    /// Persists the completion flag so the wizard does not reappear.
+    private func completeOnboarding() {
+        userDefaults.set(true, forKey: Self.onboardingCompletedDefaultsKey)
         permissionGuidanceController.dismiss()
         welcomeWindowController?.close()
+    }
+
+    private func showPermissionReminder() {
+        let hostingController = NSHostingController(
+            rootView: PermissionReminderView(
+                permissionManager: permissionManager,
+                permissionGuidanceController: permissionGuidanceController,
+                onDismiss: { [weak self] in
+                    self?.dismissPermissionReminder()
+                }
+            )
+        )
+
+        let window = NSWindow(
+            contentRect: CGRect(origin: .zero, size: NSSize(width: 540, height: 420)),
+            styleMask: [.titled, .closable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "tabby — Permissions"
+        window.titleVisibility = .hidden
+        window.titlebarAppearsTransparent = true
+        window.isMovableByWindowBackground = true
+        window.center()
+        window.isReleasedWhenClosed = false
+        window.level = .normal
+        window.collectionBehavior = [.moveToActiveSpace, .fullScreenAuxiliary]
+        window.delegate = self
+        window.contentViewController = hostingController
+
+        let windowController = NSWindowController(window: window)
+        permissionReminderWindowController = windowController
+
+        NSApp.activate(ignoringOtherApps: true)
+        windowController.showWindow(nil)
+        window.makeKeyAndOrderFront(nil)
+    }
+
+    private func dismissPermissionReminder() {
+        permissionGuidanceController.dismiss()
+        permissionReminderWindowController?.close()
     }
 
     /// Window sizing is an AppKit responsibility, so the SwiftUI onboarding view reports its

--- a/tabby/App/Core/AppDelegate.swift
+++ b/tabby/App/Core/AppDelegate.swift
@@ -115,6 +115,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         appUpdateManager.start()
         suggestionCoordinator.start()
         welcomeCoordinator.presentIfNeeded()
+        welcomeCoordinator.presentPermissionReminderIfNeeded()
     }
 
     /// Stops long-lived services before process exit so timers and runtime resources detach cleanly.

--- a/tabby/Services/Utilities/LaunchAtLoginService.swift
+++ b/tabby/Services/Utilities/LaunchAtLoginService.swift
@@ -90,7 +90,7 @@ final class LaunchAtLoginService: ObservableObject {
         case .requiresApproval:
             return .requiresApproval
         case .notFound:
-            return .unavailable("Open at Login is unavailable in this build.")
+            return .unavailable("Move tabby to the Applications folder and relaunch to enable this.")
         @unknown default:
             return .unavailable("Open at Login is unavailable for an unknown reason.")
         }

--- a/tabby/UI/PermissionReminderView.swift
+++ b/tabby/UI/PermissionReminderView.swift
@@ -1,0 +1,126 @@
+import SwiftUI
+
+/// File overview:
+/// Shown on launch when the user previously completed onboarding but one or more required
+/// permissions are missing. This happens after a permission-prompted restart or if the user
+/// revokes a permission later in System Settings.
+///
+/// Reuses the same PermissionCard-style layout as onboarding but with contextual copy and a
+/// simple dismiss button instead of the full wizard navigation.
+struct PermissionReminderView: View {
+    @ObservedObject var permissionManager: PermissionManager
+
+    let permissionGuidanceController: PermissionGuidanceController
+    let onDismiss: () -> Void
+
+    /// Only show permissions that are required and not yet granted.
+    private var missingPermissions: [TabbyPermissionKind] {
+        TabbyPermissionKind.allCases
+            .filter(\.isRequiredForAutocomplete)
+            .filter { !permissionManager.isGranted($0) }
+    }
+
+    var body: some View {
+        VStack(spacing: 28) {
+            VStack(spacing: 8) {
+                Image(systemName: "exclamationmark.shield.fill")
+                    .font(.system(size: 36))
+                    .foregroundStyle(.orange)
+
+                Text("Permissions needed")
+                    .font(.system(size: 24, weight: .semibold, design: .rounded))
+
+                Text("tabby needs these permissions to work.\nGrant them in System Settings, then come back here.")
+                    .font(.system(size: 14, design: .rounded))
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+
+            VStack(spacing: 10) {
+                ForEach(TabbyPermissionKind.allCases.filter(\.isRequiredForAutocomplete)) { permission in
+                    ReminderPermissionCard(
+                        permission: permission,
+                        granted: permissionManager.isGranted(permission),
+                        permissionGuidanceController: permissionGuidanceController
+                    )
+                }
+            }
+
+            WelcomeButton(title: permissionManager.requiredPermissionsGranted ? "Done" : "I'll do this later") {
+                onDismiss()
+            }
+        }
+        .padding(36)
+        .frame(width: 540)
+        .background(.ultraThinMaterial)
+        .onDisappear {
+            permissionGuidanceController.dismiss()
+        }
+    }
+}
+
+/// Permission card for the reminder view. Same glass-material style as onboarding but shows
+/// "Granted" for already-granted permissions so the user sees their progress.
+private struct ReminderPermissionCard: View {
+    let permission: TabbyPermissionKind
+    let granted: Bool
+    let permissionGuidanceController: PermissionGuidanceController
+
+    @State private var actionButtonFrame = CGRect.zero
+
+    var body: some View {
+        HStack(spacing: 14) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(granted ? Color.green.opacity(0.12) : Color.orange.opacity(0.12))
+
+                Image(systemName: permission.systemImageName)
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundStyle(granted ? .green : .orange)
+            }
+            .frame(width: 32, height: 32)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(permission.title)
+                    .font(.system(size: 14, weight: .medium))
+
+                Text(permission.onboardingSubtitle)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: 0)
+
+            if granted {
+                HStack(spacing: 4) {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 11, weight: .semibold))
+                    Text("Done")
+                        .font(.system(size: 12, weight: .medium))
+                }
+                .foregroundStyle(.green)
+            } else {
+                Button("Allow") {
+                    permissionGuidanceController.requestAccess(
+                        for: permission,
+                        sourceFrameInScreen: actionButtonFrame
+                    )
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.regular)
+                .background(ScreenFrameReader(frameInScreen: $actionButtonFrame))
+            }
+        }
+        .padding(18)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(.regularMaterial)
+                .shadow(color: .black.opacity(0.06), radius: 2, y: 1)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(.white.opacity(0.08), lineWidth: 0.5)
+        )
+    }
+}

--- a/tabby/UI/PermissionReminderView.swift
+++ b/tabby/UI/PermissionReminderView.swift
@@ -13,13 +13,6 @@ struct PermissionReminderView: View {
     let permissionGuidanceController: PermissionGuidanceController
     let onDismiss: () -> Void
 
-    /// Only show permissions that are required and not yet granted.
-    private var missingPermissions: [TabbyPermissionKind] {
-        TabbyPermissionKind.allCases
-            .filter(\.isRequiredForAutocomplete)
-            .filter { !permissionManager.isGranted($0) }
-    }
-
     var body: some View {
         VStack(spacing: 28) {
             VStack(spacing: 8) {
@@ -53,9 +46,6 @@ struct PermissionReminderView: View {
         .padding(36)
         .frame(width: 540)
         .background(.ultraThinMaterial)
-        .onDisappear {
-            permissionGuidanceController.dismiss()
-        }
     }
 }
 

--- a/tabby/UI/SettingsView.swift
+++ b/tabby/UI/SettingsView.swift
@@ -182,16 +182,10 @@ struct SettingsView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
-            Stepper(
-                "Focus Poll Interval: \(suggestionSettings.focusPollIntervalMilliseconds)ms",
-                value: focusPollIntervalMillisecondsBinding,
-                in: 10...500,
-                step: 10
-            )
-
-            Text("How often Tabby checks for focus and caret changes. Lower values detect changes faster but use more CPU.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
+            // Focus poll interval is intentionally hidden from the UI. The default (50 ms)
+            // is tuned for the best balance of responsiveness and CPU usage. Exposing it
+            // invites misconfiguration without meaningful benefit. The backing setting and
+            // UserDefaults plumbing remain so we can re-surface it later if needed.
         }
     }
 
@@ -481,12 +475,15 @@ struct SettingsView: View {
         )
     }
 
-    private var focusPollIntervalMillisecondsBinding: Binding<Int> {
-        Binding(
-            get: { suggestionSettings.focusPollIntervalMilliseconds },
-            set: { suggestionSettings.setFocusPollIntervalMilliseconds($0) }
-        )
-    }
+    // focusPollIntervalMillisecondsBinding removed — the poll interval stepper is hidden from
+    // the UI (see performanceSection). Binding kept commented for easy restoration:
+    //
+    // private var focusPollIntervalMillisecondsBinding: Binding<Int> {
+    //     Binding(
+    //         get: { suggestionSettings.focusPollIntervalMilliseconds },
+    //         set: { suggestionSettings.setFocusPollIntervalMilliseconds($0) }
+    //     )
+    // }
 
     /// The color picker always needs a concrete color. When the user has not picked one yet we feed
     /// it the current automatic fallback so the control still previews something sensible. The first

--- a/tabby/UI/SettingsView.swift
+++ b/tabby/UI/SettingsView.swift
@@ -335,7 +335,11 @@ struct SettingsView: View {
     @ViewBuilder
     private var uninstallSection: some View {
         Section("Uninstall") {
-            Text("Drag tabby.app from Applications to the Trash. To remove leftover data, also delete ~/Library/Application Support/tabby. Privacy permissions can only be revoked in System Settings → Privacy & Security.")
+            Text(
+                "Drag tabby.app from Applications to the Trash. "
+                + "To remove leftover data, also delete ~/Library/Application Support/tabby. "
+                + "Privacy permissions can only be revoked in System Settings → Privacy & Security."
+            )
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }


### PR DESCRIPTION
## Summary

- **Onboarding completion flag moved from presentation-time to finish-time** — if the user closes the wizard mid-flow or macOS prompts a restart for permissions, the wizard reappears on next launch so they don't lose their place
- **Permission reminder window on every launch** — when onboarding was previously completed but required permissions are missing (post-restart gap or later revocation), a focused permission-only window appears with the same glass-material cards
- **Legacy migration** — existing users with the old `hasShownWelcomeWindow` flag are auto-migrated so they aren't forced through onboarding again
- **Better "Open at Login" error message** — tells the user to move tabby to Applications folder instead of the cryptic "unavailable in this build"

## Test plan

- [ ] Fresh install: full wizard appears, closing mid-flow → wizard reappears on next launch
- [ ] Complete wizard → relaunch → no window shown (flag persisted)
- [ ] Complete wizard → revoke a permission in System Settings → relaunch → permission reminder appears
- [ ] Grant permission during reminder → card updates live (2-second poll)
- [ ] Existing user upgrade (has `hasShownWelcomeWindow=true`): no forced re-onboarding
- [ ] "Open at Login" toggle shows helpful message when app not in /Applications

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a UX regression where the onboarding wizard could be permanently lost after a mid-flow close or a macOS permission-prompted restart, by moving the completion flag from presentation-time to finish-time. It also adds a focused permission-reminder window for post-onboarding permission gaps, a one-time migration for existing users, and a friendlier "Open at Login" error message.

- **Onboarding completion flag** now set in `completeOnboarding()` when the user presses "Start Using tabby", not in `presentIfNeeded()`, so a mid-flow close or restart brings the wizard back on next launch.
- **`PermissionReminderView`** is a new SwiftUI screen shown on launch only when onboarding was completed but required permissions are missing; it reuses the same card style as onboarding with a live-updating granted state.
- **Legacy migration** in `isOnboardingCompleted` auto-promotes `hasShownWelcomeWindow=true` to `onboardingCompleted=true` so existing users are not re-onboarded, and the `SettingsView` focus-poll-interval stepper is quietly hidden with commented-out code preserved for easy restoration.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the completion-flag move is well-guarded and the two presentation paths are mutually exclusive at launch.

The logic in WelcomeCoordinator is sound: presentIfNeeded and presentPermissionReminderIfNeeded check opposite sides of isOnboardingCompleted, so they cannot both open a window in the same launch. The migration is idempotent and the legacy key is preserved for downgrade safety. No auth, data-loss, or crash paths were introduced.

tabby/App/Coordinators/WelcomeCoordinator.swift — the migration side effect inside the isOnboardingCompleted getter is worth cleaning up, but it is functionally correct as written.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tabby/App/Coordinators/WelcomeCoordinator.swift | Core logic change: onboarding completion flag moved to finish-time, permission reminder window added, migration from legacy key implemented. Well-structured and mutually exclusive presentation guards. Minor: `isOnboardingCompleted` has a UserDefaults write side effect inside a computed property getter. |
| tabby/UI/PermissionReminderView.swift | New view: clean SwiftUI implementation with reactive @ObservedObject permissionManager updates; card layout mirrors onboarding style; no dead properties in the current version. |
| tabby/App/Core/AppDelegate.swift | Single line added calling presentPermissionReminderIfNeeded() after presentIfNeeded(); guards in WelcomeCoordinator ensure the two calls are mutually exclusive. |
| tabby/Services/Utilities/LaunchAtLoginService.swift | One-line error message improvement for .notFound state; actionable user guidance replacing the cryptic previous message. |
| tabby/UI/SettingsView.swift | Focus poll interval stepper hidden from UI with code commented out for easy restoration; uninstall text reformatted for readability. Low-risk change. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[applicationDidFinishLaunching] --> B[presentIfNeeded]
    A --> C[presentPermissionReminderIfNeeded]

    B --> D{isOnboardingCompleted?}
    D -- No --> E[showWelcome wizard]
    D -- Yes --> F[return early]

    D --> G{legacy hasShownWelcomeWindow?}
    G -- Yes --> H[migrate: write onboardingCompleted=true]
    G -- No --> I[return false]

    E --> J[User presses Start Using tabby]
    J --> K[completeOnboarding: write flag, close window]

    E --> L[User closes window mid-flow]
    L --> M[windowWillClose: nil controller, flag NOT written]

    C --> N{isOnboardingCompleted AND permissions missing AND no reminder window?}
    N -- Yes --> O[showPermissionReminder]
    N -- No --> P[return early]

    O --> Q[User grants permissions]
    Q --> R[onDismiss: dismissPermissionReminder, close window]

    O --> S[User presses I'll do this later]
    S --> R
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22fix%2Fpermission-onboarding-resume%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpermission-onboarding-resume%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atabby%2FApp%2FCoordinators%2FWelcomeCoordinator.swift%3A53-69%0AThe%20migration%20write%20inside%20%60isOnboardingCompleted%60's%20getter%20is%20a%20side%20effect%20hidden%20behind%20what%20reads%20as%20a%20pure%20boolean%20check.%20It%20fires%20on%20every%20call%20until%20the%20key%20is%20promoted%20%E2%80%94%20including%20the%20back-to-back%20calls%20from%20%60presentIfNeeded%60%20and%20%60presentPermissionReminderIfNeeded%60%20in%20%60applicationDidFinishLaunching%60.%20Separating%20the%20migration%20into%20an%20explicit%2C%20one-shot%20call%20at%20the%20top%20of%20%60presentIfNeeded%60%20%28or%20in%20a%20dedicated%20%60migrateOnboardingStateIfNeeded%28%29%60%29%20makes%20the%20execution%20order%20self-evident%20and%20keeps%20the%20property%20a%20true%20read.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Whether%20the%20user%20completed%20the%20full%20onboarding%20wizard%20%28reached%20%22done%22%20and%20dismissed%29.%0A%20%20%20%20private%20var%20isOnboardingCompleted%3A%20Bool%20%7B%0A%20%20%20%20%20%20%20%20userDefaults.bool%28forKey%3A%20Self.onboardingCompletedDefaultsKey%29%0A%20%20%20%20%7D%0A%0A%20%20%20%20%2F%2F%2F%20Promotes%20the%20legacy%20%60hasShownWelcomeWindow%60%20flag%20to%20%60onboardingCompleted%60%20once.%0A%20%20%20%20%2F%2F%2F%20Called%20once%20at%20startup%3B%20safe%20to%20call%20multiple%20times%20%28idempotent%29.%0A%20%20%20%20private%20func%20migrateOnboardingStateIfNeeded%28%29%20%7B%0A%20%20%20%20%20%20%20%20guard%20!userDefaults.bool%28forKey%3A%20Self.onboardingCompletedDefaultsKey%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20userDefaults.bool%28forKey%3A%20Self.legacyHasShownWelcomeDefaultsKey%29%0A%20%20%20%20%20%20%20%20else%20%7B%20return%20%7D%0A%0A%20%20%20%20%20%20%20%20userDefaults.set%28true%2C%20forKey%3A%20Self.onboardingCompletedDefaultsKey%29%0A%20%20%20%20%7D%0A%0A%20%20%20%20%2F%2F%2F%20Presents%20the%20welcome%20wizard%20if%20the%20user%20has%20never%20completed%20onboarding.%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Atabby%2FApp%2FCoordinators%2FWelcomeCoordinator.swift%3A75-81%0AWith%20the%20migration%20extracted%2C%20%60presentIfNeeded%60%20should%20call%20%60migrateOnboardingStateIfNeeded%28%29%60%20first%20so%20the%20state%20is%20promoted%20before%20either%20presentation%20guard%20reads%20it.%0A%0A%60%60%60suggestion%0A%20%20%20%20func%20presentIfNeeded%28%29%20%7B%0A%20%20%20%20%20%20%20%20migrateOnboardingStateIfNeeded%28%29%0A%0A%20%20%20%20%20%20%20%20guard%20!isOnboardingCompleted%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20showWelcome%28%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atabby%2FApp%2FCoordinators%2FWelcomeCoordinator.swift%3A53-69%0AThe%20migration%20write%20inside%20%60isOnboardingCompleted%60's%20getter%20is%20a%20side%20effect%20hidden%20behind%20what%20reads%20as%20a%20pure%20boolean%20check.%20It%20fires%20on%20every%20call%20until%20the%20key%20is%20promoted%20%E2%80%94%20including%20the%20back-to-back%20calls%20from%20%60presentIfNeeded%60%20and%20%60presentPermissionReminderIfNeeded%60%20in%20%60applicationDidFinishLaunching%60.%20Separating%20the%20migration%20into%20an%20explicit%2C%20one-shot%20call%20at%20the%20top%20of%20%60presentIfNeeded%60%20%28or%20in%20a%20dedicated%20%60migrateOnboardingStateIfNeeded%28%29%60%29%20makes%20the%20execution%20order%20self-evident%20and%20keeps%20the%20property%20a%20true%20read.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Whether%20the%20user%20completed%20the%20full%20onboarding%20wizard%20%28reached%20%22done%22%20and%20dismissed%29.%0A%20%20%20%20private%20var%20isOnboardingCompleted%3A%20Bool%20%7B%0A%20%20%20%20%20%20%20%20userDefaults.bool%28forKey%3A%20Self.onboardingCompletedDefaultsKey%29%0A%20%20%20%20%7D%0A%0A%20%20%20%20%2F%2F%2F%20Promotes%20the%20legacy%20%60hasShownWelcomeWindow%60%20flag%20to%20%60onboardingCompleted%60%20once.%0A%20%20%20%20%2F%2F%2F%20Called%20once%20at%20startup%3B%20safe%20to%20call%20multiple%20times%20%28idempotent%29.%0A%20%20%20%20private%20func%20migrateOnboardingStateIfNeeded%28%29%20%7B%0A%20%20%20%20%20%20%20%20guard%20!userDefaults.bool%28forKey%3A%20Self.onboardingCompletedDefaultsKey%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20userDefaults.bool%28forKey%3A%20Self.legacyHasShownWelcomeDefaultsKey%29%0A%20%20%20%20%20%20%20%20else%20%7B%20return%20%7D%0A%0A%20%20%20%20%20%20%20%20userDefaults.set%28true%2C%20forKey%3A%20Self.onboardingCompletedDefaultsKey%29%0A%20%20%20%20%7D%0A%0A%20%20%20%20%2F%2F%2F%20Presents%20the%20welcome%20wizard%20if%20the%20user%20has%20never%20completed%20onboarding.%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Atabby%2FApp%2FCoordinators%2FWelcomeCoordinator.swift%3A75-81%0AWith%20the%20migration%20extracted%2C%20%60presentIfNeeded%60%20should%20call%20%60migrateOnboardingStateIfNeeded%28%29%60%20first%20so%20the%20state%20is%20promoted%20before%20either%20presentation%20guard%20reads%20it.%0A%0A%60%60%60suggestion%0A%20%20%20%20func%20presentIfNeeded%28%29%20%7B%0A%20%20%20%20%20%20%20%20migrateOnboardingStateIfNeeded%28%29%0A%0A%20%20%20%20%20%20%20%20guard%20!isOnboardingCompleted%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20showWelcome%28%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=fujacob%2Ftabby&pr=149&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["Hide Focus Poll Interval from settings U..."](https://github.com/fujacob/tabby/commit/76b1950fa9100dcae8d18511a5482d82c6dbf4c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33196883)</sub>

<!-- /greptile_comment -->