### PR TITLE
Add LM Studio folder button to model settings

### DIFF
--- a/tabby/App/Coordinators/SuggestionCoordinator+Input.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator+Input.swift
@@ -86,7 +86,7 @@ extension SuggestionCoordinator {
             return false
         }
 
-        if event.kind == .tab {
+        if event.kind == .acceptance {
             return acceptCurrentSuggestion()
         }
 
@@ -161,7 +161,7 @@ extension SuggestionCoordinator {
             state = .idle
             return false
 
-        case .other, .tab:
+        case .other, .acceptance:
             return false
         }
     }

--- a/tabby/App/Core/TabbyAppEnvironment.swift
+++ b/tabby/App/Core/TabbyAppEnvironment.swift
@@ -45,6 +45,7 @@ final class TabbyAppEnvironment {
             permissionProvider: { permissionManager.inputMonitoringGranted },
             suppressionController: suppressionController
         )
+        inputMonitor.acceptanceKeyCode = suggestionSettings.acceptanceKeyCode
         let focusModel = FocusTrackingModel(
             permissionProvider: { permissionManager.accessibilityGranted },
             ignoredBundleIdentifier: Bundle.main.bundleIdentifier,
@@ -146,6 +147,14 @@ final class TabbyAppEnvironment {
             .removeDuplicates()
             .sink { [weak focusModel] milliseconds in
                 focusModel?.updatePollInterval(milliseconds: milliseconds)
+            }
+            .store(in: &cancellables)
+
+        // Push acceptance key changes from settings into the event classifier.
+        suggestionSettings.$acceptanceKeyCode
+            .removeDuplicates()
+            .sink { [weak inputMonitor] keyCode in
+                inputMonitor?.acceptanceKeyCode = keyCode
             }
             .store(in: &cancellables)
     }

--- a/tabby/Models/InputModels.swift
+++ b/tabby/Models/InputModels.swift
@@ -10,7 +10,7 @@ struct CapturedInputEvent: Equatable {
     /// This enum is intentionally smaller than the raw CGEvent universe.
     /// A reduced vocabulary keeps the suggestion state machine easier to reason about and test.
     enum Kind: String, Equatable {
-        case tab
+        case acceptance
         case textMutation
         case navigation
         case shortcutMutation
@@ -36,7 +36,7 @@ struct CapturedInputEvent: Equatable {
         switch kind {
         case .textMutation, .navigation, .shortcutMutation, .dismissal:
             return true
-        case .tab, .other:
+        case .acceptance, .other:
             return false
         }
     }

--- a/tabby/Models/SuggestionSettingsModel.swift
+++ b/tabby/Models/SuggestionSettingsModel.swift
@@ -1,3 +1,4 @@
+import ApplicationServices
 import Combine
 import Foundation
 
@@ -21,6 +22,8 @@ final class SuggestionSettingsModel: ObservableObject {
     @Published private(set) var userName: String
     @Published private(set) var debounceMilliseconds: Int
     @Published private(set) var focusPollIntervalMilliseconds: Int
+    @Published private(set) var acceptanceKeyCode: CGKeyCode
+    @Published private(set) var acceptanceKeyLabel: String
     private let userDefaults: UserDefaults
 
     private static let isGloballyEnabledDefaultsKey = "tabbyGloballyEnabled"
@@ -35,6 +38,11 @@ final class SuggestionSettingsModel: ObservableObject {
     private static let userNameDefaultsKey = "tabbyUserName"
     private static let debounceMillisecondsDefaultsKey = "tabbyDebounceMilliseconds"
     private static let focusPollIntervalMillisecondsDefaultsKey = "tabbyFocusPollIntervalMilliseconds"
+    private static let acceptanceKeyCodeDefaultsKey = "tabbyAcceptanceKeyCode"
+    private static let acceptanceKeyLabelDefaultsKey = "tabbyAcceptanceKeyLabel"
+
+    static let defaultAcceptanceKeyCode: CGKeyCode = 48
+    static let defaultAcceptanceKeyLabel = "Tab"
 
     init(
         configuration: SuggestionConfiguration,
@@ -81,6 +89,13 @@ final class SuggestionSettingsModel: ObservableObject {
             return max(10, min(500, raw))
         }()
 
+        let resolvedAcceptanceKeyCode = CGKeyCode(
+            userDefaults.object(forKey: Self.acceptanceKeyCodeDefaultsKey) as? Int
+                ?? Int(Self.defaultAcceptanceKeyCode)
+        )
+        let resolvedAcceptanceKeyLabel = userDefaults.string(forKey: Self.acceptanceKeyLabelDefaultsKey)
+            ?? Self.defaultAcceptanceKeyLabel
+
         isGloballyEnabled = resolvedGloballyEnabled
         disabledAppRules = resolvedDisabledAppRules
         showIndicator = resolvedShowIndicator
@@ -91,6 +106,8 @@ final class SuggestionSettingsModel: ObservableObject {
         userName = resolvedUserName
         debounceMilliseconds = resolvedDebounceMilliseconds
         focusPollIntervalMilliseconds = resolvedFocusPollIntervalMilliseconds
+        acceptanceKeyCode = resolvedAcceptanceKeyCode
+        acceptanceKeyLabel = resolvedAcceptanceKeyLabel
 
         userDefaults.set(resolvedGloballyEnabled, forKey: Self.isGloballyEnabledDefaultsKey)
         persistDisabledAppRules(resolvedDisabledAppRules)
@@ -282,6 +299,17 @@ final class SuggestionSettingsModel: ObservableObject {
 
         userName = name
         persistUserName(name)
+    }
+
+    func setAcceptanceKey(keyCode: CGKeyCode, label: String) {
+        guard acceptanceKeyCode != keyCode || acceptanceKeyLabel != label else {
+            return
+        }
+
+        acceptanceKeyCode = keyCode
+        acceptanceKeyLabel = label
+        userDefaults.set(Int(keyCode), forKey: Self.acceptanceKeyCodeDefaultsKey)
+        userDefaults.set(label, forKey: Self.acceptanceKeyLabelDefaultsKey)
     }
 
     private func persistSelectedEngine(_ engine: SuggestionEngineKind) {

--- a/tabby/Models/SuggestionSettingsModel.swift
+++ b/tabby/Models/SuggestionSettingsModel.swift
@@ -119,6 +119,8 @@ final class SuggestionSettingsModel: ObservableObject {
         persistUserName(resolvedUserName)
         userDefaults.set(resolvedDebounceMilliseconds, forKey: Self.debounceMillisecondsDefaultsKey)
         userDefaults.set(resolvedFocusPollIntervalMilliseconds, forKey: Self.focusPollIntervalMillisecondsDefaultsKey)
+        userDefaults.set(Int(resolvedAcceptanceKeyCode), forKey: Self.acceptanceKeyCodeDefaultsKey)
+        userDefaults.set(resolvedAcceptanceKeyLabel, forKey: Self.acceptanceKeyLabelDefaultsKey)
     }
 
     /// Legacy compatibility shim. Reads through to `showIndicator`.

--- a/tabby/Services/Input/InputMonitor.swift
+++ b/tabby/Services/Input/InputMonitor.swift
@@ -16,6 +16,10 @@ final class InputMonitor {
     var onEvent: ((CapturedInputEvent) -> Bool)?
     var onSuppressedSyntheticInput: (() -> Void)?
 
+    /// The key code that triggers suggestion acceptance. Updated by the coordinator
+    /// when the user changes the keybind in Settings.
+    var acceptanceKeyCode: CGKeyCode = 48
+
     private let permissionProvider: @MainActor () -> Bool
     private let suppressionController: InputSuppressionController
 
@@ -138,10 +142,10 @@ final class InputMonitor {
         let flags = event.flags
         let characters = event.unicodeString
 
-        // Key code 48 is the hardware Tab key on macOS keyboard events.
-        if keyCode == 48,
+        // Matches the user-configured acceptance key (default: Tab, key code 48).
+        if keyCode == acceptanceKeyCode,
            flags.isDisjoint(with: [.maskCommand, .maskControl, .maskAlternate, .maskShift]) {
-            return CapturedInputEvent(kind: .tab, keyCode: keyCode, characters: characters, flags: flags)
+            return CapturedInputEvent(kind: .acceptance, keyCode: keyCode, characters: characters, flags: flags)
         }
 
         // We classify events by behavior instead of raw key codes alone.

--- a/tabby/Services/UI/FocusDebugOverlayController.swift
+++ b/tabby/Services/UI/FocusDebugOverlayController.swift
@@ -19,7 +19,10 @@ final class FocusDebugOverlayController {
 
     private lazy var caretPanel: NSPanel = makePanel()
     private lazy var framePanel: NSPanel = makePanel()
-    private lazy var bottomStatusPanel: NSPanel = makePanel()
+    private lazy var bottomStatusPanel: NSPanel = makeDraggablePanel()
+
+    /// User-dragged origin for the bottom panel. `nil` means use the default centered position.
+    private var bottomPanelDraggedOrigin: CGPoint?
 
     private var latestCaretRect: CGRect?
     private var latestVisualContextStatus: VisualContextStatus = .idle
@@ -118,6 +121,11 @@ final class FocusDebugOverlayController {
             return
         }
 
+        // Capture any user drag that happened since the last render.
+        if bottomStatusPanel.isVisible {
+            bottomPanelDraggedOrigin = bottomStatusPanel.frame.origin
+        }
+
         let screenFrame = targetScreenVisibleFrame()
         let maxWidth = min(screenFrame.width - 32, 620)
         let contentView = NSHostingView(rootView: BottomDebugStatusView(
@@ -129,10 +137,15 @@ final class FocusDebugOverlayController {
         contentView.layoutSubtreeIfNeeded()
         let contentSize = contentView.fittingSize
 
-        let origin = CGPoint(
-            x: screenFrame.midX - (contentSize.width / 2),
-            y: screenFrame.minY + 14
-        )
+        let origin: CGPoint
+        if let dragged = bottomPanelDraggedOrigin {
+            origin = dragged
+        } else {
+            origin = CGPoint(
+                x: screenFrame.midX - (contentSize.width / 2),
+                y: screenFrame.minY + 14
+            )
+        }
 
         bottomStatusPanel.contentView = contentView
         bottomStatusPanel.setFrame(
@@ -152,6 +165,24 @@ final class FocusDebugOverlayController {
         latestCaretRect = nil
         caretPanel.orderOut(nil)
         framePanel.orderOut(nil)
+    }
+
+    private func makeDraggablePanel() -> NSPanel {
+        let panel = NSPanel(
+            contentRect: CGRect(x: 0, y: 0, width: 10, height: 10),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: true
+        )
+        panel.isReleasedWhenClosed = false
+        panel.backgroundColor = .clear
+        panel.isOpaque = false
+        panel.ignoresMouseEvents = false
+        panel.isMovableByWindowBackground = true
+        panel.hasShadow = false
+        panel.level = NSWindow.Level(rawValue: NSWindow.Level.statusBar.rawValue + 2)
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .ignoresCycle]
+        return panel
     }
 
     private func makePanel() -> NSPanel {

--- a/tabby/Services/UI/FocusDebugOverlayController.swift
+++ b/tabby/Services/UI/FocusDebugOverlayController.swift
@@ -19,10 +19,13 @@ final class FocusDebugOverlayController {
 
     private lazy var caretPanel: NSPanel = makePanel()
     private lazy var framePanel: NSPanel = makePanel()
-    private lazy var bottomStatusPanel: NSPanel = makeDraggablePanel()
+    private lazy var bottomStatusPanel: NSPanel = makePanel(draggable: true)
 
     /// User-dragged origin for the bottom panel. `nil` means use the default centered position.
     private var bottomPanelDraggedOrigin: CGPoint?
+
+    /// The last origin we set programmatically, used to detect genuine user drags.
+    private var bottomPanelProgrammaticOrigin: CGPoint?
 
     private var latestCaretRect: CGRect?
     private var latestVisualContextStatus: VisualContextStatus = .idle
@@ -121,9 +124,13 @@ final class FocusDebugOverlayController {
             return
         }
 
-        // Capture any user drag that happened since the last render.
-        if bottomStatusPanel.isVisible {
-            bottomPanelDraggedOrigin = bottomStatusPanel.frame.origin
+        // Detect genuine user drags by comparing against the last programmatic origin.
+        if bottomStatusPanel.isVisible,
+           let programmatic = bottomPanelProgrammaticOrigin {
+            let current = bottomStatusPanel.frame.origin
+            if current != programmatic {
+                bottomPanelDraggedOrigin = current
+            }
         }
 
         let screenFrame = targetScreenVisibleFrame()
@@ -147,11 +154,10 @@ final class FocusDebugOverlayController {
             )
         }
 
+        let frame = CGRect(origin: origin, size: contentSize).integral
         bottomStatusPanel.contentView = contentView
-        bottomStatusPanel.setFrame(
-            CGRect(origin: origin, size: contentSize).integral,
-            display: true
-        )
+        bottomStatusPanel.setFrame(frame, display: true)
+        bottomPanelProgrammaticOrigin = frame.origin
         bottomStatusPanel.orderFrontRegardless()
     }
 
@@ -167,7 +173,7 @@ final class FocusDebugOverlayController {
         framePanel.orderOut(nil)
     }
 
-    private func makeDraggablePanel() -> NSPanel {
+    private func makePanel(draggable: Bool = false) -> NSPanel {
         let panel = NSPanel(
             contentRect: CGRect(x: 0, y: 0, width: 10, height: 10),
             styleMask: [.borderless, .nonactivatingPanel],
@@ -177,25 +183,8 @@ final class FocusDebugOverlayController {
         panel.isReleasedWhenClosed = false
         panel.backgroundColor = .clear
         panel.isOpaque = false
-        panel.ignoresMouseEvents = false
-        panel.isMovableByWindowBackground = true
-        panel.hasShadow = false
-        panel.level = NSWindow.Level(rawValue: NSWindow.Level.statusBar.rawValue + 2)
-        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .ignoresCycle]
-        return panel
-    }
-
-    private func makePanel() -> NSPanel {
-        let panel = NSPanel(
-            contentRect: CGRect(x: 0, y: 0, width: 10, height: 10),
-            styleMask: [.borderless, .nonactivatingPanel],
-            backing: .buffered,
-            defer: true
-        )
-        panel.isReleasedWhenClosed = false
-        panel.backgroundColor = .clear
-        panel.isOpaque = false
-        panel.ignoresMouseEvents = true
+        panel.ignoresMouseEvents = !draggable
+        panel.isMovableByWindowBackground = draggable
         panel.hasShadow = false
         // Above activation indicator and ghost text so it is always visible during debugging.
         panel.level = NSWindow.Level(rawValue: NSWindow.Level.statusBar.rawValue + 2)

--- a/tabby/Support/KeyCodeLabels.swift
+++ b/tabby/Support/KeyCodeLabels.swift
@@ -1,0 +1,32 @@
+import ApplicationServices
+
+/// Maps macOS virtual key codes to human-readable labels for the settings UI.
+/// Only covers keys that don't produce a useful `charactersIgnoringModifiers` string.
+enum KeyCodeLabels {
+    private static let specialKeys: [CGKeyCode: String] = [
+        48: "Tab",
+        49: "Space",
+        51: "Delete",
+        53: "Escape",
+        117: "Forward Delete",
+        36: "Return",
+        76: "Enter",
+        123: "Left Arrow",
+        124: "Right Arrow",
+        125: "Down Arrow",
+        126: "Up Arrow",
+        122: "F1", 120: "F2", 99: "F3", 118: "F4",
+        96: "F5", 97: "F6", 98: "F7", 100: "F8",
+        101: "F9", 109: "F10", 103: "F11", 111: "F12"
+    ]
+
+    static func label(for keyCode: CGKeyCode, fallback: String?) -> String {
+        if let special = specialKeys[keyCode] {
+            return special
+        }
+        if let chars = fallback, !chars.isEmpty {
+            return chars.uppercased()
+        }
+        return "Key \(keyCode)"
+    }
+}

--- a/tabby/Support/SuggestionSessionReconciler.swift
+++ b/tabby/Support/SuggestionSessionReconciler.swift
@@ -256,7 +256,7 @@ enum SuggestionSessionReconciler {
             return "Overlay hidden because caret navigation invalidated the current suggestion."
         case .dismissal:
             return "Overlay hidden because a dismissal key was pressed."
-        case .tab, .other:
+        case .acceptance, .other:
             return "Overlay hidden."
         }
     }

--- a/tabby/UI/KeyRecorderView.swift
+++ b/tabby/UI/KeyRecorderView.swift
@@ -6,12 +6,12 @@ import SwiftUI
 /// so no leaked monitors accumulate.
 struct KeyRecorderView: View {
     let onKeyRecorded: (CGKeyCode, String) -> Void
+    var onCancelled: (() -> Void)?
 
     @State private var monitor: Any?
 
     /// Keys that conflict with the suggestion pipeline's built-in classification.
     private static let reservedKeyCodes: Set<UInt16> = [
-        53,                     // Escape
         36, 76,                 // Return, Enter
         123, 124, 125, 126      // Arrow keys
     ]
@@ -24,8 +24,16 @@ struct KeyRecorderView: View {
     }
 
     private func installMonitor() {
+        guard monitor == nil else { return }
         monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [self] event in
             let keyCode = event.keyCode
+
+            if keyCode == 53 { // Escape cancels recording
+                removeMonitor()
+                onCancelled?()
+                return nil
+            }
+
             guard !Self.reservedKeyCodes.contains(keyCode) else {
                 return event
             }

--- a/tabby/UI/KeyRecorderView.swift
+++ b/tabby/UI/KeyRecorderView.swift
@@ -1,0 +1,49 @@
+import ApplicationServices
+import SwiftUI
+
+/// A small inline view that captures the next keypress and reports its key code and label.
+/// Installs an `NSEvent` local monitor on appear and removes it on disappear or capture,
+/// so no leaked monitors accumulate.
+struct KeyRecorderView: View {
+    let onKeyRecorded: (CGKeyCode, String) -> Void
+
+    @State private var monitor: Any?
+
+    /// Keys that conflict with the suggestion pipeline's built-in classification.
+    private static let reservedKeyCodes: Set<UInt16> = [
+        53,                     // Escape
+        36, 76,                 // Return, Enter
+        123, 124, 125, 126      // Arrow keys
+    ]
+
+    var body: some View {
+        Text("Press a key…")
+            .foregroundStyle(.secondary)
+            .onAppear { installMonitor() }
+            .onDisappear { removeMonitor() }
+    }
+
+    private func installMonitor() {
+        monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [self] event in
+            let keyCode = event.keyCode
+            guard !Self.reservedKeyCodes.contains(keyCode) else {
+                return event
+            }
+
+            let label = KeyCodeLabels.label(
+                for: CGKeyCode(keyCode),
+                fallback: event.charactersIgnoringModifiers
+            )
+            removeMonitor()
+            onKeyRecorded(CGKeyCode(keyCode), label)
+            return nil
+        }
+    }
+
+    private func removeMonitor() {
+        if let monitor {
+            NSEvent.removeMonitor(monitor)
+        }
+        monitor = nil
+    }
+}

--- a/tabby/UI/SettingsView.swift
+++ b/tabby/UI/SettingsView.swift
@@ -327,6 +327,15 @@ struct SettingsView: View {
                         .multilineTextAlignment(.trailing)
 
                     HStack(spacing: 8) {
+                        let lmStudioURL = FileManager.default.homeDirectoryForCurrentUser
+                            .appendingPathComponent(".lmstudio/models")
+                        Button("LM Studio Folder") {
+                            NSWorkspace.shared.open(lmStudioURL)
+                        }
+                        .disabled(
+                            !FileManager.default.fileExists(atPath: lmStudioURL.path)
+                        )
+
                         Button("Open Folder") {
                             modelDownloadManager.openModelsDirectory()
                         }

--- a/tabby/UI/SettingsView.swift
+++ b/tabby/UI/SettingsView.swift
@@ -179,10 +179,15 @@ struct SettingsView: View {
                         )
 
                     if isRecordingKeybind {
-                        KeyRecorderView { keyCode, label in
-                            suggestionSettings.setAcceptanceKey(keyCode: keyCode, label: label)
-                            isRecordingKeybind = false
-                        }
+                        KeyRecorderView(
+                            onKeyRecorded: { keyCode, label in
+                                suggestionSettings.setAcceptanceKey(keyCode: keyCode, label: label)
+                                isRecordingKeybind = false
+                            },
+                            onCancelled: {
+                                isRecordingKeybind = false
+                            }
+                        )
                     } else {
                         Button("Change") {
                             isRecordingKeybind = true

--- a/tabby/UI/SettingsView.swift
+++ b/tabby/UI/SettingsView.swift
@@ -24,6 +24,7 @@ struct SettingsView: View {
     @Environment(\.colorScheme) private var colorScheme
 
     @State private var pendingDeletionModel: RuntimeModelOption?
+    @State private var isRecordingKeybind = false
 
     var body: some View {
         Form {
@@ -32,6 +33,7 @@ struct SettingsView: View {
             uninstallSection
             generalSection
             autocompleteSection
+            keybindSection
             // performanceSection — hidden until these controls are productized.
             // Both suggestion delay and focus poll interval are developer-facing
             // tuning knobs that invite misconfiguration for end users.
@@ -158,6 +160,44 @@ struct SettingsView: View {
                 ForEach(SuggestionWordCountPreset.allCases) { preset in
                     Text(preset.displayLabel)
                         .tag(preset)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var keybindSection: some View {
+        Section("Keybind") {
+            LabeledContent("Accept Suggestion") {
+                HStack(spacing: 8) {
+                    Text(suggestionSettings.acceptanceKeyLabel)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(
+                            RoundedRectangle(cornerRadius: 6)
+                                .fill(.quaternary)
+                        )
+
+                    if isRecordingKeybind {
+                        KeyRecorderView { keyCode, label in
+                            suggestionSettings.setAcceptanceKey(keyCode: keyCode, label: label)
+                            isRecordingKeybind = false
+                        }
+                    } else {
+                        Button("Change") {
+                            isRecordingKeybind = true
+                        }
+                    }
+
+                    if suggestionSettings.acceptanceKeyCode != SuggestionSettingsModel.defaultAcceptanceKeyCode {
+                        Button("Reset to Default") {
+                            suggestionSettings.setAcceptanceKey(
+                                keyCode: SuggestionSettingsModel.defaultAcceptanceKeyCode,
+                                label: SuggestionSettingsModel.defaultAcceptanceKeyLabel
+                            )
+                            isRecordingKeybind = false
+                        }
+                    }
                 }
             }
         }

--- a/tabbyTests/ModelAndPresentationValueTests.swift
+++ b/tabbyTests/ModelAndPresentationValueTests.swift
@@ -161,7 +161,7 @@ final class RuntimeAndInputModelValueTests: XCTestCase {
         XCTAssertFalse(TabbyTestFixtures.inputEvent(kind: .navigation).shouldSchedulePrediction)
 
         XCTAssertTrue(TabbyTestFixtures.inputEvent(kind: .dismissal).shouldClearSuggestion)
-        XCTAssertFalse(TabbyTestFixtures.inputEvent(kind: .tab).shouldClearSuggestion)
+        XCTAssertFalse(TabbyTestFixtures.inputEvent(kind: .acceptance).shouldClearSuggestion)
         XCTAssertFalse(TabbyTestFixtures.inputEvent(kind: .other).shouldClearSuggestion)
     }
 }


### PR DESCRIPTION
## Summary
- Adds an "LM Studio Folder" button to the left of "Open Folder" in model settings
- Opens `~/.lmstudio/models` directly for users who have GGUFs stored there
- Button is disabled when the LM Studio models directory doesn't exist

## Test plan
- [x] SwiftLint passes
- [x] Build succeeds
- [x] Test build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers three distinct improvements: an LM Studio Folder shortcut button in the Local Models section, a fully configurable acceptance-key keybind (replacing the hardcoded Tab/48 check throughout the suggestion pipeline), and a draggable debug status panel. The `.tab` event kind is renamed to `.acceptance` end-to-end to reflect that any key—not just Tab—can now trigger suggestion acceptance.

- **LM Studio button**: adds a disabled-when-missing shortcut that opens `~/.lmstudio/models` directly from model settings.
- **Configurable acceptance key**: persists `acceptanceKeyCode`/`acceptanceKeyLabel` in `UserDefaults`, propagates changes via a Combine subscription from `SuggestionSettingsModel` into `InputMonitor`, and provides a `KeyRecorderView` for in-settings key capture.
- **Debug panel dragging**: `FocusDebugOverlayController` now remembers a user-dragged origin and restores it on subsequent `updateOverlay` calls instead of always centering the panel.

<h3>Confidence Score: 4/5</h3>

Safe to merge once the missing Delete/Forward Delete reserved key codes are addressed; all other changes are well-scoped and cleanly wired.

The acceptance-key pipeline is correctly wired end-to-end, but `KeyRecorderView.reservedKeyCodes` does not block Delete (51) or Forward Delete (117). A user who sets either key as their acceptance key would find that pressing Delete while a suggestion is active accepts the suggestion rather than deleting text — exactly the problem the reserved list was designed to prevent for Return and Enter. The LM Studio button and the debug panel drag feature are straightforward and carry no meaningful risk.

tabby/UI/KeyRecorderView.swift — the incomplete reserved key set is the only file that needs a fix before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tabby/UI/KeyRecorderView.swift | New view for capturing key presses to remap the acceptance key; missing Delete (51) and Forward Delete (117) from the reserved key set, which allows users to set destructive text-editing keys as the acceptance key |
| tabby/UI/SettingsView.swift | Adds keybind section with live key recorder UI and an LM Studio Folder button; FileManager.fileExists and URL construction are evaluated inline on every render pass |
| tabby/Models/SuggestionSettingsModel.swift | Adds acceptanceKeyCode/acceptanceKeyLabel persistence and setAcceptanceKey mutation; logic is clean and correct |
| tabby/App/Core/TabbyAppEnvironment.swift | Wires initial acceptanceKeyCode into InputMonitor at construction and subscribes to future changes via Combine; explicit initial assignment is correct because @Published does not emit on subscription |
| tabby/Services/Input/InputMonitor.swift | Replaces hardcoded Tab key code with configurable acceptanceKeyCode; @MainActor class with MainActor.assumeIsolated in CGEvent callback ensures safe access from the tap callback |
| tabby/Models/InputModels.swift | Renames .tab to .acceptance throughout CapturedInputEvent.Kind; straightforward semantic rename with no behavioral change |
| tabby/Support/KeyCodeLabels.swift | New helper mapping virtual key codes to human-readable labels for the settings UI; complete and correct for the keys covered |
| tabby/Services/UI/FocusDebugOverlayController.swift | Makes the bottom debug status panel draggable by the user; drag detection compares current vs last programmatic origin and is debug-only |
| tabby/App/Coordinators/SuggestionCoordinator+Input.swift | Updates two switch/if sites to use .acceptance instead of .tab; mechanical rename, no logic change |
| tabby/Support/SuggestionSessionReconciler.swift | Updates debug description switch case from .tab to .acceptance; no behavioral change |
| tabbyTests/ModelAndPresentationValueTests.swift | Updates test fixture reference from .tab to .acceptance; test logic unchanged |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User presses a key] --> B[CGEvent tap callback\nInputMonitor.classify]
    B --> C{keyCode == acceptanceKeyCode\nno modifier flags?}
    C -- Yes --> D[CapturedInputEvent kind: .acceptance]
    C -- No --> E{Arrow keys 123-126?}
    E -- Yes --> F[kind: .navigation]
    E -- No --> G{Delete / Return\n51 117 36 76?}
    G -- Yes --> H[kind: .textMutation]
    G -- No --> I{Escape 53?}
    I -- Yes --> J[kind: .dismissal]
    I -- No --> K[kind: .other / .shortcutMutation]
    D --> L[SuggestionCoordinator\nacceptCurrentSuggestion]
    F --> M[SuggestionCoordinator\ndismiss overlay]
    H --> M
    N[User changes key in SettingsView] --> O[KeyRecorderView\nNSEvent local monitor]
    O --> P[SuggestionSettingsModel\nsetAcceptanceKey]
    P --> Q[Published acceptanceKeyCode]
    Q --> R[TabbyAppEnvironment sink\nremoveDuplicates]
    R --> S[InputMonitor\nacceptanceKeyCode updated]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22configurable-keybind%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22configurable-keybind%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atabby%2FUI%2FKeyRecorderView.swift%3A13-17%0ADelete%20%2851%29%20and%20Forward%20Delete%20%28117%29%20are%20missing%20from%20%60reservedKeyCodes%60.%20Both%20are%20classified%20as%20%60.textMutation%60%20in%20%60InputMonitor.classify%60%2C%20so%20if%20a%20user%20sets%20either%20as%20their%20acceptance%20key%2C%20any%20keypress%20while%20a%20suggestion%20is%20active%20will%20accept%20the%20suggestion%20instead%20of%20deleting%20text%20%E2%80%94%20making%20it%20impossible%20to%20edit%20text%20while%20a%20suggestion%20is%20displayed.%20This%20mirrors%20the%20same%20reasoning%20that%20already%20reserves%20Return%20and%20Enter.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Keys%20that%20conflict%20with%20the%20suggestion%20pipeline's%20built-in%20classification.%0A%20%20%20%20private%20static%20let%20reservedKeyCodes%3A%20Set%3CUInt16%3E%20%3D%20%5B%0A%20%20%20%20%20%20%20%2036%2C%2076%2C%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Return%2C%20Enter%0A%20%20%20%20%20%20%20%2051%2C%20117%2C%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Delete%2C%20Forward%20Delete%0A%20%20%20%20%20%20%20%20123%2C%20124%2C%20125%2C%20126%20%20%20%20%20%20%2F%2F%20Arrow%20keys%0A%20%20%20%20%5D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Atabby%2FUI%2FSettingsView.swift%3A329-337%0AThe%20URL%20is%20constructed%20and%20%60fileExists%28atPath%3A%29%60%20is%20evaluated%20on%20the%20main%20thread%20on%20every%20render%20of%20the%20settings%20form.%20Settings%20re-renders%20whenever%20any%20%60%40ObservedObject%60%20publishes%20a%20change%20%28e.g.%2C%20download%20progress%20updates%20from%20%60modelDownloadManager%60%29.%20Moving%20the%20URL%20and%20the%20existence%20flag%20into%20a%20%60%40State%60%20property%20computed%20once%20on%20%60onAppear%60%20would%20avoid%20the%20repeated%20filesystem%20stat.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20HStack%28spacing%3A%208%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20let%20lmStudioURL%20%3D%20FileManager.default.homeDirectoryForCurrentUser%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.appendingPathComponent%28%22.lmstudio%2Fmodels%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Button%28%22LM%20Studio%20Folder%22%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20NSWorkspace.shared.open%28lmStudioURL%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.disabled%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20!FileManager.default.fileExists%28atPath%3A%20lmStudioURL.path%28percentEncoded%3A%20false%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atabby%2FUI%2FKeyRecorderView.swift%3A13-17%0ADelete%20%2851%29%20and%20Forward%20Delete%20%28117%29%20are%20missing%20from%20%60reservedKeyCodes%60.%20Both%20are%20classified%20as%20%60.textMutation%60%20in%20%60InputMonitor.classify%60%2C%20so%20if%20a%20user%20sets%20either%20as%20their%20acceptance%20key%2C%20any%20keypress%20while%20a%20suggestion%20is%20active%20will%20accept%20the%20suggestion%20instead%20of%20deleting%20text%20%E2%80%94%20making%20it%20impossible%20to%20edit%20text%20while%20a%20suggestion%20is%20displayed.%20This%20mirrors%20the%20same%20reasoning%20that%20already%20reserves%20Return%20and%20Enter.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Keys%20that%20conflict%20with%20the%20suggestion%20pipeline's%20built-in%20classification.%0A%20%20%20%20private%20static%20let%20reservedKeyCodes%3A%20Set%3CUInt16%3E%20%3D%20%5B%0A%20%20%20%20%20%20%20%2036%2C%2076%2C%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Return%2C%20Enter%0A%20%20%20%20%20%20%20%2051%2C%20117%2C%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Delete%2C%20Forward%20Delete%0A%20%20%20%20%20%20%20%20123%2C%20124%2C%20125%2C%20126%20%20%20%20%20%20%2F%2F%20Arrow%20keys%0A%20%20%20%20%5D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Atabby%2FUI%2FSettingsView.swift%3A329-337%0AThe%20URL%20is%20constructed%20and%20%60fileExists%28atPath%3A%29%60%20is%20evaluated%20on%20the%20main%20thread%20on%20every%20render%20of%20the%20settings%20form.%20Settings%20re-renders%20whenever%20any%20%60%40ObservedObject%60%20publishes%20a%20change%20%28e.g.%2C%20download%20progress%20updates%20from%20%60modelDownloadManager%60%29.%20Moving%20the%20URL%20and%20the%20existence%20flag%20into%20a%20%60%40State%60%20property%20computed%20once%20on%20%60onAppear%60%20would%20avoid%20the%20repeated%20filesystem%20stat.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20HStack%28spacing%3A%208%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20let%20lmStudioURL%20%3D%20FileManager.default.homeDirectoryForCurrentUser%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.appendingPathComponent%28%22.lmstudio%2Fmodels%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Button%28%22LM%20Studio%20Folder%22%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20NSWorkspace.shared.open%28lmStudioURL%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.disabled%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20!FileManager.default.fileExists%28atPath%3A%20lmStudioURL.path%28percentEncoded%3A%20false%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%60%60%60%0A%0A&repo=fujacob%2Ftabby&pr=176&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add LM Studio folder button to model set..."](https://github.com/fujacob/tabby/commit/e52c697229cf59956a47a0f4a9f920d325755b0e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33572576)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->