### PR TITLE
Fix external monitor geometry conversion

### DIFF
--- a/tabby.xcodeproj/project.pbxproj
+++ b/tabby.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		E10000022F93000100DDD002 /* PermissionAndContextModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10000122F93000100DDD012 /* PermissionAndContextModelTests.swift */; };
 		E10000032F93000100DDD003 /* GhostSuggestionLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10000132F93000100DDD013 /* GhostSuggestionLayoutTests.swift */; };
 		E10000042F93000100DDD004 /* BundledRuntimeLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10000142F93000100DDD014 /* BundledRuntimeLocatorTests.swift */; };
+		E10000052F93000100DDD005 /* DisplayCoordinateConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10000152F93000100DDD015 /* DisplayCoordinateConverterTests.swift */; };
 		F10000012FA0000100EEE001 /* TextDirectionDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10000112FA0000100EEE011 /* TextDirectionDetectorTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -60,6 +61,7 @@
 		E10000122F93000100DDD012 /* PermissionAndContextModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PermissionAndContextModelTests.swift; sourceTree = "<group>"; };
 		E10000132F93000100DDD013 /* GhostSuggestionLayoutTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GhostSuggestionLayoutTests.swift; sourceTree = "<group>"; };
 		E10000142F93000100DDD014 /* BundledRuntimeLocatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BundledRuntimeLocatorTests.swift; sourceTree = "<group>"; };
+		E10000152F93000100DDD015 /* DisplayCoordinateConverterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DisplayCoordinateConverterTests.swift; sourceTree = "<group>"; };
 		F10000112FA0000100EEE011 /* TextDirectionDetectorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TextDirectionDetectorTests.swift; sourceTree = "<group>"; };
 		F29623C5C0A67B992D383A3C /* LlamaPromptRendererTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LlamaPromptRendererTests.swift; sourceTree = "<group>"; };
 		F9D35DB9E86506B9FAE1CFE9 /* ModelFileValidatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ModelFileValidatorTests.swift; sourceTree = "<group>"; };
@@ -133,6 +135,7 @@
 				E10000122F93000100DDD012 /* PermissionAndContextModelTests.swift */,
 				E10000132F93000100DDD013 /* GhostSuggestionLayoutTests.swift */,
 				E10000142F93000100DDD014 /* BundledRuntimeLocatorTests.swift */,
+				E10000152F93000100DDD015 /* DisplayCoordinateConverterTests.swift */,
 				F10000112FA0000100EEE011 /* TextDirectionDetectorTests.swift */,
 			);
 			path = tabbyTests;
@@ -271,6 +274,7 @@
 				E10000022F93000100DDD002 /* PermissionAndContextModelTests.swift in Sources */,
 				E10000032F93000100DDD003 /* GhostSuggestionLayoutTests.swift in Sources */,
 				E10000042F93000100DDD004 /* BundledRuntimeLocatorTests.swift in Sources */,
+				E10000052F93000100DDD005 /* DisplayCoordinateConverterTests.swift in Sources */,
 				F10000012FA0000100EEE001 /* TextDirectionDetectorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/tabby/Services/UI/OverlayController.swift
+++ b/tabby/Services/UI/OverlayController.swift
@@ -135,6 +135,12 @@ final class OverlayController: SuggestionOverlayControlling {
     }
 
     private func targetScreenVisibleFrame(for caretRect: CGRect) -> CGRect {
+        let midpoint = CGPoint(x: caretRect.midX, y: caretRect.midY)
+
+        if let screen = NSScreen.screens.first(where: { $0.visibleFrame.contains(midpoint) }) {
+            return screen.visibleFrame
+        }
+
         if let screen = NSScreen.screens.first(where: { $0.frame.intersects(caretRect) }) {
             return screen.visibleFrame
         }

--- a/tabby/Support/AXHelper.swift
+++ b/tabby/Support/AXHelper.swift
@@ -287,7 +287,7 @@ enum AXHelper {
 
     // MARK: - Coordinate Conversion
 
-    /// Converts raw Accessibility coordinates into global AppKit points via a simple Y-flip.
+    /// Converts raw Accessibility coordinates into global AppKit points via a per-display Y-flip.
     /// Use this for element-level rects (AXFrame) that are reliably in Cocoa points.
     /// For text-range rects (BoundsForRange, TextMarker), use `validatedCocoaTextRect` instead.
     static func cocoaRect(fromAccessibilityRect rect: CGRect) -> CGRect {
@@ -295,17 +295,15 @@ enum AXHelper {
             return rect
         }
 
-        let desktopBounds = desktopUnionFrame()
-        guard !desktopBounds.isNull else {
-            return rect
+        let displays = displayGeometries()
+        if let converted = DisplayCoordinateConverter.appKitRect(
+            fromCoreGraphicsRect: rect,
+            displays: displays
+        ) {
+            return converted
         }
 
-        return CGRect(
-            x: rect.origin.x,
-            y: desktopBounds.maxY - rect.origin.y - rect.height,
-            width: rect.width,
-            height: rect.height
-        )
+        return legacyDesktopUnionFlip(rect)
     }
 
     /// Converts a text-range AX rect to Cocoa coordinates, using the element's AXFrame (already
@@ -322,18 +320,16 @@ enum AXHelper {
             return textRect
         }
 
-        let desktopBounds = desktopUnionFrame()
-        guard !desktopBounds.isNull else {
+        let displays = displayGeometries()
+        guard !displays.isEmpty else {
             return textRect
         }
 
         // Candidate A: plain Y-flip, assuming the AX rect is already in Cocoa points.
-        let flipped = CGRect(
-            x: textRect.origin.x,
-            y: desktopBounds.maxY - textRect.origin.y - textRect.height,
-            width: textRect.width,
-            height: textRect.height
-        )
+        let flipped = DisplayCoordinateConverter.appKitRect(
+            fromCoreGraphicsRect: textRect,
+            displays: displays
+        ) ?? legacyDesktopUnionFlip(textRect)
 
         guard let anchor = cocoaAnchorFrame, !anchor.isEmpty else {
             // No anchor available — plain Y-flip is the safest default.
@@ -348,41 +344,55 @@ enum AXHelper {
             return flipped
         }
 
-        // Candidate B: divide by backing scale factor first (Chromium pixel-space workaround),
-        // then Y-flip. Some apps return physical pixels for text ranges on Retina.
-        let fallbackScale = NSScreen.main?.backingScaleFactor ?? 2.0
-        let scale: CGFloat = NSScreen.screens.first(where: {
-            $0.frame.contains(CGPoint(
-                x: textRect.origin.x / fallbackScale,
-                y: $0.frame.maxY - (textRect.origin.y / fallbackScale)
-            ))
-        })?.backingScaleFactor ?? fallbackScale
-
-        let scaled = CGRect(
-            x: textRect.origin.x / scale,
-            y: textRect.origin.y / scale,
-            width: textRect.width / scale,
-            height: textRect.height / scale
-        )
-        let scaledFlipped = CGRect(
-            x: scaled.origin.x,
-            y: desktopBounds.maxY - scaled.origin.y - scaled.height,
-            width: scaled.width,
-            height: scaled.height
-        )
-
-        if expandedAnchor.contains(CGPoint(x: scaledFlipped.midX, y: scaledFlipped.midY)) {
-            return scaledFlipped
+        // Candidate B: some apps report text-range bounds in physical pixels on Retina screens.
+        // Scale relative to the owning display's origin; dividing global coordinates directly
+        // breaks when an external monitor has a non-zero or negative origin.
+        for scaledFlipped in DisplayCoordinateConverter.appKitRectsFromPixelRect(
+            textRect,
+            displays: displays
+        ) {
+            if expandedAnchor.contains(CGPoint(x: scaledFlipped.midX, y: scaledFlipped.midY)) {
+                return scaledFlipped
+            }
         }
 
         // Neither candidate landed near the anchor. Return unscaled as best-effort.
         return flipped
     }
 
-    /// Union of all connected screen frames — used for AX top-left → Cocoa bottom-left conversion.
-    private static func desktopUnionFrame() -> CGRect {
-        NSScreen.screens
+    private static func displayGeometries() -> [DisplayGeometry] {
+        NSScreen.screens.compactMap { screen in
+            guard let number = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")]
+                as? NSNumber
+            else {
+                return nil
+            }
+
+            let displayID = CGDirectDisplayID(number.uint32Value)
+            return DisplayGeometry(
+                appKitFrame: screen.frame,
+                visibleFrame: screen.visibleFrame,
+                coreGraphicsBounds: CGDisplayBounds(displayID),
+                backingScaleFactor: screen.backingScaleFactor
+            )
+        }
+    }
+
+    /// Last-resort fallback for unusual virtual displays where AppKit cannot expose a display ID.
+    private static func legacyDesktopUnionFlip(_ rect: CGRect) -> CGRect {
+        let desktopBounds = NSScreen.screens
             .map(\.frame)
             .reduce(into: CGRect.null) { $0 = $0.union($1) }
+
+        guard !desktopBounds.isNull else {
+            return rect
+        }
+
+        return CGRect(
+            x: rect.origin.x,
+            y: desktopBounds.maxY - rect.origin.y - rect.height,
+            width: rect.width,
+            height: rect.height
+        )
     }
 }

--- a/tabby/Support/DisplayCoordinateConverter.swift
+++ b/tabby/Support/DisplayCoordinateConverter.swift
@@ -1,0 +1,110 @@
+import CoreGraphics
+
+/// Describes one physical display in both coordinate systems Tabby has to bridge.
+///
+/// Accessibility and CoreGraphics APIs report rectangles in a top-left-origin display space.
+/// AppKit windows use a bottom-left-origin screen space. Keeping both frames together lets the
+/// conversion flip Y inside the display that actually owns the rectangle instead of using a
+/// fragile union of every connected monitor.
+struct DisplayGeometry: Equatable {
+    let appKitFrame: CGRect
+    let visibleFrame: CGRect
+    let coreGraphicsBounds: CGRect
+    let backingScaleFactor: CGFloat
+}
+
+/// Pure display-coordinate conversion shared by AX geometry and tests.
+///
+/// This type intentionally knows nothing about `NSScreen`; callers pass snapshots of display
+/// geometry in. That keeps the math testable for external-monitor arrangements that are awkward
+/// to reproduce in CI, such as a secondary display above the primary display.
+enum DisplayCoordinateConverter {
+    static func appKitRect(
+        fromCoreGraphicsRect rect: CGRect,
+        displays: [DisplayGeometry]
+    ) -> CGRect? {
+        guard let display = bestDisplay(
+            for: rect,
+            displays: displays,
+            keyPath: \.coreGraphicsBounds
+        ) else {
+            return nil
+        }
+
+        return appKitRect(fromCoreGraphicsRect: rect, on: display)
+    }
+
+    static func appKitRectsFromPixelRect(
+        _ rect: CGRect,
+        displays: [DisplayGeometry]
+    ) -> [CGRect] {
+        displays.compactMap { display in
+            guard display.backingScaleFactor > 0 else { return nil }
+
+            let pixelBounds = CGRect(
+                x: display.coreGraphicsBounds.minX * display.backingScaleFactor,
+                y: display.coreGraphicsBounds.minY * display.backingScaleFactor,
+                width: display.coreGraphicsBounds.width * display.backingScaleFactor,
+                height: display.coreGraphicsBounds.height * display.backingScaleFactor
+            )
+
+            let midpoint = CGPoint(x: rect.midX, y: rect.midY)
+            guard pixelBounds.intersects(rect) || pixelBounds.contains(midpoint) else {
+                return nil
+            }
+
+            let pointRect = CGRect(
+                x: display.coreGraphicsBounds.minX
+                    + (rect.minX - pixelBounds.minX) / display.backingScaleFactor,
+                y: display.coreGraphicsBounds.minY
+                    + (rect.minY - pixelBounds.minY) / display.backingScaleFactor,
+                width: rect.width / display.backingScaleFactor,
+                height: rect.height / display.backingScaleFactor
+            )
+
+            return appKitRect(fromCoreGraphicsRect: pointRect, on: display)
+        }
+    }
+
+    private static func appKitRect(
+        fromCoreGraphicsRect rect: CGRect,
+        on display: DisplayGeometry
+    ) -> CGRect {
+        let localX = rect.minX - display.coreGraphicsBounds.minX
+        let localY = rect.minY - display.coreGraphicsBounds.minY
+
+        return CGRect(
+            x: display.appKitFrame.minX + localX,
+            y: display.appKitFrame.maxY - localY - rect.height,
+            width: rect.width,
+            height: rect.height
+        )
+    }
+
+    private static func bestDisplay(
+        for rect: CGRect,
+        displays: [DisplayGeometry],
+        keyPath: KeyPath<DisplayGeometry, CGRect>
+    ) -> DisplayGeometry? {
+        let midpoint = CGPoint(x: rect.midX, y: rect.midY)
+
+        if let containingDisplay = displays.first(where: {
+            $0[keyPath: keyPath].contains(midpoint)
+        }) {
+            return containingDisplay
+        }
+
+        return displays
+            .filter { $0[keyPath: keyPath].intersects(rect) }
+            .max { lhs, rhs in
+                intersectionArea(lhs[keyPath: keyPath], rect)
+                    < intersectionArea(rhs[keyPath: keyPath], rect)
+            }
+    }
+
+    private static func intersectionArea(_ lhs: CGRect, _ rhs: CGRect) -> CGFloat {
+        let intersection = lhs.intersection(rhs)
+        guard !intersection.isNull else { return 0 }
+        return intersection.width * intersection.height
+    }
+}

--- a/tabbyTests/DisplayCoordinateConverterTests.swift
+++ b/tabbyTests/DisplayCoordinateConverterTests.swift
@@ -1,0 +1,71 @@
+import CoreGraphics
+import XCTest
+@testable import tabby
+
+final class DisplayCoordinateConverterTests: XCTestCase {
+    func test_appKitRect_flipsWithinOwningDisplayAbovePrimary() {
+        let primary = DisplayGeometry(
+            appKitFrame: CGRect(x: 0, y: 0, width: 1440, height: 900),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1440, height: 875),
+            coreGraphicsBounds: CGRect(x: 0, y: 0, width: 1440, height: 900),
+            backingScaleFactor: 2
+        )
+        let displayAbove = DisplayGeometry(
+            appKitFrame: CGRect(x: 0, y: 900, width: 1920, height: 1080),
+            visibleFrame: CGRect(x: 0, y: 900, width: 1920, height: 1055),
+            coreGraphicsBounds: CGRect(x: 0, y: -1080, width: 1920, height: 1080),
+            backingScaleFactor: 1
+        )
+
+        let rect = DisplayCoordinateConverter.appKitRect(
+            fromCoreGraphicsRect: CGRect(x: 120, y: -1000, width: 300, height: 20),
+            displays: [primary, displayAbove]
+        )
+
+        XCTAssertEqual(rect, CGRect(x: 120, y: 1880, width: 300, height: 20))
+    }
+
+    func test_appKitRect_preservesNegativeXWhenRectCrossesDisplayBoundary() {
+        let left = DisplayGeometry(
+            appKitFrame: CGRect(x: -1280, y: 0, width: 1280, height: 720),
+            visibleFrame: CGRect(x: -1280, y: 0, width: 1280, height: 700),
+            coreGraphicsBounds: CGRect(x: -1280, y: 0, width: 1280, height: 720),
+            backingScaleFactor: 1
+        )
+        let primary = DisplayGeometry(
+            appKitFrame: CGRect(x: 0, y: 0, width: 1440, height: 900),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1440, height: 875),
+            coreGraphicsBounds: CGRect(x: 0, y: 0, width: 1440, height: 900),
+            backingScaleFactor: 2
+        )
+
+        let rect = DisplayCoordinateConverter.appKitRect(
+            fromCoreGraphicsRect: CGRect(x: -20, y: 100, width: 80, height: 20),
+            displays: [left, primary]
+        )
+
+        XCTAssertEqual(rect, CGRect(x: -20, y: 780, width: 80, height: 20))
+    }
+
+    func test_appKitRectsFromPixelRect_scalesRelativeToDisplayOrigin() {
+        let primary = DisplayGeometry(
+            appKitFrame: CGRect(x: 0, y: 0, width: 1440, height: 900),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1440, height: 875),
+            coreGraphicsBounds: CGRect(x: 0, y: 0, width: 1440, height: 900),
+            backingScaleFactor: 2
+        )
+        let rightRetina = DisplayGeometry(
+            appKitFrame: CGRect(x: 1440, y: 0, width: 1512, height: 982),
+            visibleFrame: CGRect(x: 1440, y: 0, width: 1512, height: 957),
+            coreGraphicsBounds: CGRect(x: 1440, y: 0, width: 1512, height: 982),
+            backingScaleFactor: 2
+        )
+
+        let rects = DisplayCoordinateConverter.appKitRectsFromPixelRect(
+            CGRect(x: 1440 * 2 + 200, y: 120, width: 80, height: 40),
+            displays: [primary, rightRetina]
+        )
+
+        XCTAssertEqual(rects, [CGRect(x: 1540, y: 902, width: 40, height: 20)])
+    }
+}


### PR DESCRIPTION
## Summary
- convert Accessibility/CoreGraphics rectangles by matching the owning display before flipping into AppKit coordinates
- preserve Retina text-range fallback behavior while scaling relative to the display origin instead of the main screen
- choose overlay visible frames by caret midpoint before falling back to intersection order
- add pure display-coordinate tests for above-primary, negative-X, and Retina-origin monitor layouts

## Validation
- xcodebuild -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' -only-testing:tabbyTests/DisplayCoordinateConverterTests test CODE_SIGNING_ALLOWED=NO
- xcodebuild -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' build CODE_SIGNING_ALLOWED=NO
- xcodebuild -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' build-for-testing CODE_SIGNING_ALLOWED=NO

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes AX/CG rectangle conversion for multi-monitor setups by replacing a single desktop-union Y-flip with per-display geometry. A new `DisplayCoordinateConverter` enum handles all coordinate math against injected `DisplayGeometry` snapshots, keeping it fully testable without `NSScreen`.

- Adds `DisplayCoordinateConverter` and `DisplayGeometry` to `tabby/Support/`, correctly flipping CG rects within their owning display and handling Retina pixel-to-point scaling anchored at each display's own origin rather than the global origin.
- Updates `AXHelper.cocoaRect` and `validatedCocoaTextRect` to use the new per-display converter with `legacyDesktopUnionFlip` as a last-resort fallback, and refactors `OverlayController.targetScreenVisibleFrame` to prefer caret-midpoint containment in `visibleFrame` before the frame-intersection fallback.
- Adds `DisplayCoordinateConverterTests` with three pure-geometry tests covering above-primary, negative-X boundary-crossing, and Retina-origin display layouts.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the per-display Y-flip math is correct for primary, side-by-side, above-primary, and Retina configurations, and the legacy fallback is preserved for virtual/mirrored displays without an NSScreenNumber.

The coordinate arithmetic has been verified against all three test scenarios and the fallback paths (legacyDesktopUnionFlip, displays.isEmpty early-return) correctly mirror the pre-existing behavior. No new crash paths, data loss, or security concerns were introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tabby/Support/DisplayCoordinateConverter.swift | New pure-math type for CG→AppKit rect conversion; bestDisplay uses midpoint containment then intersection-area fallback; appKitRectsFromPixelRect correctly anchors pixel-to-point scaling at each display's own CG origin. |
| tabby/Support/AXHelper.swift | Replaces desktop-union Y-flip in cocoaRect and validatedCocoaTextRect with per-display converter calls; legacyDesktopUnionFlip kept as fallback for displays without an NSScreenNumber; logic is clean and symmetric between both methods. |
| tabby/Services/UI/OverlayController.swift | Adds midpoint-in-visibleFrame priority check before the existing frame-intersection fallback, correctly routing the overlay to the screen that owns the caret rather than any intersecting screen. |
| tabbyTests/DisplayCoordinateConverterTests.swift | Three new deterministic geometry tests; expected values are arithmetically verified for above-primary, negative-X boundary crossing, and Retina pixel scaling on a right-side 2x display. |
| tabby.xcodeproj/project.pbxproj | Registers DisplayCoordinateConverterTests.swift in the test target; mechanical Xcode project file change. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[AX/CG rect from Accessibility API] --> B{cocoaRect or validatedCocoaTextRect?}
    B -->|cocoaRect| C[displayGeometries]
    B -->|validatedCocoaTextRect| D[displayGeometries]
    C --> E{displays empty?}
    E -->|no| F[DisplayCoordinateConverter.appKitRect]
    E -->|yes| G[legacyDesktopUnionFlip]
    F -->|nil| G
    F -->|converted| H[Return AppKit rect]
    G --> H
    D --> I{displays empty?}
    I -->|yes| J[Return raw textRect no Y-flip]
    I -->|no| K[Candidate A: appKitRect ?? legacyDesktopUnionFlip]
    K --> L{anchor available?}
    L -->|no| M[Return Candidate A]
    L -->|yes| N{Candidate A midpoint inside expandedAnchor?}
    N -->|yes| M
    N -->|no| O[Candidate B: appKitRectsFromPixelRect]
    O --> P{Any Candidate B inside expandedAnchor?}
    P -->|yes| Q[Return first matching Candidate B]
    P -->|no| R[Return Candidate A best-effort]
```

<sub>Reviews (2): Last reviewed commit: ["Fix external monitor geometry conversion"](https://github.com/fujacob/tabby/commit/2076102b536b2d601e8c101d7405661e5c5379f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33697273)</sub>

<!-- /greptile_comment -->