### PR TITLE
Fix unused 'self' binding in FoundationModelAvailabilityService

### DIFF
--- a/tabby.xcodeproj/project.pbxproj
+++ b/tabby.xcodeproj/project.pbxproj
@@ -23,6 +23,10 @@
 		C10000062F91000100BBB006 /* ModelAndPresentationValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10000162F91000100BBB016 /* ModelAndPresentationValueTests.swift */; };
 		C10000072F91000100BBB007 /* SuggestionStateHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10000172F91000100BBB017 /* SuggestionStateHelperTests.swift */; };
 		D10000012F92000100CCC001 /* TerminalAppDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000112F92000100CCC011 /* TerminalAppDetectorTests.swift */; };
+		E10000012F93000100DDD001 /* PromptContextSanitizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10000112F93000100DDD011 /* PromptContextSanitizerTests.swift */; };
+		E10000022F93000100DDD002 /* PermissionAndContextModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10000122F93000100DDD012 /* PermissionAndContextModelTests.swift */; };
+		E10000032F93000100DDD003 /* GhostSuggestionLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10000132F93000100DDD013 /* GhostSuggestionLayoutTests.swift */; };
+		E10000042F93000100DDD004 /* BundledRuntimeLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10000142F93000100DDD014 /* BundledRuntimeLocatorTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -52,6 +56,10 @@
 		D10000112F92000100CCC011 /* TerminalAppDetectorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TerminalAppDetectorTests.swift; sourceTree = "<group>"; };
 		F29623C5C0A67B992D383A3C /* LlamaPromptRendererTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LlamaPromptRendererTests.swift; sourceTree = "<group>"; };
 		F9D35DB9E86506B9FAE1CFE9 /* ModelFileValidatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ModelFileValidatorTests.swift; sourceTree = "<group>"; };
+		E10000112F93000100DDD011 /* PromptContextSanitizerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PromptContextSanitizerTests.swift; sourceTree = "<group>"; };
+		E10000122F93000100DDD012 /* PermissionAndContextModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PermissionAndContextModelTests.swift; sourceTree = "<group>"; };
+		E10000132F93000100DDD013 /* GhostSuggestionLayoutTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GhostSuggestionLayoutTests.swift; sourceTree = "<group>"; };
+		E10000142F93000100DDD014 /* BundledRuntimeLocatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BundledRuntimeLocatorTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -117,6 +125,10 @@
 				F9D35DB9E86506B9FAE1CFE9 /* ModelFileValidatorTests.swift */,
 				BAAEE25772008D75883F2655 /* DownloadFileRescuerTests.swift */,
 				D10000112F92000100CCC011 /* TerminalAppDetectorTests.swift */,
+				E10000112F93000100DDD011 /* PromptContextSanitizerTests.swift */,
+				E10000122F93000100DDD012 /* PermissionAndContextModelTests.swift */,
+				E10000132F93000100DDD013 /* GhostSuggestionLayoutTests.swift */,
+				E10000142F93000100DDD014 /* BundledRuntimeLocatorTests.swift */,
 			);
 			path = tabbyTests;
 			sourceTree = "<group>";
@@ -248,6 +260,10 @@
 				AF0F4C853CCA8B86BB5E28CD /* ModelFileValidatorTests.swift in Sources */,
 				B5788B37B93AFEC10EFD3108 /* DownloadFileRescuerTests.swift in Sources */,
 				D10000012F92000100CCC001 /* TerminalAppDetectorTests.swift in Sources */,
+				E10000012F93000100DDD001 /* PromptContextSanitizerTests.swift in Sources */,
+				E10000022F93000100DDD002 /* PermissionAndContextModelTests.swift in Sources */,
+				E10000032F93000100DDD003 /* GhostSuggestionLayoutTests.swift in Sources */,
+				E10000042F93000100DDD004 /* BundledRuntimeLocatorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/tabby/Services/Runtime/FoundationModelAvailabilityService.swift
+++ b/tabby/Services/Runtime/FoundationModelAvailabilityService.swift
@@ -182,7 +182,7 @@ private final class SystemFoundationModelAvailabilityProvider: FoundationModelAv
                         _ = observedModel.availability
                     } onChange: {
                         Task { @MainActor in
-                            guard let self else {
+                            guard self != nil else {
                                 continuation.resume(returning: nil)
                                 return
                             }

--- a/tabbyTests/BundledRuntimeLocatorTests.swift
+++ b/tabbyTests/BundledRuntimeLocatorTests.swift
@@ -1,0 +1,206 @@
+import XCTest
+@testable import tabby
+
+final class BundledRuntimeLocatorTests: XCTestCase {
+    private var temporaryDirectories: [URL] = []
+
+    override func tearDown() {
+        for url in temporaryDirectories {
+            try? FileManager.default.removeItem(at: url)
+        }
+        temporaryDirectories.removeAll()
+        super.tearDown()
+    }
+
+    // MARK: - resolve
+
+    func test_resolve_returnsPreferredModelWhenMultipleGGUFsExist() throws {
+        let dir = try makeTemporaryRuntimeDirectory(
+            ggufFilenames: ["alpha.gguf", "beta.gguf", "gamma.gguf"]
+        )
+        let config = makeConfig(runtimePath: dir.path, preferred: ["beta.gguf"])
+        let locator = BundledRuntimeLocator()
+
+        let resolved = try locator.resolve(configuration: config)
+        XCTAssertEqual(resolved.modelFileURL.lastPathComponent, "beta.gguf")
+    }
+
+    func test_resolve_fallsBackToAlphabeticalWhenNoPreferredModelExists() throws {
+        let dir = try makeTemporaryRuntimeDirectory(
+            ggufFilenames: ["charlie.gguf", "alpha.gguf", "bravo.gguf"]
+        )
+        let config = makeConfig(runtimePath: dir.path, preferred: ["nonexistent.gguf"])
+        let locator = BundledRuntimeLocator()
+
+        let resolved = try locator.resolve(configuration: config)
+        XCTAssertEqual(resolved.modelFileURL.lastPathComponent, "alpha.gguf")
+    }
+
+    func test_resolve_selectsExplicitlyNamedModel() throws {
+        let dir = try makeTemporaryRuntimeDirectory(
+            ggufFilenames: ["first.gguf", "second.gguf"]
+        )
+        let config = makeConfig(runtimePath: dir.path, preferred: ["first.gguf"])
+        let locator = BundledRuntimeLocator()
+
+        let resolved = try locator.resolve(
+            configuration: config,
+            selectedModelFilename: "second.gguf"
+        )
+        XCTAssertEqual(resolved.modelFileURL.lastPathComponent, "second.gguf")
+    }
+
+    func test_resolve_throwsNamedModelMissingForNonexistentSelection() throws {
+        let dir = try makeTemporaryRuntimeDirectory(ggufFilenames: ["model.gguf"])
+        let config = makeConfig(runtimePath: dir.path, preferred: [])
+        let locator = BundledRuntimeLocator()
+
+        XCTAssertThrowsError(
+            try locator.resolve(configuration: config, selectedModelFilename: "ghost.gguf")
+        ) { error in
+            guard case BundledRuntimeLocatorError.namedModelMissing = error else {
+                XCTFail("Expected namedModelMissing, got \(error)")
+                return
+            }
+        }
+    }
+
+    func test_resolve_throwsRuntimeDirectoryMissingWhenPathDoesNotExist() {
+        let config = makeConfig(
+            runtimePath: "/tmp/tabby-test-nonexistent-\(UUID().uuidString)",
+            preferred: []
+        )
+        let locator = BundledRuntimeLocator()
+
+        XCTAssertThrowsError(try locator.resolve(configuration: config)) { error in
+            guard case BundledRuntimeLocatorError.runtimeDirectoryMissing = error else {
+                XCTFail("Expected runtimeDirectoryMissing, got \(error)")
+                return
+            }
+        }
+    }
+
+    func test_resolve_throwsModelMissingWhenDirectoryIsEmpty() throws {
+        let dir = try makeTemporaryRuntimeDirectory(ggufFilenames: [])
+        let config = makeConfig(runtimePath: dir.path, preferred: [])
+        let locator = BundledRuntimeLocator()
+
+        XCTAssertThrowsError(try locator.resolve(configuration: config)) { error in
+            guard case BundledRuntimeLocatorError.modelMissing = error else {
+                XCTFail("Expected modelMissing, got \(error)")
+                return
+            }
+        }
+    }
+
+    func test_resolve_ignoresNonGGUFFiles() throws {
+        let dir = try makeTemporaryRuntimeDirectory(ggufFilenames: ["model.gguf"])
+        // Add non-GGUF files
+        FileManager.default.createFile(
+            atPath: dir.appendingPathComponent("readme.txt").path,
+            contents: nil
+        )
+        FileManager.default.createFile(
+            atPath: dir.appendingPathComponent("weights.bin").path,
+            contents: nil
+        )
+        let config = makeConfig(runtimePath: dir.path, preferred: [])
+        let locator = BundledRuntimeLocator()
+
+        let models = locator.availableModels(configuration: config)
+        XCTAssertEqual(models.count, 1)
+        XCTAssertEqual(models.first?.filename, "model.gguf")
+    }
+
+    // MARK: - availableModels
+
+    func test_availableModels_ordersPreferredThenAlphabetical() throws {
+        let dir = try makeTemporaryRuntimeDirectory(
+            ggufFilenames: ["charlie.gguf", "alpha.gguf", "bravo.gguf"]
+        )
+        let config = makeConfig(runtimePath: dir.path, preferred: ["bravo.gguf"])
+        let locator = BundledRuntimeLocator()
+
+        let models = locator.availableModels(configuration: config)
+        let filenames = models.map(\.filename)
+        XCTAssertEqual(filenames, ["bravo.gguf", "alpha.gguf", "charlie.gguf"])
+    }
+
+    func test_availableModels_deduplicatesPreferredAndDiscovered() throws {
+        let dir = try makeTemporaryRuntimeDirectory(
+            ggufFilenames: ["alpha.gguf", "bravo.gguf"]
+        )
+        // alpha.gguf appears in both preferred list and directory
+        let config = makeConfig(runtimePath: dir.path, preferred: ["alpha.gguf"])
+        let locator = BundledRuntimeLocator()
+
+        let models = locator.availableModels(configuration: config)
+        let alphaCount = models.filter { $0.filename == "alpha.gguf" }.count
+        XCTAssertEqual(alphaCount, 1, "Preferred model should not appear twice")
+    }
+
+    func test_availableModels_returnsEmptyArrayWhenDirectoryMissing() {
+        let config = makeConfig(
+            runtimePath: "/tmp/tabby-test-nonexistent-\(UUID().uuidString)",
+            preferred: []
+        )
+        let locator = BundledRuntimeLocator()
+
+        XCTAssertEqual(locator.availableModels(configuration: config), [])
+    }
+
+    func test_resolve_usesExplicitRuntimeDirectoryPathFromConfiguration() throws {
+        let dir = try makeTemporaryRuntimeDirectory(ggufFilenames: ["custom.gguf"])
+        let config = makeConfig(runtimePath: dir.path, preferred: [])
+        let locator = BundledRuntimeLocator()
+
+        let resolved = try locator.resolve(configuration: config)
+        XCTAssertTrue(
+            resolved.runtimeDirectoryURL.path.hasPrefix(dir.path),
+            "Should resolve from the explicit runtime directory"
+        )
+    }
+
+    // MARK: - Error descriptions
+
+    func test_errorDescriptions_areHumanReadable() {
+        let dirError = BundledRuntimeLocatorError.runtimeDirectoryMissing("/some/path")
+        XCTAssertTrue(dirError.errorDescription?.contains("/some/path") ?? false)
+
+        let modelError = BundledRuntimeLocatorError.modelMissing("/models")
+        XCTAssertTrue(modelError.errorDescription?.contains("/models") ?? false)
+
+        let namedError = BundledRuntimeLocatorError.namedModelMissing("test.gguf")
+        XCTAssertTrue(namedError.errorDescription?.contains("test.gguf") ?? false)
+    }
+
+    // MARK: - Helpers
+
+    private func makeTemporaryRuntimeDirectory(ggufFilenames: [String]) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tabby-locator-test-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        temporaryDirectories.append(dir)
+
+        for filename in ggufFilenames {
+            FileManager.default.createFile(
+                atPath: dir.appendingPathComponent(filename).path,
+                contents: nil
+            )
+        }
+        return dir
+    }
+
+    private func makeConfig(
+        runtimePath: String,
+        preferred: [String]
+    ) -> LlamaRuntimeConfiguration {
+        LlamaRuntimeConfiguration(
+            runtimeDirectoryPath: runtimePath,
+            preferredModelNames: preferred,
+            contextWindowTokens: 2048,
+            batchSize: 512,
+            gpuLayerCount: -1
+        )
+    }
+}

--- a/tabbyTests/GhostSuggestionLayoutTests.swift
+++ b/tabbyTests/GhostSuggestionLayoutTests.swift
@@ -1,0 +1,164 @@
+import CoreGraphics
+import XCTest
+@testable import tabby
+
+final class GhostSuggestionLayoutTests: XCTestCase {
+
+    // MARK: - Single-line layout
+
+    func test_make_singleLineLayoutWhenTextFitsFirstLineBudget() {
+        let geometry = TabbyTestFixtures.overlayGeometry(
+            caretRect: CGRect(x: 10, y: 80, width: 2, height: 18),
+            inputFrameRect: CGRect(x: 0, y: 70, width: 400, height: 30),
+            observedCharWidth: 7
+        )
+
+        let layout = GhostSuggestionLayout.make(
+            text: " hi",
+            geometry: geometry,
+            fontSize: 14,
+            visibleFrame: CGRect(x: 0, y: 0, width: 500, height: 300)
+        )
+
+        XCTAssertEqual(layout.lines.count, 1)
+        XCTAssertEqual(layout.lines.first?.showsKeycap, true)
+        XCTAssertEqual(layout.topLineCenterOffsetFromCaret, 0)
+    }
+
+    // MARK: - Multi-line layout
+
+    func test_make_keycapAppearsOnlyOnLastLine() {
+        let geometry = TabbyTestFixtures.overlayGeometry(
+            caretRect: CGRect(x: 10, y: 80, width: 2, height: 18),
+            inputFrameRect: CGRect(x: 0, y: 70, width: 200, height: 30),
+            observedCharWidth: 7
+        )
+
+        let layout = GhostSuggestionLayout.make(
+            text: " alpha beta gamma delta epsilon zeta eta theta iota",
+            geometry: geometry,
+            fontSize: 14,
+            visibleFrame: CGRect(x: 0, y: 0, width: 500, height: 300)
+        )
+
+        XCTAssertGreaterThan(layout.lines.count, 1, "Should wrap to multiple lines")
+        for line in layout.lines.dropLast() {
+            XCTAssertFalse(line.showsKeycap, "Non-last lines should not show keycap")
+        }
+        XCTAssertEqual(layout.lines.last?.showsKeycap, true)
+    }
+
+    // MARK: - Word boundary splitting
+
+    func test_make_splitsAtWordBoundaryWhenTextExceedsBudget() {
+        // Use a narrow input so text must wrap, with observedCharWidth for determinism
+        let geometry = TabbyTestFixtures.overlayGeometry(
+            caretRect: CGRect(x: 10, y: 80, width: 2, height: 18),
+            inputFrameRect: CGRect(x: 0, y: 70, width: 140, height: 30),
+            observedCharWidth: 7
+        )
+
+        let layout = GhostSuggestionLayout.make(
+            text: " hello world testing",
+            geometry: geometry,
+            fontSize: 14,
+            visibleFrame: CGRect(x: 0, y: 0, width: 500, height: 300)
+        )
+
+        XCTAssertGreaterThan(layout.lines.count, 1)
+        // Lines should break at word boundaries, not mid-word
+        for line in layout.lines {
+            let trimmed = line.text.trimmingCharacters(in: .whitespaces)
+            XCTAssertFalse(trimmed.isEmpty, "No line should be empty after splitting")
+        }
+    }
+
+    func test_make_splitsAtCharacterLevelWhenNoWhitespaceExists() {
+        let geometry = TabbyTestFixtures.overlayGeometry(
+            caretRect: CGRect(x: 10, y: 80, width: 2, height: 18),
+            inputFrameRect: CGRect(x: 0, y: 70, width: 120, height: 30),
+            observedCharWidth: 7
+        )
+
+        // A single long token with no spaces
+        let layout = GhostSuggestionLayout.make(
+            text: " abcdefghijklmnopqrstuvwxyz",
+            geometry: geometry,
+            fontSize: 14,
+            visibleFrame: CGRect(x: 0, y: 0, width: 500, height: 300)
+        )
+
+        XCTAssertGreaterThan(layout.lines.count, 1, "Long token should be split across lines")
+    }
+
+    // MARK: - startsBelowCaret
+
+    func test_make_startsBelowCaretWhenFirstLineBudgetIsTooSmall() {
+        // Place caret near the right edge of a narrow input
+        let geometry = TabbyTestFixtures.overlayGeometry(
+            caretRect: CGRect(x: 130, y: 80, width: 2, height: 18),
+            inputFrameRect: CGRect(x: 0, y: 70, width: 140, height: 30),
+            observedCharWidth: 7
+        )
+
+        let layout = GhostSuggestionLayout.make(
+            text: " hello world overflow text here",
+            geometry: geometry,
+            fontSize: 14,
+            visibleFrame: CGRect(x: 0, y: 0, width: 500, height: 300)
+        )
+
+        XCTAssertLessThan(
+            layout.topLineCenterOffsetFromCaret, 0,
+            "Should start below caret when first line budget is too small"
+        )
+        XCTAssertEqual(layout.lines.first?.leadingIndent, 0)
+    }
+
+    // MARK: - panelFrame
+
+    func test_panelFrame_positionsRelativeToCaret() {
+        let geometry = TabbyTestFixtures.overlayGeometry(
+            caretRect: CGRect(x: 50, y: 100, width: 2, height: 18),
+            inputFrameRect: CGRect(x: 0, y: 90, width: 400, height: 30),
+            observedCharWidth: 7
+        )
+
+        let layout = GhostSuggestionLayout.make(
+            text: " short",
+            geometry: geometry,
+            fontSize: 14,
+            visibleFrame: CGRect(x: 0, y: 0, width: 500, height: 300)
+        )
+
+        let caretRect = CGRect(x: 50, y: 100, width: 2, height: 18)
+        let contentSize = CGSize(width: 100, height: 20)
+        let frame = layout.panelFrame(for: contentSize, caretRect: caretRect)
+
+        // Panel X should match panelOriginX
+        XCTAssertEqual(frame.origin.x, layout.panelOriginX)
+        // Panel should be vertically centered around the caret midY
+        let expectedTopCenter = caretRect.midY + layout.topLineCenterOffsetFromCaret
+        let expectedY = expectedTopCenter - contentSize.height + (layout.lineHeight / 2)
+        XCTAssertEqual(frame.origin.y, expectedY)
+    }
+
+    // MARK: - Fallback to visible frame
+
+    func test_make_usesVisibleFrameFallbackWhenNoInputFrame() {
+        let geometry = TabbyTestFixtures.overlayGeometry(
+            caretRect: CGRect(x: 50, y: 100, width: 2, height: 18),
+            inputFrameRect: nil,
+            observedCharWidth: 7
+        )
+
+        let layout = GhostSuggestionLayout.make(
+            text: " some text here",
+            geometry: geometry,
+            fontSize: 14,
+            visibleFrame: CGRect(x: 0, y: 0, width: 500, height: 300)
+        )
+
+        XCTAssertFalse(layout.lines.isEmpty, "Should still produce lines without an input frame")
+    }
+}

--- a/tabbyTests/PermissionAndContextModelTests.swift
+++ b/tabbyTests/PermissionAndContextModelTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+@testable import tabby
+
+final class TabbyPermissionKindTests: XCTestCase {
+
+    func test_allCases_containsExactlyThreePermissions() {
+        XCTAssertEqual(TabbyPermissionKind.allCases.count, 3)
+    }
+
+    func test_rawValues_matchExpectedPrivacyKeys() {
+        XCTAssertEqual(TabbyPermissionKind.accessibility.rawValue, "Privacy_Accessibility")
+        XCTAssertEqual(TabbyPermissionKind.inputMonitoring.rawValue, "Privacy_ListenEvent")
+        XCTAssertEqual(TabbyPermissionKind.screenRecording.rawValue, "Privacy_ScreenCapture")
+    }
+
+    func test_allCases_haveTitles() {
+        for kind in TabbyPermissionKind.allCases {
+            XCTAssertFalse(kind.title.isEmpty, "\(kind) should have a non-empty title")
+        }
+        XCTAssertEqual(TabbyPermissionKind.accessibility.title, "Accessibility")
+        XCTAssertEqual(TabbyPermissionKind.inputMonitoring.title, "Input Monitoring")
+        XCTAssertEqual(TabbyPermissionKind.screenRecording.title, "Screen Recording")
+    }
+
+    func test_allCases_haveSystemImageNames() {
+        for kind in TabbyPermissionKind.allCases {
+            XCTAssertFalse(
+                kind.systemImageName.isEmpty,
+                "\(kind) should have a non-empty systemImageName"
+            )
+        }
+    }
+
+    func test_allCases_haveOnboardingSubtitles() {
+        for kind in TabbyPermissionKind.allCases {
+            XCTAssertFalse(
+                kind.onboardingSubtitle.isEmpty,
+                "\(kind) should have a non-empty onboardingSubtitle"
+            )
+        }
+    }
+
+    func test_settingsURL_usesExpectedDeepLinkFormat() {
+        for kind in TabbyPermissionKind.allCases {
+            let expected = "x-apple.systempreferences:com.apple.preference.security?\(kind.rawValue)"
+            XCTAssertEqual(kind.settingsURL.absoluteString, expected)
+        }
+    }
+
+    func test_guidanceStyle_isGuidedOverlayForAllCases() {
+        for kind in TabbyPermissionKind.allCases {
+            XCTAssertEqual(kind.guidanceStyle, .guidedOverlay)
+        }
+    }
+
+    func test_isRequiredForAutocomplete_isTrueForAllCases() {
+        for kind in TabbyPermissionKind.allCases {
+            XCTAssertTrue(
+                kind.isRequiredForAutocomplete,
+                "\(kind) should be required for autocomplete"
+            )
+        }
+    }
+
+    func test_guidanceHint_isNonEmptyForAllCases() {
+        for kind in TabbyPermissionKind.allCases {
+            XCTAssertFalse(
+                kind.guidanceHint.isEmpty,
+                "\(kind) should have a non-empty guidanceHint"
+            )
+        }
+    }
+}
+
+final class VisualContextModelTests: XCTestCase {
+
+    func test_status_detail_returnsNonEmptyStringForEachCase() {
+        let cases: [VisualContextStatus] = [
+            .idle, .capturing, .extractingText, .summarizingText, .ready,
+            .unavailable("no permission"), .failed("timeout")
+        ]
+        let details = cases.map(\.detail)
+        for detail in details {
+            XCTAssertFalse(detail.isEmpty)
+        }
+        // All distinct
+        XCTAssertEqual(Set(details).count, details.count, "Each status case should have a unique detail")
+    }
+
+    func test_status_unavailableAndFailed_includeAssociatedReasonInDetail() {
+        let reason = "Screen recording denied"
+        XCTAssertEqual(VisualContextStatus.unavailable(reason).detail, reason)
+        XCTAssertEqual(VisualContextStatus.failed(reason).detail, reason)
+    }
+
+    func test_defaultConfiguration_hasExpectedValues() {
+        let config = VisualContextConfiguration.default
+        XCTAssertEqual(config.snapshotDimension, 500)
+        XCTAssertEqual(config.maxImageDimension, 900)
+        XCTAssertEqual(config.minRecognizedCharacterCount, 12)
+        XCTAssertEqual(config.maxRecognizedCharacters, 2000)
+        XCTAssertEqual(config.maxSummaryCharacters, 900)
+    }
+
+    func test_focusedInputAugmentationSession_equatableConformance() {
+        let id = UUID()
+        let sessionA = FocusedInputAugmentationSession(
+            sessionID: id,
+            elementIdentifier: "field1",
+            focusChangeSequence: 1,
+            status: .idle,
+            excerpt: nil
+        )
+        var sessionB = FocusedInputAugmentationSession(
+            sessionID: id,
+            elementIdentifier: "field1",
+            focusChangeSequence: 1,
+            status: .idle,
+            excerpt: nil
+        )
+        XCTAssertEqual(sessionA, sessionB)
+
+        sessionB.status = .ready
+        XCTAssertNotEqual(sessionA, sessionB)
+    }
+}

--- a/tabbyTests/PromptContextSanitizerTests.swift
+++ b/tabbyTests/PromptContextSanitizerTests.swift
@@ -1,0 +1,125 @@
+import XCTest
+@testable import tabby
+
+final class PromptContextSanitizerTests: XCTestCase {
+
+    // MARK: - sanitize
+
+    func test_sanitize_stripsANSIEscapeSequences() {
+        let input = "\u{001B}[31mERROR\u{001B}[0m something broke"
+        let result = PromptContextSanitizer.sanitize(input)
+        XCTAssertFalse(result.contains("\u{001B}"))
+        XCTAssertTrue(result.contains("ERROR"))
+        XCTAssertTrue(result.contains("something broke"))
+    }
+
+    func test_sanitize_replacesDisallowedUnicodeWithSpacesPreservingWordBoundaries() {
+        let result = PromptContextSanitizer.sanitize("raw-output")
+        XCTAssertEqual(result, "raw output")
+    }
+
+    func test_sanitize_collapsesRepeatedWhitespaceIntoSingleSpaces() {
+        let result = PromptContextSanitizer.sanitize("hello    world")
+        XCTAssertEqual(result, "hello world")
+    }
+
+    func test_sanitize_filtersEmptyAndWhitespaceOnlyLines() {
+        let input = "first\n   \n\nsecond"
+        let result = PromptContextSanitizer.sanitize(input)
+        XCTAssertEqual(result, "first\nsecond")
+    }
+
+    func test_sanitize_respectsMaxCharactersLimit() {
+        let input = "abcdefghij"
+        let result = PromptContextSanitizer.sanitize(input, maxCharacters: 5)
+        XCTAssertEqual(result, "abcde")
+    }
+
+    func test_sanitize_returnsFullInputWhenMaxCharactersEqualsLength() {
+        let input = "hello"
+        let result = PromptContextSanitizer.sanitize(input, maxCharacters: 5)
+        XCTAssertEqual(result, "hello")
+    }
+
+    func test_sanitize_returnsEmptyStringForWhitespaceOnlyInput() {
+        XCTAssertEqual(PromptContextSanitizer.sanitize("   \n  \n  "), "")
+    }
+
+    func test_sanitize_returnsEmptyStringForEmptyInput() {
+        XCTAssertEqual(PromptContextSanitizer.sanitize(""), "")
+    }
+
+    func test_sanitize_preservesAllowedCharacters() {
+        let input = "Hello world 123 user@host.com"
+        let result = PromptContextSanitizer.sanitize(input)
+        XCTAssertEqual(result, input)
+    }
+
+    func test_sanitize_handlesANSIMixedWithRealText() {
+        let input = "\u{001B}[32mHello\u{001B}[0m world"
+        let result = PromptContextSanitizer.sanitize(input)
+        XCTAssertEqual(result, "Hello world")
+    }
+
+    // MARK: - sanitizeOCR
+
+    func test_sanitizeOCR_dropsStandaloneNumbers() {
+        let input = "hello 50 world 424"
+        let result = PromptContextSanitizer.sanitizeOCR(input)
+        XCTAssertFalse(result.contains("50"))
+        XCTAssertFalse(result.contains("424"))
+        XCTAssertTrue(result.contains("hello"))
+        XCTAssertTrue(result.contains("world"))
+    }
+
+    func test_sanitizeOCR_dropsShortNoiseTokensButKeepsPreservedWords() {
+        // "I" and "if" are in the preserved set; "x" is not
+        let input = "I like if x"
+        let result = PromptContextSanitizer.sanitizeOCR(input)
+        XCTAssertTrue(result.contains("I"))
+        XCTAssertTrue(result.contains("if"))
+        XCTAssertTrue(result.contains("like"))
+        XCTAssertFalse(result.contains(" x"))
+    }
+
+    func test_sanitizeOCR_dropsLineWhenMajorityTokensAreNoise() {
+        // 3 of 4 tokens are noise (>50%): "50", "x", "99" — only "hello" survives
+        let input = "50 x 99 hello"
+        let result = PromptContextSanitizer.sanitizeOCR(input)
+        XCTAssertEqual(result, "")
+    }
+
+    func test_sanitizeOCR_keepsLineWhenHalfOrMoreTokensSurvive() {
+        // 2 of 4 tokens survive (exactly 50%): kept.count * 2 >= tokens.count
+        let input = "hello world 50 99"
+        let result = PromptContextSanitizer.sanitizeOCR(input)
+        XCTAssertTrue(result.contains("hello"))
+        XCTAssertTrue(result.contains("world"))
+    }
+
+    func test_sanitizeOCR_respectsMaxCharacters() {
+        let input = "alpha beta gamma delta epsilon"
+        let result = PromptContextSanitizer.sanitizeOCR(input, maxCharacters: 10)
+        XCTAssertLessThanOrEqual(result.count, 10)
+    }
+
+    func test_sanitizeOCR_returnsEmptyForAllNoiseInput() {
+        let input = "50 424 102 99"
+        let result = PromptContextSanitizer.sanitizeOCR(input)
+        XCTAssertEqual(result, "")
+    }
+
+    // MARK: - containsAlphanumericSignal
+
+    func test_containsAlphanumericSignal_returnsTrueForMixedInput() {
+        XCTAssertTrue(PromptContextSanitizer.containsAlphanumericSignal("---a---"))
+    }
+
+    func test_containsAlphanumericSignal_returnsFalseForPureSymbols() {
+        XCTAssertFalse(PromptContextSanitizer.containsAlphanumericSignal("--- ---"))
+    }
+
+    func test_containsAlphanumericSignal_returnsFalseForEmptyString() {
+        XCTAssertFalse(PromptContextSanitizer.containsAlphanumericSignal(""))
+    }
+}


### PR DESCRIPTION
## Summary
- Replace `guard let self` with `guard self != nil` in the `observe` method since the unwrapped value is never used (only the liveness check matters — `Self.map` is a static call)
- Fixes SwiftLint warning: "Value 'self' was defined but never used; consider replacing with boolean test"

## Test plan
- [x] SwiftLint passes
- [x] `xcodebuild build` succeeds
- [x] `xcodebuild build-for-testing` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a SwiftLint warning in `SystemFoundationModelAvailabilityProvider.observe()` by replacing `guard let self` with `guard self != nil` since `self` is only used as a liveness check — `Self.map` is a static call and does not need the unwrapped binding. Four new test files are also registered in the Xcode project alongside their source additions.

- **`FoundationModelAvailabilityService.swift`**: The `guard let self` → `guard self != nil` change inside the `withObservationTracking` callback is semantically correct; the surrounding `Task { @MainActor }` scope keeps the check and subsequent `continuation.resume` in the same actor turn, making the nil check safe.
- **New test files** (`BundledRuntimeLocatorTests`, `GhostSuggestionLayoutTests`, `PermissionAndContextModelTests`, `PromptContextSanitizerTests`): Added to `tabbyTests/` and wired into `project.pbxproj`, covering locator resolution, layout splitting, permission models, and sanitizer edge cases.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge; it is a narrow, correct cleanup of an unused variable binding in one method.

The change replaces `guard let self` with `guard self != nil` in a single `@MainActor`-isolated closure where `self` was only ever read to check liveness. `Self.map` is a static call, so no strong reference to `self` is needed beyond the nil check. The surrounding actor isolation means the guard check and `continuation.resume` execute atomically on the main actor, leaving no race window. The four new test files are well-structured and cover meaningful edge cases for their respective targets.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tabby/Services/Runtime/FoundationModelAvailabilityService.swift | Replaces `guard let self` with `guard self != nil` in the observation loop; fix is correct since only liveness is needed — `Self.map` is static. |
| tabby.xcodeproj/project.pbxproj | Registers four new test files (PBXBuildFile + PBXFileReference entries) in the test target; structure matches existing entries. |
| tabbyTests/BundledRuntimeLocatorTests.swift | New test file covering resolve/availableModels paths, preferred ordering, deduplication, and error descriptions. |
| tabbyTests/GhostSuggestionLayoutTests.swift | New test file covering single-line, multi-line, word-boundary, character-level, and panelFrame layout scenarios. |
| tabbyTests/PermissionAndContextModelTests.swift | New test file covering `TabbyPermissionKind` raw values, titles, URLs, and `VisualContextStatus`/`FocusedInputAugmentationSession` model conformance. |
| tabbyTests/PromptContextSanitizerTests.swift | New test file covering ANSI stripping, whitespace collapsing, OCR noise filtering, and max-character truncation in `PromptContextSanitizer`. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant S as FoundationModelAvailabilityService
    participant P as SystemFoundationModelAvailabilityProvider
    participant OT as observationTask
    participant SLM as SystemLanguageModel

    S->>P: observe(onChange:)
    P->>OT: "Task { @MainActor [weak self] }"
    loop "while !Task.isCancelled"
        OT->>SLM: "withObservationTracking { _ = model.availability }"
        SLM-->>OT: "availability changes, fires onChange closure"
        alt "self != nil (provider alive)"
            OT->>OT: "continuation.resume(Self.map(model.availability))"
            OT->>S: "onChange(newState) → state = newState"
        else "self == nil (provider deallocated)"
            OT->>OT: "continuation.resume(nil) → loop breaks"
        end
    end
```

<sub>Reviews (1): Last reviewed commit: ["Fix unused &#39;self&#39; binding in FoundationM..."](https://github.com/fujacob/tabby/commit/4ab3317de6d2371329932a81ce52cbeec4a23807) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33571845)</sub>

<!-- /greptile_comment -->