### PR TITLE
Observe Apple Intelligence availability reactively

### DIFF
--- a/tabby/Services/Runtime/FoundationModelAvailabilityService.swift
+++ b/tabby/Services/Runtime/FoundationModelAvailabilityService.swift
@@ -39,12 +39,15 @@ final class FoundationModelAvailabilityService: ObservableObject {
     @Published private(set) var state: FoundationModelAvailabilityState
 
     private let provider: any FoundationModelAvailabilityProviding
+    private var observationTask: Task<Void, Never>?
 
     init(provider: (any FoundationModelAvailabilityProviding)? = nil) {
         let resolvedProvider = provider ?? Self.makeDefaultProvider()
 
         self.provider = resolvedProvider
         self.state = resolvedProvider.currentState
+
+        startObserving()
     }
 
     /// Refreshes the cached availability before a generation attempt.
@@ -61,6 +64,16 @@ final class FoundationModelAvailabilityService: ObservableObject {
     var userVisibleMessage: String {
         state.summary
     }
+
+    /// Starts a reactive observation loop so availability changes propagate to the UI without
+    /// manual `refresh()` calls. The provider owns the observation mechanism: the system provider
+    /// watches `SystemLanguageModel.availability` via Swift Observation, while the unsupported
+    /// provider is a no-op since its state never changes.
+    private func startObserving() {
+        observationTask = provider.observe { [weak self] newState in
+            self?.state = newState
+        }
+    }
 }
 
 /// Abstracts the availability state and refresh operation for the Apple Intelligence backend.
@@ -75,6 +88,11 @@ protocol FoundationModelAvailabilityProviding {
 
     /// Re-reads provider-specific availability and returns it in Tabby's app-level vocabulary.
     func refresh() -> FoundationModelAvailabilityState
+
+    /// Returns a long-lived task that calls `onChange` whenever availability changes.
+    /// The system provider uses Swift Observation to watch `SystemLanguageModel`; the unsupported
+    /// provider returns nil because its state is constant.
+    func observe(onChange: @escaping @MainActor (FoundationModelAvailabilityState) -> Void) -> Task<Void, Never>?
 }
 
 /// Reports a stable unavailable state for the Apple Intelligence backend.
@@ -93,6 +111,10 @@ private struct UnsupportedFoundationModelAvailabilityProvider: FoundationModelAv
 
     func refresh() -> FoundationModelAvailabilityState {
         currentState
+    }
+
+    func observe(onChange: @escaping @MainActor (FoundationModelAvailabilityState) -> Void) -> Task<Void, Never>? {
+        nil
     }
 }
 
@@ -146,6 +168,32 @@ private final class SystemFoundationModelAvailabilityProvider: FoundationModelAv
 
     func refresh() -> FoundationModelAvailabilityState {
         Self.map(model.availability)
+    }
+
+    /// Uses Swift Observation to watch `SystemLanguageModel.availability` and push changes
+    /// back to the service. `withObservationTracking` fires once per change, so the loop
+    /// re-registers after each callback to stay subscribed for the lifetime of the task.
+    func observe(onChange: @escaping @MainActor (FoundationModelAvailabilityState) -> Void) -> Task<Void, Never>? {
+        let observedModel = model
+        return Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                let newState: FoundationModelAvailabilityState? = await withCheckedContinuation { continuation in
+                    withObservationTracking {
+                        _ = observedModel.availability
+                    } onChange: {
+                        Task { @MainActor in
+                            guard let self else {
+                                continuation.resume(returning: nil)
+                                return
+                            }
+                            continuation.resume(returning: Self.map(observedModel.availability))
+                        }
+                    }
+                }
+                guard let newState else { break }
+                onChange(newState)
+            }
+        }
     }
 
     private static func map(

--- a/tabby/UI/MenuBarView.swift
+++ b/tabby/UI/MenuBarView.swift
@@ -43,10 +43,6 @@ struct MenuBarView: View {
             // The background poll eventually catches changes too, but this avoids showing stale
             // "Grant" rows after the user just updated System Settings.
             permissionManager.refresh()
-            refreshAppleIntelligenceAvailabilityIfNeeded()
-        }
-        .onChange(of: suggestionSettings.selectedEngine) { _, _ in
-            refreshAppleIntelligenceAvailabilityIfNeeded()
         }
     }
 
@@ -102,6 +98,13 @@ struct MenuBarView: View {
                 }
                 .labelsHidden()
                 .pickerStyle(.menu)
+            }
+
+            if suggestionSettings.selectedEngine == .appleIntelligence,
+               !foundationModelAvailabilityService.isAvailable {
+                Text(foundationModelAvailabilityService.userVisibleMessage)
+                    .font(.caption)
+                    .foregroundStyle(.orange)
             }
 
             if suggestionSettings.selectedEngine.supportsLocalModelManagement {
@@ -297,11 +300,4 @@ struct MenuBarView: View {
         permissionManager.requiredPermissionsGranted
     }
 
-    private func refreshAppleIntelligenceAvailabilityIfNeeded() {
-        guard suggestionSettings.selectedEngine == .appleIntelligence else {
-            return
-        }
-
-        foundationModelAvailabilityService.refresh()
-    }
 }

--- a/tabby/UI/SettingsView.swift
+++ b/tabby/UI/SettingsView.swift
@@ -41,13 +41,11 @@ struct SettingsView: View {
         .formStyle(.grouped)
         .frame(minWidth: 620, minHeight: 560)
         .onAppear {
-            refreshAppleIntelligenceAvailabilityIfNeeded()
             launchAtLoginService.refresh()
             permissionManager.refresh()
         }
         .onChange(of: suggestionSettings.selectedEngine) { _, _ in
             pendingDeletionModel = nil
-            refreshAppleIntelligenceAvailabilityIfNeeded()
         }
         .alert(
             "Delete Model?",
@@ -625,11 +623,4 @@ struct SettingsView: View {
         runtimeModel.refreshAvailableModels()
     }
 
-    private func refreshAppleIntelligenceAvailabilityIfNeeded() {
-        guard suggestionSettings.selectedEngine == .appleIntelligence else {
-            return
-        }
-
-        foundationModelAvailabilityService.refresh()
-    }
 }


### PR DESCRIPTION
## Summary
- Replace manual `refresh()` calls with Swift Observation on `SystemLanguageModel.availability` so the UI updates automatically when Apple Intelligence is enabled/disabled in System Settings
- Show an inline warning in the menu bar when Apple Intelligence is selected but unavailable
- Remove stale `refreshAppleIntelligenceAvailabilityIfNeeded` from MenuBarView and SettingsView

## Test plan
- [ ] Select Apple Intelligence engine, disable it in System Settings, verify the menu bar shows the unavailability warning without reopening
- [ ] Select Apple Intelligence engine, enable it in System Settings, verify the warning disappears
- [ ] Verify Open Source engine selection is unaffected
- [ ] Build and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces manual `refreshAppleIntelligenceAvailabilityIfNeeded()` calls in `MenuBarView` and `SettingsView` with a reactive observation loop that watches `SystemLanguageModel.availability` via `withObservationTracking`, pushing state changes to the UI automatically. It also adds an inline orange warning in the menu bar when Apple Intelligence is selected but unavailable.

- **`FoundationModelAvailabilityService`** gains a new `observe(onChange:)` protocol requirement and a `startObserving()` method that creates a long-lived `Task` using a `withObservationTracking` loop; the unsupported provider returns `nil` (no-op), and `SystemFoundationModelAvailabilityProvider` implements the loop.
- **`MenuBarView`** drops the engine-change and appear-time refresh hooks and instead renders an inline caption when `foundationModelAvailabilityService.isAvailable` is false and the Apple Intelligence engine is selected.
- **`SettingsView`** removes two call sites for the same now-deleted helper with no replacement needed.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the reactive observation wiring is functionally correct and the UI changes are a straightforward improvement over manual refresh calls.

The observation loop works correctly for the intended use case. The `withCheckedContinuation` inside the loop cannot be interrupted by cooperative task cancellation, and there is a narrow window between successive `withObservationTracking` registrations where a rapid back-to-back change could be silently dropped. Neither affects real-world behaviour given how infrequently Apple Intelligence availability changes.

tabby/Services/Runtime/FoundationModelAvailabilityService.swift — specifically the `observe` implementation in `SystemFoundationModelAvailabilityProvider`

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tabby/Services/Runtime/FoundationModelAvailabilityService.swift | Adds reactive `observe(onChange:)` to the provider protocol, implements a `withObservationTracking` polling loop for `SystemFoundationModelAvailabilityProvider`, and wires it up in `FoundationModelAvailabilityService.startObserving()`. The task is never explicitly cancelled and the observation loop cannot respond to cooperative cancellation while suspended. |
| tabby/UI/MenuBarView.swift | Removes manual `refreshAppleIntelligenceAvailabilityIfNeeded` calls and replaces them with an inline `.caption` warning driven by the reactive service state. Clean, straightforward change with no issues. |
| tabby/UI/SettingsView.swift | Removes the two manual `refreshAppleIntelligenceAvailabilityIfNeeded` call sites from `onAppear` and `onChange(of: selectedEngine)`. No new logic added; change is safe. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Service as FoundationModelAvailabilityService
    participant Provider as SystemFoundationModelAvailabilityProvider
    participant SLM as SystemLanguageModel
    participant UI as MenuBarView / SettingsView

    Service->>Provider: observe(onChange:)
    Provider->>Provider: "Task { @MainActor }"
    loop while !Task.isCancelled
        Provider->>SLM: "withObservationTracking { availability }"
        SLM-->>Provider: onChange fires (availability changed)
        Provider->>Provider: "Task { @MainActor } map state"
        Provider->>Service: continuation.resume(newState)
        Service->>Service: "self.state = newState (@Published)"
        Service-->>UI: "@Published state triggers SwiftUI redraw"
        UI->>UI: Show/hide inline warning
    end
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22jafu%2Fapple-intelligence-availability-observation%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22jafu%2Fapple-intelligence-availability-observation%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atabby%2FServices%2FRuntime%2FFoundationModelAvailabilityService.swift%3A179-196%0A%60observationTask%60%20is%20never%20cancelled%20and%20%60withCheckedContinuation%60%20doesn't%20honour%20Swift's%20cooperative%20cancellation.%20If%20%60observationTask%3F.cancel%28%29%60%20were%20called%20%28e.g.%20in%20a%20future%20%60deinit%60%29%2C%20the%20loop%20only%20checks%20%60Task.isCancelled%60%20at%20the%20top%20of%20each%20iteration%20%E2%80%94%20but%20it%20can't%20reach%20that%20check%20while%20suspended%20inside%20%60withCheckedContinuation%60%20waiting%20for%20the%20next%20%60onChange%60%20callback.%20The%20task%20would%20stay%20alive%20until%20the%20next%20availability%20change%20fires%2C%20rather%20than%20exiting%20promptly.%20Adding%20a%20%60withTaskCancellationHandler%60%20around%20the%20continuation%20call%20would%20make%20the%20task%20responsive%20to%20cancellation%20signals%20and%20allow%20a%20clean%20%60deinit%20%7B%20observationTask%3F.cancel%28%29%20%7D%60%20teardown.%0A%0A%23%23%23%20Issue%202%20of%202%0Atabby%2FServices%2FRuntime%2FFoundationModelAvailabilityService.swift%3A176-197%0A**Narrow%20state-change%20window%20between%20loop%20iterations**%0A%0A%60withObservationTracking%60%20is%20a%20one-shot%20registration%3A%20the%20%60onChange%60%20fires%20once%2C%20and%20the%20loop%20must%20fall%20through%20%60onChange%28newState%29%60%20and%20reach%20the%20next%20%60withObservationTracking%60%20call%20before%20it%20is%20re-subscribed.%20Any%20availability%20change%20that%20occurs%20in%20that%20gap%20is%20silently%20dropped.%20For%20Apple%20Intelligence%20toggled%20via%20System%20Settings%20this%20window%20is%20practically%20impossible%20to%20hit%2C%20but%20rapid%20back-to-back%20changes%20%28e.g.%20a%20scripted%20test%20or%20a%20model%20going%20through%20multiple%20download%20states%29%20could%20leave%20%60state%60%20stale%20until%20the%20next%20external%20change%20arrives.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atabby%2FServices%2FRuntime%2FFoundationModelAvailabilityService.swift%3A179-196%0A%60observationTask%60%20is%20never%20cancelled%20and%20%60withCheckedContinuation%60%20doesn't%20honour%20Swift's%20cooperative%20cancellation.%20If%20%60observationTask%3F.cancel%28%29%60%20were%20called%20%28e.g.%20in%20a%20future%20%60deinit%60%29%2C%20the%20loop%20only%20checks%20%60Task.isCancelled%60%20at%20the%20top%20of%20each%20iteration%20%E2%80%94%20but%20it%20can't%20reach%20that%20check%20while%20suspended%20inside%20%60withCheckedContinuation%60%20waiting%20for%20the%20next%20%60onChange%60%20callback.%20The%20task%20would%20stay%20alive%20until%20the%20next%20availability%20change%20fires%2C%20rather%20than%20exiting%20promptly.%20Adding%20a%20%60withTaskCancellationHandler%60%20around%20the%20continuation%20call%20would%20make%20the%20task%20responsive%20to%20cancellation%20signals%20and%20allow%20a%20clean%20%60deinit%20%7B%20observationTask%3F.cancel%28%29%20%7D%60%20teardown.%0A%0A%23%23%23%20Issue%202%20of%202%0Atabby%2FServices%2FRuntime%2FFoundationModelAvailabilityService.swift%3A176-197%0A**Narrow%20state-change%20window%20between%20loop%20iterations**%0A%0A%60withObservationTracking%60%20is%20a%20one-shot%20registration%3A%20the%20%60onChange%60%20fires%20once%2C%20and%20the%20loop%20must%20fall%20through%20%60onChange%28newState%29%60%20and%20reach%20the%20next%20%60withObservationTracking%60%20call%20before%20it%20is%20re-subscribed.%20Any%20availability%20change%20that%20occurs%20in%20that%20gap%20is%20silently%20dropped.%20For%20Apple%20Intelligence%20toggled%20via%20System%20Settings%20this%20window%20is%20practically%20impossible%20to%20hit%2C%20but%20rapid%20back-to-back%20changes%20%28e.g.%20a%20scripted%20test%20or%20a%20model%20going%20through%20multiple%20download%20states%29%20could%20leave%20%60state%60%20stale%20until%20the%20next%20external%20change%20arrives.%0A%0A&repo=fujacob%2Ftabby&pr=152&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Observe Apple Intelligence availability ..."](https://github.com/fujacob/tabby/commit/d6b660f80d7dc88719166fce8b1a8f62655a7003) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33203634)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->