### PR TITLE
Add RTL ghost text alignment support

### DIFF
--- a/tabby.xcodeproj/project.pbxproj
+++ b/tabby.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		E10000022F93000100DDD002 /* PermissionAndContextModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10000122F93000100DDD012 /* PermissionAndContextModelTests.swift */; };
 		E10000032F93000100DDD003 /* GhostSuggestionLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10000132F93000100DDD013 /* GhostSuggestionLayoutTests.swift */; };
 		E10000042F93000100DDD004 /* BundledRuntimeLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10000142F93000100DDD014 /* BundledRuntimeLocatorTests.swift */; };
+		F10000012FA0000100EEE001 /* TextDirectionDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10000112FA0000100EEE011 /* TextDirectionDetectorTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,6 +61,7 @@
 		E10000122F93000100DDD012 /* PermissionAndContextModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PermissionAndContextModelTests.swift; sourceTree = "<group>"; };
 		E10000132F93000100DDD013 /* GhostSuggestionLayoutTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GhostSuggestionLayoutTests.swift; sourceTree = "<group>"; };
 		E10000142F93000100DDD014 /* BundledRuntimeLocatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BundledRuntimeLocatorTests.swift; sourceTree = "<group>"; };
+		F10000112FA0000100EEE011 /* TextDirectionDetectorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TextDirectionDetectorTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -129,6 +131,7 @@
 				E10000122F93000100DDD012 /* PermissionAndContextModelTests.swift */,
 				E10000132F93000100DDD013 /* GhostSuggestionLayoutTests.swift */,
 				E10000142F93000100DDD014 /* BundledRuntimeLocatorTests.swift */,
+				F10000112FA0000100EEE011 /* TextDirectionDetectorTests.swift */,
 			);
 			path = tabbyTests;
 			sourceTree = "<group>";
@@ -264,6 +267,7 @@
 				E10000022F93000100DDD002 /* PermissionAndContextModelTests.swift in Sources */,
 				E10000032F93000100DDD003 /* GhostSuggestionLayoutTests.swift in Sources */,
 				E10000042F93000100DDD004 /* BundledRuntimeLocatorTests.swift in Sources */,
+				F10000012FA0000100EEE001 /* TextDirectionDetectorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/tabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
@@ -103,7 +103,7 @@ extension SuggestionCoordinator {
                 inputFrameRect: liveContext.inputFrameRect,
                 caretQuality: liveContext.caretQuality,
                 observedCharWidth: liveContext.observedCharWidth,
-                precedingText: liveContext.precedingText
+                isRightToLeft: isRTL
             )
             // Force an early AX refresh so the real caret position corrects any prediction
             // error faster than the normal 250ms poll interval.
@@ -310,14 +310,14 @@ extension SuggestionCoordinator {
         inputFrameRect: CGRect?,
         caretQuality: CaretGeometryQuality,
         observedCharWidth: CGFloat?,
-        precedingText: String = ""
+        isRightToLeft: Bool = false
     ) {
         let geometry = SuggestionOverlayGeometry(
             caretRect: caretRect,
             inputFrameRect: inputFrameRect,
             caretQuality: caretQuality,
             observedCharWidth: observedCharWidth,
-            isRightToLeft: TextDirectionDetector.isRightToLeft(precedingText)
+            isRightToLeft: isRightToLeft
         )
         if let message = overlayPresenter.present(
             text: text,

--- a/tabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
@@ -89,18 +89,21 @@ extension SuggestionCoordinator {
             // Predict where the caret will land after the inserted chunk. This eliminates the
             // visible jump where the overlay stays at the old position then snaps rightward
             // when AX catches up 100–250ms later.
+            let isRTL = TextDirectionDetector.isRightToLeft(liveContext.precedingText)
             let predictedCaret = Self.predictedCaretRect(
                 after: acceptedChunk,
                 oldCaretRect: liveContext.caretRect,
                 caretQuality: liveContext.caretQuality,
-                observedCharWidth: liveContext.observedCharWidth
+                observedCharWidth: liveContext.observedCharWidth,
+                isRightToLeft: isRTL
             )
             presentOverlay(
                 text: advancedSession.remainingText,
                 at: predictedCaret,
                 inputFrameRect: liveContext.inputFrameRect,
                 caretQuality: liveContext.caretQuality,
-                observedCharWidth: liveContext.observedCharWidth
+                observedCharWidth: liveContext.observedCharWidth,
+                precedingText: liveContext.precedingText
             )
             // Force an early AX refresh so the real caret position corrects any prediction
             // error faster than the normal 250ms poll interval.
@@ -228,14 +231,16 @@ extension SuggestionCoordinator {
 
     // MARK: - Caret Prediction
 
-    /// Estimates the caret rect after inserting a chunk by shifting the old caret rightward.
+    /// Estimates the caret rect after inserting a chunk by shifting the old caret in the text
+    /// direction. LTR shifts right; RTL shifts left.
     /// When `observedCharWidth` is available (measured from real AX child frames), we use it
     /// directly — this matches the target app's actual font. Falls back to NSFont measurement.
     static func predictedCaretRect(
         after insertedChunk: String,
         oldCaretRect: CGRect,
         caretQuality: CaretGeometryQuality,
-        observedCharWidth: CGFloat?
+        observedCharWidth: CGFloat?,
+        isRightToLeft: Bool = false
     ) -> CGRect {
         let measuredWidth = predictedChunkWidth(
             insertedChunk: insertedChunk,
@@ -264,8 +269,9 @@ extension SuggestionCoordinator {
             )
         }
 
+        let shift = isRightToLeft ? -chunkWidth : chunkWidth
         return CGRect(
-            x: oldCaretRect.origin.x + chunkWidth,
+            x: oldCaretRect.origin.x + shift,
             y: oldCaretRect.origin.y,
             width: oldCaretRect.width,
             height: oldCaretRect.height
@@ -303,13 +309,15 @@ extension SuggestionCoordinator {
         at caretRect: CGRect,
         inputFrameRect: CGRect?,
         caretQuality: CaretGeometryQuality,
-        observedCharWidth: CGFloat?
+        observedCharWidth: CGFloat?,
+        precedingText: String = ""
     ) {
         let geometry = SuggestionOverlayGeometry(
             caretRect: caretRect,
             inputFrameRect: inputFrameRect,
             caretQuality: caretQuality,
-            observedCharWidth: observedCharWidth
+            observedCharWidth: observedCharWidth,
+            isRightToLeft: TextDirectionDetector.isRightToLeft(precedingText)
         )
         if let message = overlayPresenter.present(
             text: text,

--- a/tabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
@@ -214,7 +214,8 @@ extension SuggestionCoordinator {
             at: liveContext.caretRect,
             inputFrameRect: liveContext.inputFrameRect,
             caretQuality: liveContext.caretQuality,
-            observedCharWidth: liveContext.observedCharWidth
+            observedCharWidth: liveContext.observedCharWidth,
+            precedingText: liveContext.precedingText
         )
         logStage(
             "ready",
@@ -308,7 +309,8 @@ extension SuggestionCoordinator {
                 at: liveContext.caretRect,
                 inputFrameRect: liveContext.inputFrameRect,
                 caretQuality: liveContext.caretQuality,
-                observedCharWidth: liveContext.observedCharWidth
+                observedCharWidth: liveContext.observedCharWidth,
+                precedingText: liveContext.precedingText
             )
             if let advancement {
                 logStage(

--- a/tabby/Models/SuggestionModels.swift
+++ b/tabby/Models/SuggestionModels.swift
@@ -341,6 +341,9 @@ struct SuggestionOverlayGeometry: Equatable, Sendable {
     /// Average character width from AX child-frame sampling when available. Layout uses this as a
     /// cheap approximation for host-editor text width before falling back to local font metrics.
     let observedCharWidth: CGFloat?
+    /// When `true`, the text near the caret is Right-to-Left (Arabic, Hebrew, etc.) and the ghost
+    /// text overlay should appear to the left of the caret instead of the right.
+    let isRightToLeft: Bool
 }
 
 /// The overlay is intentionally modeled as data so diagnostics can reason about visibility

--- a/tabby/Services/UI/OverlayController.swift
+++ b/tabby/Services/UI/OverlayController.swift
@@ -167,20 +167,25 @@ private struct GhostSuggestionView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
+        let alignment: HorizontalAlignment = layout.isRightToLeft ? .trailing : .leading
+        VStack(alignment: alignment, spacing: 0) {
             ForEach(layout.lines) { line in
                 HStack(alignment: .firstTextBaseline, spacing: line.showsKeycap ? 6 : 0) {
+                    if layout.isRightToLeft && line.showsKeycap {
+                        GhostTabKeycap()
+                    }
+
                     Text(line.text)
                         .font(.system(size: fontSize))
                         .foregroundStyle(ghostColor)
                         .lineLimit(1)
                         .fixedSize(horizontal: true, vertical: true)
 
-                    if line.showsKeycap {
+                    if !layout.isRightToLeft && line.showsKeycap {
                         GhostTabKeycap()
                     }
                 }
-                .padding(.leading, line.leadingIndent)
+                .padding(layout.isRightToLeft ? .trailing : .leading, line.leadingIndent)
                 .fixedSize(horizontal: true, vertical: true)
             }
         }

--- a/tabby/Support/GhostSuggestionLayout.swift
+++ b/tabby/Support/GhostSuggestionLayout.swift
@@ -19,9 +19,12 @@ struct GhostSuggestionLayout: Equatable {
     }
 
     let lines: [Line]
+    /// For LTR, the left edge of the panel. For RTL, the right-edge anchor — `panelFrame()`
+    /// subtracts the content width to derive the actual AppKit origin.
     let panelOriginX: CGFloat
     let lineHeight: CGFloat
     let topLineCenterOffsetFromCaret: CGFloat
+    let isRightToLeft: Bool
 
     private enum Metrics {
         static let caretGap: CGFloat = 6
@@ -40,18 +43,37 @@ struct GhostSuggestionLayout: Equatable {
     ) -> GhostSuggestionLayout {
         let normalizedText = normalizedDisplayText(text)
         let lineHeight = ceil(fontSize * Metrics.lineHeightMultiplier)
+        let isRTL = geometry.isRightToLeft
         let usableFrame = usableTextFrame(
             geometry: geometry,
             visibleFrame: visibleFrame
         )
-        let firstLineX = min(
-            max(geometry.caretRect.maxX + Metrics.caretGap, usableFrame.minX),
-            usableFrame.maxX
-        )
-        let firstLineBudget = max(
-            0,
-            usableFrame.maxX - firstLineX - Metrics.estimatedKeycapAndSpacingWidth
-        )
+
+        // Direction-dependent anchor and budget.
+        // LTR: anchor at the right edge of the caret, budget extends rightward.
+        // RTL: anchor at the left edge of the caret, budget extends leftward.
+        let firstLineAnchor: CGFloat
+        let firstLineBudget: CGFloat
+        if isRTL {
+            firstLineAnchor = min(
+                max(geometry.caretRect.minX - Metrics.caretGap, usableFrame.minX),
+                usableFrame.maxX
+            )
+            firstLineBudget = max(
+                0,
+                firstLineAnchor - usableFrame.minX - Metrics.estimatedKeycapAndSpacingWidth
+            )
+        } else {
+            firstLineAnchor = min(
+                max(geometry.caretRect.maxX + Metrics.caretGap, usableFrame.minX),
+                usableFrame.maxX
+            )
+            firstLineBudget = max(
+                0,
+                usableFrame.maxX - firstLineAnchor - Metrics.estimatedKeycapAndSpacingWidth
+            )
+        }
+
         let overflowBudget = max(
             Metrics.minimumLineWidth,
             usableFrame.width - Metrics.estimatedKeycapAndSpacingWidth
@@ -68,13 +90,16 @@ struct GhostSuggestionLayout: Equatable {
                 lines: [
                     Line(index: 0, text: normalizedText, leadingIndent: 0, showsKeycap: true)
                 ],
-                panelOriginX: firstLineX,
+                panelOriginX: firstLineAnchor,
                 lineHeight: lineHeight,
-                topLineCenterOffsetFromCaret: 0
+                topLineCenterOffsetFromCaret: 0,
+                isRightToLeft: isRTL
             )
         }
 
-        let panelOriginX = usableFrame.minX
+        // Multi-line wrapping. The panel spans the full usable width so overflow lines can
+        // use the entire field. The first line is indented to stay aligned with the caret.
+        let panelOriginX = isRTL ? usableFrame.maxX : usableFrame.minX
         var remainingText = normalizedText
         var rawLines: [(text: String, leadingIndent: CGFloat)] = []
         var startsBelowCaret = false
@@ -87,7 +112,13 @@ struct GhostSuggestionLayout: Equatable {
                 observedCharWidth: geometry.observedCharWidth
             )
             if !split.line.isEmpty {
-                rawLines.append((split.line, firstLineX - panelOriginX))
+                let indent: CGFloat
+                if isRTL {
+                    indent = panelOriginX - firstLineAnchor
+                } else {
+                    indent = firstLineAnchor - panelOriginX
+                }
+                rawLines.append((split.line, indent))
                 remainingText = split.remainder
             } else {
                 startsBelowCaret = true
@@ -129,16 +160,18 @@ struct GhostSuggestionLayout: Equatable {
             lines: finalLines,
             panelOriginX: panelOriginX,
             lineHeight: lineHeight,
-            topLineCenterOffsetFromCaret: startsBelowCaret ? -lineHeight : 0
+            topLineCenterOffsetFromCaret: startsBelowCaret ? -lineHeight : 0,
+            isRightToLeft: isRTL
         )
     }
 
     func panelFrame(for contentSize: CGSize, caretRect: CGRect) -> CGRect {
         let topLineCenterY = caretRect.midY + topLineCenterOffsetFromCaret
         let originY = topLineCenterY - contentSize.height + (lineHeight / 2)
+        let originX = isRightToLeft ? panelOriginX - contentSize.width : panelOriginX
 
         return CGRect(
-            origin: CGPoint(x: panelOriginX, y: originY),
+            origin: CGPoint(x: originX, y: originY),
             size: contentSize
         )
     }
@@ -147,39 +180,44 @@ struct GhostSuggestionLayout: Equatable {
         geometry: SuggestionOverlayGeometry,
         visibleFrame: CGRect
     ) -> CGRect {
-        let fallbackMinX = geometry.caretRect.maxX + Metrics.caretGap
-        let fallbackMaxX = visibleFrame.maxX - Metrics.fallbackScreenMargin
-        let fallbackFrame = CGRect(
+        if let inputFrame = geometry.inputFrameRect?.standardized,
+           inputFrame.width > Metrics.minimumLineWidth {
+            let minX = max(
+                inputFrame.minX + Metrics.inputHorizontalPadding,
+                visibleFrame.minX + Metrics.fallbackScreenMargin
+            )
+            let maxX = min(
+                inputFrame.maxX - Metrics.inputHorizontalPadding,
+                visibleFrame.maxX - Metrics.fallbackScreenMargin
+            )
+
+            if maxX - minX > Metrics.minimumLineWidth {
+                return CGRect(
+                    x: minX,
+                    y: inputFrame.minY,
+                    width: maxX - minX,
+                    height: inputFrame.height
+                )
+            }
+        }
+
+        // Fallback when no input frame is available. For LTR, use the area to the right
+        // of the caret. For RTL, use the area to the left.
+        let fallbackMinX: CGFloat
+        let fallbackMaxX: CGFloat
+        if geometry.isRightToLeft {
+            fallbackMinX = visibleFrame.minX + Metrics.fallbackScreenMargin
+            fallbackMaxX = geometry.caretRect.minX - Metrics.caretGap
+        } else {
+            fallbackMinX = geometry.caretRect.maxX + Metrics.caretGap
+            fallbackMaxX = visibleFrame.maxX - Metrics.fallbackScreenMargin
+        }
+
+        return CGRect(
             x: fallbackMinX,
             y: geometry.caretRect.minY,
             width: max(Metrics.minimumLineWidth, fallbackMaxX - fallbackMinX),
             height: geometry.caretRect.height
-        )
-
-        guard let inputFrame = geometry.inputFrameRect?.standardized,
-              inputFrame.width > Metrics.minimumLineWidth
-        else {
-            return fallbackFrame
-        }
-
-        let minX = max(
-            inputFrame.minX + Metrics.inputHorizontalPadding,
-            visibleFrame.minX + Metrics.fallbackScreenMargin
-        )
-        let maxX = min(
-            inputFrame.maxX - Metrics.inputHorizontalPadding,
-            visibleFrame.maxX - Metrics.fallbackScreenMargin
-        )
-
-        guard maxX - minX > Metrics.minimumLineWidth else {
-            return fallbackFrame
-        }
-
-        return CGRect(
-            x: minX,
-            y: inputFrame.minY,
-            width: maxX - minX,
-            height: inputFrame.height
         )
     }
 

--- a/tabby/Support/TextDirectionDetector.swift
+++ b/tabby/Support/TextDirectionDetector.swift
@@ -20,8 +20,9 @@ enum TextDirectionDetector {
 
     private static func isStrongRTL(_ scalar: Unicode.Scalar) -> Bool {
         let value = scalar.value
-        // Arabic (0600–06FF), Syriac (0700–074F), Arabic Supplement (0750–077F),
-        // Thaana (0780–07BF), NKo (07C0–07FF), Arabic Extended (0870–08FF) — one contiguous test
+        // Hebrew (0590–05FF), Arabic (0600–06FF), Syriac (0700–074F),
+        // Arabic Supplement (0750–077F), Thaana (0780–07BF), NKo (07C0–07FF),
+        // Arabic Extended (0870–08FF) — one contiguous test
         if value >= 0x0590 && value <= 0x08FF { return true }
         // Arabic/Hebrew presentation forms + Arabic Presentation Forms-B
         if value >= 0xFB1D && value <= 0xFDFF { return true }

--- a/tabby/Support/TextDirectionDetector.swift
+++ b/tabby/Support/TextDirectionDetector.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Detects whether text near the caret is Right-to-Left by examining Unicode bidi properties.
+///
+/// The detector walks the string backwards because the characters closest to the caret are the
+/// strongest signal for which direction the ghost text should render. Falls back to LTR when
+/// no strong directional character is found.
+enum TextDirectionDetector {
+    /// Returns `true` when the dominant script near the end of `text` is Right-to-Left
+    /// (Arabic, Hebrew, or another RTL script).
+    static func isRightToLeft(_ text: String) -> Bool {
+        for scalar in text.unicodeScalars.reversed() {
+            if isStrongRTL(scalar) { return true }
+            if isStrongLTR(scalar) { return false }
+        }
+        return false
+    }
+
+    // MARK: - Unicode bidi classification
+
+    private static func isStrongRTL(_ scalar: Unicode.Scalar) -> Bool {
+        let value = scalar.value
+        // Arabic (0600–06FF), Syriac (0700–074F), Arabic Supplement (0750–077F),
+        // Thaana (0780–07BF), NKo (07C0–07FF), Arabic Extended (0870–08FF) — one contiguous test
+        if value >= 0x0590 && value <= 0x08FF { return true }
+        // Arabic/Hebrew presentation forms + Arabic Presentation Forms-B
+        if value >= 0xFB1D && value <= 0xFDFF { return true }
+        if value >= 0xFE70 && value <= 0xFEFF { return true }
+        // RTL marks
+        if value == 0x200F || value == 0x061C { return true }
+        return false
+    }
+
+    private static func isStrongLTR(_ scalar: Unicode.Scalar) -> Bool {
+        let value = scalar.value
+        // Basic Latin letters
+        if value >= 0x0041 && value <= 0x005A { return true }
+        if value >= 0x0061 && value <= 0x007A { return true }
+        // Latin Extended
+        if value >= 0x00C0 && value <= 0x024F { return true }
+        // Greek
+        if value >= 0x0370 && value <= 0x03FF { return true }
+        // Cyrillic
+        if value >= 0x0400 && value <= 0x04FF { return true }
+        // CJK Unified Ideographs (treated as LTR)
+        if value >= 0x4E00 && value <= 0x9FFF { return true }
+        // LTR mark
+        if value == 0x200E { return true }
+        return false
+    }
+}

--- a/tabbyTests/GhostSuggestionLayoutTests.swift
+++ b/tabbyTests/GhostSuggestionLayoutTests.swift
@@ -161,4 +161,99 @@ final class GhostSuggestionLayoutTests: XCTestCase {
 
         XCTAssertFalse(layout.lines.isEmpty, "Should still produce lines without an input frame")
     }
+
+    // MARK: - RTL single-line layout
+
+    func test_make_rtlSingleLineLayoutPlacesLeftOfCaret() {
+        let geometry = TabbyTestFixtures.overlayGeometry(
+            caretRect: CGRect(x: 200, y: 80, width: 2, height: 18),
+            inputFrameRect: CGRect(x: 0, y: 70, width: 400, height: 30),
+            observedCharWidth: 7,
+            isRightToLeft: true
+        )
+
+        let layout = GhostSuggestionLayout.make(
+            text: "مرحبا",
+            geometry: geometry,
+            fontSize: 14,
+            visibleFrame: CGRect(x: 0, y: 0, width: 500, height: 300)
+        )
+
+        XCTAssertEqual(layout.lines.count, 1)
+        XCTAssertTrue(layout.isRightToLeft)
+        XCTAssertEqual(layout.topLineCenterOffsetFromCaret, 0)
+        // panelOriginX is a right-edge anchor for RTL, so it should be left of the caret
+        XCTAssertLessThanOrEqual(layout.panelOriginX, geometry.caretRect.minX)
+    }
+
+    func test_panelFrame_rtlSubtractsContentWidth() {
+        let geometry = TabbyTestFixtures.overlayGeometry(
+            caretRect: CGRect(x: 200, y: 100, width: 2, height: 18),
+            inputFrameRect: CGRect(x: 0, y: 90, width: 400, height: 30),
+            observedCharWidth: 7,
+            isRightToLeft: true
+        )
+
+        let layout = GhostSuggestionLayout.make(
+            text: "مرحبا",
+            geometry: geometry,
+            fontSize: 14,
+            visibleFrame: CGRect(x: 0, y: 0, width: 500, height: 300)
+        )
+
+        let contentSize = CGSize(width: 80, height: 20)
+        let frame = layout.panelFrame(for: contentSize, caretRect: geometry.caretRect)
+
+        // RTL: actual origin.x = panelOriginX - contentSize.width
+        XCTAssertEqual(frame.origin.x, layout.panelOriginX - contentSize.width)
+        // Panel should be entirely to the left of the caret
+        XCTAssertLessThan(frame.maxX, geometry.caretRect.minX)
+    }
+
+    // MARK: - RTL multi-line layout
+
+    func test_make_rtlMultiLineWrapsCorrectly() {
+        let geometry = TabbyTestFixtures.overlayGeometry(
+            caretRect: CGRect(x: 200, y: 80, width: 2, height: 18),
+            inputFrameRect: CGRect(x: 0, y: 70, width: 300, height: 30),
+            observedCharWidth: 7,
+            isRightToLeft: true
+        )
+
+        let layout = GhostSuggestionLayout.make(
+            text: "هذا نص طويل جدا يحتاج إلى التفاف على عدة أسطر",
+            geometry: geometry,
+            fontSize: 14,
+            visibleFrame: CGRect(x: 0, y: 0, width: 500, height: 300)
+        )
+
+        XCTAssertGreaterThan(layout.lines.count, 1, "Should wrap to multiple lines in RTL")
+        XCTAssertTrue(layout.isRightToLeft)
+        XCTAssertEqual(layout.lines.last?.showsKeycap, true)
+        for line in layout.lines.dropLast() {
+            XCTAssertFalse(line.showsKeycap)
+        }
+    }
+
+    func test_make_rtlStartsBelowCaretWhenLeftBudgetTooSmall() {
+        // Caret near the left edge — no room to the left
+        let geometry = TabbyTestFixtures.overlayGeometry(
+            caretRect: CGRect(x: 15, y: 80, width: 2, height: 18),
+            inputFrameRect: CGRect(x: 0, y: 70, width: 300, height: 30),
+            observedCharWidth: 7,
+            isRightToLeft: true
+        )
+
+        let layout = GhostSuggestionLayout.make(
+            text: "نص عربي طويل يحتاج مساحة كبيرة",
+            geometry: geometry,
+            fontSize: 14,
+            visibleFrame: CGRect(x: 0, y: 0, width: 500, height: 300)
+        )
+
+        XCTAssertLessThan(
+            layout.topLineCenterOffsetFromCaret, 0,
+            "Should start below caret when left budget is too small for RTL"
+        )
+    }
 }

--- a/tabbyTests/TabbyTestFixtures.swift
+++ b/tabbyTests/TabbyTestFixtures.swift
@@ -149,13 +149,15 @@ enum TabbyTestFixtures {
         caretRect: CGRect = CGRect(x: 10, y: 20, width: 2, height: 18),
         inputFrameRect: CGRect? = CGRect(x: 0, y: 0, width: 240, height: 32),
         caretQuality: CaretGeometryQuality = .exact,
-        observedCharWidth: CGFloat? = nil
+        observedCharWidth: CGFloat? = nil,
+        isRightToLeft: Bool = false
     ) -> SuggestionOverlayGeometry {
         SuggestionOverlayGeometry(
             caretRect: caretRect,
             inputFrameRect: inputFrameRect,
             caretQuality: caretQuality,
-            observedCharWidth: observedCharWidth
+            observedCharWidth: observedCharWidth,
+            isRightToLeft: isRightToLeft
         )
     }
 

--- a/tabbyTests/TextDirectionDetectorTests.swift
+++ b/tabbyTests/TextDirectionDetectorTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+@testable import tabby
+
+final class TextDirectionDetectorTests: XCTestCase {
+
+    // MARK: - RTL detection
+
+    func test_arabicText_isRTL() {
+        XCTAssertTrue(TextDirectionDetector.isRightToLeft("مرحبا بالعالم"))
+    }
+
+    func test_hebrewText_isRTL() {
+        XCTAssertTrue(TextDirectionDetector.isRightToLeft("שלום עולם"))
+    }
+
+    func test_arabicWithTrailingSpaces_isRTL() {
+        XCTAssertTrue(TextDirectionDetector.isRightToLeft("مرحبا   "))
+    }
+
+    // MARK: - LTR detection
+
+    func test_englishText_isLTR() {
+        XCTAssertFalse(TextDirectionDetector.isRightToLeft("hello world"))
+    }
+
+    func test_emptyString_isLTR() {
+        XCTAssertFalse(TextDirectionDetector.isRightToLeft(""))
+    }
+
+    func test_whitespaceOnly_isLTR() {
+        XCTAssertFalse(TextDirectionDetector.isRightToLeft("   "))
+    }
+
+    func test_numbersOnly_isLTR() {
+        XCTAssertFalse(TextDirectionDetector.isRightToLeft("12345"))
+    }
+
+    // MARK: - Mixed text (last strong character wins)
+
+    func test_arabicThenEnglish_lastStrongIsLTR() {
+        // "hello" is at the end — last strong character is Latin
+        XCTAssertFalse(TextDirectionDetector.isRightToLeft("مرحبا hello"))
+    }
+
+    func test_englishThenArabic_lastStrongIsRTL() {
+        // Arabic is at the end — last strong character is Arabic
+        XCTAssertTrue(TextDirectionDetector.isRightToLeft("hello مرحبا"))
+    }
+
+    func test_arabicWithTrailingNumbers_isRTL() {
+        // Numbers are weak — the last strong character is Arabic
+        XCTAssertTrue(TextDirectionDetector.isRightToLeft("مرحبا 123"))
+    }
+}


### PR DESCRIPTION
## Summary

Detect text direction from Unicode bidi properties of the preceding text and
mirror the ghost text overlay positioning for RTL scripts (Arabic, Hebrew, etc.).
Ghost text now appears to the left of the caret instead of the right when the
user is typing in a Right-to-Left language.

<img width="1522" height="633" alt="image" src="https://github.com/user-attachments/assets/6e174b3c-76d6-4078-839d-8a866373b3e8" />

## Validation

```
xcodebuild -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

xcodebuild -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' build-for-testing
# ** TEST BUILD SUCCEEDED **

swiftlint lint --quiet
# exit 0 (no new warnings)
```

Manual testing with Arabic keyboard pending — needs verification in TextEdit,
Notes, and Chrome to confirm AX caret rects behave correctly for RTL text.

## Linked issues

Fixes #160

## Risk / rollout notes

- Adds `isRightToLeft: Bool` to `SuggestionOverlayGeometry` — all existing call
  sites default to `false`, so LTR behavior is unchanged.
- `GhostSuggestionLayout.panelOriginX` now means "right-edge anchor" when
  `isRightToLeft` is true; `panelFrame()` handles the conversion.
- New test file `TextDirectionDetectorTests.swift` registered in pbxproj.
- AX caret rect branches in `AXTextGeometryResolver` are unchanged — if RTL
  caret rects prove inaccurate in specific apps, that's a follow-up.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces RTL ghost-text support by adding `TextDirectionDetector` (a reverse-scan Unicode bidi heuristic), extending `SuggestionOverlayGeometry` with `isRightToLeft`, mirroring the layout anchor/budget/indent math in `GhostSuggestionLayout`, reversing the keycap position in `OverlayController`, and shifting the predicted caret leftward on Tab-acceptance for RTL. The model is well-structured and the pure-logic changes in `Support/` and `Models/` are sound.

- **Compile error in `SuggestionCoordinator+Prediction.swift`**: both `presentOverlay` call sites pass `precedingText: liveContext.precedingText`, but `presentOverlay` only accepts `isRightToLeft: Bool`. There is no overload that takes `precedingText`. The fix, matching the approach in `Acceptance.swift`, is to resolve the direction first: `isRightToLeft: TextDirectionDetector.isRightToLeft(liveContext.precedingText)`.
- **RTL layout and detection logic** in `GhostSuggestionLayout`, `TextDirectionDetector`, and `OverlayController` is geometrically correct and well-tested; the new `GhostSuggestionLayoutTests` and `TextDirectionDetectorTests` cover the key edge cases (small budget, multi-line wrap, mixed scripts, trailing numerals).

<h3>Confidence Score: 3/5</h3>

Not safe to merge — the app will not build due to a broken call site in the prediction path.

The two `presentOverlay` calls in `SuggestionCoordinator+Prediction.swift` pass `precedingText: liveContext.precedingText`, but the function expects `isRightToLeft: Bool`. Swift will reject this at compile time, blocking the entire build. Once that one-line fix is in place (compute the direction and pass `isRightToLeft:` instead), the rest of the RTL changes look correct and safe.

tabby/App/Coordinators/SuggestionCoordinator+Prediction.swift — the two `presentOverlay` call sites use the wrong parameter label and type.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tabby/App/Coordinators/SuggestionCoordinator+Prediction.swift | Two `presentOverlay` call sites pass `precedingText: liveContext.precedingText`, but the function only accepts `isRightToLeft: Bool`. This is a Swift compiler error that prevents the build from succeeding. |
| tabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift | Correctly extends `predictedCaretRect` and `presentOverlay` with `isRightToLeft` support; RTL caret shift negation and overlay geometry wiring look sound. |
| tabby/Support/GhostSuggestionLayout.swift | Direction-dependent anchor, budget, indent, and `panelFrame` origin calculation are correctly symmetric for RTL; `usableTextFrame` fallback is cleanly refactored to respect RTL. |
| tabby/Support/TextDirectionDetector.swift | New pure helper; reverse-scan bidi heuristic is correct; Unicode ranges cover Hebrew, Arabic, Syriac, Thaana, NKo, and presentation forms accurately. |
| tabby/Services/UI/OverlayController.swift | RTL keycap reordering and trailing/leading padding flip look correct; `VStack` alignment switch to `.trailing` for RTL is appropriate. |
| tabby/Models/SuggestionModels.swift | Adds `isRightToLeft: Bool` to `SuggestionOverlayGeometry`; both instantiation sites are updated. |
| tabbyTests/TextDirectionDetectorTests.swift | Good coverage of Arabic, Hebrew, empty string, whitespace, number-only, and mixed-direction inputs; last-strong-character semantics are tested directly. |
| tabbyTests/GhostSuggestionLayoutTests.swift | Four new RTL tests verify single-line anchor, `panelFrame` RTL offset, multi-line wrapping, and below-caret fallback when left budget is exhausted. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant FocusModel
    participant Coordinator as SuggestionCoordinator
    participant TDD as TextDirectionDetector
    participant PresentOverlay as presentOverlay
    participant Geometry as SuggestionOverlayGeometry
    participant Layout as GhostSuggestionLayout
    participant View as GhostSuggestionView

    FocusModel->>Coordinator: liveContext (precedingText, caretRect, ...)

    alt Prediction path (Prediction.swift)
        Coordinator->>PresentOverlay: precedingText: liveContext.precedingText COMPILE ERROR
        Note over PresentOverlay: No such parameter — should be isRightToLeft: TDD.isRightToLeft(precedingText)
    end

    alt Acceptance path (Acceptance.swift)
        Coordinator->>TDD: isRightToLeft(liveContext.precedingText)
        TDD-->>Coordinator: isRTL: Bool
        Coordinator->>PresentOverlay: isRightToLeft: isRTL
    end

    PresentOverlay->>Geometry: SuggestionOverlayGeometry(isRightToLeft:)
    Geometry->>Layout: GhostSuggestionLayout.make(geometry:)
    Layout-->>Layout: direction-aware anchor, budget, indent
    Layout->>View: GhostSuggestionLayout(isRightToLeft:)
    View-->>View: trailing padding, keycap left-of-text for RTL
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tabby/App/Coordinators/SuggestionCoordinator+Prediction.swift`, line 212-219 ([link](https://github.com/fujacob/tabby/blob/489b1adb3b70393d7f13dfcc9346b7dc4dfb911f/tabby/App/Coordinators/SuggestionCoordinator+Prediction.swift#L212-L219)) 

   **`precedingText:` is not a valid parameter of `presentOverlay`**

   Both `presentOverlay` call sites in this file pass `precedingText: liveContext.precedingText`, but the function signature (defined in `SuggestionCoordinator+Acceptance.swift`) expects `isRightToLeft: Bool = false`. There is only one `presentOverlay` definition in the codebase, and it has no `precedingText` parameter. Swift will produce a compiler error — "extraneous argument label 'precedingText:'" — because the label doesn't exist and `String` cannot be coerced to `Bool`. The correct fix, consistent with how `acceptCurrentSuggestion` already handles this, is to resolve the direction before the call: `isRightToLeft: TextDirectionDetector.isRightToLeft(liveContext.precedingText)`.

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22fix%2Frtl-ghost-text-alignment%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Frtl-ghost-text-alignment%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BPrediction.swift%3A212-219%0A**%60precedingText%3A%60%20is%20not%20a%20valid%20parameter%20of%20%60presentOverlay%60**%0A%0ABoth%20%60presentOverlay%60%20call%20sites%20in%20this%20file%20pass%20%60precedingText%3A%20liveContext.precedingText%60%2C%20but%20the%20function%20signature%20%28defined%20in%20%60SuggestionCoordinator%2BAcceptance.swift%60%29%20expects%20%60isRightToLeft%3A%20Bool%20%3D%20false%60.%20There%20is%20only%20one%20%60presentOverlay%60%20definition%20in%20the%20codebase%2C%20and%20it%20has%20no%20%60precedingText%60%20parameter.%20Swift%20will%20produce%20a%20compiler%20error%20%E2%80%94%20%22extraneous%20argument%20label%20'precedingText%3A'%22%20%E2%80%94%20because%20the%20label%20doesn't%20exist%20and%20%60String%60%20cannot%20be%20coerced%20to%20%60Bool%60.%20The%20correct%20fix%2C%20consistent%20with%20how%20%60acceptCurrentSuggestion%60%20already%20handles%20this%2C%20is%20to%20resolve%20the%20direction%20before%20the%20call%3A%20%60isRightToLeft%3A%20TextDirectionDetector.isRightToLeft%28liveContext.precedingText%29%60.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BPrediction.swift%3A212-219%0A**%60precedingText%3A%60%20is%20not%20a%20valid%20parameter%20of%20%60presentOverlay%60**%0A%0ABoth%20%60presentOverlay%60%20call%20sites%20in%20this%20file%20pass%20%60precedingText%3A%20liveContext.precedingText%60%2C%20but%20the%20function%20signature%20%28defined%20in%20%60SuggestionCoordinator%2BAcceptance.swift%60%29%20expects%20%60isRightToLeft%3A%20Bool%20%3D%20false%60.%20There%20is%20only%20one%20%60presentOverlay%60%20definition%20in%20the%20codebase%2C%20and%20it%20has%20no%20%60precedingText%60%20parameter.%20Swift%20will%20produce%20a%20compiler%20error%20%E2%80%94%20%22extraneous%20argument%20label%20'precedingText%3A'%22%20%E2%80%94%20because%20the%20label%20doesn't%20exist%20and%20%60String%60%20cannot%20be%20coerced%20to%20%60Bool%60.%20The%20correct%20fix%2C%20consistent%20with%20how%20%60acceptCurrentSuggestion%60%20already%20handles%20this%2C%20is%20to%20resolve%20the%20direction%20before%20the%20call%3A%20%60isRightToLeft%3A%20TextDirectionDetector.isRightToLeft%28liveContext.precedingText%29%60.%0A%0A&repo=fujacob%2Ftabby&pr=180&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Address Greptile review: fix Hebrew comm..."](https://github.com/fujacob/tabby/commit/489b1adb3b70393d7f13dfcc9346b7dc4dfb911f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33577191)</sub>

<!-- /greptile_comment -->