### PR TITLE
Skip event tap processing in terminals and disabled apps

### DIFF
--- a/Cotabby/App/Core/CotabbyAppEnvironment.swift
+++ b/Cotabby/App/Core/CotabbyAppEnvironment.swift
@@ -56,6 +56,16 @@ final class CotabbyAppEnvironment {
             ignoredBundleIdentifier: Bundle.main.bundleIdentifier,
             publishesPollingEvents: FocusDebugOverlayController.isEnabled
         )
+        inputMonitor.shouldProcessEventsProvider = { [weak focusModel] in
+            guard suggestionSettings.isGloballyEnabled else { return false }
+            guard let snapshot = focusModel?.snapshot else { return false }
+            if TerminalAppDetector.isTerminal(bundleIdentifier: snapshot.bundleIdentifier) { return false }
+            if let bundleID = snapshot.bundleIdentifier,
+               suggestionSettings.isApplicationDisabled(bundleIdentifier: bundleID) {
+                return false
+            }
+            return true
+        }
         let appUpdateManager = AppUpdateManager()
         let launchAtLoginService = LaunchAtLoginService()
         let welcomeCoordinator = WelcomeCoordinator(

--- a/Cotabby/App/Core/CotabbyAppEnvironment.swift
+++ b/Cotabby/App/Core/CotabbyAppEnvironment.swift
@@ -56,9 +56,12 @@ final class CotabbyAppEnvironment {
             ignoredBundleIdentifier: Bundle.main.bundleIdentifier,
             publishesPollingEvents: FocusDebugOverlayController.isEnabled
         )
+        // The snapshot is poll-based, so after a fast app switch the closure may briefly
+        // evaluate against the previous app's identity until the next AX poll fires. This
+        // is the same race the downstream evaluator already has — not a new regression.
         inputMonitor.shouldProcessEventsProvider = { [weak focusModel] in
             guard suggestionSettings.isGloballyEnabled else { return false }
-            guard let snapshot = focusModel?.snapshot else { return false }
+            guard let snapshot = focusModel?.snapshot else { return true }
             if TerminalAppDetector.isTerminal(bundleIdentifier: snapshot.bundleIdentifier) { return false }
             if let bundleID = snapshot.bundleIdentifier,
                suggestionSettings.isApplicationDisabled(bundleIdentifier: bundleID) {

--- a/Cotabby/Services/Input/InputMonitor.swift
+++ b/Cotabby/Services/Input/InputMonitor.swift
@@ -24,6 +24,11 @@ final class InputMonitor {
     /// Reads the current full-accept key code from the model at event time.
     var fullAcceptanceKeyCodeProvider: @MainActor () -> CGKeyCode = { CGKeyCode(UInt16.max) }
 
+    /// When false, the tap passes keystrokes through without classifying or notifying the
+    /// coordinator. This eliminates per-keystroke overhead in apps where Tabby will never act
+    /// (terminals, globally disabled, per-app disabled).
+    var shouldProcessEventsProvider: @MainActor () -> Bool = { true }
+
     private let permissionProvider: @MainActor () -> Bool
     private let suppressionController: InputSuppressionController
 
@@ -131,6 +136,14 @@ final class InputMonitor {
         case .keyDown:
             if suppressionController.consumeIfNeeded() {
                 onSuppressedSyntheticInput?()
+                return Unmanaged.passUnretained(event)
+            }
+
+            // Short-circuit before classification when Tabby won't act on events for the
+            // current app (terminals, globally disabled, per-app disabled). The tap callback
+            // runs synchronously before macOS delivers the keystroke, so any work here adds
+            // latency the user feels in the target app.
+            guard shouldProcessEventsProvider() else {
                 return Unmanaged.passUnretained(event)
             }
 


### PR DESCRIPTION
## Summary

The CGEvent tap callback runs synchronously before macOS delivers each keystroke to the target app. Previously every keypress was classified and routed through the coordinator even in terminals and disabled apps where Tabby will never act, adding per-keystroke latency.

Now `InputMonitor` checks a `shouldProcessEventsProvider` closure at the top of the tap callback. When it returns false (terminal focused, Tabby globally off, or app in the disabled list), the event passes through immediately with zero classification, zero callback overhead.

## Validation

```
xcodebuild -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

xcodebuild -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' build-for-testing CODE_SIGNING_ALLOWED=NO
# ** TEST BUILD SUCCEEDED **

swiftlint lint --quiet
# No new warnings
```

Manual verification requires opening a terminal (e.g. iTerm2, Terminal.app) and confirming no typing lag. The evaluator already blocked suggestions; this eliminates the remaining overhead in the tap callback path.

## Linked issues

Fixes typing lag in terminal apps caused by unnecessary event tap processing.

## Risk / rollout notes

- No behavior change for non-terminal, non-disabled apps — the `shouldProcessEventsProvider` defaults to `true`.
- The closure reads from `FocusTrackingModel.snapshot` and `SuggestionSettingsModel` at event time, same pattern used by the key code providers.
- `[weak focusModel]` capture returns `false` (skip processing) if the model is deallocated, which is safe since no coordinator would be running either.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR short-circuits the CGEvent tap callback for terminals, globally-disabled state, and per-app disabled apps, eliminating per-keystroke classification overhead in contexts where Tabby will never act.

- **`InputMonitor`** gains a `shouldProcessEventsProvider: @MainActor () -> Bool` property (defaulting to `true`) with a guard inserted after `suppressionController.consumeIfNeeded()`, preserving correct synthetic-event handling.
- **`CotabbyAppEnvironment`** wires the provider with `isGloballyEnabled`, `TerminalAppDetector.isTerminal`, and `isApplicationDisabled` checks, capturing `focusModel` weakly and `suggestionSettings` strongly; falls back to `true` (pass-through) when the focus model is deallocated.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the early-exit guard is correctly placed after suppression handling, defaults to pass-through, and has no behavior change for non-terminal, non-disabled apps.

Both changed files are straightforward: `InputMonitor` adds a single guard that is well-positioned and defaults to `true`, and `CotabbyAppEnvironment` wires a closure whose fallback on nil model is conservative. The only concern is a maintenance risk from duplicating gating logic already in `SuggestionAvailabilityEvaluator`, but there is no present defect.

No files require special attention, though future edits to `SuggestionAvailabilityEvaluator` should be cross-checked against the `shouldProcessEventsProvider` closure in `CotabbyAppEnvironment`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Services/Input/InputMonitor.swift | Adds `shouldProcessEventsProvider` property with a default of `true`; inserts an early-return guard in `handleTap` after the suppression check — minimal, well-placed, and correctly positioned after `consumeIfNeeded`. |
| Cotabby/App/Core/CotabbyAppEnvironment.swift | Wires `shouldProcessEventsProvider` with global-enabled, terminal, and per-app disabled checks. The gating logic is a partial re-implementation of `SuggestionAvailabilityEvaluator.disabledReason`, creating a maintenance risk if future conditions are added to the evaluator but not reflected here. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant OS as macOS CGEvent
    participant IT as InputMonitor (tap callback)
    participant SC as InputSuppressionController
    participant SP as shouldProcessEventsProvider
    participant CL as classify() + onEvent
    participant App as Target App

    OS->>IT: keyDown event (synchronous)
    IT->>SC: consumeIfNeeded()
    alt synthetic event
        SC-->>IT: consumed
        IT->>App: passUnretained (pass through)
    else real keystroke
        SC-->>IT: not consumed
        IT->>SP: shouldProcessEventsProvider()
        alt false (terminal / disabled / globally off)
            SP-->>IT: false
            IT->>App: passUnretained (pass through, zero overhead)
        else true (normal app)
            SP-->>IT: true
            IT->>CL: classify(event)
            CL-->>IT: CapturedInputEvent
            IT->>IT: onEvent?(capturedEvent)
            alt shouldIntercept
                IT->>App: nil (event consumed)
            else
                IT->>App: passUnretained
            end
        end
    end
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22fix%2Fskip-event-tap-in-terminals%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fskip-event-tap-in-terminals%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FApp%2FCore%2FCotabbyAppEnvironment.swift%3A62-71%0A**Gating%20logic%20duplicated%20from%20%60SuggestionAvailabilityEvaluator%60**%0A%0AThe%20three%20conditions%20checked%20here%20%28%60isGloballyEnabled%60%2C%20%60TerminalAppDetector.isTerminal%60%2C%20%60isApplicationDisabled%60%29%20are%20a%20subset%20of%20%60SuggestionAvailabilityEvaluator.disabledReason%60%2C%20which%20already%20owns%20these%20rules%20authoritatively.%20The%20ordering%20also%20differs%20%E2%80%94%20the%20evaluator%20checks%20disabled%20apps%20before%20terminal%2C%20while%20this%20closure%20checks%20terminal%20first.%20If%20a%20new%20gating%20category%20is%20added%20to%20the%20evaluator%20in%20the%20future%20%28e.g.%20a%20%22focus%20mode%22%20or%20additional%20blocked%20app%20class%29%2C%20the%20short-circuit%20closure%20won't%20be%20updated%20automatically%2C%20causing%20the%20tap%20to%20process%20events%20that%20the%20evaluator%20would%20ultimately%20discard.%20A%20more%20durable%20pattern%20would%20be%20to%20give%20the%20closure%20access%20to%20the%20evaluator%20%28possibly%20with%20a%20lightweight%20variant%20that%20accepts%20an%20optional%20snapshot%29%2C%20keeping%20gating%20logic%20in%20one%20place.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FApp%2FCore%2FCotabbyAppEnvironment.swift%3A62-71%0A**Gating%20logic%20duplicated%20from%20%60SuggestionAvailabilityEvaluator%60**%0A%0AThe%20three%20conditions%20checked%20here%20%28%60isGloballyEnabled%60%2C%20%60TerminalAppDetector.isTerminal%60%2C%20%60isApplicationDisabled%60%29%20are%20a%20subset%20of%20%60SuggestionAvailabilityEvaluator.disabledReason%60%2C%20which%20already%20owns%20these%20rules%20authoritatively.%20The%20ordering%20also%20differs%20%E2%80%94%20the%20evaluator%20checks%20disabled%20apps%20before%20terminal%2C%20while%20this%20closure%20checks%20terminal%20first.%20If%20a%20new%20gating%20category%20is%20added%20to%20the%20evaluator%20in%20the%20future%20%28e.g.%20a%20%22focus%20mode%22%20or%20additional%20blocked%20app%20class%29%2C%20the%20short-circuit%20closure%20won't%20be%20updated%20automatically%2C%20causing%20the%20tap%20to%20process%20events%20that%20the%20evaluator%20would%20ultimately%20discard.%20A%20more%20durable%20pattern%20would%20be%20to%20give%20the%20closure%20access%20to%20the%20evaluator%20%28possibly%20with%20a%20lightweight%20variant%20that%20accepts%20an%20optional%20snapshot%29%2C%20keeping%20gating%20logic%20in%20one%20place.%0A%0A&repo=fujacob%2Ftabby&pr=201&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (4): Last reviewed commit: ["Address review: fall through on nil snap..."](https://github.com/fujacob/tabby/commit/de0e9dfc7aa4ac1f3e4a17d24c09e7dd9b72fb46) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33691949)</sub>

<!-- /greptile_comment -->