### PR TITLE
Update menu bar footer labels and add feedback link

### DIFF
--- a/tabby/App/Core/TabbyApp.swift
+++ b/tabby/App/Core/TabbyApp.swift
@@ -25,8 +25,8 @@ struct TabbyApp: App {
                 onOpenSettings: {
                     appDelegate.settingsCoordinator.showSettings()
                 },
-                onCheckForUpdates: {
-                    appDelegate.appUpdateManager.checkForUpdates()
+                onReportFeedback: {
+                    NSWorkspace.shared.open(URL(string: "https://www.tabbyapp.dev/feedback")!)
                 }
             )
         } label: {

--- a/tabby/App/Core/TabbyApp.swift
+++ b/tabby/App/Core/TabbyApp.swift
@@ -26,7 +26,10 @@ struct TabbyApp: App {
                     appDelegate.settingsCoordinator.showSettings()
                 },
                 onReportFeedback: {
-                    NSWorkspace.shared.open(URL(string: "https://www.tabbyapp.dev/feedback")!)
+                    // The URL literal is always valid, but if-let avoids the force-unwrap.
+                    if let feedbackURL = URL(string: "https://www.tabbyapp.dev/feedback") {
+                        NSWorkspace.shared.open(feedbackURL)
+                    }
                 }
             )
         } label: {

--- a/tabby/Services/UI/FocusDebugOverlayController.swift
+++ b/tabby/Services/UI/FocusDebugOverlayController.swift
@@ -19,7 +19,10 @@ final class FocusDebugOverlayController {
 
     private lazy var caretPanel: NSPanel = makePanel()
     private lazy var framePanel: NSPanel = makePanel()
-    private lazy var bottomStatusPanel: NSPanel = makePanel()
+    private lazy var bottomStatusPanel: NSPanel = makeDraggablePanel()
+
+    /// User-dragged origin for the bottom panel. `nil` means use the default centered position.
+    private var bottomPanelDraggedOrigin: CGPoint?
 
     private var latestCaretRect: CGRect?
     private var latestVisualContextStatus: VisualContextStatus = .idle
@@ -118,6 +121,11 @@ final class FocusDebugOverlayController {
             return
         }
 
+        // Capture any user drag that happened since the last render.
+        if bottomStatusPanel.isVisible {
+            bottomPanelDraggedOrigin = bottomStatusPanel.frame.origin
+        }
+
         let screenFrame = targetScreenVisibleFrame()
         let maxWidth = min(screenFrame.width - 32, 620)
         let contentView = NSHostingView(rootView: BottomDebugStatusView(
@@ -129,10 +137,15 @@ final class FocusDebugOverlayController {
         contentView.layoutSubtreeIfNeeded()
         let contentSize = contentView.fittingSize
 
-        let origin = CGPoint(
-            x: screenFrame.midX - (contentSize.width / 2),
-            y: screenFrame.minY + 14
-        )
+        let origin: CGPoint
+        if let dragged = bottomPanelDraggedOrigin {
+            origin = dragged
+        } else {
+            origin = CGPoint(
+                x: screenFrame.midX - (contentSize.width / 2),
+                y: screenFrame.minY + 14
+            )
+        }
 
         bottomStatusPanel.contentView = contentView
         bottomStatusPanel.setFrame(
@@ -152,6 +165,24 @@ final class FocusDebugOverlayController {
         latestCaretRect = nil
         caretPanel.orderOut(nil)
         framePanel.orderOut(nil)
+    }
+
+    private func makeDraggablePanel() -> NSPanel {
+        let panel = NSPanel(
+            contentRect: CGRect(x: 0, y: 0, width: 10, height: 10),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: true
+        )
+        panel.isReleasedWhenClosed = false
+        panel.backgroundColor = .clear
+        panel.isOpaque = false
+        panel.ignoresMouseEvents = false
+        panel.isMovableByWindowBackground = true
+        panel.hasShadow = false
+        panel.level = NSWindow.Level(rawValue: NSWindow.Level.statusBar.rawValue + 2)
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .ignoresCycle]
+        return panel
     }
 
     private func makePanel() -> NSPanel {

--- a/tabby/Services/UI/FocusDebugOverlayController.swift
+++ b/tabby/Services/UI/FocusDebugOverlayController.swift
@@ -19,10 +19,13 @@ final class FocusDebugOverlayController {
 
     private lazy var caretPanel: NSPanel = makePanel()
     private lazy var framePanel: NSPanel = makePanel()
-    private lazy var bottomStatusPanel: NSPanel = makeDraggablePanel()
+    private lazy var bottomStatusPanel: NSPanel = makePanel(draggable: true)
 
     /// User-dragged origin for the bottom panel. `nil` means use the default centered position.
     private var bottomPanelDraggedOrigin: CGPoint?
+
+    /// The last origin we set programmatically, used to detect genuine user drags.
+    private var bottomPanelProgrammaticOrigin: CGPoint?
 
     private var latestCaretRect: CGRect?
     private var latestVisualContextStatus: VisualContextStatus = .idle
@@ -121,9 +124,13 @@ final class FocusDebugOverlayController {
             return
         }
 
-        // Capture any user drag that happened since the last render.
-        if bottomStatusPanel.isVisible {
-            bottomPanelDraggedOrigin = bottomStatusPanel.frame.origin
+        // Detect genuine user drags by comparing against the last programmatic origin.
+        if bottomStatusPanel.isVisible,
+           let programmatic = bottomPanelProgrammaticOrigin {
+            let current = bottomStatusPanel.frame.origin
+            if current != programmatic {
+                bottomPanelDraggedOrigin = current
+            }
         }
 
         let screenFrame = targetScreenVisibleFrame()
@@ -147,11 +154,10 @@ final class FocusDebugOverlayController {
             )
         }
 
+        let frame = CGRect(origin: origin, size: contentSize).integral
         bottomStatusPanel.contentView = contentView
-        bottomStatusPanel.setFrame(
-            CGRect(origin: origin, size: contentSize).integral,
-            display: true
-        )
+        bottomStatusPanel.setFrame(frame, display: true)
+        bottomPanelProgrammaticOrigin = frame.origin
         bottomStatusPanel.orderFrontRegardless()
     }
 
@@ -167,7 +173,7 @@ final class FocusDebugOverlayController {
         framePanel.orderOut(nil)
     }
 
-    private func makeDraggablePanel() -> NSPanel {
+    private func makePanel(draggable: Bool = false) -> NSPanel {
         let panel = NSPanel(
             contentRect: CGRect(x: 0, y: 0, width: 10, height: 10),
             styleMask: [.borderless, .nonactivatingPanel],
@@ -177,25 +183,8 @@ final class FocusDebugOverlayController {
         panel.isReleasedWhenClosed = false
         panel.backgroundColor = .clear
         panel.isOpaque = false
-        panel.ignoresMouseEvents = false
-        panel.isMovableByWindowBackground = true
-        panel.hasShadow = false
-        panel.level = NSWindow.Level(rawValue: NSWindow.Level.statusBar.rawValue + 2)
-        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .ignoresCycle]
-        return panel
-    }
-
-    private func makePanel() -> NSPanel {
-        let panel = NSPanel(
-            contentRect: CGRect(x: 0, y: 0, width: 10, height: 10),
-            styleMask: [.borderless, .nonactivatingPanel],
-            backing: .buffered,
-            defer: true
-        )
-        panel.isReleasedWhenClosed = false
-        panel.backgroundColor = .clear
-        panel.isOpaque = false
-        panel.ignoresMouseEvents = true
+        panel.ignoresMouseEvents = !draggable
+        panel.isMovableByWindowBackground = draggable
         panel.hasShadow = false
         // Above activation indicator and ghost text so it is always visible during debugging.
         panel.level = NSWindow.Level(rawValue: NSWindow.Level.statusBar.rawValue + 2)

--- a/tabby/UI/MenuBarView.swift
+++ b/tabby/UI/MenuBarView.swift
@@ -22,7 +22,7 @@ struct MenuBarView: View {
     @ObservedObject var foundationModelAvailabilityService: FoundationModelAvailabilityService
     @ObservedObject var suggestionCoordinator: SuggestionCoordinator
     let onOpenSettings: () -> Void
-    let onCheckForUpdates: () -> Void
+    let onReportFeedback: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -199,15 +199,15 @@ struct MenuBarView: View {
             .padding(.bottom, 10)
 
         HStack {
-            Button("Settings…", action: onOpenSettings)
+            Button("Settings", action: onOpenSettings)
                 .buttonStyle(.borderless)
 
-            Button("Check for Updates…", action: onCheckForUpdates)
+            Button("Report Bug / Feedback", action: onReportFeedback)
                 .buttonStyle(.borderless)
 
             Spacer(minLength: 0)
 
-            Button("Quit tabby") {
+            Button("Quit") {
                 NSApplication.shared.terminate(nil)
             }
             .buttonStyle(.borderless)


### PR DESCRIPTION
## Summary
- Renamed "Settings…" to "Settings"
- Replaced "Check for Updates…" with "Report Bug / Feedback" that opens https://www.tabbyapp.dev/feedback in the user's default browser
- Renamed "Quit tabby" to "Quit"

## Test plan
- [ ] Open menu bar panel and verify footer shows "Settings", "Report Bug / Feedback", and "Quit"
- [ ] Click "Report Bug / Feedback" and confirm it opens the feedback form in the default browser
- [ ] Click "Settings" and "Quit" to confirm they still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes two independent sets of changes: it updates the menu bar footer UI (renaming labels and replacing the "Check for Updates" action with a "Report Bug / Feedback" link that opens the tabby feedback page in the browser), and it adds drag-to-reposition support to the debug bottom-status panel in `FocusDebugOverlayController`.

- **Menu bar footer**: Labels renamed to "Settings", "Report Bug / Feedback", and "Quit"; the `onCheckForUpdates` callback is replaced with `onReportFeedback`, which opens `https://www.tabbyapp.dev/feedback` via `NSWorkspace`.
- **Debug overlay**: `makePanel` gains a `draggable` parameter; two new properties (`bottomPanelDraggedOrigin`, `bottomPanelProgrammaticOrigin`) track whether the panel was moved by the user so its position is preserved across re-renders within a session.
- The drag-detection logic — comparing the current frame origin against the last programmatically-set origin — is sound and correctly handles the first-render, drag, and re-render cycle.

<h3>Confidence Score: 4/5</h3>

Safe to merge — changes are UI label renames, a simple URL open action, and a debug-only draggable panel enhancement.

The menu bar and debug overlay changes are straightforward and well-isolated. The only minor rough edge is the force-unwrap on the feedback URL literal in TabbyApp.swift, which is functionally harmless since the URL is a compile-time constant.

No files require special attention. The force-unwrap in TabbyApp.swift is worth cleaning up but does not affect correctness.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tabby/App/Core/TabbyApp.swift | Replaced `onCheckForUpdates` callback with `onReportFeedback`, opening a hardcoded feedback URL via `NSWorkspace`. Force-unwrap on the URL literal is safe but non-idiomatic. |
| tabby/UI/MenuBarView.swift | Straightforward label renames ("Settings", "Report Bug / Feedback", "Quit") and callback rename from `onCheckForUpdates` to `onReportFeedback`. No logic changes. |
| tabby/Services/UI/FocusDebugOverlayController.swift | Added draggable support to the debug bottom-status panel by tracking programmatic vs user-drag origins. Logic is well-structured and gated behind the existing debug flag. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant MenuBarView
    participant TabbyApp
    participant NSWorkspace

    User->>MenuBarView: Click "Report Bug / Feedback"
    MenuBarView->>TabbyApp: onReportFeedback()
    TabbyApp->>NSWorkspace: open(URL("https://www.tabbyapp.dev/feedback"))
    NSWorkspace-->>User: Opens browser at feedback page
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22menu-bar-cleanup%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22menu-bar-cleanup%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atabby%2FApp%2FCore%2FTabbyApp.swift%3A28-30%0AForce-unwrapping%20%60URL%28string%3A%29%60%20on%20a%20string%20literal%20is%20safe%20here%20because%20the%20URL%20is%20a%20valid%20constant%2C%20but%20it%20is%20idiomatic%20Swift%20to%20avoid%20force%20unwraps.%20Defining%20the%20URL%20as%20a%20static%20constant%20makes%20the%20intent%20clearer%20and%20avoids%20the%20unsafe%20operator%20at%20the%20call%20site.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20onReportFeedback%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20The%20URL%20literal%20is%20always%20valid%2C%20but%20if-let%20avoids%20the%20force-unwrap.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20let%20feedbackURL%20%3D%20URL%28string%3A%20%22https%3A%2F%2Fwww.tabbyapp.dev%2Ffeedback%22%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20NSWorkspace.shared.open%28feedbackURL%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atabby%2FApp%2FCore%2FTabbyApp.swift%3A28-30%0AForce-unwrapping%20%60URL%28string%3A%29%60%20on%20a%20string%20literal%20is%20safe%20here%20because%20the%20URL%20is%20a%20valid%20constant%2C%20but%20it%20is%20idiomatic%20Swift%20to%20avoid%20force%20unwraps.%20Defining%20the%20URL%20as%20a%20static%20constant%20makes%20the%20intent%20clearer%20and%20avoids%20the%20unsafe%20operator%20at%20the%20call%20site.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20onReportFeedback%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20The%20URL%20literal%20is%20always%20valid%2C%20but%20if-let%20avoids%20the%20force-unwrap.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20let%20feedbackURL%20%3D%20URL%28string%3A%20%22https%3A%2F%2Fwww.tabbyapp.dev%2Ffeedback%22%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20NSWorkspace.shared.open%28feedbackURL%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=fujacob%2Ftabby&pr=166&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Update menu bar footer: rename items and..."](https://github.com/fujacob/tabby/commit/bee16ee413364217ecf6c5a2c0c15d60ac64574f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33569146)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->