### PR TITLE
Fix onboarding skipping profile and model steps

### DIFF
--- a/tabby/App/Coordinators/WelcomeCoordinator.swift
+++ b/tabby/App/Coordinators/WelcomeCoordinator.swift
@@ -28,10 +28,6 @@ final class WelcomeCoordinator: NSObject, NSWindowDelegate {
 
     private static let onboardingCompletedDefaultsKey = "onboardingCompleted"
 
-    /// Legacy key from when the flag was set at presentation time rather than completion.
-    /// Migrated once so existing users who finished onboarding aren't forced through it again.
-    private static let legacyHasShownWelcomeDefaultsKey = "hasShownWelcomeWindow"
-
     init(
         permissionManager: PermissionManager,
         permissionGuidanceController: PermissionGuidanceController,
@@ -51,19 +47,13 @@ final class WelcomeCoordinator: NSObject, NSWindowDelegate {
     }
 
     /// Whether the user completed the full onboarding wizard (reached "done" and dismissed).
+    ///
+    /// The legacy `hasShownWelcomeWindow` key is intentionally NOT migrated here. That key was
+    /// set at presentation time (before the user finished), so treating it as "completed" would
+    /// skip profile and model selection for upgrading users. Forcing one more pass through the
+    /// wizard on upgrade is better than silently dropping steps.
     private var isOnboardingCompleted: Bool {
-        if userDefaults.bool(forKey: Self.onboardingCompletedDefaultsKey) {
-            return true
-        }
-
-        // Migrate from the legacy key: existing users who saw onboarding before this change
-        // should not be forced through the wizard again.
-        if userDefaults.bool(forKey: Self.legacyHasShownWelcomeDefaultsKey) {
-            userDefaults.set(true, forKey: Self.onboardingCompletedDefaultsKey)
-            return true
-        }
-
-        return false
+        userDefaults.bool(forKey: Self.onboardingCompletedDefaultsKey)
     }
 
     /// Presents the welcome wizard if the user has never completed onboarding.


### PR DESCRIPTION
## Summary

- Remove legacy `hasShownWelcomeWindow` → `onboardingCompleted` migration that caused the app to skip profile and model selection steps
- The legacy key was set at presentation time (not completion), so migrating it treated incomplete onboarding as done
- Now only the new `onboardingCompleted` key (set when user taps "Start Using tabby") controls whether onboarding shows
- Upgrading users will see the wizard once more — better than silently dropping steps

## Test plan

- [ ] Fresh install (clear UserDefaults): full wizard flows through all 5 steps
- [ ] Grant permission mid-wizard → restart → wizard reappears from step 1, all steps accessible
- [ ] Complete wizard → relaunch → no wizard, no reminder (if permissions granted)
- [ ] Complete wizard → revoke permission → relaunch → permission reminder only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the one-time migration that copied `hasShownWelcomeWindow` into `onboardingCompleted`, because that legacy key was written at window-presentation time rather than at wizard completion — causing the profile and model-selection steps to be silently skipped for affected users.

- `isOnboardingCompleted` is simplified to a single `UserDefaults` read of `onboardingCompleted`, with an inline doc comment explaining why the legacy key is deliberately not migrated.
- The `legacyHasShownWelcomeDefaultsKey` constant is removed entirely; upgrading users who only had the legacy key set will see the onboarding wizard once more, which is the correct trade-off.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a focused, well-documented removal of a single faulty migration path with no risk of data loss or new regressions.

The diff is a net deletion of 10 lines and a rewrite of one computed property. The new implementation is simpler and correct: only users who genuinely completed the wizard (had `onboardingCompleted` written at the 'Start Using tabby' step) will skip the wizard on relaunch. The behaviour change for users who only had the legacy key is intentional and clearly documented. No other logic is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tabby/App/Coordinators/WelcomeCoordinator.swift | Removes the legacy hasShownWelcomeWindow → onboardingCompleted migration; isOnboardingCompleted now reads only the new key, with a clear inline rationale for skipping the migration. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[App Launch] --> B{isOnboardingCompleted?\nonboardingCompleted key}
    B -- true --> C{presentPermissionReminderIfNeeded}
    B -- false --> D[showWelcome wizard]
    C -- permissions granted --> E[No window shown]
    C -- permissions missing --> F[showPermissionReminder]
    D --> G[User completes wizard\n'Start Using tabby']
    G --> H[completeOnboarding\nsets onboardingCompleted = true\nin UserDefaults]
    H --> I[Close welcome window]

    style D fill:#f9a825,color:#000
    style H fill:#2e7d32,color:#fff
```

<sub>Reviews (1): Last reviewed commit: ["Fix onboarding skipping steps due to leg..."](https://github.com/fujacob/tabby/commit/5b83f0e461e07f630619574c9900ef280c068a06) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33201115)</sub>

<!-- /greptile_comment -->