### PR TITLE
Add multi-line completion support with menu bar toggle

### DIFF
--- a/Cotabby/Models/SuggestionEngineModels.swift
+++ b/Cotabby/Models/SuggestionEngineModels.swift
@@ -71,4 +71,5 @@ struct SuggestionSettingsSnapshot: Equatable, Sendable {
     let userName: String
     let debounceMilliseconds: Int
     let focusPollIntervalMilliseconds: Int
+    let isMultiLineEnabled: Bool
 }

--- a/Cotabby/Models/SuggestionModels.swift
+++ b/Cotabby/Models/SuggestionModels.swift
@@ -208,6 +208,8 @@ struct SuggestionRequest: Equatable, Sendable {
     let clipboardContext: String?
     /// Ephemeral screen context summary injected only when available for the active text field.
     let visualContextSummary: String?
+    /// When enabled, the normalizer keeps multiple lines instead of truncating to the first line.
+    let isMultiLineEnabled: Bool
 }
 
 /// The engine's normalized response, including raw model text for debugging.

--- a/Cotabby/Models/SuggestionSettingsModel.swift
+++ b/Cotabby/Models/SuggestionSettingsModel.swift
@@ -22,6 +22,7 @@ final class SuggestionSettingsModel: ObservableObject {
     @Published private(set) var userName: String
     @Published private(set) var debounceMilliseconds: Int
     @Published private(set) var focusPollIntervalMilliseconds: Int
+    @Published private(set) var isMultiLineEnabled: Bool
     @Published private(set) var acceptanceKeyCode: CGKeyCode
     @Published private(set) var acceptanceKeyLabel: String
     @Published private(set) var fullAcceptanceKeyCode: CGKeyCode
@@ -40,6 +41,7 @@ final class SuggestionSettingsModel: ObservableObject {
     private static let userNameDefaultsKey = "tabbyUserName"
     private static let debounceMillisecondsDefaultsKey = "tabbyDebounceMilliseconds"
     private static let focusPollIntervalMillisecondsDefaultsKey = "tabbyFocusPollIntervalMilliseconds"
+    private static let multiLineEnabledDefaultsKey = "tabbyMultiLineEnabled"
     private static let acceptanceKeyCodeDefaultsKey = "tabbyAcceptanceKeyCode"
     private static let acceptanceKeyLabelDefaultsKey = "tabbyAcceptanceKeyLabel"
     private static let fullAcceptanceKeyCodeDefaultsKey = "tabbyFullAcceptanceKeyCode"
@@ -98,6 +100,8 @@ final class SuggestionSettingsModel: ObservableObject {
             return max(10, min(500, raw))
         }()
 
+        let resolvedMultiLineEnabled = userDefaults.object(forKey: Self.multiLineEnabledDefaultsKey) as? Bool ?? false
+
         let resolvedAcceptanceKeyCode = CGKeyCode(
             userDefaults.object(forKey: Self.acceptanceKeyCodeDefaultsKey) as? Int
                 ?? Int(Self.defaultAcceptanceKeyCode)
@@ -122,6 +126,7 @@ final class SuggestionSettingsModel: ObservableObject {
         userName = resolvedUserName
         debounceMilliseconds = resolvedDebounceMilliseconds
         focusPollIntervalMilliseconds = resolvedFocusPollIntervalMilliseconds
+        isMultiLineEnabled = resolvedMultiLineEnabled
         acceptanceKeyCode = resolvedAcceptanceKeyCode
         acceptanceKeyLabel = resolvedAcceptanceKeyLabel
         fullAcceptanceKeyCode = resolvedFullAcceptanceKeyCode
@@ -137,6 +142,7 @@ final class SuggestionSettingsModel: ObservableObject {
         persistUserName(resolvedUserName)
         userDefaults.set(resolvedDebounceMilliseconds, forKey: Self.debounceMillisecondsDefaultsKey)
         userDefaults.set(resolvedFocusPollIntervalMilliseconds, forKey: Self.focusPollIntervalMillisecondsDefaultsKey)
+        userDefaults.set(resolvedMultiLineEnabled, forKey: Self.multiLineEnabledDefaultsKey)
         userDefaults.set(Int(resolvedAcceptanceKeyCode), forKey: Self.acceptanceKeyCodeDefaultsKey)
         userDefaults.set(resolvedAcceptanceKeyLabel, forKey: Self.acceptanceKeyLabelDefaultsKey)
         userDefaults.set(Int(resolvedFullAcceptanceKeyCode), forKey: Self.fullAcceptanceKeyCodeDefaultsKey)
@@ -157,7 +163,8 @@ final class SuggestionSettingsModel: ObservableObject {
             isClipboardContextEnabled: isClipboardContextEnabled,
             userName: userName,
             debounceMilliseconds: debounceMilliseconds,
-            focusPollIntervalMilliseconds: focusPollIntervalMilliseconds
+            focusPollIntervalMilliseconds: focusPollIntervalMilliseconds,
+            isMultiLineEnabled: isMultiLineEnabled
         )
     }
 
@@ -186,6 +193,14 @@ final class SuggestionSettingsModel: ObservableObject {
 
         isClipboardContextEnabled = enabled
         persistClipboardContextEnabled(enabled)
+    }
+
+    func setMultiLineEnabled(_ enabled: Bool) {
+        guard isMultiLineEnabled != enabled else {
+            return
+        }
+        isMultiLineEnabled = enabled
+        userDefaults.set(enabled, forKey: Self.multiLineEnabledDefaultsKey)
     }
 
     func setDebounceMilliseconds(_ value: Int) {
@@ -497,11 +512,11 @@ extension SuggestionSettingsModel: SuggestionSettingsProviding {
             ),
             $isClipboardContextEnabled,
             $userName,
-            Publishers.CombineLatest($debounceMilliseconds, $focusPollIntervalMilliseconds)
+            Publishers.CombineLatest3($debounceMilliseconds, $focusPollIntervalMilliseconds, $isMultiLineEnabled)
         )
         .map { combinedSettings, clipboardContextEnabled, userName, timing in
             let (globallyEnabled, disabledAppRules, engine, wordCountPreset) = combinedSettings
-            let (debounce, focusPoll) = timing
+            let (debounce, focusPoll, multiLine) = timing
             return SuggestionSettingsSnapshot(
                 isGloballyEnabled: globallyEnabled,
                 disabledAppBundleIdentifiers: Set(disabledAppRules.map(\.bundleIdentifier)),
@@ -510,7 +525,8 @@ extension SuggestionSettingsModel: SuggestionSettingsProviding {
                 isClipboardContextEnabled: clipboardContextEnabled,
                 userName: userName,
                 debounceMilliseconds: debounce,
-                focusPollIntervalMilliseconds: focusPoll
+                focusPollIntervalMilliseconds: focusPoll,
+                isMultiLineEnabled: multiLine
             )
         }
         .removeDuplicates()

--- a/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
+++ b/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
@@ -148,7 +148,6 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
         }
 
         var generatedText = ""
-        var hasVisibleContent = false
 
         for _ in 0 ..< options.maxPredictionTokens {
             let result = engine.sampleNext(sequenceID)
@@ -159,14 +158,6 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
 
             let piece = Self.extractPiece(result)
             generatedText += piece
-
-            // Allow leading formatting noise but stop once a newline appears after visible content.
-            if piece.unicodeScalars.contains(where: Self.isVisibleOutputScalar) {
-                hasVisibleContent = true
-            }
-            if hasVisibleContent && generatedText.contains("\n") {
-                break
-            }
         }
 
         return generatedText
@@ -380,12 +371,6 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
             repetition_penalty: Float(options.repetitionPenalty),
             seed: options.seed ?? 0
         )
-    }
-
-    /// Inline autocomplete cares about visible suggestion text, not formatting-only tokens.
-    private static func isVisibleOutputScalar(_ scalar: UnicodeScalar) -> Bool {
-        if CharacterSet.controlCharacters.contains(scalar) { return false }
-        return !CharacterSet.whitespacesAndNewlines.contains(scalar)
     }
 
     private static func reusableTokenCount(commonTokenPrefix: Int, newPromptTokenCount: Int) -> Int {

--- a/Cotabby/Support/GhostSuggestionLayout.swift
+++ b/Cotabby/Support/GhostSuggestionLayout.swift
@@ -79,7 +79,7 @@ struct GhostSuggestionLayout: Equatable {
             usableFrame.width - Metrics.estimatedKeycapAndSpacingWidth
         )
 
-        let singleLineFits = measuredWidth(
+        let singleLineFits = !normalizedText.contains("\n") && measuredWidth(
             of: normalizedText,
             fontSize: fontSize,
             observedCharWidth: geometry.observedCharWidth
@@ -222,13 +222,14 @@ struct GhostSuggestionLayout: Equatable {
     }
 
     private static func normalizedDisplayText(_ text: String) -> String {
-        let words = text.split(whereSeparator: \.isWhitespace).map(String.init)
-        guard !words.isEmpty else {
-            return text
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+        let normalizedLines = lines.map { line -> String in
+            let words = line.split(whereSeparator: \.isWhitespace).map(String.init)
+            guard !words.isEmpty else { return "" }
+            let joined = words.joined(separator: " ")
+            return line.first?.isWhitespace == true ? " \(joined)" : joined
         }
-
-        let joined = words.joined(separator: " ")
-        return text.first?.isWhitespace == true ? " \(joined)" : joined
+        return normalizedLines.joined(separator: "\n")
     }
 
     private static func splitPrefix(
@@ -243,6 +244,36 @@ struct GhostSuggestionLayout: Equatable {
         }
 
         let safeMaxWidth = max(maxWidth, Metrics.minimumLineWidth)
+
+        // Explicit newline: force a line break at the first one.
+        if let newlineIndex = source.firstIndex(of: "\n") {
+            let segment = String(source[..<newlineIndex]).trimmingCharacters(in: .whitespaces)
+            let afterIndex = source.index(after: newlineIndex)
+            let afterNewline = afterIndex < source.endIndex
+                ? String(source[afterIndex...]).trimmingCharacters(in: .whitespaces)
+                : ""
+
+            guard !segment.isEmpty else {
+                return splitPrefix(from: afterNewline, maxWidth: maxWidth, fontSize: fontSize, observedCharWidth: observedCharWidth)
+            }
+
+            if measuredWidth(of: segment, fontSize: fontSize, observedCharWidth: observedCharWidth) <= safeMaxWidth {
+                return (segment, afterNewline)
+            }
+
+            // Segment before newline is too wide — width-wrap it, keep post-newline as remainder.
+            let widthSplit = splitPrefix(from: segment, maxWidth: maxWidth, fontSize: fontSize, observedCharWidth: observedCharWidth)
+            let combined: String
+            if widthSplit.remainder.isEmpty {
+                combined = afterNewline
+            } else if afterNewline.isEmpty {
+                combined = widthSplit.remainder
+            } else {
+                combined = widthSplit.remainder + "\n" + afterNewline
+            }
+            return (widthSplit.line, combined)
+        }
+
         if measuredWidth(of: source, fontSize: fontSize, observedCharWidth: observedCharWidth) <= safeMaxWidth {
             return (source, "")
         }

--- a/Cotabby/Support/SuggestionRequestFactory.swift
+++ b/Cotabby/Support/SuggestionRequestFactory.swift
@@ -65,7 +65,8 @@ enum SuggestionRequestFactory {
             generation: context.generation,
             maxPredictionTokens: activeMaxPredictionTokens(
                 configuration: configuration,
-                wordCountPreset: settings.selectedWordCountPreset
+                wordCountPreset: settings.selectedWordCountPreset,
+                isMultiLineEnabled: settings.isMultiLineEnabled
             ),
             temperature: configuration.temperature,
             topK: configuration.topK,
@@ -77,7 +78,8 @@ enum SuggestionRequestFactory {
             completionLengthInstruction: completionLengthInstruction,
             userName: userName,
             clipboardContext: boundedClipboardContext,
-            visualContextSummary: boundedVisualContextSummary
+            visualContextSummary: boundedVisualContextSummary,
+            isMultiLineEnabled: settings.isMultiLineEnabled
         )
 
         return SuggestionRequestBuildResult(
@@ -155,9 +157,11 @@ enum SuggestionRequestFactory {
 
     private static func activeMaxPredictionTokens(
         configuration: SuggestionConfiguration,
-        wordCountPreset: SuggestionWordCountPreset
+        wordCountPreset: SuggestionWordCountPreset,
+        isMultiLineEnabled: Bool
     ) -> Int {
-        max(configuration.maxPredictionTokens, wordCountPreset.suggestedPredictionTokenBudget)
+        let base = max(configuration.maxPredictionTokens, wordCountPreset.suggestedPredictionTokenBudget)
+        return isMultiLineEnabled ? min(base * 2, 60) : base
     }
 
     private static func promptPreview(

--- a/Cotabby/Support/SuggestionTextNormalizer.swift
+++ b/Cotabby/Support/SuggestionTextNormalizer.swift
@@ -53,9 +53,18 @@ enum SuggestionTextNormalizer {
         // continuation that followed.
         normalized = normalized.trimmingCharacters(in: .newlines)
 
-        // Inline autocomplete should only surface the immediate continuation, not a paragraph.
-        if let firstLine = normalized.split(separator: "\n", maxSplits: 1).first {
-            normalized = String(firstLine)
+        if request.isMultiLineEnabled {
+            // Multi-line mode: keep content up to the first blank-line boundary (double newline)
+            // to prevent runaway paragraph generation while still allowing multi-line completions.
+            if let blankLine = normalized.range(of: "\n\n") {
+                normalized = String(normalized[..<blankLine.lowerBound])
+            }
+            normalized = normalized.trimmingCharacters(in: .whitespacesAndNewlines)
+        } else {
+            // Single-line mode: only surface the immediate continuation line.
+            if let firstLine = normalized.split(separator: "\n", maxSplits: 1).first {
+                normalized = String(firstLine)
+            }
         }
 
         // If the model starts by repeating text that already exists after the caret, we treat the

--- a/Cotabby/UI/MenuBarView.swift
+++ b/Cotabby/UI/MenuBarView.swift
@@ -122,6 +122,10 @@ struct MenuBarView: View {
                 .labelsHidden()
                 .pickerStyle(.menu)
             }
+
+            Toggle("Multi-line", isOn: multiLineEnabledBinding)
+                .toggleStyle(.switch)
+                .controlSize(.small)
         }
         .padding(.bottom, 12)
     }
@@ -264,6 +268,13 @@ struct MenuBarView: View {
             set: { engine in
                 suggestionSettings.selectEngine(engine)
             }
+        )
+    }
+
+    private var multiLineEnabledBinding: Binding<Bool> {
+        Binding(
+            get: { suggestionSettings.isMultiLineEnabled },
+            set: { suggestionSettings.setMultiLineEnabled($0) }
         )
     }
 

--- a/CotabbyTests/CotabbyTestFixtures.swift
+++ b/CotabbyTests/CotabbyTestFixtures.swift
@@ -96,7 +96,8 @@ enum CotabbyTestFixtures {
         completionLengthInstruction: String = "Return only the next few words.",
         userName: String? = nil,
         clipboardContext: String? = nil,
-        visualContextSummary: String? = nil
+        visualContextSummary: String? = nil,
+        isMultiLineEnabled: Bool = false
     ) -> SuggestionRequest {
         let resolvedPrecedingText = precedingText ?? prefixText
         let context = focusedInputContext(
@@ -121,7 +122,8 @@ enum CotabbyTestFixtures {
             completionLengthInstruction: completionLengthInstruction,
             userName: userName,
             clipboardContext: clipboardContext,
-            visualContextSummary: visualContextSummary
+            visualContextSummary: visualContextSummary,
+            isMultiLineEnabled: isMultiLineEnabled
         )
     }
 
@@ -209,7 +211,8 @@ enum CotabbyTestFixtures {
         isClipboardContextEnabled: Bool = true,
         userName: String = "",
         debounceMilliseconds: Int = 50,
-        focusPollIntervalMilliseconds: Int = 50
+        focusPollIntervalMilliseconds: Int = 50,
+        isMultiLineEnabled: Bool = false
     ) -> SuggestionSettingsSnapshot {
         SuggestionSettingsSnapshot(
             isGloballyEnabled: isGloballyEnabled,
@@ -219,7 +222,8 @@ enum CotabbyTestFixtures {
             isClipboardContextEnabled: isClipboardContextEnabled,
             userName: userName,
             debounceMilliseconds: debounceMilliseconds,
-            focusPollIntervalMilliseconds: focusPollIntervalMilliseconds
+            focusPollIntervalMilliseconds: focusPollIntervalMilliseconds,
+            isMultiLineEnabled: isMultiLineEnabled
         )
     }
 }

--- a/CotabbyTests/LlamaPromptRendererTests.swift
+++ b/CotabbyTests/LlamaPromptRendererTests.swift
@@ -231,7 +231,8 @@ final class LlamaPromptRendererTests: XCTestCase {
             completionLengthInstruction: "Return only the next few words.",
             userName: nil,
             clipboardContext: nil,
-            visualContextSummary: nil
+            visualContextSummary: nil,
+            isMultiLineEnabled: false
         )
     }
 }


### PR DESCRIPTION
## Summary

Removes the generation-time newline break from `LlamaRuntimeCore` and moves output shaping entirely into `SuggestionTextNormalizer`. This cleaner separation lets the model use its full token budget, avoiding edge-case empty completions when the model's best continuation starts with a newline. A new "Multi-line" toggle in the menu bar controls whether the normalizer truncates to the first line (default, unchanged behavior) or keeps content up to a blank-line boundary.

## Validation

```
xcodebuild -project tabby.xcodeproj -scheme tabby \
  -destination 'platform=macOS' build \
  CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO
# ** BUILD SUCCEEDED **

xcodebuild -project tabby.xcodeproj -scheme tabby \
  -destination 'platform=macOS' build-for-testing \
  CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO
# ** TEST BUILD SUCCEEDED **
```

UI and insertion behavior require manual verification with the app running — toggle multi-line on, type in TextEdit/Notes/VS Code, confirm ghost text renders across multiple lines and inserts correctly on accept.

## Linked issues

Fixes #208

## Risk / rollout notes

- **New UserDefaults key** `tabbyMultiLineEnabled` (defaults to `false`) — no migration needed, existing users get unchanged single-line behavior.
- **Generation loop change is unconditional**: the newline break is removed even in single-line mode. Single-line truncation is now handled entirely by the normalizer (same output, different enforcement point). This means slightly more tokens may be generated before being trimmed, bounded by the existing token budget (11-30 tokens).
- **Token budget doubles when multi-line is on** (capped at 60). This increases generation latency proportionally on smaller machines.
- **GhostSuggestionLayout** now handles explicit `\n` as forced line breaks via recursive `splitPrefix`. The recursion depth is bounded by the number of newlines in the text (at most ~3 lines given the normalizer's blank-line truncation).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds multi-line completion support by removing the generation-time newline break from `LlamaRuntimeCore` and centralizing output shaping in `SuggestionTextNormalizer`. A new "Multi-line" menu bar toggle (backed by `tabbyMultiLineEnabled` in UserDefaults, defaulting to `false`) controls whether the normalizer truncates at the first line or keeps content up to the first blank-line boundary.

- **`LlamaRuntimeCore`**: removes the `hasVisibleContent` / newline early-stop, letting the model run to EOS or token budget; `SuggestionTextNormalizer` now owns the truncation in both modes.
- **`SuggestionTextNormalizer`**: in multi-line mode, truncates at the first `\n\n` boundary and trims; in single-line mode, behavior is unchanged.
- **`GhostSuggestionLayout`**: `normalizedDisplayText` now processes per-line, and `splitPrefix` handles explicit `\n` as forced visual line breaks via bounded recursion; `singleLineFits` is guarded with `!normalizedText.contains("\n")` to prevent multi-line text from being rendered as a single line.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the generation-time newline break removal is unconditional but bounded by the existing token budget, single-line mode output is functionally identical to before, and the new multi-line path is cleanly gated behind a false-defaulting UserDefaults flag.

The change is well-scoped: the only unconditional behavioral difference in the generation loop is removing an early-stop that the normalizer now handles equivalently. Multi-line rendering is new territory but is guarded behind a disabled-by-default toggle, the recursion in splitPrefix is bounded by newline count, and the singleLineFits guard prevents multi-line text from silently collapsing to one line. No data is persisted or modified in a breaking way.

No files require special attention. The token budget formula in SuggestionRequestFactory.swift has a known edge case flagged in a previous review thread that does not affect current presets.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/SuggestionTextNormalizer.swift | Multi-line truncation at first blank-line boundary added; single-line path unchanged. Logic is correct and the \r → "" stripping before \n\n detection prevents Windows line-ending issues. |
| Cotabby/Support/GhostSuggestionLayout.swift | Two focused changes: singleLineFits now short-circuits on \n presence, and splitPrefix gains a bounded-recursive newline handler. Edge cases (empty segment before newline, over-wide segment before newline) are handled correctly. |
| Cotabby/Support/SuggestionRequestFactory.swift | Token budget doubles and is capped at 60 for multi-line mode. Formula min(base * 2, 60) can produce fewer tokens than single-line when base > 60, though current presets cap base at 30. |
| Cotabby/Services/Runtime/LlamaRuntimeCore.swift | Removes hasVisibleContent early-stop and the isVisibleOutputScalar helper; generation now runs to EOS or budget. Clean delegation to the normalizer. |
| Cotabby/Models/SuggestionSettingsModel.swift | Adds isMultiLineEnabled as a @Published property with UserDefaults persistence and a dedicated setter, consistent with existing patterns. CombineLatest upgraded to CombineLatest3 to include the new setting in the snapshot stream. |
| Cotabby/UI/MenuBarView.swift | Adds a compact Toggle("Multi-line", ...) bound through a private Binding<Bool> helper, matching the existing UI pattern. |
| CotabbyTests/CotabbyTestFixtures.swift | Adds isMultiLineEnabled: Bool = false to suggestionRequest and suggestionSettingsSnapshot fixtures, maintaining backward-compatible defaults. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant MenuBarView
    participant SuggestionSettingsModel
    participant SuggestionRequestFactory
    participant LlamaRuntimeCore
    participant SuggestionTextNormalizer
    participant GhostSuggestionLayout

    User->>MenuBarView: Toggle "Multi-line"
    MenuBarView->>SuggestionSettingsModel: setMultiLineEnabled(true)
    SuggestionSettingsModel->>SuggestionSettingsModel: persist to UserDefaults

    Note over SuggestionSettingsModel: CombineLatest3 emits new snapshot

    SuggestionRequestFactory->>SuggestionRequestFactory: activeMaxPredictionTokens
    SuggestionRequestFactory->>LlamaRuntimeCore: SuggestionRequest(isMultiLineEnabled: true)

    LlamaRuntimeCore->>LlamaRuntimeCore: Generate until EOS or budget
    LlamaRuntimeCore-->>SuggestionTextNormalizer: rawSuggestion (may contain newlines)

    SuggestionTextNormalizer->>SuggestionTextNormalizer: truncate at first blank-line boundary
    SuggestionTextNormalizer-->>GhostSuggestionLayout: normalized multi-line text

    GhostSuggestionLayout->>GhostSuggestionLayout: splitPrefix handles newlines as forced breaks
    GhostSuggestionLayout-->>User: Ghost text rendered across multiple lines
```

<sub>Reviews (2): Last reviewed commit: ["Add multi-line completion support with m..."](https://github.com/fujacob/tabby/commit/5bbb38862689e282f97418780977e2be96370731) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33704200)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=45fae5fd-3007-4631-a2b0-92b2beb3df2a))

<!-- /greptile_comment -->