### PR TITLE
Add structured logging with swift-log and Console.app support

### DIFF
--- a/tabby.xcodeproj/project.pbxproj
+++ b/tabby.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		8B6282F0C1CCA0746D96B914 /* DownloadOutcomeClassifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562F89255AF340C15A0554BE /* DownloadOutcomeClassifierTests.swift */; };
+		9E25D3832FC3BE0E0069BE7B /* Logging in Frameworks */ = {isa = PBXBuildFile; productRef = A1C3E0202F90000100AAA001 /* Logging */; };
 		A1C3E0012F90000100AAA001 /* LlamaSwift in Frameworks */ = {isa = PBXBuildFile; productRef = A1C3E0002F90000100AAA001 /* LlamaSwift */; };
 		A1C3E0112F90000100AAA001 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = A1C3E0102F90000100AAA001 /* Sparkle */; };
 		A404828463CADB2ECDAE7AF3 /* LlamaPromptRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F29623C5C0A67B992D383A3C /* LlamaPromptRendererTests.swift */; };
@@ -55,13 +56,13 @@
 		C10000162F91000100BBB016 /* ModelAndPresentationValueTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ModelAndPresentationValueTests.swift; sourceTree = "<group>"; };
 		C10000172F91000100BBB017 /* SuggestionStateHelperTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SuggestionStateHelperTests.swift; sourceTree = "<group>"; };
 		D10000112F92000100CCC011 /* TerminalAppDetectorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TerminalAppDetectorTests.swift; sourceTree = "<group>"; };
-		F29623C5C0A67B992D383A3C /* LlamaPromptRendererTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LlamaPromptRendererTests.swift; sourceTree = "<group>"; };
-		F9D35DB9E86506B9FAE1CFE9 /* ModelFileValidatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ModelFileValidatorTests.swift; sourceTree = "<group>"; };
 		E10000112F93000100DDD011 /* PromptContextSanitizerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PromptContextSanitizerTests.swift; sourceTree = "<group>"; };
 		E10000122F93000100DDD012 /* PermissionAndContextModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PermissionAndContextModelTests.swift; sourceTree = "<group>"; };
 		E10000132F93000100DDD013 /* GhostSuggestionLayoutTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GhostSuggestionLayoutTests.swift; sourceTree = "<group>"; };
 		E10000142F93000100DDD014 /* BundledRuntimeLocatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BundledRuntimeLocatorTests.swift; sourceTree = "<group>"; };
 		F10000112FA0000100EEE011 /* TextDirectionDetectorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TextDirectionDetectorTests.swift; sourceTree = "<group>"; };
+		F29623C5C0A67B992D383A3C /* LlamaPromptRendererTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LlamaPromptRendererTests.swift; sourceTree = "<group>"; };
+		F9D35DB9E86506B9FAE1CFE9 /* ModelFileValidatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ModelFileValidatorTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -77,6 +78,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9E25D3832FC3BE0E0069BE7B /* Logging in Frameworks */,
 				A1C3E0012F90000100AAA001 /* LlamaSwift in Frameworks */,
 				A1C3E0112F90000100AAA001 /* Sparkle in Frameworks */,
 			);
@@ -158,6 +160,7 @@
 			packageProductDependencies = (
 				A1C3E0002F90000100AAA001 /* LlamaSwift */,
 				A1C3E0102F90000100AAA001 /* Sparkle */,
+				A1C3E0202F90000100AAA001 /* Logging */,
 			);
 			productName = tabby;
 			productReference = 193741492F81DE7000BEC04F /* tabby.app */;
@@ -208,6 +211,7 @@
 			packageReferences = (
 				A1C3E0022F90000100AAA001 /* XCRemoteSwiftPackageReference "llama" */,
 				A1C3E0122F90000100AAA001 /* XCRemoteSwiftPackageReference "Sparkle" */,
+				A1C3E0222F90000100AAA001 /* XCRemoteSwiftPackageReference "swift-log" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 1937414A2F81DE7000BEC04F /* Products */;
@@ -411,7 +415,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = G946M8K23B;
+				DEVELOPMENT_TEAM = C4BVFMK9V2;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
@@ -444,7 +448,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = G946M8K23B;
+				DEVELOPMENT_TEAM = C4BVFMK9V2;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
@@ -566,6 +570,14 @@
 				version = 2.9.1;
 			};
 		};
+		A1C3E0222F90000100AAA001 /* XCRemoteSwiftPackageReference "swift-log" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-log.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.6.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -578,6 +590,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = A1C3E0122F90000100AAA001 /* XCRemoteSwiftPackageReference "Sparkle" */;
 			productName = Sparkle;
+		};
+		A1C3E0202F90000100AAA001 /* Logging */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A1C3E0222F90000100AAA001 /* XCRemoteSwiftPackageReference "swift-log" */;
+			productName = Logging;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/tabby.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/tabby.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b8e898721f3ddc9b0783c2c3695043183f3d5cccd2940dfdb3aed5cf26ff31f4",
+  "originHash" : "4668c515093e812763c91a7febbb465c9f0ae14ec31b6d42bddd0119f76238fb",
   "pins" : [
     {
       "identity" : "llama.swift",
@@ -17,6 +17,15 @@
       "state" : {
         "revision" : "066e75a8b3e99962685d6a90cdd5293ebffd9261",
         "version" : "2.9.1"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "a012e0ad8a8a72de92b0e008c81a9b793f70e73a",
+        "version" : "1.12.1"
       }
     }
   ],

--- a/tabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
@@ -1,6 +1,7 @@
 import AppKit
 import CoreGraphics
 import Foundation
+import Logging
 
 /// File overview:
 /// Suggestion acceptance, live-session advancement, overlay presentation, and debug logging.
@@ -182,6 +183,7 @@ extension SuggestionCoordinator {
         reason: String,
         clearDiagnostics: Bool = true
     ) {
+        TabbyLogger.suggestion.debug("Invalidating active suggestion: \(reason)")
         cancelPredictionWork()
         clearSuggestion(clearDiagnostics: clearDiagnostics)
         hideOverlay(reason: reason)

--- a/tabby/App/Coordinators/SuggestionCoordinator+Input.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator+Input.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Logging
 
 /// File overview:
 /// Focus, permission, and keyboard-event entry points for `SuggestionCoordinator`.
@@ -7,6 +8,7 @@ extension SuggestionCoordinator {
     // MARK: - Environment and Input Handling
 
     func handlePermissionChange() {
+        TabbyLogger.suggestion.debug("Permission state changed, reconciling")
         reconcileWithCurrentEnvironment()
 
         if SuggestionAvailabilityEvaluator.shouldSchedulePrediction(
@@ -21,6 +23,7 @@ extension SuggestionCoordinator {
     }
 
     func handleFocusSnapshotChange(_ snapshot: FocusSnapshot) {
+        TabbyLogger.suggestion.trace("Focus snapshot changed: app=\(snapshot.applicationName ?? "nil") capability=\(snapshot.capability.shortLabel)")
         // Start capturing visual context for a newly focused input even when predictions are
         // temporarily disabled (e.g., "text is selected" or "secure field"). The OCR pipeline
         // is field-scoped and should start as early as possible so context is ready by the

--- a/tabby/App/Coordinators/SuggestionCoordinator+Lifecycle.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator+Lifecycle.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Logging
 
 /// File overview:
 /// Lifecycle entry points and user preference changes for `SuggestionCoordinator`.
@@ -8,11 +9,13 @@ extension SuggestionCoordinator {
 
     /// Reconciles coordinator state with the current permission and focus environment.
     func start() {
+        TabbyLogger.suggestion.info("Suggestion coordinator starting")
         reconcileWithCurrentEnvironment()
     }
 
     /// Cancels any pending work and detaches long-lived callbacks during shutdown.
     func stop() {
+        TabbyLogger.suggestion.info("Suggestion coordinator stopping")
         cancelPredictionWork()
         resetCachedGenerationContext()
         visualContextCoordinator.cancel(resetState: true)
@@ -27,6 +30,7 @@ extension SuggestionCoordinator {
     /// Clears any active suggestion work before the runtime swaps to a different model.
     /// This prevents stale completions from the previous model from surviving the switch.
     func prepareForRuntimeModelSwitch() {
+        TabbyLogger.suggestion.info("Preparing for runtime model switch, clearing active state")
         cancelPredictionWork()
         resetCachedGenerationContext()
         interactionState.resetAll()
@@ -46,6 +50,7 @@ extension SuggestionCoordinator {
             return
         }
 
+        TabbyLogger.suggestion.info("Settings changed, resetting suggestion state")
         let previousSnapshot = settingsSnapshot
         settingsSnapshot = snapshot
         cancelPredictionWork()

--- a/tabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
+++ b/tabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Logging
 
 /// File overview:
 /// Debounce, generation, stale-result handling, and visual-context-triggered rescheduling.
@@ -329,6 +330,7 @@ extension SuggestionCoordinator {
 
     /// Fully disables prediction, clears cached context, and updates UI messaging with the cause.
     func disablePredictions(reason: String) {
+        TabbyLogger.suggestion.debug("Predictions disabled: \(reason)")
         cancelPredictionWork()
         resetCachedGenerationContext()
         visualContextCoordinator.cancel(resetState: true)

--- a/tabby/App/Core/AppDelegate.swift
+++ b/tabby/App/Core/AppDelegate.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Combine
+import Logging
 
 /// File overview:
 /// Starts the long-lived services that power permissions, focus tracking, suggestion generation,
@@ -32,6 +33,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var cancellables = Set<AnyCancellable>()
 
     override init() {
+        TabbyLogger.bootstrap()
+
         // Build the dependency graph once up front so every scene/view observes the same
         // long-lived objects for the entire app session. `TabbyAppEnvironment` is a composition
         // helper here; the app delegate retains the root objects it needs directly.
@@ -109,6 +112,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     /// Starts runtime and polling services once AppKit reports that app launch finished.
     func applicationDidFinishLaunching(_ notification: Notification) {
+        let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?"
+        let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "?"
+        TabbyLogger.app.info("Tabby \(version) (build \(build)) launching on macOS \(ProcessInfo.processInfo.operatingSystemVersionString)")
         startRuntimeIfPreferredEngineRequiresIt()
         focusModel.start()
         inputMonitor.start()
@@ -116,10 +122,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         suggestionCoordinator.start()
         welcomeCoordinator.presentIfNeeded()
         welcomeCoordinator.presentPermissionReminderIfNeeded()
+        TabbyLogger.app.info("All services started")
     }
 
     /// Stops long-lived services before process exit so timers and runtime resources detach cleanly.
     func applicationWillTerminate(_ notification: Notification) {
+        TabbyLogger.app.info("Tabby terminating, stopping services")
         activationIndicatorController.hide(reason: "Activation indicator hidden because Tabby is terminating.")
         focusDebugOverlayController?.hide()
         suggestionCoordinator.stop()

--- a/tabby/App/Core/TabbyAppEnvironment.swift
+++ b/tabby/App/Core/TabbyAppEnvironment.swift
@@ -1,5 +1,6 @@
 import Combine
 import Foundation
+import Logging
 
 /// File overview:
 /// Builds Tabby's long-lived dependency graph in one place. This is the app's composition model:
@@ -30,6 +31,7 @@ final class TabbyAppEnvironment {
     private var cancellables = Set<AnyCancellable>()
 
     init() {
+        TabbyLogger.app.info("Building dependency graph")
         let configuration = SuggestionConfiguration.standard
         let permissionManager = PermissionManager()
         let permissionGuidanceController = PermissionGuidanceController(
@@ -89,15 +91,18 @@ final class TabbyAppEnvironment {
             foundationModelEngine = FoundationModelSuggestionEngine(
                 availabilityService: foundationModelAvailabilityService
             )
+            TabbyLogger.app.info("Foundation model engine available")
         } else {
             foundationModelEngine = UnavailableSuggestionEngine(
                 message: foundationModelAvailabilityService.userVisibleMessage
             )
+            TabbyLogger.app.info("Foundation model engine unavailable (macOS version)")
         }
         #else
         foundationModelEngine = UnavailableSuggestionEngine(
             message: foundationModelAvailabilityService.userVisibleMessage
         )
+        TabbyLogger.app.info("Foundation model engine unavailable (SDK)")
         #endif
 
         let suggestionEngine: any SuggestionGenerating = SuggestionEngineRouter(

--- a/tabby/Models/RuntimeBootstrapModel.swift
+++ b/tabby/Models/RuntimeBootstrapModel.swift
@@ -1,5 +1,6 @@
 import Combine
 import Foundation
+import Logging
 
 /// File overview:
 /// Owns app-facing runtime lifecycle state and republishes diagnostics from the in-process
@@ -87,7 +88,7 @@ final class RuntimeBootstrapModel: ObservableObject {
             do {
                 try await self.runtimeManager.prepare()
             } catch {
-                print("Runtime startup failed: \(error.localizedDescription)")
+                TabbyLogger.runtime.error("Runtime startup failed: \(error.localizedDescription)")
             }
         }
     }
@@ -123,7 +124,7 @@ final class RuntimeBootstrapModel: ObservableObject {
             do {
                 try await self.runtimeManager.selectModel(filename: filename)
             } catch {
-                print("Runtime model switch failed: \(error.localizedDescription)")
+                TabbyLogger.runtime.error("Runtime model switch failed: \(error.localizedDescription)")
             }
         }
 

--- a/tabby/Services/Focus/FocusSnapshotResolver.swift
+++ b/tabby/Services/Focus/FocusSnapshotResolver.swift
@@ -1,6 +1,7 @@
 import AppKit
 import ApplicationServices
 import Foundation
+import Logging
 
 /// File overview:
 /// Resolves the most usable editable candidate around the current AX focus and materializes a
@@ -506,7 +507,7 @@ struct FocusSnapshotResolver {
         dumpChildrenRecursive(of: focusedElement, into: &out, indent: "", depth: 0)
 
         out += "========== END DUMP ==========\n"
-        print(out)
+        TabbyLogger.focus.debug("\(out)")
     }
 
     private func dumpChildrenRecursive(

--- a/tabby/Services/Focus/FocusSnapshotResolver.swift
+++ b/tabby/Services/Focus/FocusSnapshotResolver.swift
@@ -68,6 +68,7 @@ struct FocusSnapshotResolver {
         guard let resolvedCandidate = selectedCandidate,
             resolution.resolvedCandidate != nil
         else {
+            TabbyLogger.focus.trace("Focus unsupported in \(applicationName): \(resolution.unsupportedReason)")
             return FocusSnapshot(
                 applicationName: applicationName,
                 bundleIdentifier: bundleIdentifier,

--- a/tabby/Services/Focus/FocusTracker.swift
+++ b/tabby/Services/Focus/FocusTracker.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import Logging
 
 /// File overview:
 /// Polls the Accessibility tree on a fixed timer and publishes the latest `FocusSnapshot`.
@@ -50,6 +51,7 @@ final class FocusTracker {
             return
         }
 
+        TabbyLogger.focus.info("Focus polling started at \(Int(self.pollInterval * 1000))ms interval")
         refreshNow()
 
         let timer = Timer(timeInterval: pollInterval, repeats: true) { [weak self] _ in
@@ -63,6 +65,7 @@ final class FocusTracker {
 
     /// Stops polling while leaving the most recent snapshot available to callers.
     func stop() {
+        TabbyLogger.focus.info("Focus polling stopped")
         timer?.invalidate()
         timer = nil
     }
@@ -73,6 +76,7 @@ final class FocusTracker {
             return
         }
 
+        TabbyLogger.focus.info("Focus poll interval changed to \(Int(interval * 1000))ms")
         pollInterval = interval
 
         // Only restart if a timer is already running.

--- a/tabby/Services/Input/InputMonitor.swift
+++ b/tabby/Services/Input/InputMonitor.swift
@@ -1,5 +1,6 @@
 import ApplicationServices
 import Foundation
+import Logging
 
 /// File overview:
 /// Owns the global keyboard event tap used to detect typing, navigation, dismissal keys,
@@ -36,11 +37,13 @@ final class InputMonitor {
 
     /// Installs the event tap and begins listening for global keyboard activity.
     func start() {
+        TabbyLogger.app.info("Input monitor starting")
         refresh()
     }
 
     /// Removes the event tap and stops observing keyboard events.
     func stop() {
+        TabbyLogger.app.info("Input monitor stopping")
         destroyTap()
     }
 
@@ -81,8 +84,10 @@ final class InputMonitor {
             callback: callback,
             userInfo: Unmanaged.passUnretained(self).toOpaque()
         ) else {
+            TabbyLogger.app.warning("Failed to create CGEvent tap — Input Monitoring permission may be missing")
             return
         }
+        TabbyLogger.app.info("CGEvent tap installed")
 
         eventTap = tap
         let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
@@ -114,8 +119,7 @@ final class InputMonitor {
     private func handleTap(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         switch type {
         case .tapDisabledByTimeout, .tapDisabledByUserInput:
-            // macOS may disable a tap if the callback runs too slowly or during certain system events.
-            // Re-enabling keeps the monitor self-healing instead of silently dying.
+            TabbyLogger.app.warning("CGEvent tap was disabled by system, re-enabling")
             if let eventTap {
                 CGEvent.tapEnable(tap: eventTap, enable: true)
             }

--- a/tabby/Services/Input/InputSuppressionController.swift
+++ b/tabby/Services/Input/InputSuppressionController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Logging
 
 /// File overview:
 /// Tracks Tabby's own synthetic key events so inserted suggestions do not recursively trigger
@@ -16,6 +17,7 @@ final class InputSuppressionController {
     func registerSyntheticInsertion(expectedKeyDownCount: Int) {
         remainingKeyDownSuppressions = max(expectedKeyDownCount, 0)
         suppressionExpiry = Date().addingTimeInterval(1.0)
+        TabbyLogger.app.trace("Suppression armed for \(expectedKeyDownCount) synthetic key event(s)")
     }
 
     /// Consumes one pending suppression token if the current event still falls inside the expiry window.

--- a/tabby/Services/Permission/PermissionManager.swift
+++ b/tabby/Services/Permission/PermissionManager.swift
@@ -2,6 +2,7 @@ import AppKit
 import ApplicationServices
 import Combine
 import CoreGraphics
+import Logging
 
 /// File overview:
 /// Polls and exposes the three system permissions Tabby depends on: Accessibility for reading
@@ -43,14 +44,17 @@ final class PermissionManager: ObservableObject {
         // `@Published` notifies on assignment, even when the value is unchanged. Compare first so
         // the 2-second poll does not redraw SwiftUI surfaces that already have the right state.
         if accessibilityGranted != latestAccessibilityGranted {
+            TabbyLogger.app.info("Accessibility permission changed: \(latestAccessibilityGranted)")
             accessibilityGranted = latestAccessibilityGranted
         }
 
         if inputMonitoringGranted != latestInputMonitoringGranted {
+            TabbyLogger.app.info("Input Monitoring permission changed: \(latestInputMonitoringGranted)")
             inputMonitoringGranted = latestInputMonitoringGranted
         }
 
         if screenRecordingGranted != latestScreenRecordingGranted {
+            TabbyLogger.app.info("Screen Recording permission changed: \(latestScreenRecordingGranted)")
             screenRecordingGranted = latestScreenRecordingGranted
         }
     }

--- a/tabby/Services/Runtime/FoundationModelAvailabilityService.swift
+++ b/tabby/Services/Runtime/FoundationModelAvailabilityService.swift
@@ -1,5 +1,6 @@
 import Combine
 import Foundation
+import Logging
 
 #if canImport(FoundationModels)
 import FoundationModels
@@ -54,7 +55,11 @@ final class FoundationModelAvailabilityService: ObservableObject {
     /// Availability can change at runtime if the user enables Apple Intelligence or if the model
     /// finishes downloading in the background.
     func refresh() {
+        let previousState = state
         state = provider.refresh()
+        if state != previousState {
+            TabbyLogger.runtime.info("Foundation model availability changed: \(self.state.summary)")
+        }
     }
 
     var isAvailable: Bool {

--- a/tabby/Services/Runtime/FoundationModelSuggestionEngine.swift
+++ b/tabby/Services/Runtime/FoundationModelSuggestionEngine.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Logging
 
 #if canImport(FoundationModels)
 import FoundationModels
@@ -30,10 +31,12 @@ final class FoundationModelSuggestionEngine {
         availabilityService.refresh()
 
         guard availabilityService.isAvailable else {
+            TabbyLogger.suggestion.debug("Foundation model unavailable: \(self.availabilityService.userVisibleMessage)")
             throw SuggestionClientError.unavailable(availabilityService.userVisibleMessage)
         }
 
         do {
+            TabbyLogger.suggestion.debug("Foundation model generating: prompt=\(request.prompt.count) bytes, max_tokens=\(request.maxPredictionTokens)")
             let startTime = Date()
             let prompt = FoundationModelPromptRenderer.prompt(for: request)
             // In production, `isAvailable == true` implies `systemLanguageModel` is non-nil because
@@ -63,19 +66,24 @@ final class FoundationModelSuggestionEngine {
                 promptEchoCandidates: [prompt]
             )
 
+            let latency = Date().timeIntervalSince(startTime)
+            TabbyLogger.suggestion.debug("Foundation model generated: raw=\(rawSuggestion.count) chars, normalized=\(normalizedSuggestion.count) chars, latency=\(Int(latency * 1000))ms")
             return SuggestionResult(
                 generation: request.generation,
                 rawText: rawSuggestion,
                 text: normalizedSuggestion,
-                latency: Date().timeIntervalSince(startTime)
+                latency: latency
             )
         } catch is CancellationError {
+            TabbyLogger.suggestion.debug("Foundation model generation cancelled")
             throw SuggestionClientError.cancelled
         } catch let error as LanguageModelSession.GenerationError {
+            TabbyLogger.suggestion.error("Foundation model generation error: \(error.localizedDescription)")
             throw mapGenerationError(error)
         } catch let error as SuggestionClientError {
             throw error
         } catch {
+            TabbyLogger.suggestion.error("Foundation model unexpected error: \(error.localizedDescription)")
             throw SuggestionClientError.generationFailed(error.localizedDescription)
         }
     }

--- a/tabby/Services/Runtime/LlamaRuntimeCore.swift
+++ b/tabby/Services/Runtime/LlamaRuntimeCore.swift
@@ -1,5 +1,6 @@
 import Foundation
 import LlamaSwift
+import Logging
 
 /// File overview:
 /// Owns the raw llama.cpp lifecycle behind one serialized actor. This file is the lowest-level
@@ -85,10 +86,12 @@ actor LlamaRuntimeCore {
     ) throws -> PreparedLlamaRuntime {
         if let preparedRuntime,
            preparedRuntime.resolvedRuntime.modelFileURL == resolvedRuntime.modelFileURL {
+            TabbyLogger.runtime.trace("Model already prepared, reusing")
             return preparedRuntime
         }
 
         if preparedRuntime != nil {
+            TabbyLogger.runtime.info("Shutting down existing runtime before reload")
             shutdown()
         }
 
@@ -106,9 +109,11 @@ actor LlamaRuntimeCore {
         modelParams.use_mmap = true
         modelParams.use_mlock = false
 
+        TabbyLogger.runtime.info("Loading GGUF model: \(resolvedRuntime.modelDisplayName)")
         guard let loadedModel = resolvedRuntime.modelFileURL.path.withCString({
             llama_model_load_from_file($0, modelParams)
         }) else {
+            TabbyLogger.runtime.error("llama_model_load_from_file failed for \(resolvedRuntime.modelDisplayName)")
             throw LlamaRuntimeError.unavailable("Unable to load \(resolvedRuntime.modelDisplayName) with llama.cpp.")
         }
 
@@ -146,14 +151,14 @@ actor LlamaRuntimeCore {
 
         let allPromptTokens = try tokenize(prompt, vocab: vocab)
 
-        // Reserve space for generation and trim from the front if needed. The tail of the prompt
-        // is closest to the caret and matters most for completion quality.
         let maxPromptTokens = max(1, preparedRuntime.contextWindowTokens - options.maxPredictionTokens)
         let promptTokens: [llama_token]
         let adjustedCachedPrefixBytes: Int?
         if allPromptTokens.count > maxPromptTokens {
+            TabbyLogger.runtime.debug(
+                "Prompt trimmed: \(allPromptTokens.count) tokens → \(maxPromptTokens)"
+            )
             promptTokens = Array(allPromptTokens.suffix(maxPromptTokens))
-            // Front-trimming invalidates any byte-level prefix overlap with the cache.
             adjustedCachedPrefixBytes = nil
         } else {
             promptTokens = allPromptTokens
@@ -220,16 +225,19 @@ actor LlamaRuntimeCore {
             throw error
         }
 
+        TabbyLogger.runtime.debug("Generated \(generatedText.count) chars in \(position - Int32(promptTokens.count)) tokens")
         return generatedText
     }
 
     /// Drops the reusable prompt context while keeping the loaded model alive.
     func resetPromptCache() {
+        TabbyLogger.runtime.debug("Prompt cache reset")
         clearPromptCache()
     }
 
     /// Frees any loaded model/backend state owned by the actor.
     func shutdown() {
+        TabbyLogger.runtime.info("LlamaRuntimeCore shutting down")
         clearPromptCache()
 
         if let model {
@@ -259,6 +267,7 @@ actor LlamaRuntimeCore {
               let cache = promptCache,
               cache.samplingFingerprint == request.samplingFingerprint
         else {
+            TabbyLogger.runtime.debug("KV cache miss, rebuilding context")
             return try rebuildPromptContext(
                 model: model,
                 preparedRuntime: preparedRuntime,
@@ -283,6 +292,9 @@ actor LlamaRuntimeCore {
         }
 
         let commonTokenPrefix = Self.commonPrefixCount(cache.promptTokens, request.promptTokens)
+        TabbyLogger.runtime.debug(
+            "KV cache: common_prefix=\(commonTokenPrefix)/\(request.promptTokens.count) tokens"
+        )
         let reusableTokenCount = Self.reusableTokenCount(
             commonTokenPrefix: commonTokenPrefix,
             newPromptTokenCount: request.promptTokens.count

--- a/tabby/Services/Runtime/LlamaRuntimeCore.swift
+++ b/tabby/Services/Runtime/LlamaRuntimeCore.swift
@@ -151,6 +151,8 @@ actor LlamaRuntimeCore {
 
         let allPromptTokens = try tokenize(prompt, vocab: vocab)
 
+        // Reserve space for generation and trim from the front if needed. The tail of the prompt
+        // is closest to the caret and matters most for completion quality.
         let maxPromptTokens = max(1, preparedRuntime.contextWindowTokens - options.maxPredictionTokens)
         let promptTokens: [llama_token]
         let adjustedCachedPrefixBytes: Int?
@@ -159,6 +161,7 @@ actor LlamaRuntimeCore {
                 "Prompt trimmed: \(allPromptTokens.count) tokens → \(maxPromptTokens)"
             )
             promptTokens = Array(allPromptTokens.suffix(maxPromptTokens))
+            // Front-trimming invalidates any byte-level prefix overlap with the cache.
             adjustedCachedPrefixBytes = nil
         } else {
             promptTokens = allPromptTokens

--- a/tabby/Services/Runtime/LlamaRuntimeManager.swift
+++ b/tabby/Services/Runtime/LlamaRuntimeManager.swift
@@ -1,5 +1,6 @@
 import Combine
 import Foundation
+import Logging
 
 /// File overview:
 /// Publishes runtime bootstrap state and user-facing diagnostics for the menu bar and startup UI.
@@ -44,12 +45,14 @@ final class LlamaRuntimeManager: ObservableObject {
     func refreshAvailableModels() {
         availableModels = runtimeLocator.availableModels(configuration: configuration)
         selectedModelFilename = normalizedModelFilename(selectedModelFilename)
+        TabbyLogger.runtime.info("Discovered \(self.availableModels.count) model(s)")
     }
 
     /// Records which discovered model should be loaded when preparation starts.
     /// This keeps persisted UI state separate from the runtime loading lifecycle.
     func configureSelectedModel(filename: String?) {
         selectedModelFilename = normalizedModelFilename(filename)
+        TabbyLogger.runtime.info("Configured selected model: \(self.selectedModelFilename ?? "none")")
     }
 
     /// Ensures the selected local model is resolved and prepared before any generation requests run.
@@ -60,6 +63,7 @@ final class LlamaRuntimeManager: ObservableObject {
     /// Reloads the runtime in place with a newly selected local model.
     /// The manager instance stays alive; only the loaded model changes.
     func selectModel(filename: String) async throws {
+        TabbyLogger.runtime.info("Selecting model: \(filename)")
         guard let normalizedFilename = normalizedModelFilename(filename) else {
             let error = LlamaRuntimeError.unavailable(
                 "The selected model \(filename) is unavailable.")
@@ -98,11 +102,14 @@ final class LlamaRuntimeManager: ObservableObject {
                 options: options
             )
         } catch is CancellationError {
+            TabbyLogger.runtime.debug("Generation cancelled")
             throw LlamaRuntimeError.cancelled
         } catch let error as LlamaRuntimeError {
+            TabbyLogger.runtime.error("Generation runtime error: \(error.localizedDescription)")
             diagnostics.lastError = error.localizedDescription
             throw error
         } catch {
+            TabbyLogger.runtime.error("Generation failed: \(error.localizedDescription)")
             let runtimeError = LlamaRuntimeError.generationFailed(error.localizedDescription)
             diagnostics.lastError = runtimeError.localizedDescription
             throw runtimeError
@@ -147,6 +154,7 @@ final class LlamaRuntimeManager: ObservableObject {
 
     /// Cancels any retained prepared runtime and asks the actor to release backend resources.
     func stop() {
+        TabbyLogger.runtime.info("Runtime stop requested")
         prepareForStop()
 
         Task {
@@ -158,6 +166,7 @@ final class LlamaRuntimeManager: ObservableObject {
     /// Destructive flows such as uninstall need this stronger guarantee before deleting model files
     /// that may have been memory-mapped by the runtime.
     func stopAndWait() async {
+        TabbyLogger.runtime.info("Runtime stop-and-wait requested")
         prepareForStop()
         await core.shutdown()
     }
@@ -179,16 +188,17 @@ final class LlamaRuntimeManager: ObservableObject {
 
         if let cachedRuntime,
             cachedRuntime.resolvedRuntime.modelFileURL == resolvedRuntime.modelFileURL {
+            TabbyLogger.runtime.trace("Using cached runtime for \(requestedModelFilename)")
             return cachedRuntime
         }
 
         if let startupTask {
-            // Deduplicate concurrent prepare calls for the same selected model, but cancel and
-            // replace the task if the requested model changed while startup was already in flight.
             if startupModelFilename == requestedModelFilename {
+                TabbyLogger.runtime.debug("Reusing in-flight startup for \(requestedModelFilename)")
                 return try await awaitPreparedRuntime(startupTask)
             }
 
+            TabbyLogger.runtime.info("Model changed to \(requestedModelFilename), cancelling previous startup")
             startupTask.cancel()
             self.startupTask = nil
             startupModelFilename = nil
@@ -208,6 +218,7 @@ final class LlamaRuntimeManager: ObservableObject {
         }
         self.startupTask = startupTask
         startupModelFilename = requestedModelFilename
+        TabbyLogger.runtime.info("Loading \(resolvedRuntime.modelDisplayName) into memory")
         state = .loading("Loading \(resolvedRuntime.modelDisplayName) into memory.")
 
         return try await awaitPreparedRuntime(startupTask)
@@ -284,6 +295,11 @@ final class LlamaRuntimeManager: ObservableObject {
 
     /// Copies prepared runtime metadata into published diagnostics for the menu and startup UI.
     private func apply(_ preparedRuntime: PreparedLlamaRuntime) {
+        let model = preparedRuntime.resolvedRuntime.modelDisplayName
+        let ctx = preparedRuntime.contextWindowTokens
+        TabbyLogger.runtime.info(
+            "Runtime ready: model=\(model) ctx=\(ctx) threads=\(preparedRuntime.threadCount) gpu=\(preparedRuntime.gpuLayerCount)"
+        )
         diagnostics.runtimeDirectoryPath = preparedRuntime.resolvedRuntime.runtimeDirectoryURL.path
         diagnostics.modelFilePath = preparedRuntime.resolvedRuntime.modelFileURL.path
         diagnostics.backendName = preparedRuntime.backendName

--- a/tabby/Services/Runtime/LlamaRuntimeManager.swift
+++ b/tabby/Services/Runtime/LlamaRuntimeManager.swift
@@ -192,6 +192,8 @@ final class LlamaRuntimeManager: ObservableObject {
             return cachedRuntime
         }
 
+        // Deduplicate concurrent prepare calls for the same selected model, but cancel and
+        // replace the task if the requested model changed while startup was already in flight.
         if let startupTask {
             if startupModelFilename == requestedModelFilename {
                 TabbyLogger.runtime.debug("Reusing in-flight startup for \(requestedModelFilename)")

--- a/tabby/Services/Runtime/LlamaSuggestionEngine.swift
+++ b/tabby/Services/Runtime/LlamaSuggestionEngine.swift
@@ -1,5 +1,6 @@
 import CoreGraphics
 import Foundation
+import Logging
 
 /// File overview:
 /// Wraps the raw llama runtime with prompt/result normalization that is specific to inline
@@ -21,6 +22,10 @@ final class LlamaSuggestionEngine {
         do {
             let startTime = Date()
             let cachedPrefixBytes = promptCacheHintTracker.cachedPrefixBytes(for: request)
+            let hintDesc = cachedPrefixBytes.map(String.init) ?? "none"
+            TabbyLogger.suggestion.debug(
+                "Llama generating: prompt=\(request.prompt.count)B cache_hint=\(hintDesc) max_tokens=\(request.maxPredictionTokens)"
+            )
             let rawSuggestion = try await runtimeManager.generate(
                 prompt: request.prompt,
                 cachedPrefixBytes: cachedPrefixBytes,
@@ -38,21 +43,27 @@ final class LlamaSuggestionEngine {
 
             promptCacheHintTracker.recordSuccessfulRequest(request)
             let normalizedSuggestion = SuggestionTextNormalizer.normalize(rawSuggestion, for: request)
+            let latency = Date().timeIntervalSince(startTime)
+            TabbyLogger.suggestion.debug("Llama generated: raw=\(rawSuggestion.count) chars, normalized=\(normalizedSuggestion.count) chars, latency=\(Int(latency * 1000))ms")
             return SuggestionResult(
                 generation: request.generation,
                 rawText: rawSuggestion,
                 text: normalizedSuggestion,
-                latency: Date().timeIntervalSince(startTime)
+                latency: latency
             )
         } catch is CancellationError {
+            TabbyLogger.suggestion.debug("Llama generation cancelled")
             throw SuggestionClientError.cancelled
         } catch let error as LlamaRuntimeError {
+            TabbyLogger.suggestion.error("Llama runtime error, resetting cache: \(error.localizedDescription)")
             await resetCachedGenerationContext()
             throw SuggestionClientError.unavailable(error.localizedDescription)
         } catch let error as SuggestionClientError {
+            TabbyLogger.suggestion.error("Suggestion client error, resetting cache: \(error.localizedDescription)")
             await resetCachedGenerationContext()
             throw error
         } catch {
+            TabbyLogger.suggestion.error("Unexpected generation error, resetting cache: \(error.localizedDescription)")
             await resetCachedGenerationContext()
             throw SuggestionClientError.generationFailed(error.localizedDescription)
         }

--- a/tabby/Services/Runtime/SuggestionEngineRouter.swift
+++ b/tabby/Services/Runtime/SuggestionEngineRouter.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Logging
 
 /// File overview:
 /// Routes generation requests to the currently selected autocomplete engine.
@@ -23,15 +24,18 @@ final class SuggestionEngineRouter {
     func generateSuggestion(for request: SuggestionRequest) async throws -> SuggestionResult {
         switch suggestionSettings.selectedEngine {
         case .appleIntelligence:
+            TabbyLogger.suggestion.debug("Routing to Apple Intelligence engine")
             do {
                 return try await foundationModelEngine.generateSuggestion(for: request)
             } catch SuggestionClientError.unsupportedLanguageOrLocale(let message) {
+                TabbyLogger.suggestion.info("Apple Intelligence unsupported for locale, falling back to open-source: \(message)")
                 return try await generateOpenSourceFallback(
                     for: request,
                     appleFailureMessage: message
                 )
             }
         case .llamaOpenSource:
+            TabbyLogger.suggestion.debug("Routing to open-source llama engine")
             return try await llamaEngine.generateSuggestion(for: request)
         }
     }
@@ -77,6 +81,7 @@ final class UnavailableSuggestionEngine: SuggestionGenerating {
     }
 
     func generateSuggestion(for request: SuggestionRequest) async throws -> SuggestionResult {
+        TabbyLogger.suggestion.warning("Engine unavailable: \(self.message)")
         throw SuggestionClientError.unavailable(message)
     }
 

--- a/tabby/Services/Suggestion/SuggestionInserter.swift
+++ b/tabby/Services/Suggestion/SuggestionInserter.swift
@@ -1,5 +1,6 @@
 import ApplicationServices
 import Foundation
+import Logging
 
 /// File overview:
 /// Commits accepted suggestions back into the host app by synthesizing Unicode keyboard events.
@@ -22,12 +23,14 @@ final class SuggestionInserter {
         let normalized = suggestion.replacingOccurrences(of: "\r", with: "")
         guard !normalized.isEmpty else {
             lastErrorMessage = "Suggestion was empty."
+            TabbyLogger.suggestion.warning("Insertion skipped: suggestion was empty after normalization")
             return false
         }
 
         guard let keyDownEvent = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: true),
               let keyUpEvent = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: false) else {
             lastErrorMessage = "Unable to create a synthetic keyboard event."
+            TabbyLogger.suggestion.error("Failed to create synthetic keyboard events for insertion")
             return false
         }
 
@@ -38,6 +41,7 @@ final class SuggestionInserter {
         keyDownEvent.post(tap: .cghidEventTap)
         keyUpEvent.post(tap: .cghidEventTap)
         lastErrorMessage = nil
+        TabbyLogger.suggestion.debug("Inserted \(normalized.count) characters via synthetic keystroke")
         return true
     }
 }

--- a/tabby/Services/Utilities/AppUpdateManager.swift
+++ b/tabby/Services/Utilities/AppUpdateManager.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Logging
 import Sparkle
 
 /// File overview:
@@ -93,6 +94,6 @@ final class AppUpdateManager {
     }
 
     private func log(_ message: String) {
-        print("[AppUpdateManager] \(message)")
+        TabbyLogger.updates.info("\(message)")
     }
 }

--- a/tabby/Services/Utilities/ModelDownloadManager.swift
+++ b/tabby/Services/Utilities/ModelDownloadManager.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Combine
 import Foundation
+import Logging
 
 /// One model's current install/download lifecycle state in local storage.
 enum ModelDownloadState: Equatable {
@@ -107,14 +108,17 @@ final class ModelDownloadManager: ObservableObject {
 
     func download(_ model: DownloadableRuntimeModel) {
         guard downloadTasks[model.filename] == nil else {
+            TabbyLogger.models.debug("Download already in progress for \(model.filename)")
             return
         }
 
         if isInstalled(model: model) {
+            TabbyLogger.models.debug("Model \(model.filename) already installed, skipping download")
             modelStates[model.filename] = .downloaded
             return
         }
 
+        TabbyLogger.models.info("Starting download for \(model.filename)")
         modelStates[model.filename] = .downloading(progress: 0)
         let task = Task { [weak self] in
             guard let self else {
@@ -187,7 +191,7 @@ final class ModelDownloadManager: ObservableObject {
             refreshModelStates()
             onModelDirectoryChanged?()
         } catch {
-            print("Failed to delete model \(filename): \(error.localizedDescription)")
+            TabbyLogger.models.error("Failed to delete model \(filename): \(error.localizedDescription)")
         }
     }
 
@@ -248,6 +252,7 @@ final class ModelDownloadManager: ObservableObject {
             }
             try fileManager.moveItem(at: stagingURL, to: destinationURL)
 
+            TabbyLogger.models.info("Download complete for \(model.filename)")
             modelStates[model.filename] = .downloaded
             onModelDirectoryChanged?()
         } catch {
@@ -258,8 +263,10 @@ final class ModelDownloadManager: ObservableObject {
             // they did. DownloadOutcomeClassifier owns the discrimination so
             // the rule is unit-tested in isolation.
             if DownloadOutcomeClassifier.isUserCancellation(error) {
+                TabbyLogger.models.info("Download cancelled by user for \(model.filename)")
                 modelStates[model.filename] = isInstalled(model: model) ? .downloaded : .idle
             } else {
+                TabbyLogger.models.error("Download failed for \(model.filename): \(error.localizedDescription)")
                 modelStates[model.filename] = .failed(error.localizedDescription)
             }
         }

--- a/tabby/Services/Visual/LlamaVisualContextSummarizer.swift
+++ b/tabby/Services/Visual/LlamaVisualContextSummarizer.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Logging
 
 /// Converts OCR text into a compact prompt-safe visual context summary.
 ///
@@ -24,6 +25,7 @@ final class LlamaVisualContextSummarizer: VisualContextSummarizing {
     }
 
     func summarize(text: String, applicationName: String) async throws -> String {
+        TabbyLogger.app.debug("Summarizing visual context for \(applicationName): \(text.count) chars input")
         // Deduplicate repeated lines before sending to the model. OCR from screens showing
         // chatbot output (e.g. "Final Answer\nFinal Answer\n...") teaches the model to loop
         // that pattern verbatim in its output. Collapsing consecutive duplicates removes the
@@ -76,10 +78,15 @@ final class LlamaVisualContextSummarizer: VisualContextSummarizing {
         do {
             result = try await generationTask.value
         } catch {
-            // Real error (model not loaded, etc.) — no partial text available.
+            TabbyLogger.app.warning("Visual context summarization failed: \(error.localizedDescription)")
             result = ""
         }
         timeoutTask.cancel()
+        if result.isEmpty {
+            TabbyLogger.app.debug("Summarization produced empty result")
+        } else {
+            TabbyLogger.app.debug("Summarization produced \(result.count) chars")
+        }
 
         return result
     }

--- a/tabby/Services/Visual/ScreenTextExtractor.swift
+++ b/tabby/Services/Visual/ScreenTextExtractor.swift
@@ -1,5 +1,6 @@
 import CoreGraphics
 import Foundation
+import Logging
 @preconcurrency import Vision
 
 /// File overview:
@@ -147,7 +148,7 @@ struct ScreenTextExtractor {
     }
 
     private func log(_ message: String) {
-        _ = message
+        TabbyLogger.app.debug("\(message)")
     }
 
     private func preview(_ text: String) -> String {

--- a/tabby/Services/Visual/ScreenTextExtractor.swift
+++ b/tabby/Services/Visual/ScreenTextExtractor.swift
@@ -148,7 +148,9 @@ struct ScreenTextExtractor {
     }
 
     private func log(_ message: String) {
-        TabbyLogger.app.debug("\(message)")
+        // OCR log messages include preview text from the user's screen. Route them through
+        // the debug gate so they only appear when the developer explicitly opts in.
+        TabbyDebugOptions.log(message)
     }
 
     private func preview(_ text: String) -> String {

--- a/tabby/Services/Visual/ScreenshotContextGenerator.swift
+++ b/tabby/Services/Visual/ScreenshotContextGenerator.swift
@@ -1,6 +1,7 @@
 import CoreGraphics
 import Foundation
 import ImageIO
+import Logging
 import UniformTypeIdentifiers
 
 /// File overview:
@@ -56,6 +57,7 @@ final class ScreenshotContextGenerator {
     ) async throws -> VisualContextExcerpt {
         await onStatusChange?(.capturing)
 
+        TabbyLogger.app.debug("Capturing screenshot for \(context.applicationName)")
         let screenshot: CapturedWindowScreenshot
         do {
             screenshot = try await screenshotService.captureSnapshot(
@@ -63,8 +65,10 @@ final class ScreenshotContextGenerator {
                 snapshotDimension: configuration.snapshotDimension
             )
         } catch let error as WindowScreenshotError {
+            TabbyLogger.app.warning("Screenshot unavailable: \(error.localizedDescription)")
             throw ScreenshotContextGenerationError.unavailable(error.localizedDescription)
         } catch {
+            TabbyLogger.app.error("Screenshot failed: \(error.localizedDescription)")
             throw ScreenshotContextGenerationError.failed(error.localizedDescription)
         }
 
@@ -101,6 +105,7 @@ final class ScreenshotContextGenerator {
             )
         }
 
+        TabbyLogger.app.debug("OCR extracted \(normalizedText.count) chars from screenshot")
         guard hasMeaningfulSignal(normalizedText) else {
             throw ScreenshotContextGenerationError.unavailable(
                 "The screenshot did not contain enough visible text to build prompt context."

--- a/tabby/Services/Visual/VisualContextCoordinator.swift
+++ b/tabby/Services/Visual/VisualContextCoordinator.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Logging
 
 /// File overview:
 /// Owns the screenshot-derived prompt-augmentation lifecycle for the currently focused input.
@@ -54,6 +55,7 @@ final class VisualContextCoordinator {
 
         cancel(resetState: false)
 
+        TabbyLogger.app.debug("Starting visual context session for element \(snapshotContext.elementIdentifier)")
         let hasPermission = screenRecordingPermissionProvider()
         let initialStatus: VisualContextStatus =
             hasPermission
@@ -98,10 +100,13 @@ final class VisualContextCoordinator {
                     identity: snapshotContext.identity
                 )
             } catch is CancellationError {
+                TabbyLogger.app.debug("Visual context generation cancelled")
                 return
             } catch let error as ScreenshotContextGenerationError {
+                TabbyLogger.app.warning("Visual context generation error: \(error.localizedDescription)")
                 setStatus(errorStatus(for: error), for: session.sessionID)
             } catch {
+                TabbyLogger.app.error("Visual context generation failed: \(error.localizedDescription)")
                 setStatus(.failed(error.localizedDescription), for: session.sessionID)
             }
         }
@@ -166,6 +171,7 @@ final class VisualContextCoordinator {
         activeAugmentationSession?.excerpt = excerpt
         status = .ready
         latestExcerpt = excerpt.text
+        TabbyLogger.app.debug("Visual context ready: \(excerpt.text.count) chars")
         publishState()
         onInjectedContextReady?(identity)
     }

--- a/tabby/Services/Visual/WindowScreenshotService.swift
+++ b/tabby/Services/Visual/WindowScreenshotService.swift
@@ -1,6 +1,7 @@
 import AppKit
 import CoreGraphics
 import Foundation
+import Logging
 import ScreenCaptureKit
 
 /// File overview:
@@ -54,6 +55,7 @@ struct WindowScreenshotService {
         let processIdentifier = pid_t(context.processIdentifier)
 
         guard CGPreflightScreenCaptureAccess() else {
+            TabbyLogger.app.warning("Screenshot blocked: Screen Recording permission missing")
             throw WindowScreenshotError.screenRecordingPermissionMissing
         }
 
@@ -67,8 +69,10 @@ struct WindowScreenshotService {
             })
 
         guard let matchingWindow else {
+            TabbyLogger.app.debug("No visible window for pid \(processIdentifier)")
             throw WindowScreenshotError.noVisibleWindowForProcess(processIdentifier)
         }
+        TabbyLogger.app.trace("Capturing window: \(matchingWindow.title ?? "untitled") (\(Int(matchingWindow.frame.width))x\(Int(matchingWindow.frame.height)))")
 
         let sourceRect = snapshotRect(
             around: context,

--- a/tabby/Support/TabbyDebugOptions.swift
+++ b/tabby/Support/TabbyDebugOptions.swift
@@ -64,10 +64,15 @@ struct OSLogHandler: LogHandler {
 
     private let osLogger: os.Logger
 
+    /// Apple's convention: `subsystem` is the app-wide identifier (constant for all loggers),
+    /// `category` is the per-component label. This way Console.app can filter all Tabby output
+    /// with one subsystem while still distinguishing components by category.
+    private static let subsystem = "com.tabby.app"
+
     init(label: String) {
         let parts = label.split(separator: ".", maxSplits: 2)
         let category = parts.count > 2 ? String(parts[2]) : label
-        osLogger = os.Logger(subsystem: label, category: category)
+        osLogger = os.Logger(subsystem: Self.subsystem, category: category)
     }
 
     subscript(metadataKey key: String) -> Logging.Logger.Metadata.Value? {

--- a/tabby/Support/TabbyDebugOptions.swift
+++ b/tabby/Support/TabbyDebugOptions.swift
@@ -1,7 +1,9 @@
 import Foundation
+import Logging
+import os
 
 /// File overview:
-/// Centralizes Tabby's developer-only runtime switches.
+/// Centralizes Tabby's developer-only runtime switches and the shared logger factory.
 ///
 /// A single launch argument is easier to reason about than separate feature flags because every
 /// privacy-sensitive diagnostic path has one obvious gate. Passing `-tabby-debug` means the
@@ -24,6 +26,78 @@ enum TabbyDebugOptions {
             return
         }
 
-        print(message())
+        TabbyLogger.debug.debug("\(message())")
+    }
+}
+
+/// Provides subsystem-scoped loggers for the entire app.
+///
+/// All loggers route through `OSLogHandler`, so messages appear in Console.app
+/// with the subsystem as a filterable column. Open Console.app and filter by
+/// process "tabby" or subsystem "com.tabby.*" to see structured output.
+enum TabbyLogger {
+    private static let bootstrapOnce: Void = {
+        LoggingSystem.bootstrap { label in
+            OSLogHandler(label: label)
+        }
+    }()
+
+    /// Call once at app startup (e.g. in AppDelegate.init) before any logger is used.
+    static func bootstrap() {
+        _ = bootstrapOnce
+    }
+
+    static let app = Logger(label: "com.tabby.app")
+    static let debug = Logger(label: "com.tabby.debug")
+    static let runtime = Logger(label: "com.tabby.runtime")
+    static let focus = Logger(label: "com.tabby.focus")
+    static let updates = Logger(label: "com.tabby.updates")
+    static let models = Logger(label: "com.tabby.models")
+    static let suggestion = Logger(label: "com.tabby.suggestion")
+}
+
+/// Bridges swift-log into Apple's Unified Logging so every log line appears in Console.app
+/// with the correct subsystem, category, and native log level.
+struct OSLogHandler: LogHandler {
+    var metadata: Logging.Logger.Metadata = [:]
+    var logLevel: Logging.Logger.Level = .trace
+
+    private let osLogger: os.Logger
+
+    init(label: String) {
+        let parts = label.split(separator: ".", maxSplits: 2)
+        let category = parts.count > 2 ? String(parts[2]) : label
+        osLogger = os.Logger(subsystem: label, category: category)
+    }
+
+    subscript(metadataKey key: String) -> Logging.Logger.Metadata.Value? {
+        get { metadata[key] }
+        set { metadata[key] = newValue }
+    }
+
+    func log(
+        level: Logging.Logger.Level,
+        message: Logging.Logger.Message,
+        metadata: Logging.Logger.Metadata?,
+        source: String,
+        file: String,
+        function: String,
+        line: UInt
+    ) {
+        let text = "\(message)"
+        switch level {
+        case .trace:
+            osLogger.trace("\(text, privacy: .public)")
+        case .debug:
+            osLogger.debug("\(text, privacy: .public)")
+        case .info, .notice:
+            osLogger.info("\(text, privacy: .public)")
+        case .warning:
+            osLogger.warning("\(text, privacy: .public)")
+        case .error:
+            osLogger.error("\(text, privacy: .public)")
+        case .critical:
+            osLogger.critical("\(text, privacy: .public)")
+        }
     }
 }


### PR DESCRIPTION
## Summary

Replace all `print()` logging with Apple's [swift-log](https://github.com/apple/swift-log) package,
routed through a custom `OSLogHandler` so every log line appears in Console.app with filterable
subsystem labels (`com.tabby.app`, `com.tabby.runtime`, `com.tabby.suggestion`, etc.) and native
log levels.

## Validation

```
xcodebuild -project tabby.xcodeproj -scheme tabby \
  -destination 'platform=macOS' build \
  CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
# ** BUILD SUCCEEDED **

swiftlint lint --quiet 2>&1 | grep "error:"
# (no output — zero lint errors)
```

## Linked issues

None.

## Risk / rollout notes

- Adds `swift-log` (1.6+) as a new SPM dependency. Resolved to 1.12.1.
- `OSLogHandler` marks all messages `privacy: .public` so they're readable without a debugger. No
  user content (typed text, prompts, OCR output) is logged — only lifecycle events, durations, and
  decision metadata.
- `LoggingSystem.bootstrap()` is called once in `AppDelegate.init` before any services start.
- The existing `TabbyDebugOptions.log()` / `SuggestionDebugLogger` debug-gated paths still work;
  they now emit through the same swift-log pipeline instead of raw `print()`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces all `print()` calls with Apple's swift-log package, routed through a custom `OSLogHandler` that bridges into `os.Logger` so every message appears in Console.app with a filterable subsystem (`com.tabby.app`) and per-component category. The implementation adds `TabbyLogger` and `OSLogHandler` in `TabbyDebugOptions.swift`, bootstraps the logging system once in `AppDelegate.init`, and touches 25 Swift files to replace ad-hoc print statements with structured, level-appropriate log calls.

- **New infrastructure** (`TabbyDebugOptions.swift`): `TabbyLogger` provides seven named `Logger` instances; `OSLogHandler` correctly uses a fixed subsystem with a category derived from the label's third dotted component, matching Apple's Unified Logging convention. The `bootstrapOnce` pattern ensures thread-safe single initialization.
- **Privacy-sensitive paths**: `ScreenTextExtractor.log()` now correctly routes OCR preview text through `TabbyDebugOptions.log()` rather than a live logger, maintaining the existing debug gate for screen content.
- **Incidental change**: `DEVELOPMENT_TEAM` in `project.pbxproj` was updated to the PR author's personal team ID, which will break automatic code signing for all other contributors.

<h3>Confidence Score: 4/5</h3>

Safe to merge after reverting the DEVELOPMENT_TEAM change in project.pbxproj and restoring one teaching comment in InputMonitor.swift.

The logging infrastructure itself is sound — the bootstrap ordering is correct, the OSLogHandler convention is right, and privacy-sensitive OCR paths are correctly gated. The one concrete blocker is the DEVELOPMENT_TEAM replacement: committing the PR author's personal Apple team ID will cause code-signing failures for every other contributor who opens the project with automatic signing enabled.

tabby.xcodeproj/project.pbxproj — DEVELOPMENT_TEAM must be reverted to the original value before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tabby.xcodeproj/project.pbxproj | Adds swift-log SPM dependency correctly, but also replaces DEVELOPMENT_TEAM from the original team ID (G946M8K23B) to the PR author's personal team ID (C4BVFMK9V2) in both Debug and Release build configs — this will break code signing for all other contributors. |
| tabby/Support/TabbyDebugOptions.swift | Adds TabbyLogger enum with per-subsystem swift-log Logger instances and OSLogHandler bridging to os.Logger. The category extraction and fixed subsystem conventions look correct. bootstrapOnce pattern safely ensures one-time initialization. |
| tabby/Services/Input/InputMonitor.swift | Migrates print/comment to structured logging, but removes the teaching comment that explained why CGEvent taps are re-enabled on timeout (macOS disables slow callbacks; the pattern is deliberate self-healing, not a no-op retry). |
| tabby/Services/Visual/WindowScreenshotService.swift | Adds lifecycle and diagnostic logs. A trace-level log includes matchingWindow.title (an SCWindow property), which may contain user-visible document names, at odds with the PR's stated privacy guarantee. |
| tabby/Services/Visual/LlamaVisualContextSummarizer.swift | Log added for summarization warnings and results. A teaching comment explaining why result='' is correct on error was removed; the replacement log line does not preserve the design rationale. |
| tabby/App/Core/AppDelegate.swift | Adds TabbyLogger.bootstrap() at the correct call site (before any logger is first accessed) and lifecycle info logs around app startup/shutdown. |
| tabby/Services/Runtime/LlamaRuntimeManager.swift | Extensive runtime lifecycle logging added. The concurrency-deduplication comment was relocated (not deleted) — it now sits above the if let startupTask block rather than inside it, preserving the invariant documentation. |
| tabby/Services/Runtime/LlamaRuntimeCore.swift | KV-cache and generation lifecycle logging added. The inline comment explaining why front-trimming invalidates adjustedCachedPrefixBytes is preserved. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[AppDelegate.init] -->|TabbyLogger.bootstrap| B[LoggingSystem.bootstrap]
    B --> C[OSLogHandler factory registered]

    subgraph TabbyLogger
        D[TabbyLogger.app]
        E[TabbyLogger.runtime]
        F[TabbyLogger.suggestion]
        G[TabbyLogger.focus]
        H[TabbyLogger.models]
        I[TabbyLogger.updates]
        J[TabbyLogger.debug]
    end

    C --> D & E & F & G & H & I & J

    subgraph OSLogHandler
        K["os.Logger(subsystem: com.tabby.app, category: component)"]
    end

    D & E & F & G & H & I & J -->|log call| K
    K -->|privacy: .public| L[Apple Unified Log / Console.app]

    M[TabbyDebugOptions.log] -->|isEnabled gate| J
    M -.->|OCR preview text stays gated| M
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22james%2Fimprove-logging%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22james%2Fimprove-logging%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Atabby.xcodeproj%2Fproject.pbxproj%3A418%0A**Personal%20DEVELOPMENT_TEAM%20committed%20to%20shared%20project%20file**%0A%0A%60DEVELOPMENT_TEAM%60%20was%20changed%20from%20the%20original%20team%20ID%20%28%60G946M8K23B%60%29%20to%20%60C4BVFMK9V2%60%20in%20both%20the%20Debug%20and%20Release%20build%20configurations.%20Every%20other%20contributor%20who%20opens%20this%20project%20with%20%22Automatically%20manage%20signing%22%20will%20have%20Xcode%20attempt%20to%20sign%20under%20%60C4BVFMK9V2%60%2C%20fail%20to%20find%20the%20certificate%2C%20and%20get%20a%20signing%20error%20that%20blocks%20normal%20development%20builds.%20The%20original%20team%20ID%20should%20be%20restored%20before%20merging.%0A%0A%23%23%23%20Issue%202%20of%204%0Atabby%2FServices%2FInput%2FInputMonitor.swift%3A121-123%0A**Teaching%20comment%20removed%20from%20CGEvent%20tap%20self-healing%20path**%0A%0AThe%20removed%20comment%20explained%20two%20non-obvious%20facts%20required%20to%20understand%20this%20branch%3A%20%281%29%20*why*%20macOS%20disables%20the%20tap%20%28the%20callback%20ran%20too%20slowly%2C%20or%20a%20system%20event%20triggered%20it%29%2C%20and%20%282%29%20the%20deliberate%20design%20intent%20%E2%80%94%20%22self-healing%20instead%20of%20silently%20dying.%22%20The%20log%20line%20captures%20the%20runtime%20event%20but%20does%20not%20teach%20a%20reader%20why%20re-enabling%20is%20the%20correct%20response%20here.%20Per%20%60AGENTS.md%60%2C%20inline%20comments%20must%20explain%20the%20invariant%20being%20protected%20or%20the%20pitfall%20being%20avoided%2C%20not%20just%20label%20what%20the%20code%20does.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20case%20.tapDisabledByTimeout%2C%20.tapDisabledByUserInput%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20macOS%20may%20disable%20a%20tap%20if%20the%20callback%20runs%20too%20slowly%20or%20during%20certain%20system%20events.%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Re-enabling%20here%20keeps%20the%20monitor%20self-healing%20instead%20of%20silently%20dying.%0A%20%20%20%20%20%20%20%20%20%20%20%20TabbyLogger.app.warning%28%22CGEvent%20tap%20was%20disabled%20by%20system%2C%20re-enabling%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20let%20eventTap%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Atabby%2FServices%2FVisual%2FLlamaVisualContextSummarizer.swift%3A80-83%0A**Teaching%20comment%20removed%20%E2%80%94%20the%20%22why%22%20for%20%60result%20%3D%20%22%22%60**%0A%0AThe%20replaced%20comment%20explained%20the%20design%20rationale%3A%20because%20a%20real%20error%20%28e.g.%20model%20not%20loaded%29%20means%20no%20partial%20text%20is%20available%2C%20%60%22%22%60%20is%20the%20correct%20fallback%20rather%20than%20a%20partial%20or%20stale%20value.%20Without%20that%20explanation%20a%20reader%20might%20wonder%20whether%20partial%20results%20could%20be%20surfaced%20instead.%20The%20log%20message%20captures%20the%20occurrence%20but%20not%20the%20reasoning.%20Per%20%60AGENTS.md%60%2C%20comments%20should%20explain%20*why*%20the%20code%20is%20correct%2C%20not%20just%20label%20the%20outcome.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%7D%20catch%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Real%20error%20%28model%20not%20loaded%2C%20etc.%29%20%E2%80%94%20no%20partial%20text%20available.%0A%20%20%20%20%20%20%20%20%20%20%20%20TabbyLogger.app.warning%28%22Visual%20context%20summarization%20failed%3A%20%5C%28error.localizedDescription%29%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20result%20%3D%20%22%22%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Atabby%2FServices%2FVisual%2FWindowScreenshotService.swift%3A75%0A**Window%20title%20logged%20as%20%60privacy%3A%20.public%60%20%E2%80%94%20may%20expose%20user-visible%20document%20names**%0A%0A%60SCWindow.title%60%20reflects%20the%20title%20bar%20text%20of%20another%20app's%20window%20%28e.g.%20%60%22Q4%20Revenue%20Report.xlsx%20%E2%80%93%20Microsoft%20Excel%22%60%29.%20Since%20%60OSLogHandler%60%20marks%20all%20messages%20%60privacy%3A%20.public%60%2C%20this%20text%20persists%20in%20the%20unified%20log%20when%20anyone%20enables%20trace-level%20capture%20in%20Console.app.%20The%20PR%20description%20explicitly%20states%20%22No%20user%20content%20%E2%80%A6%20is%20logged%20%E2%80%94%20only%20lifecycle%20events%2C%20durations%2C%20and%20decision%20metadata.%22%20Window%20titles%20are%20user-visible%20content%20and%20contradict%20that%20guarantee.%20Logging%20only%20the%20dimensions%20preserves%20the%20diagnostic%20value%20without%20the%20data-exposure%20risk.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20TabbyLogger.app.trace%28%22Capturing%20window%3A%20%28%5C%28Int%28matchingWindow.frame.width%29%29x%5C%28Int%28matchingWindow.frame.height%29%29%29%22%29%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Atabby.xcodeproj%2Fproject.pbxproj%3A418%0A**Personal%20DEVELOPMENT_TEAM%20committed%20to%20shared%20project%20file**%0A%0A%60DEVELOPMENT_TEAM%60%20was%20changed%20from%20the%20original%20team%20ID%20%28%60G946M8K23B%60%29%20to%20%60C4BVFMK9V2%60%20in%20both%20the%20Debug%20and%20Release%20build%20configurations.%20Every%20other%20contributor%20who%20opens%20this%20project%20with%20%22Automatically%20manage%20signing%22%20will%20have%20Xcode%20attempt%20to%20sign%20under%20%60C4BVFMK9V2%60%2C%20fail%20to%20find%20the%20certificate%2C%20and%20get%20a%20signing%20error%20that%20blocks%20normal%20development%20builds.%20The%20original%20team%20ID%20should%20be%20restored%20before%20merging.%0A%0A%23%23%23%20Issue%202%20of%204%0Atabby%2FServices%2FInput%2FInputMonitor.swift%3A121-123%0A**Teaching%20comment%20removed%20from%20CGEvent%20tap%20self-healing%20path**%0A%0AThe%20removed%20comment%20explained%20two%20non-obvious%20facts%20required%20to%20understand%20this%20branch%3A%20%281%29%20*why*%20macOS%20disables%20the%20tap%20%28the%20callback%20ran%20too%20slowly%2C%20or%20a%20system%20event%20triggered%20it%29%2C%20and%20%282%29%20the%20deliberate%20design%20intent%20%E2%80%94%20%22self-healing%20instead%20of%20silently%20dying.%22%20The%20log%20line%20captures%20the%20runtime%20event%20but%20does%20not%20teach%20a%20reader%20why%20re-enabling%20is%20the%20correct%20response%20here.%20Per%20%60AGENTS.md%60%2C%20inline%20comments%20must%20explain%20the%20invariant%20being%20protected%20or%20the%20pitfall%20being%20avoided%2C%20not%20just%20label%20what%20the%20code%20does.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20case%20.tapDisabledByTimeout%2C%20.tapDisabledByUserInput%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20macOS%20may%20disable%20a%20tap%20if%20the%20callback%20runs%20too%20slowly%20or%20during%20certain%20system%20events.%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Re-enabling%20here%20keeps%20the%20monitor%20self-healing%20instead%20of%20silently%20dying.%0A%20%20%20%20%20%20%20%20%20%20%20%20TabbyLogger.app.warning%28%22CGEvent%20tap%20was%20disabled%20by%20system%2C%20re-enabling%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20let%20eventTap%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Atabby%2FServices%2FVisual%2FLlamaVisualContextSummarizer.swift%3A80-83%0A**Teaching%20comment%20removed%20%E2%80%94%20the%20%22why%22%20for%20%60result%20%3D%20%22%22%60**%0A%0AThe%20replaced%20comment%20explained%20the%20design%20rationale%3A%20because%20a%20real%20error%20%28e.g.%20model%20not%20loaded%29%20means%20no%20partial%20text%20is%20available%2C%20%60%22%22%60%20is%20the%20correct%20fallback%20rather%20than%20a%20partial%20or%20stale%20value.%20Without%20that%20explanation%20a%20reader%20might%20wonder%20whether%20partial%20results%20could%20be%20surfaced%20instead.%20The%20log%20message%20captures%20the%20occurrence%20but%20not%20the%20reasoning.%20Per%20%60AGENTS.md%60%2C%20comments%20should%20explain%20*why*%20the%20code%20is%20correct%2C%20not%20just%20label%20the%20outcome.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%7D%20catch%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Real%20error%20%28model%20not%20loaded%2C%20etc.%29%20%E2%80%94%20no%20partial%20text%20available.%0A%20%20%20%20%20%20%20%20%20%20%20%20TabbyLogger.app.warning%28%22Visual%20context%20summarization%20failed%3A%20%5C%28error.localizedDescription%29%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20result%20%3D%20%22%22%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%281%20more%20issue%20omitted%20due%20to%20length%20limits.%20Use%20individual%20%22Fix%20in%20Claude%20Code%22%20links%20for%20remaining%20issues.%29%0A&repo=fujacob%2Ftabby&pr=200&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Address review: fix OCR privacy leak, re..."](https://github.com/fujacob/tabby/commit/4002863aab8f1719a844fee9c9915f3f335b988a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33691503)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=45fae5fd-3007-4631-a2b0-92b2beb3df2a))

<!-- /greptile_comment -->