### PR TITLE
Add MLX model engine scaffolding

### DIFF
--- a/tabby/App/Coordinators/SettingsCoordinator.swift
+++ b/tabby/App/Coordinators/SettingsCoordinator.swift
@@ -17,6 +17,7 @@ final class SettingsCoordinator: NSObject, NSWindowDelegate {
     private let suggestionSettings: SuggestionSettingsModel
     private let foundationModelAvailabilityService: FoundationModelAvailabilityService
     private let runtimeModel: RuntimeBootstrapModel
+    private let mlxRuntimeManager: MLXRuntimeManager
     private let modelDownloadManager: ModelDownloadManager
     private let onShowWelcome: () -> Void
 
@@ -29,6 +30,7 @@ final class SettingsCoordinator: NSObject, NSWindowDelegate {
         suggestionSettings: SuggestionSettingsModel,
         foundationModelAvailabilityService: FoundationModelAvailabilityService,
         runtimeModel: RuntimeBootstrapModel,
+        mlxRuntimeManager: MLXRuntimeManager,
         modelDownloadManager: ModelDownloadManager,
         onShowWelcome: @escaping () -> Void
     ) {
@@ -38,6 +40,7 @@ final class SettingsCoordinator: NSObject, NSWindowDelegate {
         self.suggestionSettings = suggestionSettings
         self.foundationModelAvailabilityService = foundationModelAvailabilityService
         self.runtimeModel = runtimeModel
+        self.mlxRuntimeManager = mlxRuntimeManager
         self.modelDownloadManager = modelDownloadManager
         self.onShowWelcome = onShowWelcome
     }
@@ -60,6 +63,7 @@ final class SettingsCoordinator: NSObject, NSWindowDelegate {
                 suggestionSettings: suggestionSettings,
                 foundationModelAvailabilityService: foundationModelAvailabilityService,
                 runtimeModel: runtimeModel,
+                mlxRuntimeManager: mlxRuntimeManager,
                 modelDownloadManager: modelDownloadManager,
                 onShowWelcome: onShowWelcome
             )

--- a/tabby/App/Coordinators/WelcomeCoordinator.swift
+++ b/tabby/App/Coordinators/WelcomeCoordinator.swift
@@ -18,6 +18,7 @@ final class WelcomeCoordinator: NSObject, NSWindowDelegate {
     private let permissionManager: PermissionManager
     private let permissionGuidanceController: PermissionGuidanceController
     private let runtimeModel: RuntimeBootstrapModel
+    private let mlxRuntimeManager: MLXRuntimeManager
     private let modelDownloadManager: ModelDownloadManager
     private let suggestionSettings: SuggestionSettingsModel
     private let foundationModelAvailabilityService: FoundationModelAvailabilityService
@@ -32,6 +33,7 @@ final class WelcomeCoordinator: NSObject, NSWindowDelegate {
         permissionManager: PermissionManager,
         permissionGuidanceController: PermissionGuidanceController,
         runtimeModel: RuntimeBootstrapModel,
+        mlxRuntimeManager: MLXRuntimeManager,
         modelDownloadManager: ModelDownloadManager,
         suggestionSettings: SuggestionSettingsModel,
         foundationModelAvailabilityService: FoundationModelAvailabilityService,
@@ -40,6 +42,7 @@ final class WelcomeCoordinator: NSObject, NSWindowDelegate {
         self.permissionManager = permissionManager
         self.permissionGuidanceController = permissionGuidanceController
         self.runtimeModel = runtimeModel
+        self.mlxRuntimeManager = mlxRuntimeManager
         self.modelDownloadManager = modelDownloadManager
         self.suggestionSettings = suggestionSettings
         self.foundationModelAvailabilityService = foundationModelAvailabilityService
@@ -96,6 +99,7 @@ final class WelcomeCoordinator: NSObject, NSWindowDelegate {
             rootView: WelcomeView(
                 permissionManager: permissionManager,
                 runtimeModel: runtimeModel,
+                mlxRuntimeManager: mlxRuntimeManager,
                 modelDownloadManager: modelDownloadManager,
                 suggestionSettings: suggestionSettings,
                 foundationModelAvailabilityService: foundationModelAvailabilityService,

--- a/tabby/App/Core/AppDelegate.swift
+++ b/tabby/App/Core/AppDelegate.swift
@@ -195,6 +195,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// warm the runtime only if the current engine choice needs it.
     private func handleModelDirectoryChange() {
         runtimeModel.refreshAvailableModels()
+        mlxRuntimeManager.refreshAvailableModels()
         startRuntimeIfPreferredEngineRequiresIt()
     }
 }

--- a/tabby/App/Core/AppDelegate.swift
+++ b/tabby/App/Core/AppDelegate.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Combine
+import os
 
 /// File overview:
 /// Starts the long-lived services that power permissions, focus tracking, suggestion generation,
@@ -15,6 +16,7 @@ import Combine
 final class AppDelegate: NSObject, NSApplicationDelegate {
     let permissionManager: PermissionManager
     let runtimeModel: RuntimeBootstrapModel
+    let mlxRuntimeManager: MLXRuntimeManager
     let modelDownloadManager: ModelDownloadManager
     let focusModel: FocusTrackingModel
     let inputMonitor: InputMonitor
@@ -38,6 +40,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let environment = TabbyAppEnvironment()
         permissionManager = environment.permissionManager
         runtimeModel = environment.runtimeModel
+        mlxRuntimeManager = environment.mlxRuntimeManager
         modelDownloadManager = environment.modelDownloadManager
         focusModel = environment.focusModel
         inputMonitor = environment.inputMonitor
@@ -119,13 +122,41 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     /// Stops long-lived services before process exit so timers and runtime resources detach cleanly.
-    func applicationWillTerminate(_ notification: Notification) {
+    ///
+    /// AppKit lets an app defer termination by returning `.terminateLater`. We use that path because
+    /// native runtime cleanup may need to release Metal/GPU resources before the process starts
+    /// tearing down C++ static state. The timeout keeps a stuck native call from blocking quit forever.
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         activationIndicatorController.hide(reason: "Activation indicator hidden because Tabby is terminating.")
         focusDebugOverlayController?.hide()
         suggestionCoordinator.stop()
         inputMonitor.stop()
         focusModel.stop()
-        runtimeModel.stop()
+
+        let didReply = OSAllocatedUnfairLock(initialState: false)
+
+        func replyOnce() {
+            let alreadyReplied = didReply.withLock { replied -> Bool in
+                let was = replied
+                replied = true
+                return was
+            }
+            guard !alreadyReplied else { return }
+            sender.reply(toApplicationShouldTerminate: true)
+        }
+
+        Task.detached {
+            await self.runtimeModel.stopAndWait()
+            await self.mlxRuntimeManager.stopAndWait()
+            await MainActor.run { replyOnce() }
+        }
+
+        Task {
+            try? await Task.sleep(nanoseconds: 5_000_000_000)
+            replyOnce()
+        }
+
+        return .terminateLater
     }
 
     /// Shows or hides the field-edge tabby icon based on focus state, global enable, per-app
@@ -147,14 +178,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
     }
 
-    /// Warm the local runtime only when the user is actually on the open-source engine path.
+    /// Warm the local runtime only when the user is actually on a local engine path.
     /// This avoids noisy startup failures and wasted work for Apple Intelligence users.
     private func startRuntimeIfPreferredEngineRequiresIt() {
-        guard suggestionSettings.selectedEngine == .llamaOpenSource else {
-            return
+        switch suggestionSettings.selectedEngine {
+        case .llamaOpenSource:
+            runtimeModel.startIfNeeded()
+        case .mlxSwift:
+            Task { try? await mlxRuntimeManager.prepare() }
+        case .appleIntelligence:
+            break
         }
-
-        runtimeModel.startIfNeeded()
     }
 
     /// Model availability can change after downloads or manual file drops. Re-scan first, then

--- a/tabby/App/Core/TabbyAppEnvironment.swift
+++ b/tabby/App/Core/TabbyAppEnvironment.swift
@@ -12,6 +12,7 @@ import Foundation
 final class TabbyAppEnvironment {
     let permissionManager: PermissionManager
     let runtimeModel: RuntimeBootstrapModel
+    let mlxRuntimeManager: MLXRuntimeManager
     let modelDownloadManager: ModelDownloadManager
     let focusModel: FocusTrackingModel
     let inputMonitor: InputMonitor
@@ -37,6 +38,7 @@ final class TabbyAppEnvironment {
         )
         let runtimeManager = LlamaRuntimeManager()
         let runtimeModel = RuntimeBootstrapModel(runtimeManager: runtimeManager)
+        let mlxRuntimeManager = MLXRuntimeManager()
         let modelDownloadManager = ModelDownloadManager()
         let suggestionSettings = SuggestionSettingsModel(configuration: configuration)
         let foundationModelAvailabilityService = FoundationModelAvailabilityService()
@@ -68,6 +70,7 @@ final class TabbyAppEnvironment {
             suggestionSettings: suggestionSettings,
             foundationModelAvailabilityService: foundationModelAvailabilityService,
             runtimeModel: runtimeModel,
+            mlxRuntimeManager: mlxRuntimeManager,
             modelDownloadManager: modelDownloadManager,
             onShowWelcome: { [weak welcomeCoordinator] in
                 welcomeCoordinator?.showWelcome()
@@ -100,10 +103,15 @@ final class TabbyAppEnvironment {
         )
         #endif
 
+        let mlxEngine: any SuggestionGenerating = MLXSuggestionEngine(
+            runtimeManager: mlxRuntimeManager
+        )
+
         let suggestionEngine: any SuggestionGenerating = SuggestionEngineRouter(
             suggestionSettings: suggestionSettings,
             foundationModelEngine: foundationModelEngine,
-            llamaEngine: LlamaSuggestionEngine(runtimeManager: runtimeManager)
+            llamaEngine: LlamaSuggestionEngine(runtimeManager: runtimeManager),
+            mlxEngine: mlxEngine
         )
 
         let interactionState = SuggestionInteractionState()
@@ -125,6 +133,7 @@ final class TabbyAppEnvironment {
 
         self.permissionManager = permissionManager
         self.runtimeModel = runtimeModel
+        self.mlxRuntimeManager = mlxRuntimeManager
         self.modelDownloadManager = modelDownloadManager
         self.focusModel = focusModel
         self.inputMonitor = inputMonitor

--- a/tabby/App/Core/TabbyAppEnvironment.swift
+++ b/tabby/App/Core/TabbyAppEnvironment.swift
@@ -59,6 +59,7 @@ final class TabbyAppEnvironment {
             permissionManager: permissionManager,
             permissionGuidanceController: permissionGuidanceController,
             runtimeModel: runtimeModel,
+            mlxRuntimeManager: mlxRuntimeManager,
             modelDownloadManager: modelDownloadManager,
             suggestionSettings: suggestionSettings,
             foundationModelAvailabilityService: foundationModelAvailabilityService

--- a/tabby/Models/LlamaRuntimeModels.swift
+++ b/tabby/Models/LlamaRuntimeModels.swift
@@ -4,6 +4,13 @@ import Foundation
 /// Shared value types for runtime bootstrap, model selection, diagnostics, and runtime errors.
 /// These types keep runtime state serializable, testable, and separate from the service layer.
 ///
+/// Distinguishes the on-disk layout so discovery, download, and runtime loading
+/// can branch on format without inspecting file contents.
+enum ModelFormat: String, Sendable, Equatable, Hashable {
+    case gguf
+    case mlx
+}
+
 /// Human-readable lifecycle states surfaced to the UI during runtime bootstrap.
 enum RuntimeBootstrapState: Equatable, Sendable {
     case idle
@@ -31,6 +38,7 @@ enum RuntimeBootstrapState: Equatable, Sendable {
 struct RuntimeModelOption: Equatable, Hashable, Sendable, Identifiable {
     let filename: String
     let url: URL
+    let format: ModelFormat
 
     var id: String { filename }
     var displayName: String { RuntimeModelCatalog.displayName(for: filename) }
@@ -42,7 +50,8 @@ struct RuntimeModelOption: Equatable, Hashable, Sendable, Identifiable {
 struct DownloadableRuntimeModel: Equatable, Hashable, Sendable, Identifiable {
     let filename: String
     let displayName: String
-    let downloadURL: URL
+    let format: ModelFormat
+    let artifact: ModelArtifactKind
     let approximateSizeInGigabytes: Double
     /// Exact byte count of the served file. Optional so future catalog entries
     /// can land while metadata is still being filled in. When non-nil, the
@@ -63,6 +72,15 @@ struct DownloadableRuntimeModel: Equatable, Hashable, Sendable, Identifiable {
         [filename] + alternateFilenames
     }
 
+    /// Returns the download URL for single-file artifacts.
+    var downloadURL: URL? {
+        switch artifact {
+        case .singleFile(let url): return url
+        case .multiFile: return nil
+        }
+    }
+
+    /// Convenience initializer for single-file GGUF models (preserves existing call sites).
     init(
         filename: String,
         displayName: String,
@@ -74,12 +92,49 @@ struct DownloadableRuntimeModel: Equatable, Hashable, Sendable, Identifiable {
     ) {
         self.filename = filename
         self.displayName = displayName
-        self.downloadURL = downloadURL
+        self.format = .gguf
+        self.artifact = .singleFile(url: downloadURL)
         self.approximateSizeInGigabytes = approximateSizeInGigabytes
         self.expectedSizeBytes = expectedSizeBytes
         self.sha256 = sha256
         self.alternateFilenames = alternateFilenames
     }
+
+    init(
+        filename: String,
+        displayName: String,
+        format: ModelFormat,
+        artifact: ModelArtifactKind,
+        approximateSizeInGigabytes: Double,
+        expectedSizeBytes: Int64? = nil,
+        sha256: String? = nil,
+        alternateFilenames: [String] = []
+    ) {
+        self.filename = filename
+        self.displayName = displayName
+        self.format = format
+        self.artifact = artifact
+        self.approximateSizeInGigabytes = approximateSizeInGigabytes
+        self.expectedSizeBytes = expectedSizeBytes
+        self.sha256 = sha256
+        self.alternateFilenames = alternateFilenames
+    }
+}
+
+/// Describes how a model's files are fetched from a remote source.
+enum ModelArtifactKind: Equatable, Hashable, Sendable {
+    /// A single file download (e.g. one .gguf file).
+    case singleFile(url: URL)
+    /// Multiple files downloaded into a named directory (e.g. MLX model repos).
+    case multiFile(files: [RemoteModelFile])
+}
+
+/// One file within a multi-file model artifact.
+struct RemoteModelFile: Equatable, Hashable, Sendable {
+    let url: URL
+    let relativePath: String
+    let expectedSizeBytes: Int64?
+    let sha256: String?
 }
 
 enum RuntimeModelCatalog {
@@ -89,16 +144,16 @@ enum RuntimeModelCatalog {
             return "tabby-fast-1"
         case "gemma-3-1b-it-Q4_K_M.gguf":
             return "tabby-balanced-1"
-        // case "Qwen3.5-0.8B-Q4_K_M.gguf":
-        //     return "tabby-fast"
-        // case "gemma-4-E2B-it-Q4_K_M.gguf":
-        //     return "tabby-quality"
+        case "Qwen2.5-0.5B-Instruct-4bit":
+            return "tabby-mlx-fast"
+        case "gemma-3-1b-it-4bit":
+            return "tabby-mlx-balanced"
         default:
             return filename
         }
     }
 
-    /// Canonical downloadable model list shown in Welcome and menu UI.
+    /// Canonical downloadable GGUF model list shown in Welcome and menu UI.
     ///
     /// `expectedSizeBytes` and `sha256` were captured from HuggingFace's CDN
     /// response headers (`x-linked-size` and `x-linked-etag` respectively).
@@ -128,24 +183,90 @@ enum RuntimeModelCatalog {
             expectedSizeBytes: 806_058_272,
             sha256: "8270790f3ab69fdfe860b7b64008d9a19986d8df7e407bb018184caa08798ebd"
         )
-        // Newer models — commented out pending further testing:
-        // DownloadableRuntimeModel(
-        //     filename: "Qwen3.5-0.8B-Q4_K_M.gguf",
-        //     displayName: "tabby-fast",
-        //     downloadURL: URL(string: "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/Qwen3.5-0.8B-Q4_K_M.gguf?download=true")!,
-        //     approximateSizeInGigabytes: 0.5,
-        //     expectedSizeBytes: 532_517_120,
-        //     sha256: "bd258782e35f7f458f8aced1adc053e6e92e89bc735ba3be89d38a06121dc517"
-        // ),
-        // DownloadableRuntimeModel(
-        //     filename: "gemma-4-E2B-it-Q4_K_M.gguf",
-        //     displayName: "tabby-quality",
-        //     downloadURL: URL(string: "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/gemma-4-E2B-it-Q4_K_M.gguf?download=true")!,
-        //     approximateSizeInGigabytes: 3.1,
-        //     expectedSizeBytes: 3_106_736_256,
-        //     sha256: "9378bc471710229ef165709b62e34bfb62231420ddaf6d729e727305b5b8672d"
-        // )
     ]
+
+    // swiftlint:disable function_body_length
+    /// Canonical downloadable MLX model list. Each model is a directory of files
+    /// downloaded from HuggingFace's mlx-community organization.
+    static let downloadableMLXModels: [DownloadableRuntimeModel] = [
+        DownloadableRuntimeModel(
+            filename: "Qwen2.5-0.5B-Instruct-4bit",
+            displayName: displayName(for: "Qwen2.5-0.5B-Instruct-4bit"),
+            format: .mlx,
+            artifact: .multiFile(files: [
+                RemoteModelFile(
+                    url: URL(string: "https://huggingface.co/mlx-community/Qwen2.5-0.5B-Instruct-4bit/resolve/main/config.json")!,
+                    relativePath: "config.json",
+                    expectedSizeBytes: 783,
+                    sha256: nil
+                ),
+                RemoteModelFile(
+                    url: URL(string: "https://huggingface.co/mlx-community/Qwen2.5-0.5B-Instruct-4bit/resolve/main/model.safetensors")!,
+                    relativePath: "model.safetensors",
+                    expectedSizeBytes: 278_064_920,
+                    sha256: nil
+                ),
+                RemoteModelFile(
+                    url: URL(string: "https://huggingface.co/mlx-community/Qwen2.5-0.5B-Instruct-4bit/resolve/main/tokenizer.json")!,
+                    relativePath: "tokenizer.json",
+                    expectedSizeBytes: 7_031_673,
+                    sha256: nil
+                ),
+                RemoteModelFile(
+                    url: URL(string: "https://huggingface.co/mlx-community/Qwen2.5-0.5B-Instruct-4bit/resolve/main/tokenizer_config.json")!,
+                    relativePath: "tokenizer_config.json",
+                    expectedSizeBytes: 7_308,
+                    sha256: nil
+                ),
+                RemoteModelFile(
+                    url: URL(string: "https://huggingface.co/mlx-community/Qwen2.5-0.5B-Instruct-4bit/resolve/main/special_tokens_map.json")!,
+                    relativePath: "special_tokens_map.json",
+                    expectedSizeBytes: 613,
+                    sha256: nil
+                )
+            ]),
+            approximateSizeInGigabytes: 0.3
+        ),
+        DownloadableRuntimeModel(
+            filename: "gemma-3-1b-it-4bit",
+            displayName: displayName(for: "gemma-3-1b-it-4bit"),
+            format: .mlx,
+            artifact: .multiFile(files: [
+                RemoteModelFile(
+                    url: URL(string: "https://huggingface.co/mlx-community/gemma-3-1b-it-4bit/resolve/main/config.json")!,
+                    relativePath: "config.json",
+                    expectedSizeBytes: 1_098,
+                    sha256: nil
+                ),
+                RemoteModelFile(
+                    url: URL(string: "https://huggingface.co/mlx-community/gemma-3-1b-it-4bit/resolve/main/model.safetensors")!,
+                    relativePath: "model.safetensors",
+                    expectedSizeBytes: 732_577_304,
+                    sha256: nil
+                ),
+                RemoteModelFile(
+                    url: URL(string: "https://huggingface.co/mlx-community/gemma-3-1b-it-4bit/resolve/main/tokenizer.json")!,
+                    relativePath: "tokenizer.json",
+                    expectedSizeBytes: 33_384_568,
+                    sha256: nil
+                ),
+                RemoteModelFile(
+                    url: URL(string: "https://huggingface.co/mlx-community/gemma-3-1b-it-4bit/resolve/main/tokenizer_config.json")!,
+                    relativePath: "tokenizer_config.json",
+                    expectedSizeBytes: 1_156_999,
+                    sha256: nil
+                ),
+                RemoteModelFile(
+                    url: URL(string: "https://huggingface.co/mlx-community/gemma-3-1b-it-4bit/resolve/main/special_tokens_map.json")!,
+                    relativePath: "special_tokens_map.json",
+                    expectedSizeBytes: 662,
+                    sha256: nil
+                )
+            ]),
+            approximateSizeInGigabytes: 0.7
+        )
+    ]
+    // swiftlint:enable function_body_length
 }
 
 /// Startup configuration that controls which GGUF model to load and how large the runtime should be.

--- a/tabby/Models/SuggestionEngineModels.swift
+++ b/tabby/Models/SuggestionEngineModels.swift
@@ -6,10 +6,11 @@ import Foundation
 ///
 /// The important architectural distinction is:
 /// - a local GGUF file is a model option inside the llama runtime
-/// - Apple Intelligence vs. local llama is an engine choice above the runtime layer
+/// - Apple Intelligence vs. local llama vs. MLX is an engine choice above the runtime layer
 enum SuggestionEngineKind: String, CaseIterable, Equatable, Hashable, Sendable, Identifiable {
     case appleIntelligence
     case llamaOpenSource
+    case mlxSwift
 
     var id: String { rawValue }
 
@@ -19,6 +20,8 @@ enum SuggestionEngineKind: String, CaseIterable, Equatable, Hashable, Sendable, 
             return "Apple Intelligence [BETA]"
         case .llamaOpenSource:
             return "Open Source"
+        case .mlxSwift:
+            return "MLX (Apple Silicon)"
         }
     }
 
@@ -26,8 +29,19 @@ enum SuggestionEngineKind: String, CaseIterable, Equatable, Hashable, Sendable, 
         switch self {
         case .appleIntelligence:
             return false
-        case .llamaOpenSource:
+        case .llamaOpenSource, .mlxSwift:
             return true
+        }
+    }
+
+    var modelFormat: ModelFormat? {
+        switch self {
+        case .appleIntelligence:
+            return nil
+        case .llamaOpenSource:
+            return .gguf
+        case .mlxSwift:
+            return .mlx
         }
     }
 }

--- a/tabby/Services/Runtime/MLXRuntimeCore.swift
+++ b/tabby/Services/Runtime/MLXRuntimeCore.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+/// File overview:
+/// Low-level actor that owns the MLX model lifecycle: loading weights from a local directory,
+/// tokenizing prompts, running inference, and releasing GPU/memory resources on shutdown.
+///
+/// This mirrors `LlamaRuntimeCore`'s role but targets Apple's MLX framework for Apple Silicon.
+/// All mutable native state is isolated inside this actor so concurrent generation requests
+/// are serialized without external locks.
+
+#if canImport(MLX)
+import MLX
+import MLXLLM
+import MLXLMCommon
+#endif
+
+/// Metadata returned after a successful model load.
+struct PreparedMLXRuntime: Equatable, Sendable {
+    let modelDirectoryURL: URL
+    let modelDisplayName: String
+}
+
+actor MLXRuntimeCore {
+    private var isShutdown = false
+
+    #if canImport(MLX)
+    private var loadedModel: MLXLMCommon.ModelContainer?
+    #endif
+
+    /// Loads an MLX model from a local directory containing config.json and safetensors weights.
+    func prepare(modelDirectoryURL: URL) async throws -> PreparedMLXRuntime {
+        #if canImport(MLX)
+        isShutdown = false
+        let modelName = modelDirectoryURL.lastPathComponent
+
+        let configuration = ModelConfiguration(directory: modelDirectoryURL)
+        let container = try await MLXLMCommon.ModelFactory.shared.loadContainer(
+            configuration: configuration
+        )
+        loadedModel = container
+
+        return PreparedMLXRuntime(
+            modelDirectoryURL: modelDirectoryURL,
+            modelDisplayName: RuntimeModelCatalog.displayName(for: modelName)
+        )
+        #else
+        throw LlamaRuntimeError.unavailable(
+            "MLX framework is not available. Add the mlx-swift SPM dependency to enable MLX inference."
+        )
+        #endif
+    }
+
+    /// Generates text from a prompt using the loaded MLX model.
+    func generate(
+        prompt: String,
+        maxTokens: Int,
+        temperature: Float
+    ) async throws -> String {
+        #if canImport(MLX)
+        guard let container = loadedModel else {
+            throw LlamaRuntimeError.unavailable("No MLX model is loaded.")
+        }
+
+        let result = try await container.perform { (model, tokenizer) in
+            let promptTokens = tokenizer.encode(text: prompt)
+            var generatedTokens: [Int] = []
+
+            let generateParameters = GenerateParameters(temperature: temperature)
+            try MLXLMCommon.generate(
+                input: LMInput(tokens: MLXArray(promptTokens)),
+                parameters: generateParameters,
+                model: model,
+                tokenizer: tokenizer,
+                extraEOSTokens: nil
+            ) { tokens in
+                generatedTokens.append(contentsOf: tokens.map { Int($0) })
+                if generatedTokens.count >= maxTokens {
+                    return .stop
+                }
+                return .more
+            }
+
+            return tokenizer.decode(tokens: generatedTokens)
+        }
+
+        return result
+        #else
+        throw LlamaRuntimeError.unavailable(
+            "MLX framework is not available."
+        )
+        #endif
+    }
+
+    /// Releases the loaded model and frees GPU/unified memory.
+    func shutdown() {
+        isShutdown = true
+        #if canImport(MLX)
+        loadedModel = nil
+        #endif
+    }
+}

--- a/tabby/Services/Runtime/MLXRuntimeCore.swift
+++ b/tabby/Services/Runtime/MLXRuntimeCore.swift
@@ -21,8 +21,6 @@ struct PreparedMLXRuntime: Equatable, Sendable {
 }
 
 actor MLXRuntimeCore {
-    private var isShutdown = false
-
     #if canImport(MLX)
     private var loadedModel: MLXLMCommon.ModelContainer?
     #endif
@@ -30,7 +28,6 @@ actor MLXRuntimeCore {
     /// Loads an MLX model from a local directory containing config.json and safetensors weights.
     func prepare(modelDirectoryURL: URL) async throws -> PreparedMLXRuntime {
         #if canImport(MLX)
-        isShutdown = false
         let modelName = modelDirectoryURL.lastPathComponent
 
         let configuration = ModelConfiguration(directory: modelDirectoryURL)
@@ -93,7 +90,6 @@ actor MLXRuntimeCore {
 
     /// Releases the loaded model and frees GPU/unified memory.
     func shutdown() {
-        isShutdown = true
         #if canImport(MLX)
         loadedModel = nil
         #endif

--- a/tabby/Services/Runtime/MLXRuntimeManager.swift
+++ b/tabby/Services/Runtime/MLXRuntimeManager.swift
@@ -1,0 +1,176 @@
+import Combine
+import Foundation
+
+/// File overview:
+/// Publishes MLX runtime bootstrap state and manages the model lifecycle for the MLX engine.
+/// Mirrors `LlamaRuntimeManager` but targets directory-based MLX models instead of single GGUF files.
+@MainActor
+final class MLXRuntimeManager: ObservableObject {
+    @Published private(set) var state: RuntimeBootstrapState = .idle
+    @Published private(set) var availableModels: [RuntimeModelOption] = []
+
+    private let runtimeLocator: BundledRuntimeLocator
+    private let core: MLXRuntimeCore
+    private var startupTask: Task<PreparedMLXRuntime, Error>?
+    private var startupModelName: String?
+    private var cachedRuntime: PreparedMLXRuntime?
+    private var selectedModelName: String?
+
+    convenience init() {
+        self.init(runtimeLocator: BundledRuntimeLocator())
+    }
+
+    init(runtimeLocator: BundledRuntimeLocator) {
+        self.runtimeLocator = runtimeLocator
+        core = MLXRuntimeCore()
+        refreshAvailableModels()
+    }
+
+    func refreshAvailableModels() {
+        availableModels = runtimeLocator.availableMLXModels()
+        selectedModelName = normalizedModelName(selectedModelName)
+    }
+
+    func configureSelectedModel(name: String?) {
+        selectedModelName = normalizedModelName(name)
+    }
+
+    func prepare() async throws {
+        _ = try await preparedRuntime()
+    }
+
+    func selectModel(name: String) async throws {
+        guard let normalizedName = normalizedModelName(name) else {
+            let error = LlamaRuntimeError.unavailable(
+                "The selected MLX model \(name) is unavailable.")
+            throw error
+        }
+
+        selectedModelName = normalizedName
+
+        if cachedRuntime?.modelDirectoryURL.lastPathComponent == normalizedName {
+            return
+        }
+
+        startupTask?.cancel()
+        startupTask = nil
+        startupModelName = nil
+        cachedRuntime = nil
+
+        _ = try await preparedRuntime()
+    }
+
+    func generate(
+        prompt: String,
+        maxTokens: Int,
+        temperature: Float
+    ) async throws -> String {
+        _ = try await preparedRuntime()
+
+        do {
+            return try await core.generate(
+                prompt: prompt,
+                maxTokens: maxTokens,
+                temperature: temperature
+            )
+        } catch is CancellationError {
+            throw LlamaRuntimeError.cancelled
+        } catch let error as LlamaRuntimeError {
+            throw error
+        } catch {
+            throw LlamaRuntimeError.generationFailed(error.localizedDescription)
+        }
+    }
+
+    func stop() {
+        prepareForStop()
+        Task { await core.shutdown() }
+    }
+
+    func stopAndWait() async {
+        prepareForStop()
+        await core.shutdown()
+    }
+
+    private func prepareForStop() {
+        startupTask?.cancel()
+        startupTask = nil
+        startupModelName = nil
+        cachedRuntime = nil
+        state = .idle
+    }
+
+    private func preparedRuntime() async throws -> PreparedMLXRuntime {
+        guard let modelOption = resolveSelectedModel() else {
+            let error = LlamaRuntimeError.unavailable("No MLX model is available.")
+            state = .failed(error.localizedDescription)
+            throw error
+        }
+
+        let requestedName = modelOption.filename
+
+        if let cachedRuntime,
+           cachedRuntime.modelDirectoryURL.lastPathComponent == requestedName {
+            return cachedRuntime
+        }
+
+        if let startupTask {
+            if startupModelName == requestedName {
+                return try await awaitStartup(startupTask)
+            }
+            startupTask.cancel()
+            self.startupTask = nil
+            startupModelName = nil
+        }
+
+        cachedRuntime = nil
+        state = .starting("Initializing the MLX runtime.")
+
+        let modelURL = modelOption.url
+        let startupTask = Task { [core] in
+            try await core.prepare(modelDirectoryURL: modelURL)
+        }
+        self.startupTask = startupTask
+        startupModelName = requestedName
+        state = .loading("Loading \(modelOption.displayName) into memory.")
+
+        return try await awaitStartup(startupTask)
+    }
+
+    private func resolveSelectedModel() -> RuntimeModelOption? {
+        if let selectedModelName,
+           let match = availableModels.first(where: { $0.filename == selectedModelName }) {
+            return match
+        }
+        return availableModels.first
+    }
+
+    private func normalizedModelName(_ name: String?) -> String? {
+        guard !availableModels.isEmpty else { return nil }
+        guard let name else { return availableModels.first?.filename }
+        if availableModels.contains(where: { $0.filename == name }) { return name }
+        return availableModels.first?.filename
+    }
+
+    private func awaitStartup(
+        _ startupTask: Task<PreparedMLXRuntime, Error>
+    ) async throws -> PreparedMLXRuntime {
+        do {
+            let prepared = try await startupTask.value
+            cachedRuntime = prepared
+            self.startupTask = nil
+            startupModelName = nil
+            state = .ready("Loaded \(prepared.modelDisplayName) via MLX.")
+            return prepared
+        } catch is CancellationError {
+            self.startupTask = nil
+            startupModelName = nil
+            throw LlamaRuntimeError.cancelled
+        } catch {
+            self.startupTask = nil
+            startupModelName = nil
+            state = .failed(error.localizedDescription)
+            throw LlamaRuntimeError.unavailable(error.localizedDescription)
+        }
+    }
+}

--- a/tabby/Services/Runtime/MLXRuntimeManager.swift
+++ b/tabby/Services/Runtime/MLXRuntimeManager.swift
@@ -8,13 +8,13 @@ import Foundation
 final class MLXRuntimeManager: ObservableObject {
     @Published private(set) var state: RuntimeBootstrapState = .idle
     @Published private(set) var availableModels: [RuntimeModelOption] = []
+    @Published private(set) var selectedModelName: String?
 
     private let runtimeLocator: BundledRuntimeLocator
     private let core: MLXRuntimeCore
     private var startupTask: Task<PreparedMLXRuntime, Error>?
     private var startupModelName: String?
     private var cachedRuntime: PreparedMLXRuntime?
-    private var selectedModelName: String?
 
     convenience init() {
         self.init(runtimeLocator: BundledRuntimeLocator())

--- a/tabby/Services/Runtime/MLXSuggestionEngine.swift
+++ b/tabby/Services/Runtime/MLXSuggestionEngine.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// File overview:
+/// Wraps the MLX runtime with prompt/result normalization for inline completion.
+/// Mirrors `LlamaSuggestionEngine` — same prompt rendering, same text normalization,
+/// different underlying runtime.
+@MainActor
+final class MLXSuggestionEngine {
+    private let runtimeManager: MLXRuntimeManager
+
+    init(runtimeManager: MLXRuntimeManager) {
+        self.runtimeManager = runtimeManager
+    }
+
+    func generateSuggestion(for request: SuggestionRequest) async throws -> SuggestionResult {
+        do {
+            let startTime = Date()
+            let rawSuggestion = try await runtimeManager.generate(
+                prompt: request.prompt,
+                maxTokens: request.maxPredictionTokens,
+                temperature: Float(request.temperature)
+            )
+            try Task.checkCancellation()
+
+            let normalizedSuggestion = SuggestionTextNormalizer.normalize(
+                rawSuggestion, for: request
+            )
+            return SuggestionResult(
+                generation: request.generation,
+                rawText: rawSuggestion,
+                text: normalizedSuggestion,
+                latency: Date().timeIntervalSince(startTime)
+            )
+        } catch is CancellationError {
+            throw SuggestionClientError.cancelled
+        } catch let error as LlamaRuntimeError {
+            throw SuggestionClientError.unavailable(error.localizedDescription)
+        } catch let error as SuggestionClientError {
+            throw error
+        } catch {
+            throw SuggestionClientError.generationFailed(error.localizedDescription)
+        }
+    }
+
+    func resetCachedGenerationContext() async {
+        // MLX does not maintain a KV cache across requests currently.
+    }
+}
+
+extension MLXSuggestionEngine: SuggestionGenerating {}

--- a/tabby/Services/Runtime/SuggestionEngineRouter.swift
+++ b/tabby/Services/Runtime/SuggestionEngineRouter.swift
@@ -9,15 +9,18 @@ final class SuggestionEngineRouter {
     private let suggestionSettings: SuggestionSettingsModel
     private let foundationModelEngine: any SuggestionGenerating
     private let llamaEngine: any SuggestionGenerating
+    private let mlxEngine: any SuggestionGenerating
 
     init(
         suggestionSettings: SuggestionSettingsModel,
         foundationModelEngine: any SuggestionGenerating,
-        llamaEngine: any SuggestionGenerating
+        llamaEngine: any SuggestionGenerating,
+        mlxEngine: any SuggestionGenerating
     ) {
         self.suggestionSettings = suggestionSettings
         self.foundationModelEngine = foundationModelEngine
         self.llamaEngine = llamaEngine
+        self.mlxEngine = mlxEngine
     }
 
     func generateSuggestion(for request: SuggestionRequest) async throws -> SuggestionResult {
@@ -33,15 +36,18 @@ final class SuggestionEngineRouter {
             }
         case .llamaOpenSource:
             return try await llamaEngine.generateSuggestion(for: request)
+        case .mlxSwift:
+            return try await mlxEngine.generateSuggestion(for: request)
         }
     }
 
     /// Clears backend-local continuation state when the coordinator knows the editing context is
     /// no longer continuous. The router fans this out so switching engines cannot leave stale
-    /// llama KV state behind.
+    /// state behind.
     func resetCachedGenerationContext() async {
         await foundationModelEngine.resetCachedGenerationContext()
         await llamaEngine.resetCachedGenerationContext()
+        await mlxEngine.resetCachedGenerationContext()
     }
 
     /// Apple Intelligence can reject a request after global availability reports success because

--- a/tabby/Services/Utilities/ModelDownloadManager.swift
+++ b/tabby/Services/Utilities/ModelDownloadManager.swift
@@ -81,11 +81,29 @@ final class ModelDownloadManager: ObservableObject {
     }
 
     var models: [DownloadableRuntimeModel] {
-        RuntimeModelCatalog.downloadableModels
+        models(for: .gguf)
+    }
+
+    func models(for format: ModelFormat) -> [DownloadableRuntimeModel] {
+        switch format {
+        case .gguf:
+            return RuntimeModelCatalog.downloadableModels
+        case .mlx:
+            return RuntimeModelCatalog.downloadableMLXModels
+        }
     }
 
     var modelsDirectoryPath: String {
-        runtimeDirectoryURL.path
+        modelsDirectoryPath(for: .gguf)
+    }
+
+    func modelsDirectoryPath(for format: ModelFormat) -> String {
+        switch format {
+        case .gguf:
+            return runtimeDirectoryURL.path
+        case .mlx:
+            return mlxRuntimeDirectoryURL.path
+        }
     }
 
     func state(for model: DownloadableRuntimeModel) -> ModelDownloadState {
@@ -93,7 +111,7 @@ final class ModelDownloadManager: ObservableObject {
     }
 
     func refreshModelStates() {
-        for model in models {
+        for model in models(for: .gguf) + models(for: .mlx) {
             if downloadTasks[model.filename] != nil {
                 if case .downloading(let progress) = modelStates[model.filename] {
                     modelStates[model.filename] = .downloading(progress: progress)
@@ -159,14 +177,24 @@ final class ModelDownloadManager: ObservableObject {
         }
     }
 
-    func openModelsDirectory() {
+    func openModelsDirectory(format: ModelFormat = .gguf) {
         do {
-            try ensureRuntimeDirectoryExists()
+            switch format {
+            case .gguf:
+                try ensureRuntimeDirectoryExists()
+            case .mlx:
+                try ensureMLXRuntimeDirectoryExists()
+            }
         } catch {
             return
         }
 
-        NSWorkspace.shared.open(runtimeDirectoryURL)
+        switch format {
+        case .gguf:
+            NSWorkspace.shared.open(runtimeDirectoryURL)
+        case .mlx:
+            NSWorkspace.shared.open(mlxRuntimeDirectoryURL)
+        }
     }
 
     /// Returns `true` only when the model lives in Tabby's user-writable model directory.

--- a/tabby/Services/Utilities/ModelDownloadManager.swift
+++ b/tabby/Services/Utilities/ModelDownloadManager.swift
@@ -57,13 +57,16 @@ final class ModelDownloadManager: ObservableObject {
     var onModelDirectoryChanged: (() -> Void)?
 
     private let runtimeDirectoryURL: URL
+    private let mlxRuntimeDirectoryURL: URL
     private let runtimeSearchDirectories: [URL]
     private var downloadTasks: [String: Task<Void, Never>] = [:]
 
-    init(runtimeDirectoryURL: URL? = nil) {
+    init(runtimeDirectoryURL: URL? = nil, mlxRuntimeDirectoryURL: URL? = nil) {
         let primaryDirectoryURL =
             runtimeDirectoryURL ?? BundledRuntimeLocator.userRuntimeDirectoryURL()
         self.runtimeDirectoryURL = primaryDirectoryURL
+        self.mlxRuntimeDirectoryURL =
+            mlxRuntimeDirectoryURL ?? BundledRuntimeLocator.mlxRuntimeDirectoryURL()
 
         var directories = [primaryDirectoryURL]
         for directoryURL in BundledRuntimeLocator.runtimeSearchDirectories() {
@@ -166,24 +169,36 @@ final class ModelDownloadManager: ObservableObject {
         NSWorkspace.shared.open(runtimeDirectoryURL)
     }
 
-    /// Returns `true` only when the concrete GGUF file lives in Tabby's user-writable model
-    /// directory. This is the boundary we use for destructive actions so settings never offers
-    /// "delete" for assets outside the app-managed local model directory.
-    func canDeleteModel(filename: String) -> Bool {
-        FileManager.default.fileExists(atPath: modelFileURL(filename: filename).path)
+    /// Returns `true` only when the model lives in Tabby's user-writable model directory.
+    /// GGUF models are single files; MLX models are subdirectories.
+    func canDeleteModel(filename: String, format: ModelFormat = .gguf) -> Bool {
+        switch format {
+        case .gguf:
+            return FileManager.default.fileExists(atPath: modelFileURL(filename: filename).path)
+        case .mlx:
+            return FileManager.default.fileExists(
+                atPath: mlxModelDirectoryURL(dirname: filename).path
+            )
+        }
     }
 
-    /// Removes one concrete GGUF file from the user-managed runtime directory.
-    /// The caller decides whether deletion should be offered; this method only enforces the storage
-    /// boundary and refreshes observers after a successful removal.
-    func deleteModel(filename: String) {
-        let fileURL = modelFileURL(filename: filename)
-        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+    /// Removes one model from the user-managed runtime directory.
+    /// GGUF: deletes a single file. MLX: deletes an entire directory.
+    func deleteModel(filename: String, format: ModelFormat = .gguf) {
+        let targetURL: URL
+        switch format {
+        case .gguf:
+            targetURL = modelFileURL(filename: filename)
+        case .mlx:
+            targetURL = mlxModelDirectoryURL(dirname: filename)
+        }
+
+        guard FileManager.default.fileExists(atPath: targetURL.path) else {
             return
         }
 
         do {
-            try FileManager.default.removeItem(at: fileURL)
+            try FileManager.default.removeItem(at: targetURL)
             refreshModelStates()
             onModelDirectoryChanged?()
         } catch {
@@ -197,72 +212,128 @@ final class ModelDownloadManager: ObservableObject {
         }
 
         do {
-            try ensureRuntimeDirectoryExists()
-            let destinationURL = modelFileURL(filename: model.filename)
-            let delegate = ModelDownloadSessionDelegate { [weak self] progress in
-                Task { @MainActor [weak self] in
-                    guard let self, self.downloadTasks[model.filename] != nil else {
-                        return
-                    }
-
-                    self.modelStates[model.filename] = .downloading(progress: progress)
-                }
+            switch model.artifact {
+            case .singleFile(let url):
+                try await performSingleFileDownload(model, url: url)
+            case .multiFile(let files):
+                try await performMultiFileDownload(model, files: files)
             }
-            let downloadResult = try await delegate.download(from: model.downloadURL)
-            try Task.checkCancellation()
-            try validate(response: downloadResult.response)
-
-            let fileManager = FileManager.default
-
-            // Stage-validate-swap so a corrupt download can't take out a
-            // working previous install. If validation throws, the staged
-            // file is removed and the existing destinationURL (if any)
-            // stays untouched.
-            let stagingURL = runtimeDirectoryURL.appendingPathComponent(
-                "\(model.filename).staging-\(UUID().uuidString)",
-                isDirectory: false
-            )
-            try fileManager.moveItem(at: downloadResult.temporaryURL, to: stagingURL)
-
-            do {
-                try ModelFileValidator.validateSize(
-                    of: stagingURL,
-                    expectedBytes: model.expectedSizeBytes
-                )
-                try ModelFileValidator.validateSHA256(
-                    of: stagingURL,
-                    expectedSHA256: model.sha256
-                )
-            } catch {
-                // Don't leave a partial or corrupt file in the runtime
-                // directory where the locator might pick it up later.
-                try? fileManager.removeItem(at: stagingURL)
-                throw error
-            }
-
-            // Validation passed — atomically swap the new file in. The
-            // existing copy is removed only at this point, so any failure
-            // before here leaves the prior install intact.
-            if fileManager.fileExists(atPath: destinationURL.path) {
-                try fileManager.removeItem(at: destinationURL)
-            }
-            try fileManager.moveItem(at: stagingURL, to: destinationURL)
 
             modelStates[model.filename] = .downloaded
             onModelDirectoryChanged?()
         } catch {
-            // A user-initiated cancel surfaces here as either CancellationError
-            // (cancelled before URLSession ran) or URLError.cancelled
-            // (cancelled while in flight). Both should restore the prior
-            // visible state, not show a failure — the user already knows what
-            // they did. DownloadOutcomeClassifier owns the discrimination so
-            // the rule is unit-tested in isolation.
             if DownloadOutcomeClassifier.isUserCancellation(error) {
                 modelStates[model.filename] = isInstalled(model: model) ? .downloaded : .idle
             } else {
                 modelStates[model.filename] = .failed(error.localizedDescription)
             }
         }
+    }
+
+    private func performSingleFileDownload(
+        _ model: DownloadableRuntimeModel, url: URL
+    ) async throws {
+        try ensureRuntimeDirectoryExists()
+        let destinationURL = modelFileURL(filename: model.filename)
+        let delegate = ModelDownloadSessionDelegate { [weak self] progress in
+            Task { @MainActor [weak self] in
+                guard let self, self.downloadTasks[model.filename] != nil else { return }
+                self.modelStates[model.filename] = .downloading(progress: progress)
+            }
+        }
+        let downloadResult = try await delegate.download(from: url)
+        try Task.checkCancellation()
+        try validate(response: downloadResult.response)
+
+        let fileManager = FileManager.default
+        let stagingURL = runtimeDirectoryURL.appendingPathComponent(
+            "\(model.filename).staging-\(UUID().uuidString)",
+            isDirectory: false
+        )
+        try fileManager.moveItem(at: downloadResult.temporaryURL, to: stagingURL)
+
+        do {
+            try ModelFileValidator.validateSize(
+                of: stagingURL, expectedBytes: model.expectedSizeBytes
+            )
+            try ModelFileValidator.validateSHA256(
+                of: stagingURL, expectedSHA256: model.sha256
+            )
+        } catch {
+            try? fileManager.removeItem(at: stagingURL)
+            throw error
+        }
+
+        if fileManager.fileExists(atPath: destinationURL.path) {
+            try fileManager.removeItem(at: destinationURL)
+        }
+        try fileManager.moveItem(at: stagingURL, to: destinationURL)
+    }
+
+    private func performMultiFileDownload(
+        _ model: DownloadableRuntimeModel, files: [RemoteModelFile]
+    ) async throws {
+        try ensureMLXRuntimeDirectoryExists()
+        let fileManager = FileManager.default
+        let stagingDirName = "\(model.filename).staging-\(UUID().uuidString)"
+        let stagingURL = mlxRuntimeDirectoryURL.appendingPathComponent(
+            stagingDirName, isDirectory: true
+        )
+        try fileManager.createDirectory(at: stagingURL, withIntermediateDirectories: true)
+
+        do {
+            var completedFiles = 0
+            let totalFiles = files.count
+
+            for file in files {
+                try Task.checkCancellation()
+
+                let delegate = ModelDownloadSessionDelegate { [weak self] fileProgress in
+                    Task { @MainActor [weak self] in
+                        guard let self, self.downloadTasks[model.filename] != nil else { return }
+                        let baseProgress = Double(completedFiles) / Double(totalFiles)
+                        let fileContribution = (fileProgress ?? 0) / Double(totalFiles)
+                        self.modelStates[model.filename] = .downloading(
+                            progress: baseProgress + fileContribution
+                        )
+                    }
+                }
+
+                let result = try await delegate.download(from: file.url)
+                try validate(response: result.response)
+
+                let fileDestination = stagingURL.appendingPathComponent(file.relativePath)
+                let parentDir = fileDestination.deletingLastPathComponent()
+                if !fileManager.fileExists(atPath: parentDir.path) {
+                    try fileManager.createDirectory(
+                        at: parentDir, withIntermediateDirectories: true
+                    )
+                }
+                try fileManager.moveItem(at: result.temporaryURL, to: fileDestination)
+
+                if let expectedBytes = file.expectedSizeBytes {
+                    try ModelFileValidator.validateSize(
+                        of: fileDestination, expectedBytes: expectedBytes
+                    )
+                }
+                if let sha256 = file.sha256 {
+                    try ModelFileValidator.validateSHA256(
+                        of: fileDestination, expectedSHA256: sha256
+                    )
+                }
+
+                completedFiles += 1
+            }
+        } catch {
+            try? fileManager.removeItem(at: stagingURL)
+            throw error
+        }
+
+        let destinationURL = mlxModelDirectoryURL(dirname: model.filename)
+        if fileManager.fileExists(atPath: destinationURL.path) {
+            try fileManager.removeItem(at: destinationURL)
+        }
+        try fileManager.moveItem(at: stagingURL, to: destinationURL)
     }
 
     private func validate(response: URLResponse) throws {
@@ -283,12 +354,28 @@ final class ModelDownloadManager: ObservableObject {
         )
     }
 
+    private func ensureMLXRuntimeDirectoryExists() throws {
+        try FileManager.default.createDirectory(
+            at: mlxRuntimeDirectoryURL,
+            withIntermediateDirectories: true
+        )
+    }
+
     private func modelFileURL(filename: String) -> URL {
         runtimeDirectoryURL.appendingPathComponent(filename, isDirectory: false)
     }
 
+    private func mlxModelDirectoryURL(dirname: String) -> URL {
+        mlxRuntimeDirectoryURL.appendingPathComponent(dirname, isDirectory: true)
+    }
+
     private func isInstalled(model: DownloadableRuntimeModel) -> Bool {
-        model.allKnownFilenames.contains(where: isInstalled(filename:))
+        switch model.format {
+        case .gguf:
+            return model.allKnownFilenames.contains(where: isInstalled(filename:))
+        case .mlx:
+            return isMLXModelInstalled(dirname: model.filename)
+        }
     }
 
     private func isInstalled(filename: String) -> Bool {
@@ -296,6 +383,12 @@ final class ModelDownloadManager: ObservableObject {
             let fileURL = directoryURL.appendingPathComponent(filename, isDirectory: false)
             return FileManager.default.fileExists(atPath: fileURL.path)
         }
+    }
+
+    private func isMLXModelInstalled(dirname: String) -> Bool {
+        let dirURL = mlxModelDirectoryURL(dirname: dirname)
+        let configURL = dirURL.appendingPathComponent("config.json")
+        return FileManager.default.fileExists(atPath: configURL.path)
     }
 }
 

--- a/tabby/Support/BundledRuntimeLocator.swift
+++ b/tabby/Support/BundledRuntimeLocator.swift
@@ -1,7 +1,8 @@
 import Foundation
 
 /// File overview:
-/// Resolves which GGUF assets Tabby should load from user-managed local storage.
+/// Resolves which local model assets Tabby should load from user-managed storage.
+/// Supports both single-file GGUF models and directory-based MLX models.
 /// This keeps startup deterministic while ensuring large model files are never required in the app bundle.
 ///
 enum BundledRuntimeLocatorError: LocalizedError {
@@ -21,9 +22,9 @@ enum BundledRuntimeLocatorError: LocalizedError {
     }
 }
 
-/// Resolves locally installed GGUF assets from user-writable runtime directories.
-/// The folder name is still `LlamaRuntime` for now, but it is model storage only.
-/// Tabby links llama.cpp in-process through `llama.swift`; it no longer launches a server.
+/// Resolves locally installed model assets from user-writable runtime directories.
+/// GGUF models are single files in `LlamaRuntime/`; MLX models are subdirectories
+/// in `MLXRuntime/` containing `config.json` and `.safetensors` weight files.
 struct BundledRuntimeLocator {
     private struct RuntimeCandidate {
         let runtimeDirectoryURL: URL
@@ -31,6 +32,7 @@ struct BundledRuntimeLocator {
     }
 
     static let runtimeFolderName = "LlamaRuntime"
+    static let mlxRuntimeFolderName = "MLXRuntime"
 
     let bundle: Bundle
 
@@ -54,10 +56,30 @@ struct BundledRuntimeLocator {
             .appendingPathComponent(Self.runtimeFolderName, isDirectory: true)
     }
 
+    /// Returns the user-writable directory for MLX model storage.
+    static func mlxRuntimeDirectoryURL(bundle: Bundle = .main) -> URL {
+        let appSupportRoot =
+            FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+        let appFolderName =
+            (bundle.object(forInfoDictionaryKey: "CFBundleName") as? String) ?? "Tabby"
+        return
+            appSupportRoot
+            .appendingPathComponent(appFolderName, isDirectory: true)
+            .appendingPathComponent(Self.mlxRuntimeFolderName, isDirectory: true)
+    }
+
     /// Ordered runtime search directories used to discover GGUF files.
     /// This mirrors runtime resolution order and is shared by model-install status checks.
     static func runtimeSearchDirectories(bundle: Bundle = .main) -> [URL] {
         [userRuntimeDirectoryURL(bundle: bundle)]
+    }
+
+    /// Search directories for MLX model discovery.
+    static func mlxRuntimeSearchDirectories(bundle: Bundle = .main) -> [URL] {
+        [mlxRuntimeDirectoryURL(bundle: bundle)]
     }
 
     /// Finds the first preferred local model that exists and returns the fully resolved runtime asset paths.
@@ -188,7 +210,8 @@ struct BundledRuntimeLocator {
             uniqueKeysWithValues: discoveredModelURLs.map { modelURL in
                 let option = RuntimeModelOption(
                     filename: modelURL.lastPathComponent,
-                    url: modelURL
+                    url: modelURL,
+                    format: .gguf
                 )
                 return (option.filename, option)
             })
@@ -213,7 +236,8 @@ struct BundledRuntimeLocator {
             .map { modelURL in
                 RuntimeModelOption(
                     filename: modelURL.lastPathComponent,
-                    url: modelURL
+                    url: modelURL,
+                    format: .gguf
                 )
             }
             .sorted { lhs, rhs in
@@ -246,5 +270,80 @@ struct BundledRuntimeLocator {
             modelFileURL: modelOption.url,
             modelDisplayName: modelOption.displayName
         )
+    }
+
+    // MARK: - MLX Model Discovery
+
+    /// Discovers MLX models installed as subdirectories containing `config.json`
+    /// and at least one `.safetensors` weight file.
+    func availableMLXModels(preferredModelNames: [String] = []) -> [RuntimeModelOption] {
+        let directoryURL = Self.mlxRuntimeDirectoryURL(bundle: bundle)
+        let fileManager = FileManager.default
+        var isDirectory = ObjCBool(false)
+
+        guard
+            fileManager.fileExists(atPath: directoryURL.path, isDirectory: &isDirectory),
+            isDirectory.boolValue
+        else {
+            return []
+        }
+
+        guard
+            let contents = try? fileManager.contentsOfDirectory(
+                at: directoryURL,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            )
+        else {
+            return []
+        }
+
+        let validModelDirs = contents.filter { url in
+            var isDirFlag = ObjCBool(false)
+            guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirFlag),
+                isDirFlag.boolValue
+            else {
+                return false
+            }
+            let configExists = fileManager.fileExists(
+                atPath: url.appendingPathComponent("config.json").path
+            )
+            let hasSafetensors = (try? fileManager.contentsOfDirectory(
+                at: url, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles]
+            ))?.contains { $0.pathExtension == "safetensors" } ?? false
+            return configExists && hasSafetensors
+        }
+
+        guard !validModelDirs.isEmpty else { return [] }
+
+        let optionsByName = Dictionary(
+            uniqueKeysWithValues: validModelDirs.map { dirURL in
+                let option = RuntimeModelOption(
+                    filename: dirURL.lastPathComponent,
+                    url: dirURL,
+                    format: .mlx
+                )
+                return (option.filename, option)
+            }
+        )
+
+        var ordered: [RuntimeModelOption] = []
+        var seen = Set<String>()
+
+        for name in preferredModelNames {
+            if let option = optionsByName[name], seen.insert(name).inserted {
+                ordered.append(option)
+            }
+        }
+
+        let sorted = validModelDirs
+            .map { RuntimeModelOption(filename: $0.lastPathComponent, url: $0, format: .mlx) }
+            .sorted { $0.filename.localizedCaseInsensitiveCompare($1.filename) == .orderedAscending }
+
+        for option in sorted where seen.insert(option.filename).inserted {
+            ordered.append(option)
+        }
+
+        return ordered
     }
 }

--- a/tabby/Support/SuggestionRequestFactory.swift
+++ b/tabby/Support/SuggestionRequestFactory.swift
@@ -167,7 +167,7 @@ enum SuggestionRequestFactory {
         switch selectedEngine {
         case .appleIntelligence:
             return FoundationModelPromptRenderer.promptPreview(for: request)
-        case .llamaOpenSource:
+        case .llamaOpenSource, .mlxSwift:
             return request.prompt
         }
     }

--- a/tabby/UI/DownloadableModelCatalogView.swift
+++ b/tabby/UI/DownloadableModelCatalogView.swift
@@ -10,11 +10,25 @@ import SwiftUI
 struct DownloadableModelCatalogView: View {
     @ObservedObject var modelDownloadManager: ModelDownloadManager
 
+    private let models: [DownloadableRuntimeModel]
+    private let modelFormat: ModelFormat
     let onRefreshModels: () -> Void
+
+    init(
+        modelDownloadManager: ModelDownloadManager,
+        models: [DownloadableRuntimeModel]? = nil,
+        modelFormat: ModelFormat = .gguf,
+        onRefreshModels: @escaping () -> Void
+    ) {
+        self.modelDownloadManager = modelDownloadManager
+        self.models = models ?? modelDownloadManager.models(for: modelFormat)
+        self.modelFormat = modelFormat
+        self.onRefreshModels = onRefreshModels
+    }
 
     var body: some View {
         VStack(spacing: 8) {
-            ForEach(modelDownloadManager.models) { model in
+            ForEach(models) { model in
                 DownloadableModelRow(
                     model: model,
                     state: modelDownloadManager.state(for: model),
@@ -25,9 +39,9 @@ struct DownloadableModelCatalogView: View {
 
             HStack(spacing: 12) {
                 Button {
-                    modelDownloadManager.openModelsDirectory()
+                    modelDownloadManager.openModelsDirectory(format: modelFormat)
                 } label: {
-                    Label("Add Your Own", systemImage: "folder.badge.plus")
+                    Label(openFolderLabel, systemImage: "folder.badge.plus")
                         .font(.system(size: 12))
                 }
                 .buttonStyle(.plain)
@@ -44,10 +58,28 @@ struct DownloadableModelCatalogView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
-            Text("Drop any .gguf model into the folder above.")
+            Text(folderHint)
                 .font(.system(size: 11))
                 .foregroundStyle(.tertiary)
                 .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var openFolderLabel: String {
+        switch modelFormat {
+        case .gguf:
+            return "Add Your Own"
+        case .mlx:
+            return "Open MLX Folder"
+        }
+    }
+
+    private var folderHint: String {
+        switch modelFormat {
+        case .gguf:
+            return "Drop any .gguf model into the folder above."
+        case .mlx:
+            return "MLX models are folders containing config.json and .safetensors files."
         }
     }
 }

--- a/tabby/UI/SettingsView.swift
+++ b/tabby/UI/SettingsView.swift
@@ -309,12 +309,12 @@ struct SettingsView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
-            if runtimeModel.availableModels.isEmpty {
-                Text("No local GGUF models found. Download one below or add your own model file.")
+            if activeRuntimeModels.isEmpty {
+                Text(noLocalModelsText)
                     .foregroundStyle(.secondary)
             } else {
                 Picker("Selected Model", selection: selectedModelBinding) {
-                    ForEach(runtimeModel.availableModels) { model in
+                    ForEach(activeRuntimeModels) { model in
                         Text(model.displayName)
                             .tag(model.filename)
                     }
@@ -323,28 +323,32 @@ struct SettingsView: View {
 
             DownloadableModelCatalogView(
                 modelDownloadManager: modelDownloadManager,
+                models: downloadableModelsForSelectedEngine,
+                modelFormat: selectedLocalModelFormat,
                 onRefreshModels: refreshModels
             )
 
             LabeledContent("Folder") {
                 VStack(alignment: .trailing, spacing: 8) {
-                    Text(modelDownloadManager.modelsDirectoryPath)
+                    Text(modelDownloadManager.modelsDirectoryPath(for: selectedLocalModelFormat))
                         .font(.callout.monospaced())
                         .textSelection(.enabled)
                         .multilineTextAlignment(.trailing)
 
                     HStack(spacing: 8) {
-                        let lmStudioURL = FileManager.default.homeDirectoryForCurrentUser
-                            .appendingPathComponent(".lmstudio/models")
-                        Button("LM Studio Folder") {
-                            NSWorkspace.shared.open(lmStudioURL)
+                        if selectedLocalModelFormat == .gguf {
+                            let lmStudioURL = FileManager.default.homeDirectoryForCurrentUser
+                                .appendingPathComponent(".lmstudio/models")
+                            Button("LM Studio Folder") {
+                                NSWorkspace.shared.open(lmStudioURL)
+                            }
+                            .disabled(
+                                !FileManager.default.fileExists(atPath: lmStudioURL.path)
+                            )
                         }
-                        .disabled(
-                            !FileManager.default.fileExists(atPath: lmStudioURL.path)
-                        )
 
                         Button("Open Folder") {
-                            modelDownloadManager.openModelsDirectory()
+                            modelDownloadManager.openModelsDirectory(format: selectedLocalModelFormat)
                         }
 
                         Button("Refresh") {
@@ -354,12 +358,12 @@ struct SettingsView: View {
                 }
             }
 
-            if !runtimeModel.availableModels.isEmpty {
+            if !activeRuntimeModels.isEmpty {
                 Text("Installed")
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
-                ForEach(runtimeModel.availableModels) { model in
+                ForEach(activeRuntimeModels) { model in
                     installedModelRow(model)
                 }
             }
@@ -410,10 +414,13 @@ struct SettingsView: View {
 
             Spacer(minLength: 0)
 
-            if model.filename == runtimeModel.selectedModelFilename {
+            if model.filename == selectedRuntimeModelName {
                 Image(systemName: "checkmark.circle.fill")
                     .foregroundStyle(.tint)
-            } else if modelDownloadManager.canDeleteModel(filename: model.filename) {
+            } else if modelDownloadManager.canDeleteModel(
+                filename: model.filename,
+                format: model.format
+            ) {
                 Button {
                     pendingDeletionModel = model
                 } label: {
@@ -584,13 +591,18 @@ struct SettingsView: View {
     private var selectedModelBinding: Binding<String> {
         Binding(
             get: {
-                runtimeModel.selectedModelFilename
-                    ?? runtimeModel.availableModels.first?.filename
+                selectedRuntimeModelName
+                    ?? activeRuntimeModels.first?.filename
                     ?? ""
             },
             set: { filename in
                 Task {
-                    await runtimeModel.selectModel(filename)
+                    switch suggestionSettings.selectedEngine {
+                    case .llamaOpenSource, .appleIntelligence:
+                        await runtimeModel.selectModel(filename)
+                    case .mlxSwift:
+                        try? await mlxRuntimeManager.selectModel(name: filename)
+                    }
                 }
             }
         )
@@ -618,6 +630,41 @@ struct SettingsView: View {
             return "Download an MLX model below. Models are stored locally on your Mac."
         case .appleIntelligence:
             return "These models are used when Engine is set to Open Source or MLX."
+        }
+    }
+
+    private var selectedLocalModelFormat: ModelFormat {
+        suggestionSettings.selectedEngine.modelFormat ?? .gguf
+    }
+
+    private var activeRuntimeModels: [RuntimeModelOption] {
+        switch suggestionSettings.selectedEngine {
+        case .mlxSwift:
+            return mlxRuntimeManager.availableModels
+        case .llamaOpenSource, .appleIntelligence:
+            return runtimeModel.availableModels
+        }
+    }
+
+    private var downloadableModelsForSelectedEngine: [DownloadableRuntimeModel] {
+        modelDownloadManager.models(for: selectedLocalModelFormat)
+    }
+
+    private var selectedRuntimeModelName: String? {
+        switch suggestionSettings.selectedEngine {
+        case .mlxSwift:
+            return mlxRuntimeManager.selectedModelName
+        case .llamaOpenSource, .appleIntelligence:
+            return runtimeModel.selectedModelFilename
+        }
+    }
+
+    private var noLocalModelsText: String {
+        switch selectedLocalModelFormat {
+        case .gguf:
+            return "No local GGUF models found. Download one below or add your own model file."
+        case .mlx:
+            return "No local MLX models found. Download one below."
         }
     }
 
@@ -674,14 +721,15 @@ struct SettingsView: View {
     }
 
     private func deleteModel(_ model: RuntimeModelOption) {
-        modelDownloadManager.deleteModel(filename: model.filename)
-        runtimeModel.refreshAvailableModels()
+        modelDownloadManager.deleteModel(filename: model.filename, format: model.format)
+        refreshModels()
         pendingDeletionModel = nil
     }
 
     private func refreshModels() {
         modelDownloadManager.refreshModelStates()
         runtimeModel.refreshAvailableModels()
+        mlxRuntimeManager.refreshAvailableModels()
     }
 
 }

--- a/tabby/UI/SettingsView.swift
+++ b/tabby/UI/SettingsView.swift
@@ -17,6 +17,7 @@ struct SettingsView: View {
     @ObservedObject var suggestionSettings: SuggestionSettingsModel
     @ObservedObject var foundationModelAvailabilityService: FoundationModelAvailabilityService
     @ObservedObject var runtimeModel: RuntimeBootstrapModel
+    @ObservedObject var mlxRuntimeManager: MLXRuntimeManager
     @ObservedObject var modelDownloadManager: ModelDownloadManager
 
     let onShowWelcome: () -> Void
@@ -144,14 +145,20 @@ struct SettingsView: View {
                 }
             }
 
-            if suggestionSettings.selectedEngine == .appleIntelligence {
+            switch suggestionSettings.selectedEngine {
+            case .appleIntelligence:
                 LabeledContent("Availability") {
                     Text(foundationModelAvailabilityService.userVisibleMessage)
                         .foregroundStyle(.secondary)
                 }
-            } else {
+            case .llamaOpenSource:
                 LabeledContent("Runtime") {
                     Text(runtimeModel.state.summary)
+                        .foregroundStyle(.secondary)
+                }
+            case .mlxSwift:
+                LabeledContent("Runtime") {
+                    Text(mlxRuntimeManager.state.summary)
                         .foregroundStyle(.secondary)
                 }
             }
@@ -604,11 +611,14 @@ struct SettingsView: View {
     }
 
     private var localModelsDescription: String {
-        if suggestionSettings.selectedEngine == .llamaOpenSource {
+        switch suggestionSettings.selectedEngine {
+        case .llamaOpenSource:
             return "Download a model or add your own below. Models are stored locally on your Mac."
+        case .mlxSwift:
+            return "Download an MLX model below. Models are stored locally on your Mac."
+        case .appleIntelligence:
+            return "These models are used when Engine is set to Open Source or MLX."
         }
-
-        return "These models are used when Engine is set to Open Source."
     }
 
     private var launchAtLoginMessage: String? {

--- a/tabby/UI/WelcomeView.swift
+++ b/tabby/UI/WelcomeView.swift
@@ -255,7 +255,7 @@ extension WelcomeView {
         switch suggestionSettings.selectedEngine {
         case .appleIntelligence:
             return foundationModelAvailabilityService.isAvailable
-        case .llamaOpenSource:
+        case .llamaOpenSource, .mlxSwift:
             return hasAtLeastOneModel
         }
     }
@@ -264,7 +264,7 @@ extension WelcomeView {
         switch suggestionSettings.selectedEngine {
         case .appleIntelligence:
             return "Apple Intelligence is not available on this Mac."
-        case .llamaOpenSource:
+        case .llamaOpenSource, .mlxSwift:
             return "Add or download at least one model to continue."
         }
     }

--- a/tabby/UI/WelcomeView.swift
+++ b/tabby/UI/WelcomeView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct WelcomeView: View {
     @ObservedObject var permissionManager: PermissionManager
     @ObservedObject var runtimeModel: RuntimeBootstrapModel
+    @ObservedObject var mlxRuntimeManager: MLXRuntimeManager
     @ObservedObject var modelDownloadManager: ModelDownloadManager
     @ObservedObject var suggestionSettings: SuggestionSettingsModel
     @ObservedObject var foundationModelAvailabilityService: FoundationModelAvailabilityService
@@ -255,8 +256,10 @@ extension WelcomeView {
         switch suggestionSettings.selectedEngine {
         case .appleIntelligence:
             return foundationModelAvailabilityService.isAvailable
-        case .llamaOpenSource, .mlxSwift:
+        case .llamaOpenSource:
             return hasAtLeastOneModel
+        case .mlxSwift:
+            return !mlxRuntimeManager.availableModels.isEmpty
         }
     }
 

--- a/tabbyTests/PromptPolicyTests.swift
+++ b/tabbyTests/PromptPolicyTests.swift
@@ -110,7 +110,8 @@ final class SuggestionEngineRouterTests: XCTestCase {
         let router = SuggestionEngineRouter(
             suggestionSettings: settings,
             foundationModelEngine: appleEngine,
-            llamaEngine: openSourceEngine
+            llamaEngine: openSourceEngine,
+            mlxEngine: StubSuggestionEngine(behavior: .success(fallbackResult))
         )
 
         let result = try await router.generateSuggestion(for: request)
@@ -118,6 +119,37 @@ final class SuggestionEngineRouterTests: XCTestCase {
         XCTAssertEqual(result, fallbackResult)
         XCTAssertEqual(appleEngine.generateCallCount, 1)
         XCTAssertEqual(openSourceEngine.generateCallCount, 1)
+    }
+
+    func test_generateSuggestion_routesToMLXEngineWhenSelected() async throws {
+        let settings = SuggestionSettingsModel(
+            configuration: .standard,
+            userDefaults: makeUserDefaults()
+        )
+        settings.selectEngine(.mlxSwift)
+        let request = TabbyTestFixtures.suggestionRequest()
+        let mlxResult = SuggestionResult(
+            generation: request.generation,
+            rawText: "mlx raw",
+            text: "mlx text",
+            latency: 0.1
+        )
+        let appleEngine = StubSuggestionEngine(behavior: .failure(SuggestionClientError.unavailable("unused")))
+        let openSourceEngine = StubSuggestionEngine(behavior: .failure(SuggestionClientError.unavailable("unused")))
+        let mlxEngine = StubSuggestionEngine(behavior: .success(mlxResult))
+        let router = SuggestionEngineRouter(
+            suggestionSettings: settings,
+            foundationModelEngine: appleEngine,
+            llamaEngine: openSourceEngine,
+            mlxEngine: mlxEngine
+        )
+
+        let result = try await router.generateSuggestion(for: request)
+
+        XCTAssertEqual(result, mlxResult)
+        XCTAssertEqual(appleEngine.generateCallCount, 0)
+        XCTAssertEqual(openSourceEngine.generateCallCount, 0)
+        XCTAssertEqual(mlxEngine.generateCallCount, 1)
     }
 
     private func makeUserDefaults() -> UserDefaults {


### PR DESCRIPTION
## Summary

- Adds MLX as a third suggestion engine option alongside Apple Intelligence and llama.cpp.
- Generalizes local model metadata, discovery, and downloads for GGUF files and MLX directory-based models.
- Adds MLX runtime core/manager/suggestion-engine boundaries that mirror the existing llama runtime architecture.
- Wires MLX through app composition, settings status, onboarding gating, router dispatch, and shutdown.

## Validation

- `xcodebuild -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build`

## Notes

- The current MLX runtime is guarded with `#if canImport(MLX)`; live inference still requires wiring the upstream MLX Swift LM package into the Xcode project.
- Kept local project signing/team-ID noise out of this PR.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR scaffolds MLX as a third suggestion engine alongside Apple Intelligence and llama.cpp, mirroring the existing llama runtime architecture (`MLXRuntimeCore` actor, `MLXRuntimeManager`, `MLXSuggestionEngine`) and generalizing model metadata, discovery, and download to support both single-file GGUF and directory-based MLX models.

- **Runtime layer**: `MLXRuntimeCore` (actor) + `MLXRuntimeManager` (`@MainActor`) follow the same startup-task deduplication and state-publishing pattern as the llama path; guarded by `#if canImport(MLX)` until the SPM dependency is wired in.
- **Model infrastructure**: `ModelArtifactKind` (.singleFile / .multiFile), `ModelFormat`, and `RemoteModelFile` generalize the catalog, download manager, and locator; `performMultiFileDownload` adds a staged download with per-file progress reporting.
- **UI and composition**: `SettingsView`, `WelcomeView`, coordinators, and `AppDelegate` thread `mlxRuntimeManager` through the dependency graph and branch on `selectedEngine` for model lists, download catalogs, runtime status, and shutdown.

<h3>Confidence Score: 4/5</h3>

Safe to merge as scaffolding; the one concrete correctness gap is in MLX installation detection.

The architecture is sound and closely mirrors the proven llama path. The main concrete gap is that `isMLXModelInstalled` checks only `config.json` while `availableMLXModels()` requires both `config.json` and a `.safetensors` file — a user who lands an incomplete MLX directory would see the model marked as downloaded in the catalog but absent from the model picker, with no recovery path short of manual deletion. The download's stage-and-swap reduces how often this occurs in practice, but the detection logic should be consistent. Everything else — actor isolation, startup-task deduplication, stage-and-swap for multi-file downloads, UI branching — is well-structured.

tabby/Services/Utilities/ModelDownloadManager.swift — isMLXModelInstalled detection; tabby/App/Core/AppDelegate.swift — sequential shutdown under shared timeout

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tabby/Services/Runtime/MLXRuntimeCore.swift | New actor wrapping the MLX model lifecycle; correctly isolated, mirrors LlamaRuntimeCore; generation loop and shutdown are sound for scaffolding |
| tabby/Services/Runtime/MLXRuntimeManager.swift | @MainActor manager publishing runtime state; startup-task deduplication and model-swap logic closely mirrors LlamaRuntimeManager and looks correct |
| tabby/Services/Utilities/ModelDownloadManager.swift | Multi-file download path added correctly with stage-and-swap; isMLXModelInstalled checks only config.json while availableMLXModels requires safetensors too — inconsistent detection (see comment) |
| tabby/Support/BundledRuntimeLocator.swift | MLX discovery logic is correct; minor wasted allocation — optionsByName built but unused at the only call site that passes no preferredModelNames |
| tabby/App/Core/AppDelegate.swift | Shutdown promoted to terminateLater with OSAllocatedUnfairLock guard; llama and MLX shutdowns are sequential under a shared 5s timeout — MLX cleanup could be skipped if llama takes too long |
| tabby/Models/LlamaRuntimeModels.swift | ModelFormat, ModelArtifactKind, and RemoteModelFile added cleanly; MLX catalog entries have no SHA-256 checksums (flagged in previous review) |
| tabby/UI/SettingsView.swift | Engine-aware branching via activeRuntimeModels and downloadableModelsForSelectedEngine correctly addresses the previous GGUF/MLX display mismatch |
| tabby/UI/WelcomeView.swift | MLX onboarding gate now correctly checks mlxRuntimeManager.availableModels instead of GGUF state |
| tabby/Services/Runtime/SuggestionEngineRouter.swift | MLX case added to both generateSuggestion dispatch and resetCachedGenerationContext fan-out; clean and complete |
| tabbyTests/PromptPolicyTests.swift | New router test for MLX engine dispatch added; existing test updated with stub MLX engine parameter |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    SER[SuggestionEngineRouter] -->|appleIntelligence| FM[FoundationModelSuggestionEngine]
    SER -->|llamaOpenSource| LS[LlamaSuggestionEngine]
    SER -->|mlxSwift| MS[MLXSuggestionEngine]

    LS --> LRM[LlamaRuntimeManager]
    MS --> MRM[MLXRuntimeManager]

    LRM --> LRC[LlamaRuntimeCore actor]
    MRM --> MRC[MLXRuntimeCore actor]

    MRC -->|canImport MLX| MLX[MLXLMCommon ModelFactory]
    MRC -->|else| ERR[throws unavailable]

    subgraph Discovery
        BRL[BundledRuntimeLocator]
        BRL -->|availableModels| LRM
        BRL -->|availableMLXModels| MRM
    end

    subgraph Download
        MDM[ModelDownloadManager]
        MDM -->|singleFile| SFD[performSingleFileDownload]
        MDM -->|multiFile| MFD[performMultiFileDownload]
    end

    MDM -->|onModelDirectoryChanged| BRL
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `tabby/UI/WelcomeView.swift`, line 272-276 ([link](https://github.com/fujacob/tabby/blob/425de03043dbf8d71fe9a5fd999c2f7706f4412e/tabby/UI/WelcomeView.swift#L272-L276)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`hasAtLeastOneModel` gates MLX with GGUF state**

   When `selectedEngine == .mlxSwift`, this property returns `true` if GGUF models are present via `!runtimeModel.availableModels.isEmpty`. A user who has installed a `.gguf` file and switches to the MLX engine would pass the onboarding gate without any MLX model, then immediately get a "no MLX model available" error at runtime. The GGUF-based fallback should be absent for the MLX path, which needs its own check against `mlxRuntimeManager.availableModels`.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22feature%2Fmlx-model-engine%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fmlx-model-engine%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tabby%2FUI%2FWelcomeView.swift%0ALine%3A%20272-276%0A%0AComment%3A%0A**%60hasAtLeastOneModel%60%20gates%20MLX%20with%20GGUF%20state**%0A%0AWhen%20%60selectedEngine%20%3D%3D%20.mlxSwift%60%2C%20this%20property%20returns%20%60true%60%20if%20GGUF%20models%20are%20present%20via%20%60!runtimeModel.availableModels.isEmpty%60.%20A%20user%20who%20has%20installed%20a%20%60.gguf%60%20file%20and%20switches%20to%20the%20MLX%20engine%20would%20pass%20the%20onboarding%20gate%20without%20any%20MLX%20model%2C%20then%20immediately%20get%20a%20%22no%20MLX%20model%20available%22%20error%20at%20runtime.%20The%20GGUF-based%20fallback%20should%20be%20absent%20for%20the%20MLX%20path%2C%20which%20needs%20its%20own%20check%20against%20%60mlxRuntimeManager.availableModels%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tabby%2FUI%2FWelcomeView.swift%0ALine%3A%20272-276%0A%0AComment%3A%0A**%60hasAtLeastOneModel%60%20gates%20MLX%20with%20GGUF%20state**%0A%0AWhen%20%60selectedEngine%20%3D%3D%20.mlxSwift%60%2C%20this%20property%20returns%20%60true%60%20if%20GGUF%20models%20are%20present%20via%20%60!runtimeModel.availableModels.isEmpty%60.%20A%20user%20who%20has%20installed%20a%20%60.gguf%60%20file%20and%20switches%20to%20the%20MLX%20engine%20would%20pass%20the%20onboarding%20gate%20without%20any%20MLX%20model%2C%20then%20immediately%20get%20a%20%22no%20MLX%20model%20available%22%20error%20at%20runtime.%20The%20GGUF-based%20fallback%20should%20be%20absent%20for%20the%20MLX%20path%2C%20which%20needs%20its%20own%20check%20against%20%60mlxRuntimeManager.availableModels%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Ftabby&pr=204&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

2. `tabby/Models/LlamaRuntimeModels.swift`, line 337-415 ([link](https://github.com/fujacob/tabby/blob/425de03043dbf8d71fe9a5fd999c2f7706f4412e/tabby/Models/LlamaRuntimeModels.swift#L337-L415)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **No SHA-256 checksums for any MLX model files**

   Every `RemoteModelFile` entry in `downloadableMLXModels` sets `sha256: nil`. The GGUF catalog provides SHA-256 hashes captured from HuggingFace CDN headers, enabling the existing `ModelFileValidator.validateSHA256` step that guards the staging-to-destination move. For MLX, only `expectedSizeBytes` is validated. A corrupt or MitM-replaced `model.safetensors` download would be accepted as long as it matches the expected byte count.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22feature%2Fmlx-model-engine%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fmlx-model-engine%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tabby%2FModels%2FLlamaRuntimeModels.swift%0ALine%3A%20337-415%0A%0AComment%3A%0A**No%20SHA-256%20checksums%20for%20any%20MLX%20model%20files**%0A%0AEvery%20%60RemoteModelFile%60%20entry%20in%20%60downloadableMLXModels%60%20sets%20%60sha256%3A%20nil%60.%20The%20GGUF%20catalog%20provides%20SHA-256%20hashes%20captured%20from%20HuggingFace%20CDN%20headers%2C%20enabling%20the%20existing%20%60ModelFileValidator.validateSHA256%60%20step%20that%20guards%20the%20staging-to-destination%20move.%20For%20MLX%2C%20only%20%60expectedSizeBytes%60%20is%20validated.%20A%20corrupt%20or%20MitM-replaced%20%60model.safetensors%60%20download%20would%20be%20accepted%20as%20long%20as%20it%20matches%20the%20expected%20byte%20count.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tabby%2FModels%2FLlamaRuntimeModels.swift%0ALine%3A%20337-415%0A%0AComment%3A%0A**No%20SHA-256%20checksums%20for%20any%20MLX%20model%20files**%0A%0AEvery%20%60RemoteModelFile%60%20entry%20in%20%60downloadableMLXModels%60%20sets%20%60sha256%3A%20nil%60.%20The%20GGUF%20catalog%20provides%20SHA-256%20hashes%20captured%20from%20HuggingFace%20CDN%20headers%2C%20enabling%20the%20existing%20%60ModelFileValidator.validateSHA256%60%20step%20that%20guards%20the%20staging-to-destination%20move.%20For%20MLX%2C%20only%20%60expectedSizeBytes%60%20is%20validated.%20A%20corrupt%20or%20MitM-replaced%20%60model.safetensors%60%20download%20would%20be%20accepted%20as%20long%20as%20it%20matches%20the%20expected%20byte%20count.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Ftabby&pr=204&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

3. `tabby/UI/SettingsView.swift`, line 306-366 ([link](https://github.com/fujacob/tabby/blob/c3d77f372ec3ccc3eecffef4eed1d003ba5810f9/tabby/UI/SettingsView.swift#L306-L366)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Local Models section shows GGUF state for all engines**

   When the user selects the MLX engine, `localModelsSection` still reads from `runtimeModel.availableModels` (GGUF only). A user who has no GGUF files will see "No local GGUF models found" and a GGUF download catalog even though they're on the MLX path. The "Installed" list, model picker, and download catalog all reflect GGUF state regardless of `suggestionSettings.selectedEngine`. The WelcomeView already gates on `mlxRuntimeManager.availableModels.isEmpty` for the MLX path; Settings should follow the same pattern and branch on `selectedEngine` to show `mlxRuntimeManager.availableModels` and the MLX downloadable catalog when `.mlxSwift` is selected.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22feature%2Fmlx-model-engine%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fmlx-model-engine%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tabby%2FUI%2FSettingsView.swift%0ALine%3A%20306-366%0A%0AComment%3A%0A**Local%20Models%20section%20shows%20GGUF%20state%20for%20all%20engines**%0A%0AWhen%20the%20user%20selects%20the%20MLX%20engine%2C%20%60localModelsSection%60%20still%20reads%20from%20%60runtimeModel.availableModels%60%20%28GGUF%20only%29.%20A%20user%20who%20has%20no%20GGUF%20files%20will%20see%20%22No%20local%20GGUF%20models%20found%22%20and%20a%20GGUF%20download%20catalog%20even%20though%20they're%20on%20the%20MLX%20path.%20The%20%22Installed%22%20list%2C%20model%20picker%2C%20and%20download%20catalog%20all%20reflect%20GGUF%20state%20regardless%20of%20%60suggestionSettings.selectedEngine%60.%20The%20WelcomeView%20already%20gates%20on%20%60mlxRuntimeManager.availableModels.isEmpty%60%20for%20the%20MLX%20path%3B%20Settings%20should%20follow%20the%20same%20pattern%20and%20branch%20on%20%60selectedEngine%60%20to%20show%20%60mlxRuntimeManager.availableModels%60%20and%20the%20MLX%20downloadable%20catalog%20when%20%60.mlxSwift%60%20is%20selected.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tabby%2FUI%2FSettingsView.swift%0ALine%3A%20306-366%0A%0AComment%3A%0A**Local%20Models%20section%20shows%20GGUF%20state%20for%20all%20engines**%0A%0AWhen%20the%20user%20selects%20the%20MLX%20engine%2C%20%60localModelsSection%60%20still%20reads%20from%20%60runtimeModel.availableModels%60%20%28GGUF%20only%29.%20A%20user%20who%20has%20no%20GGUF%20files%20will%20see%20%22No%20local%20GGUF%20models%20found%22%20and%20a%20GGUF%20download%20catalog%20even%20though%20they're%20on%20the%20MLX%20path.%20The%20%22Installed%22%20list%2C%20model%20picker%2C%20and%20download%20catalog%20all%20reflect%20GGUF%20state%20regardless%20of%20%60suggestionSettings.selectedEngine%60.%20The%20WelcomeView%20already%20gates%20on%20%60mlxRuntimeManager.availableModels.isEmpty%60%20for%20the%20MLX%20path%3B%20Settings%20should%20follow%20the%20same%20pattern%20and%20branch%20on%20%60selectedEngine%60%20to%20show%20%60mlxRuntimeManager.availableModels%60%20and%20the%20MLX%20downloadable%20catalog%20when%20%60.mlxSwift%60%20is%20selected.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Ftabby&pr=204&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22feature%2Fmlx-model-engine%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fmlx-model-engine%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Atabby%2FServices%2FUtilities%2FModelDownloadManager.swift%3A416-420%0A%60isMLXModelInstalled%60%20only%20checks%20for%20the%20presence%20of%20%60config.json%60%2C%20but%20%60availableMLXModels%28%29%60%20in%20%60BundledRuntimeLocator%60%20requires%20both%20%60config.json%60%20**and**%20at%20least%20one%20%60.safetensors%60%20file%20before%20it%20surfaces%20a%20model.%20If%20a%20user%20manually%20drops%20an%20incomplete%20directory%20%28only%20%60config.json%60%2C%20no%20weights%29%2C%20%60refreshModelStates%28%29%60%20would%20mark%20the%20model%20as%20%60.downloaded%60%20in%20%60modelStates%60%20%E2%80%94%20showing%20it%20as%20available%20in%20the%20download%20catalog%20%E2%80%94%20while%20%60availableMLXModels%28%29%60%20returns%20nothing%2C%20so%20the%20model%20picker%20shows%20%22No%20local%20MLX%20models%20found.%22%20The%20two%20detection%20paths%20need%20to%20agree%20on%20what%20constitutes%20a%20valid%20install.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20func%20isMLXModelInstalled%28dirname%3A%20String%29%20-%3E%20Bool%20%7B%0A%20%20%20%20%20%20%20%20let%20dirURL%20%3D%20mlxModelDirectoryURL%28dirname%3A%20dirname%29%0A%20%20%20%20%20%20%20%20guard%20FileManager.default.fileExists%28%0A%20%20%20%20%20%20%20%20%20%20%20%20atPath%3A%20dirURL.appendingPathComponent%28%22config.json%22%29.path%0A%20%20%20%20%20%20%20%20%29%20else%20%7B%20return%20false%20%7D%0A%20%20%20%20%20%20%20%20let%20hasSafetensors%20%3D%20%28try%3F%20FileManager.default.contentsOfDirectory%28%0A%20%20%20%20%20%20%20%20%20%20%20%20at%3A%20dirURL%2C%20includingPropertiesForKeys%3A%20nil%2C%20options%3A%20%5B.skipsHiddenFiles%5D%0A%20%20%20%20%20%20%20%20%29%29%3F.contains%20%7B%20%240.pathExtension%20%3D%3D%20%22safetensors%22%20%7D%20%3F%3F%20false%0A%20%20%20%20%20%20%20%20return%20hasSafetensors%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Atabby%2FSupport%2FBundledRuntimeLocator.swift%3A319-347%0A%60optionsByName%60%20is%20built%20from%20%60validModelDirs%60%20but%20is%20only%20consulted%20inside%20the%20%60for%20name%20in%20preferredModelNames%60%20loop.%20The%20only%20call%20site%20%E2%80%94%20%60runtimeLocator.availableMLXModels%28%29%60%20%E2%80%94%20passes%20no%20arguments%2C%20so%20%60preferredModelNames%60%20is%20always%20%60%5B%5D%60%2C%20meaning%20the%20dictionary%20is%20allocated%20and%20populated%20on%20every%20discovery%20call%20but%20never%20read.%20The%20%60sorted%60%20array%20duplicates%20the%20same%20mapping.%20Both%20can%20be%20collapsed%20into%20a%20single%20pass.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20allOptions%20%3D%20validModelDirs%0A%20%20%20%20%20%20%20%20%20%20%20%20.map%20%7B%20RuntimeModelOption%28filename%3A%20%240.lastPathComponent%2C%20url%3A%20%240%2C%20format%3A%20.mlx%29%20%7D%0A%0A%20%20%20%20%20%20%20%20let%20optionsByName%20%3D%20Dictionary%28uniqueKeysWithValues%3A%20allOptions.map%20%7B%20%28%240.filename%2C%20%240%29%20%7D%29%0A%0A%20%20%20%20%20%20%20%20var%20ordered%3A%20%5BRuntimeModelOption%5D%20%3D%20%5B%5D%0A%20%20%20%20%20%20%20%20var%20seen%20%3D%20Set%3CString%3E%28%29%0A%0A%20%20%20%20%20%20%20%20for%20name%20in%20preferredModelNames%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20let%20option%20%3D%20optionsByName%5Bname%5D%2C%20seen.insert%28name%29.inserted%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20ordered.append%28option%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20let%20sorted%20%3D%20allOptions.sorted%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%240.filename.localizedCaseInsensitiveCompare%28%241.filename%29%20%3D%3D%20.orderedAscending%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20for%20option%20in%20sorted%20where%20seen.insert%28option.filename%29.inserted%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20ordered.append%28option%29%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20return%20ordered%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Atabby%2FApp%2FCore%2FAppDelegate.swift%3A148-157%0A**Sequential%20shutdown%20against%20a%20single%20shared%20timeout**%0A%0A%60runtimeModel.stopAndWait%28%29%60%20and%20%60mlxRuntimeManager.stopAndWait%28%29%60%20run%20one-after-the-other%20under%20a%20single%205-second%20timeout.%20If%20the%20llama%20shutdown%20consumes%20most%20of%20that%20window%20%28e.g.%2C%20waiting%20for%20a%20long-running%20generation%20to%20drain%29%2C%20the%20MLX%20cleanup%20task%20will%20never%20run%20before%20%60replyOnce%28%29%60%20fires%20from%20the%20timer.%20For%20now%2C%20MLX%20carries%20no%20real%20GPU%20resources%2C%20so%20this%20is%20benign%20%E2%80%94%20but%20once%20live%20inference%20is%20wired%20in%2C%20GPU%20buffers%20could%20be%20leaked%20on%20quit.%20Running%20both%20shutdowns%20concurrently%20with%20%60async%20let%60%20%28or%20a%20%60TaskGroup%60%29%20would%20let%20them%20race%20against%20the%20same%20deadline%20independently.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Atabby%2FServices%2FUtilities%2FModelDownloadManager.swift%3A416-420%0A%60isMLXModelInstalled%60%20only%20checks%20for%20the%20presence%20of%20%60config.json%60%2C%20but%20%60availableMLXModels%28%29%60%20in%20%60BundledRuntimeLocator%60%20requires%20both%20%60config.json%60%20**and**%20at%20least%20one%20%60.safetensors%60%20file%20before%20it%20surfaces%20a%20model.%20If%20a%20user%20manually%20drops%20an%20incomplete%20directory%20%28only%20%60config.json%60%2C%20no%20weights%29%2C%20%60refreshModelStates%28%29%60%20would%20mark%20the%20model%20as%20%60.downloaded%60%20in%20%60modelStates%60%20%E2%80%94%20showing%20it%20as%20available%20in%20the%20download%20catalog%20%E2%80%94%20while%20%60availableMLXModels%28%29%60%20returns%20nothing%2C%20so%20the%20model%20picker%20shows%20%22No%20local%20MLX%20models%20found.%22%20The%20two%20detection%20paths%20need%20to%20agree%20on%20what%20constitutes%20a%20valid%20install.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20func%20isMLXModelInstalled%28dirname%3A%20String%29%20-%3E%20Bool%20%7B%0A%20%20%20%20%20%20%20%20let%20dirURL%20%3D%20mlxModelDirectoryURL%28dirname%3A%20dirname%29%0A%20%20%20%20%20%20%20%20guard%20FileManager.default.fileExists%28%0A%20%20%20%20%20%20%20%20%20%20%20%20atPath%3A%20dirURL.appendingPathComponent%28%22config.json%22%29.path%0A%20%20%20%20%20%20%20%20%29%20else%20%7B%20return%20false%20%7D%0A%20%20%20%20%20%20%20%20let%20hasSafetensors%20%3D%20%28try%3F%20FileManager.default.contentsOfDirectory%28%0A%20%20%20%20%20%20%20%20%20%20%20%20at%3A%20dirURL%2C%20includingPropertiesForKeys%3A%20nil%2C%20options%3A%20%5B.skipsHiddenFiles%5D%0A%20%20%20%20%20%20%20%20%29%29%3F.contains%20%7B%20%240.pathExtension%20%3D%3D%20%22safetensors%22%20%7D%20%3F%3F%20false%0A%20%20%20%20%20%20%20%20return%20hasSafetensors%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Atabby%2FSupport%2FBundledRuntimeLocator.swift%3A319-347%0A%60optionsByName%60%20is%20built%20from%20%60validModelDirs%60%20but%20is%20only%20consulted%20inside%20the%20%60for%20name%20in%20preferredModelNames%60%20loop.%20The%20only%20call%20site%20%E2%80%94%20%60runtimeLocator.availableMLXModels%28%29%60%20%E2%80%94%20passes%20no%20arguments%2C%20so%20%60preferredModelNames%60%20is%20always%20%60%5B%5D%60%2C%20meaning%20the%20dictionary%20is%20allocated%20and%20populated%20on%20every%20discovery%20call%20but%20never%20read.%20The%20%60sorted%60%20array%20duplicates%20the%20same%20mapping.%20Both%20can%20be%20collapsed%20into%20a%20single%20pass.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20allOptions%20%3D%20validModelDirs%0A%20%20%20%20%20%20%20%20%20%20%20%20.map%20%7B%20RuntimeModelOption%28filename%3A%20%240.lastPathComponent%2C%20url%3A%20%240%2C%20format%3A%20.mlx%29%20%7D%0A%0A%20%20%20%20%20%20%20%20let%20optionsByName%20%3D%20Dictionary%28uniqueKeysWithValues%3A%20allOptions.map%20%7B%20%28%240.filename%2C%20%240%29%20%7D%29%0A%0A%20%20%20%20%20%20%20%20var%20ordered%3A%20%5BRuntimeModelOption%5D%20%3D%20%5B%5D%0A%20%20%20%20%20%20%20%20var%20seen%20%3D%20Set%3CString%3E%28%29%0A%0A%20%20%20%20%20%20%20%20for%20name%20in%20preferredModelNames%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20let%20option%20%3D%20optionsByName%5Bname%5D%2C%20seen.insert%28name%29.inserted%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20ordered.append%28option%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20let%20sorted%20%3D%20allOptions.sorted%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%240.filename.localizedCaseInsensitiveCompare%28%241.filename%29%20%3D%3D%20.orderedAscending%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20for%20option%20in%20sorted%20where%20seen.insert%28option.filename%29.inserted%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20ordered.append%28option%29%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20return%20ordered%0A%60%60%60%0A%0A%281%20more%20issue%20omitted%20due%20to%20length%20limits.%20Use%20individual%20%22Fix%20in%20Claude%20Code%22%20links%20for%20remaining%20issues.%29%0A&repo=fujacob%2Ftabby&pr=204&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["Show MLX models in local model settings"](https://github.com/fujacob/tabby/commit/94c39f59f9b2723a2cbc6f5672a7cdedebd41c05) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33695953)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->