### PR TITLE
Add manual GitHub Pages republish workflow

### DIFF
--- a/.github/workflows/republish-pages.yml
+++ b/.github/workflows/republish-pages.yml
@@ -1,0 +1,99 @@
+# Manually republish the Sparkle appcast to GitHub Pages.
+#
+# Use this when the Pages custom domain changes or when you need to redeploy
+# without cutting a new release. It downloads the appcast.xml from the latest
+# GitHub Release and publishes it to Pages with the configured CNAME.
+
+name: Republish Pages
+
+on:
+  workflow_dispatch:
+    inputs:
+      custom_domain:
+        description: "Custom domain for the CNAME file (e.g. updates.tabbyapp.dev)"
+        required: true
+        default: "updates.tabbyapp.dev"
+        type: string
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  republish:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - name: Download appcast.xml from latest release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          # Find the latest release that has an appcast in its artifacts.
+          # The release workflow uploads appcast.xml inside the release-artifacts bundle,
+          # but it also publishes appcast.xml to Pages. We can reconstruct it from the
+          # release assets or fall back to the repo's existing Pages deployment.
+
+          # Try downloading from the latest release artifacts
+          LATEST_RUN=$(gh run list \
+            --repo "${{ github.repository }}" \
+            --workflow release.yml \
+            --status success \
+            --limit 1 \
+            --json databaseId \
+            --jq '.[0].databaseId')
+
+          if [ -n "$LATEST_RUN" ]; then
+            echo "Downloading appcast from release run $LATEST_RUN"
+            gh run download "$LATEST_RUN" \
+              --repo "${{ github.repository }}" \
+              --name release-artifacts \
+              --dir artifacts/ || true
+          fi
+
+          if [ -f artifacts/appcast.xml ]; then
+            echo "Found appcast.xml from release artifacts"
+            cp artifacts/appcast.xml appcast.xml
+          else
+            echo "::error::No appcast.xml found in latest release artifacts. Run a full release first."
+            exit 1
+          fi
+
+      - name: Prepare Pages artifact
+        run: |
+          set -euo pipefail
+          mkdir -p pages/Cotabby
+          cp appcast.xml pages/appcast.xml
+          cp appcast.xml pages/Cotabby/appcast.xml
+          printf '%s\n' "${{ inputs.custom_domain }}" > pages/CNAME
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: pages
+
+      - name: Deploy GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4
+
+      - name: Summary
+        run: |
+          {
+            echo "### Pages Republished"
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| Custom domain | ${{ inputs.custom_domain }} |"
+            echo "| Appcast URL | https://${{ inputs.custom_domain }}/appcast.xml |"
+            echo "| Pages URL | ${{ steps.deploy.outputs.page_url }} |"
+          } >> "${GITHUB_STEP_SUMMARY}"


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch` workflow (`republish-pages.yml`) that re-deploys the Sparkle appcast to GitHub Pages with a configurable custom domain input. This lets us change the Pages CNAME (e.g. from `updates.tabbyapp.dev` to a new domain) without cutting a full release.

## Validation

Workflow syntax validated — uses the same `configure-pages`, `upload-pages-artifact`, and `deploy-pages` actions as the existing release workflow. Cannot be end-to-end tested until merged to a branch with Actions enabled.

## Linked issues

Refs #202

## Risk / rollout notes

- No impact on existing release workflow or appcast content.
- The workflow downloads `appcast.xml` from the latest successful release run's artifacts, so at least one prior release must exist.
- Custom domain input defaults to `updates.tabbyapp.dev` (current production value).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `workflow_dispatch` workflow (`republish-pages.yml`) that re-deploys the Sparkle appcast to GitHub Pages without cutting a new release, useful when the Pages custom domain changes.

- The workflow downloads `appcast.xml` from the latest successful `release.yml` run's artifacts, then prepares and deploys a Pages artifact with a configurable CNAME — but two logic bugs mean every run would fail or produce wrong output: the artifact extraction path check looks at `artifacts/appcast.xml` instead of `artifacts/build/appcast.xml` (matching how `upload-artifact` preserves the `build/` prefix), and the subdirectory is named `Cotabby` instead of `tabby` (as used in `release.yml`), which would drop the `/tabby/appcast.xml` path from Pages.
- The `inputs.custom_domain` value is also interpolated directly into shell in the Summary step rather than passed via an environment variable.

<h3>Confidence Score: 2/5</h3>

Not safe to merge as-is — two bugs in the new workflow guarantee it either always errors out or deploys a Pages structure that diverges from every prior release.

The artifact path check (`artifacts/appcast.xml`) will never match the actual extracted location (`artifacts/build/appcast.xml`), so the workflow will always exit with an error and never publish. Additionally, the subdirectory name `Cotabby` differs from `tabby` used by the release workflow; if the path check were fixed, running this workflow would still produce a Pages deployment missing the `/tabby/appcast.xml` path that existing release artifacts establish. Both issues are on the sole code path this workflow exercises.

.github/workflows/republish-pages.yml — the artifact extraction path and subdirectory name both need correction before this workflow can function correctly.

<details open><summary><h3>Security Review</h3></summary>

- **Shell injection via `inputs.custom_domain`** (`.github/workflows/republish-pages.yml`, Summary step): the user-supplied domain input is expanded directly into the shell script by GitHub Actions template substitution before Bash parses it. A value containing shell metacharacters would be executed as code. Risk is bounded to repository collaborators who can trigger `workflow_dispatch`, but the fix (passing the value through an `env:` variable) is straightforward.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/republish-pages.yml | New manual republish workflow; has two logic bugs (wrong artifact extraction path and mismatched subdirectory name vs release.yml) that would cause every run to fail or produce divergent Pages content, plus a minor shell injection surface in the Summary step. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    actor Operator
    participant GHA as GitHub Actions
    participant GHAPI as GitHub API
    participant Pages as GitHub Pages

    Operator->>GHA: trigger workflow_dispatch (custom_domain input)
    GHA->>GHAPI: "gh run list (release.yml, status=success, limit=1)"
    GHAPI-->>GHA: latest release run ID
    GHA->>GHAPI: gh run download release-artifacts
    GHAPI-->>GHA: artifact zip (build/appcast.xml inside)
    Note over GHA: check artifacts/appcast.xml ❌ actual path: artifacts/build/appcast.xml
    GHA->>GHA: mkdir pages/Cotabby ⚠️ should be pages/tabby
    GHA->>GHA: write CNAME with custom_domain
    GHA->>Pages: configure-pages → upload-pages-artifact → deploy-pages
    Pages-->>GHA: page_url
    GHA->>GHA: write GITHUB_STEP_SUMMARY
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22feat%2Frepublish-pages-workflow%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Frepublish-pages-workflow%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0A.github%2Fworkflows%2Frepublish-pages.yml%3A62-65%0AThe%20path%20check%20looks%20at%20%60artifacts%2Fappcast.xml%60%2C%20but%20%60actions%2Fupload-artifact%40v4%60%20preserves%20the%20workspace-relative%20directory%20structure%20when%20uploading.%20In%20%60release.yml%60%2C%20the%20file%20is%20staged%20at%20%60build%2Fappcast.xml%60%2C%20so%20when%20%60gh%20run%20download%20--dir%20artifacts%2F%60%20extracts%20the%20artifact%2C%20the%20file%20lands%20at%20%60artifacts%2Fbuild%2Fappcast.xml%60%20%E2%80%94%20not%20%60artifacts%2Fappcast.xml%60.%20The%20condition%20will%20always%20be%20false%20and%20the%20workflow%20will%20always%20exit%20with%20the%20%22No%20appcast.xml%20found%22%20error.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20if%20%5B%20-f%20artifacts%2Fbuild%2Fappcast.xml%20%5D%3B%20then%0A%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22Found%20appcast.xml%20from%20release%20artifacts%22%0A%20%20%20%20%20%20%20%20%20%20%20%20cp%20artifacts%2Fbuild%2Fappcast.xml%20appcast.xml%0A%20%20%20%20%20%20%20%20%20%20else%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0A.github%2Fworkflows%2Frepublish-pages.yml%3A73-75%0AThe%20subdirectory%20name%20%60Cotabby%60%20doesn't%20match%20the%20%60tabby%60%20subdirectory%20that%20%60release.yml%60%20writes%20%28%60build%2Fpages%2Ftabby%2Fappcast.xml%60%29.%20Running%20this%20workflow%20would%20produce%20a%20Pages%20deployment%20where%20%60https%3A%2F%2Fupdates.tabbyapp.dev%2Ftabby%2Fappcast.xml%60%20no%20longer%20exists%20and%20a%20new%20%60https%3A%2F%2Fupdates.tabbyapp.dev%2FCotabby%2Fappcast.xml%60%20appears%20instead%20%E2%80%94%20diverging%20from%20every%20prior%20release%20deployment.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20mkdir%20-p%20pages%2Ftabby%0A%20%20%20%20%20%20%20%20%20%20cp%20appcast.xml%20pages%2Fappcast.xml%0A%20%20%20%20%20%20%20%20%20%20cp%20appcast.xml%20pages%2Ftabby%2Fappcast.xml%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0A.github%2Fworkflows%2Frepublish-pages.yml%3A90-99%0A%60%24%7B%7B%20inputs.custom_domain%20%7D%7D%60%20is%20expanded%20directly%20into%20the%20shell%20script%20before%20Bash%20parses%20it.%20Any%20shell%20metacharacters%20in%20the%20input%20%28e.g.%20a%20value%20containing%20%60%22%3B%20rm%20%E2%80%A6%3B%20%23%60%29%20would%20be%20executed.%20Pass%20the%20value%20through%20an%20environment%20variable%20instead%20so%20Bash%20never%20sees%20it%20as%20code.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20name%3A%20Summary%0A%20%20%20%20%20%20%20%20env%3A%0A%20%20%20%20%20%20%20%20%20%20CUSTOM_DOMAIN%3A%20%24%7B%7B%20inputs.custom_domain%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20PAGES_URL%3A%20%24%7B%7B%20steps.deploy.outputs.page_url%20%7D%7D%0A%20%20%20%20%20%20%20%20run%3A%20%7C%0A%20%20%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22%23%23%23%20Pages%20Republished%22%0A%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22%7C%20Field%20%7C%20Value%20%7C%22%0A%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22%7C-------%7C-------%7C%22%0A%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22%7C%20Custom%20domain%20%7C%20%24%7BCUSTOM_DOMAIN%7D%20%7C%22%0A%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22%7C%20Appcast%20URL%20%7C%20https%3A%2F%2F%24%7BCUSTOM_DOMAIN%7D%2Fappcast.xml%20%7C%22%0A%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22%7C%20Pages%20URL%20%7C%20%24%7BPAGES_URL%7D%20%7C%22%0A%20%20%20%20%20%20%20%20%20%20%7D%20%3E%3E%20%22%24%7BGITHUB_STEP_SUMMARY%7D%22%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0A.github%2Fworkflows%2Frepublish-pages.yml%3A62-65%0AThe%20path%20check%20looks%20at%20%60artifacts%2Fappcast.xml%60%2C%20but%20%60actions%2Fupload-artifact%40v4%60%20preserves%20the%20workspace-relative%20directory%20structure%20when%20uploading.%20In%20%60release.yml%60%2C%20the%20file%20is%20staged%20at%20%60build%2Fappcast.xml%60%2C%20so%20when%20%60gh%20run%20download%20--dir%20artifacts%2F%60%20extracts%20the%20artifact%2C%20the%20file%20lands%20at%20%60artifacts%2Fbuild%2Fappcast.xml%60%20%E2%80%94%20not%20%60artifacts%2Fappcast.xml%60.%20The%20condition%20will%20always%20be%20false%20and%20the%20workflow%20will%20always%20exit%20with%20the%20%22No%20appcast.xml%20found%22%20error.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20if%20%5B%20-f%20artifacts%2Fbuild%2Fappcast.xml%20%5D%3B%20then%0A%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22Found%20appcast.xml%20from%20release%20artifacts%22%0A%20%20%20%20%20%20%20%20%20%20%20%20cp%20artifacts%2Fbuild%2Fappcast.xml%20appcast.xml%0A%20%20%20%20%20%20%20%20%20%20else%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0A.github%2Fworkflows%2Frepublish-pages.yml%3A73-75%0AThe%20subdirectory%20name%20%60Cotabby%60%20doesn't%20match%20the%20%60tabby%60%20subdirectory%20that%20%60release.yml%60%20writes%20%28%60build%2Fpages%2Ftabby%2Fappcast.xml%60%29.%20Running%20this%20workflow%20would%20produce%20a%20Pages%20deployment%20where%20%60https%3A%2F%2Fupdates.tabbyapp.dev%2Ftabby%2Fappcast.xml%60%20no%20longer%20exists%20and%20a%20new%20%60https%3A%2F%2Fupdates.tabbyapp.dev%2FCotabby%2Fappcast.xml%60%20appears%20instead%20%E2%80%94%20diverging%20from%20every%20prior%20release%20deployment.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20mkdir%20-p%20pages%2Ftabby%0A%20%20%20%20%20%20%20%20%20%20cp%20appcast.xml%20pages%2Fappcast.xml%0A%20%20%20%20%20%20%20%20%20%20cp%20appcast.xml%20pages%2Ftabby%2Fappcast.xml%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0A.github%2Fworkflows%2Frepublish-pages.yml%3A90-99%0A%60%24%7B%7B%20inputs.custom_domain%20%7D%7D%60%20is%20expanded%20directly%20into%20the%20shell%20script%20before%20Bash%20parses%20it.%20Any%20shell%20metacharacters%20in%20the%20input%20%28e.g.%20a%20value%20containing%20%60%22%3B%20rm%20%E2%80%A6%3B%20%23%60%29%20would%20be%20executed.%20Pass%20the%20value%20through%20an%20environment%20variable%20instead%20so%20Bash%20never%20sees%20it%20as%20code.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20name%3A%20Summary%0A%20%20%20%20%20%20%20%20env%3A%0A%20%20%20%20%20%20%20%20%20%20CUSTOM_DOMAIN%3A%20%24%7B%7B%20inputs.custom_domain%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20PAGES_URL%3A%20%24%7B%7B%20steps.deploy.outputs.page_url%20%7D%7D%0A%20%20%20%20%20%20%20%20run%3A%20%7C%0A%20%20%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22%23%23%23%20Pages%20Republished%22%0A%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22%7C%20Field%20%7C%20Value%20%7C%22%0A%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22%7C-------%7C-------%7C%22%0A%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22%7C%20Custom%20domain%20%7C%20%24%7BCUSTOM_DOMAIN%7D%20%7C%22%0A%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22%7C%20Appcast%20URL%20%7C%20https%3A%2F%2F%24%7BCUSTOM_DOMAIN%7D%2Fappcast.xml%20%7C%22%0A%20%20%20%20%20%20%20%20%20%20%20%20echo%20%22%7C%20Pages%20URL%20%7C%20%24%7BPAGES_URL%7D%20%7C%22%0A%20%20%20%20%20%20%20%20%20%20%7D%20%3E%3E%20%22%24%7BGITHUB_STEP_SUMMARY%7D%22%0A%60%60%60%0A%0A&repo=fujacob%2Ftabby&pr=212&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add manual GitHub Pages republish workfl..."](https://github.com/fujacob/tabby/commit/abfe8976c4bb68c0343335effaea995896a12128) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33701110)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->