### PR TITLE
Fall back to raw OCR text when summarization fails

### DIFF
--- a/Cotabby/Services/Visual/ScreenshotContextGenerator.swift
+++ b/Cotabby/Services/Visual/ScreenshotContextGenerator.swift
@@ -106,9 +106,10 @@ final class ScreenshotContextGenerator {
                     applicationName: context.applicationName
                 )
             } catch {
-                throw ScreenshotContextGenerationError.failed(
-                    "Summarization failed: \(error.localizedDescription)"
-                )
+                // Summarization can fail when no GGUF model is available (e.g. the user
+                // hasn't downloaded one yet, or is using Apple Intelligence). Fall back to
+                // the raw OCR text so visual context still reaches the prompt.
+                generatedContextText = normalizedText
             }
         } else {
             generatedContextText = normalizedText


### PR DESCRIPTION
## Summary

When no GGUF model is available (user hasn't downloaded one, or is using Apple Intelligence), `LlamaVisualContextSummarizer.summarize()` throws because `LlamaRuntimeManager.preparedRuntime()` fails with `.unavailable`. Previously this threw `ScreenshotContextGenerationError.failed`, killing the entire visual context pipeline — the screenshot and OCR work was wasted, and the prompt received no screen context.

Now the catch block falls back to raw OCR text instead of re-throwing, so visual context still reaches the completion prompt regardless of whether a local model is available for summarization.

## Validation

```
xcodebuild -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' build CODE_SIGNING_ALLOWED=NO
# ** BUILD SUCCEEDED **

xcodebuild test -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO
# ** TEST SUCCEEDED **

swiftlint lint --quiet tabby/Services/Visual/ScreenshotContextGenerator.swift
# Only pre-existing cyclomatic_complexity warning
```

## Linked issues

N/A

## Risk / rollout notes

- Users on Apple Intelligence will now get raw OCR text in their prompts instead of no visual context at all. The Foundation Model prompt renderer already handles `visualContextSummary` gracefully — it just appends whatever text it gets.
- Users on llama who haven't downloaded a model yet will also benefit: they'll get raw OCR context instead of a failed pipeline.
- When a GGUF model IS available, behavior is unchanged — summarization still runs and produces a condensed summary.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves resilience of the visual context pipeline by converting a hard failure into a graceful fallback. When `LlamaVisualContextSummarizer.summarize()` throws — because no GGUF model is downloaded or Apple Intelligence is active — the catch block now assigns `normalizedText` directly to `generatedContextText` instead of re-throwing, so callers still receive a bounded OCR excerpt.

- The fallback is safe: `normalizedText` has already passed `hasMeaningfulSignal` and the downstream `boundedSummaryText` call enforces `maxSummaryCharacters` for both the summarized and raw-OCR paths, as the existing comment on line 159 already anticipates.
- Behavior is unchanged when a GGUF model is present and summarization succeeds; the else-branch path (`generatedContextText = normalizedText`) already existed for the no-summarizer case.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fallback assigns already-validated OCR text and passes through the existing boundedSummaryText cap, so no new data flows reach the prompt unchecked.

The change is a small, self-contained substitution in a single catch block. The fallback value normalizedText has already passed hasMeaningfulSignal and the final boundedSummaryText truncation applies on every exit path, including the new one. The no-summarizer else-branch already used the same value, so the fallback mirrors existing, tested behavior.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Services/Visual/ScreenshotContextGenerator.swift | Summarization catch block replaced with OCR fallback; downstream bounds and signal checks still apply correctly on both the success and fallback paths. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[generateContext] --> B[captureScreenshot]
    B --> C[textExtractor.extractText]
    C --> D{OCR result}
    D -- noRecognizedText --> E{windowTitle signal?}
    E -- yes --> F[return VisualContextExcerpt from title]
    E -- no --> G[throw .unavailable]
    D -- success --> H[normalizeRecognizedText]
    H --> I{hasMeaningfulSignal?}
    I -- no --> G
    I -- yes --> J{summarizer != nil?}
    J -- no --> M[generatedContextText = normalizedText]
    J -- yes --> K[summarizer.summarize]
    K -- success --> L[generatedContextText = summary]
    K -- throws --> N["[NEW] generatedContextText = normalizedText (fallback)"]
    L --> O[boundedSummaryText]
    M --> O
    N --> O
    O --> P{hasMeaningfulSignal?}
    P -- no --> G
    P -- yes --> Q[return VisualContextExcerpt]

    style N fill:#d4edda,stroke:#28a745
```

<sub>Reviews (2): Last reviewed commit: ["Fall back to raw OCR text when visual co..."](https://github.com/fujacob/tabby/commit/93b3d3e0c673c63430c7bb52202d848eae6262e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33704975)</sub>

<!-- /greptile_comment -->