### PR TITLE
Change Apple Intelligence status from BETA to EXPERIMENTAL

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Everything runs on-device. No hosted API, no cloud round-trip.
 
 ## Engines
 
-**Apple Intelligence [BETA]**: uses Apple's on-device `FoundationModels` runtime on macOS 26 or later. No download required. Availability depends on your Mac; tabby checks at runtime and explains when this engine is unavailable. Apple Intelligence support is currently in beta and may not perform as well as the Open Source models. We're actively working on improving it.
+**Apple Intelligence [EXPERIMENTAL]**: uses Apple's on-device `FoundationModels` runtime on macOS 26 or later, no download required. Currently does not perform as well as the Open Source models. We're actively working on improving it.
 
 **Open Source**: runs local GGUF models in-process through llama.cpp via `llama.swift`. Built-in downloadable models suggested for use:
 


### PR DESCRIPTION
Updated the description of the Apple Intelligence engine from 'BETA' to 'EXPERIMENTAL' and clarified performance expectations.

## Summary

<!--
One or two sentences: what changed and why. Skip the play-by-play.
The diff already shows what; this section should explain why.
-->

## Validation

<!--
What you actually ran and what you actually saw, not what you intended to run.
Examples:

  xcodebuild test -project tabby.xcodeproj -scheme tabby \
    -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO
  # ** TEST SUCCEEDED **  N tests, 0 failures

  swiftlint lint --config .swiftlint.yml --quiet
  # exit 0

For UI changes, attach a screenshot or short screen recording.
For changes that can't be verified end-to-end yet, say so explicitly.
-->

## Linked issues

<!--
Use `Fixes #N` to auto-close on merge, `Refs #N` to link without closing.
-->

## Risk / rollout notes

<!--
Anything reviewers should know that isn't visible from the diff:
- Schema, settings, or pbxproj migrations
- Behavior changes that touch existing user flows
- Performance characteristics worth flagging
- Follow-up issues filed (link them)

Skip this section entirely if there's nothing to flag.
-->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the Apple Intelligence engine label in `README.md` from `[BETA]` to `[EXPERIMENTAL]` and simplifies the associated description.

- The status label is changed and the prose is tightened, but the sentence explaining that device availability is checked at runtime has been removed, which may leave some users without context when the engine is unavailable on their hardware.

<h3>Confidence Score: 5/5</h3>

Documentation-only change; no code or configuration is touched, so there is no risk to runtime behavior.

The change is limited to a single README sentence — no source files, build configs, or feature flags are modified. The only open question is whether the dropped runtime-availability note should be preserved for users whose hardware doesn't support Apple Intelligence.

README.md — consider whether the removed availability callout should be restored.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Relabels Apple Intelligence from [BETA] to [EXPERIMENTAL] and trims the description; removes the runtime availability explanation sentence. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant SuggestionEngineRouter
    participant FoundationModelSuggestionEngine
    participant LlamaSuggestionEngine

    User->>SuggestionEngineRouter: request autocomplete
    SuggestionEngineRouter->>SuggestionEngineRouter: check Apple Intelligence availability
    alt Apple Intelligence [EXPERIMENTAL] available
        SuggestionEngineRouter->>FoundationModelSuggestionEngine: generate(request)
        FoundationModelSuggestionEngine-->>User: suggestion (on-device, FoundationModels)
    else Fallback to Open Source
        SuggestionEngineRouter->>LlamaSuggestionEngine: generate(request)
        LlamaSuggestionEngine-->>User: suggestion (llama.cpp, local GGUF)
    end
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22FuJacob-patch-5%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22FuJacob-patch-5%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AREADME.md%3A81%0AThe%20edit%20removes%20the%20sentence%20%22Availability%20depends%20on%20your%20Mac%3B%20tabby%20checks%20at%20runtime%20and%20explains%20when%20this%20engine%20is%20unavailable.%22%20This%20is%20useful%20user-facing%20guidance%3A%20Apple%20Intelligence%20is%20not%20available%20on%20Intel%20Macs%20or%20older%20Apple%20Silicon%2C%20and%20without%20this%20note%20a%20user%20whose%20hardware%20doesn't%20qualify%20will%20have%20no%20README%20context%20for%20why%20the%20engine%20is%20missing.%20Consider%20preserving%20or%20rewording%20that%20availability%20callout.%0A%0A%60%60%60suggestion%0A**Apple%20Intelligence%20%5BEXPERIMENTAL%5D**%3A%20uses%20Apple's%20on-device%20%60FoundationModels%60%20runtime%20on%20macOS%2026%20or%20later%2C%20no%20download%20required.%20Availability%20depends%20on%20your%20Mac%3B%20tabby%20checks%20at%20runtime%20and%20explains%20when%20this%20engine%20is%20unavailable.%20Currently%20does%20not%20perform%20as%20well%20as%20the%20Open%20Source%20models.%20We're%20actively%20working%20on%20improving%20it.%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AREADME.md%3A81%0AThe%20edit%20removes%20the%20sentence%20%22Availability%20depends%20on%20your%20Mac%3B%20tabby%20checks%20at%20runtime%20and%20explains%20when%20this%20engine%20is%20unavailable.%22%20This%20is%20useful%20user-facing%20guidance%3A%20Apple%20Intelligence%20is%20not%20available%20on%20Intel%20Macs%20or%20older%20Apple%20Silicon%2C%20and%20without%20this%20note%20a%20user%20whose%20hardware%20doesn't%20qualify%20will%20have%20no%20README%20context%20for%20why%20the%20engine%20is%20missing.%20Consider%20preserving%20or%20rewording%20that%20availability%20callout.%0A%0A%60%60%60suggestion%0A**Apple%20Intelligence%20%5BEXPERIMENTAL%5D**%3A%20uses%20Apple's%20on-device%20%60FoundationModels%60%20runtime%20on%20macOS%2026%20or%20later%2C%20no%20download%20required.%20Availability%20depends%20on%20your%20Mac%3B%20tabby%20checks%20at%20runtime%20and%20explains%20when%20this%20engine%20is%20unavailable.%20Currently%20does%20not%20perform%20as%20well%20as%20the%20Open%20Source%20models.%20We're%20actively%20working%20on%20improving%20it.%0A%60%60%60%0A%0A&repo=fujacob%2Ftabby&pr=156&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Change Apple Intelligence status from BE..."](https://github.com/fujacob/tabby/commit/ac6207ef2ab82c9a9bb6f197e4c7e0a20446f415) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33222752)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->