### PR TITLE
Skip OCR pipeline when Tabby is disabled globally or per-app

### DIFF
--- a/tabby/App/Coordinators/SuggestionCoordinator+Input.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator+Input.swift
@@ -22,11 +22,17 @@ extension SuggestionCoordinator {
 
     func handleFocusSnapshotChange(_ snapshot: FocusSnapshot) {
         // Start capturing visual context for a newly focused input even when predictions are
-        // temporarily disabled (e.g., "text is selected" or "secure field"). The OCR pipeline
-        // is field-scoped and should start as early as possible so context is ready by the
-        // time the user starts typing. Without this, switching between fields can leave the
-        // visual context coordinator dormant if the snapshot is transiently unsupported.
-        if let context = snapshot.context {
+        // temporarily disabled by transient field states (e.g., "text is selected" or "secure
+        // field"). Skip capture entirely when the subsystem is hard-disabled (globally off,
+        // per-app disabled, terminal apps, or missing permissions) to avoid wasted compute.
+        if let context = snapshot.context,
+           SuggestionAvailabilityEvaluator.shouldCaptureVisualContext(
+               globallyEnabled: settingsSnapshot.isGloballyEnabled,
+               disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
+               inputMonitoringGranted: permissionManager.inputMonitoringGranted,
+               screenRecordingGranted: permissionManager.screenRecordingGranted,
+               focusSnapshot: snapshot
+           ) {
             visualContextCoordinator.startSessionIfNeeded(for: context)
         }
 

--- a/tabby/App/Coordinators/SuggestionCoordinator+Lifecycle.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator+Lifecycle.swift
@@ -62,9 +62,16 @@ extension SuggestionCoordinator {
             latestStageMessage = "Updated autocomplete settings."
         }
 
-        // Cancel any obsolete context, then restart it if focus is still active.
+        // Cancel any obsolete context, then restart only when the subsystem is not disabled.
         visualContextCoordinator.cancel(resetState: true)
-        if let focusedSnapshot = focusModel.snapshot.context {
+        if let focusedSnapshot = focusModel.snapshot.context,
+           SuggestionAvailabilityEvaluator.shouldCaptureVisualContext(
+               globallyEnabled: settingsSnapshot.isGloballyEnabled,
+               disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
+               inputMonitoringGranted: permissionManager.inputMonitoringGranted,
+               screenRecordingGranted: permissionManager.screenRecordingGranted,
+               focusSnapshot: focusModel.snapshot
+           ) {
             visualContextCoordinator.startSessionIfNeeded(for: focusedSnapshot)
         }
 

--- a/tabby/Support/SuggestionAvailabilityEvaluator.swift
+++ b/tabby/Support/SuggestionAvailabilityEvaluator.swift
@@ -12,7 +12,8 @@ enum SuggestionAvailabilityEvaluator {
         disabledAppBundleIdentifiers: Set<String> = [],
         inputMonitoringGranted: Bool,
         screenRecordingGranted: Bool,
-        focusSnapshot: FocusSnapshot
+        focusSnapshot: FocusSnapshot,
+        checkCapability: Bool = true
     ) -> String? {
         guard globallyEnabled else {
             return "Tabby is turned off."
@@ -34,6 +35,10 @@ enum SuggestionAvailabilityEvaluator {
         guard screenRecordingGranted else {
             return "Screen Recording permission is required before Tabby can build visual context "
                 + "for autocomplete."
+        }
+
+        guard checkCapability else {
+            return nil
         }
 
         switch focusSnapshot.capability {
@@ -62,10 +67,9 @@ enum SuggestionAvailabilityEvaluator {
 
     /// Whether the environment allows visual context capture to start.
     ///
-    /// Unlike `disabledReason`, this ignores transient field-level states (text selected,
-    /// secure field) so the OCR pipeline can start early and be ready by the time the user
-    /// types. Returns `false` only for hard environment disables: globally off, per-app
-    /// disabled, terminal apps, and missing permissions.
+    /// Delegates to `disabledReason` with capability checking disabled so transient field
+    /// states (text selected, secure field) are intentionally ignored — OCR should start
+    /// early in those cases and be ready by the time the user begins typing.
     static func shouldCaptureVisualContext(
         globallyEnabled: Bool = true,
         disabledAppBundleIdentifiers: Set<String> = [],
@@ -73,21 +77,14 @@ enum SuggestionAvailabilityEvaluator {
         screenRecordingGranted: Bool,
         focusSnapshot: FocusSnapshot
     ) -> Bool {
-        guard globallyEnabled else { return false }
-
-        if let bundleIdentifier = focusSnapshot.bundleIdentifier,
-           disabledAppBundleIdentifiers.contains(bundleIdentifier) {
-            return false
-        }
-
-        if TerminalAppDetector.isTerminal(bundleIdentifier: focusSnapshot.bundleIdentifier) {
-            return false
-        }
-
-        guard inputMonitoringGranted else { return false }
-        guard screenRecordingGranted else { return false }
-
-        return true
+        disabledReason(
+            globallyEnabled: globallyEnabled,
+            disabledAppBundleIdentifiers: disabledAppBundleIdentifiers,
+            inputMonitoringGranted: inputMonitoringGranted,
+            screenRecordingGranted: screenRecordingGranted,
+            focusSnapshot: focusSnapshot,
+            checkCapability: false
+        ) == nil
     }
 
     static func shouldSchedulePredictionWhenVisualContextBecomesReady(

--- a/tabby/Support/SuggestionAvailabilityEvaluator.swift
+++ b/tabby/Support/SuggestionAvailabilityEvaluator.swift
@@ -60,6 +60,36 @@ enum SuggestionAvailabilityEvaluator {
         ) == nil
     }
 
+    /// Whether the environment allows visual context capture to start.
+    ///
+    /// Unlike `disabledReason`, this ignores transient field-level states (text selected,
+    /// secure field) so the OCR pipeline can start early and be ready by the time the user
+    /// types. Returns `false` only for hard environment disables: globally off, per-app
+    /// disabled, terminal apps, and missing permissions.
+    static func shouldCaptureVisualContext(
+        globallyEnabled: Bool = true,
+        disabledAppBundleIdentifiers: Set<String> = [],
+        inputMonitoringGranted: Bool,
+        screenRecordingGranted: Bool,
+        focusSnapshot: FocusSnapshot
+    ) -> Bool {
+        guard globallyEnabled else { return false }
+
+        if let bundleIdentifier = focusSnapshot.bundleIdentifier,
+           disabledAppBundleIdentifiers.contains(bundleIdentifier) {
+            return false
+        }
+
+        if TerminalAppDetector.isTerminal(bundleIdentifier: focusSnapshot.bundleIdentifier) {
+            return false
+        }
+
+        guard inputMonitoringGranted else { return false }
+        guard screenRecordingGranted else { return false }
+
+        return true
+    }
+
     static func shouldSchedulePredictionWhenVisualContextBecomesReady(
         focusSnapshot: FocusSnapshot,
         matching identity: FocusedInputIdentity


### PR DESCRIPTION
## Summary

The visual context coordinator (screenshot capture + OCR) was starting unconditionally on every focus change and settings update — even when Tabby was turned off globally, disabled for the current app, focused in a terminal, or missing permissions. This wasted CPU on work whose results would never be used.

Adds a `shouldCaptureVisualContext` gate in `SuggestionAvailabilityEvaluator` that checks only hard environment disables while still allowing early capture during transient field states (text selected, secure field). Gates both OCR start sites (`handleFocusSnapshotChange`, `handleSuggestionSettingsChange`) on this check.

## Validation

```
xcodebuild -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

swiftlint lint --quiet --config .swiftlint.yml <changed files>
# exit 0, no warnings
```

Cannot fully verify end-to-end OCR skipping without a running app and a per-app disable toggle, but the control flow is straightforward: the new guard short-circuits before `startSessionIfNeeded` is ever called.

## Linked issues

n/a

## Risk / rollout notes

- The new `shouldCaptureVisualContext` method mirrors the first five checks of the existing `disabledReason` method, intentionally omitting the snapshot capability check so transient field states still allow early OCR warm-up.
- No behavior change for users who have Tabby enabled — OCR still starts eagerly on focus change as before.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `shouldCaptureVisualContext` gate in `SuggestionAvailabilityEvaluator` and applies it at both OCR start sites in the suggestion coordinator, preventing screenshot/OCR work from starting when Tabby is hard-disabled while still allowing early capture for transient field states.

- The `checkCapability: Bool = true` parameter on `disabledReason` cleanly solves the earlier duplicated-logic concern: `shouldCaptureVisualContext` delegates directly rather than re-implementing the checks.
- Both coordinator callsites are updated consistently and correctly read the authoritative settings/permission state at call time.
- `SuggestionAvailabilityEvaluatorTests` has no coverage for the new `shouldCaptureVisualContext` method; tests for the transient-capability-allowed and hard-disabled cases would lock in the invariant the PR relies on.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the gate is additive, delegation prevents future logic drift, and the OCR warm-up path for transient field states is preserved.

All three changed files touch only the new gate. Hard-disable conditions are correctly delegated rather than duplicated, and no existing coordinator paths are altered for users with Tabby enabled. The only gap is missing unit tests for the new public method, which does not affect runtime correctness.

No files in the changeset require special attention; the untested shouldCaptureVisualContext path is the only follow-up worth tracking.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tabby/Support/SuggestionAvailabilityEvaluator.swift | Adds checkCapability param to disabledReason and a new shouldCaptureVisualContext that delegates with checkCapability: false; cleanly avoids the duplicated-logic concern from the prior thread. |
| tabby/App/Coordinators/SuggestionCoordinator+Input.swift | Gates visualContextCoordinator.startSessionIfNeeded in handleFocusSnapshotChange on shouldCaptureVisualContext; consistent with the lifecycle file. |
| tabby/App/Coordinators/SuggestionCoordinator+Lifecycle.swift | Gates OCR restart in handleSuggestionSettingsChange on shouldCaptureVisualContext after settingsSnapshot is updated; correctly reads new settings when evaluating the gate. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Focus change / Settings change] --> B{snapshot.context non-nil?}
    B -- No --> END1[Skip OCR start]
    B -- Yes --> C{shouldCaptureVisualContext?}
    C -- false: hard disabled --> END2[Skip OCR start]
    C -- true --> D[visualContextCoordinator.startSessionIfNeeded]
    D --> E{disabledReason? capability check included}
    E -- reason exists --> F[disablePredictionsPreservingVisualContext]
    E -- nil: fully supported --> G[handleSupportedSnapshot]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22fix%2Fskip-ocr-when-disabled%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fskip-ocr-when-disabled%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AtabbyTests%2FSuggestionAvailabilityEvaluatorTests.swift%3A192-214%0A**Missing%20test%20coverage%20for%20%60shouldCaptureVisualContext%60**%0A%0AThe%20test%20suite%20has%20a%20clear%20pattern%20of%20%22test%20both%20sides%20of%20the%20nil%20boundary%22%20for%20%60shouldSchedulePrediction%60%2C%20but%20%60shouldCaptureVisualContext%60%20%E2%80%94%20the%20new%20public%20entry%20point%20exercised%20by%20both%20coordinator%20sites%20%E2%80%94%20has%20no%20tests%20at%20all.%20The%20key%20invariant%20to%20lock%20in%20is%20that%20a%20%60.blocked%60%20or%20%60.unsupported%60%20capability%20still%20returns%20%60true%60%20%28transient%20states%20should%20not%20suppress%20OCR%29%2C%20while%20a%20globally-disabled%20or%20per-app-disabled%20environment%20returns%20%60false%60.%20Without%20tests%2C%20a%20future%20change%20to%20the%20%60checkCapability%60%20path%20could%20silently%20break%20the%20warm-up%20behavior%20described%20in%20the%20PR%20without%20any%20test%20failing.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AtabbyTests%2FSuggestionAvailabilityEvaluatorTests.swift%3A192-214%0A**Missing%20test%20coverage%20for%20%60shouldCaptureVisualContext%60**%0A%0AThe%20test%20suite%20has%20a%20clear%20pattern%20of%20%22test%20both%20sides%20of%20the%20nil%20boundary%22%20for%20%60shouldSchedulePrediction%60%2C%20but%20%60shouldCaptureVisualContext%60%20%E2%80%94%20the%20new%20public%20entry%20point%20exercised%20by%20both%20coordinator%20sites%20%E2%80%94%20has%20no%20tests%20at%20all.%20The%20key%20invariant%20to%20lock%20in%20is%20that%20a%20%60.blocked%60%20or%20%60.unsupported%60%20capability%20still%20returns%20%60true%60%20%28transient%20states%20should%20not%20suppress%20OCR%29%2C%20while%20a%20globally-disabled%20or%20per-app-disabled%20environment%20returns%20%60false%60.%20Without%20tests%2C%20a%20future%20change%20to%20the%20%60checkCapability%60%20path%20could%20silently%20break%20the%20warm-up%20behavior%20described%20in%20the%20PR%20without%20any%20test%20failing.%0A%0A&repo=fujacob%2Ftabby&pr=197&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Eliminate duplicated disable logic in sh..."](https://github.com/fujacob/tabby/commit/16e2bee67dcf9d402a2a7143ccb4fab216c000ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33685144)</sub>

<!-- /greptile_comment -->