### PR TITLE
Fix Sparkle update loop and harden release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,6 +201,7 @@ jobs:
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           RELEASE_VERSION: ${{ steps.metadata.outputs.release_version }}
+          BUILD_NUMBER: ${{ steps.metadata.outputs.build_number }}
         run: |
           set -euo pipefail
 
@@ -221,6 +222,7 @@ jobs:
             CODE_SIGN_IDENTITY="Developer ID Application" \
             OTHER_CODE_SIGN_FLAGS="--timestamp" \
             MARKETING_VERSION="${RELEASE_VERSION}" \
+            CURRENT_PROJECT_VERSION="${BUILD_NUMBER}" \
             archive
 
       - name: Re-sign nested code for notarization

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,9 @@ env:
   PAGES_CUSTOM_DOMAIN: updates.tabbyapp.dev
   NOTARIZATION_TIMEOUT_SECONDS: 3300
   NOTARIZATION_POLL_INTERVAL_SECONDS: 60
+  # SHA-256 of the Sparkle release tarball used for signing tools. Update
+  # this hash whenever Sparkle is bumped in Package.resolved.
+  SPARKLE_SHA256: c0dde519fd2a43ddfc6a1eb76aec284d7d888fe281414f9177de3164d98ba4c7
 
 jobs:
   release:
@@ -83,6 +86,101 @@ jobs:
 
           python3 -m pip install --upgrade pip
           python3 -m pip install "dmgbuild[badge_icons]==1.6.7"
+
+      - name: Resolve Sparkle version
+        id: sparkle-version
+        run: |
+          set -euo pipefail
+
+          sparkle_version="$(python3 -c "
+          import json, sys
+          resolved = json.load(open('tabby.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved'))
+          pins = {p['identity']: p for p in resolved['pins']}
+          if 'sparkle' not in pins:
+              print('Sparkle not found in Package.resolved', file=sys.stderr)
+              sys.exit(1)
+          print(pins['sparkle']['state']['version'])
+          ")"
+
+          if [[ -z "${sparkle_version}" ]]; then
+            echo "Failed to resolve Sparkle version from Package.resolved." >&2
+            exit 1
+          fi
+
+          echo "sparkle_version=${sparkle_version}" >> "$GITHUB_OUTPUT"
+          echo "Resolved Sparkle version: ${sparkle_version}"
+
+      - name: Download Sparkle tools
+        id: sparkle-tools
+        env:
+          SPARKLE_VERSION: ${{ steps.sparkle-version.outputs.sparkle_version }}
+        run: |
+          set -euo pipefail
+
+          # Download the official Sparkle release tarball directly rather than
+          # scavenging DerivedData, where SPM artifact extraction is
+          # non-deterministic.
+          sparkle_dir="${RUNNER_TEMP}/sparkle-tools"
+          mkdir -p "${sparkle_dir}"
+
+          curl -fsSL \
+            "https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_VERSION}/Sparkle-${SPARKLE_VERSION}.tar.xz" \
+            -o "${sparkle_dir}/Sparkle.tar.xz"
+
+          echo "${SPARKLE_SHA256}  ${sparkle_dir}/Sparkle.tar.xz" | shasum -a 256 --check
+
+          tar -xf "${sparkle_dir}/Sparkle.tar.xz" -C "${sparkle_dir}"
+
+          sign_update="${sparkle_dir}/bin/sign_update"
+          generate_keys="${sparkle_dir}/bin/generate_keys"
+
+          if [[ ! -x "${sign_update}" || ! -x "${generate_keys}" ]]; then
+            echo "Sparkle ${SPARKLE_VERSION} archive did not contain expected tools." >&2
+            ls -la "${sparkle_dir}/bin/" >&2 || true
+            exit 1
+          fi
+
+          echo "sign_update=${sign_update}" >> "$GITHUB_OUTPUT"
+          echo "generate_keys=${generate_keys}" >> "$GITHUB_OUTPUT"
+
+      - name: Write Sparkle private key
+        id: sparkle-key
+        env:
+          SPARKLE_ED25519_PRIVATE_KEY: ${{ secrets.SPARKLE_ED25519_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${SPARKLE_ED25519_PRIVATE_KEY}" ]]; then
+            echo "SPARKLE_ED25519_PRIVATE_KEY is not configured — skipping." >&2
+            echo "has_key=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          sparkle_key_file="${RUNNER_TEMP}/sparkle-ed25519-private-key.txt"
+          printf '%s' "${SPARKLE_ED25519_PRIVATE_KEY}" > "${sparkle_key_file}"
+          chmod 600 "${sparkle_key_file}"
+
+          echo "SPARKLE_KEY_FILE=${sparkle_key_file}" >> "$GITHUB_ENV"
+          echo "has_key=true" >> "$GITHUB_OUTPUT"
+
+      - name: Verify Sparkle key matches Info.plist
+        if: steps.sparkle-key.outputs.has_key == 'true'
+        env:
+          GENERATE_KEYS_TOOL: ${{ steps.sparkle-tools.outputs.generate_keys }}
+        run: |
+          set -euo pipefail
+
+          "${GENERATE_KEYS_TOOL}" -f "${SPARKLE_KEY_FILE}"
+
+          expected_public_key="$(/usr/libexec/PlistBuddy \
+            -c 'Print :SUPublicEDKey' \
+            TabbyInfo.plist)"
+          actual_public_key="$("${GENERATE_KEYS_TOOL}" -p)"
+
+          if [[ "${actual_public_key}" != "${expected_public_key}" ]]; then
+            echo "Sparkle private key does not match SUPublicEDKey in TabbyInfo.plist." >&2
+            exit 1
+          fi
 
       - name: Resolve release metadata
         id: metadata
@@ -207,9 +305,8 @@ jobs:
 
           mkdir -p build
 
-          # Strip any pre-release suffix for the marketing version shown in
-          # Settings and Sparkle. "0.0.1-beta" → "0.0.1-beta" is kept as-is
-          # so users see the full version string including the channel tag.
+          # "0.0.1-beta" is kept as-is so users see the full version
+          # string including the channel tag.
           xcodebuild archive \
             -project "${PROJECT_PATH}" \
             -scheme "${SCHEME}" \
@@ -224,6 +321,21 @@ jobs:
             MARKETING_VERSION="${RELEASE_VERSION}" \
             CURRENT_PROJECT_VERSION="${BUILD_NUMBER}" \
             archive
+
+      - name: Verify build number in archive
+        env:
+          BUILD_NUMBER: ${{ steps.metadata.outputs.build_number }}
+        run: |
+          set -euo pipefail
+
+          info_plist="build/${APP_NAME}.xcarchive/Products/Applications/${APP_NAME}.app/Contents/Info.plist"
+          actual="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "${info_plist}")"
+          if [[ "${actual}" != "${BUILD_NUMBER}" ]]; then
+            echo "CFBundleVersion is '${actual}', expected '${BUILD_NUMBER}'." >&2
+            echo "xcodebuild silently ignored the CURRENT_PROJECT_VERSION override." >&2
+            exit 1
+          fi
+          echo "Verified CFBundleVersion: ${actual}"
 
       - name: Re-sign nested code for notarization
         run: |
@@ -258,6 +370,19 @@ jobs:
           done
 
           codesign --verify --deep --strict --verbose=4 "${app_path}"
+
+          # Catch any executable inside Sparkle.framework that the hardcoded
+          # list above missed. If Sparkle reorganizes its internals in a future
+          # version, this prevents shipping unsigned code that Apple will reject.
+          # Uses BSD find's -perm +111 (macOS runners only).
+          unsigned="$(find "${app_path}/Contents/Frameworks/Sparkle.framework" \
+            -type f -perm +111 \
+            -exec sh -c 'codesign -dvv "$1" 2>&1 | grep -q "Developer ID" || echo "$1"' _ {} \;)"
+          if [[ -n "${unsigned}" ]]; then
+            echo "Unsigned binaries found inside Sparkle.framework — update the re-sign list:" >&2
+            echo "${unsigned}" >&2
+            exit 1
+          fi
 
       - name: Package DMG
         run: |
@@ -438,74 +563,8 @@ jobs:
           xcrun stapler staple "${dmg_path}"
           xcrun stapler validate "${dmg_path}"
 
-      - name: Download Sparkle tools
-        id: sparkle-tools
-        env:
-          SPARKLE_VERSION: "2.9.1"
-        run: |
-          set -euo pipefail
-
-          # SPM's artifact extraction is non-deterministic — the bin/ directory
-          # containing sign_update and generate_keys is sometimes missing from
-          # DerivedData even though the xcframework resolves fine. Downloading the
-          # official release tarball directly is deterministic and fast (~3s).
-          sparkle_dir="${RUNNER_TEMP}/sparkle-tools"
-          mkdir -p "${sparkle_dir}"
-
-          curl -fsSL \
-            "https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_VERSION}/Sparkle-${SPARKLE_VERSION}.tar.xz" \
-            -o "${sparkle_dir}/Sparkle.tar.xz"
-
-          tar -xf "${sparkle_dir}/Sparkle.tar.xz" -C "${sparkle_dir}"
-
-          sign_update="${sparkle_dir}/bin/sign_update"
-          generate_keys="${sparkle_dir}/bin/generate_keys"
-
-          if [[ ! -x "${sign_update}" || ! -x "${generate_keys}" ]]; then
-            echo "Sparkle ${SPARKLE_VERSION} archive did not contain expected tools." >&2
-            ls -la "${sparkle_dir}/bin/" >&2 || true
-            exit 1
-          fi
-
-          echo "sign_update=${sign_update}" >> "$GITHUB_OUTPUT"
-          echo "generate_keys=${generate_keys}" >> "$GITHUB_OUTPUT"
-
-      - name: Write Sparkle private key
-        env:
-          SPARKLE_ED25519_PRIVATE_KEY: ${{ secrets.SPARKLE_ED25519_PRIVATE_KEY }}
-        run: |
-          set -euo pipefail
-
-          if [[ -z "${SPARKLE_ED25519_PRIVATE_KEY}" ]]; then
-            echo "SPARKLE_ED25519_PRIVATE_KEY is not configured." >&2
-            exit 1
-          fi
-
-          sparkle_key_file="${RUNNER_TEMP}/sparkle-ed25519-private-key.txt"
-          printf '%s' "${SPARKLE_ED25519_PRIVATE_KEY}" > "${sparkle_key_file}"
-          chmod 600 "${sparkle_key_file}"
-
-          echo "SPARKLE_KEY_FILE=${sparkle_key_file}" >> "$GITHUB_ENV"
-
-      - name: Verify Sparkle key matches Info.plist
-        env:
-          GENERATE_KEYS_TOOL: ${{ steps.sparkle-tools.outputs.generate_keys }}
-        run: |
-          set -euo pipefail
-
-          "${GENERATE_KEYS_TOOL}" -f "${SPARKLE_KEY_FILE}"
-
-          expected_public_key="$(/usr/libexec/PlistBuddy \
-            -c 'Print :SUPublicEDKey' \
-            TabbyInfo.plist)"
-          actual_public_key="$("${GENERATE_KEYS_TOOL}" -p)"
-
-          if [[ "${actual_public_key}" != "${expected_public_key}" ]]; then
-            echo "Sparkle private key does not match SUPublicEDKey in TabbyInfo.plist." >&2
-            exit 1
-          fi
-
       - name: Generate signed appcast
+        if: steps.sparkle-key.outputs.has_key == 'true'
         env:
           SIGN_UPDATE_TOOL: ${{ steps.sparkle-tools.outputs.sign_update }}
           RELEASE_VERSION: ${{ steps.metadata.outputs.release_version }}
@@ -517,6 +576,7 @@ jobs:
             --release-version "${RELEASE_VERSION}" \
             --build-number "${BUILD_NUMBER}" \
             --archive "build/${DMG_NAME}" \
+            --archive-filename "${DMG_NAME}" \
             --output "build/appcast.xml" \
             --sign-update-tool "${SIGN_UPDATE_TOOL}" \
             --ed-key-file "${SPARKLE_KEY_FILE}"
@@ -525,6 +585,7 @@ jobs:
           grep -q 'length="' build/appcast.xml
 
       - name: Verify Sparkle signature against final DMG
+        if: steps.sparkle-key.outputs.has_key == 'true'
         env:
           SIGN_UPDATE_TOOL: ${{ steps.sparkle-tools.outputs.sign_update }}
         run: |
@@ -554,15 +615,38 @@ jobs:
 
           # Prereleases must not become "Latest" on the GitHub release page —
           # otherwise beta DMGs get surfaced to users browsing the repo.
-          prerelease_flag=()
+          release_flags=()
           if [[ "${IS_PRERELEASE}" == "true" ]]; then
-            prerelease_flag=(--prerelease)
+            release_flags=(--prerelease)
+          else
+            release_flags=(--latest)
           fi
 
           gh release create "${RELEASE_TAG}" "build/${DMG_NAME}" \
             --title "tabby ${RELEASE_VERSION}" \
             --generate-notes \
-            "${prerelease_flag[@]}"
+            "${release_flags[@]}"
+
+      - name: Release summary
+        if: always() && steps.metadata.outputs.release_version != ''
+        env:
+          RELEASE_TAG: ${{ steps.metadata.outputs.release_tag }}
+          RELEASE_VERSION: ${{ steps.metadata.outputs.release_version }}
+          BUILD_NUMBER: ${{ steps.metadata.outputs.build_number }}
+          IS_PRERELEASE: ${{ steps.metadata.outputs.is_prerelease }}
+          PUBLISH: ${{ steps.metadata.outputs.publish }}
+        run: |
+          {
+            echo "### Release"
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| Version | ${RELEASE_VERSION} |"
+            echo "| Tag | ${RELEASE_TAG} |"
+            echo "| Build number | ${BUILD_NUMBER} |"
+            echo "| Prerelease | ${IS_PRERELEASE} |"
+            echo "| Published | ${PUBLISH} |"
+            echo "| Appcast URL | https://${PAGES_CUSTOM_DOMAIN}/appcast.xml |"
+          } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Prepare Pages artifact
         if: steps.metadata.outputs.publish == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,6 +240,12 @@ jobs:
           echo "publish=${publish}" >> "$GITHUB_OUTPUT"
           echo "is_prerelease=${is_prerelease}" >> "$GITHUB_OUTPUT"
 
+      - name: Require Sparkle key for publishing
+        if: steps.metadata.outputs.publish == 'true' && steps.sparkle-key.outputs.has_key != 'true'
+        run: |
+          echo "Cannot publish a release without SPARKLE_ED25519_PRIVATE_KEY." >&2
+          exit 1
+
       - name: Ensure release does not already exist
         if: steps.metadata.outputs.publish == 'true'
         env:

--- a/scripts/generate_appcast.py
+++ b/scripts/generate_appcast.py
@@ -58,6 +58,11 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--archive-filename",
+        default=None,
+        help="Filename in the GitHub Release download URL. Defaults to basename of --archive.",
+    )
+    parser.add_argument(
         "--github-owner",
         default=DEFAULT_OWNER,
         help="GitHub owner used to build release and repository URLs",
@@ -200,7 +205,8 @@ def main() -> int:
     repository_url = f"https://github.com/{args.github_owner}/{args.github_repository}"
     release_tag = f"v{args.release_version}"
     release_page_url = f"{repository_url}/releases/tag/{release_tag}"
-    archive_url = f"{repository_url}/releases/download/{release_tag}/Tabby.dmg"
+    archive_filename = args.archive_filename or archive.name
+    archive_url = f"{repository_url}/releases/download/{release_tag}/{archive_filename}"
 
     rendered_appcast = render_appcast(
         template_path=template_path,

--- a/tabby.xcodeproj/project.pbxproj
+++ b/tabby.xcodeproj/project.pbxproj
@@ -562,8 +562,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/sparkle-project/Sparkle";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.9.1;
+				kind = exactVersion;
+				version = 2.9.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
## Summary

Two changes in this PR:

1. **Fix the infinite update loop** (bf7234d): The release workflow derived
   the build number for the appcast but never passed it to `xcodebuild
   archive`. The app binary always shipped with `CFBundleVersion=1` while the
   appcast advertised `sparkle:version=5`. Sparkle compares these two values
   — when they don't match, users get stuck in an update loop.

2. **Harden the release pipeline** (184168e): Implements 10 items from a
   staff-eng review of the release workflow. The recurring theme across
   recent CI failures (#181, #184, #185) was missing verification — each
   piece was individually correct but nothing checked end-to-end consistency.

### Pipeline hardening changes

| # | Change | Why |
|---|--------|-----|
| 1 | Verify `CFBundleVersion` in archive post-build | Catches silent `xcodebuild` override failures |
| 2 | Resolve Sparkle version from `Package.resolved` | Eliminates manual version drift between SPM and CI |
| 3 | Discover unsigned binaries in `Sparkle.framework` | Prevents opaque notarization rejections if Sparkle reorganizes |
| 4 | Pin SHA-256 of Sparkle signing tools tarball | Supply chain integrity for the root of update trust |
| 5 | Fix appcast download URL filename (`Tabby.dmg` → `tabby.dmg`) | Appcast pointed to wrong asset name |
| 6 | Add release summary to `GITHUB_STEP_SUMMARY` | Version, tag, build number visible in Actions UI |
| 8 | Move Sparkle tool download before archive | Fail in 3s instead of after 30+ min notarization |
| 9 | Fix stale comment | Comment said "strip" but code kept suffix |
| 11 | Add `--latest` flag on `gh release create` | Explicit instead of relying on GitHub default |
| 12 | Gate Sparkle signing for `workflow_dispatch` dry runs | Forks and envs without secrets can validate builds |

## Validation

```
python3 scripts/generate_appcast.py --help
# --archive-filename argument registered

xcodebuild -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **
```

Verified all `steps.*.outputs.*` references point to valid step IDs with no
forward references. Traced dry-run gating: when `has_key=false`, Sparkle
signing/verification/key-check steps are all skipped; Pages steps are gated
behind `publish == 'true'`.

Cannot end-to-end test notarization and Sparkle signing without pushing a
tag. Recommend a `workflow_dispatch` validation run with `publish: false`
before the next release tag.

## Linked issues

Fixes #185

## Risk / rollout notes

- The SHA-256 hash (`c0dde51...`) must be updated whenever Sparkle is
  bumped in `Package.resolved`. A comment in the env block documents this.
- The unsigned-binary discovery uses BSD `find -perm +111`, which is
  macOS-specific. The workflow is pinned to macOS runners so this is safe.
- Existing users on `v0.0.5-beta` (build 1) will see one final update
  prompt. After accepting, the loop stops.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the infinite Sparkle update loop caused by the app binary always shipping with `CFBundleVersion=1` while the appcast advertised a higher `sparkle:version`, and hardens the release pipeline with end-to-end consistency checks.

- **Root cause fix**: `CURRENT_PROJECT_VERSION="${BUILD_NUMBER}"` is now passed to `xcodebuild archive`, and a post-archive step verifies `CFBundleVersion` in the `.xcarchive` plist — catching any silent override failures before notarization starts.
- **Supply chain hardening**: Sparkle tools are downloaded before the ~30 min notarization window, the tarball is verified with a pinned SHA-256, and the Sparkle version is resolved dynamically from `Package.resolved` rather than hardcoded, with `project.pbxproj` pinned to `exactVersion` to keep them in sync.
- **Pipeline correctness**: The appcast download URL filename is fixed (`Tabby.dmg` → `tabby.dmg`), unsigned-binary detection is added for future Sparkle framework reorganization, and Sparkle signing is gated on key presence so forks and dry runs can validate builds without secrets.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the root-cause fix is targeted and verifiable, and the pipeline hardening closes several previously untested gaps without touching application code.

The Sparkle update-loop fix is a single missing flag (CURRENT_PROJECT_VERSION) with a post-build assertion that would have caught the original bug. The pipeline changes are all fail-fast guards that make existing silent failures loud. No application logic is touched. The previously flagged appcast-without-key orphan scenario is now correctly blocked by the new Require Sparkle key for publishing guard step.

No files require special attention beyond confirming the SPARKLE_SHA256 env var is kept in sync whenever Sparkle is bumped in Package.resolved.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Core release pipeline hardening: moves Sparkle tool download before archive, pins SHA-256 of the tarball, resolves Sparkle version dynamically from Package.resolved, adds CURRENT_PROJECT_VERSION override to xcodebuild, verifies CFBundleVersion post-archive, gates Sparkle signing on key presence, and fixes the DMG filename in the appcast URL. |
| scripts/generate_appcast.py | Adds --archive-filename argument so the appcast download URL can be set explicitly rather than relying on the local archive basename; fixes the prior hardcoded Tabby.dmg (capital T) mismatch against the actual tabby.dmg release asset. |
| tabby.xcodeproj/project.pbxproj | Changes Sparkle SPM dependency resolution from upToNextMajorVersion to exactVersion 2.9.1, aligning the project file with the SPARKLE_SHA256 hash pinned in the workflow. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub Actions
    participant SPM as Package.resolved
    participant Sparkle as Sparkle CDN
    participant XC as xcodebuild
    participant AP as Apple Notarization
    participant GHR as GitHub Release
    participant Pages as GitHub Pages

    GH->>SPM: Resolve Sparkle version
    SPM-->>GH: 2.9.1
    GH->>Sparkle: Download Sparkle tarball
    GH->>GH: Verify pinned SHA-256
    GH->>GH: Write Sparkle private key
    GH->>GH: Verify key matches Info.plist

    GH->>XC: archive with CURRENT_PROJECT_VERSION
    XC-->>GH: .xcarchive
    GH->>GH: "Verify CFBundleVersion == BUILD_NUMBER"
    GH->>GH: Re-sign + unsigned binary scan
    GH->>GH: Package DMG
    GH->>AP: Submit for notarization
    AP-->>GH: Stapled DMG

    alt has_key is true
        GH->>GH: generate_appcast.py with archive-filename
        GH->>GH: Verify EdDSA signature
    end

    alt publish true and no key
        GH->>GH: FAIL before release
    end

    alt publish is true
        GH->>GHR: gh release create
        GH->>Pages: Deploy appcast.xml
    end

    GH->>GH: Release summary to step summary
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22fix%2Fsparkle-build-number-in-binary%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsparkle-build-number-in-binary%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Frelease.yml%3A654%0AThe%20%60Release%20summary%60%20step%20runs%20%60if%3A%20always%28%29%60%20and%20unconditionally%20prints%20the%20appcast%20URL%20even%20during%20dry%20runs%20%28%60publish%3A%20false%60%29%20or%20when%20the%20workflow%20failed%20before%20Pages%20was%20deployed.%20A%20reader%20who%20checks%20the%20Actions%20summary%20after%20a%20failed%20or%20dry-run%20job%20would%20see%20a%20URL%20that%20wasn't%20actually%20updated.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20%5B%5B%20%22%24%7BPUBLISH%7D%22%20%3D%3D%20%22true%22%20%5D%5D%3B%20then%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22%7C%20Appcast%20URL%20%7C%20https%3A%2F%2F%24%7BPAGES_CUSTOM_DOMAIN%7D%2Fappcast.xml%20%7C%22%0A%20%20%20%20%20%20%20%20%20%20%20%20fi%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Frelease.yml%3A654%0AThe%20%60Release%20summary%60%20step%20runs%20%60if%3A%20always%28%29%60%20and%20unconditionally%20prints%20the%20appcast%20URL%20even%20during%20dry%20runs%20%28%60publish%3A%20false%60%29%20or%20when%20the%20workflow%20failed%20before%20Pages%20was%20deployed.%20A%20reader%20who%20checks%20the%20Actions%20summary%20after%20a%20failed%20or%20dry-run%20job%20would%20see%20a%20URL%20that%20wasn't%20actually%20updated.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20%5B%5B%20%22%24%7BPUBLISH%7D%22%20%3D%3D%20%22true%22%20%5D%5D%3B%20then%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22%7C%20Appcast%20URL%20%7C%20https%3A%2F%2F%24%7BPAGES_CUSTOM_DOMAIN%7D%2Fappcast.xml%20%7C%22%0A%20%20%20%20%20%20%20%20%20%20%20%20fi%0A%60%60%60%0A%0A&repo=fujacob%2Ftabby&pr=186&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (4): Last reviewed commit: ["Fail early when publishing without Spark..."](https://github.com/fujacob/tabby/commit/b141b1aa1449a657fd084d7ff3c13f2e3425b673) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33592449)</sub>

<!-- /greptile_comment -->