### PR TITLE
Remove beta label from README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# tabby [beta]
+# tabby
 
 <p align="center">
   <img width="128" alt="tabby logo" src="https://github.com/user-attachments/assets/8a67095e-4d03-4055-8d4c-8871335152dd" />
 </p>
 
 <p align="center">
-  <em>Open-source, local-first AI autocomplete for macOS.</em>
+  <em>Open-source, local-first AI autocomplete for macOS. [beta]</em>
   </p>
   
 <p align="center">


### PR DESCRIPTION
## Summary

<!--
One or two sentences: what changed and why. Skip the play-by-play.
The diff already shows what; this section should explain why.
-->

## Validation

<!--
What you actually ran and what you actually saw, not what you intended to run.
Examples:

  xcodebuild test -project tabby.xcodeproj -scheme tabby \
    -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO
  # ** TEST SUCCEEDED **  N tests, 0 failures

  swiftlint lint --config .swiftlint.yml --quiet
  # exit 0

For UI changes, attach a screenshot or short screen recording.
For changes that can't be verified end-to-end yet, say so explicitly.
-->

## Linked issues

<!--
Use `Fixes #N` to auto-close on merge, `Refs #N` to link without closing.
-->

## Risk / rollout notes

<!--
Anything reviewers should know that isn't visible from the diff:
- Schema, settings, or pbxproj migrations
- Behavior changes that touch existing user flows
- Performance characteristics worth flagging
- Follow-up issues filed (link them)

Skip this section entirely if there's nothing to flag.
-->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves the `[beta]` label from the README's H1 header (`# tabby [beta]`) into the project subtitle line, while leaving the heading as `# tabby`.

- The `[beta]` tag is relocated from the top-level heading to the italic description sentence, so the beta status is still communicated to readers.
- No code, configuration, or build files are changed — impact is limited to the README display.

<h3>Confidence Score: 5/5</h3>

Only the README is touched — no code, build files, or configuration are affected.

The change is a one-line relocation of the `[beta]` label within a Markdown file. There is no functional code involved, and the beta status is still visible to readers in the subtitle.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Moves `[beta]` from H1 heading to the subtitle description line; purely cosmetic documentation change with no functional impact. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Remove beta label from README header"](https://github.com/fujacob/tabby/commit/e1c0857fba504296d66bf58fdd8c66bdc2d51d5b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33572376)</sub>

<!-- /greptile_comment -->