### PR TITLE
Fix flaky Sparkle tool resolution in release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -436,27 +436,32 @@ jobs:
           xcrun stapler staple "${dmg_path}"
           xcrun stapler validate "${dmg_path}"
 
-      - name: Locate Sparkle tools
+      - name: Download Sparkle tools
         id: sparkle-tools
+        env:
+          SPARKLE_VERSION: "2.9.1"
         run: |
           set -euo pipefail
 
-          sign_update="$(find build/DerivedData "$HOME/Library/Developer/Xcode/DerivedData" \
-            -type f \
-            -path '*/Sparkle/bin/sign_update' \
-            -print \
-            2>/dev/null |
-            head -n 1)"
+          # SPM's artifact extraction is non-deterministic — the bin/ directory
+          # containing sign_update and generate_keys is sometimes missing from
+          # DerivedData even though the xcframework resolves fine. Downloading the
+          # official release tarball directly is deterministic and fast (~3s).
+          sparkle_dir="${RUNNER_TEMP}/sparkle-tools"
+          mkdir -p "${sparkle_dir}"
 
-          generate_keys="$(find build/DerivedData "$HOME/Library/Developer/Xcode/DerivedData" \
-            -type f \
-            -path '*/Sparkle/bin/generate_keys' \
-            -print \
-            2>/dev/null |
-            head -n 1)"
+          curl -fsSL \
+            "https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_VERSION}/Sparkle-${SPARKLE_VERSION}.tar.xz" \
+            -o "${sparkle_dir}/Sparkle.tar.xz"
 
-          if [[ -z "${sign_update}" || -z "${generate_keys}" ]]; then
-            echo "Could not locate Sparkle sign_update and generate_keys tools." >&2
+          tar -xf "${sparkle_dir}/Sparkle.tar.xz" -C "${sparkle_dir}"
+
+          sign_update="${sparkle_dir}/bin/sign_update"
+          generate_keys="${sparkle_dir}/bin/generate_keys"
+
+          if [[ ! -x "${sign_update}" || ! -x "${generate_keys}" ]]; then
+            echo "Sparkle ${SPARKLE_VERSION} archive did not contain expected tools." >&2
+            ls -la "${sparkle_dir}/bin/" >&2 || true
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

Download `sign_update` and `generate_keys` from the official Sparkle 2.9.1
release tarball instead of searching DerivedData after the Xcode build.

SPM's artifact extraction is non-deterministic — the `bin/` directory was
present in the v0.0.4-beta CI run but completely absent in v0.0.5-beta,
despite identical Xcode (26.5) and Sparkle (2.9.1) versions. This caused
the "Locate Sparkle tools" step to fail with no candidates found.

## Validation

Cannot be fully validated without triggering a release run. The new step
downloads a ~30MB tarball from a stable GitHub Releases URL and extracts
the two binaries. Verified the archive URL returns 200 and contains the
expected `bin/` layout:

```
curl -fsSL -o /dev/null -w '%{http_code}' \
  https://github.com/sparkle-project/Sparkle/releases/download/2.9.1/Sparkle-2.9.1.tar.xz
# 200
```

## Linked issues

Fixes the v0.0.5-beta release failure.

## Risk / rollout notes

- The `SPARKLE_VERSION` env var must be kept in sync with Package.resolved
  (currently 2.9.1). A mismatch would mean the signing tools come from a
  different Sparkle version than the framework linked into the app — this
  is safe for EdDSA signing (key format hasn't changed) but worth noting.
- Adds a network dependency on `github.com/sparkle-project/Sparkle/releases`
  during CI. If GitHub Releases is down the step will fail, same as SPM
  resolution already would.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the flaky `find`-in-DerivedData approach for locating Sparkle signing tools with a direct download of the official Sparkle 2.9.1 release tarball, making the \"Download Sparkle tools\" CI step deterministic.

- The `SPARKLE_VERSION` env var is hardcoded to `\"2.9.1\"` and must be kept in sync with `Package.resolved` manually — currently they match, but there is no automated guard against drift.
- The downloaded tarball is not verified against a known SHA-256 digest before the binaries are extracted and used to sign releases; adding a pinned hash check would close a supply-chain gap in the signing pipeline.

<h3>Confidence Score: 4/5</h3>

The fix is correct and deterministic; the one concern worth resolving before merging is the absence of a hash check on the downloaded signing binaries.

The new download-and-extract approach reliably solves the flaky DerivedData lookup and the version currently matches Package.resolved. The open gap is that the tarball is fetched without verifying a pinned SHA-256 digest — since the extracted binaries sign every release artifact, a tampered archive would silently affect release integrity with no CI-level detection.

.github/workflows/release.yml — specifically the curl/tar block where the tarball is downloaded without an integrity check.

<details open><summary><h3>Security Review</h3></summary>

- **Unverified binary download** (`.github/workflows/release.yml`, lines 453–457): The Sparkle release tarball is downloaded over HTTPS but no SHA-256/SHA-512 digest is checked before extracting and executing `sign_update` and `generate_keys`. A compromised GitHub release asset would be used to sign app releases without any CI-level detection.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Replaces non-deterministic DerivedData `find` with a direct download of the Sparkle 2.9.1 release tarball; fixes flaky CI but lacks a SHA-256 integrity check on the downloaded binaries used for release signing. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CI as GitHub Actions Runner
    participant GHR as GitHub Releases (sparkle-project)
    participant XC as Xcode Build Artifacts
    participant Sign as sign_update / generate_keys

    Note over CI: "Download Sparkle tools" step (new)
    CI->>GHR: curl Sparkle-2.9.1.tar.xz
    GHR-->>CI: ~30 MB tarball
    CI->>CI: tar -xf to $RUNNER_TEMP/sparkle-tools/bin/
    CI->>CI: verify -x sign_update and -x generate_keys

    Note over XC: Old approach (removed)
    CI--xXC: find DerivedData for bin/sign_update (non-deterministic)

    CI->>Sign: sign_update (sign DMG delta)
    CI->>Sign: generate_keys -f (verify EdDSA key)
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22fix%2Fsparkle-tools-ci%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsparkle-tools-ci%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Frelease.yml%3A453-457%0A**No%20integrity%20check%20on%20downloaded%20tarball**%0A%0AThe%20tarball%20is%20fetched%20over%20HTTPS%20but%20its%20content%20is%20never%20verified%20against%20a%20known%20SHA-256%20%28or%20SHA-512%29%20digest.%20If%20the%20%60sparkle-project%60%20GitHub%20account%20were%20ever%20compromised%20and%20the%20release%20asset%20re-uploaded%2C%20or%20if%20any%20infrastructure%20in%20the%20path%20served%20a%20different%20file%2C%20the%20tampered%20%60sign_update%60%20binary%20would%20be%20silently%20used%20to%20sign%20every%20subsequent%20release.%20Because%20these%20binaries%20are%20the%20actual%20signing%20tools%20for%20your%20release%20pipeline%2C%20a%20compromised%20artifact%20has%20a%20direct%20impact%20on%20release%20integrity.%20Adding%20a%20%60shasum%20-a%20256%20-c%60%20step%20after%20the%20download%20%28using%20a%20pinned%20expected%20hash%29%20closes%20that%20gap%20without%20any%20change%20to%20the%20happy%20path.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Frelease.yml%3A453-457%0A**No%20integrity%20check%20on%20downloaded%20tarball**%0A%0AThe%20tarball%20is%20fetched%20over%20HTTPS%20but%20its%20content%20is%20never%20verified%20against%20a%20known%20SHA-256%20%28or%20SHA-512%29%20digest.%20If%20the%20%60sparkle-project%60%20GitHub%20account%20were%20ever%20compromised%20and%20the%20release%20asset%20re-uploaded%2C%20or%20if%20any%20infrastructure%20in%20the%20path%20served%20a%20different%20file%2C%20the%20tampered%20%60sign_update%60%20binary%20would%20be%20silently%20used%20to%20sign%20every%20subsequent%20release.%20Because%20these%20binaries%20are%20the%20actual%20signing%20tools%20for%20your%20release%20pipeline%2C%20a%20compromised%20artifact%20has%20a%20direct%20impact%20on%20release%20integrity.%20Adding%20a%20%60shasum%20-a%20256%20-c%60%20step%20after%20the%20download%20%28using%20a%20pinned%20expected%20hash%29%20closes%20that%20gap%20without%20any%20change%20to%20the%20happy%20path.%0A%0A&repo=fujacob%2Ftabby&pr=184&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Fix flaky Sparkle tool resolution in rel..."](https://github.com/fujacob/tabby/commit/46646b236d258af8d503d454c364c9bbc11716ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33580549)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->