### PR TITLE
Make debug status panel draggable

### DIFF
--- a/tabby/Services/UI/FocusDebugOverlayController.swift
+++ b/tabby/Services/UI/FocusDebugOverlayController.swift
@@ -19,7 +19,10 @@ final class FocusDebugOverlayController {
 
     private lazy var caretPanel: NSPanel = makePanel()
     private lazy var framePanel: NSPanel = makePanel()
-    private lazy var bottomStatusPanel: NSPanel = makePanel()
+    private lazy var bottomStatusPanel: NSPanel = makeDraggablePanel()
+
+    /// User-dragged origin for the bottom panel. `nil` means use the default centered position.
+    private var bottomPanelDraggedOrigin: CGPoint?
 
     private var latestCaretRect: CGRect?
     private var latestVisualContextStatus: VisualContextStatus = .idle
@@ -118,6 +121,11 @@ final class FocusDebugOverlayController {
             return
         }
 
+        // Capture any user drag that happened since the last render.
+        if bottomStatusPanel.isVisible {
+            bottomPanelDraggedOrigin = bottomStatusPanel.frame.origin
+        }
+
         let screenFrame = targetScreenVisibleFrame()
         let maxWidth = min(screenFrame.width - 32, 620)
         let contentView = NSHostingView(rootView: BottomDebugStatusView(
@@ -129,10 +137,15 @@ final class FocusDebugOverlayController {
         contentView.layoutSubtreeIfNeeded()
         let contentSize = contentView.fittingSize
 
-        let origin = CGPoint(
-            x: screenFrame.midX - (contentSize.width / 2),
-            y: screenFrame.minY + 14
-        )
+        let origin: CGPoint
+        if let dragged = bottomPanelDraggedOrigin {
+            origin = dragged
+        } else {
+            origin = CGPoint(
+                x: screenFrame.midX - (contentSize.width / 2),
+                y: screenFrame.minY + 14
+            )
+        }
 
         bottomStatusPanel.contentView = contentView
         bottomStatusPanel.setFrame(
@@ -152,6 +165,24 @@ final class FocusDebugOverlayController {
         latestCaretRect = nil
         caretPanel.orderOut(nil)
         framePanel.orderOut(nil)
+    }
+
+    private func makeDraggablePanel() -> NSPanel {
+        let panel = NSPanel(
+            contentRect: CGRect(x: 0, y: 0, width: 10, height: 10),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: true
+        )
+        panel.isReleasedWhenClosed = false
+        panel.backgroundColor = .clear
+        panel.isOpaque = false
+        panel.ignoresMouseEvents = false
+        panel.isMovableByWindowBackground = true
+        panel.hasShadow = false
+        panel.level = NSWindow.Level(rawValue: NSWindow.Level.statusBar.rawValue + 2)
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .ignoresCycle]
+        return panel
     }
 
     private func makePanel() -> NSPanel {

--- a/tabby/Services/UI/FocusDebugOverlayController.swift
+++ b/tabby/Services/UI/FocusDebugOverlayController.swift
@@ -19,10 +19,13 @@ final class FocusDebugOverlayController {
 
     private lazy var caretPanel: NSPanel = makePanel()
     private lazy var framePanel: NSPanel = makePanel()
-    private lazy var bottomStatusPanel: NSPanel = makeDraggablePanel()
+    private lazy var bottomStatusPanel: NSPanel = makePanel(draggable: true)
 
     /// User-dragged origin for the bottom panel. `nil` means use the default centered position.
     private var bottomPanelDraggedOrigin: CGPoint?
+
+    /// The last origin we set programmatically, used to detect genuine user drags.
+    private var bottomPanelProgrammaticOrigin: CGPoint?
 
     private var latestCaretRect: CGRect?
     private var latestVisualContextStatus: VisualContextStatus = .idle
@@ -121,9 +124,13 @@ final class FocusDebugOverlayController {
             return
         }
 
-        // Capture any user drag that happened since the last render.
-        if bottomStatusPanel.isVisible {
-            bottomPanelDraggedOrigin = bottomStatusPanel.frame.origin
+        // Detect genuine user drags by comparing against the last programmatic origin.
+        if bottomStatusPanel.isVisible,
+           let programmatic = bottomPanelProgrammaticOrigin {
+            let current = bottomStatusPanel.frame.origin
+            if current != programmatic {
+                bottomPanelDraggedOrigin = current
+            }
         }
 
         let screenFrame = targetScreenVisibleFrame()
@@ -147,11 +154,10 @@ final class FocusDebugOverlayController {
             )
         }
 
+        let frame = CGRect(origin: origin, size: contentSize).integral
         bottomStatusPanel.contentView = contentView
-        bottomStatusPanel.setFrame(
-            CGRect(origin: origin, size: contentSize).integral,
-            display: true
-        )
+        bottomStatusPanel.setFrame(frame, display: true)
+        bottomPanelProgrammaticOrigin = frame.origin
         bottomStatusPanel.orderFrontRegardless()
     }
 
@@ -167,7 +173,7 @@ final class FocusDebugOverlayController {
         framePanel.orderOut(nil)
     }
 
-    private func makeDraggablePanel() -> NSPanel {
+    private func makePanel(draggable: Bool = false) -> NSPanel {
         let panel = NSPanel(
             contentRect: CGRect(x: 0, y: 0, width: 10, height: 10),
             styleMask: [.borderless, .nonactivatingPanel],
@@ -177,25 +183,8 @@ final class FocusDebugOverlayController {
         panel.isReleasedWhenClosed = false
         panel.backgroundColor = .clear
         panel.isOpaque = false
-        panel.ignoresMouseEvents = false
-        panel.isMovableByWindowBackground = true
-        panel.hasShadow = false
-        panel.level = NSWindow.Level(rawValue: NSWindow.Level.statusBar.rawValue + 2)
-        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .ignoresCycle]
-        return panel
-    }
-
-    private func makePanel() -> NSPanel {
-        let panel = NSPanel(
-            contentRect: CGRect(x: 0, y: 0, width: 10, height: 10),
-            styleMask: [.borderless, .nonactivatingPanel],
-            backing: .buffered,
-            defer: true
-        )
-        panel.isReleasedWhenClosed = false
-        panel.backgroundColor = .clear
-        panel.isOpaque = false
-        panel.ignoresMouseEvents = true
+        panel.ignoresMouseEvents = !draggable
+        panel.isMovableByWindowBackground = draggable
         panel.hasShadow = false
         // Above activation indicator and ghost text so it is always visible during debugging.
         panel.level = NSWindow.Level(rawValue: NSWindow.Level.statusBar.rawValue + 2)


### PR DESCRIPTION
## Summary
- The bottom debug overlay panel (`-tabby-debug`) now accepts mouse events and can be dragged to any position on screen
- Dragged position persists across re-renders within the session, so the panel stays where you put it
- Caret indicator and frame outline panels remain non-interactive (they follow the cursor)

## Test plan
- [ ] Launch with `-tabby-debug` flag
- [ ] Verify the bottom status panel can be clicked and dragged
- [ ] Verify it stays in the dragged position as status updates flow in
- [ ] Verify caret indicator and frame outline still track the cursor normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the bottom debug status panel draggable while leaving the caret indicator and frame outline panels non-interactive. The previously flagged issue — `bottomPanelDraggedOrigin` becoming permanently locked after the first render — has been properly resolved.

- `makePanel(draggable: Bool = false)` replaces the duplicated factory, toggling `ignoresMouseEvents` and `isMovableByWindowBackground` from a single parameter.
- `bottomPanelProgrammaticOrigin` is now recorded after every `setFrame` call; the drag-detection guard in `renderBottomStatusPanel()` only updates `bottomPanelDraggedOrigin` when the panel's current origin differs from that stored value, correctly distinguishing genuine user drags from programmatic repositions.

<h3>Confidence Score: 5/5</h3>

Change is gated behind the -tabby-debug launch flag and only affects the developer-facing status panel; no production user path is touched.

The drag detection logic is sound: programmatic origins are recorded after every setFrame call, so the guard correctly fires only when the user has physically moved the panel. The unified makePanel(draggable:) factory eliminates the duplication risk. All changes are isolated to the debug overlay and carry no risk to the suggestion pipeline or core services.

No files require special attention; the single changed file is self-contained.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tabby/Services/UI/FocusDebugOverlayController.swift | Adds drag support to the bottom status panel via a unified makePanel(draggable:) factory and two new origin-tracking properties; the drag-detection logic correctly distinguishes user drags from programmatic repositions. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller as Caller (updateVisualContext / updateFocusPolling)
    participant RBS as renderBottomStatusPanel()
    participant Panel as bottomStatusPanel (NSPanel)
    participant State as bottomPanel*Origin state

    Caller->>RBS: trigger render

    alt Panel is visible AND programmaticOrigin is set
        RBS->>Panel: read frame.origin (current)
        RBS->>State: compare current vs bottomPanelProgrammaticOrigin
        alt "current != programmatic (user dragged)"
            RBS->>State: "bottomPanelDraggedOrigin = current"
        end
    end

    alt bottomPanelDraggedOrigin is set
        RBS->>RBS: "origin = draggedOrigin"
    else no drag recorded
        RBS->>RBS: "origin = screenFrame.midX / minY+14 (default)"
    end

    RBS->>Panel: setFrame(CGRect(origin, contentSize).integral)
    RBS->>State: "bottomPanelProgrammaticOrigin = frame.origin"
    RBS->>Panel: orderFrontRegardless()
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tabby/Services/UI/FocusDebugOverlayController.swift`, line 170-204 ([link](https://github.com/fujacob/tabby/blob/c6f592b621ca47612b8920458ff45c97310ca984/tabby/Services/UI/FocusDebugOverlayController.swift#L170-L204)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `makeDraggablePanel()` duplicates all of `makePanel()` and differs only in the two draggability knobs. A shared factory with parameters avoids the two copies drifting apart if any shared property (e.g. `level`, `collectionBehavior`) changes later.

   

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22draggable-debug-panel%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22draggable-debug-panel%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tabby%2FServices%2FUI%2FFocusDebugOverlayController.swift%0ALine%3A%20170-204%0A%0AComment%3A%0A%60makeDraggablePanel%28%29%60%20duplicates%20all%20of%20%60makePanel%28%29%60%20and%20differs%20only%20in%20the%20two%20draggability%20knobs.%20A%20shared%20factory%20with%20parameters%20avoids%20the%20two%20copies%20drifting%20apart%20if%20any%20shared%20property%20%28e.g.%20%60level%60%2C%20%60collectionBehavior%60%29%20changes%20later.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20func%20makeDraggablePanel%28%29%20-%3E%20NSPanel%20%7B%0A%20%20%20%20%20%20%20%20makePanel%28draggable%3A%20true%29%0A%20%20%20%20%7D%0A%0A%20%20%20%20%2F%2F%2F%20Builds%20a%20shared-configuration%20overlay%20panel.%0A%20%20%20%20%2F%2F%2F%0A%20%20%20%20%2F%2F%2F%20-%20Parameter%20draggable%3A%20When%20%60true%60%20the%20panel%20accepts%20mouse%20events%20and%20can%20be%20moved%20by%0A%20%20%20%20%2F%2F%2F%20%20%20dragging%20its%20background.%20Pass%20%60false%60%20for%20cursor-following%20panels%20that%20must%20stay%0A%20%20%20%20%2F%2F%2F%20%20%20non-interactive.%0A%20%20%20%20private%20func%20makePanel%28draggable%3A%20Bool%20%3D%20false%29%20-%3E%20NSPanel%20%7B%0A%20%20%20%20%20%20%20%20let%20panel%20%3D%20NSPanel%28%0A%20%20%20%20%20%20%20%20%20%20%20%20contentRect%3A%20CGRect%28x%3A%200%2C%20y%3A%200%2C%20width%3A%2010%2C%20height%3A%2010%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20styleMask%3A%20%5B.borderless%2C%20.nonactivatingPanel%5D%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20backing%3A%20.buffered%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20defer%3A%20true%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20panel.isReleasedWhenClosed%20%3D%20false%0A%20%20%20%20%20%20%20%20panel.backgroundColor%20%3D%20.clear%0A%20%20%20%20%20%20%20%20panel.isOpaque%20%3D%20false%0A%20%20%20%20%20%20%20%20panel.ignoresMouseEvents%20%3D%20!draggable%0A%20%20%20%20%20%20%20%20panel.isMovableByWindowBackground%20%3D%20draggable%0A%20%20%20%20%20%20%20%20panel.hasShadow%20%3D%20false%0A%20%20%20%20%20%20%20%20%2F%2F%20Above%20activation%20indicator%20and%20ghost%20text%20so%20it%20is%20always%20visible%20during%20debugging.%0A%20%20%20%20%20%20%20%20panel.level%20%3D%20NSWindow.Level%28rawValue%3A%20NSWindow.Level.statusBar.rawValue%20%2B%202%29%0A%20%20%20%20%20%20%20%20panel.collectionBehavior%20%3D%20%5B.canJoinAllSpaces%2C%20.fullScreenAuxiliary%2C%20.ignoresCycle%5D%0A%20%20%20%20%20%20%20%20return%20panel%0A%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tabby%2FServices%2FUI%2FFocusDebugOverlayController.swift%0ALine%3A%20170-204%0A%0AComment%3A%0A%60makeDraggablePanel%28%29%60%20duplicates%20all%20of%20%60makePanel%28%29%60%20and%20differs%20only%20in%20the%20two%20draggability%20knobs.%20A%20shared%20factory%20with%20parameters%20avoids%20the%20two%20copies%20drifting%20apart%20if%20any%20shared%20property%20%28e.g.%20%60level%60%2C%20%60collectionBehavior%60%29%20changes%20later.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20func%20makeDraggablePanel%28%29%20-%3E%20NSPanel%20%7B%0A%20%20%20%20%20%20%20%20makePanel%28draggable%3A%20true%29%0A%20%20%20%20%7D%0A%0A%20%20%20%20%2F%2F%2F%20Builds%20a%20shared-configuration%20overlay%20panel.%0A%20%20%20%20%2F%2F%2F%0A%20%20%20%20%2F%2F%2F%20-%20Parameter%20draggable%3A%20When%20%60true%60%20the%20panel%20accepts%20mouse%20events%20and%20can%20be%20moved%20by%0A%20%20%20%20%2F%2F%2F%20%20%20dragging%20its%20background.%20Pass%20%60false%60%20for%20cursor-following%20panels%20that%20must%20stay%0A%20%20%20%20%2F%2F%2F%20%20%20non-interactive.%0A%20%20%20%20private%20func%20makePanel%28draggable%3A%20Bool%20%3D%20false%29%20-%3E%20NSPanel%20%7B%0A%20%20%20%20%20%20%20%20let%20panel%20%3D%20NSPanel%28%0A%20%20%20%20%20%20%20%20%20%20%20%20contentRect%3A%20CGRect%28x%3A%200%2C%20y%3A%200%2C%20width%3A%2010%2C%20height%3A%2010%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20styleMask%3A%20%5B.borderless%2C%20.nonactivatingPanel%5D%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20backing%3A%20.buffered%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20defer%3A%20true%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20panel.isReleasedWhenClosed%20%3D%20false%0A%20%20%20%20%20%20%20%20panel.backgroundColor%20%3D%20.clear%0A%20%20%20%20%20%20%20%20panel.isOpaque%20%3D%20false%0A%20%20%20%20%20%20%20%20panel.ignoresMouseEvents%20%3D%20!draggable%0A%20%20%20%20%20%20%20%20panel.isMovableByWindowBackground%20%3D%20draggable%0A%20%20%20%20%20%20%20%20panel.hasShadow%20%3D%20false%0A%20%20%20%20%20%20%20%20%2F%2F%20Above%20activation%20indicator%20and%20ghost%20text%20so%20it%20is%20always%20visible%20during%20debugging.%0A%20%20%20%20%20%20%20%20panel.level%20%3D%20NSWindow.Level%28rawValue%3A%20NSWindow.Level.statusBar.rawValue%20%2B%202%29%0A%20%20%20%20%20%20%20%20panel.collectionBehavior%20%3D%20%5B.canJoinAllSpaces%2C%20.fullScreenAuxiliary%2C%20.ignoresCycle%5D%0A%20%20%20%20%20%20%20%20return%20panel%0A%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Ftabby&pr=164&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Fix debug panel drag detection and dedup..."](https://github.com/fujacob/tabby/commit/333f536d6619f9c4df8bf1a4b90594b27e5eacf8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33568648)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=45fae5fd-3007-4631-a2b0-92b2beb3df2a))

<!-- /greptile_comment -->