### PR TITLE
Add clipboard relevance filter and line-level distillation

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		19E177EA2FC1B7890067E267 /* CotabbyInference in Frameworks */ = {isa = PBXBuildFile; productRef = 19E177E92FC1B7890067E267 /* CotabbyInference */; };
 		8B6282F0C1CCA0746D96B914 /* DownloadOutcomeClassifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562F89255AF340C15A0554BE /* DownloadOutcomeClassifierTests.swift */; };
 		G10000012FB0000100FFF001 /* ClipboardRelevanceFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = G10000112FB0000100FFF011 /* ClipboardRelevanceFilterTests.swift */; };
+		G10000022FB0000100FFF002 /* ClipboardContentDistillerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = G10000122FB0000100FFF012 /* ClipboardContentDistillerTests.swift */; };
 		A1C3E0012F90000100AAA001 /* LlamaSwift in Frameworks */ = {isa = PBXBuildFile; productRef = A1C3E0002F90000100AAA001 /* LlamaSwift */; };
 		A1C3E0112F90000100AAA001 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = A1C3E0102F90000100AAA001 /* Sparkle */; };
 		A404828463CADB2ECDAE7AF3 /* LlamaPromptRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F29623C5C0A67B992D383A3C /* LlamaPromptRendererTests.swift */; };
@@ -50,6 +51,7 @@
 		3FBFA92FA44AA317135426FB /* CotabbyTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CotabbyTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		562F89255AF340C15A0554BE /* DownloadOutcomeClassifierTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DownloadOutcomeClassifierTests.swift; sourceTree = "<group>"; };
 		G10000112FB0000100FFF011 /* ClipboardRelevanceFilterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ClipboardRelevanceFilterTests.swift; sourceTree = "<group>"; };
+		G10000122FB0000100FFF012 /* ClipboardContentDistillerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ClipboardContentDistillerTests.swift; sourceTree = "<group>"; };
 		5A39EC1A44E9160E13E2AE77 /* SuggestionAvailabilityEvaluatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SuggestionAvailabilityEvaluatorTests.swift; sourceTree = "<group>"; };
 		8B1121FFDAD30C7F62E15289 /* SuggestionRequestFactoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SuggestionRequestFactoryTests.swift; sourceTree = "<group>"; };
 		BAAEE25772008D75883F2655 /* DownloadFileRescuerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DownloadFileRescuerTests.swift; sourceTree = "<group>"; };
@@ -143,6 +145,7 @@
 				E10000152F93000100DDD015 /* DisplayCoordinateConverterTests.swift */,
 				F10000112FA0000100EEE011 /* TextDirectionDetectorTests.swift */,
 				G10000112FB0000100FFF011 /* ClipboardRelevanceFilterTests.swift */,
+				G10000122FB0000100FFF012 /* ClipboardContentDistillerTests.swift */,
 			);
 			path = CotabbyTests;
 			sourceTree = "<group>";
@@ -284,6 +287,7 @@
 				E10000052F93000100DDD005 /* DisplayCoordinateConverterTests.swift in Sources */,
 				F10000012FA0000100EEE001 /* TextDirectionDetectorTests.swift in Sources */,
 				G10000012FB0000100FFF001 /* ClipboardRelevanceFilterTests.swift in Sources */,
+				G10000022FB0000100FFF002 /* ClipboardContentDistillerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		194B33B52FC3F33B00DF6F60 /* Logging in Frameworks */ = {isa = PBXBuildFile; productRef = 194B33B42FC3F33B00DF6F60 /* Logging */; };
 		19E177EA2FC1B7890067E267 /* CotabbyInference in Frameworks */ = {isa = PBXBuildFile; productRef = 19E177E92FC1B7890067E267 /* CotabbyInference */; };
 		8B6282F0C1CCA0746D96B914 /* DownloadOutcomeClassifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562F89255AF340C15A0554BE /* DownloadOutcomeClassifierTests.swift */; };
+		G10000012FB0000100FFF001 /* ClipboardRelevanceFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = G10000112FB0000100FFF011 /* ClipboardRelevanceFilterTests.swift */; };
+		A1C3E0012F90000100AAA001 /* LlamaSwift in Frameworks */ = {isa = PBXBuildFile; productRef = A1C3E0002F90000100AAA001 /* LlamaSwift */; };
 		A1C3E0112F90000100AAA001 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = A1C3E0102F90000100AAA001 /* Sparkle */; };
 		A404828463CADB2ECDAE7AF3 /* LlamaPromptRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F29623C5C0A67B992D383A3C /* LlamaPromptRendererTests.swift */; };
 		ADEFEE12C197DB6C990E3812 /* SuggestionRequestFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1121FFDAD30C7F62E15289 /* SuggestionRequestFactoryTests.swift */; };
@@ -47,6 +49,7 @@
 		193741492F81DE7000BEC04F /* Cotabby.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Cotabby.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3FBFA92FA44AA317135426FB /* CotabbyTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CotabbyTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		562F89255AF340C15A0554BE /* DownloadOutcomeClassifierTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DownloadOutcomeClassifierTests.swift; sourceTree = "<group>"; };
+		G10000112FB0000100FFF011 /* ClipboardRelevanceFilterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ClipboardRelevanceFilterTests.swift; sourceTree = "<group>"; };
 		5A39EC1A44E9160E13E2AE77 /* SuggestionAvailabilityEvaluatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SuggestionAvailabilityEvaluatorTests.swift; sourceTree = "<group>"; };
 		8B1121FFDAD30C7F62E15289 /* SuggestionRequestFactoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SuggestionRequestFactoryTests.swift; sourceTree = "<group>"; };
 		BAAEE25772008D75883F2655 /* DownloadFileRescuerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DownloadFileRescuerTests.swift; sourceTree = "<group>"; };
@@ -139,6 +142,7 @@
 				E10000142F93000100DDD014 /* BundledRuntimeLocatorTests.swift */,
 				E10000152F93000100DDD015 /* DisplayCoordinateConverterTests.swift */,
 				F10000112FA0000100EEE011 /* TextDirectionDetectorTests.swift */,
+				G10000112FB0000100FFF011 /* ClipboardRelevanceFilterTests.swift */,
 			);
 			path = CotabbyTests;
 			sourceTree = "<group>";
@@ -279,6 +283,7 @@
 				E10000042F93000100DDD004 /* BundledRuntimeLocatorTests.swift in Sources */,
 				E10000052F93000100DDD005 /* DisplayCoordinateConverterTests.swift in Sources */,
 				F10000012FA0000100EEE001 /* TextDirectionDetectorTests.swift in Sources */,
+				G10000012FB0000100FFF001 /* ClipboardRelevanceFilterTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
@@ -72,9 +72,15 @@ extension SuggestionCoordinator {
 
         let context = interactionState.materializeContext(from: rawContext)
         let visualContextSummary = visualContextCoordinator.excerpt(for: context)
-        let clipboardContext = settingsSnapshot.isClipboardContextEnabled
+        let rawClipboard = settingsSnapshot.isClipboardContextEnabled
             ? clipboardContextProvider.currentContext()
             : nil
+        let clipboardContext = clipboardRelevanceFilter.filter(
+            clipboard: rawClipboard,
+            pasteboardChangeCount: clipboardContextProvider.currentChangeCount,
+            currentBundleIdentifier: rawContext.bundleIdentifier,
+            precedingText: rawContext.precedingText
+        )
         let requestBuildResult = SuggestionRequestFactory.buildRequest(
             context: context,
             settings: settingsSnapshot,

--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
@@ -75,11 +75,16 @@ extension SuggestionCoordinator {
         let rawClipboard = settingsSnapshot.isClipboardContextEnabled
             ? clipboardContextProvider.currentContext()
             : nil
+        // Same bounded window the downstream distiller sees, so the relevance gate and the
+        // per-line filter can't disagree about what "shares tokens with the prefix" means.
+        let truncatedPrefix = SuggestionRequestFactory.truncatedPromptPrefix(
+            from: rawContext.precedingText,
+            configuration: configuration
+        )
         let clipboardContext = clipboardRelevanceFilter.filter(
             clipboard: rawClipboard,
             pasteboardChangeCount: clipboardContextProvider.currentChangeCount,
-            currentBundleIdentifier: rawContext.bundleIdentifier,
-            precedingText: rawContext.precedingText
+            precedingText: truncatedPrefix
         )
         let requestBuildResult = SuggestionRequestFactory.buildRequest(
             context: context,

--- a/Cotabby/App/Coordinators/SuggestionCoordinator.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator.swift
@@ -42,7 +42,7 @@ final class SuggestionCoordinator: ObservableObject {
     let suggestionEngine: any SuggestionGenerating
     let suggestionSettings: any SuggestionSettingsProviding
     let clipboardContextProvider: any ClipboardContextProviding
-    let clipboardRelevanceFilter: ClipboardRelevanceFilter
+    let clipboardRelevanceFilter: any ClipboardRelevanceFiltering
     let visualContextCoordinator: any VisualContextCoordinating
     let interactionState: SuggestionInteractionState
     let workController: SuggestionWorkController
@@ -71,7 +71,7 @@ final class SuggestionCoordinator: ObservableObject {
         suggestionEngine: any SuggestionGenerating,
         suggestionSettings: any SuggestionSettingsProviding,
         clipboardContextProvider: any ClipboardContextProviding,
-        clipboardRelevanceFilter: ClipboardRelevanceFilter,
+        clipboardRelevanceFilter: any ClipboardRelevanceFiltering,
         visualContextCoordinator: any VisualContextCoordinating,
         interactionState: SuggestionInteractionState,
         workController: SuggestionWorkController,

--- a/Cotabby/App/Coordinators/SuggestionCoordinator.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator.swift
@@ -42,6 +42,7 @@ final class SuggestionCoordinator: ObservableObject {
     let suggestionEngine: any SuggestionGenerating
     let suggestionSettings: any SuggestionSettingsProviding
     let clipboardContextProvider: any ClipboardContextProviding
+    let clipboardRelevanceFilter: ClipboardRelevanceFilter
     let visualContextCoordinator: any VisualContextCoordinating
     let interactionState: SuggestionInteractionState
     let workController: SuggestionWorkController
@@ -70,6 +71,7 @@ final class SuggestionCoordinator: ObservableObject {
         suggestionEngine: any SuggestionGenerating,
         suggestionSettings: any SuggestionSettingsProviding,
         clipboardContextProvider: any ClipboardContextProviding,
+        clipboardRelevanceFilter: ClipboardRelevanceFilter,
         visualContextCoordinator: any VisualContextCoordinating,
         interactionState: SuggestionInteractionState,
         workController: SuggestionWorkController,
@@ -87,6 +89,7 @@ final class SuggestionCoordinator: ObservableObject {
         self.suggestionEngine = suggestionEngine
         self.suggestionSettings = suggestionSettings
         self.clipboardContextProvider = clipboardContextProvider
+        self.clipboardRelevanceFilter = clipboardRelevanceFilter
         self.visualContextCoordinator = visualContextCoordinator
         self.interactionState = interactionState
         self.workController = workController

--- a/Cotabby/App/Core/CotabbyAppEnvironment.swift
+++ b/Cotabby/App/Core/CotabbyAppEnvironment.swift
@@ -83,6 +83,7 @@ final class CotabbyAppEnvironment {
         let overlayController = OverlayController(suggestionSettings: suggestionSettings)
         let activationIndicatorController = ActivationIndicatorController()
         let clipboardContextProvider = ClipboardContextProvider()
+        let clipboardRelevanceFilter = ClipboardRelevanceFilter()
         let summarizer = LlamaVisualContextSummarizer(runtimeManager: runtimeManager)
         let screenshotContextGenerator = ScreenshotContextGenerator(summarizer: summarizer)
         let visualContextCoordinator = VisualContextCoordinator(
@@ -131,6 +132,7 @@ final class CotabbyAppEnvironment {
             suggestionEngine: suggestionEngine,
             suggestionSettings: suggestionSettings,
             clipboardContextProvider: clipboardContextProvider,
+            clipboardRelevanceFilter: clipboardRelevanceFilter,
             visualContextCoordinator: visualContextCoordinator,
             interactionState: interactionState,
             workController: workController,

--- a/Cotabby/Models/SuggestionSubsystemContracts.swift
+++ b/Cotabby/Models/SuggestionSubsystemContracts.swift
@@ -57,6 +57,19 @@ protocol ClipboardContextProviding: AnyObject {
 }
 
 @MainActor
+protocol ClipboardRelevanceFiltering: AnyObject {
+    /// Returns `clipboard` when it should be injected into the prompt, or `nil` to drop it.
+    ///
+    /// `precedingText` should be the same bounded window the downstream distiller will see,
+    /// so the relevance gate and per-line distillation evaluate overlap consistently.
+    func filter(
+        clipboard: String?,
+        pasteboardChangeCount: Int,
+        precedingText: String
+    ) -> String?
+}
+
+@MainActor
 protocol SuggestionInserting: AnyObject {
     var lastErrorMessage: String? { get }
 

--- a/Cotabby/Models/SuggestionSubsystemContracts.swift
+++ b/Cotabby/Models/SuggestionSubsystemContracts.swift
@@ -53,6 +53,7 @@ protocol SuggestionSettingsProviding: AnyObject {
 @MainActor
 protocol ClipboardContextProviding: AnyObject {
     func currentContext() -> String?
+    var currentChangeCount: Int { get }
 }
 
 @MainActor

--- a/Cotabby/Services/Utilities/ClipboardContextProvider.swift
+++ b/Cotabby/Services/Utilities/ClipboardContextProvider.swift
@@ -15,6 +15,8 @@ final class ClipboardContextProvider: ClipboardContextProviding {
         self.pasteboard = pasteboard
     }
 
+    var currentChangeCount: Int { pasteboard.changeCount }
+
     func currentContext() -> String? {
         if let text = normalizedText(pasteboard.string(forType: .string)) {
             return text

--- a/Cotabby/Support/ClipboardContentDistiller.swift
+++ b/Cotabby/Support/ClipboardContentDistiller.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Extracts only the clipboard lines that share meaningful tokens with the user's current
+/// prefix text. Short clipboard content passes through unchanged; longer content is filtered
+/// to the lines most likely to help the autocomplete model.
+enum ClipboardContentDistiller {
+    private static let compactLineThreshold = 3
+    private static let headFallbackCharacters = 300
+
+    /// Returns a distilled version of `clipboard` containing only lines relevant to `prefixText`.
+    ///
+    /// - Clipboard with ≤3 lines or empty `prefixText` is returned as-is.
+    /// - Longer clipboard keeps only lines whose tokens overlap with `prefixText`.
+    /// - If no individual line overlaps, the first 300 characters are returned as a head fallback.
+    static func distill(clipboard: String, prefixText: String) -> String {
+        let lines = clipboard.components(separatedBy: "\n")
+        guard lines.count > compactLineThreshold else { return clipboard }
+
+        let prefixTokens = PromptContextSanitizer.significantTokens(from: prefixText)
+        guard !prefixTokens.isEmpty else { return clipboard }
+
+        let relevantLines = lines.filter { line in
+            let lineTokens = PromptContextSanitizer.significantTokens(from: line)
+            return !lineTokens.isDisjoint(with: prefixTokens)
+        }
+
+        if relevantLines.isEmpty {
+            return String(clipboard.prefix(headFallbackCharacters))
+        }
+
+        return relevantLines.joined(separator: "\n")
+    }
+}

--- a/Cotabby/Support/ClipboardRelevanceFilter.swift
+++ b/Cotabby/Support/ClipboardRelevanceFilter.swift
@@ -55,10 +55,7 @@ final class ClipboardRelevanceFilter {
         return clipboard
     }
 
-    // MARK: - Tokenization
-
     private static func tokens(from text: String) -> Set<String> {
-        let words = text.lowercased().components(separatedBy: .alphanumerics.inverted)
-        return Set(words.filter { $0.count >= minimumTokenLength })
+        PromptContextSanitizer.significantTokens(from: text, minimumLength: minimumTokenLength)
     }
 }

--- a/Cotabby/Support/ClipboardRelevanceFilter.swift
+++ b/Cotabby/Support/ClipboardRelevanceFilter.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// Decides whether the current clipboard content is relevant enough to inject into the
+/// autocomplete prompt. Tracks clipboard identity via an external change count, records when
+/// the clipboard last changed and which app was frontmost at that moment, then applies three
+/// heuristics: staleness, app affinity, and token overlap.
+///
+/// The filter never reads `NSPasteboard` directly — the caller passes in a plain `Int` change
+/// count and the raw clipboard string, keeping this type fully testable without AppKit.
+@MainActor
+final class ClipboardRelevanceFilter {
+    static let staleThresholdSeconds: TimeInterval = 300
+    private static let minimumTokenLength = 3
+
+    private var lastKnownChangeCount: Int = 0
+    private var lastChangeDate: Date?
+    private var sourceBundleIdentifier: String?
+    private let dateProvider: () -> Date
+
+    init(dateProvider: @escaping () -> Date = { Date() }) {
+        self.dateProvider = dateProvider
+    }
+
+    /// Returns `clipboard` unchanged when it looks relevant, or `nil` when it should be dropped.
+    func filter(
+        clipboard: String?,
+        pasteboardChangeCount: Int,
+        currentBundleIdentifier: String,
+        precedingText: String
+    ) -> String? {
+        guard let clipboard else { return nil }
+
+        if pasteboardChangeCount != lastKnownChangeCount {
+            lastKnownChangeCount = pasteboardChangeCount
+            lastChangeDate = dateProvider()
+            sourceBundleIdentifier = currentBundleIdentifier
+        }
+
+        guard let lastChangeDate,
+              dateProvider().timeIntervalSince(lastChangeDate) < Self.staleThresholdSeconds
+        else {
+            return nil
+        }
+
+        if sourceBundleIdentifier == currentBundleIdentifier {
+            return clipboard
+        }
+
+        let clipboardTokens = Self.tokens(from: clipboard)
+        let prefixTokens = Self.tokens(from: precedingText)
+        guard !clipboardTokens.isDisjoint(with: prefixTokens) else {
+            return nil
+        }
+
+        return clipboard
+    }
+
+    // MARK: - Tokenization
+
+    private static func tokens(from text: String) -> Set<String> {
+        let words = text.lowercased().components(separatedBy: .alphanumerics.inverted)
+        return Set(words.filter { $0.count >= minimumTokenLength })
+    }
+}

--- a/Cotabby/Support/ClipboardRelevanceFilter.swift
+++ b/Cotabby/Support/ClipboardRelevanceFilter.swift
@@ -2,19 +2,29 @@ import Foundation
 
 /// Decides whether the current clipboard content is relevant enough to inject into the
 /// autocomplete prompt. Tracks clipboard identity via an external change count, records when
-/// the clipboard last changed and which app was frontmost at that moment, then applies three
-/// heuristics: staleness, app affinity, and token overlap.
+/// the clipboard last changed during this Cotabby session, and applies two heuristics:
+/// staleness and token overlap.
+///
+/// Why no source-app affinity: we never observe the actual copier — only the app that is
+/// frontmost when autocomplete fires, which is always the typing app. Recording the typing
+/// app as the "source" granted same-app shortcuts in apps where the user merely typed,
+/// bypassing the overlap guard for unrelated clipboard content.
+///
+/// Why a sentinel baseline: `NSPasteboard.changeCount` is a non-zero cumulative counter, so
+/// initializing to `0` made every first observation look like a fresh copy event and reset
+/// the staleness clock to "now" — granting up to five minutes of injection for content
+/// copied hours before Cotabby launched. The first observation now records the baseline
+/// without stamping a date, gating injection until an actual change is detected.
 ///
 /// The filter never reads `NSPasteboard` directly — the caller passes in a plain `Int` change
 /// count and the raw clipboard string, keeping this type fully testable without AppKit.
 @MainActor
-final class ClipboardRelevanceFilter {
+final class ClipboardRelevanceFilter: ClipboardRelevanceFiltering {
     static let staleThresholdSeconds: TimeInterval = 300
     private static let minimumTokenLength = 3
 
-    private var lastKnownChangeCount: Int = 0
+    private var lastKnownChangeCount: Int?
     private var lastChangeDate: Date?
-    private var sourceBundleIdentifier: String?
     private let dateProvider: () -> Date
 
     init(dateProvider: @escaping () -> Date = { Date() }) {
@@ -25,25 +35,27 @@ final class ClipboardRelevanceFilter {
     func filter(
         clipboard: String?,
         pasteboardChangeCount: Int,
-        currentBundleIdentifier: String,
         precedingText: String
     ) -> String? {
         guard let clipboard else { return nil }
 
-        if pasteboardChangeCount != lastKnownChangeCount {
+        guard let baselineChangeCount = lastKnownChangeCount else {
+            // First observation: record the baseline so we can detect *new* copies, but leave
+            // the staleness clock unset. Pre-existing clipboard content is not injected until
+            // the user actually copies again while Cotabby is running.
+            lastKnownChangeCount = pasteboardChangeCount
+            return nil
+        }
+
+        if pasteboardChangeCount != baselineChangeCount {
             lastKnownChangeCount = pasteboardChangeCount
             lastChangeDate = dateProvider()
-            sourceBundleIdentifier = currentBundleIdentifier
         }
 
         guard let lastChangeDate,
               dateProvider().timeIntervalSince(lastChangeDate) < Self.staleThresholdSeconds
         else {
             return nil
-        }
-
-        if sourceBundleIdentifier == currentBundleIdentifier {
-            return clipboard
         }
 
         let clipboardTokens = Self.tokens(from: clipboard)

--- a/Cotabby/Support/PromptContextSanitizer.swift
+++ b/Cotabby/Support/PromptContextSanitizer.swift
@@ -59,6 +59,13 @@ enum PromptContextSanitizer {
         return bounded.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    /// Extracts lowercased tokens of at least `minimumLength` characters, splitting on
+    /// non-alphanumeric boundaries. Used by clipboard relevance and distillation logic.
+    static func significantTokens(from text: String, minimumLength: Int = 3) -> Set<String> {
+        let words = text.lowercased().components(separatedBy: .alphanumerics.inverted)
+        return Set(words.filter { $0.count >= minimumLength })
+    }
+
     static func containsAlphanumericSignal(_ text: String) -> Bool {
         text.unicodeScalars.contains { CharacterSet.alphanumerics.contains($0) }
     }

--- a/Cotabby/Support/SuggestionRequestFactory.swift
+++ b/Cotabby/Support/SuggestionRequestFactory.swift
@@ -88,7 +88,11 @@ enum SuggestionRequestFactory {
     }
 
     /// Keep only the latest short word tail to prevent long stale context from steering output.
-    private static func truncatedPromptPrefix(
+    ///
+    /// Exposed (non-private) so the coordinator can compute the same bounded window before
+    /// calling the relevance filter, ensuring the filter and the downstream distiller evaluate
+    /// token overlap against an identical prefix.
+    static func truncatedPromptPrefix(
         from precedingText: String,
         configuration: SuggestionConfiguration
     ) -> String {

--- a/Cotabby/Support/SuggestionRequestFactory.swift
+++ b/Cotabby/Support/SuggestionRequestFactory.swift
@@ -44,7 +44,8 @@ enum SuggestionRequestFactory {
         let userName = activeUserName(settings: settings)
         let boundedClipboardContext = activeClipboardContext(
             rawContext: clipboardContext,
-            settings: settings
+            settings: settings,
+            prefixText: prefixText
         )
         let boundedVisualContextSummary = activeVisualContextSummary(
             rawSummary: visualContextSummary
@@ -109,7 +110,8 @@ enum SuggestionRequestFactory {
 
     private static func activeClipboardContext(
         rawContext: String?,
-        settings: SuggestionSettingsSnapshot
+        settings: SuggestionSettingsSnapshot,
+        prefixText: String
     ) -> String? {
         guard settings.isClipboardContextEnabled,
               let rawContext
@@ -124,7 +126,11 @@ enum SuggestionRequestFactory {
             return nil
         }
 
-        return clippedText(sanitizedContext, maxCharacters: maxClipboardContextCharacters)
+        let distilled = ClipboardContentDistiller.distill(
+            clipboard: sanitizedContext,
+            prefixText: prefixText
+        )
+        return clippedText(distilled, maxCharacters: maxClipboardContextCharacters)
     }
 
     private static func activeVisualContextSummary(rawSummary: String?) -> String? {

--- a/CotabbyTests/ClipboardContentDistillerTests.swift
+++ b/CotabbyTests/ClipboardContentDistillerTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+@testable import Cotabby
+
+final class ClipboardContentDistillerTests: XCTestCase {
+
+    // MARK: - Short clipboard passes through
+
+    func test_shortClipboard_returnedAsIs() {
+        let clipboard = "line one\nline two\nline three"
+        let result = ClipboardContentDistiller.distill(
+            clipboard: clipboard,
+            prefixText: "completely unrelated text"
+        )
+        XCTAssertEqual(result, clipboard)
+    }
+
+    // MARK: - Long clipboard with partial overlap
+
+    func test_longClipboard_keepsOnlyMatchingLines() {
+        let clipboard = [
+            "import Foundation",
+            "import UIKit",
+            "func deployServer() {",
+            "    print(\"starting deploy\")",
+            "}"
+        ].joined(separator: "\n")
+
+        let result = ClipboardContentDistiller.distill(
+            clipboard: clipboard,
+            prefixText: "the deploy is running"
+        )
+        XCTAssertEqual(result, [
+            "func deployServer() {",
+            "    print(\"starting deploy\")"
+        ].joined(separator: "\n"))
+    }
+
+    // MARK: - No per-line overlap falls back to head
+
+    func test_longClipboard_noPerLineOverlap_returnsHead() {
+        let clipboard = [
+            "alpha bravo charlie",
+            "delta echo foxtrot",
+            "golf hotel india",
+            "juliet kilo lima"
+        ].joined(separator: "\n")
+
+        let result = ClipboardContentDistiller.distill(
+            clipboard: clipboard,
+            prefixText: "completely different words"
+        )
+        XCTAssertEqual(result, String(clipboard.prefix(300)))
+    }
+
+    // MARK: - Case insensitive
+
+    func test_caseInsensitiveMatching() {
+        let clipboard = [
+            "The DEPLOYMENT pipeline",
+            "Some unrelated header",
+            "Another random line",
+            "Check deployment status"
+        ].joined(separator: "\n")
+
+        let result = ClipboardContentDistiller.distill(
+            clipboard: clipboard,
+            prefixText: "our deployment is slow"
+        )
+        XCTAssertEqual(result, [
+            "The DEPLOYMENT pipeline",
+            "Check deployment status"
+        ].joined(separator: "\n"))
+    }
+
+    // MARK: - Short tokens ignored
+
+    func test_shortTokensIgnored() {
+        let clipboard = [
+            "a b c d e",
+            "x y z w v",
+            "real content here",
+            "more filler words"
+        ].joined(separator: "\n")
+
+        let result = ClipboardContentDistiller.distill(
+            clipboard: clipboard,
+            prefixText: "a b c x y z"
+        )
+        // No tokens >= 3 chars overlap, so head fallback.
+        XCTAssertEqual(result, String(clipboard.prefix(300)))
+    }
+
+    // MARK: - Empty prefix returns clipboard as-is
+
+    func test_emptyPrefixText_returnsClipboardAsIs() {
+        let clipboard = [
+            "line one content",
+            "line two content",
+            "line three content",
+            "line four content"
+        ].joined(separator: "\n")
+
+        let result = ClipboardContentDistiller.distill(
+            clipboard: clipboard,
+            prefixText: ""
+        )
+        XCTAssertEqual(result, clipboard)
+    }
+}

--- a/CotabbyTests/ClipboardContentDistillerTests.swift
+++ b/CotabbyTests/ClipboardContentDistillerTests.swift
@@ -20,7 +20,7 @@ final class ClipboardContentDistillerTests: XCTestCase {
         let clipboard = [
             "import Foundation",
             "import UIKit",
-            "func deployServer() {",
+            "func deploy() {",
             "    print(\"starting deploy\")",
             "}"
         ].joined(separator: "\n")
@@ -30,7 +30,7 @@ final class ClipboardContentDistillerTests: XCTestCase {
             prefixText: "the deploy is running"
         )
         XCTAssertEqual(result, [
-            "func deployServer() {",
+            "func deploy() {",
             "    print(\"starting deploy\")"
         ].joined(separator: "\n"))
     }

--- a/CotabbyTests/ClipboardRelevanceFilterTests.swift
+++ b/CotabbyTests/ClipboardRelevanceFilterTests.swift
@@ -19,166 +19,140 @@ final class ClipboardRelevanceFilterTests: XCTestCase {
         let result = filter.filter(
             clipboard: nil,
             pasteboardChangeCount: 1,
-            currentBundleIdentifier: "com.app.notes",
             precedingText: "hello world"
         )
         XCTAssertNil(result)
     }
 
-    // MARK: - Fresh clipboard, same app
+    // MARK: - Baseline gating
 
-    func test_freshClipboard_sameApp_returnsContent() {
-        let content = "some copied text"
+    /// `NSPasteboard.changeCount` is a non-zero cumulative counter on a real system, so the
+    /// first observation can't tell us how old the clipboard content actually is. The filter
+    /// records the baseline silently and refuses injection until a *new* copy is detected.
+    func test_firstObservation_returnsNilEvenWithOverlap() {
         let result = filter.filter(
-            clipboard: content,
-            pasteboardChangeCount: 1,
-            currentBundleIdentifier: "com.app.notes",
-            precedingText: "unrelated words here"
+            clipboard: "meeting agenda",
+            pasteboardChangeCount: 42,
+            precedingText: "the meeting starts soon"
         )
-        XCTAssertEqual(result, content)
+        XCTAssertNil(result)
     }
 
-    // MARK: - Fresh clipboard, different app, with overlap
-
-    func test_freshClipboard_differentApp_withOverlap_returnsContent() {
-        // First call establishes the source app as Notes.
+    func test_firstChangeAfterBaseline_returnsContentWhenOverlapMatches() {
+        // Baseline observation — counts as "we know nothing about how old this is".
         _ = filter.filter(
-            clipboard: "meeting agenda for Thursday",
-            pasteboardChangeCount: 1,
-            currentBundleIdentifier: "com.app.notes",
+            clipboard: "irrelevant baseline content",
+            pasteboardChangeCount: 42,
             precedingText: ""
         )
 
-        // Second call from a different app — prefix shares "meeting".
+        // User performs a fresh copy while Cotabby is running.
         let result = filter.filter(
             clipboard: "meeting agenda for Thursday",
-            pasteboardChangeCount: 1,
-            currentBundleIdentifier: "com.app.mail",
+            pasteboardChangeCount: 43,
             precedingText: "Let's discuss the meeting"
         )
         XCTAssertEqual(result, "meeting agenda for Thursday")
     }
 
-    // MARK: - Fresh clipboard, different app, no overlap
+    // MARK: - Token overlap
 
-    func test_freshClipboard_differentApp_noOverlap_returnsNil() {
+    func test_freshClipboard_noOverlap_returnsNil() {
         _ = filter.filter(
-            clipboard: "SELECT * FROM users",
+            clipboard: "irrelevant baseline content",
             pasteboardChangeCount: 1,
-            currentBundleIdentifier: "com.app.terminal",
             precedingText: ""
         )
 
         let result = filter.filter(
             clipboard: "SELECT * FROM users",
-            pasteboardChangeCount: 1,
-            currentBundleIdentifier: "com.app.notes",
+            pasteboardChangeCount: 2,
             precedingText: "Dear hiring manager"
         )
         XCTAssertNil(result)
     }
 
-    // MARK: - Staleness
-
-    func test_staleClipboard_returnsNil() {
-        _ = filter.filter(
-            clipboard: "fresh content",
-            pasteboardChangeCount: 1,
-            currentBundleIdentifier: "com.app.notes",
-            precedingText: "fresh content"
-        )
-
-        // Advance time past the staleness threshold.
-        now = now.addingTimeInterval(ClipboardRelevanceFilter.staleThresholdSeconds + 1)
-
-        let result = filter.filter(
-            clipboard: "fresh content",
-            pasteboardChangeCount: 1,
-            currentBundleIdentifier: "com.app.notes",
-            precedingText: "fresh content"
-        )
-        XCTAssertNil(result)
-    }
-
-    func test_staleClipboard_differentApp_returnsNil() {
-        _ = filter.filter(
-            clipboard: "some code",
-            pasteboardChangeCount: 1,
-            currentBundleIdentifier: "com.app.xcode",
-            precedingText: ""
-        )
-
-        now = now.addingTimeInterval(ClipboardRelevanceFilter.staleThresholdSeconds + 1)
-
-        let result = filter.filter(
-            clipboard: "some code",
-            pasteboardChangeCount: 1,
-            currentBundleIdentifier: "com.app.slack",
-            precedingText: "some code here"
-        )
-        XCTAssertNil(result)
-    }
-
-    // MARK: - Clipboard change resets metadata
-
-    func test_clipboardChange_resetsMetadata() {
-        // Initial clipboard from Notes.
-        _ = filter.filter(
-            clipboard: "old content",
-            pasteboardChangeCount: 1,
-            currentBundleIdentifier: "com.app.notes",
-            precedingText: ""
-        )
-
-        // Time passes but clipboard changes from Mail — metadata resets.
-        now = now.addingTimeInterval(ClipboardRelevanceFilter.staleThresholdSeconds + 1)
-
-        let result = filter.filter(
-            clipboard: "new content from mail",
-            pasteboardChangeCount: 2,
-            currentBundleIdentifier: "com.app.mail",
-            precedingText: "completely different"
-        )
-        // Same app as source → returned.
-        XCTAssertEqual(result, "new content from mail")
-    }
-
-    // MARK: - Short tokens ignored
-
     func test_shortTokensIgnored_inOverlapCheck() {
         _ = filter.filter(
-            clipboard: "a b c",
+            clipboard: "irrelevant baseline content",
             pasteboardChangeCount: 1,
-            currentBundleIdentifier: "com.app.terminal",
             precedingText: ""
         )
 
-        // Different app, prefix also has only short tokens — no meaningful overlap.
+        // Prefix and clipboard share only sub-3-char tokens, which the tokenizer ignores.
         let result = filter.filter(
             clipboard: "a b c",
-            pasteboardChangeCount: 1,
-            currentBundleIdentifier: "com.app.notes",
+            pasteboardChangeCount: 2,
             precedingText: "a b c d e"
         )
         XCTAssertNil(result)
     }
 
-    // MARK: - Case insensitivity
-
     func test_tokenOverlap_isCaseInsensitive() {
         _ = filter.filter(
-            clipboard: "Deployment Pipeline",
+            clipboard: "irrelevant baseline content",
             pasteboardChangeCount: 1,
-            currentBundleIdentifier: "com.app.terminal",
             precedingText: ""
         )
 
         let result = filter.filter(
             clipboard: "Deployment Pipeline",
-            pasteboardChangeCount: 1,
-            currentBundleIdentifier: "com.app.notes",
+            pasteboardChangeCount: 2,
             precedingText: "the deployment is running"
         )
         XCTAssertEqual(result, "Deployment Pipeline")
+    }
+
+    // MARK: - Staleness
+
+    func test_staleClipboard_returnsNil() {
+        // Establish baseline.
+        _ = filter.filter(
+            clipboard: "old baseline",
+            pasteboardChangeCount: 1,
+            precedingText: ""
+        )
+
+        // A fresh copy happens — staleness clock starts here.
+        _ = filter.filter(
+            clipboard: "fresh content here",
+            pasteboardChangeCount: 2,
+            precedingText: "fresh content here"
+        )
+
+        now = now.addingTimeInterval(ClipboardRelevanceFilter.staleThresholdSeconds + 1)
+
+        let result = filter.filter(
+            clipboard: "fresh content here",
+            pasteboardChangeCount: 2,
+            precedingText: "fresh content here"
+        )
+        XCTAssertNil(result)
+    }
+
+    func test_newCopyResetsStalenessClock() {
+        _ = filter.filter(
+            clipboard: "baseline",
+            pasteboardChangeCount: 1,
+            precedingText: ""
+        )
+
+        // First real copy.
+        _ = filter.filter(
+            clipboard: "first content",
+            pasteboardChangeCount: 2,
+            precedingText: "first content"
+        )
+
+        // Time passes past the staleness threshold.
+        now = now.addingTimeInterval(ClipboardRelevanceFilter.staleThresholdSeconds + 1)
+
+        // A new copy resets the clock.
+        let result = filter.filter(
+            clipboard: "second content matching prefix",
+            pasteboardChangeCount: 3,
+            precedingText: "second content"
+        )
+        XCTAssertEqual(result, "second content matching prefix")
     }
 }

--- a/CotabbyTests/ClipboardRelevanceFilterTests.swift
+++ b/CotabbyTests/ClipboardRelevanceFilterTests.swift
@@ -1,0 +1,184 @@
+import XCTest
+@testable import Cotabby
+
+@MainActor
+final class ClipboardRelevanceFilterTests: XCTestCase {
+
+    private var now: Date!
+    private var filter: ClipboardRelevanceFilter!
+
+    override func setUp() {
+        super.setUp()
+        now = Date()
+        filter = ClipboardRelevanceFilter(dateProvider: { [unowned self] in self.now })
+    }
+
+    // MARK: - Nil input
+
+    func test_nilClipboard_returnsNil() {
+        let result = filter.filter(
+            clipboard: nil,
+            pasteboardChangeCount: 1,
+            currentBundleIdentifier: "com.app.notes",
+            precedingText: "hello world"
+        )
+        XCTAssertNil(result)
+    }
+
+    // MARK: - Fresh clipboard, same app
+
+    func test_freshClipboard_sameApp_returnsContent() {
+        let content = "some copied text"
+        let result = filter.filter(
+            clipboard: content,
+            pasteboardChangeCount: 1,
+            currentBundleIdentifier: "com.app.notes",
+            precedingText: "unrelated words here"
+        )
+        XCTAssertEqual(result, content)
+    }
+
+    // MARK: - Fresh clipboard, different app, with overlap
+
+    func test_freshClipboard_differentApp_withOverlap_returnsContent() {
+        // First call establishes the source app as Notes.
+        _ = filter.filter(
+            clipboard: "meeting agenda for Thursday",
+            pasteboardChangeCount: 1,
+            currentBundleIdentifier: "com.app.notes",
+            precedingText: ""
+        )
+
+        // Second call from a different app — prefix shares "meeting".
+        let result = filter.filter(
+            clipboard: "meeting agenda for Thursday",
+            pasteboardChangeCount: 1,
+            currentBundleIdentifier: "com.app.mail",
+            precedingText: "Let's discuss the meeting"
+        )
+        XCTAssertEqual(result, "meeting agenda for Thursday")
+    }
+
+    // MARK: - Fresh clipboard, different app, no overlap
+
+    func test_freshClipboard_differentApp_noOverlap_returnsNil() {
+        _ = filter.filter(
+            clipboard: "SELECT * FROM users",
+            pasteboardChangeCount: 1,
+            currentBundleIdentifier: "com.app.terminal",
+            precedingText: ""
+        )
+
+        let result = filter.filter(
+            clipboard: "SELECT * FROM users",
+            pasteboardChangeCount: 1,
+            currentBundleIdentifier: "com.app.notes",
+            precedingText: "Dear hiring manager"
+        )
+        XCTAssertNil(result)
+    }
+
+    // MARK: - Staleness
+
+    func test_staleClipboard_returnsNil() {
+        _ = filter.filter(
+            clipboard: "fresh content",
+            pasteboardChangeCount: 1,
+            currentBundleIdentifier: "com.app.notes",
+            precedingText: "fresh content"
+        )
+
+        // Advance time past the staleness threshold.
+        now = now.addingTimeInterval(ClipboardRelevanceFilter.staleThresholdSeconds + 1)
+
+        let result = filter.filter(
+            clipboard: "fresh content",
+            pasteboardChangeCount: 1,
+            currentBundleIdentifier: "com.app.notes",
+            precedingText: "fresh content"
+        )
+        XCTAssertNil(result)
+    }
+
+    func test_staleClipboard_differentApp_returnsNil() {
+        _ = filter.filter(
+            clipboard: "some code",
+            pasteboardChangeCount: 1,
+            currentBundleIdentifier: "com.app.xcode",
+            precedingText: ""
+        )
+
+        now = now.addingTimeInterval(ClipboardRelevanceFilter.staleThresholdSeconds + 1)
+
+        let result = filter.filter(
+            clipboard: "some code",
+            pasteboardChangeCount: 1,
+            currentBundleIdentifier: "com.app.slack",
+            precedingText: "some code here"
+        )
+        XCTAssertNil(result)
+    }
+
+    // MARK: - Clipboard change resets metadata
+
+    func test_clipboardChange_resetsMetadata() {
+        // Initial clipboard from Notes.
+        _ = filter.filter(
+            clipboard: "old content",
+            pasteboardChangeCount: 1,
+            currentBundleIdentifier: "com.app.notes",
+            precedingText: ""
+        )
+
+        // Time passes but clipboard changes from Mail — metadata resets.
+        now = now.addingTimeInterval(ClipboardRelevanceFilter.staleThresholdSeconds + 1)
+
+        let result = filter.filter(
+            clipboard: "new content from mail",
+            pasteboardChangeCount: 2,
+            currentBundleIdentifier: "com.app.mail",
+            precedingText: "completely different"
+        )
+        // Same app as source → returned.
+        XCTAssertEqual(result, "new content from mail")
+    }
+
+    // MARK: - Short tokens ignored
+
+    func test_shortTokensIgnored_inOverlapCheck() {
+        _ = filter.filter(
+            clipboard: "a b c",
+            pasteboardChangeCount: 1,
+            currentBundleIdentifier: "com.app.terminal",
+            precedingText: ""
+        )
+
+        // Different app, prefix also has only short tokens — no meaningful overlap.
+        let result = filter.filter(
+            clipboard: "a b c",
+            pasteboardChangeCount: 1,
+            currentBundleIdentifier: "com.app.notes",
+            precedingText: "a b c d e"
+        )
+        XCTAssertNil(result)
+    }
+
+    // MARK: - Case insensitivity
+
+    func test_tokenOverlap_isCaseInsensitive() {
+        _ = filter.filter(
+            clipboard: "Deployment Pipeline",
+            pasteboardChangeCount: 1,
+            currentBundleIdentifier: "com.app.terminal",
+            precedingText: ""
+        )
+
+        let result = filter.filter(
+            clipboard: "Deployment Pipeline",
+            pasteboardChangeCount: 1,
+            currentBundleIdentifier: "com.app.notes",
+            precedingText: "the deployment is running"
+        )
+        XCTAssertEqual(result, "Deployment Pipeline")
+    }
+}


### PR DESCRIPTION
## Summary

Clipboard content was blindly injected into every autocomplete prompt, even when stale
or noisy. This PR adds two layers of filtering:

1. **Relevance filter** (`ClipboardRelevanceFilter`) — gates clipboard injection on three
   zero-latency heuristics: staleness (>5 min unchanged → drop), app affinity (same-app
   copy always passes), and token overlap (no shared words with prefix → drop).

2. **Content distillation** (`ClipboardContentDistiller`) — for clipboard that passes the
   relevance gate, extracts only the lines whose tokens overlap with the user's prefix
   text. Short clipboard (≤3 lines) passes through unchanged. When no individual line
   overlaps, the first 300 characters are kept as a head-biased fallback.

Also extracts shared tokenization logic into `PromptContextSanitizer.significantTokens()`
so both components use the same tokenizer.

## Validation

```
xcodebuild -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

xcodebuild -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' build-for-testing
# ** TEST BUILD SUCCEEDED **

swiftlint lint --quiet
# No new warnings
```

## Linked issues

None.

## Risk / rollout notes

- Users with clipboard context enabled will see filtered/distilled clipboard instead of raw. This is purely additive filtering — content that was previously injected may now be dropped or trimmed, but nothing new is added.
- The `ClipboardContextProviding` protocol gains a `currentChangeCount` property. Any test doubles conforming to this protocol will need updating.
- Tuning constants: staleness threshold (5 min), minimum token length (3 chars), compact line threshold (3 lines), head fallback (300 chars) — all `static let` on their respective types.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two layers of clipboard filtering to the autocomplete pipeline: a `ClipboardRelevanceFilter` that gates injection on staleness and token overlap, and a `ClipboardContentDistiller` that trims long clipboard to only the lines that share tokens with the user's prefix. It also addresses three previously identified bugs — the boot-time staleness clock reset, the erroneous app-affinity bypass, and the filter/distiller window mismatch — by adopting a nil-sentinel baseline, removing app-affinity logic entirely, and computing the truncated prefix once in the coordinator before passing it to both components.

- **`ClipboardRelevanceFilter`**: state machine keyed on `NSPasteboard.changeCount`; first observation silently records the baseline without starting the staleness clock, so content copied before Cotabby launched is never injected until the user performs a fresh copy.
- **`ClipboardContentDistiller`**: clips short (≤3 line) content through unchanged; longer content is filtered to token-overlapping lines with a 300-char head fallback when no line matches.
- **`SuggestionRequestFactory`**: `truncatedPromptPrefix` promoted to `internal` and `prefixText` threaded through to the distiller so the filter and distiller evaluate the same bounded window.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The change is purely additive filtering — clipboard content that was previously injected may now be dropped or trimmed, but no new content is introduced into prompts.

All three bugs flagged in prior review rounds have been addressed: the nil-sentinel baseline prevents the boot-time clock reset, app-affinity logic is removed entirely, and the coordinator now computes the truncated prefix once and passes it to both the filter and the distiller. New types are @MainActor-isolated, injected via narrow protocols consistent with AGENTS.md conventions, and covered by deterministic unit tests with a swappable dateProvider.

The project.pbxproj has a LlamaSwift in Frameworks build file entry that appears unrelated to this feature and has no matching Frameworks build phase addition in the diff — worth confirming it is intentional.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/ClipboardRelevanceFilter.swift | New filter type addressing three previously filed bugs: removes false app-affinity bypass, uses nil-sentinel baseline to avoid the boot-time staleness clock reset, and evaluates token overlap against the same bounded window the distiller sees. Logic, state transitions, and test coverage all look correct. |
| Cotabby/Support/ClipboardContentDistiller.swift | New distiller correctly passes short (≤3 line) clipboard through unchanged, filters longer content to token-overlapping lines, and falls back to the first 300 chars when no line matches. Uses the shared significantTokens tokenizer for consistency. |
| Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift | Computes the truncated prefix once and passes it to the relevance filter so the filter and the downstream distiller evaluate overlap against the same bounded window. Correctly replaces the old unconditional clipboard injection. |
| Cotabby/Support/SuggestionRequestFactory.swift | Promotes truncatedPromptPrefix from private to internal so the coordinator can use it, threads prefixText into activeClipboardContext, and adds the ClipboardContentDistiller call before the existing character cap. Changes are minimal and non-breaking. |
| Cotabby/Models/SuggestionSubsystemContracts.swift | Adds currentChangeCount to ClipboardContextProviding and introduces the ClipboardRelevanceFiltering protocol, both @MainActor-scoped and consistent with existing contract style. |
| CotabbyTests/ClipboardRelevanceFilterTests.swift | Good coverage of nil input, baseline gating, token overlap (case-insensitive, short-token exclusion), staleness expiry, and clock reset on new copy. Uses injectable dateProvider to make time-dependent assertions deterministic. |
| CotabbyTests/ClipboardContentDistillerTests.swift | Covers the short-passthrough, partial-overlap, no-overlap head-fallback, case-insensitive, short-token, and empty-prefix cases. All assertions match the documented behaviour. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant SC as SuggestionCoordinator
    participant CCP as ClipboardContextProvider
    participant SRF as SuggestionRequestFactory
    participant CRF as ClipboardRelevanceFilter
    participant CCD as ClipboardContentDistiller
    participant PSan as PromptContextSanitizer

    SC->>CCP: currentContext()
    CCP-->>SC: rawClipboard (String?)
    SC->>CCP: currentChangeCount
    CCP-->>SC: pasteboardChangeCount (Int)
    SC->>SRF: truncatedPromptPrefix(from: rawContext.precedingText)
    SRF-->>SC: truncatedPrefix
    SC->>CRF: filter(clipboard:, pasteboardChangeCount:, precedingText: truncatedPrefix)
    note over CRF: 1st call → record baseline, return nil
    CRF->>PSan: significantTokens(from: clipboard)
    CRF->>PSan: significantTokens(from: precedingText)
    PSan-->>CRF: "Set<String>"
    CRF-->>SC: clipboardContext (String? — nil if stale or no overlap)
    SC->>SRF: buildRequest(context:, clipboardContext:, ...)
    SRF->>SRF: truncatedPromptPrefix(from: context.precedingText)
    SRF->>PSan: sanitize(rawContext)
    PSan-->>SRF: sanitizedContext
    SRF->>CCD: distill(clipboard: sanitizedContext, prefixText:)
    CCD->>PSan: significantTokens(from: prefixText)
    CCD->>PSan: significantTokens(from: each line)
    PSan-->>CCD: "Set<String>"
    CCD-->>SRF: distilled (relevant lines or head fallback)
    SRF->>SRF: clippedText(distilled, max: 1200)
    SRF-->>SC: SuggestionRequestBuildResult
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22clipboard-relevance-filter%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22clipboard-relevance-filter%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby.xcodeproj%2Fproject.pbxproj%3A14%0A**Potentially%20stray%20%60LlamaSwift%20in%20Frameworks%60%20build%20file%20entry**%0A%0AA%20%60PBXBuildFile%60%20record%20for%20%60LlamaSwift%60%20was%20added%20alongside%20the%20new%20test%20file%20references%2C%20but%20no%20matching%20entry%20appears%20in%20a%20%60PBXFrameworksBuildPhase%60%20in%20this%20diff.%20A%20dangling%20build%20file%20entry%20that%20isn't%20wired%20into%20any%20target's%20Frameworks%20phase%20is%20harmless%20today%20%E2%80%94%20Xcode%20ignores%20it%20%E2%80%94%20but%20it%20clutters%20the%20project%20graph%20and%20risks%20confusion%20if%20a%20future%20change%20wires%20it%20to%20the%20wrong%20target.%20If%20this%20was%20intentional%20%28e.g.%20fixing%20a%20test-target%20linkage%29%2C%20the%20corresponding%20Frameworks%20build%20phase%20addition%20should%20also%20appear%20here.%20If%20it%20was%20an%20accidental%20inclusion%20from%20a%20rebase%20or%20merge%2C%20it%20should%20be%20reverted.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby.xcodeproj%2Fproject.pbxproj%3A14%0A**Potentially%20stray%20%60LlamaSwift%20in%20Frameworks%60%20build%20file%20entry**%0A%0AA%20%60PBXBuildFile%60%20record%20for%20%60LlamaSwift%60%20was%20added%20alongside%20the%20new%20test%20file%20references%2C%20but%20no%20matching%20entry%20appears%20in%20a%20%60PBXFrameworksBuildPhase%60%20in%20this%20diff.%20A%20dangling%20build%20file%20entry%20that%20isn't%20wired%20into%20any%20target's%20Frameworks%20phase%20is%20harmless%20today%20%E2%80%94%20Xcode%20ignores%20it%20%E2%80%94%20but%20it%20clutters%20the%20project%20graph%20and%20risks%20confusion%20if%20a%20future%20change%20wires%20it%20to%20the%20wrong%20target.%20If%20this%20was%20intentional%20%28e.g.%20fixing%20a%20test-target%20linkage%29%2C%20the%20corresponding%20Frameworks%20build%20phase%20addition%20should%20also%20appear%20here.%20If%20it%20was%20an%20accidental%20inclusion%20from%20a%20rebase%20or%20merge%2C%20it%20should%20be%20reverted.%0A%0A&repo=fujacob%2Ftabby&pr=210&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (6): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/fujacob/tabby/commit/74a40a2c66af6c52d57684de8d3c588617eedc68) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33698221)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=45fae5fd-3007-4631-a2b0-92b2beb3df2a))

<!-- /greptile_comment -->