### PR TITLE
Replace word counter with Report and Check for Updates buttons

### DIFF
--- a/tabby/App/Core/TabbyApp.swift
+++ b/tabby/App/Core/TabbyApp.swift
@@ -21,7 +21,7 @@ struct TabbyApp: App {
                 permissionGuidanceController: appDelegate.permissionGuidanceController,
                 suggestionSettings: appDelegate.suggestionSettings,
                 foundationModelAvailabilityService: appDelegate.foundationModelAvailabilityService,
-                suggestionCoordinator: appDelegate.suggestionCoordinator,
+                appUpdateManager: appDelegate.appUpdateManager,
                 onOpenSettings: {
                     appDelegate.settingsCoordinator.showSettings()
                 },

--- a/tabby/UI/MenuBarView.swift
+++ b/tabby/UI/MenuBarView.swift
@@ -20,7 +20,7 @@ struct MenuBarView: View {
     let permissionGuidanceController: PermissionGuidanceController
     @ObservedObject var suggestionSettings: SuggestionSettingsModel
     @ObservedObject var foundationModelAvailabilityService: FoundationModelAvailabilityService
-    @ObservedObject var suggestionCoordinator: SuggestionCoordinator
+    let appUpdateManager: AppUpdateManager
     let onOpenSettings: () -> Void
     let onReportFeedback: () -> Void
 
@@ -57,9 +57,9 @@ struct MenuBarView: View {
 
             Spacer(minLength: 0)
 
-            Text("\(suggestionCoordinator.totalTabAcceptedWordCount) words accepted")
+            Button("Report Bug / Feedback", action: onReportFeedback)
+                .buttonStyle(.borderless)
                 .font(.subheadline)
-                .foregroundStyle(.secondary)
         }
         .padding(.bottom, 12)
     }
@@ -202,8 +202,10 @@ struct MenuBarView: View {
             Button("Settings", action: onOpenSettings)
                 .buttonStyle(.borderless)
 
-            Button("Report Bug / Feedback", action: onReportFeedback)
-                .buttonStyle(.borderless)
+            Button("Check for Updates") {
+                appUpdateManager.checkForUpdates()
+            }
+            .buttonStyle(.borderless)
 
             Spacer(minLength: 0)
 


### PR DESCRIPTION
## Summary

The "N words accepted" counter in the menu bar header didn't provide actionable value. This replaces it with the "Report Bug / Feedback" button (moved up from the footer) for quicker access, and adds a "Check for Updates" button in the footer where Report used to live.

## Validation

```
xcodebuild -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **
```

UI-only change — no new logic, just button repositioning.

## Linked issues

<!-- N/A -->

## Risk / rollout notes

- Removes `suggestionCoordinator` dependency from `MenuBarView` (was only used for the word counter display).
- Adds `appUpdateManager` dependency to `MenuBarView` for the new Check for Updates button.
- The word count is still tracked in `SuggestionCoordinator` and persisted to UserDefaults — only the display was removed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR swaps the "N words accepted" counter in the menu bar header for a "Report Bug / Feedback" button and moves the old footer "Report" button to a new "Check for Updates" button backed by `AppUpdateManager.checkForUpdates()`. The dependency change (`suggestionCoordinator` → `appUpdateManager`) is threaded correctly through `TabbyApp.swift` and the `MenuBarView` struct signature.

- **Header**: word-count `Text` removed, `@ObservedObject var suggestionCoordinator` dropped; "Report Bug / Feedback" `Button` added with `.font(.subheadline)` and `.buttonStyle(.borderless)`.
- **Footer**: "Report Bug / Feedback" `Button` replaced by "Check for Updates" `Button` that calls `appUpdateManager.checkForUpdates()`; `appUpdateManager` is correctly typed as a plain `let` constant since `AppUpdateManager` is not an `ObservableObject`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely presentational button repositioning with no logic changes.

The change is UI-only: two buttons move, one dependency is swapped. `AppUpdateManager` is correctly typed as a plain `let` (it is not an `ObservableObject`), `checkForUpdates()` is already guarded against a not-started Sparkle instance, and the call site in `TabbyApp.swift` is updated in lock-step. No logic, persistence, or service behavior is altered.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tabby/UI/MenuBarView.swift | Replaces `@ObservedObject var suggestionCoordinator` + word-count Text with a `let appUpdateManager` + "Report Bug / Feedback" button in the header, and swaps the old footer "Report" button for a "Check for Updates" button backed by `appUpdateManager.checkForUpdates()`. |
| tabby/App/Core/TabbyApp.swift | Single-argument swap at the `MenuBarView` call site: `suggestionCoordinator` → `appUpdateManager`, matching the updated struct signature. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User opens Menu Bar] --> B[MenuBarView renders]
    B --> C[Header: 'Report Bug / Feedback' button]
    B --> D[Footer: 'Check for Updates' button]
    C --> E[onReportFeedback closure\nopens tabbyapp.dev/feedback]
    D --> F[appUpdateManager.checkForUpdates]
    F --> G{isStarted?}
    G -- No --> H[Silent no-op\nlog message only]
    G -- Yes --> I[SPUStandardUpdaterController\n.checkForUpdates nil\nSparkle handles UI]
```

<sub>Reviews (1): Last reviewed commit: ["Replace word counter with Report button ..."](https://github.com/fujacob/tabby/commit/93b9179a3603e291f4d29313219a373a2c571b43) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33594840)</sub>

<!-- /greptile_comment -->