### PR TITLE
Add Tabby → Cotabby rename transition reference

### DIFF
--- a/RENAME_TRANSITION.md
+++ b/RENAME_TRANSITION.md
@@ -1,0 +1,256 @@
+# Tabby → Cotabby Rename Transition
+
+This document records what changed, what intentionally stayed the same, and
+what would break if touched in the future. Keep it as a reference for any
+follow-up work on the rename.
+
+---
+
+## What Was Renamed (Visual / Cosmetic)
+
+These changes shipped in the rename PR and are safe — they don't affect
+existing installs, preferences, permissions, or update delivery.
+
+| Item | Old | New |
+|------|-----|-----|
+| Source directory | `tabby/` | `Cotabby/` |
+| Test directory | `tabbyTests/` | `CotabbyTests/` |
+| Xcode project | `tabby.xcodeproj` | `Cotabby.xcodeproj` |
+| Xcode scheme | `tabby` | `Cotabby` |
+| Info.plist | `TabbyInfo.plist` | `CotabbyInfo.plist` |
+| App struct | `TabbyApp` | `CotabbyApp` |
+| Environment | `TabbyAppEnvironment` | `CotabbyAppEnvironment` |
+| Debug options | `TabbyDebugOptions` | `CotabbyDebugOptions` |
+| Launch argument | `-tabby-debug` | `-cotabby-debug` |
+| Test fixtures | `TabbyTestFixtures` | `CotabbyTestFixtures` |
+| DMG volume name | `Tabby` | `Cotabby` |
+| DMG filename | `tabby.dmg` | `Cotabby.dmg` |
+| CI workflow names | References to "Tabby" | References to "Cotabby" |
+| README, docs, comments | "Tabby" | "Cotabby" |
+| Accessibility description | "Tabby needs..." | "Cotabby needs..." |
+| UI strings, log messages | "Tabby" | "Cotabby" |
+| Keychain profile names | `tabby-release.keychain-db` | `cotabby-release.keychain-db` |
+| Notarytool profile | `tabby-notarytool-profile` | `cotabby-notarytool-profile` |
+
+Keychain and notarytool profile names are runtime artifacts created inside
+the CI workflow — they don't map to stored secrets or external state.
+
+---
+
+## What Was Intentionally NOT Renamed
+
+These identifiers are functional — changing them would break existing user
+installs. They must stay as-is unless a migration path is implemented.
+
+### Bundle Identifier: `com.jacobfu.tabby`
+
+**What depends on it:**
+- macOS Accessibility trust (TCC database keyed by bundle ID)
+- Input Monitoring permission grant
+- Screen Recording permission grant
+- Login Items / `SMAppService` registration
+- `UserDefaults` storage domain (implicitly `com.jacobfu.tabby`)
+- macOS Gatekeeper / quarantine state
+- Any MDM or enterprise allowlist entries users may have configured
+
+**What would break:**
+Changing the bundle ID makes macOS treat the app as a completely new
+application. Every user would need to:
+- Re-grant Accessibility permission (re-drag in System Settings)
+- Re-grant Input Monitoring permission
+- Re-grant Screen Recording permission
+- Re-enable Login Items
+- Lose all saved preferences (engine choice, keybindings, disabled apps, etc.)
+
+### UserDefaults Keys: `tabby*` Prefix
+
+All 14 preference keys use the `tabby` prefix:
+
+| Key | Purpose |
+|-----|---------|
+| `tabbyGloballyEnabled` | Master on/off toggle |
+| `tabbyDisabledAppRules` | Per-app blocklist |
+| `tabbyShowCaretIndicator` | Caret indicator visibility |
+| `tabbySelectedIndicatorMode` | Indicator style |
+| `tabbyCustomSuggestionTextColorHex` | Ghost text color |
+| `tabbyClipboardContextEnabled` | Clipboard context toggle |
+| `tabbyUserName` | User's name for prompts |
+| `tabbyDebounceMilliseconds` | Input debounce timing |
+| `tabbyFocusPollIntervalMilliseconds` | Focus poll interval |
+| `tabbyAcceptanceKeyCode` | Partial accept key |
+| `tabbyAcceptanceKeyLabel` | Partial accept key label |
+| `tabbyFullAcceptanceKeyCode` | Full accept key |
+| `tabbyFullAcceptanceKeyLabel` | Full accept key label |
+| `selectedSuggestionEngine` | Engine choice (no prefix) |
+| `selectedSuggestionWordCountPreset` | Word count preset (no prefix) |
+
+**What would break:** Renaming these keys silently resets every user's
+preferences to defaults on next launch. The two keys without the `tabby`
+prefix (`selectedSuggestionEngine`, `selectedSuggestionWordCountPreset`)
+were never renamed and should also stay as-is.
+
+### Sparkle Feed URL: `https://updates.tabbyapp.dev/appcast.xml`
+
+The `SUFeedURL` in `CotabbyInfo.plist` points to the old domain. Existing
+installs have this URL baked into their running binary and poll it for
+updates.
+
+**Current setup:**
+- `updates.tabbyapp.dev` has a Cloudflare 301 redirect →
+  `updates.cotabby.app` (same path preserved)
+- GitHub Pages serves the appcast at `updates.cotabby.app`
+- Sparkle follows the redirect transparently
+
+**What would break:** Removing the `updates.tabbyapp.dev` domain or its
+redirect before all users have updated to a version with the new feed URL
+would silently break OTA updates. Users would never see new versions.
+
+**Future migration path (when ready):**
+1. Confirm `updates.tabbyapp.dev` → `updates.cotabby.app` redirect is live
+   (already done).
+2. Ship a release with `SUFeedURL` changed to
+   `https://updates.cotabby.app/appcast.xml` in `CotabbyInfo.plist`.
+3. Keep the `tabbyapp.dev` redirect alive for at least 6 months to catch
+   users who don't update immediately.
+4. After sufficient time, retire `updates.tabbyapp.dev`.
+
+### Sparkle Signing Key
+
+The Ed25519 key pair must never change unless you're willing to break all
+OTA updates for every existing install:
+
+- **Public key** (`SUPublicEDKey` in `CotabbyInfo.plist`):
+  `efJeZNfUISOs6npbxI2MLLe7sBB5tT/sVnTk9t/qBSY=`
+- **Private key**: stored in the `SPARKLE_ED25519_PRIVATE_KEY` GitHub
+  secret and backed up locally at `~/secure/Cotabby-key.txt` (per
+  `RELEASING.md`).
+
+Rotating this key means every previously-shipped build will reject all
+future updates as untrusted.
+
+### Logger Subsystem: `com.tabby.*`
+
+The `TabbyLogger` enum and its `com.tabby.app`, `com.tabby.runtime`, etc.
+subsystem strings are still in place. These appear in Console.app as
+filterable subsystem identifiers.
+
+**What would break:** Changing these is low-risk for users but would break
+any developer's Console.app saved filters. This is a candidate for a future
+rename if desired — it has no user-facing impact.
+
+### PAGES_CUSTOM_DOMAIN: `updates.tabbyapp.dev`
+
+The release workflow's `PAGES_CUSTOM_DOMAIN` environment variable is set to
+`updates.tabbyapp.dev`. This controls the CNAME file written to the GitHub
+Pages deployment.
+
+**Current state:** GitHub Pages is actually deployed under
+`updates.cotabby.app` (set via the republish-pages workflow). The release
+workflow still writes `updates.tabbyapp.dev` — this will be overwritten on
+the next release unless updated.
+
+**Action needed before next release:** Update `PAGES_CUSTOM_DOMAIN` in
+`release.yml` to `updates.cotabby.app` so the release workflow deploys
+Pages under the correct domain. This is safe because the
+`tabbyapp.dev` redirect handles old installs.
+
+---
+
+## Not Yet Renamed (Follow-Up Candidates)
+
+These are low-priority items that could be renamed in future PRs without
+breaking anything for users.
+
+### `TabbyLogger` → `CotabbyLogger`
+
+The logger factory enum is named `TabbyLogger` and is referenced across 25
+source files (86 occurrences). Renaming is purely cosmetic and can be done
+as a bulk find-and-replace.
+
+### `AppDelegate.swift` Log Message
+
+Line 117 still says `"Tabby \(version) (build \(build))..."` — should say
+`"Cotabby"`.
+
+### LlamaMiddleware / `TabbyInference` Package
+
+The local Swift package at `../LlamaMiddleware` exports a product called
+`TabbyInference`. This is a separate repository — renaming it requires:
+1. Rename the product in `LlamaMiddleware/Package.swift`
+2. Update `import TabbyInference` in `LlamaRuntimeCore.swift`
+3. Update `TabbyInference` references in `Cotabby.xcodeproj/project.pbxproj`
+
+No user impact — this is a build-time dependency name only.
+
+### Archived Marketing Text
+
+`posts.txt` and `launch.txt` in the repo root contain old "Tabby" marketing
+copy. Can be updated or deleted.
+
+### Old `tabby.xcodeproj` Skeleton
+
+An empty `tabby.xcodeproj/` directory may remain in the working tree with
+leftover `xcuserdata/`. Safe to delete — it's not tracked by git.
+
+---
+
+## External Services Checklist
+
+| Service | Account / Identifier | Status |
+|---------|---------------------|--------|
+| GitHub repo | `FuJacob/tabby` | Not yet renamed to `FuJacob/Cotabby` |
+| GitHub Pages | `updates.cotabby.app` | Live, serving appcast |
+| DNS redirect | `updates.tabbyapp.dev` → `updates.cotabby.app` | Live (Cloudflare 301) |
+| Buy Me a Coffee | `cotabbyapp` | Verify account exists |
+| Landing page | `cotabby.app` | Verify deployed |
+| Feedback form | `www.cotabby.app/feedback` | Verify deployed |
+| Apple Developer | Bundle ID `com.jacobfu.tabby` | Registered (do NOT change) |
+| Apple notarization | Team ID `C4BVFMK9V2` | No change needed |
+| Sparkle key pair | Ed25519, stored in GitHub Secrets | No change needed |
+
+---
+
+## GitHub Secrets (No Changes Needed)
+
+These secrets are stored in the repo's Actions settings. None need to be
+renamed or rotated for the Cotabby rename:
+
+| Secret | Purpose |
+|--------|---------|
+| `DEVELOPER_ID_APPLICATION_CERT` | Base64-encoded Developer ID certificate |
+| `DEVELOPER_ID_CERT_PASSWORD` | Certificate import password |
+| `APPLE_ID` | Apple ID for notarization |
+| `APPLE_TEAM_ID` | Developer Team ID |
+| `APPLE_APP_SPECIFIC_PASSWORD` | App-specific password for notarytool |
+| `SPARKLE_ED25519_PRIVATE_KEY` | Sparkle appcast signing key |
+
+---
+
+## DNS Architecture
+
+```
+Existing installs:
+  App polls → updates.tabbyapp.dev/appcast.xml
+           → Cloudflare 301 redirect
+           → updates.cotabby.app/appcast.xml
+           → GitHub Pages serves appcast
+
+New installs (after feed URL migration):
+  App polls → updates.cotabby.app/appcast.xml
+           → GitHub Pages serves appcast
+```
+
+Both paths serve the same appcast from the same GitHub Pages deployment.
+
+---
+
+## Decision Log
+
+| Decision | Rationale |
+|----------|-----------|
+| Keep bundle ID as `com.jacobfu.tabby` | Changing it resets all macOS permissions and treats the app as a new install |
+| Keep UserDefaults keys as `tabby*` | Changing them silently wipes user preferences |
+| Keep feed URL as `tabbyapp.dev` in shipped binary | Existing installs have this URL baked in; redirect handles the transition |
+| Redirect `tabbyapp.dev` via Cloudflare | Zero-downtime migration; Sparkle follows 301s transparently |
+| Rename source dirs, types, and UI strings | Purely cosmetic; no runtime or persistence impact |
+| Keep Sparkle key pair unchanged | Rotating breaks OTA updates for all existing installs |


### PR DESCRIPTION
## Summary

Adds `RENAME_TRANSITION.md` documenting the full Tabby → Cotabby rename migration: what was renamed (visual/cosmetic), what was intentionally kept unchanged (bundle ID, UserDefaults keys, feed URL, Sparkle key), what would break if touched, the DNS redirect architecture, external service status, and a decision log for future reference.

## Validation

Documentation-only change. No code, no build impact.

## Linked issues

Refs #202

## Risk / rollout notes

None — this is a reference document only.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `RENAME_TRANSITION.md`, a developer reference document that records the Tabby → Cotabby rename: what was renamed cosmetically, what must remain unchanged (bundle ID, UserDefaults keys, Sparkle feed URL, signing key), pending follow-up items, and external-service status. No code changes are included.

- Two factual inaccuracies were found: the UserDefaults section claims 14 tabby-prefixed keys but the code has 13 (and the table in the same section lists 15 total), and the `AppDelegate.swift` follow-up note cites a version-log message at line 117 that does not exist in the file.
- The `PAGES_CUSTOM_DOMAIN` misconfiguration in `release.yml` (still set to `updates.tabbyapp.dev` when GitHub Pages is live under `updates.cotabby.app`) is correctly called out as an action item; this should be fixed before the next release to avoid overwriting the CNAME on deploy.

<h3>Confidence Score: 3/5</h3>

Safe to merge as a documentation-only change, but two factual inaccuracies in the document should be corrected first so it serves as a reliable reference.

The document has two concrete inaccuracies: the UserDefaults section states 14 tabby-prefixed keys when both the code and the table in the same section show 13, and the AppDelegate follow-up item references a log message at line 117 that simply does not exist in the file. Because this document is meant to be a canonical reference for follow-up work, leaving wrong counts and wrong line numbers in place risks future developers either missing a cleanup task or wasting time looking for something that isn't there.

RENAME_TRANSITION.md — the UserDefaults key count (line 67) and the AppDelegate.swift line reference (lines 172–173) need correction.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| RENAME_TRANSITION.md | New reference document cataloguing the Tabby → Cotabby rename. Contains two factual inaccuracies: the UserDefaults key count claims 14 tabby-prefixed keys when the code has 13, and the AppDelegate.swift line 117 reference points to a log message that does not exist in the file. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Existing install polls SUFeedURL] -->|https://updates.tabbyapp.dev/appcast.xml| B[Cloudflare 301 redirect]
    B -->|https://updates.cotabby.app/appcast.xml| C[GitHub Pages appcast]
    C --> D{Sparkle checks signature with SUPublicEDKey}
    D -->|Valid Ed25519 sig| E[Update offered to user]
    F[New install after migration] -->|https://updates.cotabby.app/appcast.xml| C
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22docs%2Frename-transition%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Frename-transition%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ARENAME_TRANSITION.md%3A67%0A**UserDefaults%20key%20count%20is%20off%20by%20one**%0A%0AThe%20prose%20says%20%22All%2014%20preference%20keys%20use%20the%20%60tabby%60%20prefix%22%20but%20the%20table%20directly%20below%20lists%2013%20tabby-prefixed%20keys%20%E2%80%94%20confirmed%20by%20the%2013%20%60private%20static%20let%20%E2%80%A6DefaultsKey%60%20constants%20in%20%60SuggestionSettingsModel.swift%60.%20The%20table%20itself%20shows%2015%20rows%20total%20%2813%20with%20the%20prefix%20%2B%202%20without%29%2C%20so%20neither%20%2214%22%20nor%20%22all%20%E2%80%A6%20use%20the%20%60tabby%60%20prefix%22%20is%20accurate.%20A%20reader%20relying%20on%20this%20count%20for%20an%20audit%20would%20miss%20one%20key%20or%20assume%20the%20two%20unprefixed%20keys%20have%20the%20prefix.%0A%0A%23%23%23%20Issue%202%20of%202%0ARENAME_TRANSITION.md%3A172-173%0A**AppDelegate%20line-number%20reference%20doesn't%20match%20the%20file**%0A%0AThe%20note%20says%20line%20117%20still%20contains%20%60%22Tabby%20%5C%28version%29%20%28build%20%5C%28build%29%29...%22%60%2C%20but%20the%20current%20%60tabby%2FApp%2FCore%2FAppDelegate.swift%60%20has%20no%20such%20log%20message%20anywhere.%20Line%20117%20is%20%60welcomeCoordinator.presentIfNeeded%28%29%60%2C%20and%20a%20grep%20across%20the%20whole%20file%20finds%20no%20version%2Fbuild%20interpolation%20string.%20A%20developer%20doing%20follow-up%20cleanup%20using%20this%20reference%20would%20look%20at%20the%20wrong%20line%20and%20conclude%20the%20fix%20is%20done%20when%20no%20such%20message%20exists%20to%20be%20changed.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ARENAME_TRANSITION.md%3A67%0A**UserDefaults%20key%20count%20is%20off%20by%20one**%0A%0AThe%20prose%20says%20%22All%2014%20preference%20keys%20use%20the%20%60tabby%60%20prefix%22%20but%20the%20table%20directly%20below%20lists%2013%20tabby-prefixed%20keys%20%E2%80%94%20confirmed%20by%20the%2013%20%60private%20static%20let%20%E2%80%A6DefaultsKey%60%20constants%20in%20%60SuggestionSettingsModel.swift%60.%20The%20table%20itself%20shows%2015%20rows%20total%20%2813%20with%20the%20prefix%20%2B%202%20without%29%2C%20so%20neither%20%2214%22%20nor%20%22all%20%E2%80%A6%20use%20the%20%60tabby%60%20prefix%22%20is%20accurate.%20A%20reader%20relying%20on%20this%20count%20for%20an%20audit%20would%20miss%20one%20key%20or%20assume%20the%20two%20unprefixed%20keys%20have%20the%20prefix.%0A%0A%23%23%23%20Issue%202%20of%202%0ARENAME_TRANSITION.md%3A172-173%0A**AppDelegate%20line-number%20reference%20doesn't%20match%20the%20file**%0A%0AThe%20note%20says%20line%20117%20still%20contains%20%60%22Tabby%20%5C%28version%29%20%28build%20%5C%28build%29%29...%22%60%2C%20but%20the%20current%20%60tabby%2FApp%2FCore%2FAppDelegate.swift%60%20has%20no%20such%20log%20message%20anywhere.%20Line%20117%20is%20%60welcomeCoordinator.presentIfNeeded%28%29%60%2C%20and%20a%20grep%20across%20the%20whole%20file%20finds%20no%20version%2Fbuild%20interpolation%20string.%20A%20developer%20doing%20follow-up%20cleanup%20using%20this%20reference%20would%20look%20at%20the%20wrong%20line%20and%20conclude%20the%20fix%20is%20done%20when%20no%20such%20message%20exists%20to%20be%20changed.%0A%0A&repo=fujacob%2Ftabby&pr=213&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add rename transition reference document"](https://github.com/fujacob/tabby/commit/da8898efed3142d94585e74e914ea84f61be06bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33702068)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->