### PR TITLE
Fix missing space between word and suggestion after echo stripping

### DIFF
--- a/tabby/Support/SuggestionTextNormalizer.swift
+++ b/tabby/Support/SuggestionTextNormalizer.swift
@@ -66,21 +66,22 @@ enum SuggestionTextNormalizer {
             return ""
         }
 
-        // Deterministic space management: the user owns the word boundary, not the model.
-        // If the preceding text already ends with whitespace, strip any leading whitespace
-        // the model added to prevent double-spacing. If it doesn't, the model's leading
-        // space (or lack of one) passes through untouched — it's either a correct mid-word
-        // completion or a natural word break the model chose.
+        // Echo suppression: strip any leading words that repeat the tail of the preceding text.
+        // Small models sometimes regurgitate the prompt suffix instead of continuing from it.
+        // Word-by-word suffix–prefix overlap catches "hello world " → "world is great" and
+        // strips "world" so the ghost text shows only " is great".
+        normalized = stripEchoPrefix(normalized, precedingText: request.context.precedingText)
+
+        // Deterministic space management runs AFTER echo suppression because stripping echoed
+        // words can expose a leading space (e.g. "world is" → " is"). If the preceding text
+        // already ends with whitespace we strip the leading space to prevent double-spacing.
+        // When preceding text does NOT end with whitespace, the model's leading space (or the
+        // inter-word space exposed by echo suppression) passes through — it's the word boundary
+        // the user needs.
         if let lastScalar = request.context.precedingText.unicodeScalars.last,
            CharacterSet.whitespaces.contains(lastScalar) {
             normalized = String(normalized.drop(while: { $0.isWhitespace }))
         }
-
-        // Echo suppression: strip any leading words that repeat the tail of the preceding text.
-        // Small models sometimes regurgitate the prompt suffix instead of continuing from it.
-        // Word-by-word suffix–prefix overlap catches "hello world " → "world is great" and
-        // strips "world" so the ghost text shows only "is great".
-        normalized = stripEchoPrefix(normalized, precedingText: request.context.precedingText)
 
         return normalized
     }
@@ -128,6 +129,10 @@ enum SuggestionTextNormalizer {
             return ""
         }
 
-        return suggestionWords.dropFirst(bestOverlap).joined(separator: " ")
+        // Slice the original string at the character position where the last echoed word ends,
+        // preserving the original whitespace that follows it (typically the space between words).
+        let lastEchoedWord = suggestionWords[bestOverlap - 1]
+        let afterLastEchoed = lastEchoedWord.endIndex
+        return String(suggestion[afterLastEchoed...])
     }
 }

--- a/tabbyTests/SuggestionTextNormalizerTests.swift
+++ b/tabbyTests/SuggestionTextNormalizerTests.swift
@@ -102,7 +102,29 @@ final class SuggestionTextNormalizerTests: XCTestCase {
             for: request
         )
 
-        XCTAssertEqual(normalized, "matcha in the morning")
+        XCTAssertEqual(normalized, " matcha in the morning")
+    }
+
+    func test_normalize_preservesSpaceAfterEchoStrippingWhenPrecedingTextLacksTrailingSpace() {
+        let request = TabbyTestFixtures.suggestionRequest(precedingText: "hello world")
+
+        let normalized = SuggestionTextNormalizer.normalize(
+            "world is great",
+            for: request
+        )
+
+        XCTAssertEqual(normalized, " is great")
+    }
+
+    func test_normalize_stripsSpaceAfterEchoStrippingWhenPrecedingTextEndsWithSpace() {
+        let request = TabbyTestFixtures.suggestionRequest(precedingText: "hello world ")
+
+        let normalized = SuggestionTextNormalizer.normalize(
+            "world is great",
+            for: request
+        )
+
+        XCTAssertEqual(normalized, "is great")
     }
 
     func test_normalize_returnsEmptyWhenSuggestionIsOnlyAnEchoedTailWord() {


### PR DESCRIPTION
## Summary
- `stripEchoPrefix()` used `split`/`joined(separator:)` which destroyed original whitespace, dropping the leading space before the first non-echoed word
- Now slices the original string at the character boundary so inter-word spacing is preserved
- Reorders `normalize()` so space management runs after echo suppression, correctly handling the exposed leading space

Fixes #158

## Test plan
- [x] Build succeeds (`xcodebuild build`)
- [x] Test build succeeds (`xcodebuild build-for-testing`)
- [x] SwiftLint passes (no new warnings)
- [x] Updated existing test expectation for echo-stripped multi-word overlap
- [x] Added test: space preserved after echo stripping when preceding text lacks trailing space
- [x] Added test: space stripped after echo stripping when preceding text ends with space

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a missing-space bug where `stripEchoPrefix` used `joined(separator: " ")` to reconstruct the stripped suggestion, discarding any inter-word whitespace from the original model output. It now slices the original string at the `endIndex` of the last echoed `Substring`, preserving the original separator. The call order in `normalize()` is also corrected so that the space-deduplication step runs after echo suppression, since stripping echoed words can itself expose a leading space that then needs to be evaluated.

- `stripEchoPrefix` returns `String(suggestion[afterLastEchoed...])` using the `Substring.endIndex` — a valid index into the parent string — so the original whitespace between the echoed and non-echoed words is preserved.
- Space management now correctly handles the exposed leading space: strip it when preceding text already ends with whitespace (prevents double-spacing), pass it through when it doesn't (provides the needed word boundary).
- Three new / updated test cases lock in the behavior: preserved space after strip with no trailing whitespace, stripped space when preceding text ends with a space, and the corrected expectation for multi-word overlap.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is well-scoped, pure, and fully covered by targeted tests.

The fix is straightforward: switching from word-rejoining to a direct string slice, and reordering two independent steps. Both paths are exercised by the updated and new tests, the function remains pure, and no other callers are affected. No edge cases appear unhandled.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tabby/Support/SuggestionTextNormalizer.swift | Reorders echo suppression before space management and fixes stripEchoPrefix to slice the original string instead of rejoining split words, correctly preserving inter-word whitespace. |
| tabbyTests/SuggestionTextNormalizerTests.swift | Updates the existing multi-word echo test expectation to include the preserved leading space, and adds two new tests covering the no-trailing-space and trailing-space cases for post-echo-strip space management. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["normalize(rawSuggestion)"] --> B["Strip control chars, chat markers,\nthink blocks, prompt echo, prefix echo"]
    B --> C["Trim control chars / newlines\nCollapse to first line"]
    C --> D{"trailingText\nrepeated?"}
    D -- Yes --> E["return ''"]
    D -- No --> F["stripEchoPrefix()\n(NEW: runs first)"]
    F --> G{"bestOverlap > 0?"}
    G -- No --> H["normalized unchanged"]
    G -- Yes --> I{"bestOverlap >=\nsuggestionWords.count?"}
    I -- Yes --> E
    I -- No --> J["Slice original string at\nlastEchoedWord.endIndex\n(preserves whitespace)"]
    J --> H
    H --> K{"precedingText ends\nwith whitespace?"}
    K -- Yes --> L["drop leading whitespace\nfrom normalized\n(NEW: runs second)"]
    K -- No --> M["pass through\n(word boundary preserved)"]
    L --> N["return normalized"]
    M --> N
```

<sub>Reviews (1): Last reviewed commit: ["Fix missing space between current word a..."](https://github.com/fujacob/tabby/commit/f169d84957b1be016d1eb1cc75270d3d066b3ec3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33576509)</sub>

<!-- /greptile_comment -->