### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,11 @@
 
 <p align="center">
   <em>Open-source, local-first AI autocomplete for macOS.</em>
-</p>
-
+  </p>
+  
+  <p align="center">
+  <em>[currently in beta]</em>
+  </p>
 <p align="center">
   <a href="https://tabbyapp.dev"><strong>Visit the landing page →</strong></a>
   &nbsp;|&nbsp;
@@ -39,24 +42,25 @@
       <sub><b>Email</b></sub>
     </td>
     <td align="center" valign="top" width="50%">
-      <img src=".github/assets/readme/demo-slack.png" alt="tabby autocomplete in Slack" width="100%" />
+      <img src="https://github.com/user-attachments/assets/05c04d09-e658-478b-b10e-25c6a0d1b4ee" alt="tabby autocomplete in Slack" width="100%" />
       <br />
       <sub><b>Slack</b></sub>
     </td>
   </tr>
   <tr>
     <td align="center" valign="top" width="50%">
-      <img src=".github/assets/readme/demo-notes.png" alt="tabby autocomplete in Notes" width="100%" />
+      <img src="https://github.com/user-attachments/assets/7d16957f-e2bd-487a-9910-757286b445ea" alt="tabby autocomplete in Notes" width="100%" />
       <br />
       <sub><b>Notes</b></sub>
     </td>
     <td align="center" valign="top" width="50%">
-      <img src=".github/assets/readme/demo-imessage.png" alt="tabby autocomplete in iMessage" width="100%" />
+      <img src="https://github.com/user-attachments/assets/407ccd42-b0fb-414d-9bd2-9ce05119777e" alt="tabby autocomplete in iMessage" width="100%" />
       <br />
       <sub><b>iMessage</b></sub>
     </td>
   </tr>
 </table>
+
 
 ## What It Does
 
@@ -76,7 +80,7 @@ Everything runs on-device. No hosted API, no cloud round-trip.
 
 **Apple Intelligence [BETA]**: uses Apple's on-device `FoundationModels` runtime on macOS 26 or later. No download required. Availability depends on your Mac; tabby checks at runtime and explains when this engine is unavailable. Apple Intelligence support is currently in beta and may not perform as well as the Open Source models. We're actively working on improving it.
 
-**Open Source**: runs local GGUF models in-process through llama.cpp via `llama.swift`. Built-in downloadable models:
+**Open Source**: runs local GGUF models in-process through llama.cpp via `llama.swift`. Built-in downloadable models suggested for use:
 
 | Model              | File                            | Size    |
 | ------------------ | ------------------------------- | ------- |


### PR DESCRIPTION
## Summary

<!--
One or two sentences: what changed and why. Skip the play-by-play.
The diff already shows what; this section should explain why.
-->

## Validation

<!--
What you actually ran and what you actually saw, not what you intended to run.
Examples:

  xcodebuild test -project tabby.xcodeproj -scheme tabby \
    -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO
  # ** TEST SUCCEEDED **  N tests, 0 failures

  swiftlint lint --config .swiftlint.yml --quiet
  # exit 0

For UI changes, attach a screenshot or short screen recording.
For changes that can't be verified end-to-end yet, say so explicitly.
-->

## Linked issues

<!--
Use `Fixes #N` to auto-close on merge, `Refs #N` to link without closing.
-->

## Risk / rollout notes

<!--
Anything reviewers should know that isn't visible from the diff:
- Schema, settings, or pbxproj migrations
- Behavior changes that touch existing user flows
- Performance characteristics worth flagging
- Follow-up issues filed (link them)

Skip this section entirely if there's nothing to flag.
-->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates `README.md` to add a "[currently in beta]" notice below the project tagline, replaces three local demo image paths with GitHub user-attachment CDN URLs, and tweaks the Open Source models table caption.

- A beta status badge (`[currently in beta]`) is inserted as a new centered paragraph after the existing tagline paragraph.
- The Slack, Notes, and iMessage demo images are switched from `.github/assets/readme/` local paths to GitHub CDN URLs; the Email demo image is left on the local path, creating a minor inconsistency across the four demo cells.
- The model table intro text is softened from "Built-in downloadable models:" to "Built-in downloadable models suggested for use:".

<h3>Confidence Score: 4/5</h3>

Documentation-only change; no runtime behavior is affected and it is safe to merge.

All changes are confined to README prose and image URLs. The Email demo image was not migrated to a CDN URL like the other three, leaving a cosmetic inconsistency. The new beta paragraph has slightly misaligned HTML indentation. Neither issue affects functionality.

README.md — the Email demo image path and the indentation of the new beta badge paragraph are worth a quick look.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| README.md | Adds a "[currently in beta]" badge below the tagline, migrates three demo images from local repo paths to GitHub CDN URLs, and softens model table wording. Minor inconsistency: the Email demo image was not migrated to a CDN URL like the other three. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[README.md] --> B[Tagline paragraph]
    B --> C[New: beta badge paragraph]
    A --> D[Demo table]
    D --> E[Email image - local path unchanged]
    D --> F[Slack image - GitHub CDN URL updated]
    D --> G[Notes image - GitHub CDN URL updated]
    D --> H[iMessage image - GitHub CDN URL updated]
    A --> I[Engines section]
    I --> J[Model table caption - added 'suggested for use']
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `README.md`, line 40 ([link](https://github.com/fujacob/tabby/blob/b728a00a297cee0f8f24b8fcafb0ab688f8d3d5d/README.md#L40)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> The three demo images for Slack, Notes, and iMessage have been migrated to GitHub user-attachment CDN URLs, but the Email demo image still uses the local repo path. While the local path renders correctly on GitHub today, it is inconsistent with the approach taken for the other three images in the same table.

   

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22FuJacob-patch-4%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22FuJacob-patch-4%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20README.md%0ALine%3A%2040%0A%0AComment%3A%0AThe%20three%20demo%20images%20for%20Slack%2C%20Notes%2C%20and%20iMessage%20have%20been%20migrated%20to%20GitHub%20user-attachment%20CDN%20URLs%2C%20but%20the%20Email%20demo%20image%20still%20uses%20the%20local%20repo%20path.%20While%20the%20local%20path%20renders%20correctly%20on%20GitHub%20today%2C%20it%20is%20inconsistent%20with%20the%20approach%20taken%20for%20the%20other%20three%20images%20in%20the%20same%20table.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%3Cimg%20src%3D%22https%3A%2F%2Fgithub.com%2Fuser-attachments%2Fassets%2FREPLACE_WITH_EMAIL_ASSET_ID%22%20alt%3D%22tabby%20autocomplete%20in%20Email%22%20width%3D%22100%25%22%20%2F%3E%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20README.md%0ALine%3A%2040%0A%0AComment%3A%0AThe%20three%20demo%20images%20for%20Slack%2C%20Notes%2C%20and%20iMessage%20have%20been%20migrated%20to%20GitHub%20user-attachment%20CDN%20URLs%2C%20but%20the%20Email%20demo%20image%20still%20uses%20the%20local%20repo%20path.%20While%20the%20local%20path%20renders%20correctly%20on%20GitHub%20today%2C%20it%20is%20inconsistent%20with%20the%20approach%20taken%20for%20the%20other%20three%20images%20in%20the%20same%20table.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%3Cimg%20src%3D%22https%3A%2F%2Fgithub.com%2Fuser-attachments%2Fassets%2FREPLACE_WITH_EMAIL_ASSET_ID%22%20alt%3D%22tabby%20autocomplete%20in%20Email%22%20width%3D%22100%25%22%20%2F%3E%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Ftabby&pr=155&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22FuJacob-patch-4%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22FuJacob-patch-4%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0AREADME.md%3A40%0AThe%20three%20demo%20images%20for%20Slack%2C%20Notes%2C%20and%20iMessage%20have%20been%20migrated%20to%20GitHub%20user-attachment%20CDN%20URLs%2C%20but%20the%20Email%20demo%20image%20still%20uses%20the%20local%20repo%20path.%20While%20the%20local%20path%20renders%20correctly%20on%20GitHub%20today%2C%20it%20is%20inconsistent%20with%20the%20approach%20taken%20for%20the%20other%20three%20images%20in%20the%20same%20table.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%3Cimg%20src%3D%22https%3A%2F%2Fgithub.com%2Fuser-attachments%2Fassets%2FREPLACE_WITH_EMAIL_ASSET_ID%22%20alt%3D%22tabby%20autocomplete%20in%20Email%22%20width%3D%22100%25%22%20%2F%3E%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0AREADME.md%3A9-14%0AThe%20new%20beta%20badge%20paragraph%20has%20inconsistent%20indentation%20compared%20to%20the%20surrounding%20HTML%3A%20the%20opening%20%60%3Cp%3E%60%20tag%20sits%20at%20two-space%20indent%20while%20its%20content%20and%20the%20other%20%60%3Cp%3E%60%20blocks%20in%20this%20section%20use%20the%20top-level%20column.%20Aligning%20all%20three%20paragraphs%20the%20same%20way%20keeps%20the%20source%20tidy.%0A%0A%60%60%60suggestion%0A%3C%2Fp%3E%0A%0A%3Cp%20align%3D%22center%22%3E%0A%20%20%3Cem%3E%5Bcurrently%20in%20beta%5D%3C%2Fem%3E%0A%3C%2Fp%3E%0A%0A%3Cp%20align%3D%22center%22%3E%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0AREADME.md%3A40%0AThe%20three%20demo%20images%20for%20Slack%2C%20Notes%2C%20and%20iMessage%20have%20been%20migrated%20to%20GitHub%20user-attachment%20CDN%20URLs%2C%20but%20the%20Email%20demo%20image%20still%20uses%20the%20local%20repo%20path.%20While%20the%20local%20path%20renders%20correctly%20on%20GitHub%20today%2C%20it%20is%20inconsistent%20with%20the%20approach%20taken%20for%20the%20other%20three%20images%20in%20the%20same%20table.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%3Cimg%20src%3D%22https%3A%2F%2Fgithub.com%2Fuser-attachments%2Fassets%2FREPLACE_WITH_EMAIL_ASSET_ID%22%20alt%3D%22tabby%20autocomplete%20in%20Email%22%20width%3D%22100%25%22%20%2F%3E%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0AREADME.md%3A9-14%0AThe%20new%20beta%20badge%20paragraph%20has%20inconsistent%20indentation%20compared%20to%20the%20surrounding%20HTML%3A%20the%20opening%20%60%3Cp%3E%60%20tag%20sits%20at%20two-space%20indent%20while%20its%20content%20and%20the%20other%20%60%3Cp%3E%60%20blocks%20in%20this%20section%20use%20the%20top-level%20column.%20Aligning%20all%20three%20paragraphs%20the%20same%20way%20keeps%20the%20source%20tidy.%0A%0A%60%60%60suggestion%0A%3C%2Fp%3E%0A%0A%3Cp%20align%3D%22center%22%3E%0A%20%20%3Cem%3E%5Bcurrently%20in%20beta%5D%3C%2Fem%3E%0A%3C%2Fp%3E%0A%0A%3Cp%20align%3D%22center%22%3E%0A%60%60%60%0A%0A&repo=fujacob%2Ftabby&pr=155&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Update README.md"](https://github.com/fujacob/tabby/commit/b728a00a297cee0f8f24b8fcafb0ab688f8d3d5d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33222355)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->