### PR TITLE
Add full-suggestion acceptance keybind

### DIFF
--- a/tabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
@@ -8,12 +8,22 @@ import Foundation
 extension SuggestionCoordinator {
     // MARK: - Acceptance and Session Reconciliation
 
-    /// Accepts the current suggestion only if the field, generation, and visible overlay still match.
+    /// Accepts the next word of the current suggestion.
     func acceptCurrentSuggestion() -> Bool {
+        acceptSuggestion(fullText: false, keyName: "Tab")
+    }
+
+    /// Accepts the entire remaining suggestion at once.
+    func acceptEntireSuggestion() -> Bool {
+        acceptSuggestion(fullText: true, keyName: "full-accept")
+    }
+
+    /// Shared acceptance path used by both word-by-word and full acceptance.
+    private func acceptSuggestion(fullText: Bool, keyName: String) -> Bool {
         let snapshot = focusModel.snapshot
 
         guard permissionManager.inputMonitoringGranted else {
-            return passTabThrough(reason: "Input Monitoring permission is required before Tabby can accept Tab.")
+            return passTabThrough(reason: "Input Monitoring permission is required before Tabby can accept suggestions.")
         }
 
         guard case .supported = snapshot.capability, let rawContext = snapshot.context else {
@@ -21,17 +31,17 @@ extension SuggestionCoordinator {
         }
 
         guard case .ready = state else {
-            return passTabThrough(reason: "Tab passed through because no valid suggestion was ready.")
+            return passTabThrough(reason: "Key passed through because no valid suggestion was ready.")
         }
 
-        let acceptancePreparation = interactionState.prepareAcceptance(
-            from: rawContext,
-            overlayState: overlayState
-        )
+        let preparation = fullText
+            ? interactionState.prepareFullAcceptance(from: rawContext, overlayState: overlayState)
+            : interactionState.prepareAcceptance(from: rawContext, overlayState: overlayState)
+
         let liveContext: FocusedInputContext
         let sessionForAcceptance: ActiveSuggestionSession
         let acceptedChunk: String
-        switch acceptancePreparation {
+        switch preparation {
         case let .ready(preparedLiveContext, preparedSession, preparedAcceptedChunk):
             liveContext = preparedLiveContext
             sessionForAcceptance = preparedSession
@@ -69,11 +79,11 @@ extension SuggestionCoordinator {
         case .exhausted:
             latestGenerationNumber = liveContext.generation
             clearSuggestion(clearDiagnostics: false)
-            hideOverlay(reason: "Overlay hidden because Tab accepted the final suggestion chunk.")
-            latestAcceptanceAction = "Accepted final chunk with Tab."
+            hideOverlay(reason: "Overlay hidden because \(keyName) accepted the final suggestion chunk.")
+            latestAcceptanceAction = "Accepted final chunk with \(keyName)."
             state = .idle
             logStage(
-                "tab-accepted-final-chunk",
+                "\(keyName)-accepted-final-chunk",
                 workID: currentWorkID,
                 generation: liveContext.generation,
                 message: "Inserted the final suggestion chunk and queued a refresh.",
@@ -84,11 +94,8 @@ extension SuggestionCoordinator {
 
         case let .advanced(advancedSession, _):
             latestGenerationNumber = liveContext.generation
-            applySessionDiagnostics(advancedSession, acceptanceAction: "Accepted next chunk with Tab.")
+            applySessionDiagnostics(advancedSession, acceptanceAction: "Accepted next chunk with \(keyName).")
             state = .ready(text: advancedSession.remainingText, latency: advancedSession.latency)
-            // Predict where the caret will land after the inserted chunk. This eliminates the
-            // visible jump where the overlay stays at the old position then snaps rightward
-            // when AX catches up 100–250ms later.
             let isRTL = TextDirectionDetector.isRightToLeft(liveContext.precedingText)
             let predictedCaret = Self.predictedCaretRect(
                 after: acceptedChunk,
@@ -105,11 +112,9 @@ extension SuggestionCoordinator {
                 observedCharWidth: liveContext.observedCharWidth,
                 isRightToLeft: isRTL
             )
-            // Force an early AX refresh so the real caret position corrects any prediction
-            // error faster than the normal 250ms poll interval.
             schedulePostInsertionRefresh()
             logStage(
-                "tab-accepted-chunk",
+                "\(keyName)-accepted-chunk",
                 workID: currentWorkID,
                 generation: liveContext.generation,
                 message: "Inserted the next suggestion chunk and kept the remaining tail active.",

--- a/tabby/App/Coordinators/SuggestionCoordinator+Input.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator+Input.swift
@@ -90,6 +90,10 @@ extension SuggestionCoordinator {
             return acceptCurrentSuggestion()
         }
 
+        if event.kind == .fullAcceptance {
+            return acceptEntireSuggestion()
+        }
+
         if let activeSession = interactionState.activeSession {
             return handleInputEvent(event, with: activeSession)
         }
@@ -161,7 +165,7 @@ extension SuggestionCoordinator {
             state = .idle
             return false
 
-        case .other, .acceptance:
+        case .other, .acceptance, .fullAcceptance:
             return false
         }
     }

--- a/tabby/App/Core/TabbyAppEnvironment.swift
+++ b/tabby/App/Core/TabbyAppEnvironment.swift
@@ -45,8 +45,8 @@ final class TabbyAppEnvironment {
             permissionProvider: { permissionManager.inputMonitoringGranted },
             suppressionController: suppressionController
         )
-        inputMonitor.acceptanceKeyCode = suggestionSettings.acceptanceKeyCode
-        inputMonitor.fullAcceptanceKeyCode = suggestionSettings.fullAcceptanceKeyCode
+        inputMonitor.acceptanceKeyCodeProvider = { suggestionSettings.acceptanceKeyCode }
+        inputMonitor.fullAcceptanceKeyCodeProvider = { suggestionSettings.fullAcceptanceKeyCode }
         let focusModel = FocusTrackingModel(
             permissionProvider: { permissionManager.accessibilityGranted },
             ignoredBundleIdentifier: Bundle.main.bundleIdentifier,
@@ -151,21 +151,7 @@ final class TabbyAppEnvironment {
             }
             .store(in: &cancellables)
 
-        // Push acceptance key changes from settings into the event classifier.
-        // Captures `self` weakly — capturing the local `inputMonitor` variable would create a
-        // dangling weak ref once init() returns, silently dropping all subsequent updates.
-        suggestionSettings.$acceptanceKeyCode
-            .removeDuplicates()
-            .sink { [weak self] keyCode in
-                self?.inputMonitor.acceptanceKeyCode = keyCode
-            }
-            .store(in: &cancellables)
-
-        suggestionSettings.$fullAcceptanceKeyCode
-            .removeDuplicates()
-            .sink { [weak self] keyCode in
-                self?.inputMonitor.fullAcceptanceKeyCode = keyCode
-            }
-            .store(in: &cancellables)
+        // Key code changes reach InputMonitor through closures that read from the model
+        // at event time (set above), so no Combine subscription is needed here.
     }
 }

--- a/tabby/App/Core/TabbyAppEnvironment.swift
+++ b/tabby/App/Core/TabbyAppEnvironment.swift
@@ -46,6 +46,7 @@ final class TabbyAppEnvironment {
             suppressionController: suppressionController
         )
         inputMonitor.acceptanceKeyCode = suggestionSettings.acceptanceKeyCode
+        inputMonitor.fullAcceptanceKeyCode = suggestionSettings.fullAcceptanceKeyCode
         let focusModel = FocusTrackingModel(
             permissionProvider: { permissionManager.accessibilityGranted },
             ignoredBundleIdentifier: Bundle.main.bundleIdentifier,
@@ -157,6 +158,13 @@ final class TabbyAppEnvironment {
             .removeDuplicates()
             .sink { [weak self] keyCode in
                 self?.inputMonitor.acceptanceKeyCode = keyCode
+            }
+            .store(in: &cancellables)
+
+        suggestionSettings.$fullAcceptanceKeyCode
+            .removeDuplicates()
+            .sink { [weak self] keyCode in
+                self?.inputMonitor.fullAcceptanceKeyCode = keyCode
             }
             .store(in: &cancellables)
     }

--- a/tabby/Models/InputModels.swift
+++ b/tabby/Models/InputModels.swift
@@ -11,6 +11,7 @@ struct CapturedInputEvent: Equatable {
     /// A reduced vocabulary keeps the suggestion state machine easier to reason about and test.
     enum Kind: String, Equatable {
         case acceptance
+        case fullAcceptance
         case textMutation
         case navigation
         case shortcutMutation
@@ -36,7 +37,7 @@ struct CapturedInputEvent: Equatable {
         switch kind {
         case .textMutation, .navigation, .shortcutMutation, .dismissal:
             return true
-        case .acceptance, .other:
+        case .acceptance, .fullAcceptance, .other:
             return false
         }
     }

--- a/tabby/Models/SuggestionSettingsModel.swift
+++ b/tabby/Models/SuggestionSettingsModel.swift
@@ -24,6 +24,8 @@ final class SuggestionSettingsModel: ObservableObject {
     @Published private(set) var focusPollIntervalMilliseconds: Int
     @Published private(set) var acceptanceKeyCode: CGKeyCode
     @Published private(set) var acceptanceKeyLabel: String
+    @Published private(set) var fullAcceptanceKeyCode: CGKeyCode
+    @Published private(set) var fullAcceptanceKeyLabel: String
     private let userDefaults: UserDefaults
 
     private static let isGloballyEnabledDefaultsKey = "tabbyGloballyEnabled"
@@ -40,9 +42,16 @@ final class SuggestionSettingsModel: ObservableObject {
     private static let focusPollIntervalMillisecondsDefaultsKey = "tabbyFocusPollIntervalMilliseconds"
     private static let acceptanceKeyCodeDefaultsKey = "tabbyAcceptanceKeyCode"
     private static let acceptanceKeyLabelDefaultsKey = "tabbyAcceptanceKeyLabel"
+    private static let fullAcceptanceKeyCodeDefaultsKey = "tabbyFullAcceptanceKeyCode"
+    private static let fullAcceptanceKeyLabelDefaultsKey = "tabbyFullAcceptanceKeyLabel"
 
     static let defaultAcceptanceKeyCode: CGKeyCode = 48
     static let defaultAcceptanceKeyLabel = "Tab"
+    /// A key code that will never match a real keyboard event, used to represent "no keybind".
+    static let disabledKeyCode: CGKeyCode = CGKeyCode(UInt16.max)
+    static let disabledKeyLabel = "None"
+    static let defaultFullAcceptanceKeyCode: CGKeyCode = disabledKeyCode
+    static let defaultFullAcceptanceKeyLabel = disabledKeyLabel
 
     init(
         configuration: SuggestionConfiguration,
@@ -96,6 +105,13 @@ final class SuggestionSettingsModel: ObservableObject {
         let resolvedAcceptanceKeyLabel = userDefaults.string(forKey: Self.acceptanceKeyLabelDefaultsKey)
             ?? Self.defaultAcceptanceKeyLabel
 
+        let resolvedFullAcceptanceKeyCode = CGKeyCode(
+            userDefaults.object(forKey: Self.fullAcceptanceKeyCodeDefaultsKey) as? Int
+                ?? Int(Self.defaultFullAcceptanceKeyCode)
+        )
+        let resolvedFullAcceptanceKeyLabel = userDefaults.string(forKey: Self.fullAcceptanceKeyLabelDefaultsKey)
+            ?? Self.defaultFullAcceptanceKeyLabel
+
         isGloballyEnabled = resolvedGloballyEnabled
         disabledAppRules = resolvedDisabledAppRules
         showIndicator = resolvedShowIndicator
@@ -108,6 +124,8 @@ final class SuggestionSettingsModel: ObservableObject {
         focusPollIntervalMilliseconds = resolvedFocusPollIntervalMilliseconds
         acceptanceKeyCode = resolvedAcceptanceKeyCode
         acceptanceKeyLabel = resolvedAcceptanceKeyLabel
+        fullAcceptanceKeyCode = resolvedFullAcceptanceKeyCode
+        fullAcceptanceKeyLabel = resolvedFullAcceptanceKeyLabel
 
         userDefaults.set(resolvedGloballyEnabled, forKey: Self.isGloballyEnabledDefaultsKey)
         persistDisabledAppRules(resolvedDisabledAppRules)
@@ -121,6 +139,8 @@ final class SuggestionSettingsModel: ObservableObject {
         userDefaults.set(resolvedFocusPollIntervalMilliseconds, forKey: Self.focusPollIntervalMillisecondsDefaultsKey)
         userDefaults.set(Int(resolvedAcceptanceKeyCode), forKey: Self.acceptanceKeyCodeDefaultsKey)
         userDefaults.set(resolvedAcceptanceKeyLabel, forKey: Self.acceptanceKeyLabelDefaultsKey)
+        userDefaults.set(Int(resolvedFullAcceptanceKeyCode), forKey: Self.fullAcceptanceKeyCodeDefaultsKey)
+        userDefaults.set(resolvedFullAcceptanceKeyLabel, forKey: Self.fullAcceptanceKeyLabelDefaultsKey)
     }
 
     /// Legacy compatibility shim. Reads through to `showIndicator`.
@@ -308,10 +328,39 @@ final class SuggestionSettingsModel: ObservableObject {
             return
         }
 
+        // Clear the other keybind if it would conflict.
+        if keyCode != Self.disabledKeyCode, keyCode == fullAcceptanceKeyCode {
+            clearFullAcceptanceKey()
+        }
+
         acceptanceKeyCode = keyCode
         acceptanceKeyLabel = label
         userDefaults.set(Int(keyCode), forKey: Self.acceptanceKeyCodeDefaultsKey)
         userDefaults.set(label, forKey: Self.acceptanceKeyLabelDefaultsKey)
+    }
+
+    func clearAcceptanceKey() {
+        setAcceptanceKey(keyCode: Self.disabledKeyCode, label: Self.disabledKeyLabel)
+    }
+
+    func setFullAcceptanceKey(keyCode: CGKeyCode, label: String) {
+        guard fullAcceptanceKeyCode != keyCode || fullAcceptanceKeyLabel != label else {
+            return
+        }
+
+        // Clear the other keybind if it would conflict.
+        if keyCode != Self.disabledKeyCode, keyCode == acceptanceKeyCode {
+            clearAcceptanceKey()
+        }
+
+        fullAcceptanceKeyCode = keyCode
+        fullAcceptanceKeyLabel = label
+        userDefaults.set(Int(keyCode), forKey: Self.fullAcceptanceKeyCodeDefaultsKey)
+        userDefaults.set(label, forKey: Self.fullAcceptanceKeyLabelDefaultsKey)
+    }
+
+    func clearFullAcceptanceKey() {
+        setFullAcceptanceKey(keyCode: Self.disabledKeyCode, label: Self.disabledKeyLabel)
     }
 
     private func persistSelectedEngine(_ engine: SuggestionEngineKind) {

--- a/tabby/Services/Input/InputMonitor.swift
+++ b/tabby/Services/Input/InputMonitor.swift
@@ -16,9 +16,12 @@ final class InputMonitor {
     var onEvent: ((CapturedInputEvent) -> Bool)?
     var onSuppressedSyntheticInput: (() -> Void)?
 
-    /// The key code that triggers suggestion acceptance. Updated by the coordinator
+    /// The key code that triggers word-by-word acceptance. Updated by the coordinator
     /// when the user changes the keybind in Settings.
     var acceptanceKeyCode: CGKeyCode = 48
+
+    /// The key code that triggers full-suggestion acceptance. `disabledKeyCode` means no keybind.
+    var fullAcceptanceKeyCode: CGKeyCode = CGKeyCode(UInt16.max)
 
     private let permissionProvider: @MainActor () -> Bool
     private let suppressionController: InputSuppressionController
@@ -142,9 +145,15 @@ final class InputMonitor {
         let flags = event.flags
         let characters = event.unicodeString
 
-        // Matches the user-configured acceptance key (default: Tab, key code 48).
-        if keyCode == acceptanceKeyCode,
-           flags.isDisjoint(with: [.maskCommand, .maskControl, .maskAlternate, .maskShift]) {
+        let noModifiers = flags.isDisjoint(with: [.maskCommand, .maskControl, .maskAlternate, .maskShift])
+
+        // Full-suggestion acceptance takes priority so pressing the full-accept key
+        // doesn't silently fall through to word-accept when both are assigned.
+        if keyCode == fullAcceptanceKeyCode, noModifiers {
+            return CapturedInputEvent(kind: .fullAcceptance, keyCode: keyCode, characters: characters, flags: flags)
+        }
+
+        if keyCode == acceptanceKeyCode, noModifiers {
             return CapturedInputEvent(kind: .acceptance, keyCode: keyCode, characters: characters, flags: flags)
         }
 

--- a/tabby/Services/Input/InputMonitor.swift
+++ b/tabby/Services/Input/InputMonitor.swift
@@ -16,12 +16,12 @@ final class InputMonitor {
     var onEvent: ((CapturedInputEvent) -> Bool)?
     var onSuppressedSyntheticInput: (() -> Void)?
 
-    /// The key code that triggers word-by-word acceptance. Updated by the coordinator
-    /// when the user changes the keybind in Settings.
-    var acceptanceKeyCode: CGKeyCode = 48
+    /// Reads the current word-accept key code from the model at event time, avoiding
+    /// Combine delivery lag between settings changes and the event classifier.
+    var acceptanceKeyCodeProvider: @MainActor () -> CGKeyCode = { 48 }
 
-    /// The key code that triggers full-suggestion acceptance. `disabledKeyCode` means no keybind.
-    var fullAcceptanceKeyCode: CGKeyCode = CGKeyCode(UInt16.max)
+    /// Reads the current full-accept key code from the model at event time.
+    var fullAcceptanceKeyCodeProvider: @MainActor () -> CGKeyCode = { CGKeyCode(UInt16.max) }
 
     private let permissionProvider: @MainActor () -> Bool
     private let suppressionController: InputSuppressionController
@@ -147,13 +147,17 @@ final class InputMonitor {
 
         let noModifiers = flags.isDisjoint(with: [.maskCommand, .maskControl, .maskAlternate, .maskShift])
 
+        // Read key codes from the model at event time so changes are always current.
+        let fullAcceptKey = fullAcceptanceKeyCodeProvider()
+        let acceptKey = acceptanceKeyCodeProvider()
+
         // Full-suggestion acceptance takes priority so pressing the full-accept key
         // doesn't silently fall through to word-accept when both are assigned.
-        if keyCode == fullAcceptanceKeyCode, noModifiers {
+        if keyCode == fullAcceptKey, noModifiers {
             return CapturedInputEvent(kind: .fullAcceptance, keyCode: keyCode, characters: characters, flags: flags)
         }
 
-        if keyCode == acceptanceKeyCode, noModifiers {
+        if keyCode == acceptKey, noModifiers {
             return CapturedInputEvent(kind: .acceptance, keyCode: keyCode, characters: characters, flags: flags)
         }
 

--- a/tabby/Services/Suggestion/SuggestionInteractionState.swift
+++ b/tabby/Services/Suggestion/SuggestionInteractionState.swift
@@ -108,34 +108,73 @@ final class SuggestionInteractionState {
         from snapshot: FocusedInputSnapshot,
         overlayState: OverlayState
     ) -> SuggestionAcceptancePreparation {
+        let validated = validateSessionForAcceptance(from: snapshot, overlayState: overlayState)
+        guard let (liveContext, session) = validated.session else {
+            return .invalid(validated.failureReason ?? "Key passed through.")
+        }
+
+        let chunk = SuggestionSessionReconciler.nextAcceptanceChunk(from: session.remainingText)
+        guard !chunk.isEmpty else {
+            return .invalid("Key passed through because no remaining suggestion chunk was available.")
+        }
+        return .ready(liveContext: liveContext, session: session, acceptedChunk: chunk)
+    }
+
+    func prepareFullAcceptance(
+        from snapshot: FocusedInputSnapshot,
+        overlayState: OverlayState
+    ) -> SuggestionAcceptancePreparation {
+        let validated = validateSessionForAcceptance(from: snapshot, overlayState: overlayState)
+        guard let (liveContext, session) = validated.session else {
+            return .invalid(validated.failureReason ?? "Key passed through.")
+        }
+
+        let chunk = session.remainingText
+        guard !chunk.isEmpty else {
+            return .invalid("Key passed through because no remaining suggestion text was available.")
+        }
+        return .ready(liveContext: liveContext, session: session, acceptedChunk: chunk)
+    }
+
+    /// Shared validation for both word-by-word and full acceptance.
+    private struct SessionValidation {
+        let session: (FocusedInputContext, ActiveSuggestionSession)?
+        let failureReason: String?
+    }
+
+    private func validateSessionForAcceptance(
+        from snapshot: FocusedInputSnapshot,
+        overlayState: OverlayState
+    ) -> SessionValidation {
         guard let activeSession else {
-            return .invalid("Tab passed through because no valid suggestion was ready.")
+            return SessionValidation(session: nil, failureReason: "Key passed through because no valid suggestion was ready.")
         }
 
         guard snapshot.selection.length == 0 else {
-            return .invalid("Tab passed through because text is currently selected.")
+            return SessionValidation(session: nil, failureReason: "Key passed through because text is currently selected.")
         }
 
         guard SuggestionSessionReconciler.overlayAllowsAcceptance(
             of: activeSession.remainingText,
             overlayState: overlayState
         ) else {
-            return .invalid("Tab passed through because no visible ghost text matched the ready suggestion.")
+            return SessionValidation(
+                session: nil,
+                failureReason: "Key passed through because no visible ghost text matched the ready suggestion."
+            )
         }
 
         let liveContext = contextBuffer.materialize(from: snapshot)
         let sessionForAcceptance: ActiveSuggestionSession
 
         if overlayState.isVisible {
-            // A visible overlay means AX has already caught up to the current caret/text state,
-            // so we can insist that live editor state and session state agree before accepting.
             switch SuggestionSessionReconciler.reconcile(
                 session: activeSession,
                 with: liveContext,
                 pendingInsertionConsumedCount: pendingInsertionConsumedCount
             ) {
             case .invalid(let reason):
-                return .invalid(reason)
+                return SessionValidation(session: nil, failureReason: reason)
 
             case let .valid(reconciledSession, _, nextPendingInsertionConsumedCount):
                 self.activeSession = reconciledSession
@@ -143,30 +182,21 @@ final class SuggestionInteractionState {
                 sessionForAcceptance = reconciledSession
             }
         } else {
-            // We intentionally allow acceptance while the overlay is temporarily hidden.
-            // That hidden state usually means "waiting for host app caret sync" after a prior
-            // partial acceptance, not "there is no active suggestion anymore."
             guard liveContext.processIdentifier == activeSession.baseContext.processIdentifier else {
-                return .invalid("Tab passed through because the focused field changed.")
+                return SessionValidation(session: nil, failureReason: "Key passed through because the focused field changed.")
             }
 
             sessionForAcceptance = activeSession
         }
 
         guard !sessionForAcceptance.isExhausted else {
-            return .invalid("Tab passed through because no remaining suggestion text was available.")
+            return SessionValidation(
+                session: nil,
+                failureReason: "Key passed through because no remaining suggestion text was available."
+            )
         }
 
-        let acceptedChunk = SuggestionSessionReconciler.nextAcceptanceChunk(from: sessionForAcceptance.remainingText)
-        guard !acceptedChunk.isEmpty else {
-            return .invalid("Tab passed through because no remaining suggestion chunk was available.")
-        }
-
-        return .ready(
-            liveContext: liveContext,
-            session: sessionForAcceptance,
-            acceptedChunk: acceptedChunk
-        )
+        return SessionValidation(session: (liveContext, sessionForAcceptance), failureReason: nil)
     }
 
     /// Advances the active session after a successful insertion and updates the AX-lag sentinel.

--- a/tabby/Support/SuggestionSessionReconciler.swift
+++ b/tabby/Support/SuggestionSessionReconciler.swift
@@ -256,7 +256,7 @@ enum SuggestionSessionReconciler {
             return "Overlay hidden because caret navigation invalidated the current suggestion."
         case .dismissal:
             return "Overlay hidden because a dismissal key was pressed."
-        case .acceptance, .other:
+        case .acceptance, .fullAcceptance, .other:
             return "Overlay hidden."
         }
     }

--- a/tabby/UI/KeyRecorderView.swift
+++ b/tabby/UI/KeyRecorderView.swift
@@ -28,7 +28,7 @@ struct KeyRecorderView: View {
     }
 
     private func installMonitor() {
-        guard monitor == nil else { return }
+        removeMonitor()
         monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [self] event in
             let keyCode = event.keyCode
 

--- a/tabby/UI/SettingsView.swift
+++ b/tabby/UI/SettingsView.swift
@@ -25,6 +25,7 @@ struct SettingsView: View {
 
     @State private var pendingDeletionModel: RuntimeModelOption?
     @State private var isRecordingKeybind = false
+    @State private var isRecordingFullAcceptKeybind = false
 
     var body: some View {
         Form {
@@ -168,7 +169,7 @@ struct SettingsView: View {
     @ViewBuilder
     private var keybindSection: some View {
         Section("Keybind") {
-            LabeledContent("Accept Suggestion") {
+            LabeledContent("Accept Word") {
                 HStack(spacing: 8) {
                     Text(suggestionSettings.acceptanceKeyLabel)
                         .padding(.horizontal, 8)
@@ -195,12 +196,54 @@ struct SettingsView: View {
                     }
 
                     if suggestionSettings.acceptanceKeyCode != SuggestionSettingsModel.defaultAcceptanceKeyCode {
-                        Button("Reset to Default") {
+                        Button("Reset") {
                             suggestionSettings.setAcceptanceKey(
                                 keyCode: SuggestionSettingsModel.defaultAcceptanceKeyCode,
                                 label: SuggestionSettingsModel.defaultAcceptanceKeyLabel
                             )
                             isRecordingKeybind = false
+                        }
+                    }
+
+                    if suggestionSettings.acceptanceKeyCode != SuggestionSettingsModel.disabledKeyCode {
+                        Button("Clear") {
+                            suggestionSettings.clearAcceptanceKey()
+                            isRecordingKeybind = false
+                        }
+                    }
+                }
+            }
+
+            LabeledContent("Accept Entire Suggestion") {
+                HStack(spacing: 8) {
+                    Text(suggestionSettings.fullAcceptanceKeyLabel)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(
+                            RoundedRectangle(cornerRadius: 6)
+                                .fill(.quaternary)
+                        )
+
+                    if isRecordingFullAcceptKeybind {
+                        KeyRecorderView(
+                            onKeyRecorded: { keyCode, label in
+                                suggestionSettings.setFullAcceptanceKey(keyCode: keyCode, label: label)
+                                isRecordingFullAcceptKeybind = false
+                            },
+                            onCancelled: {
+                                isRecordingFullAcceptKeybind = false
+                            }
+                        )
+                    } else {
+                        Button("Change") {
+                            isRecordingFullAcceptKeybind = true
+                        }
+                    }
+
+                    if suggestionSettings.fullAcceptanceKeyCode != SuggestionSettingsModel.disabledKeyCode {
+                        Button("Clear") {
+                            suggestionSettings.clearFullAcceptanceKey()
+                            isRecordingFullAcceptKeybind = false
                         }
                     }
                 }

--- a/tabby/UI/WelcomeView.swift
+++ b/tabby/UI/WelcomeView.swift
@@ -21,6 +21,7 @@ struct WelcomeView: View {
 
     @State private var step: WelcomeStep = .welcome
     @State private var isRecordingOnboardingKeybind = false
+    @State private var isRecordingOnboardingFullAcceptKeybind = false
 
     /// The window should follow the active screen instead of staying pinned to the tallest step.
     /// This keeps small steps like "You're all set" feeling intentional rather than like empty
@@ -95,7 +96,7 @@ private enum WelcomeStep: Int, Comparable {
 
             return NSSize(width: 540, height: 360)
         case .keybind:
-            return NSSize(width: 540, height: 420)
+            return NSSize(width: 540, height: 500)
         case .done:
             return NSSize(width: 500, height: 340)
         }
@@ -288,16 +289,43 @@ extension WelcomeView {
                 .foregroundStyle(.secondary)
 
             VStack(spacing: 8) {
-                Text("Accept Key")
+                Text("Keybinds")
                     .font(.system(size: 24, weight: .semibold, design: .rounded))
 
-                Text("Press this key to accept a suggestion.\nYou can change it later in Settings.")
+                Text("Choose keys to accept suggestions.\nYou can change these later in Settings.")
                     .font(.system(size: 14, design: .rounded))
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
             }
 
-            keybindPicker
+            VStack(spacing: 16) {
+                keybindRow(
+                    title: "Accept Word",
+                    keyLabel: suggestionSettings.acceptanceKeyLabel,
+                    isRecording: $isRecordingOnboardingKeybind,
+                    onKeyRecorded: { keyCode, label in
+                        suggestionSettings.setAcceptanceKey(keyCode: keyCode, label: label)
+                    },
+                    onReset: suggestionSettings.acceptanceKeyCode != SuggestionSettingsModel.defaultAcceptanceKeyCode ? {
+                        suggestionSettings.setAcceptanceKey(
+                            keyCode: SuggestionSettingsModel.defaultAcceptanceKeyCode,
+                            label: SuggestionSettingsModel.defaultAcceptanceKeyLabel
+                        )
+                    } : nil
+                )
+
+                keybindRow(
+                    title: "Accept Entire Suggestion",
+                    keyLabel: suggestionSettings.fullAcceptanceKeyLabel,
+                    isRecording: $isRecordingOnboardingFullAcceptKeybind,
+                    onKeyRecorded: { keyCode, label in
+                        suggestionSettings.setFullAcceptanceKey(keyCode: keyCode, label: label)
+                    },
+                    onReset: suggestionSettings.fullAcceptanceKeyCode != SuggestionSettingsModel.defaultFullAcceptanceKeyCode ? {
+                        suggestionSettings.clearFullAcceptanceKey()
+                    } : nil
+                )
+            }
 
             WelcomeNavigation(
                 canGoBack: true,
@@ -309,40 +337,49 @@ extension WelcomeView {
     }
 
     @ViewBuilder
-    fileprivate var keybindPicker: some View {
-        HStack(spacing: 12) {
-            Text(suggestionSettings.acceptanceKeyLabel)
-                .font(.system(size: 18, weight: .medium, design: .rounded))
-                .padding(.horizontal, 14)
-                .padding(.vertical, 8)
-                .background(
-                    RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .fill(.quaternary)
-                )
+    fileprivate func keybindRow(
+        title: String,
+        keyLabel: String,
+        isRecording: Binding<Bool>,
+        onKeyRecorded: @escaping (CGKeyCode, String) -> Void,
+        onReset: (() -> Void)? = nil
+    ) -> some View {
+        VStack(spacing: 6) {
+            Text(title)
+                .font(.system(size: 13, weight: .medium, design: .rounded))
+                .foregroundStyle(.secondary)
 
-            if isRecordingOnboardingKeybind {
-                KeyRecorderView(
-                    onKeyRecorded: { keyCode, label in
-                        suggestionSettings.setAcceptanceKey(keyCode: keyCode, label: label)
-                        isRecordingOnboardingKeybind = false
-                    },
-                    onCancelled: {
-                        isRecordingOnboardingKeybind = false
-                    }
-                )
-            } else {
-                Button("Change") {
-                    isRecordingOnboardingKeybind = true
-                }
-            }
-
-            if suggestionSettings.acceptanceKeyCode != SuggestionSettingsModel.defaultAcceptanceKeyCode {
-                Button("Reset") {
-                    suggestionSettings.setAcceptanceKey(
-                        keyCode: SuggestionSettingsModel.defaultAcceptanceKeyCode,
-                        label: SuggestionSettingsModel.defaultAcceptanceKeyLabel
+            HStack(spacing: 12) {
+                Text(keyLabel)
+                    .font(.system(size: 18, weight: .medium, design: .rounded))
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 8)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8, style: .continuous)
+                            .fill(.quaternary)
                     )
-                    isRecordingOnboardingKeybind = false
+
+                if isRecording.wrappedValue {
+                    KeyRecorderView(
+                        onKeyRecorded: { keyCode, label in
+                            onKeyRecorded(keyCode, label)
+                            isRecording.wrappedValue = false
+                        },
+                        onCancelled: {
+                            isRecording.wrappedValue = false
+                        }
+                    )
+                } else {
+                    Button("Change") {
+                        isRecording.wrappedValue = true
+                    }
+                }
+
+                if let onReset {
+                    Button("Reset") {
+                        onReset()
+                        isRecording.wrappedValue = false
+                    }
                 }
             }
         }
@@ -369,7 +406,7 @@ extension WelcomeView {
                 Text("You're all set")
                     .font(.system(size: 28, weight: .semibold, design: .rounded))
 
-                Text("Start typing anywhere.\nPress \(suggestionSettings.acceptanceKeyLabel) to accept.")
+                Text(doneStepSubtitle)
                     .font(.system(size: 15, design: .rounded))
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
@@ -389,6 +426,17 @@ extension WelcomeView {
             }
             .padding(.top, 4)
         }
+    }
+
+    private var doneStepSubtitle: String {
+        let wordKey = suggestionSettings.acceptanceKeyLabel
+        let fullKey = suggestionSettings.fullAcceptanceKeyLabel
+        let hasFullAccept = suggestionSettings.fullAcceptanceKeyCode != SuggestionSettingsModel.disabledKeyCode
+
+        if hasFullAccept {
+            return "Start typing anywhere.\nPress \(wordKey) to accept a word, \(fullKey) for the full suggestion."
+        }
+        return "Start typing anywhere.\nPress \(wordKey) to accept."
     }
 }
 

--- a/tabbyTests/ModelAndPresentationValueTests.swift
+++ b/tabbyTests/ModelAndPresentationValueTests.swift
@@ -162,6 +162,8 @@ final class RuntimeAndInputModelValueTests: XCTestCase {
 
         XCTAssertTrue(TabbyTestFixtures.inputEvent(kind: .dismissal).shouldClearSuggestion)
         XCTAssertFalse(TabbyTestFixtures.inputEvent(kind: .acceptance).shouldClearSuggestion)
+        XCTAssertFalse(TabbyTestFixtures.inputEvent(kind: .fullAcceptance).shouldClearSuggestion)
+        XCTAssertFalse(TabbyTestFixtures.inputEvent(kind: .fullAcceptance).shouldSchedulePrediction)
         XCTAssertFalse(TabbyTestFixtures.inputEvent(kind: .other).shouldClearSuggestion)
     }
 }

--- a/tabbyTests/SuggestionStateHelperTests.swift
+++ b/tabbyTests/SuggestionStateHelperTests.swift
@@ -159,7 +159,7 @@ final class SuggestionInteractionStateTests: XCTestCase {
             }
             XCTAssertEqual(
                 reason,
-                "Tab passed through because no visible ghost text matched the ready suggestion."
+                "Key passed through because no visible ghost text matched the ready suggestion."
             )
         }
     }


### PR DESCRIPTION
## Summary

Adds a configurable "Accept Entire Suggestion" keybind that inserts all remaining ghost text at once, complementing the existing word-by-word Tab acceptance. Default is unbound — users opt in via Settings or onboarding.

## Validation

```
xcodebuild -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

xcodebuild -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' build-for-testing
# ** TEST BUILD SUCCEEDED **

swiftlint lint --quiet --config .swiftlint.yml
# No new warnings (5 pre-existing, none in changed files)
```

Full end-to-end acceptance flow (word + full) requires a running app with a live suggestion overlay — cannot be verified in CI alone.

## Linked issues

n/a

## Risk / rollout notes

- New UserDefaults keys (`tabbyFullAcceptanceKeyCode`, `tabbyFullAcceptanceKeyLabel`) are additive — no migration needed, defaults to disabled.
- Conflict resolution auto-clears the other keybind if both are set to the same key.
- Onboarding keybind step height increased from 420 → 500 to fit both rows.
- The full-accept key check runs before the word-accept check in `InputMonitor`, so if both are somehow the same key, full-accept wins.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a configurable "Accept Entire Suggestion" keybind that inserts all remaining ghost text at once, complementing the existing word-by-word Tab acceptance. It's disabled by default (`disabledKeyCode = UInt16.max` sentinel) and opt-in via Settings or onboarding.

- New `fullAcceptance` event kind propagates cleanly through `InputModels`, `InputMonitor`, `SuggestionInteractionState` (new `prepareFullAcceptance`), and both coordinator extensions; the shared `acceptSuggestion(fullText:keyName:)` refactor removes duplication without changing word-acceptance semantics.
- Settings and onboarding views each gain a second keybind row; conflict resolution in `SuggestionSettingsModel` auto-clears the other binding when both would map to the same key.
- The switch from a Combine subscription to closure-based key-code providers in `TabbyAppEnvironment` removes the weak-capture footgun that guarded against dangling refs on the old stored property.

<h3>Confidence Score: 5/5</h3>

Safe to merge; changes are additive and the new acceptance path reuses the same validated session machinery as the existing word-acceptance flow.

The full-acceptance feature introduces no new state machines or concurrent paths — it shares validateSessionForAcceptance with word-acceptance and always produces an exhausted commit. The only notable change outside the new feature is the keyName capitalisation in log stage names, which is cosmetic. All guard and conflict-detection logic is correct and tested.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift | Refactored acceptance into shared acceptSuggestion(fullText:keyName:) path; keyName: "Tab" (capital T) silently changes existing log stage names. |
| tabby/Services/Input/InputMonitor.swift | Switched from a stored acceptanceKeyCode property to closure-based providers; adds full-accept key check before word-accept check. Clean and correct. |
| tabby/Services/Suggestion/SuggestionInteractionState.swift | Extracted shared validateSessionForAcceptance helper; adds prepareFullAcceptance that returns the full remaining text as the accepted chunk. |
| tabby/Models/SuggestionSettingsModel.swift | Adds fullAcceptanceKeyCode/fullAcceptanceKeyLabel with disabledKeyCode sentinel; conflict resolution correctly clears the other binding on collision. |
| tabby/App/Core/TabbyAppEnvironment.swift | Replaces Combine subscription with closure providers that read from the model at event time; removes the need for the weak-self subscription that guarded against dangling refs. |
| tabby/UI/SettingsView.swift | Adds Accept Entire Suggestion row with independent recording state; two concurrent KeyRecorderViews can be active simultaneously (pre-existing shape, noted in prior review). |
| tabby/UI/WelcomeView.swift | Refactored keybind step into reusable keybindRow; adds full-accept row with same independent-recording-state shape as SettingsView. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant InputMonitor
    participant SuggestionCoordinator
    participant SuggestionInteractionState
    participant SuggestionInserter

    User->>InputMonitor: keyDown (full-accept key)
    InputMonitor->>InputMonitor: classify() - fullAcceptKey matches, noModifiers
    InputMonitor-->>SuggestionCoordinator: CapturedInputEvent(.fullAcceptance)
    SuggestionCoordinator->>SuggestionCoordinator: acceptEntireSuggestion()
    SuggestionCoordinator->>SuggestionInteractionState: prepareFullAcceptance(snapshot, overlayState)
    SuggestionInteractionState->>SuggestionInteractionState: validateSessionForAcceptance()
    SuggestionInteractionState-->>SuggestionCoordinator: ".ready(liveContext, session, chunk=remainingText)"
    SuggestionCoordinator->>SuggestionInserter: insert(entireRemainingText)
    SuggestionInserter-->>SuggestionCoordinator: true
    SuggestionCoordinator->>SuggestionInteractionState: commitAcceptedChunk(chunk)
    SuggestionInteractionState-->>SuggestionCoordinator: .exhausted
    SuggestionCoordinator->>SuggestionCoordinator: "hideOverlay, state = .idle, schedulePrediction()"
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `tabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift`, line 128-135 ([link](https://github.com/fujacob/tabby/blob/af3c67b549228c36053717dccf452be388d990f8/tabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift#L128-L135)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`passTabThrough` log stage says `"tab-passed-through"` for full-acceptance events**

   When `acceptEntireSuggestion()` calls `passTabThrough`, the hard-coded stage name `"tab-passed-through"` is emitted regardless of which key was actually pressed. A developer filtering logs for full-acceptance failures will miss these entries, and a developer searching for "tab" events will get false positives from full-accept pass-throughs.

   

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22feat%2Faccept-entire-suggestion%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Faccept-entire-suggestion%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BAcceptance.swift%0ALine%3A%20128-135%0A%0AComment%3A%0A**%60passTabThrough%60%20log%20stage%20says%20%60%22tab-passed-through%22%60%20for%20full-acceptance%20events**%0A%0AWhen%20%60acceptEntireSuggestion%28%29%60%20calls%20%60passTabThrough%60%2C%20the%20hard-coded%20stage%20name%20%60%22tab-passed-through%22%60%20is%20emitted%20regardless%20of%20which%20key%20was%20actually%20pressed.%20A%20developer%20filtering%20logs%20for%20full-acceptance%20failures%20will%20miss%20these%20entries%2C%20and%20a%20developer%20searching%20for%20%22tab%22%20events%20will%20get%20false%20positives%20from%20full-accept%20pass-throughs.%0A%0A%60%60%60suggestion%0A%20%20%20%20func%20passKeyThrough%28reason%3A%20String%2C%20stage%3A%20String%20%3D%20%22tab-passed-through%22%29%20-%3E%20Bool%20%7B%0A%20%20%20%20%20%20%20%20let%20generation%20%3D%20latestGenerationNumber%0A%20%20%20%20%20%20%20%20cancelPredictionWork%28%29%0A%20%20%20%20%20%20%20%20clearSuggestion%28clearDiagnostics%3A%20true%29%0A%20%20%20%20%20%20%20%20hideOverlay%28reason%3A%20reason%29%0A%20%20%20%20%20%20%20%20state%20%3D%20.idle%0A%20%20%20%20%20%20%20%20logStage%28%0A%20%20%20%20%20%20%20%20%20%20%20%20stage%2C%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BAcceptance.swift%0ALine%3A%20128-135%0A%0AComment%3A%0A**%60passTabThrough%60%20log%20stage%20says%20%60%22tab-passed-through%22%60%20for%20full-acceptance%20events**%0A%0AWhen%20%60acceptEntireSuggestion%28%29%60%20calls%20%60passTabThrough%60%2C%20the%20hard-coded%20stage%20name%20%60%22tab-passed-through%22%60%20is%20emitted%20regardless%20of%20which%20key%20was%20actually%20pressed.%20A%20developer%20filtering%20logs%20for%20full-acceptance%20failures%20will%20miss%20these%20entries%2C%20and%20a%20developer%20searching%20for%20%22tab%22%20events%20will%20get%20false%20positives%20from%20full-accept%20pass-throughs.%0A%0A%60%60%60suggestion%0A%20%20%20%20func%20passKeyThrough%28reason%3A%20String%2C%20stage%3A%20String%20%3D%20%22tab-passed-through%22%29%20-%3E%20Bool%20%7B%0A%20%20%20%20%20%20%20%20let%20generation%20%3D%20latestGenerationNumber%0A%20%20%20%20%20%20%20%20cancelPredictionWork%28%29%0A%20%20%20%20%20%20%20%20clearSuggestion%28clearDiagnostics%3A%20true%29%0A%20%20%20%20%20%20%20%20hideOverlay%28reason%3A%20reason%29%0A%20%20%20%20%20%20%20%20state%20%3D%20.idle%0A%20%20%20%20%20%20%20%20logStage%28%0A%20%20%20%20%20%20%20%20%20%20%20%20stage%2C%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Ftabby&pr=198&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

2. `tabby/UI/SettingsView.swift`, line 473-474 ([link](https://github.com/fujacob/tabby/blob/5115d1a741ff02151102624d7fc347d745f311be/tabby/UI/SettingsView.swift#L473-L474)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Simultaneous recording state allows two `KeyRecorderView`s to be active at once**

   `isRecordingKeybind` and `isRecordingFullAcceptKeybind` are independent, so a user can press "Change" on the word-accept row, then press "Change" on the full-accept row without first pressing a key. Both `KeyRecorderView`s install separate `NSEvent.addLocalMonitorForEvents` monitors; `NSEvent` local monitors all fire for every matching event regardless of return values, so the next keypress triggers both callbacks. Both call `onKeyRecorded` with the same key code — `setAcceptanceKey` runs first, then `setFullAcceptanceKey` detects the conflict and clears acceptance, leaving the user with only the full-accept key set even though they intended to configure both independently.

   The same problem exists in `WelcomeView.swift` since it uses the same two independent recording states (`isRecordingOnboardingKeybind` / `isRecordingOnboardingFullAcceptKeybind`).

   Fix: mutually reset the other recording state whenever one starts, e.g. set `isRecordingFullAcceptKeybind = false` inside the `Button("Change")` for the word-accept row and vice versa. The same pattern should be applied in `WelcomeView`.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22feat%2Faccept-entire-suggestion%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Faccept-entire-suggestion%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tabby%2FUI%2FSettingsView.swift%0ALine%3A%20473-474%0A%0AComment%3A%0A**Simultaneous%20recording%20state%20allows%20two%20%60KeyRecorderView%60s%20to%20be%20active%20at%20once**%0A%0A%60isRecordingKeybind%60%20and%20%60isRecordingFullAcceptKeybind%60%20are%20independent%2C%20so%20a%20user%20can%20press%20%22Change%22%20on%20the%20word-accept%20row%2C%20then%20press%20%22Change%22%20on%20the%20full-accept%20row%20without%20first%20pressing%20a%20key.%20Both%20%60KeyRecorderView%60s%20install%20separate%20%60NSEvent.addLocalMonitorForEvents%60%20monitors%3B%20%60NSEvent%60%20local%20monitors%20all%20fire%20for%20every%20matching%20event%20regardless%20of%20return%20values%2C%20so%20the%20next%20keypress%20triggers%20both%20callbacks.%20Both%20call%20%60onKeyRecorded%60%20with%20the%20same%20key%20code%20%E2%80%94%20%60setAcceptanceKey%60%20runs%20first%2C%20then%20%60setFullAcceptanceKey%60%20detects%20the%20conflict%20and%20clears%20acceptance%2C%20leaving%20the%20user%20with%20only%20the%20full-accept%20key%20set%20even%20though%20they%20intended%20to%20configure%20both%20independently.%0A%0AThe%20same%20problem%20exists%20in%20%60WelcomeView.swift%60%20since%20it%20uses%20the%20same%20two%20independent%20recording%20states%20%28%60isRecordingOnboardingKeybind%60%20%2F%20%60isRecordingOnboardingFullAcceptKeybind%60%29.%0A%0AFix%3A%20mutually%20reset%20the%20other%20recording%20state%20whenever%20one%20starts%2C%20e.g.%20set%20%60isRecordingFullAcceptKeybind%20%3D%20false%60%20inside%20the%20%60Button%28%22Change%22%29%60%20for%20the%20word-accept%20row%20and%20vice%20versa.%20The%20same%20pattern%20should%20be%20applied%20in%20%60WelcomeView%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tabby%2FUI%2FSettingsView.swift%0ALine%3A%20473-474%0A%0AComment%3A%0A**Simultaneous%20recording%20state%20allows%20two%20%60KeyRecorderView%60s%20to%20be%20active%20at%20once**%0A%0A%60isRecordingKeybind%60%20and%20%60isRecordingFullAcceptKeybind%60%20are%20independent%2C%20so%20a%20user%20can%20press%20%22Change%22%20on%20the%20word-accept%20row%2C%20then%20press%20%22Change%22%20on%20the%20full-accept%20row%20without%20first%20pressing%20a%20key.%20Both%20%60KeyRecorderView%60s%20install%20separate%20%60NSEvent.addLocalMonitorForEvents%60%20monitors%3B%20%60NSEvent%60%20local%20monitors%20all%20fire%20for%20every%20matching%20event%20regardless%20of%20return%20values%2C%20so%20the%20next%20keypress%20triggers%20both%20callbacks.%20Both%20call%20%60onKeyRecorded%60%20with%20the%20same%20key%20code%20%E2%80%94%20%60setAcceptanceKey%60%20runs%20first%2C%20then%20%60setFullAcceptanceKey%60%20detects%20the%20conflict%20and%20clears%20acceptance%2C%20leaving%20the%20user%20with%20only%20the%20full-accept%20key%20set%20even%20though%20they%20intended%20to%20configure%20both%20independently.%0A%0AThe%20same%20problem%20exists%20in%20%60WelcomeView.swift%60%20since%20it%20uses%20the%20same%20two%20independent%20recording%20states%20%28%60isRecordingOnboardingKeybind%60%20%2F%20%60isRecordingOnboardingFullAcceptKeybind%60%29.%0A%0AFix%3A%20mutually%20reset%20the%20other%20recording%20state%20whenever%20one%20starts%2C%20e.g.%20set%20%60isRecordingFullAcceptKeybind%20%3D%20false%60%20inside%20the%20%60Button%28%22Change%22%29%60%20for%20the%20word-accept%20row%20and%20vice%20versa.%20The%20same%20pattern%20should%20be%20applied%20in%20%60WelcomeView%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Ftabby&pr=198&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22feat%2Faccept-entire-suggestion%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Faccept-entire-suggestion%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BAcceptance.swift%3A11-14%0AThe%20word-acceptance%20log%20stage%20names%20changed%20casing.%20%60keyName%3A%20%22Tab%22%60%20%28capital%20T%29%20produces%20%60%22Tab-accepted-chunk%22%60%20and%20%60%22Tab-accepted-final-chunk%22%60%2C%20whereas%20the%20original%20code%20emitted%20lowercase%20%60%22tab-accepted-chunk%22%60%20and%20%60%22tab-accepted-final-chunk%22%60.%20Any%20log%20filter%2C%20Console.app%20query%2C%20or%20diagnostic%20tool%20keyed%20to%20the%20old%20lowercase%20names%20will%20silently%20miss%20these%20entries%20going%20forward.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Accepts%20the%20next%20word%20of%20the%20current%20suggestion.%0A%20%20%20%20func%20acceptCurrentSuggestion%28%29%20-%3E%20Bool%20%7B%0A%20%20%20%20%20%20%20%20acceptSuggestion%28fullText%3A%20false%2C%20keyName%3A%20%22tab%22%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BAcceptance.swift%3A11-14%0AThe%20word-acceptance%20log%20stage%20names%20changed%20casing.%20%60keyName%3A%20%22Tab%22%60%20%28capital%20T%29%20produces%20%60%22Tab-accepted-chunk%22%60%20and%20%60%22Tab-accepted-final-chunk%22%60%2C%20whereas%20the%20original%20code%20emitted%20lowercase%20%60%22tab-accepted-chunk%22%60%20and%20%60%22tab-accepted-final-chunk%22%60.%20Any%20log%20filter%2C%20Console.app%20query%2C%20or%20diagnostic%20tool%20keyed%20to%20the%20old%20lowercase%20names%20will%20silently%20miss%20these%20entries%20going%20forward.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Accepts%20the%20next%20word%20of%20the%20current%20suggestion.%0A%20%20%20%20func%20acceptCurrentSuggestion%28%29%20-%3E%20Bool%20%7B%0A%20%20%20%20%20%20%20%20acceptSuggestion%28fullText%3A%20false%2C%20keyName%3A%20%22tab%22%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=fujacob%2Ftabby&pr=198&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["Fix CI: update test assertion to match r..."](https://github.com/fujacob/tabby/commit/58d5fc386d74c17ab9c694de53fb10f697514b92) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33685672)</sub>

<!-- /greptile_comment -->