### PR TITLE
Enhance contribution guidelines for PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,12 @@ Please read and follow the [Code of Conduct](CODE_OF_CONDUCT.md) before particip
 - Read [ARCHITECTURE.md](ARCHITECTURE.md) before changing the suggestion pipeline, runtime
   lifecycle, or Accessibility behavior.
 - Check for an existing issue or open one before starting substantial work.
+- Prefer small, atomic PRs with a single clear objective. Large mixed-purpose changes are harder to
+review, validate, and revert safely.
+- Before implementing a change, make sure you can clearly explain:
+   1. The problem being solved
+   2. Why the current behavior is insufficient
+   3. Why the proposed approach fits the existing architecture
 
 ## Development Prerequisites
 


### PR DESCRIPTION
Added guidelines for creating small, atomic PRs and clarifying change rationale.

## Summary

<!--
One or two sentences: what changed and why. Skip the play-by-play.
The diff already shows what; this section should explain why.
-->

## Validation

<!--
What you actually ran and what you actually saw, not what you intended to run.
Examples:

  xcodebuild test -project tabby.xcodeproj -scheme tabby \
    -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO
  # ** TEST SUCCEEDED **  N tests, 0 failures

  swiftlint lint --config .swiftlint.yml --quiet
  # exit 0

For UI changes, attach a screenshot or short screen recording.
For changes that can't be verified end-to-end yet, say so explicitly.
-->

## Linked issues

<!--
Use `Fixes #N` to auto-close on merge, `Refs #N` to link without closing.
-->

## Risk / rollout notes

<!--
Anything reviewers should know that isn't visible from the diff:
- Schema, settings, or pbxproj migrations
- Behavior changes that touch existing user flows
- Performance characteristics worth flagging
- Follow-up issues filed (link them)

Skip this section entirely if there's nothing to flag.
-->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two new items to the "Before You Start" section of `CONTRIBUTING.md`: a preference for small, atomic PRs and a three-point pre-implementation checklist requiring contributors to articulate the problem, the insufficiency of the current behaviour, and the fit of the proposed approach.

- New bullet point encourages atomic, single-objective PRs; has a minor continuation-line indentation issue (`review, validate…` should be indented two spaces to match the rest of the list).
- New numbered sub-list (items 1–3) formalises the rationale contributors should have ready before starting; partially overlaps with the existing "Pull Requests" section's "Keep the change scoped to one problem" guidance.

<h3>Confidence Score: 4/5</h3>

Documentation-only change; no functional code is modified and the new guidelines are broadly sensible.

The change touches only CONTRIBUTING.md. A minor indentation inconsistency in the new bullet's continuation line and some overlap with the existing Pull Requests section are the only things worth addressing; neither affects functionality.

No files require special attention beyond the minor formatting fix in CONTRIBUTING.md.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CONTRIBUTING.md | Adds two new items to the "Before You Start" section: a preference for small atomic PRs and a three-point pre-implementation checklist. Minor continuation-line indentation inconsistency and some overlap with the existing "Pull Requests" section. |

</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22Jam-Cai-patch-1%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22Jam-Cai-patch-1%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACONTRIBUTING.md%3A18-19%0AThe%20continuation%20of%20the%20bullet%20runs%20flush%20to%20the%20left%20margin%2C%20which%20is%20inconsistent%20with%20the%20indentation%20expected%20for%20a%20wrapped%20list%20item.%20While%20GitHub's%20Markdown%20renderer%20handles%20lazy%20continuations%2C%20the%20lack%20of%20indentation%20stands%20out%20next%20to%20every%20other%20bullet%20in%20the%20file%20and%20can%20confuse%20parsers%20or%20editors%20that%20apply%20stricter%20CommonMark%20rules.%0A%0A%60%60%60suggestion%0A-%20Prefer%20small%2C%20atomic%20PRs%20with%20a%20single%20clear%20objective.%20Large%20mixed-purpose%20changes%20are%20harder%20to%0A%20%20review%2C%20validate%2C%20and%20revert%20safely.%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACONTRIBUTING.md%3A18-23%0A**Duplicate%20guidance%20across%20sections**%0A%0AThe%20existing%20%22Pull%20Requests%22%20section%20%28line%20147%29%20already%20says%20%22Keep%20the%20change%20scoped%20to%20one%20problem.%22%20The%20new%20bullet%20adds%20essentially%20the%20same%20advice%20in%20%22Before%20You%20Start.%22%20Having%20this%20guidance%20in%20both%20places%20is%20fine%20as%20early%20reinforcement%2C%20but%20contributors%20reading%20both%20sections%20may%20find%20the%20repetition%20slightly%20confusing.%20Consider%20whether%20the%20two%20entries%20are%20distinct%20enough%20to%20justify%20both%2C%20or%20if%20one%20could%20link%20to%20the%20other.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACONTRIBUTING.md%3A18-19%0AThe%20continuation%20of%20the%20bullet%20runs%20flush%20to%20the%20left%20margin%2C%20which%20is%20inconsistent%20with%20the%20indentation%20expected%20for%20a%20wrapped%20list%20item.%20While%20GitHub's%20Markdown%20renderer%20handles%20lazy%20continuations%2C%20the%20lack%20of%20indentation%20stands%20out%20next%20to%20every%20other%20bullet%20in%20the%20file%20and%20can%20confuse%20parsers%20or%20editors%20that%20apply%20stricter%20CommonMark%20rules.%0A%0A%60%60%60suggestion%0A-%20Prefer%20small%2C%20atomic%20PRs%20with%20a%20single%20clear%20objective.%20Large%20mixed-purpose%20changes%20are%20harder%20to%0A%20%20review%2C%20validate%2C%20and%20revert%20safely.%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACONTRIBUTING.md%3A18-23%0A**Duplicate%20guidance%20across%20sections**%0A%0AThe%20existing%20%22Pull%20Requests%22%20section%20%28line%20147%29%20already%20says%20%22Keep%20the%20change%20scoped%20to%20one%20problem.%22%20The%20new%20bullet%20adds%20essentially%20the%20same%20advice%20in%20%22Before%20You%20Start.%22%20Having%20this%20guidance%20in%20both%20places%20is%20fine%20as%20early%20reinforcement%2C%20but%20contributors%20reading%20both%20sections%20may%20find%20the%20repetition%20slightly%20confusing.%20Consider%20whether%20the%20two%20entries%20are%20distinct%20enough%20to%20justify%20both%2C%20or%20if%20one%20could%20link%20to%20the%20other.%0A%0A&repo=fujacob%2Ftabby&pr=163&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Enhance contribution guidelines for PRs"](https://github.com/fujacob/tabby/commit/2151d680a414780261a284063ec77fa1e9457d37) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33567608)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->