### PR TITLE
Enable Sparkle update checks and add Check for Updates button

### DIFF
--- a/TabbyInfo.plist
+++ b/TabbyInfo.plist
@@ -29,7 +29,7 @@
 	<key>SUAutomaticallyUpdate</key>
 	<false/>
 	<key>SUEnableAutomaticChecks</key>
-	<false/>
+	<true/>
 	<key>SUFeedURL</key>
 	<string>https://updates.tabbyapp.dev/appcast.xml</string>
     <key>SUPublicEDKey</key>

--- a/tabby/App/Core/TabbyApp.swift
+++ b/tabby/App/Core/TabbyApp.swift
@@ -24,6 +24,9 @@ struct TabbyApp: App {
                 suggestionCoordinator: appDelegate.suggestionCoordinator,
                 onOpenSettings: {
                     appDelegate.settingsCoordinator.showSettings()
+                },
+                onCheckForUpdates: {
+                    appDelegate.appUpdateManager.checkForUpdates()
                 }
             )
         } label: {

--- a/tabby/UI/MenuBarView.swift
+++ b/tabby/UI/MenuBarView.swift
@@ -22,6 +22,7 @@ struct MenuBarView: View {
     @ObservedObject var foundationModelAvailabilityService: FoundationModelAvailabilityService
     @ObservedObject var suggestionCoordinator: SuggestionCoordinator
     let onOpenSettings: () -> Void
+    let onCheckForUpdates: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -199,6 +200,9 @@ struct MenuBarView: View {
 
         HStack {
             Button("Settings…", action: onOpenSettings)
+                .buttonStyle(.borderless)
+
+            Button("Check for Updates…", action: onCheckForUpdates)
                 .buttonStyle(.borderless)
 
             Spacer(minLength: 0)


### PR DESCRIPTION
## Summary

- Enable `SUEnableAutomaticChecks` so Sparkle checks for updates on launch and shows a dialog when a new version is available
- Add "Check for Updates…" button in the menu bar footer for manual checks
- Auto-install remains disabled — users always choose whether to update

## Test plan

- [ ] Launch app → Sparkle checks for updates automatically (verify in console log)
- [ ] Menu bar → "Check for Updates…" button triggers Sparkle update dialog
- [ ] If no update available, Sparkle shows "up to date" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enables Sparkle's automatic update-check-on-launch (`SUEnableAutomaticChecks = true`) and adds a manual "Check for Updates…" button to the menu bar footer, wired through a new `onCheckForUpdates` closure on `MenuBarView`. Auto-install stays disabled so users always confirm before updating.

- `TabbyInfo.plist` flips `SUEnableAutomaticChecks` to `true`; `SUAutomaticallyUpdate` is left `false`, which correctly separates checking from installing.
- `MenuBarView` gains the `onCheckForUpdates` callback and a borderless footer button; the existing `AppUpdateManager.checkForUpdates()` method is reused without modification.
- The file-level design comment in `MenuBarView.swift` explicitly lists \"updates\" as belonging in the Settings window, which now contradicts this placement.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the Sparkle wiring is correct and auto-install remains opt-in.

The plist change is a one-liner that correctly separates checking from installing. The closure wiring follows the same pattern as the existing Settings button and delegates cleanly to AppUpdateManager. The only friction points are a doc comment in MenuBarView that now contradicts the button placement, and the button having no awareness of Sparkle's canCheckForUpdates state — both are cosmetic rather than functional.

tabby/UI/MenuBarView.swift — the file-level design comment conflicts with the new button placement, and the button is always enabled regardless of whether Sparkle is already checking.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| TabbyInfo.plist | Flips SUEnableAutomaticChecks from false to true; SUAutomaticallyUpdate remains false, so users still approve installs. Change is minimal and correct. |
| tabby/App/Core/TabbyApp.swift | Wires onCheckForUpdates closure to appDelegate.appUpdateManager.checkForUpdates(); follows the same pattern as onOpenSettings. No issues. |
| tabby/UI/MenuBarView.swift | Adds onCheckForUpdates property and "Check for Updates…" button to the footer HStack. Contradicts the file-level design comment; button is always enabled with no Sparkle canCheckForUpdates feedback. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant MenuBarView
    participant TabbyApp
    participant AppUpdateManager
    participant Sparkle

    Note over AppUpdateManager,Sparkle: On launch (SUEnableAutomaticChecks=true)
    AppUpdateManager->>Sparkle: startUpdater()
    Sparkle-->>User: Automatic check (background)

    Note over User,Sparkle: Manual check via menu bar
    User->>MenuBarView: Click "Check for Updates…"
    MenuBarView->>TabbyApp: onCheckForUpdates()
    TabbyApp->>AppUpdateManager: checkForUpdates()
    AppUpdateManager->>Sparkle: checkForUpdates(nil)
    Sparkle-->>User: Update dialog (or "up to date")
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tabby/UI/MenuBarView.swift`, line 1-14 ([link](https://github.com/fujacob/tabby/blob/db437cd83478d5bc02dc1f2c38f2dc5e25c8e17f/tabby/UI/MenuBarView.swift#L1-L14)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **Design philosophy comment contradicts the placement**

   The file-level doc comment at the top of `MenuBarView.swift` explicitly categorises "updates" as a rarely-changed setting that belongs in the Settings window, not the menu bar: `Rarely-changed settings (model management, profile personalization, updates) live in the Settings window.` Adding the "Check for Updates…" button here contradicts that stated intent. If the team has decided to move update triggers to the menu bar, the architecture comment should be updated to reflect the new decision — otherwise it will mislead future contributors about where new update-related UI should go.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22feature%2Fenable-sparkle-update-checks%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fenable-sparkle-update-checks%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tabby%2FUI%2FMenuBarView.swift%0ALine%3A%201-14%0A%0AComment%3A%0A**Design%20philosophy%20comment%20contradicts%20the%20placement**%0A%0AThe%20file-level%20doc%20comment%20at%20the%20top%20of%20%60MenuBarView.swift%60%20explicitly%20categorises%20%22updates%22%20as%20a%20rarely-changed%20setting%20that%20belongs%20in%20the%20Settings%20window%2C%20not%20the%20menu%20bar%3A%20%60Rarely-changed%20settings%20%28model%20management%2C%20profile%20personalization%2C%20updates%29%20live%20in%20the%20Settings%20window.%60%20Adding%20the%20%22Check%20for%20Updates%E2%80%A6%22%20button%20here%20contradicts%20that%20stated%20intent.%20If%20the%20team%20has%20decided%20to%20move%20update%20triggers%20to%20the%20menu%20bar%2C%20the%20architecture%20comment%20should%20be%20updated%20to%20reflect%20the%20new%20decision%20%E2%80%94%20otherwise%20it%20will%20mislead%20future%20contributors%20about%20where%20new%20update-related%20UI%20should%20go.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tabby%2FUI%2FMenuBarView.swift%0ALine%3A%201-14%0A%0AComment%3A%0A**Design%20philosophy%20comment%20contradicts%20the%20placement**%0A%0AThe%20file-level%20doc%20comment%20at%20the%20top%20of%20%60MenuBarView.swift%60%20explicitly%20categorises%20%22updates%22%20as%20a%20rarely-changed%20setting%20that%20belongs%20in%20the%20Settings%20window%2C%20not%20the%20menu%20bar%3A%20%60Rarely-changed%20settings%20%28model%20management%2C%20profile%20personalization%2C%20updates%29%20live%20in%20the%20Settings%20window.%60%20Adding%20the%20%22Check%20for%20Updates%E2%80%A6%22%20button%20here%20contradicts%20that%20stated%20intent.%20If%20the%20team%20has%20decided%20to%20move%20update%20triggers%20to%20the%20menu%20bar%2C%20the%20architecture%20comment%20should%20be%20updated%20to%20reflect%20the%20new%20decision%20%E2%80%94%20otherwise%20it%20will%20mislead%20future%20contributors%20about%20where%20new%20update-related%20UI%20should%20go.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Ftabby&pr=153&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22feature%2Fenable-sparkle-update-checks%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fenable-sparkle-update-checks%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atabby%2FUI%2FMenuBarView.swift%3A1-14%0A**Design%20philosophy%20comment%20contradicts%20the%20placement**%0A%0AThe%20file-level%20doc%20comment%20at%20the%20top%20of%20%60MenuBarView.swift%60%20explicitly%20categorises%20%22updates%22%20as%20a%20rarely-changed%20setting%20that%20belongs%20in%20the%20Settings%20window%2C%20not%20the%20menu%20bar%3A%20%60Rarely-changed%20settings%20%28model%20management%2C%20profile%20personalization%2C%20updates%29%20live%20in%20the%20Settings%20window.%60%20Adding%20the%20%22Check%20for%20Updates%E2%80%A6%22%20button%20here%20contradicts%20that%20stated%20intent.%20If%20the%20team%20has%20decided%20to%20move%20update%20triggers%20to%20the%20menu%20bar%2C%20the%20architecture%20comment%20should%20be%20updated%20to%20reflect%20the%20new%20decision%20%E2%80%94%20otherwise%20it%20will%20mislead%20future%20contributors%20about%20where%20new%20update-related%20UI%20should%20go.%0A%0A%23%23%23%20Issue%202%20of%202%0Atabby%2FUI%2FMenuBarView.swift%3A205-207%0A**%22Check%20for%20Updates%E2%80%A6%22%20button%20is%20always%20enabled%20regardless%20of%20Sparkle%20state**%0A%0A%60SPUStandardUpdaterController%60%20exposes%20a%20%60canCheckForUpdates%60%20property%20on%20its%20%60updater%60%20that%20becomes%20%60false%60%20while%20a%20check%20is%20already%20in%20flight%20or%20Sparkle%20is%20presenting%20an%20update%20sheet.%20Because%20%60AppUpdateManager%60%20doesn't%20surface%20this%20flag%2C%20the%20button%20is%20always%20tappable.%20Sparkle%20guards%20internally%20against%20duplicate%20checks%2C%20so%20correctness%20isn't%20broken%2C%20but%20repeated%20taps%20give%20no%20visual%20feedback%20that%20a%20check%20is%20already%20running.%20Exposing%20a%20%60%40Published%20var%20canCheckForUpdates%3A%20Bool%60%20on%20%60AppUpdateManager%60%20%28or%20a%20simple%20%60isCheckingForUpdates%60%20flag%20toggled%20around%20the%20call%29%20would%20let%20the%20button%20be%20%60.disabled%28%29%60%20appropriately.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atabby%2FUI%2FMenuBarView.swift%3A1-14%0A**Design%20philosophy%20comment%20contradicts%20the%20placement**%0A%0AThe%20file-level%20doc%20comment%20at%20the%20top%20of%20%60MenuBarView.swift%60%20explicitly%20categorises%20%22updates%22%20as%20a%20rarely-changed%20setting%20that%20belongs%20in%20the%20Settings%20window%2C%20not%20the%20menu%20bar%3A%20%60Rarely-changed%20settings%20%28model%20management%2C%20profile%20personalization%2C%20updates%29%20live%20in%20the%20Settings%20window.%60%20Adding%20the%20%22Check%20for%20Updates%E2%80%A6%22%20button%20here%20contradicts%20that%20stated%20intent.%20If%20the%20team%20has%20decided%20to%20move%20update%20triggers%20to%20the%20menu%20bar%2C%20the%20architecture%20comment%20should%20be%20updated%20to%20reflect%20the%20new%20decision%20%E2%80%94%20otherwise%20it%20will%20mislead%20future%20contributors%20about%20where%20new%20update-related%20UI%20should%20go.%0A%0A%23%23%23%20Issue%202%20of%202%0Atabby%2FUI%2FMenuBarView.swift%3A205-207%0A**%22Check%20for%20Updates%E2%80%A6%22%20button%20is%20always%20enabled%20regardless%20of%20Sparkle%20state**%0A%0A%60SPUStandardUpdaterController%60%20exposes%20a%20%60canCheckForUpdates%60%20property%20on%20its%20%60updater%60%20that%20becomes%20%60false%60%20while%20a%20check%20is%20already%20in%20flight%20or%20Sparkle%20is%20presenting%20an%20update%20sheet.%20Because%20%60AppUpdateManager%60%20doesn't%20surface%20this%20flag%2C%20the%20button%20is%20always%20tappable.%20Sparkle%20guards%20internally%20against%20duplicate%20checks%2C%20so%20correctness%20isn't%20broken%2C%20but%20repeated%20taps%20give%20no%20visual%20feedback%20that%20a%20check%20is%20already%20running.%20Exposing%20a%20%60%40Published%20var%20canCheckForUpdates%3A%20Bool%60%20on%20%60AppUpdateManager%60%20%28or%20a%20simple%20%60isCheckingForUpdates%60%20flag%20toggled%20around%20the%20call%29%20would%20let%20the%20button%20be%20%60.disabled%28%29%60%20appropriately.%0A%0A&repo=fujacob%2Ftabby&pr=153&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Enable Sparkle automatic update checks a..."](https://github.com/fujacob/tabby/commit/db437cd83478d5bc02dc1f2c38f2dc5e25c8e17f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33210697)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->