### PR TITLE
Add GitHub automation rules to CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -72,6 +72,17 @@ change as shipping to end users, not as an exercise.
   in `.swiftlint.yml` (line length 140/200, trailing commas disallowed).
 - Wiki lives at https://github.com/FuJacob/tabby/wiki for contributor onboarding.
 
+## GitHub Automation Rules
+
+- **No Co-Authored-By lines.** Never add `Co-Authored-By` trailers to commits.
+- **PRs must use the repo template.** When creating a pull request, read
+  `.github/PULL_REQUEST_TEMPLATE.md` and fill in every section (Summary,
+  Validation, Linked issues, Risk / rollout notes). Do not invent your own
+  format or use a generic body.
+- **Issues must use the repo templates.** When opening an issue, read the
+  matching template in `.github/ISSUE_TEMPLATE/` (bug_report.md or
+  feature_request.md) and fill in every field. Do not invent your own format.
+
 ## Swift And macOS Expectations
 
 - UI, AppKit, SwiftUI, and most Accessibility interactions belong on the main actor.


### PR DESCRIPTION
## Summary

AI agents were creating PRs and issues with ad-hoc formats instead of
using the repo templates, and adding unwanted Co-Authored-By trailers.
Added explicit rules to CLAUDE.md to enforce template usage and ban
co-authorship lines.

## Validation

Docs-only change — read the diff and confirmed the new section follows
the existing CLAUDE.md structure.

## Linked issues

None.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a "GitHub Automation Rules" section to `CLAUDE.md` to enforce consistent PR/issue formatting and ban `Co-Authored-By` commit trailers when AI agents interact with the repo.

- Adds a `No Co-Authored-By lines` rule to prevent unwanted commit trailers.
- Adds rules requiring agents to use `.github/PULL_REQUEST_TEMPLATE.md` and the matching `.github/ISSUE_TEMPLATE/` files instead of inventing their own formats.
- The equivalent `AGENTS.md` (used by Codex-based agents) is not updated with the same rules, leaving that class of agent unaffected.

<h3>Confidence Score: 4/5</h3>

Safe to merge — docs-only change with no runtime impact.

The change is confined to CLAUDE.md and has no effect on compiled code. The main concern is that the "fill in every section" wording conflicts with the PR template's explicit instruction to skip "Risk / rollout notes" when there is nothing to flag, which could cause agents to add empty boilerplate sections. Additionally, the parallel AGENTS.md file is left without equivalent rules. Neither issue blocks merging, but the wording inconsistency could produce the exact formatting noise the PR is trying to prevent.

.claude/CLAUDE.md — the "fill in every section" phrasing and the missing AGENTS.md parity are both worth a second look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .claude/CLAUDE.md | Adds "GitHub Automation Rules" section with three directives; one rule contradicts the PR template's optional "Risk / rollout notes" section, and the equivalent AGENTS.md is not updated. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[AI Agent opens PR or Issue] --> B{Which agent type?}
    B -->|Claude / reads CLAUDE.md| C[GitHub Automation Rules applied]
    B -->|Codex / reads AGENTS.md| D[No automation rules — gap]
    C --> E{Action}
    E -->|Open PR| F[Read .github/PULL_REQUEST_TEMPLATE.md\nFill in all applicable sections]
    E -->|Open Issue| G[Read .github/ISSUE_TEMPLATE/\nbug_report.md or feature_request.md]
    E -->|Commit| H[No Co-Authored-By trailer]
    D --> I[Ad-hoc formats\nCo-Authored-By lines still possible]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22claude-md-github-rules%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude-md-github-rules%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.claude%2FCLAUDE.md%3A78-81%0AThe%20rule%20says%20to%20%22fill%20in%20every%20section%22%20and%20explicitly%20names%20%22Risk%20%2F%20rollout%20notes%22%2C%20but%20the%20actual%20template%20instructs%20contributors%20to%20%22Skip%20this%20section%20entirely%20if%20there's%20nothing%20to%20flag.%22%20An%20AI%20agent%20following%20CLAUDE.md%20literally%20would%20add%20an%20empty%20or%20boilerplate%20Risk%20section%20to%20every%20PR%2C%20which%20is%20the%20opposite%20of%20the%20template's%20intent.%20Narrowing%20to%20%22all%20applicable%20sections%22%20eliminates%20the%20contradiction.%0A%0A%60%60%60suggestion%0A-%20**PRs%20must%20use%20the%20repo%20template.**%20When%20creating%20a%20pull%20request%2C%20read%0A%20%20%60.github%2FPULL_REQUEST_TEMPLATE.md%60%20and%20fill%20in%20every%20applicable%20section%0A%20%20%28Summary%2C%20Validation%2C%20Linked%20issues%3B%20include%20Risk%20%2F%20rollout%20notes%20only%20when%0A%20%20there%20is%20something%20to%20flag%29.%20Do%20not%20invent%20your%20own%20format%20or%20use%20a%20generic%0A%20%20body.%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0A.claude%2FCLAUDE.md%3A75-84%0A**AGENTS.md%20parity%20gap**%0A%0AThe%20repo%20also%20ships%20%60AGENTS.md%60%20for%20Codex-based%20agents%2C%20and%20it%20currently%20has%20no%20equivalent%20GitHub%20automation%20rules.%20Any%20Codex-driven%20workflow%20will%20keep%20creating%20ad-hoc%20PR%2Fissue%20formats%20and%20Co-Authored-By%20trailers%20unless%20the%20same%20three%20rules%20are%20mirrored%20there.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.claude%2FCLAUDE.md%3A78-81%0AThe%20rule%20says%20to%20%22fill%20in%20every%20section%22%20and%20explicitly%20names%20%22Risk%20%2F%20rollout%20notes%22%2C%20but%20the%20actual%20template%20instructs%20contributors%20to%20%22Skip%20this%20section%20entirely%20if%20there's%20nothing%20to%20flag.%22%20An%20AI%20agent%20following%20CLAUDE.md%20literally%20would%20add%20an%20empty%20or%20boilerplate%20Risk%20section%20to%20every%20PR%2C%20which%20is%20the%20opposite%20of%20the%20template's%20intent.%20Narrowing%20to%20%22all%20applicable%20sections%22%20eliminates%20the%20contradiction.%0A%0A%60%60%60suggestion%0A-%20**PRs%20must%20use%20the%20repo%20template.**%20When%20creating%20a%20pull%20request%2C%20read%0A%20%20%60.github%2FPULL_REQUEST_TEMPLATE.md%60%20and%20fill%20in%20every%20applicable%20section%0A%20%20%28Summary%2C%20Validation%2C%20Linked%20issues%3B%20include%20Risk%20%2F%20rollout%20notes%20only%20when%0A%20%20there%20is%20something%20to%20flag%29.%20Do%20not%20invent%20your%20own%20format%20or%20use%20a%20generic%0A%20%20body.%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0A.claude%2FCLAUDE.md%3A75-84%0A**AGENTS.md%20parity%20gap**%0A%0AThe%20repo%20also%20ships%20%60AGENTS.md%60%20for%20Codex-based%20agents%2C%20and%20it%20currently%20has%20no%20equivalent%20GitHub%20automation%20rules.%20Any%20Codex-driven%20workflow%20will%20keep%20creating%20ad-hoc%20PR%2Fissue%20formats%20and%20Co-Authored-By%20trailers%20unless%20the%20same%20three%20rules%20are%20mirrored%20there.%0A%0A&repo=fujacob%2Ftabby&pr=182&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add GitHub automation rules to CLAUDE.md"](https://github.com/fujacob/tabby/commit/f58f9388b49d62bb8825966224504f0b159d0f74) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33580089)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->