### PR TITLE
Fix Sparkle update detection with derived build numbers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,12 +121,20 @@ jobs:
             is_prerelease="false"
           fi
 
-          build_number="$(xcodebuild \
-            -project "${PROJECT_PATH}" \
-            -scheme "${SCHEME}" \
-            -configuration "${CONFIGURATION}" \
-            -showBuildSettings |
-            awk -F '= ' '/CURRENT_PROJECT_VERSION/ { print $2; exit }')"
+          # Derive build number from the release version so Sparkle can detect
+          # upgrades. CURRENT_PROJECT_VERSION in the Xcode project is static and
+          # was always "1", which made every appcast report the same build number
+          # and Sparkle would say "You're up to date!" even when a newer release
+          # existed. The formula (major*100000 + minor*1000 + patch) gives each
+          # component room up to 999 before collisions.
+          build_number="$(echo "${release_version}" |
+            sed 's/-.*$//' |
+            awk -F. '{ printf "%d", $1*100000 + $2*1000 + $3 }')"
+
+          if [[ -z "${build_number}" || "${build_number}" -le 0 ]]; then
+            echo "Derived build number '${build_number}' from version '${release_version}' is not a positive integer." >&2
+            exit 1
+          fi
 
           echo "release_tag=${release_tag}" >> "$GITHUB_OUTPUT"
           echo "release_version=${release_version}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

`CURRENT_PROJECT_VERSION` was hardcoded to `1` in the Xcode project, so every
release had `sparkle:version=1` in its appcast. Sparkle compares build numbers
(not marketing versions) to detect updates, so it always reported "You're up
to date!" — even when a newer release existed.

Derive the build number from the release version string instead
(`major*10000 + minor*100 + patch`), giving each release a strictly increasing
integer: `0.0.3-beta → 3`, `0.0.4-beta → 4`, `1.2.3 → 10203`.

## Validation

```
echo "0.0.3-beta" | sed 's/-.*$//' | awk -F. '{ printf "%d\n", $1*10000 + $2*100 + $3 }'
# 3
echo "0.0.4-beta" | sed 's/-.*$//' | awk -F. '{ printf "%d\n", $1*10000 + $2*100 + $3 }'
# 4
echo "1.2.3" | sed 's/-.*$//' | awk -F. '{ printf "%d\n", $1*10000 + $2*100 + $3 }'
# 10203
```

Full verification requires re-running the release workflow for v0.0.4-beta
so the published appcast gets `sparkle:version=4` instead of `1`.

## Linked issues

Refs #160

## Risk / rollout notes

- The existing v0.0.4-beta appcast still has `sparkle:version=1`. After merging,
  the release workflow must be re-run for v0.0.4-beta (or the appcast manually
  regenerated) for existing 0.0.3-beta users to see the update.
- No changes to the Xcode project — `CURRENT_PROJECT_VERSION` stays at `1` but
  is no longer read by the workflow.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Sparkle's always-reporting-up-to-date bug by deriving the build number from the release version string (`major*10000 + minor*100 + patch`) instead of reading the hardcoded `CURRENT_PROJECT_VERSION=1` from Xcode. It also replaces the landscape DMG background with a new portrait-oriented design and renames the asset file from `dmg-background.png` to `dmg_background.png`.

- **Build number derivation** (`release.yml`): a `sed`+`awk` pipeline now converts the release version tag into a monotonically increasing integer embedded in the appcast as `sparkle:version`, enabling Sparkle clients to compare builds correctly.
- **DMG layout overhaul** (`build_release_dmg.py`, new PNG): window dimensions changed from 960×640 to 675×950 and icons repositioned to a vertical stacking layout matching the new background art.
- **Rollout note**: the existing `v0.0.4-beta` appcast still carries `sparkle:version=1`; the release workflow must be re-run for that tag before `0.0.3-beta` users see the pending update.

<h3>Confidence Score: 3/5</h3>

The core fix is correct for normal version strings, but the derived build number is never validated before being written to the appcast, leaving a gap where a malformed tag produces build_number=0 and silently breaks update detection for all existing users.

The build number derivation works correctly for the project's current 0.0.x-beta version scheme, and the DMG layout changes are straightforward. The gap is that there is no guard after the awk computation — a version string that produces 0 would be accepted without error, generating an appcast entry with sparkle:version=0. Any installed copy carrying the old hardcoded build number 1 would treat that as a downgrade and never surface the update, which is exactly the problem this PR is trying to fix.

.github/workflows/release.yml — the build number derivation step lacks a post-computation validity check.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Replaces Xcode-read CURRENT_PROJECT_VERSION with a version-derived build number; missing validation means a malformed or all-zero version could produce build_number=0 and silently break Sparkle update detection. |
| scripts/build_release_dmg.py | Window geometry updated to 675×950 (portrait) and icon positions switched to vertical stacking; no logic issues found. |
| RELEASING.md | Documentation updated to reflect the new dmg_background.png filename and revised DMG icon layout description. |
| assets/release/dmg_background.png | New portrait-oriented DMG background asset replacing the old landscape dmg-background.png. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Tag push / workflow_dispatch] --> B[Resolve release metadata]
    B --> C{version format valid?}
    C -- no --> FAIL1[exit 1]
    C -- yes --> D["Derive build_number\nsed strips pre-release suffix\nawk: major×10000 + minor×100 + patch"]
    D --> E{build_number > 0?}
    E -- no\n⚠️ not validated --> SKIP[silently continues with 0]
    E -- yes\n✅ recommended guard --> F[Write to GITHUB_OUTPUT]
    F --> G[Archive & sign app]
    G --> H["Package DMG\nwith dmg_background.png"]
    H --> I[Notarize & staple]
    I --> J["Generate appcast.xml\nsparkle:version = build_number"]
    J --> K[Publish GitHub Release + Pages]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22fix%2Fsparkle-build-number%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsparkle-build-number%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Frelease.yml%3A114-118%0AMissing%20validation%20of%20the%20derived%20%60build_number%60.%20If%20the%20version%20string%20somehow%20passes%20the%20non-empty%20check%20but%20has%20no%20numeric%20dot-components%20%28e.g.%20a%20tag%20like%20%60v-rc1%60%20yields%20%60release_version%3D%22-rc1%22%60%2C%20sed%20strips%20everything%20leaving%20an%20empty%20string%2C%20and%20%60awk%60%20prints%20%600%60%29%2C%20%60build_number%60%20is%20silently%20written%20as%20%600%60.%20Any%20installed%20copy%20carrying%20the%20old%20hardcoded%20build%20number%20%601%60%20would%20treat%20Sparkle%20build%200%20as%20a%20downgrade%20and%20never%20prompt%20for%20the%20update.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20build_number%3D%22%24%28echo%20%22%24%7Brelease_version%7D%22%20%7C%0A%20%20%20%20%20%20%20%20%20%20%20%20sed%20's%2F-.*%24%2F%2F'%20%7C%0A%20%20%20%20%20%20%20%20%20%20%20%20awk%20-F.%20'%7B%20printf%20%22%25d%22%2C%20%241*10000%20%2B%20%242*100%20%2B%20%243%20%7D'%29%22%0A%0A%20%20%20%20%20%20%20%20%20%20if%20%5B%5B%20-z%20%22%24%7Bbuild_number%7D%22%20%7C%7C%20%22%24%7Bbuild_number%7D%22%20-le%200%20%5D%5D%3B%20then%0A%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22Derived%20build%20number%20'%24%7Bbuild_number%7D'%20from%20version%20'%24%7Brelease_version%7D'%20is%20not%20a%20positive%20integer.%22%20%3E%262%0A%20%20%20%20%20%20%20%20%20%20%20%20exit%201%0A%20%20%20%20%20%20%20%20%20%20fi%0A%0A%20%20%20%20%20%20%20%20%20%20echo%20%22release_tag%3D%24%7Brelease_tag%7D%22%20%3E%3E%20%22%24GITHUB_OUTPUT%22%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Frelease.yml%3A114-116%0A**Build%20number%20formula%20collision%20for%20versions%20with%20minor%20or%20patch%20%E2%89%A5%20100**%0A%0AThe%20formula%20%60major*10000%20%2B%20minor*100%20%2B%20patch%60%20is%20not%20collision-free%20once%20any%20component%20reaches%20100.%20For%20example%2C%20%600.1.100%60%20and%20%600.2.0%60%20both%20produce%20%60200%60%2C%20so%20Sparkle%20would%20treat%20them%20as%20the%20same%20build%20and%20never%20offer%20the%20upgrade.%20The%20project%20is%20at%20%600.0.x%60%20today%20so%20this%20is%20far%20off%2C%20but%20worth%20documenting%20or%20switching%20to%20a%20scheme%20with%20wider%20component%20slots%20%28e.g.%20%60major*100000%20%2B%20minor*1000%20%2B%20patch%60%2C%20allowing%20up%20to%20999%20for%20minor%2Fpatch%29.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Frelease.yml%3A114-118%0AMissing%20validation%20of%20the%20derived%20%60build_number%60.%20If%20the%20version%20string%20somehow%20passes%20the%20non-empty%20check%20but%20has%20no%20numeric%20dot-components%20%28e.g.%20a%20tag%20like%20%60v-rc1%60%20yields%20%60release_version%3D%22-rc1%22%60%2C%20sed%20strips%20everything%20leaving%20an%20empty%20string%2C%20and%20%60awk%60%20prints%20%600%60%29%2C%20%60build_number%60%20is%20silently%20written%20as%20%600%60.%20Any%20installed%20copy%20carrying%20the%20old%20hardcoded%20build%20number%20%601%60%20would%20treat%20Sparkle%20build%200%20as%20a%20downgrade%20and%20never%20prompt%20for%20the%20update.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20build_number%3D%22%24%28echo%20%22%24%7Brelease_version%7D%22%20%7C%0A%20%20%20%20%20%20%20%20%20%20%20%20sed%20's%2F-.*%24%2F%2F'%20%7C%0A%20%20%20%20%20%20%20%20%20%20%20%20awk%20-F.%20'%7B%20printf%20%22%25d%22%2C%20%241*10000%20%2B%20%242*100%20%2B%20%243%20%7D'%29%22%0A%0A%20%20%20%20%20%20%20%20%20%20if%20%5B%5B%20-z%20%22%24%7Bbuild_number%7D%22%20%7C%7C%20%22%24%7Bbuild_number%7D%22%20-le%200%20%5D%5D%3B%20then%0A%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22Derived%20build%20number%20'%24%7Bbuild_number%7D'%20from%20version%20'%24%7Brelease_version%7D'%20is%20not%20a%20positive%20integer.%22%20%3E%262%0A%20%20%20%20%20%20%20%20%20%20%20%20exit%201%0A%20%20%20%20%20%20%20%20%20%20fi%0A%0A%20%20%20%20%20%20%20%20%20%20echo%20%22release_tag%3D%24%7Brelease_tag%7D%22%20%3E%3E%20%22%24GITHUB_OUTPUT%22%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Frelease.yml%3A114-116%0A**Build%20number%20formula%20collision%20for%20versions%20with%20minor%20or%20patch%20%E2%89%A5%20100**%0A%0AThe%20formula%20%60major*10000%20%2B%20minor*100%20%2B%20patch%60%20is%20not%20collision-free%20once%20any%20component%20reaches%20100.%20For%20example%2C%20%600.1.100%60%20and%20%600.2.0%60%20both%20produce%20%60200%60%2C%20so%20Sparkle%20would%20treat%20them%20as%20the%20same%20build%20and%20never%20offer%20the%20upgrade.%20The%20project%20is%20at%20%600.0.x%60%20today%20so%20this%20is%20far%20off%2C%20but%20worth%20documenting%20or%20switching%20to%20a%20scheme%20with%20wider%20component%20slots%20%28e.g.%20%60major*100000%20%2B%20minor*1000%20%2B%20patch%60%2C%20allowing%20up%20to%20999%20for%20minor%2Fpatch%29.%0A%0A&repo=fujacob%2Ftabby&pr=181&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Fix Sparkle update detection by deriving..."](https://github.com/fujacob/tabby/commit/ace259b7319cea4536dc46bf3395cf640636631d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33578056)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->