### PR TITLE
Show MLX models in local model settings

### DIFF
--- a/tabby/App/Core/AppDelegate.swift
+++ b/tabby/App/Core/AppDelegate.swift
@@ -195,6 +195,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// warm the runtime only if the current engine choice needs it.
     private func handleModelDirectoryChange() {
         runtimeModel.refreshAvailableModels()
+        mlxRuntimeManager.refreshAvailableModels()
         startRuntimeIfPreferredEngineRequiresIt()
     }
 }

--- a/tabby/Services/Runtime/MLXRuntimeManager.swift
+++ b/tabby/Services/Runtime/MLXRuntimeManager.swift
@@ -8,13 +8,13 @@ import Foundation
 final class MLXRuntimeManager: ObservableObject {
     @Published private(set) var state: RuntimeBootstrapState = .idle
     @Published private(set) var availableModels: [RuntimeModelOption] = []
+    @Published private(set) var selectedModelName: String?
 
     private let runtimeLocator: BundledRuntimeLocator
     private let core: MLXRuntimeCore
     private var startupTask: Task<PreparedMLXRuntime, Error>?
     private var startupModelName: String?
     private var cachedRuntime: PreparedMLXRuntime?
-    private var selectedModelName: String?
 
     convenience init() {
         self.init(runtimeLocator: BundledRuntimeLocator())

--- a/tabby/Services/Utilities/ModelDownloadManager.swift
+++ b/tabby/Services/Utilities/ModelDownloadManager.swift
@@ -81,11 +81,29 @@ final class ModelDownloadManager: ObservableObject {
     }
 
     var models: [DownloadableRuntimeModel] {
-        RuntimeModelCatalog.downloadableModels
+        models(for: .gguf)
+    }
+
+    func models(for format: ModelFormat) -> [DownloadableRuntimeModel] {
+        switch format {
+        case .gguf:
+            return RuntimeModelCatalog.downloadableModels
+        case .mlx:
+            return RuntimeModelCatalog.downloadableMLXModels
+        }
     }
 
     var modelsDirectoryPath: String {
-        runtimeDirectoryURL.path
+        modelsDirectoryPath(for: .gguf)
+    }
+
+    func modelsDirectoryPath(for format: ModelFormat) -> String {
+        switch format {
+        case .gguf:
+            return runtimeDirectoryURL.path
+        case .mlx:
+            return mlxRuntimeDirectoryURL.path
+        }
     }
 
     func state(for model: DownloadableRuntimeModel) -> ModelDownloadState {
@@ -93,7 +111,7 @@ final class ModelDownloadManager: ObservableObject {
     }
 
     func refreshModelStates() {
-        for model in models {
+        for model in models(for: .gguf) + models(for: .mlx) {
             if downloadTasks[model.filename] != nil {
                 if case .downloading(let progress) = modelStates[model.filename] {
                     modelStates[model.filename] = .downloading(progress: progress)
@@ -159,14 +177,24 @@ final class ModelDownloadManager: ObservableObject {
         }
     }
 
-    func openModelsDirectory() {
+    func openModelsDirectory(format: ModelFormat = .gguf) {
         do {
-            try ensureRuntimeDirectoryExists()
+            switch format {
+            case .gguf:
+                try ensureRuntimeDirectoryExists()
+            case .mlx:
+                try ensureMLXRuntimeDirectoryExists()
+            }
         } catch {
             return
         }
 
-        NSWorkspace.shared.open(runtimeDirectoryURL)
+        switch format {
+        case .gguf:
+            NSWorkspace.shared.open(runtimeDirectoryURL)
+        case .mlx:
+            NSWorkspace.shared.open(mlxRuntimeDirectoryURL)
+        }
     }
 
     /// Returns `true` only when the model lives in Tabby's user-writable model directory.

--- a/tabby/UI/DownloadableModelCatalogView.swift
+++ b/tabby/UI/DownloadableModelCatalogView.swift
@@ -10,11 +10,25 @@ import SwiftUI
 struct DownloadableModelCatalogView: View {
     @ObservedObject var modelDownloadManager: ModelDownloadManager
 
+    private let models: [DownloadableRuntimeModel]
+    private let modelFormat: ModelFormat
     let onRefreshModels: () -> Void
+
+    init(
+        modelDownloadManager: ModelDownloadManager,
+        models: [DownloadableRuntimeModel]? = nil,
+        modelFormat: ModelFormat = .gguf,
+        onRefreshModels: @escaping () -> Void
+    ) {
+        self.modelDownloadManager = modelDownloadManager
+        self.models = models ?? modelDownloadManager.models(for: modelFormat)
+        self.modelFormat = modelFormat
+        self.onRefreshModels = onRefreshModels
+    }
 
     var body: some View {
         VStack(spacing: 8) {
-            ForEach(modelDownloadManager.models) { model in
+            ForEach(models) { model in
                 DownloadableModelRow(
                     model: model,
                     state: modelDownloadManager.state(for: model),
@@ -25,9 +39,9 @@ struct DownloadableModelCatalogView: View {
 
             HStack(spacing: 12) {
                 Button {
-                    modelDownloadManager.openModelsDirectory()
+                    modelDownloadManager.openModelsDirectory(format: modelFormat)
                 } label: {
-                    Label("Add Your Own", systemImage: "folder.badge.plus")
+                    Label(openFolderLabel, systemImage: "folder.badge.plus")
                         .font(.system(size: 12))
                 }
                 .buttonStyle(.plain)
@@ -44,10 +58,28 @@ struct DownloadableModelCatalogView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
-            Text("Drop any .gguf model into the folder above.")
+            Text(folderHint)
                 .font(.system(size: 11))
                 .foregroundStyle(.tertiary)
                 .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var openFolderLabel: String {
+        switch modelFormat {
+        case .gguf:
+            return "Add Your Own"
+        case .mlx:
+            return "Open MLX Folder"
+        }
+    }
+
+    private var folderHint: String {
+        switch modelFormat {
+        case .gguf:
+            return "Drop any .gguf model into the folder above."
+        case .mlx:
+            return "MLX models are folders containing config.json and .safetensors files."
         }
     }
 }

--- a/tabby/UI/SettingsView.swift
+++ b/tabby/UI/SettingsView.swift
@@ -309,12 +309,12 @@ struct SettingsView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
-            if runtimeModel.availableModels.isEmpty {
-                Text("No local GGUF models found. Download one below or add your own model file.")
+            if activeRuntimeModels.isEmpty {
+                Text(noLocalModelsText)
                     .foregroundStyle(.secondary)
             } else {
                 Picker("Selected Model", selection: selectedModelBinding) {
-                    ForEach(runtimeModel.availableModels) { model in
+                    ForEach(activeRuntimeModels) { model in
                         Text(model.displayName)
                             .tag(model.filename)
                     }
@@ -323,28 +323,32 @@ struct SettingsView: View {
 
             DownloadableModelCatalogView(
                 modelDownloadManager: modelDownloadManager,
+                models: downloadableModelsForSelectedEngine,
+                modelFormat: selectedLocalModelFormat,
                 onRefreshModels: refreshModels
             )
 
             LabeledContent("Folder") {
                 VStack(alignment: .trailing, spacing: 8) {
-                    Text(modelDownloadManager.modelsDirectoryPath)
+                    Text(modelDownloadManager.modelsDirectoryPath(for: selectedLocalModelFormat))
                         .font(.callout.monospaced())
                         .textSelection(.enabled)
                         .multilineTextAlignment(.trailing)
 
                     HStack(spacing: 8) {
-                        let lmStudioURL = FileManager.default.homeDirectoryForCurrentUser
-                            .appendingPathComponent(".lmstudio/models")
-                        Button("LM Studio Folder") {
-                            NSWorkspace.shared.open(lmStudioURL)
+                        if selectedLocalModelFormat == .gguf {
+                            let lmStudioURL = FileManager.default.homeDirectoryForCurrentUser
+                                .appendingPathComponent(".lmstudio/models")
+                            Button("LM Studio Folder") {
+                                NSWorkspace.shared.open(lmStudioURL)
+                            }
+                            .disabled(
+                                !FileManager.default.fileExists(atPath: lmStudioURL.path)
+                            )
                         }
-                        .disabled(
-                            !FileManager.default.fileExists(atPath: lmStudioURL.path)
-                        )
 
                         Button("Open Folder") {
-                            modelDownloadManager.openModelsDirectory()
+                            modelDownloadManager.openModelsDirectory(format: selectedLocalModelFormat)
                         }
 
                         Button("Refresh") {
@@ -354,12 +358,12 @@ struct SettingsView: View {
                 }
             }
 
-            if !runtimeModel.availableModels.isEmpty {
+            if !activeRuntimeModels.isEmpty {
                 Text("Installed")
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
-                ForEach(runtimeModel.availableModels) { model in
+                ForEach(activeRuntimeModels) { model in
                     installedModelRow(model)
                 }
             }
@@ -410,10 +414,13 @@ struct SettingsView: View {
 
             Spacer(minLength: 0)
 
-            if model.filename == runtimeModel.selectedModelFilename {
+            if model.filename == selectedRuntimeModelName {
                 Image(systemName: "checkmark.circle.fill")
                     .foregroundStyle(.tint)
-            } else if modelDownloadManager.canDeleteModel(filename: model.filename) {
+            } else if modelDownloadManager.canDeleteModel(
+                filename: model.filename,
+                format: model.format
+            ) {
                 Button {
                     pendingDeletionModel = model
                 } label: {
@@ -584,13 +591,18 @@ struct SettingsView: View {
     private var selectedModelBinding: Binding<String> {
         Binding(
             get: {
-                runtimeModel.selectedModelFilename
-                    ?? runtimeModel.availableModels.first?.filename
+                selectedRuntimeModelName
+                    ?? activeRuntimeModels.first?.filename
                     ?? ""
             },
             set: { filename in
                 Task {
-                    await runtimeModel.selectModel(filename)
+                    switch suggestionSettings.selectedEngine {
+                    case .llamaOpenSource, .appleIntelligence:
+                        await runtimeModel.selectModel(filename)
+                    case .mlxSwift:
+                        try? await mlxRuntimeManager.selectModel(name: filename)
+                    }
                 }
             }
         )
@@ -618,6 +630,41 @@ struct SettingsView: View {
             return "Download an MLX model below. Models are stored locally on your Mac."
         case .appleIntelligence:
             return "These models are used when Engine is set to Open Source or MLX."
+        }
+    }
+
+    private var selectedLocalModelFormat: ModelFormat {
+        suggestionSettings.selectedEngine.modelFormat ?? .gguf
+    }
+
+    private var activeRuntimeModels: [RuntimeModelOption] {
+        switch suggestionSettings.selectedEngine {
+        case .mlxSwift:
+            return mlxRuntimeManager.availableModels
+        case .llamaOpenSource, .appleIntelligence:
+            return runtimeModel.availableModels
+        }
+    }
+
+    private var downloadableModelsForSelectedEngine: [DownloadableRuntimeModel] {
+        modelDownloadManager.models(for: selectedLocalModelFormat)
+    }
+
+    private var selectedRuntimeModelName: String? {
+        switch suggestionSettings.selectedEngine {
+        case .mlxSwift:
+            return mlxRuntimeManager.selectedModelName
+        case .llamaOpenSource, .appleIntelligence:
+            return runtimeModel.selectedModelFilename
+        }
+    }
+
+    private var noLocalModelsText: String {
+        switch selectedLocalModelFormat {
+        case .gguf:
+            return "No local GGUF models found. Download one below or add your own model file."
+        case .mlx:
+            return "No local MLX models found. Download one below."
         }
     }
 
@@ -674,14 +721,15 @@ struct SettingsView: View {
     }
 
     private func deleteModel(_ model: RuntimeModelOption) {
-        modelDownloadManager.deleteModel(filename: model.filename)
-        runtimeModel.refreshAvailableModels()
+        modelDownloadManager.deleteModel(filename: model.filename, format: model.format)
+        refreshModels()
         pendingDeletionModel = nil
     }
 
     private func refreshModels() {
         modelDownloadManager.refreshModelStates()
         runtimeModel.refreshAvailableModels()
+        mlxRuntimeManager.refreshAvailableModels()
     }
 
 }


### PR DESCRIPTION
## Summary
- switch Settings local-model lists, picker, folder path, and delete behavior by selected engine format
- show MLX downloadable catalog entries and MLX folder affordances when the MLX engine is selected
- refresh both GGUF and MLX model discovery after model directory changes

## Validation
- xcodebuild -project tabby.xcodeproj -scheme tabby -destination 'platform=macOS' build CODE_SIGNING_ALLOWED=NO

Note: This PR is intentionally based on mlx-model-engine-base so the diff contains only the UI/settings fix commit on top of the MLX engine work.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires the Settings UI to display MLX model entries, folder paths, and delete/select affordances when the MLX engine is selected, complementing the existing GGUF-only view. It also ensures that both runtime managers refresh their model lists after any directory change.

- `MLXRuntimeManager.selectedModelName` is promoted to `@Published` so the Settings picker can observe it reactively; `activeRuntimeModels`, `selectedRuntimeModelName`, and `selectedLocalModelFormat` computed properties centralize engine-based branching in `SettingsView`.
- `ModelDownloadManager` gains format-aware overloads for `models(for:)`, `modelsDirectoryPath(for:)`, `openModelsDirectory(format:)`, and `deleteModel(filename:format:)`; `refreshModelStates()` now covers both GGUF and MLX catalog entries.
- `DownloadableModelCatalogView` gains explicit `models` and `modelFormat` parameters to render format-appropriate folder labels and hint text without changing existing call sites.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the UI routing is correct and the static catalog data eliminates reactivity edge cases.

The engine-dispatch branching in SettingsView is thorough and the format-aware ModelDownloadManager overloads are clean. The only gaps are a silently swallowed MLX selection error and a redundant double-refresh on model delete, both of which are cosmetic rather than data-corrupting.

tabby/UI/SettingsView.swift — the selectedModelBinding error handling and the deleteModel double-refresh path.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tabby/App/Core/AppDelegate.swift | Adds mlxRuntimeManager.refreshAvailableModels() to handleModelDirectoryChange, ensuring MLX model list stays in sync after any directory change. |
| tabby/Services/Runtime/MLXRuntimeManager.swift | Promotes selectedModelName from private to @Published private(set) so SettingsView can observe and drive the model picker reactively. |
| tabby/Services/Utilities/ModelDownloadManager.swift | Adds format-aware models(for:), modelsDirectoryPath(for:), openModelsDirectory(format:), and deleteModel(filename:format:); refreshModelStates now iterates both GGUF and MLX entries. |
| tabby/UI/DownloadableModelCatalogView.swift | Adds models and modelFormat parameters so the catalog can render either GGUF or MLX entries with format-appropriate folder label and hint text. |
| tabby/UI/SettingsView.swift | Adds activeRuntimeModels, selectedRuntimeModelName, downloadableModelsForSelectedEngine, and selectedLocalModelFormat computed properties to switch between GGUF and MLX in the Local Models section; MLX model selection errors are silently swallowed with try?. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant S as SettingsView
    participant MDM as ModelDownloadManager
    participant AD as AppDelegate
    participant LRM as LlamaRuntimeModel
    participant MLX as MLXRuntimeManager

    Note over S: User selects MLX engine
    S->>S: selectedLocalModelFormat → .mlx
    S->>S: activeRuntimeModels → mlxRuntimeManager.availableModels
    S->>S: downloadableModelsForSelectedEngine → models(for: .mlx)

    Note over S: User picks a model in Picker
    S->>MLX: selectModel(name: filename)
    MLX->>MLX: "state = .loading(...)"
    MLX-->>S: "@Published state update"

    Note over S: User clicks Delete
    S->>MDM: deleteModel(filename:, format: .mlx)
    MDM->>MDM: removeItem(mlxModelDirectoryURL)
    MDM->>MDM: refreshModelStates()
    MDM->>AD: onModelDirectoryChanged()
    AD->>LRM: refreshAvailableModels()
    AD->>MLX: refreshAvailableModels()
    AD->>AD: startRuntimeIfPreferredEngineRequiresIt()
    S->>S: refreshModels() [redundant]
    S->>MDM: refreshModelStates()
    S->>LRM: refreshAvailableModels()
    S->>MLX: refreshAvailableModels()

    Note over S: User clicks Open Folder
    S->>MDM: openModelsDirectory(format: .mlx)
    MDM->>MDM: ensureMLXRuntimeDirectoryExists()
    MDM-->>S: NSWorkspace.shared.open(mlxRuntimeDirectoryURL)
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22pr%2Fmlx-model-engine-settings-fix%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22pr%2Fmlx-model-engine-settings-fix%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atabby%2FUI%2FSettingsView.swift%3A603-604%0AMLX%20model%20selection%20errors%20are%20silently%20discarded%20with%20%60try%3F%60.%20%60MLXRuntimeManager.selectModel%28name%3A%29%60%20throws%20%60LlamaRuntimeError.unavailable%60%20when%20the%20requested%20model%20isn't%20found%2C%20but%20swallowing%20it%20means%20the%20Picker%20briefly%20reflects%20an%20invalid%20selection%20while%20the%20runtime's%20%60state%60%20eventually%20settles%20to%20%60.failed%28%E2%80%A6%29%60.%20The%20equivalent%20GGUF%20call%20doesn't%20throw%2C%20so%20the%20asymmetry%20stands%20out%20here.%20Propagating%20the%20error%20%28or%20at%20least%20updating%20%60state%60%20visibly%20before%20the%20task%20completes%29%20would%20give%20the%20user%20earlier%2C%20explicit%20feedback.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20case%20.mlxSwift%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20do%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20try%20await%20mlxRuntimeManager.selectModel%28name%3A%20filename%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%20catch%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20selectModel%20updates%20mlxRuntimeManager.state%20to%20.failed%20on%20error%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20the%20Runtime%20row%20in%20the%20Autocomplete%20section%20surfaces%20the%20detail%20to%20the%20user.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Atabby%2FUI%2FSettingsView.swift%3A723-727%0AWhen%20a%20model%20is%20deleted%2C%20%60refreshModels%28%29%60%20%28called%20directly%20after%20%60deleteModel%60%29%20duplicates%20the%20work%20already%20triggered%20by%20the%20%60onModelDirectoryChanged%60%20callback%20inside%20%60ModelDownloadManager.deleteModel%60%3A%20that%20callback%20fires%20%60AppDelegate.handleModelDirectoryChange%28%29%60%2C%20which%20already%20calls%20both%20%60runtimeModel.refreshAvailableModels%28%29%60%20and%20%60mlxRuntimeManager.refreshAvailableModels%28%29%60.%20Both%20runtime%20managers%20then%20discover%20models%20twice%20on%20every%20deletion.%20Replacing%20%60refreshModels%28%29%60%20with%20just%20%60modelDownloadManager.refreshModelStates%28%29%60%20avoids%20the%20redundant%20passes.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20func%20deleteModel%28_%20model%3A%20RuntimeModelOption%29%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20deleteModel%20internally%20calls%20refreshModelStates%28%29%20and%20onModelDirectoryChanged%3F%2C%0A%20%20%20%20%20%20%20%20%2F%2F%20which%20triggers%20AppDelegate.handleModelDirectoryChange%28%29%20for%20runtime%20refresh.%0A%20%20%20%20%20%20%20%20%2F%2F%20We%20only%20need%20to%20sync%20the%20download-manager's%20UI%20state%20here.%0A%20%20%20%20%20%20%20%20modelDownloadManager.deleteModel%28filename%3A%20model.filename%2C%20format%3A%20model.format%29%0A%20%20%20%20%20%20%20%20modelDownloadManager.refreshModelStates%28%29%0A%20%20%20%20%20%20%20%20pendingDeletionModel%20%3D%20nil%0A%20%20%20%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atabby%2FUI%2FSettingsView.swift%3A603-604%0AMLX%20model%20selection%20errors%20are%20silently%20discarded%20with%20%60try%3F%60.%20%60MLXRuntimeManager.selectModel%28name%3A%29%60%20throws%20%60LlamaRuntimeError.unavailable%60%20when%20the%20requested%20model%20isn't%20found%2C%20but%20swallowing%20it%20means%20the%20Picker%20briefly%20reflects%20an%20invalid%20selection%20while%20the%20runtime's%20%60state%60%20eventually%20settles%20to%20%60.failed%28%E2%80%A6%29%60.%20The%20equivalent%20GGUF%20call%20doesn't%20throw%2C%20so%20the%20asymmetry%20stands%20out%20here.%20Propagating%20the%20error%20%28or%20at%20least%20updating%20%60state%60%20visibly%20before%20the%20task%20completes%29%20would%20give%20the%20user%20earlier%2C%20explicit%20feedback.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20case%20.mlxSwift%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20do%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20try%20await%20mlxRuntimeManager.selectModel%28name%3A%20filename%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%20catch%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20selectModel%20updates%20mlxRuntimeManager.state%20to%20.failed%20on%20error%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20the%20Runtime%20row%20in%20the%20Autocomplete%20section%20surfaces%20the%20detail%20to%20the%20user.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Atabby%2FUI%2FSettingsView.swift%3A723-727%0AWhen%20a%20model%20is%20deleted%2C%20%60refreshModels%28%29%60%20%28called%20directly%20after%20%60deleteModel%60%29%20duplicates%20the%20work%20already%20triggered%20by%20the%20%60onModelDirectoryChanged%60%20callback%20inside%20%60ModelDownloadManager.deleteModel%60%3A%20that%20callback%20fires%20%60AppDelegate.handleModelDirectoryChange%28%29%60%2C%20which%20already%20calls%20both%20%60runtimeModel.refreshAvailableModels%28%29%60%20and%20%60mlxRuntimeManager.refreshAvailableModels%28%29%60.%20Both%20runtime%20managers%20then%20discover%20models%20twice%20on%20every%20deletion.%20Replacing%20%60refreshModels%28%29%60%20with%20just%20%60modelDownloadManager.refreshModelStates%28%29%60%20avoids%20the%20redundant%20passes.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20func%20deleteModel%28_%20model%3A%20RuntimeModelOption%29%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20deleteModel%20internally%20calls%20refreshModelStates%28%29%20and%20onModelDirectoryChanged%3F%2C%0A%20%20%20%20%20%20%20%20%2F%2F%20which%20triggers%20AppDelegate.handleModelDirectoryChange%28%29%20for%20runtime%20refresh.%0A%20%20%20%20%20%20%20%20%2F%2F%20We%20only%20need%20to%20sync%20the%20download-manager's%20UI%20state%20here.%0A%20%20%20%20%20%20%20%20modelDownloadManager.deleteModel%28filename%3A%20model.filename%2C%20format%3A%20model.format%29%0A%20%20%20%20%20%20%20%20modelDownloadManager.refreshModelStates%28%29%0A%20%20%20%20%20%20%20%20pendingDeletionModel%20%3D%20nil%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=fujacob%2Ftabby&pr=223&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Show MLX models in local model settings"](https://github.com/fujacob/tabby/commit/94c39f59f9b2723a2cbc6f5672a7cdedebd41c05) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33708566)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->