### PR TITLE
Route GGUF model discovery through LM Studio folder

### DIFF
--- a/Cotabby/Services/Utilities/ModelDownloadManager.swift
+++ b/Cotabby/Services/Utilities/ModelDownloadManager.swift
@@ -59,7 +59,7 @@ final class ModelDownloadManager: ObservableObject {
 
     private let runtimeDirectoryURL: URL
     private let mlxRuntimeDirectoryURL: URL
-    private let runtimeSearchDirectories: [URL]
+    private var runtimeSearchDirectories: [URL]
     private var downloadTasks: [String: Task<Void, Never>] = [:]
 
     init(runtimeDirectoryURL: URL? = nil, mlxRuntimeDirectoryURL: URL? = nil) {
@@ -86,7 +86,20 @@ final class ModelDownloadManager: ObservableObject {
     }
 
     var modelsDirectoryPath: String {
-        runtimeDirectoryURL.path
+        BundledRuntimeLocator.customModelDirectoryURL()?.path ?? runtimeDirectoryURL.path
+    }
+
+    /// Re-reads the current search directories (including any custom path) and refreshes model states.
+    func refreshSearchDirectories() {
+        var directories = [runtimeDirectoryURL]
+        for directoryURL in BundledRuntimeLocator.runtimeSearchDirectories() {
+            let normalizedPath = directoryURL.standardizedFileURL.path
+            if !directories.contains(where: { $0.standardizedFileURL.path == normalizedPath }) {
+                directories.append(directoryURL)
+            }
+        }
+        runtimeSearchDirectories = directories
+        refreshModelStates()
     }
 
     func state(for model: DownloadableRuntimeModel) -> ModelDownloadState {

--- a/Cotabby/Support/BundledRuntimeLocator.swift
+++ b/Cotabby/Support/BundledRuntimeLocator.swift
@@ -71,10 +71,30 @@ struct BundledRuntimeLocator {
             .appendingPathComponent(Self.mlxRuntimeFolderName, isDirectory: true)
     }
 
+    private static let customModelDirectoryKey = "customModelDirectoryPath"
+
+    /// Returns the user-configured custom model directory, if one is set.
+    static func customModelDirectoryURL() -> URL? {
+        guard let path = UserDefaults.standard.string(forKey: customModelDirectoryKey),
+              !path.isEmpty
+        else { return nil }
+        return URL(fileURLWithPath: path, isDirectory: true)
+    }
+
+    /// Persists (or clears) a custom model directory that is searched before the default path.
+    static func setCustomModelDirectory(_ url: URL?) {
+        UserDefaults.standard.set(url?.path, forKey: customModelDirectoryKey)
+    }
+
     /// Ordered runtime search directories used to discover GGUF files.
     /// This mirrors runtime resolution order and is shared by model-install status checks.
     static func runtimeSearchDirectories(bundle: Bundle = .main) -> [URL] {
-        [userRuntimeDirectoryURL(bundle: bundle)]
+        var directories: [URL] = []
+        if let custom = customModelDirectoryURL() {
+            directories.append(custom)
+        }
+        directories.append(userRuntimeDirectoryURL(bundle: bundle))
+        return directories
     }
 
     /// Search directories for MLX model discovery.
@@ -146,6 +166,7 @@ struct BundledRuntimeLocator {
 
     /// Enumerates runtime directories. By default we only load from the user-managed model directory.
     /// An explicit `runtimeDirectoryPath` can override this for tests or advanced local setups.
+    /// A user-configured custom directory (e.g. LM Studio) is searched before the default.
     private func runtimeCandidates(for configuration: LlamaRuntimeConfiguration)
         -> [RuntimeCandidate] {
         if let runtimeDirectoryPath = configuration.runtimeDirectoryPath,
@@ -159,13 +180,23 @@ struct BundledRuntimeLocator {
             ]
         }
 
-        let userRuntimeDirectoryURL = Self.userRuntimeDirectoryURL(bundle: bundle)
-        return [
-            RuntimeCandidate(
-                runtimeDirectoryURL: userRuntimeDirectoryURL,
-                modelDirectoryURL: userRuntimeDirectoryURL
+        var candidates: [RuntimeCandidate] = []
+        if let custom = Self.customModelDirectoryURL() {
+            candidates.append(
+                RuntimeCandidate(
+                    runtimeDirectoryURL: custom,
+                    modelDirectoryURL: custom
+                )
             )
-        ]
+        }
+        let userDir = Self.userRuntimeDirectoryURL(bundle: bundle)
+        candidates.append(
+            RuntimeCandidate(
+                runtimeDirectoryURL: userDir,
+                modelDirectoryURL: userDir
+            )
+        )
+        return candidates
     }
 
     /// Enumerates and orders all GGUF models for one runtime candidate.

--- a/Cotabby/UI/SettingsView.swift
+++ b/Cotabby/UI/SettingsView.swift
@@ -379,12 +379,22 @@ struct SettingsView: View {
                     HStack(spacing: 8) {
                         let lmStudioURL = FileManager.default.homeDirectoryForCurrentUser
                             .appendingPathComponent(".lmstudio/models")
-                        Button("LM Studio Folder") {
-                            NSWorkspace.shared.open(lmStudioURL)
+                        let isUsingCustomPath = BundledRuntimeLocator.customModelDirectoryURL() != nil
+                        Button("Use LM Studio") {
+                            BundledRuntimeLocator.setCustomModelDirectory(lmStudioURL)
+                            modelDownloadManager.refreshSearchDirectories()
+                            refreshModels()
                         }
                         .disabled(
                             !FileManager.default.fileExists(atPath: lmStudioURL.path)
                         )
+
+                        Button("Reset Path") {
+                            BundledRuntimeLocator.setCustomModelDirectory(nil)
+                            modelDownloadManager.refreshSearchDirectories()
+                            refreshModels()
+                        }
+                        .disabled(!isUsingCustomPath)
 
                         Button("Open Folder") {
                             modelDownloadManager.openModelsDirectory()


### PR DESCRIPTION
## Summary

The "LM Studio Folder" button previously just opened `~/.lmstudio/models` in Finder.
Now it tells Tabby to look for GGUF models in that directory, so users with LM Studio
can reuse their existing model collection without copying files. A new "Reset Path"
button reverts to the default `~/Library/Application Support/Tabby/LlamaRuntime/`.

## Validation

```
xcodebuild -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' build CODE_SIGNING_ALLOWED=NO
# ** BUILD SUCCEEDED **

xcodebuild -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' build-for-testing CODE_SIGNING_ALLOWED=NO
# ** TEST BUILD SUCCEEDED **

swiftlint lint --quiet
# No new warnings
```

## Linked issues

None.

## Risk / rollout notes

- The custom model path is persisted in UserDefaults (`customModelDirectoryPath`). Users who previously clicked "LM Studio Folder" (which only opened Finder) will now see "Use LM Studio" which changes the search path — different behavior, same button location.
- The custom directory is searched **before** the default directory, so if the same model filename exists in both, the LM Studio copy takes precedence.
- `ModelDownloadManager.runtimeSearchDirectories` changed from `let` to `var` to support runtime refresh when the custom path changes.
- The displayed folder path in settings now reflects the active custom directory when one is set.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the old "LM Studio Folder" button (which just opened Finder) with a "Use LM Studio" button that routes GGUF model discovery through `~/.lmstudio/models`, backed by a `customModelDirectoryPath` UserDefaults key, and adds a "Reset Path" button to revert to the default Tabby directory.

- `BundledRuntimeLocator` gains `customModelDirectoryURL()` / `setCustomModelDirectory(_:)` and prepends the custom path in both `runtimeSearchDirectories()` and `runtimeCandidates()`, so the LM Studio folder is searched before the default path at load time and for existence checks.
- `ModelDownloadManager` changes `runtimeSearchDirectories` to `var` and exposes `refreshSearchDirectories()` so the UI can trigger a rebuild of the search list and a model-state refresh after the custom path changes.
- `SettingsView` wires the two new buttons to call `setCustomModelDirectory`, `refreshSearchDirectories`, and `refreshModels` in sequence; `modelsDirectoryPath` now reflects the active custom directory in the Folder label.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the previously flagged Open Folder mismatch is the only outstanding functional gap, and this PR otherwise handles the custom-path lifecycle correctly end-to-end.

The custom path persists and is applied consistently in both BundledRuntimeLocator (model loading) and ModelDownloadManager (install-status checks). The already-noted openModelsDirectory() opens the wrong folder when a custom path is active. The only new finding is a minor UX inconsistency in the disabled state of the Use LM Studio button.

Cotabby/Services/Utilities/ModelDownloadManager.swift — openModelsDirectory() still hard-codes runtimeDirectoryURL instead of the active custom path (flagged in a prior review round).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/UI/SettingsView.swift | Replaces the old LM Studio Folder (open Finder) button with Use LM Studio (set custom search path) and adds a Reset Path button; the Reset Path disabled state is tied to isUsingCustomPath but Use LM Studio lacks a parallel check. |
| Cotabby/Services/Utilities/ModelDownloadManager.swift | Changed runtimeSearchDirectories from let to var and added refreshSearchDirectories() to rebuild the list after a custom path is set or cleared; modelsDirectoryPath now reflects the active custom directory. |
| Cotabby/Support/BundledRuntimeLocator.swift | Introduces customModelDirectoryURL() / setCustomModelDirectory(_:) backed by UserDefaults, prepends the custom path in runtimeSearchDirectories() and runtimeCandidates() so LM Studio models are resolved before the default Tabby path. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    actor User
    participant SettingsView
    participant BundledRuntimeLocator
    participant UserDefaults
    participant ModelDownloadManager

    User->>SettingsView: clicks Use LM Studio
    SettingsView->>BundledRuntimeLocator: setCustomModelDirectory(lmStudioURL)
    BundledRuntimeLocator->>UserDefaults: persist custom path
    SettingsView->>ModelDownloadManager: refreshSearchDirectories()
    ModelDownloadManager->>BundledRuntimeLocator: runtimeSearchDirectories()
    BundledRuntimeLocator->>UserDefaults: read custom path
    UserDefaults-->>BundledRuntimeLocator: lmStudio path
    BundledRuntimeLocator-->>ModelDownloadManager: [lmStudioURL, userRuntimeURL]
    ModelDownloadManager->>ModelDownloadManager: refreshModelStates()
    ModelDownloadManager-->>SettingsView: "@Published modelStates updated - redraw"
    SettingsView->>SettingsView: recomputes modelsDirectoryPath and isUsingCustomPath

    User->>SettingsView: clicks Reset Path
    SettingsView->>BundledRuntimeLocator: setCustomModelDirectory(nil)
    BundledRuntimeLocator->>UserDefaults: clear custom path
    SettingsView->>ModelDownloadManager: refreshSearchDirectories()
    ModelDownloadManager->>BundledRuntimeLocator: runtimeSearchDirectories()
    BundledRuntimeLocator-->>ModelDownloadManager: [userRuntimeURL]
    ModelDownloadManager->>ModelDownloadManager: refreshModelStates()
    ModelDownloadManager-->>SettingsView: "@Published modelStates updated - redraw"
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tabby/Services/Utilities/ModelDownloadManager.swift`, line 179-187 ([link](https://github.com/fujacob/tabby/blob/5e05a9c3eacd8d10b1c424c7eec54d2c8cabc450/tabby/Services/Utilities/ModelDownloadManager.swift#L179-L187)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`openModelsDirectory()` opens the wrong folder when a custom path is set**

   After the user clicks "Use LM Studio", the "Folder" label in settings renders the LM Studio path (`modelsDirectoryPath` now returns the custom URL). However, clicking "Open Folder" still calls this method, which always opens `runtimeDirectoryURL` — the default `~/Library/Application Support/Tabby/LlamaRuntime/` — rather than the active custom directory. The user sees one path on screen and Finder opens a completely different one.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22lm-studio-model-path%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22lm-studio-model-path%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tabby%2FServices%2FUtilities%2FModelDownloadManager.swift%0ALine%3A%20179-187%0A%0AComment%3A%0A**%60openModelsDirectory%28%29%60%20opens%20the%20wrong%20folder%20when%20a%20custom%20path%20is%20set**%0A%0AAfter%20the%20user%20clicks%20%22Use%20LM%20Studio%22%2C%20the%20%22Folder%22%20label%20in%20settings%20renders%20the%20LM%20Studio%20path%20%28%60modelsDirectoryPath%60%20now%20returns%20the%20custom%20URL%29.%20However%2C%20clicking%20%22Open%20Folder%22%20still%20calls%20this%20method%2C%20which%20always%20opens%20%60runtimeDirectoryURL%60%20%E2%80%94%20the%20default%20%60~%2FLibrary%2FApplication%20Support%2FTabby%2FLlamaRuntime%2F%60%20%E2%80%94%20rather%20than%20the%20active%20custom%20directory.%20The%20user%20sees%20one%20path%20on%20screen%20and%20Finder%20opens%20a%20completely%20different%20one.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tabby%2FServices%2FUtilities%2FModelDownloadManager.swift%0ALine%3A%20179-187%0A%0AComment%3A%0A**%60openModelsDirectory%28%29%60%20opens%20the%20wrong%20folder%20when%20a%20custom%20path%20is%20set**%0A%0AAfter%20the%20user%20clicks%20%22Use%20LM%20Studio%22%2C%20the%20%22Folder%22%20label%20in%20settings%20renders%20the%20LM%20Studio%20path%20%28%60modelsDirectoryPath%60%20now%20returns%20the%20custom%20URL%29.%20However%2C%20clicking%20%22Open%20Folder%22%20still%20calls%20this%20method%2C%20which%20always%20opens%20%60runtimeDirectoryURL%60%20%E2%80%94%20the%20default%20%60~%2FLibrary%2FApplication%20Support%2FTabby%2FLlamaRuntime%2F%60%20%E2%80%94%20rather%20than%20the%20active%20custom%20directory.%20The%20user%20sees%20one%20path%20on%20screen%20and%20Finder%20opens%20a%20completely%20different%20one.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Ftabby&pr=217&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22lm-studio-model-path%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22lm-studio-model-path%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FSettingsView.swift%3A383-390%0AThe%20%22Use%20LM%20Studio%22%20button's%20%60disabled%60%20modifier%20only%20checks%20whether%20the%20LM%20Studio%20directory%20exists%20on%20disk%2C%20but%20it%20doesn't%20check%20whether%20it's%20already%20the%20active%20custom%20path.%20When%20LM%20Studio%20is%20already%20selected%2C%20both%20%22Use%20LM%20Studio%22%20and%20%22Reset%20Path%22%20are%20simultaneously%20enabled%20with%20no%20visual%20indication%20of%20the%20current%20state.%20Adding%20%60%7C%7C%20isUsingCustomPath%60%20mirrors%20the%20symmetry%20the%20%22Reset%20Path%22%20button%20already%20applies%20in%20reverse.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Button%28%22Use%20LM%20Studio%22%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20BundledRuntimeLocator.setCustomModelDirectory%28lmStudioURL%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20modelDownloadManager.refreshSearchDirectories%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20refreshModels%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.disabled%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20!FileManager.default.fileExists%28atPath%3A%20lmStudioURL.path%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%7C%20isUsingCustomPath%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FSettingsView.swift%3A383-390%0AThe%20%22Use%20LM%20Studio%22%20button's%20%60disabled%60%20modifier%20only%20checks%20whether%20the%20LM%20Studio%20directory%20exists%20on%20disk%2C%20but%20it%20doesn't%20check%20whether%20it's%20already%20the%20active%20custom%20path.%20When%20LM%20Studio%20is%20already%20selected%2C%20both%20%22Use%20LM%20Studio%22%20and%20%22Reset%20Path%22%20are%20simultaneously%20enabled%20with%20no%20visual%20indication%20of%20the%20current%20state.%20Adding%20%60%7C%7C%20isUsingCustomPath%60%20mirrors%20the%20symmetry%20the%20%22Reset%20Path%22%20button%20already%20applies%20in%20reverse.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Button%28%22Use%20LM%20Studio%22%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20BundledRuntimeLocator.setCustomModelDirectory%28lmStudioURL%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20modelDownloadManager.refreshSearchDirectories%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20refreshModels%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.disabled%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20!FileManager.default.fileExists%28atPath%3A%20lmStudioURL.path%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%7C%20isUsingCustomPath%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%60%60%60%0A%0A&repo=fujacob%2Ftabby&pr=217&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Route GGUF model discovery through LM St..."](https://github.com/fujacob/tabby/commit/2cb9486694e5565d5b853e6dcedaeb8db75ee769) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33704597)</sub>

<!-- /greptile_comment -->