### PR TITLE
Hide activation indicator when tabby is disabled

### DIFF
--- a/tabby/App/Core/AppDelegate.swift
+++ b/tabby/App/Core/AppDelegate.swift
@@ -128,9 +128,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         runtimeModel.stop()
     }
 
-    /// Shows or hides the field-edge tabby icon based on focus state and the user's toggle.
+    /// Shows or hides the field-edge tabby icon based on focus state, global enable, per-app
+    /// disable rules, and the user's indicator toggle.
     private func updateActivationIndicator(for snapshot: FocusSnapshot) {
-        guard case .supported = snapshot.capability,
+        guard suggestionSettings.isGloballyEnabled,
+              !suggestionSettings.isApplicationDisabled(bundleIdentifier: snapshot.bundleIdentifier),
+              case .supported = snapshot.capability,
               let context = snapshot.context
         else {
             activationIndicatorController.hide(reason: "Activation indicator hidden.")


### PR DESCRIPTION
## Summary

- Activation indicator now respects global disable toggle and per-app disable rules
- Previously the edge indicator stayed visible even when tabby was turned off globally or disabled for a specific app (e.g. Chrome)
- Adds `isGloballyEnabled` and `isApplicationDisabled` checks before showing the indicator

## Test plan

- [ ] Disable tabby globally → indicator disappears
- [ ] Re-enable globally → indicator reappears
- [ ] Disable tabby for a specific app → switch to that app → indicator gone
- [ ] Switch to a non-disabled app → indicator shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the activation indicator so it respects the global enable toggle and per-app disable rules, matching the behaviour already enforced by suggestion generation. The change is small and targeted to `updateActivationIndicator`.

- Two guard conditions (`isGloballyEnabled`, `isApplicationDisabled`) are prepended to the existing `case .supported` and context checks; failing any one of them hides the indicator with the same `hide(reason:)` call.
- In practice the fix works correctly because toggling the global setting through the menu bar briefly shifts focus, emitting a new `FocusSnapshot` that triggers re-evaluation. A follow-up hardening step could make the indicator subscription reactive to settings changes directly (via `combineLatest`), mirroring how `SuggestionCoordinator` already handles this.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the guard conditions are correct and handle all the described scenarios.

The logic is correct for the common case — opening the menu to toggle settings inherently emits a new focus snapshot, so the indicator updates as expected. The only gap is that the indicator subscription is purely snapshot-driven and won't react to a settings change that occurs without any focus movement, unlike the suggestion coordinator which combines both publishers. This is unlikely to surface in current usage but is worth a follow-up.

No files require special attention; the change is confined to three lines in `AppDelegate.swift` and the new guards reference well-tested methods on `SuggestionSettingsModel`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tabby/App/Core/AppDelegate.swift | Adds `isGloballyEnabled` and `isApplicationDisabled` guards to `updateActivationIndicator`; correct logic but the indicator only re-evaluates on focus-snapshot changes, not on settings changes in isolation. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[focusModel.$snapshot fires] --> B{isGloballyEnabled?}
    B -- No --> H[activationIndicatorController.hide]
    B -- Yes --> C{isApplicationDisabled\nbundleIdentifier?}
    C -- Yes --> H
    C -- No --> D{snapshot.capability\n== .supported?}
    D -- No --> H
    D -- Yes --> E{snapshot.context\nnot nil?}
    E -- No --> H
    E -- Yes --> F[activationIndicatorController.show\nenabled: showIndicator\ncaret & frame rects]

    style H fill:#f66,color:#fff
    style F fill:#6a6,color:#fff
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tabby/App/Core/AppDelegate.swift`, line 82-87 ([link](https://github.com/fujacob/tabby/blob/12b527b9b42ed38f946ffb787311cc9bd6b310f8/tabby/App/Core/AppDelegate.swift#L82-L87)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **Indicator stale when settings change without a focus event**

   `updateActivationIndicator` is only called from the `focusModel.$snapshot` sink, so the new `isGloballyEnabled` and `isApplicationDisabled` checks are only evaluated when the focus snapshot changes. If the user's settings change while the focus snapshot stays identical (e.g., a future keyboard shortcut or programmatic toggle that doesn't move focus), the indicator won't update until the next focus event. `SuggestionCoordinator` avoids this by using `combineLatest` between focus and settings publishers; the indicator subscription could be hardened the same way — combining `focusModel.$snapshot` with `suggestionSettings.$isGloballyEnabled` and `suggestionSettings.$disabledAppRules` and re-calling `updateActivationIndicator` on any change.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22fix%2Findicator-respects-disable-state%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Findicator-respects-disable-state%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tabby%2FApp%2FCore%2FAppDelegate.swift%0ALine%3A%2082-87%0A%0AComment%3A%0A**Indicator%20stale%20when%20settings%20change%20without%20a%20focus%20event**%0A%0A%60updateActivationIndicator%60%20is%20only%20called%20from%20the%20%60focusModel.%24snapshot%60%20sink%2C%20so%20the%20new%20%60isGloballyEnabled%60%20and%20%60isApplicationDisabled%60%20checks%20are%20only%20evaluated%20when%20the%20focus%20snapshot%20changes.%20If%20the%20user's%20settings%20change%20while%20the%20focus%20snapshot%20stays%20identical%20%28e.g.%2C%20a%20future%20keyboard%20shortcut%20or%20programmatic%20toggle%20that%20doesn't%20move%20focus%29%2C%20the%20indicator%20won't%20update%20until%20the%20next%20focus%20event.%20%60SuggestionCoordinator%60%20avoids%20this%20by%20using%20%60combineLatest%60%20between%20focus%20and%20settings%20publishers%3B%20the%20indicator%20subscription%20could%20be%20hardened%20the%20same%20way%20%E2%80%94%20combining%20%60focusModel.%24snapshot%60%20with%20%60suggestionSettings.%24isGloballyEnabled%60%20and%20%60suggestionSettings.%24disabledAppRules%60%20and%20re-calling%20%60updateActivationIndicator%60%20on%20any%20change.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tabby%2FApp%2FCore%2FAppDelegate.swift%0ALine%3A%2082-87%0A%0AComment%3A%0A**Indicator%20stale%20when%20settings%20change%20without%20a%20focus%20event**%0A%0A%60updateActivationIndicator%60%20is%20only%20called%20from%20the%20%60focusModel.%24snapshot%60%20sink%2C%20so%20the%20new%20%60isGloballyEnabled%60%20and%20%60isApplicationDisabled%60%20checks%20are%20only%20evaluated%20when%20the%20focus%20snapshot%20changes.%20If%20the%20user's%20settings%20change%20while%20the%20focus%20snapshot%20stays%20identical%20%28e.g.%2C%20a%20future%20keyboard%20shortcut%20or%20programmatic%20toggle%20that%20doesn't%20move%20focus%29%2C%20the%20indicator%20won't%20update%20until%20the%20next%20focus%20event.%20%60SuggestionCoordinator%60%20avoids%20this%20by%20using%20%60combineLatest%60%20between%20focus%20and%20settings%20publishers%3B%20the%20indicator%20subscription%20could%20be%20hardened%20the%20same%20way%20%E2%80%94%20combining%20%60focusModel.%24snapshot%60%20with%20%60suggestionSettings.%24isGloballyEnabled%60%20and%20%60suggestionSettings.%24disabledAppRules%60%20and%20re-calling%20%60updateActivationIndicator%60%20on%20any%20change.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Ftabby&pr=154&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22fix%2Findicator-respects-disable-state%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Findicator-respects-disable-state%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atabby%2FApp%2FCore%2FAppDelegate.swift%3A82-87%0A**Indicator%20stale%20when%20settings%20change%20without%20a%20focus%20event**%0A%0A%60updateActivationIndicator%60%20is%20only%20called%20from%20the%20%60focusModel.%24snapshot%60%20sink%2C%20so%20the%20new%20%60isGloballyEnabled%60%20and%20%60isApplicationDisabled%60%20checks%20are%20only%20evaluated%20when%20the%20focus%20snapshot%20changes.%20If%20the%20user's%20settings%20change%20while%20the%20focus%20snapshot%20stays%20identical%20%28e.g.%2C%20a%20future%20keyboard%20shortcut%20or%20programmatic%20toggle%20that%20doesn't%20move%20focus%29%2C%20the%20indicator%20won't%20update%20until%20the%20next%20focus%20event.%20%60SuggestionCoordinator%60%20avoids%20this%20by%20using%20%60combineLatest%60%20between%20focus%20and%20settings%20publishers%3B%20the%20indicator%20subscription%20could%20be%20hardened%20the%20same%20way%20%E2%80%94%20combining%20%60focusModel.%24snapshot%60%20with%20%60suggestionSettings.%24isGloballyEnabled%60%20and%20%60suggestionSettings.%24disabledAppRules%60%20and%20re-calling%20%60updateActivationIndicator%60%20on%20any%20change.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atabby%2FApp%2FCore%2FAppDelegate.swift%3A82-87%0A**Indicator%20stale%20when%20settings%20change%20without%20a%20focus%20event**%0A%0A%60updateActivationIndicator%60%20is%20only%20called%20from%20the%20%60focusModel.%24snapshot%60%20sink%2C%20so%20the%20new%20%60isGloballyEnabled%60%20and%20%60isApplicationDisabled%60%20checks%20are%20only%20evaluated%20when%20the%20focus%20snapshot%20changes.%20If%20the%20user's%20settings%20change%20while%20the%20focus%20snapshot%20stays%20identical%20%28e.g.%2C%20a%20future%20keyboard%20shortcut%20or%20programmatic%20toggle%20that%20doesn't%20move%20focus%29%2C%20the%20indicator%20won't%20update%20until%20the%20next%20focus%20event.%20%60SuggestionCoordinator%60%20avoids%20this%20by%20using%20%60combineLatest%60%20between%20focus%20and%20settings%20publishers%3B%20the%20indicator%20subscription%20could%20be%20hardened%20the%20same%20way%20%E2%80%94%20combining%20%60focusModel.%24snapshot%60%20with%20%60suggestionSettings.%24isGloballyEnabled%60%20and%20%60suggestionSettings.%24disabledAppRules%60%20and%20re-calling%20%60updateActivationIndicator%60%20on%20any%20change.%0A%0A&repo=fujacob%2Ftabby&pr=154&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Hide activation indicator when tabby is ..."](https://github.com/fujacob/tabby/commit/12b527b9b42ed38f946ffb787311cc9bd6b310f8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33217717)</sub>

<!-- /greptile_comment -->