### PR TITLE
Add CI check for Sparkle exact version pin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,34 @@ jobs:
           xcodebuild -version
           swift --version
 
+      - name: Verify Sparkle version pin
+        run: |
+          set -euo pipefail
+
+          # Sparkle must use exactVersion pinning. upToNextMajorVersion lets
+          # Xcode silently upgrade the framework, which drifts the signing
+          # tools hash and breaks releases.
+          if ! grep -q 'kind = exactVersion' tabby.xcodeproj/project.pbxproj; then
+            echo "Sparkle must use exactVersion pinning in project.pbxproj." >&2
+            exit 1
+          fi
+
+          # pbxproj and Package.resolved must agree on the version.
+          pbxproj_version="$(grep -A1 'kind = exactVersion' tabby.xcodeproj/project.pbxproj | grep 'version' | sed 's/.*= //;s/;.*//' | tr -d '[:space:]')"
+          resolved_version="$(python3 -c "
+          import json
+          resolved = json.load(open('tabby.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved'))
+          pins = {p['identity']: p for p in resolved['pins']}
+          print(pins['sparkle']['state']['version'])
+          ")"
+
+          if [[ "${pbxproj_version}" != "${resolved_version}" ]]; then
+            echo "Sparkle version mismatch: pbxproj=${pbxproj_version}, Package.resolved=${resolved_version}" >&2
+            exit 1
+          fi
+
+          echo "Sparkle pin verified: ${resolved_version}"
+
       # CODE_SIGNING_ALLOWED=NO because CI runners don't have the dev cert.
       # The project uses Automatic signing, so we can't simply strip the team
       # identifier without pbxproj surgery — disabling signing for the build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,19 +53,26 @@ jobs:
           # Sparkle must use exactVersion pinning. upToNextMajorVersion lets
           # Xcode silently upgrade the framework, which drifts the signing
           # tools hash and breaks releases.
-          if ! grep -q 'kind = exactVersion' tabby.xcodeproj/project.pbxproj; then
+          sparkle_block="$(sed -n '/XCRemoteSwiftPackageReference "Sparkle" \*\/ = {/,/};/p' tabby.xcodeproj/project.pbxproj)"
+
+          if ! echo "${sparkle_block}" | grep -q 'kind = exactVersion'; then
             echo "Sparkle must use exactVersion pinning in project.pbxproj." >&2
             exit 1
           fi
 
           # pbxproj and Package.resolved must agree on the version.
-          pbxproj_version="$(grep -A1 'kind = exactVersion' tabby.xcodeproj/project.pbxproj | grep 'version' | sed 's/.*= //;s/;.*//' | tr -d '[:space:]')"
+          pbxproj_version="$(echo "${sparkle_block}" | grep -A1 'kind = exactVersion' | grep 'version' | sed 's/.*= //;s/;.*//' | tr -d '[:space:]')"
           resolved_version="$(python3 -c "
           import json
           resolved = json.load(open('tabby.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved'))
           pins = {p['identity']: p for p in resolved['pins']}
           print(pins['sparkle']['state']['version'])
           ")"
+
+          if [[ -z "${pbxproj_version}" ]]; then
+            echo "Could not extract Sparkle version from pbxproj." >&2
+            exit 1
+          fi
 
           if [[ "${pbxproj_version}" != "${resolved_version}" ]]; then
             echo "Sparkle version mismatch: pbxproj=${pbxproj_version}, Package.resolved=${resolved_version}" >&2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,9 +63,12 @@ jobs:
           # pbxproj and Package.resolved must agree on the version.
           pbxproj_version="$(echo "${sparkle_block}" | grep -A1 'kind = exactVersion' | grep 'version' | sed 's/.*= //;s/;.*//' | tr -d '[:space:]')"
           resolved_version="$(python3 -c "
-          import json
+          import json, sys
           resolved = json.load(open('tabby.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved'))
           pins = {p['identity']: p for p in resolved['pins']}
+          if 'sparkle' not in pins:
+              print('sparkle not found in Package.resolved. Available: ' + ', '.join(sorted(pins.keys())), file=sys.stderr)
+              sys.exit(1)
           print(pins['sparkle']['state']['version'])
           ")"
 


### PR DESCRIPTION
## Summary

Adds a build-time check that validates Sparkle uses `exactVersion` pinning
in the pbxproj and that the pinned version matches `Package.resolved`. This
catches accidental reverts during merge conflict resolution — the pbxproj
is too noisy for humans to review reliably.

Companion to #186, which pins Sparkle to `exactVersion` and adds SHA-256
verification of the signing tools tarball in the release workflow.

## Validation

```
# Simulate the check locally:
grep -q 'kind = exactVersion' tabby.xcodeproj/project.pbxproj && echo "pin ok"
# pin ok

pbxproj_version="$(grep -A1 'kind = exactVersion' tabby.xcodeproj/project.pbxproj | grep 'version' | sed 's/.*= //;s/;.*//' | tr -d '[:space:]')"
resolved_version="$(python3 -c "import json; r=json.load(open('tabby.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved')); print([p['state']['version'] for p in r['pins'] if p['identity']=='sparkle'][0])")"
[[ "${pbxproj_version}" == "${resolved_version}" ]] && echo "versions match: ${resolved_version}"
# versions match: 2.9.1
```

Note: this check will only pass once #186 merges (which changes the pin
from `upToNextMajorVersion` to `exactVersion`). Until then, CI on this
branch will show the check failing against `main` — that's expected.

## Linked issues

Refs #186

## Risk / rollout notes

Build-only check, no behavior change. Adds ~1s to the build workflow.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a "Verify Sparkle version pin" step to the build workflow that guards against accidental reversion of the `exactVersion` pin during merge conflict resolution in `project.pbxproj`. The implementation correctly scopes all checks to the Sparkle-specific block by first extracting it with `sed`, addressing the main concern from prior review threads.

- **Scoped block extraction**: `sed -n '/XCRemoteSwiftPackageReference \"Sparkle\" .../,/};/p'` isolates the Sparkle package block before any grep/version extraction, preventing false positives or garbled results from other `exactVersion`-pinned dependencies.
- **Version cross-check**: pbxproj version is compared against `Package.resolved` via Python, with an explicit guard and diagnostic message when `sparkle` is missing from the resolved file.
- **Ordering**: The step runs before the `xcodebuild` build step, so a pin regression surfaces immediately with a clear message rather than a cryptic build failure.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a build-only lint step with no runtime behaviour change, and the implementation is well-scoped and handles the key failure modes.

The `sed`-based block extraction correctly confines all grep/version logic to the Sparkle entry in `project.pbxproj`, and the Python script guards against a missing sparkle identity in `Package.resolved` with a useful diagnostic message. The only gap is a bare `KeyError` if the sparkle state dict unexpectedly lacks a `version` key — very unlikely for an `exactVersion` pin and non-blocking for the merge.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/build.yml | Adds a scoped "Verify Sparkle version pin" CI step that extracts the Sparkle-specific pbxproj block via sed before running checks, correctly addressing prior scoping concerns; minor: `state['version']` is accessed without a guard if the key is unexpectedly absent. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CI: Verify Sparkle version pin] --> B["sed extracts Sparkle block from project.pbxproj"]
    B --> C{Block contains 'kind = exactVersion'?}
    C -- No --> D[❌ Exit 1: Sparkle must use exactVersion pinning]
    C -- Yes --> E["grep -A1 + sed extracts pbxproj_version from Sparkle block"]
    E --> F["Python reads Package.resolved, checks 'sparkle' identity exists"]
    F -- Not found --> G[❌ Exit 1: sparkle not found in Package.resolved]
    F -- Found --> H["resolved_version = pins['sparkle']['state']['version']"]
    H --> I{pbxproj_version empty?}
    I -- Yes --> J[❌ Exit 1: Could not extract Sparkle version from pbxproj]
    I -- No --> K{pbxproj_version == resolved_version?}
    K -- No --> L[❌ Exit 1: Sparkle version mismatch]
    K -- Yes --> M[✅ Sparkle pin verified: version]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22ci%2Fverify-sparkle-pin%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ci%2Fverify-sparkle-pin%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fbuild.yml%3A69-72%0AIf%20%60sparkle%60%20is%20present%20in%20%60Package.resolved%60%20but%20its%20%60state%60%20dict%20lacks%20a%20%60version%60%20key%20%28e.g.%20a%20revision-only%20or%20corrupted%20entry%29%2C%20the%20script%20raises%20a%20bare%20%60KeyError%3A%20'version'%60%20with%20no%20context.%20The%20existing%20guard%20for%20the%20missing-sparkle%20case%20already%20prints%20available%20identities%3B%20a%20similar%20explicit%20access%20for%20%60state%60%20keeps%20the%20diagnostic%20quality%20consistent.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20if%20'sparkle'%20not%20in%20pins%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20print%28'sparkle%20not%20found%20in%20Package.resolved.%20Available%3A%20'%20%2B%20'%2C%20'.join%28sorted%28pins.keys%28%29%29%29%2C%20file%3Dsys.stderr%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20sys.exit%281%29%0A%20%20%20%20%20%20%20%20%20%20state%20%3D%20pins%5B'sparkle'%5D.get%28'state'%2C%20%7B%7D%29%0A%20%20%20%20%20%20%20%20%20%20if%20'version'%20not%20in%20state%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20print%28'sparkle%20entry%20has%20no%20version%20in%20state.%20state%3D'%20%2B%20repr%28state%29%2C%20file%3Dsys.stderr%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20sys.exit%281%29%0A%20%20%20%20%20%20%20%20%20%20print%28state%5B'version'%5D%29%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fbuild.yml%3A69-72%0AIf%20%60sparkle%60%20is%20present%20in%20%60Package.resolved%60%20but%20its%20%60state%60%20dict%20lacks%20a%20%60version%60%20key%20%28e.g.%20a%20revision-only%20or%20corrupted%20entry%29%2C%20the%20script%20raises%20a%20bare%20%60KeyError%3A%20'version'%60%20with%20no%20context.%20The%20existing%20guard%20for%20the%20missing-sparkle%20case%20already%20prints%20available%20identities%3B%20a%20similar%20explicit%20access%20for%20%60state%60%20keeps%20the%20diagnostic%20quality%20consistent.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20if%20'sparkle'%20not%20in%20pins%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20print%28'sparkle%20not%20found%20in%20Package.resolved.%20Available%3A%20'%20%2B%20'%2C%20'.join%28sorted%28pins.keys%28%29%29%29%2C%20file%3Dsys.stderr%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20sys.exit%281%29%0A%20%20%20%20%20%20%20%20%20%20state%20%3D%20pins%5B'sparkle'%5D.get%28'state'%2C%20%7B%7D%29%0A%20%20%20%20%20%20%20%20%20%20if%20'version'%20not%20in%20state%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20print%28'sparkle%20entry%20has%20no%20version%20in%20state.%20state%3D'%20%2B%20repr%28state%29%2C%20file%3Dsys.stderr%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20sys.exit%281%29%0A%20%20%20%20%20%20%20%20%20%20print%28state%5B'version'%5D%29%0A%60%60%60%0A%0A&repo=fujacob%2Ftabby&pr=188&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (5): Last reviewed commit: ["Address review: add diagnostic guard for..."](https://github.com/fujacob/tabby/commit/05dfa838c03252da38db9ab994b453cb8ec9285b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33594443)</sub>

<!-- /greptile_comment -->