### PR TITLE
Replace build number formula with github.run_number

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,20 +219,11 @@ jobs:
             is_prerelease="false"
           fi
 
-          # Derive build number from the release version so Sparkle can detect
-          # upgrades. CURRENT_PROJECT_VERSION in the Xcode project is static and
-          # was always "1", which made every appcast report the same build number
-          # and Sparkle would say "You're up to date!" even when a newer release
-          # existed. The formula (major*100000 + minor*1000 + patch) gives each
-          # component room up to 999 before collisions.
-          build_number="$(echo "${release_version}" |
-            sed 's/-.*$//' |
-            awk -F. '{ printf "%d", $1*100000 + $2*1000 + $3 }')"
-
-          if [[ -z "${build_number}" || "${build_number}" -le 0 ]]; then
-            echo "Derived build number '${build_number}' from version '${release_version}' is not a positive integer." >&2
-            exit 1
-          fi
+          # Use the workflow run number as the build number. It auto-increments
+          # per workflow run, is always positive, and requires no formulas or
+          # edge-case handling. Sparkle only needs build numbers to increase
+          # monotonically — it doesn't care about gaps or specific values.
+          build_number="${{ github.run_number }}"
 
           echo "release_tag=${release_tag}" >> "$GITHUB_OUTPUT"
           echo "release_version=${release_version}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Replaces the custom build number derivation formula
(`major*100000 + minor*1000 + patch`) with `github.run_number`. The
formula was a bespoke scheme that could collide at component values >= 1000
and was one more thing contributors had to understand. `github.run_number`
is a built-in monotonic counter that just goes up — no math, no edge cases.

Sparkle only needs build numbers to increase between releases. It doesn't
care about gaps or specific values.

## Validation

`github.run_number` is currently at ~27 for this workflow, which is higher
than the previous build number of 6 (from v0.0.6-beta). Sparkle will see
the next release as an upgrade.

Cannot test the actual `github.run_number` injection locally — it's a
GitHub Actions context variable. Verified the YAML is structurally correct
and the metadata step still emits `build_number` to `GITHUB_OUTPUT`.

## Linked issues

Refs #185

## Risk / rollout notes

- Build numbers will jump from 6 (v0.0.6-beta) to ~28+ on next release.
  This is fine — Sparkle only checks "is the new number higher?"
- `workflow_dispatch` dry runs consume run numbers. This is expected and
  harmless — numbers just need to go up, not be sequential.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the custom build number derivation formula (`major*100000 + minor*1000 + patch`) in the release workflow with GitHub's built-in `github.run_number`. The old formula was unnecessary complexity that could collide for component values ≥ 1000 and required a separate validation guard; `github.run_number` is always a positive integer so both the formula and the guard are cleanly removed.

- The `build_number` variable is now set directly to `${{ github.run_number }}` inside the `Resolve release metadata` step; all subsequent steps (`Archive signed app`, `Generate signed appcast`, `Release summary`) consume it identically through `steps.metadata.outputs.build_number` — no other changes required.
- The removed validation (`-z \"${build_number}\" || \"${build_number}\" -le 0`) was genuinely unnecessary for `github.run_number`, which the GitHub Actions runtime guarantees is always a positive integer starting from 1.

<h3>Confidence Score: 5/5</h3>

This is a safe, surgical change that removes nine lines of formula-and-validation logic and replaces them with a single well-understood GitHub Actions built-in.

The change is minimal and correct. github.run_number is monotonically increasing and always a positive integer, so removing the old validation guard leaves no gap in correctness. All downstream consumers of build_number remain unmodified and continue to work through the same steps.metadata.outputs reference. The jump in build number value from ~6 to ~28 is intentional and harmless for Sparkle's update detection.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Replaces bespoke major*100000 + minor*1000 + patch formula and its validation guard with a single github.run_number assignment; all downstream consumers (CURRENT_PROJECT_VERSION, appcast generation, step summary) continue to receive build_number from the same steps.metadata.outputs reference unchanged. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Replace build number formula with github..."](https://github.com/fujacob/tabby/commit/577336531df24d770bfdccd4cc06ab07ab880999) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33595088)</sub>

<!-- /greptile_comment -->