### PR TITLE
Update Package.resolved for remote CotabbyInference dependency

### DIFF
--- a/Cotabby.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Cotabby.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "15917f6c704efbd9d9d0d2e112a45a9b5ea8ad13504a7b7fe1adeb7284fac91b",
+  "originHash" : "7031b9362993444c1f5da32db95632c27f0c7072b27a75510fdccfa8e8b6af24",
   "pins" : [
+    {
+      "identity" : "cotabbyinference",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/FuJacob/cotabbyinference.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "662df9f1b71b900231629171572181806bd2fa36"
+      }
+    },
     {
       "identity" : "sparkle",
       "kind" : "remoteSourceControl",


### PR DESCRIPTION
## Summary

The Package.resolved update was pushed to `rename/cotabby` after #202 was merged, so it didn't make it into main. This adds the resolved entry for the remote `cotabbyinference` git dependency.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build-for-testing
# ** TEST BUILD SUCCEEDED **
```

## Linked issues

Follow-up to #202.

## Risk / rollout notes

Lock file only — no code changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the missing `Package.resolved` pin for the remote `cotabbyinference` SwiftPM dependency that was omitted when #202 was merged into `main`; no source code is changed.

- Adds a new `cotabbyinference` entry pinned to commit `662df9f` on the `main` branch of `https://github.com/FuJacob/cotabbyinference.git`, and updates the file's `originHash` accordingly.
- The two existing pins (`sparkle 2.9.1`, `swift-log 1.12.1`) remain unchanged; `cotabbyinference` is the only dependency without a version tag, meaning a future package-resolve step could silently advance the pin.

<h3>Confidence Score: 4/5</h3>

Safe to merge — lock file only, no source changes, build validation passed.

The change is a single lock file update that restores a missing dependency pin. The revision is captured, so current builds are reproducible. The only concern is that the pin tracks a branch rather than a version tag, which means a future Xcode 'Resolve Package Versions' step could silently move to a newer commit without an explicit version bump in the manifest.

No files require special attention beyond the branch-only pin in Package.resolved.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved | Adds the missing `cotabbyinference` pin (branch: main, revision: 662df9f) and updates the originHash; pin uses a branch instead of a version tag, unlike the other two dependencies in the file. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Package.resolved] --> B[cotabbyinference\nbranch: main\nrevision: 662df9f]
    A --> C[sparkle\nversion: 2.9.1\nrevision: 066e75a]
    A --> D[swift-log\nversion: 1.12.1\nrevision: a012e0a]

    B -->|branch pin| E["⚠️ Future resolve may\nadvance to new commit"]
    C -->|version tag| F["✅ Stable semantic anchor"]
    D -->|version tag| F
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22fix%2Fpost-merge-cleanup%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpost-merge-cleanup%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby.xcodeproj%2Fproject.xcworkspace%2Fxcshareddata%2Fswiftpm%2FPackage.resolved%3A8-11%0A**Branch-based%20pin%20instead%20of%20version%20tag**%0A%0AThe%20%60cotabbyinference%60%20entry%20uses%20%60%22branch%22%3A%20%22main%22%60%20rather%20than%20a%20version%20tag.%20The%20other%20two%20dependencies%20%28%60sparkle%60%20and%20%60swift-log%60%29%20carry%20a%20%60%22version%22%60%20field%20alongside%20their%20revision%2C%20giving%20SPM%20a%20stable%20semantic%20anchor.%20With%20a%20branch-only%20pin%2C%20any%20%60swift%20package%20update%60%20or%20Xcode%20%22Resolve%20Package%20Versions%22%20step%20will%20silently%20advance%20to%20whatever%20commit%20is%20at%20the%20tip%20of%20%60main%60%20at%20that%20moment%2C%20potentially%20pulling%20in%20breaking%20changes%20without%20an%20explicit%20version%20bump%20in%20the%20manifest.%20Consider%20publishing%20a%20version%20tag%20on%20%60cotabbyinference%60%20and%20referencing%20it%20here%20so%20the%20lock%20file%20entry%20gains%20the%20same%20reproducibility%20as%20the%20other%20pins.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby.xcodeproj%2Fproject.xcworkspace%2Fxcshareddata%2Fswiftpm%2FPackage.resolved%3A8-11%0A**Branch-based%20pin%20instead%20of%20version%20tag**%0A%0AThe%20%60cotabbyinference%60%20entry%20uses%20%60%22branch%22%3A%20%22main%22%60%20rather%20than%20a%20version%20tag.%20The%20other%20two%20dependencies%20%28%60sparkle%60%20and%20%60swift-log%60%29%20carry%20a%20%60%22version%22%60%20field%20alongside%20their%20revision%2C%20giving%20SPM%20a%20stable%20semantic%20anchor.%20With%20a%20branch-only%20pin%2C%20any%20%60swift%20package%20update%60%20or%20Xcode%20%22Resolve%20Package%20Versions%22%20step%20will%20silently%20advance%20to%20whatever%20commit%20is%20at%20the%20tip%20of%20%60main%60%20at%20that%20moment%2C%20potentially%20pulling%20in%20breaking%20changes%20without%20an%20explicit%20version%20bump%20in%20the%20manifest.%20Consider%20publishing%20a%20version%20tag%20on%20%60cotabbyinference%60%20and%20referencing%20it%20here%20so%20the%20lock%20file%20entry%20gains%20the%20same%20reproducibility%20as%20the%20other%20pins.%0A%0A&repo=fujacob%2Ftabby&pr=221&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Update Package.resolved for remote Cotab..."](https://github.com/fujacob/tabby/commit/f043510b9ff02c166a14b990ae1f4d73fa32c21d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33708118)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->