### PR TITLE
Add test coverage for sanitizer, models, layout, and runtime locator

### DIFF
--- a/tabby.xcodeproj/project.pbxproj
+++ b/tabby.xcodeproj/project.pbxproj
@@ -23,6 +23,10 @@
 		C10000062F91000100BBB006 /* ModelAndPresentationValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10000162F91000100BBB016 /* ModelAndPresentationValueTests.swift */; };
 		C10000072F91000100BBB007 /* SuggestionStateHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10000172F91000100BBB017 /* SuggestionStateHelperTests.swift */; };
 		D10000012F92000100CCC001 /* TerminalAppDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000112F92000100CCC011 /* TerminalAppDetectorTests.swift */; };
+		E10000012F93000100DDD001 /* PromptContextSanitizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10000112F93000100DDD011 /* PromptContextSanitizerTests.swift */; };
+		E10000022F93000100DDD002 /* PermissionAndContextModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10000122F93000100DDD012 /* PermissionAndContextModelTests.swift */; };
+		E10000032F93000100DDD003 /* GhostSuggestionLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10000132F93000100DDD013 /* GhostSuggestionLayoutTests.swift */; };
+		E10000042F93000100DDD004 /* BundledRuntimeLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10000142F93000100DDD014 /* BundledRuntimeLocatorTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -52,6 +56,10 @@
 		D10000112F92000100CCC011 /* TerminalAppDetectorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TerminalAppDetectorTests.swift; sourceTree = "<group>"; };
 		F29623C5C0A67B992D383A3C /* LlamaPromptRendererTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LlamaPromptRendererTests.swift; sourceTree = "<group>"; };
 		F9D35DB9E86506B9FAE1CFE9 /* ModelFileValidatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ModelFileValidatorTests.swift; sourceTree = "<group>"; };
+		E10000112F93000100DDD011 /* PromptContextSanitizerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PromptContextSanitizerTests.swift; sourceTree = "<group>"; };
+		E10000122F93000100DDD012 /* PermissionAndContextModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PermissionAndContextModelTests.swift; sourceTree = "<group>"; };
+		E10000132F93000100DDD013 /* GhostSuggestionLayoutTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GhostSuggestionLayoutTests.swift; sourceTree = "<group>"; };
+		E10000142F93000100DDD014 /* BundledRuntimeLocatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BundledRuntimeLocatorTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -117,6 +125,10 @@
 				F9D35DB9E86506B9FAE1CFE9 /* ModelFileValidatorTests.swift */,
 				BAAEE25772008D75883F2655 /* DownloadFileRescuerTests.swift */,
 				D10000112F92000100CCC011 /* TerminalAppDetectorTests.swift */,
+				E10000112F93000100DDD011 /* PromptContextSanitizerTests.swift */,
+				E10000122F93000100DDD012 /* PermissionAndContextModelTests.swift */,
+				E10000132F93000100DDD013 /* GhostSuggestionLayoutTests.swift */,
+				E10000142F93000100DDD014 /* BundledRuntimeLocatorTests.swift */,
 			);
 			path = tabbyTests;
 			sourceTree = "<group>";
@@ -248,6 +260,10 @@
 				AF0F4C853CCA8B86BB5E28CD /* ModelFileValidatorTests.swift in Sources */,
 				B5788B37B93AFEC10EFD3108 /* DownloadFileRescuerTests.swift in Sources */,
 				D10000012F92000100CCC001 /* TerminalAppDetectorTests.swift in Sources */,
+				E10000012F93000100DDD001 /* PromptContextSanitizerTests.swift in Sources */,
+				E10000022F93000100DDD002 /* PermissionAndContextModelTests.swift in Sources */,
+				E10000032F93000100DDD003 /* GhostSuggestionLayoutTests.swift in Sources */,
+				E10000042F93000100DDD004 /* BundledRuntimeLocatorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/tabbyTests/BundledRuntimeLocatorTests.swift
+++ b/tabbyTests/BundledRuntimeLocatorTests.swift
@@ -1,0 +1,206 @@
+import XCTest
+@testable import tabby
+
+final class BundledRuntimeLocatorTests: XCTestCase {
+    private var temporaryDirectories: [URL] = []
+
+    override func tearDown() {
+        for url in temporaryDirectories {
+            try? FileManager.default.removeItem(at: url)
+        }
+        temporaryDirectories.removeAll()
+        super.tearDown()
+    }
+
+    // MARK: - resolve
+
+    func test_resolve_returnsPreferredModelWhenMultipleGGUFsExist() throws {
+        let dir = try makeTemporaryRuntimeDirectory(
+            ggufFilenames: ["alpha.gguf", "beta.gguf", "gamma.gguf"]
+        )
+        let config = makeConfig(runtimePath: dir.path, preferred: ["beta.gguf"])
+        let locator = BundledRuntimeLocator()
+
+        let resolved = try locator.resolve(configuration: config)
+        XCTAssertEqual(resolved.modelFileURL.lastPathComponent, "beta.gguf")
+    }
+
+    func test_resolve_fallsBackToAlphabeticalWhenNoPreferredModelExists() throws {
+        let dir = try makeTemporaryRuntimeDirectory(
+            ggufFilenames: ["charlie.gguf", "alpha.gguf", "bravo.gguf"]
+        )
+        let config = makeConfig(runtimePath: dir.path, preferred: ["nonexistent.gguf"])
+        let locator = BundledRuntimeLocator()
+
+        let resolved = try locator.resolve(configuration: config)
+        XCTAssertEqual(resolved.modelFileURL.lastPathComponent, "alpha.gguf")
+    }
+
+    func test_resolve_selectsExplicitlyNamedModel() throws {
+        let dir = try makeTemporaryRuntimeDirectory(
+            ggufFilenames: ["first.gguf", "second.gguf"]
+        )
+        let config = makeConfig(runtimePath: dir.path, preferred: ["first.gguf"])
+        let locator = BundledRuntimeLocator()
+
+        let resolved = try locator.resolve(
+            configuration: config,
+            selectedModelFilename: "second.gguf"
+        )
+        XCTAssertEqual(resolved.modelFileURL.lastPathComponent, "second.gguf")
+    }
+
+    func test_resolve_throwsNamedModelMissingForNonexistentSelection() throws {
+        let dir = try makeTemporaryRuntimeDirectory(ggufFilenames: ["model.gguf"])
+        let config = makeConfig(runtimePath: dir.path, preferred: [])
+        let locator = BundledRuntimeLocator()
+
+        XCTAssertThrowsError(
+            try locator.resolve(configuration: config, selectedModelFilename: "ghost.gguf")
+        ) { error in
+            guard case BundledRuntimeLocatorError.namedModelMissing = error else {
+                XCTFail("Expected namedModelMissing, got \(error)")
+                return
+            }
+        }
+    }
+
+    func test_resolve_throwsRuntimeDirectoryMissingWhenPathDoesNotExist() {
+        let config = makeConfig(
+            runtimePath: "/tmp/tabby-test-nonexistent-\(UUID().uuidString)",
+            preferred: []
+        )
+        let locator = BundledRuntimeLocator()
+
+        XCTAssertThrowsError(try locator.resolve(configuration: config)) { error in
+            guard case BundledRuntimeLocatorError.runtimeDirectoryMissing = error else {
+                XCTFail("Expected runtimeDirectoryMissing, got \(error)")
+                return
+            }
+        }
+    }
+
+    func test_resolve_throwsModelMissingWhenDirectoryIsEmpty() throws {
+        let dir = try makeTemporaryRuntimeDirectory(ggufFilenames: [])
+        let config = makeConfig(runtimePath: dir.path, preferred: [])
+        let locator = BundledRuntimeLocator()
+
+        XCTAssertThrowsError(try locator.resolve(configuration: config)) { error in
+            guard case BundledRuntimeLocatorError.modelMissing = error else {
+                XCTFail("Expected modelMissing, got \(error)")
+                return
+            }
+        }
+    }
+
+    func test_resolve_ignoresNonGGUFFiles() throws {
+        let dir = try makeTemporaryRuntimeDirectory(ggufFilenames: ["model.gguf"])
+        // Add non-GGUF files
+        FileManager.default.createFile(
+            atPath: dir.appendingPathComponent("readme.txt").path,
+            contents: nil
+        )
+        FileManager.default.createFile(
+            atPath: dir.appendingPathComponent("weights.bin").path,
+            contents: nil
+        )
+        let config = makeConfig(runtimePath: dir.path, preferred: [])
+        let locator = BundledRuntimeLocator()
+
+        let models = locator.availableModels(configuration: config)
+        XCTAssertEqual(models.count, 1)
+        XCTAssertEqual(models.first?.filename, "model.gguf")
+    }
+
+    // MARK: - availableModels
+
+    func test_availableModels_ordersPreferredThenAlphabetical() throws {
+        let dir = try makeTemporaryRuntimeDirectory(
+            ggufFilenames: ["charlie.gguf", "alpha.gguf", "bravo.gguf"]
+        )
+        let config = makeConfig(runtimePath: dir.path, preferred: ["bravo.gguf"])
+        let locator = BundledRuntimeLocator()
+
+        let models = locator.availableModels(configuration: config)
+        let filenames = models.map(\.filename)
+        XCTAssertEqual(filenames, ["bravo.gguf", "alpha.gguf", "charlie.gguf"])
+    }
+
+    func test_availableModels_deduplicatesPreferredAndDiscovered() throws {
+        let dir = try makeTemporaryRuntimeDirectory(
+            ggufFilenames: ["alpha.gguf", "bravo.gguf"]
+        )
+        // alpha.gguf appears in both preferred list and directory
+        let config = makeConfig(runtimePath: dir.path, preferred: ["alpha.gguf"])
+        let locator = BundledRuntimeLocator()
+
+        let models = locator.availableModels(configuration: config)
+        let alphaCount = models.filter { $0.filename == "alpha.gguf" }.count
+        XCTAssertEqual(alphaCount, 1, "Preferred model should not appear twice")
+    }
+
+    func test_availableModels_returnsEmptyArrayWhenDirectoryMissing() {
+        let config = makeConfig(
+            runtimePath: "/tmp/tabby-test-nonexistent-\(UUID().uuidString)",
+            preferred: []
+        )
+        let locator = BundledRuntimeLocator()
+
+        XCTAssertEqual(locator.availableModels(configuration: config), [])
+    }
+
+    func test_resolve_usesExplicitRuntimeDirectoryPathFromConfiguration() throws {
+        let dir = try makeTemporaryRuntimeDirectory(ggufFilenames: ["custom.gguf"])
+        let config = makeConfig(runtimePath: dir.path, preferred: [])
+        let locator = BundledRuntimeLocator()
+
+        let resolved = try locator.resolve(configuration: config)
+        XCTAssertTrue(
+            resolved.runtimeDirectoryURL.path.hasPrefix(dir.path),
+            "Should resolve from the explicit runtime directory"
+        )
+    }
+
+    // MARK: - Error descriptions
+
+    func test_errorDescriptions_areHumanReadable() {
+        let dirError = BundledRuntimeLocatorError.runtimeDirectoryMissing("/some/path")
+        XCTAssertTrue(dirError.errorDescription?.contains("/some/path") ?? false)
+
+        let modelError = BundledRuntimeLocatorError.modelMissing("/models")
+        XCTAssertTrue(modelError.errorDescription?.contains("/models") ?? false)
+
+        let namedError = BundledRuntimeLocatorError.namedModelMissing("test.gguf")
+        XCTAssertTrue(namedError.errorDescription?.contains("test.gguf") ?? false)
+    }
+
+    // MARK: - Helpers
+
+    private func makeTemporaryRuntimeDirectory(ggufFilenames: [String]) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tabby-locator-test-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        temporaryDirectories.append(dir)
+
+        for filename in ggufFilenames {
+            FileManager.default.createFile(
+                atPath: dir.appendingPathComponent(filename).path,
+                contents: nil
+            )
+        }
+        return dir
+    }
+
+    private func makeConfig(
+        runtimePath: String,
+        preferred: [String]
+    ) -> LlamaRuntimeConfiguration {
+        LlamaRuntimeConfiguration(
+            runtimeDirectoryPath: runtimePath,
+            preferredModelNames: preferred,
+            contextWindowTokens: 2048,
+            batchSize: 512,
+            gpuLayerCount: -1
+        )
+    }
+}

--- a/tabbyTests/GhostSuggestionLayoutTests.swift
+++ b/tabbyTests/GhostSuggestionLayoutTests.swift
@@ -1,0 +1,164 @@
+import CoreGraphics
+import XCTest
+@testable import tabby
+
+final class GhostSuggestionLayoutTests: XCTestCase {
+
+    // MARK: - Single-line layout
+
+    func test_make_singleLineLayoutWhenTextFitsFirstLineBudget() {
+        let geometry = TabbyTestFixtures.overlayGeometry(
+            caretRect: CGRect(x: 10, y: 80, width: 2, height: 18),
+            inputFrameRect: CGRect(x: 0, y: 70, width: 400, height: 30),
+            observedCharWidth: 7
+        )
+
+        let layout = GhostSuggestionLayout.make(
+            text: " hi",
+            geometry: geometry,
+            fontSize: 14,
+            visibleFrame: CGRect(x: 0, y: 0, width: 500, height: 300)
+        )
+
+        XCTAssertEqual(layout.lines.count, 1)
+        XCTAssertEqual(layout.lines.first?.showsKeycap, true)
+        XCTAssertEqual(layout.topLineCenterOffsetFromCaret, 0)
+    }
+
+    // MARK: - Multi-line layout
+
+    func test_make_keycapAppearsOnlyOnLastLine() {
+        let geometry = TabbyTestFixtures.overlayGeometry(
+            caretRect: CGRect(x: 10, y: 80, width: 2, height: 18),
+            inputFrameRect: CGRect(x: 0, y: 70, width: 200, height: 30),
+            observedCharWidth: 7
+        )
+
+        let layout = GhostSuggestionLayout.make(
+            text: " alpha beta gamma delta epsilon zeta eta theta iota",
+            geometry: geometry,
+            fontSize: 14,
+            visibleFrame: CGRect(x: 0, y: 0, width: 500, height: 300)
+        )
+
+        XCTAssertGreaterThan(layout.lines.count, 1, "Should wrap to multiple lines")
+        for line in layout.lines.dropLast() {
+            XCTAssertFalse(line.showsKeycap, "Non-last lines should not show keycap")
+        }
+        XCTAssertEqual(layout.lines.last?.showsKeycap, true)
+    }
+
+    // MARK: - Word boundary splitting
+
+    func test_make_splitsAtWordBoundaryWhenTextExceedsBudget() {
+        // Use a narrow input so text must wrap, with observedCharWidth for determinism
+        let geometry = TabbyTestFixtures.overlayGeometry(
+            caretRect: CGRect(x: 10, y: 80, width: 2, height: 18),
+            inputFrameRect: CGRect(x: 0, y: 70, width: 140, height: 30),
+            observedCharWidth: 7
+        )
+
+        let layout = GhostSuggestionLayout.make(
+            text: " hello world testing",
+            geometry: geometry,
+            fontSize: 14,
+            visibleFrame: CGRect(x: 0, y: 0, width: 500, height: 300)
+        )
+
+        XCTAssertGreaterThan(layout.lines.count, 1)
+        // Lines should break at word boundaries, not mid-word
+        for line in layout.lines {
+            let trimmed = line.text.trimmingCharacters(in: .whitespaces)
+            XCTAssertFalse(trimmed.isEmpty, "No line should be empty after splitting")
+        }
+    }
+
+    func test_make_splitsAtCharacterLevelWhenNoWhitespaceExists() {
+        let geometry = TabbyTestFixtures.overlayGeometry(
+            caretRect: CGRect(x: 10, y: 80, width: 2, height: 18),
+            inputFrameRect: CGRect(x: 0, y: 70, width: 120, height: 30),
+            observedCharWidth: 7
+        )
+
+        // A single long token with no spaces
+        let layout = GhostSuggestionLayout.make(
+            text: " abcdefghijklmnopqrstuvwxyz",
+            geometry: geometry,
+            fontSize: 14,
+            visibleFrame: CGRect(x: 0, y: 0, width: 500, height: 300)
+        )
+
+        XCTAssertGreaterThan(layout.lines.count, 1, "Long token should be split across lines")
+    }
+
+    // MARK: - startsBelowCaret
+
+    func test_make_startsBelowCaretWhenFirstLineBudgetIsTooSmall() {
+        // Place caret near the right edge of a narrow input
+        let geometry = TabbyTestFixtures.overlayGeometry(
+            caretRect: CGRect(x: 130, y: 80, width: 2, height: 18),
+            inputFrameRect: CGRect(x: 0, y: 70, width: 140, height: 30),
+            observedCharWidth: 7
+        )
+
+        let layout = GhostSuggestionLayout.make(
+            text: " hello world overflow text here",
+            geometry: geometry,
+            fontSize: 14,
+            visibleFrame: CGRect(x: 0, y: 0, width: 500, height: 300)
+        )
+
+        XCTAssertLessThan(
+            layout.topLineCenterOffsetFromCaret, 0,
+            "Should start below caret when first line budget is too small"
+        )
+        XCTAssertEqual(layout.lines.first?.leadingIndent, 0)
+    }
+
+    // MARK: - panelFrame
+
+    func test_panelFrame_positionsRelativeToCaret() {
+        let geometry = TabbyTestFixtures.overlayGeometry(
+            caretRect: CGRect(x: 50, y: 100, width: 2, height: 18),
+            inputFrameRect: CGRect(x: 0, y: 90, width: 400, height: 30),
+            observedCharWidth: 7
+        )
+
+        let layout = GhostSuggestionLayout.make(
+            text: " short",
+            geometry: geometry,
+            fontSize: 14,
+            visibleFrame: CGRect(x: 0, y: 0, width: 500, height: 300)
+        )
+
+        let caretRect = CGRect(x: 50, y: 100, width: 2, height: 18)
+        let contentSize = CGSize(width: 100, height: 20)
+        let frame = layout.panelFrame(for: contentSize, caretRect: caretRect)
+
+        // Panel X should match panelOriginX
+        XCTAssertEqual(frame.origin.x, layout.panelOriginX)
+        // Panel should be vertically centered around the caret midY
+        let expectedTopCenter = caretRect.midY + layout.topLineCenterOffsetFromCaret
+        let expectedY = expectedTopCenter - contentSize.height + (layout.lineHeight / 2)
+        XCTAssertEqual(frame.origin.y, expectedY)
+    }
+
+    // MARK: - Fallback to visible frame
+
+    func test_make_usesVisibleFrameFallbackWhenNoInputFrame() {
+        let geometry = TabbyTestFixtures.overlayGeometry(
+            caretRect: CGRect(x: 50, y: 100, width: 2, height: 18),
+            inputFrameRect: nil,
+            observedCharWidth: 7
+        )
+
+        let layout = GhostSuggestionLayout.make(
+            text: " some text here",
+            geometry: geometry,
+            fontSize: 14,
+            visibleFrame: CGRect(x: 0, y: 0, width: 500, height: 300)
+        )
+
+        XCTAssertFalse(layout.lines.isEmpty, "Should still produce lines without an input frame")
+    }
+}

--- a/tabbyTests/PermissionAndContextModelTests.swift
+++ b/tabbyTests/PermissionAndContextModelTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+@testable import tabby
+
+final class TabbyPermissionKindTests: XCTestCase {
+
+    func test_allCases_containsExactlyThreePermissions() {
+        XCTAssertEqual(TabbyPermissionKind.allCases.count, 3)
+    }
+
+    func test_rawValues_matchExpectedPrivacyKeys() {
+        XCTAssertEqual(TabbyPermissionKind.accessibility.rawValue, "Privacy_Accessibility")
+        XCTAssertEqual(TabbyPermissionKind.inputMonitoring.rawValue, "Privacy_ListenEvent")
+        XCTAssertEqual(TabbyPermissionKind.screenRecording.rawValue, "Privacy_ScreenCapture")
+    }
+
+    func test_allCases_haveTitles() {
+        for kind in TabbyPermissionKind.allCases {
+            XCTAssertFalse(kind.title.isEmpty, "\(kind) should have a non-empty title")
+        }
+        XCTAssertEqual(TabbyPermissionKind.accessibility.title, "Accessibility")
+        XCTAssertEqual(TabbyPermissionKind.inputMonitoring.title, "Input Monitoring")
+        XCTAssertEqual(TabbyPermissionKind.screenRecording.title, "Screen Recording")
+    }
+
+    func test_allCases_haveSystemImageNames() {
+        for kind in TabbyPermissionKind.allCases {
+            XCTAssertFalse(
+                kind.systemImageName.isEmpty,
+                "\(kind) should have a non-empty systemImageName"
+            )
+        }
+    }
+
+    func test_allCases_haveOnboardingSubtitles() {
+        for kind in TabbyPermissionKind.allCases {
+            XCTAssertFalse(
+                kind.onboardingSubtitle.isEmpty,
+                "\(kind) should have a non-empty onboardingSubtitle"
+            )
+        }
+    }
+
+    func test_settingsURL_usesExpectedDeepLinkFormat() {
+        for kind in TabbyPermissionKind.allCases {
+            let expected = "x-apple.systempreferences:com.apple.preference.security?\(kind.rawValue)"
+            XCTAssertEqual(kind.settingsURL.absoluteString, expected)
+        }
+    }
+
+    func test_guidanceStyle_isGuidedOverlayForAllCases() {
+        for kind in TabbyPermissionKind.allCases {
+            XCTAssertEqual(kind.guidanceStyle, .guidedOverlay)
+        }
+    }
+
+    func test_isRequiredForAutocomplete_isTrueForAllCases() {
+        for kind in TabbyPermissionKind.allCases {
+            XCTAssertTrue(
+                kind.isRequiredForAutocomplete,
+                "\(kind) should be required for autocomplete"
+            )
+        }
+    }
+
+    func test_guidanceHint_isNonEmptyForAllCases() {
+        for kind in TabbyPermissionKind.allCases {
+            XCTAssertFalse(
+                kind.guidanceHint.isEmpty,
+                "\(kind) should have a non-empty guidanceHint"
+            )
+        }
+    }
+}
+
+final class VisualContextModelTests: XCTestCase {
+
+    func test_status_detail_returnsNonEmptyStringForEachCase() {
+        let cases: [VisualContextStatus] = [
+            .idle, .capturing, .extractingText, .summarizingText, .ready,
+            .unavailable("no permission"), .failed("timeout")
+        ]
+        let details = cases.map(\.detail)
+        for detail in details {
+            XCTAssertFalse(detail.isEmpty)
+        }
+        // All distinct
+        XCTAssertEqual(Set(details).count, details.count, "Each status case should have a unique detail")
+    }
+
+    func test_status_unavailableAndFailed_includeAssociatedReasonInDetail() {
+        let reason = "Screen recording denied"
+        XCTAssertEqual(VisualContextStatus.unavailable(reason).detail, reason)
+        XCTAssertEqual(VisualContextStatus.failed(reason).detail, reason)
+    }
+
+    func test_defaultConfiguration_hasExpectedValues() {
+        let config = VisualContextConfiguration.default
+        XCTAssertEqual(config.snapshotDimension, 500)
+        XCTAssertEqual(config.maxImageDimension, 900)
+        XCTAssertEqual(config.minRecognizedCharacterCount, 12)
+        XCTAssertEqual(config.maxRecognizedCharacters, 2000)
+        XCTAssertEqual(config.maxSummaryCharacters, 900)
+    }
+
+    func test_focusedInputAugmentationSession_equatableConformance() {
+        let id = UUID()
+        let sessionA = FocusedInputAugmentationSession(
+            sessionID: id,
+            elementIdentifier: "field1",
+            focusChangeSequence: 1,
+            status: .idle,
+            excerpt: nil
+        )
+        var sessionB = FocusedInputAugmentationSession(
+            sessionID: id,
+            elementIdentifier: "field1",
+            focusChangeSequence: 1,
+            status: .idle,
+            excerpt: nil
+        )
+        XCTAssertEqual(sessionA, sessionB)
+
+        sessionB.status = .ready
+        XCTAssertNotEqual(sessionA, sessionB)
+    }
+}

--- a/tabbyTests/PromptContextSanitizerTests.swift
+++ b/tabbyTests/PromptContextSanitizerTests.swift
@@ -1,0 +1,125 @@
+import XCTest
+@testable import tabby
+
+final class PromptContextSanitizerTests: XCTestCase {
+
+    // MARK: - sanitize
+
+    func test_sanitize_stripsANSIEscapeSequences() {
+        let input = "\u{001B}[31mERROR\u{001B}[0m something broke"
+        let result = PromptContextSanitizer.sanitize(input)
+        XCTAssertFalse(result.contains("\u{001B}"))
+        XCTAssertTrue(result.contains("ERROR"))
+        XCTAssertTrue(result.contains("something broke"))
+    }
+
+    func test_sanitize_replacesDisallowedUnicodeWithSpacesPreservingWordBoundaries() {
+        let result = PromptContextSanitizer.sanitize("raw-output")
+        XCTAssertEqual(result, "raw output")
+    }
+
+    func test_sanitize_collapsesRepeatedWhitespaceIntoSingleSpaces() {
+        let result = PromptContextSanitizer.sanitize("hello    world")
+        XCTAssertEqual(result, "hello world")
+    }
+
+    func test_sanitize_filtersEmptyAndWhitespaceOnlyLines() {
+        let input = "first\n   \n\nsecond"
+        let result = PromptContextSanitizer.sanitize(input)
+        XCTAssertEqual(result, "first\nsecond")
+    }
+
+    func test_sanitize_respectsMaxCharactersLimit() {
+        let input = "abcdefghij"
+        let result = PromptContextSanitizer.sanitize(input, maxCharacters: 5)
+        XCTAssertEqual(result, "abcde")
+    }
+
+    func test_sanitize_returnsFullInputWhenMaxCharactersEqualsLength() {
+        let input = "hello"
+        let result = PromptContextSanitizer.sanitize(input, maxCharacters: 5)
+        XCTAssertEqual(result, "hello")
+    }
+
+    func test_sanitize_returnsEmptyStringForWhitespaceOnlyInput() {
+        XCTAssertEqual(PromptContextSanitizer.sanitize("   \n  \n  "), "")
+    }
+
+    func test_sanitize_returnsEmptyStringForEmptyInput() {
+        XCTAssertEqual(PromptContextSanitizer.sanitize(""), "")
+    }
+
+    func test_sanitize_preservesAllowedCharacters() {
+        let input = "Hello world 123 user@host.com"
+        let result = PromptContextSanitizer.sanitize(input)
+        XCTAssertEqual(result, input)
+    }
+
+    func test_sanitize_handlesANSIMixedWithRealText() {
+        let input = "\u{001B}[32mHello\u{001B}[0m world"
+        let result = PromptContextSanitizer.sanitize(input)
+        XCTAssertEqual(result, "Hello world")
+    }
+
+    // MARK: - sanitizeOCR
+
+    func test_sanitizeOCR_dropsStandaloneNumbers() {
+        let input = "hello 50 world 424"
+        let result = PromptContextSanitizer.sanitizeOCR(input)
+        XCTAssertFalse(result.contains("50"))
+        XCTAssertFalse(result.contains("424"))
+        XCTAssertTrue(result.contains("hello"))
+        XCTAssertTrue(result.contains("world"))
+    }
+
+    func test_sanitizeOCR_dropsShortNoiseTokensButKeepsPreservedWords() {
+        // "I" and "if" are in the preserved set; "x" is not
+        let input = "I like if x"
+        let result = PromptContextSanitizer.sanitizeOCR(input)
+        XCTAssertTrue(result.contains("I"))
+        XCTAssertTrue(result.contains("if"))
+        XCTAssertTrue(result.contains("like"))
+        XCTAssertFalse(result.contains(" x"))
+    }
+
+    func test_sanitizeOCR_dropsLineWhenMajorityTokensAreNoise() {
+        // 3 of 4 tokens are noise (>50%): "50", "x", "99" — only "hello" survives
+        let input = "50 x 99 hello"
+        let result = PromptContextSanitizer.sanitizeOCR(input)
+        XCTAssertEqual(result, "")
+    }
+
+    func test_sanitizeOCR_keepsLineWhenHalfOrMoreTokensSurvive() {
+        // 2 of 4 tokens survive (exactly 50%): kept.count * 2 >= tokens.count
+        let input = "hello world 50 99"
+        let result = PromptContextSanitizer.sanitizeOCR(input)
+        XCTAssertTrue(result.contains("hello"))
+        XCTAssertTrue(result.contains("world"))
+    }
+
+    func test_sanitizeOCR_respectsMaxCharacters() {
+        let input = "alpha beta gamma delta epsilon"
+        let result = PromptContextSanitizer.sanitizeOCR(input, maxCharacters: 10)
+        XCTAssertLessThanOrEqual(result.count, 10)
+    }
+
+    func test_sanitizeOCR_returnsEmptyForAllNoiseInput() {
+        let input = "50 424 102 99"
+        let result = PromptContextSanitizer.sanitizeOCR(input)
+        XCTAssertEqual(result, "")
+    }
+
+    // MARK: - containsAlphanumericSignal
+
+    func test_containsAlphanumericSignal_returnsTrueForMixedInput() {
+        XCTAssertTrue(PromptContextSanitizer.containsAlphanumericSignal("---a---"))
+    }
+
+    func test_containsAlphanumericSignal_returnsFalseForPureSymbols() {
+        XCTAssertFalse(PromptContextSanitizer.containsAlphanumericSignal("--- ---"))
+    }
+
+    func test_containsAlphanumericSignal_returnsFalseForEmptyString() {
+        XCTAssertFalse(PromptContextSanitizer.containsAlphanumericSignal(""))
+    }
+}


### PR DESCRIPTION
## Summary
- Adds 4 new test files (~52 tests) covering the highest-value pure-logic gaps from the test coverage audit
- **PromptContextSanitizerTests** — ANSI stripping, OCR noise filtering, character limits, whitespace handling
- **PermissionAndContextModelTests** — permission enum metadata, settings URLs, visual context status details, config defaults
- **GhostSuggestionLayoutTests** — word/char boundary splitting, startsBelowCaret, keycap placement, panel positioning, fallback frames
- **BundledRuntimeLocatorTests** — model discovery ordering, preferred/explicit selection, error cases, deduplication (uses temp directories)
- No source code changes — test-only PR with pbxproj registration

## Test plan
- [x] SwiftLint passes with no warnings
- [x] `xcodebuild build-for-testing` succeeds
- [ ] `xcodebuild test` — blocked by pre-existing Team ID signing mismatch (affects all tests, not just new ones). Run tests from Xcode IDE to verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a test-only PR that adds 52 tests across four new files, targeting the highest-value pure-logic gaps identified in a coverage audit: prompt sanitization, bundled runtime model resolution, ghost-text layout, and permission/visual-context model metadata. No production source code is changed.

- **`PromptContextSanitizerTests`** and **`BundledRuntimeLocatorTests`** are thorough and their assertions are fully consistent with the source implementations, including error-case discrimination and deduplication ordering.
- **`GhostSuggestionLayoutTests`** and **`PermissionAndContextModelTests`** have minor assertion gaps: one layout test claims to verify word-boundary splitting but its checks are too weak to catch mid-word breaks, and the `VisualContextStatus` case list is manually enumerated without a guard that would surface a newly added case.

<h3>Confidence Score: 4/5</h3>

Safe to merge — no production source is touched and all new tests compile and build cleanly against the current source.

The sanitizer and runtime-locator tests are well-constructed and their assertions match the source behavior precisely. The layout and model tests have two minor gaps: one layout test does not actually verify the word-boundary contract it names, and the VisualContextStatus coverage relies on a manually maintained case list with no self-enforcing guard. These are refinement opportunities, not correctness failures.

tabbyTests/GhostSuggestionLayoutTests.swift (word-boundary assertion) and tabbyTests/PermissionAndContextModelTests.swift (hardcoded VisualContextStatus case list)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tabbyTests/PromptContextSanitizerTests.swift | 25 tests covering ANSI stripping, OCR noise filtering, whitespace collapsing, and alphanumeric signal detection; all assertions verified against the source implementation. |
| tabbyTests/BundledRuntimeLocatorTests.swift | 14 tests covering model discovery ordering, preferred/explicit selection, deduplication, error cases, and runtime directory handling using real temp directories; logic aligns with source. |
| tabbyTests/GhostSuggestionLayoutTests.swift | 8 layout tests covering single-line, multi-line, word/char boundary splitting, startsBelowCaret, panelFrame, and fallback; one test claims to verify word-boundary splits but assertions are too weak to catch mid-word breaks. |
| tabbyTests/PermissionAndContextModelTests.swift | Two test classes covering enum metadata, settings URLs, status detail strings, config defaults, and equatability; VisualContextStatus case list is manually enumerated without CaseIterable coverage. |
| tabby.xcodeproj/project.pbxproj | Registers the four new test files in PBXBuildFile, PBXFileReference, group membership, and Sources build phase; IDs follow the same sequential pattern used in prior test additions. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Tests["tabbyTests/ (new files)"]
        PST["PromptContextSanitizerTests\n25 tests"]
        BRL["BundledRuntimeLocatorTests\n14 tests"]
        GSL["GhostSuggestionLayoutTests\n8 tests"]
        PCM["PermissionAndContextModelTests\n~12 tests"]
    end
    subgraph Support["tabby/Support/"]
        PS["PromptContextSanitizer"]
        BRLSrc["BundledRuntimeLocator"]
        GSLSrc["GhostSuggestionLayout"]
    end
    subgraph Models["tabby/Models/"]
        PM["PermissionModels"]
        VCM["VisualContextModels"]
    end
    PST -->|"sanitize / sanitizeOCR"| PS
    BRL -->|"resolve / availableModels"| BRLSrc
    GSL -->|"make / panelFrame"| GSLSrc
    PCM --> PM
    PCM --> VCM
    Fixtures["TabbyTestFixtures"]
    GSL -->|uses| Fixtures
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22test-coverage-sweep%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22test-coverage-sweep%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0AtabbyTests%2FGhostSuggestionLayoutTests.swift%3A68-73%0AThe%20test%20name%20claims%20to%20verify%20word-boundary%20splitting%2C%20but%20the%20only%20assertions%20are%20%60lines.count%20%3E%201%60%20and%20no%20line%20is%20empty%20%E2%80%94%20a%20character-level%20mid-word%20break%20%28e.g.%20%22hello%20wo%22%20%2F%20%22rld%20testing%22%29%20would%20pass%20them%20too.%20Pinning%20the%20actual%20line%20content%20locks%20in%20the%20word-boundary%20contract%20and%20prevents%20a%20regression%20in%20%60splitPrefix%60%20from%20silently%20passing.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20XCTAssertGreaterThan%28layout.lines.count%2C%201%29%0A%20%20%20%20%20%20%20%20%2F%2F%20Lines%20should%20break%20at%20word%20boundaries%2C%20not%20mid-word%0A%20%20%20%20%20%20%20%20for%20line%20in%20layout.lines%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20let%20trimmed%20%3D%20line.text.trimmingCharacters%28in%3A%20.whitespaces%29%0A%20%20%20%20%20%20%20%20%20%20%20%20XCTAssertFalse%28trimmed.isEmpty%2C%20%22No%20line%20should%20be%20empty%20after%20splitting%22%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%2F%2F%20Verify%20the%20first-line%20content%20is%20a%20whole-word%20prefix%2C%20not%20a%20mid-word%20break.%0A%20%20%20%20%20%20%20%20%2F%2F%20With%20observedCharWidth%3D7%20and%20firstLineBudget%E2%89%8880px%20the%20first%20line%20should%20hold%0A%20%20%20%20%20%20%20%20%2F%2F%20%22hello%20world%22%20%2811%20chars%20%C3%97%207%20%3D%2077%20px%29%20but%20not%20%22hello%20world%20t%22%20%2891%20px%29.%0A%20%20%20%20%20%20%20%20XCTAssertEqual%28layout.lines.first%3F.text%2C%20%22hello%20world%22%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0AtabbyTests%2FPermissionAndContextModelTests.swift%3A77-88%0A%60VisualContextStatus%60%20is%20not%20%60CaseIterable%60%2C%20so%20this%20test%20manually%20enumerates%20all%20seven%20cases.%20If%20a%20new%20case%20is%20added%20without%20a%20non-empty%20%60.detail%60%20return%2C%20nothing%20here%20will%20catch%20it.%20Adding%20a%20sentinel%20count%20assertion%20makes%20the%20staleness%20explicit.%0A%0A%60%60%60suggestion%0A%20%20%20%20func%20test_status_detail_returnsNonEmptyStringForEachCase%28%29%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20VisualContextStatus%20is%20not%20CaseIterable%3B%20keep%20this%20list%20in%20sync%20with%20the%20enum.%0A%20%20%20%20%20%20%20%20let%20cases%3A%20%5BVisualContextStatus%5D%20%3D%20%5B%0A%20%20%20%20%20%20%20%20%20%20%20%20.idle%2C%20.capturing%2C%20.extractingText%2C%20.summarizingText%2C%20.ready%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20.unavailable%28%22no%20permission%22%29%2C%20.failed%28%22timeout%22%29%0A%20%20%20%20%20%20%20%20%5D%0A%20%20%20%20%20%20%20%20XCTAssertEqual%28cases.count%2C%207%2C%20%22Update%20this%20test%20when%20VisualContextStatus%20cases%20change%22%29%0A%20%20%20%20%20%20%20%20let%20details%20%3D%20cases.map%28%5C.detail%29%0A%20%20%20%20%20%20%20%20for%20detail%20in%20details%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20XCTAssertFalse%28detail.isEmpty%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%2F%2F%20All%20distinct%0A%20%20%20%20%20%20%20%20XCTAssertEqual%28Set%28details%29.count%2C%20details.count%2C%20%22Each%20status%20case%20should%20have%20a%20unique%20detail%22%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0AtabbyTests%2FGhostSuggestionLayoutTests.swift%3A68-73%0AThe%20test%20name%20claims%20to%20verify%20word-boundary%20splitting%2C%20but%20the%20only%20assertions%20are%20%60lines.count%20%3E%201%60%20and%20no%20line%20is%20empty%20%E2%80%94%20a%20character-level%20mid-word%20break%20%28e.g.%20%22hello%20wo%22%20%2F%20%22rld%20testing%22%29%20would%20pass%20them%20too.%20Pinning%20the%20actual%20line%20content%20locks%20in%20the%20word-boundary%20contract%20and%20prevents%20a%20regression%20in%20%60splitPrefix%60%20from%20silently%20passing.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20XCTAssertGreaterThan%28layout.lines.count%2C%201%29%0A%20%20%20%20%20%20%20%20%2F%2F%20Lines%20should%20break%20at%20word%20boundaries%2C%20not%20mid-word%0A%20%20%20%20%20%20%20%20for%20line%20in%20layout.lines%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20let%20trimmed%20%3D%20line.text.trimmingCharacters%28in%3A%20.whitespaces%29%0A%20%20%20%20%20%20%20%20%20%20%20%20XCTAssertFalse%28trimmed.isEmpty%2C%20%22No%20line%20should%20be%20empty%20after%20splitting%22%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%2F%2F%20Verify%20the%20first-line%20content%20is%20a%20whole-word%20prefix%2C%20not%20a%20mid-word%20break.%0A%20%20%20%20%20%20%20%20%2F%2F%20With%20observedCharWidth%3D7%20and%20firstLineBudget%E2%89%8880px%20the%20first%20line%20should%20hold%0A%20%20%20%20%20%20%20%20%2F%2F%20%22hello%20world%22%20%2811%20chars%20%C3%97%207%20%3D%2077%20px%29%20but%20not%20%22hello%20world%20t%22%20%2891%20px%29.%0A%20%20%20%20%20%20%20%20XCTAssertEqual%28layout.lines.first%3F.text%2C%20%22hello%20world%22%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0AtabbyTests%2FPermissionAndContextModelTests.swift%3A77-88%0A%60VisualContextStatus%60%20is%20not%20%60CaseIterable%60%2C%20so%20this%20test%20manually%20enumerates%20all%20seven%20cases.%20If%20a%20new%20case%20is%20added%20without%20a%20non-empty%20%60.detail%60%20return%2C%20nothing%20here%20will%20catch%20it.%20Adding%20a%20sentinel%20count%20assertion%20makes%20the%20staleness%20explicit.%0A%0A%60%60%60suggestion%0A%20%20%20%20func%20test_status_detail_returnsNonEmptyStringForEachCase%28%29%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20VisualContextStatus%20is%20not%20CaseIterable%3B%20keep%20this%20list%20in%20sync%20with%20the%20enum.%0A%20%20%20%20%20%20%20%20let%20cases%3A%20%5BVisualContextStatus%5D%20%3D%20%5B%0A%20%20%20%20%20%20%20%20%20%20%20%20.idle%2C%20.capturing%2C%20.extractingText%2C%20.summarizingText%2C%20.ready%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20.unavailable%28%22no%20permission%22%29%2C%20.failed%28%22timeout%22%29%0A%20%20%20%20%20%20%20%20%5D%0A%20%20%20%20%20%20%20%20XCTAssertEqual%28cases.count%2C%207%2C%20%22Update%20this%20test%20when%20VisualContextStatus%20cases%20change%22%29%0A%20%20%20%20%20%20%20%20let%20details%20%3D%20cases.map%28%5C.detail%29%0A%20%20%20%20%20%20%20%20for%20detail%20in%20details%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20XCTAssertFalse%28detail.isEmpty%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%2F%2F%20All%20distinct%0A%20%20%20%20%20%20%20%20XCTAssertEqual%28Set%28details%29.count%2C%20details.count%2C%20%22Each%20status%20case%20should%20have%20a%20unique%20detail%22%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=fujacob%2Ftabby&pr=172&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add tests for PromptContextSanitizer, mo..."](https://github.com/fujacob/tabby/commit/177a24ffdf6302283c9d8d3cb0c2bbc1a4bff796) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33570934)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->