### PR TITLE
Rework menu bar: word count in icon, Report button in header, Check for Updates in footer

### DIFF
--- a/tabby/App/Core/TabbyApp.swift
+++ b/tabby/App/Core/TabbyApp.swift
@@ -21,7 +21,7 @@ struct TabbyApp: App {
                 permissionGuidanceController: appDelegate.permissionGuidanceController,
                 suggestionSettings: appDelegate.suggestionSettings,
                 foundationModelAvailabilityService: appDelegate.foundationModelAvailabilityService,
-                suggestionCoordinator: appDelegate.suggestionCoordinator,
+                appUpdateManager: appDelegate.appUpdateManager,
                 onOpenSettings: {
                     appDelegate.settingsCoordinator.showSettings()
                 },

--- a/tabby/UI/MenuBarView.swift
+++ b/tabby/UI/MenuBarView.swift
@@ -20,7 +20,7 @@ struct MenuBarView: View {
     let permissionGuidanceController: PermissionGuidanceController
     @ObservedObject var suggestionSettings: SuggestionSettingsModel
     @ObservedObject var foundationModelAvailabilityService: FoundationModelAvailabilityService
-    @ObservedObject var suggestionCoordinator: SuggestionCoordinator
+    let appUpdateManager: AppUpdateManager
     let onOpenSettings: () -> Void
     let onReportFeedback: () -> Void
 
@@ -57,9 +57,9 @@ struct MenuBarView: View {
 
             Spacer(minLength: 0)
 
-            Text("\(suggestionCoordinator.totalTabAcceptedWordCount) words accepted")
+            Button("Report Bug / Feedback", action: onReportFeedback)
+                .buttonStyle(.borderless)
                 .font(.subheadline)
-                .foregroundStyle(.secondary)
         }
         .padding(.bottom, 12)
     }
@@ -202,8 +202,10 @@ struct MenuBarView: View {
             Button("Settings", action: onOpenSettings)
                 .buttonStyle(.borderless)
 
-            Button("Report Bug / Feedback", action: onReportFeedback)
-                .buttonStyle(.borderless)
+            Button("Check for Updates") {
+                appUpdateManager.checkForUpdates()
+            }
+            .buttonStyle(.borderless)
 
             Spacer(minLength: 0)
 


### PR DESCRIPTION
## Summary

- **Menu bar icon:** Surface the running total of accepted (tabbed) words as a compact label next to the paw-print icon. Uses abbreviated formatting (1.2k, 3.5M) and only appears after at least one word is accepted.
- **Menu header:** Replace the "N words accepted" counter with the "Report Bug / Feedback" button for quicker access.
- **Menu footer:** Move "Check for Updates" to the footer where Report used to be.

## Validation

```
xcodebuild -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

xcodebuild -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' build-for-testing
# ** TEST BUILD SUCCEEDED **

swiftlint lint --quiet
# No new warnings (only pre-existing ones in unrelated files)
```

## Linked issues

None.

## Risk / rollout notes

- `MenuBarStatusLabelView` now observes `SuggestionCoordinator` to display the word count. The label re-renders only when the count changes.
- `MenuBarView` no longer depends on `SuggestionCoordinator`; it takes `AppUpdateManager` instead.