### PR TITLE
Replace deferred termination with synchronous llama shutdown

### DIFF
--- a/Cotabby/App/Core/AppDelegate.swift
+++ b/Cotabby/App/Core/AppDelegate.swift
@@ -1,7 +1,6 @@
 import AppKit
 import Combine
 import Logging
-import os
 
 /// File overview:
 /// Starts the long-lived services that power permissions, focus tracking, suggestion generation,
@@ -128,48 +127,35 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         TabbyLogger.app.info("All services started")
     }
 
-    /// Defers termination until the llama runtime releases native Metal/GPU resources.
-    /// Without this, `exit()` triggers C++ static destructors that tear down the Metal
-    /// device while llama contexts are still live, causing `ggml_metal_rsets_free` to abort.
+    /// Synchronously releases native runtime resources before AppKit calls `exit()`.
     ///
-    /// Returns `.terminateLater` so AppKit keeps the run loop alive while the async Task
-    /// awaits native cleanup. `reply(toApplicationShouldTerminate: true)` resumes the
-    /// quit once llama resources are freed. A 5-second timeout prevents a hung native
-    /// call (e.g. a stalled Metal command queue) from freezing the app indefinitely.
+    /// `exit()` runs C++ static destructors that tear down the Metal device. If llama contexts
+    /// are still live at that point, `ggml_metal_rsets_free` aborts. We MUST release them first
+    /// — but we cannot use `.terminateLater` to do it: a deferred reply leaves the app alive
+    /// long enough that macOS's "Quit & Reopen" TCC handshake (after a permission grant) does
+    /// not propagate the new grant to the relaunched process, leaving users stuck on the
+    /// permission reminder forever.
     ///
-    /// `stopAndWait()` runs in a detached task so it is never implicitly awaited — if the
-    /// native C call ignores Swift cancellation, the timeout still fires and replies.
-    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+    /// The compromise: stop new work synchronously, then call `shutdownSync` which blocks up to
+    /// ~1.5s for in-flight `generate()` calls to drain before forcing `engine.unloadModel()`.
+    /// In the common case (no autocomplete mid-flight) this returns in milliseconds. If a
+    /// generation is genuinely stuck, we accept the small risk of the original ggml crash over
+    /// the larger UX bug of a broken permission flow.
+    func applicationWillTerminate(_ notification: Notification) {
+        TabbyLogger.app.info("Cotabby terminating, releasing services")
         activationIndicatorController.hide(reason: "Activation indicator hidden because Cotabby is terminating.")
         focusDebugOverlayController?.hide()
         suggestionCoordinator.stop()
         inputMonitor.stop()
         focusModel.stop()
 
-        let didReply = OSAllocatedUnfairLock(initialState: false)
+        runtimeModel.shutdownSync(timeoutSeconds: 1.5)
 
-        func replyOnce() {
-            let alreadyReplied = didReply.withLock { replied -> Bool in
-                let was = replied
-                replied = true
-                return was
-            }
-            guard !alreadyReplied else { return }
-            sender.reply(toApplicationShouldTerminate: true)
-        }
-
-        Task.detached {
-            await self.runtimeModel.stopAndWait()
-            await self.mlxRuntimeManager.stopAndWait()
-            await MainActor.run { replyOnce() }
-        }
-
-        Task {
-            try? await Task.sleep(nanoseconds: 5_000_000_000)
-            replyOnce()
-        }
-
-        return .terminateLater
+        // MLX is actor-isolated so we cannot block on it synchronously. Setting `loadedModel = nil`
+        // is fast and ARC-driven; on the rare termination where MLX is mid-generation we fall back
+        // to the OS reclaiming GPU resources during `exit()`. MLX has not been reported to hit the
+        // same Metal teardown crash as llama.cpp.
+        mlxRuntimeManager.stop()
     }
 
     /// Shows or hides the field-edge Cotabby icon based on focus state, global enable, per-app

--- a/Cotabby/Models/RuntimeBootstrapModel.swift
+++ b/Cotabby/Models/RuntimeBootstrapModel.swift
@@ -147,6 +147,15 @@ final class RuntimeBootstrapModel: ObservableObject {
         await runtimeManager.stopAndWait()
     }
 
+    /// Synchronously releases the runtime on the calling thread, bounded by `timeoutSeconds`.
+    /// Used by `applicationWillTerminate` so llama Metal resources are torn down before `exit()`
+    /// runs C++ static destructors. See `LlamaRuntimeManager.shutdownSync` for rationale.
+    func shutdownSync(timeoutSeconds: TimeInterval) {
+        runtimeTask?.cancel()
+        runtimeTask = nil
+        runtimeManager.shutdownSync(timeoutSeconds: timeoutSeconds)
+    }
+
     /// Returns the selected model when present, otherwise falls back to the first discovered option.
     private static func initialSelectedModelFilename(
         _ persistedFilename: String?,

--- a/Cotabby/Services/Runtime/FoundationModelSuggestionEngine.swift
+++ b/Cotabby/Services/Runtime/FoundationModelSuggestionEngine.swift
@@ -31,12 +31,15 @@ final class FoundationModelSuggestionEngine {
         availabilityService.refresh()
 
         guard availabilityService.isAvailable else {
-            TabbyLogger.suggestion.debug("Foundation model unavailable: \(self.availabilityService.userVisibleMessage)")
-            throw SuggestionClientError.unavailable(availabilityService.userVisibleMessage)
+            let message = availabilityService.userVisibleMessage
+            TabbyLogger.suggestion.debug("Foundation model unavailable: \(message)")
+            throw SuggestionClientError.unavailable(message)
         }
 
         do {
-            TabbyLogger.suggestion.debug("Foundation model generating: prompt=\(request.prompt.count) bytes, max_tokens=\(request.maxPredictionTokens)")
+            let promptBytes = request.prompt.count
+            let maxTokens = request.maxPredictionTokens
+            TabbyLogger.suggestion.debug("Foundation model generating: prompt=\(promptBytes) bytes, max_tokens=\(maxTokens)")
             let startTime = Date()
             let prompt = FoundationModelPromptRenderer.prompt(for: request)
             // In production, `isAvailable == true` implies `systemLanguageModel` is non-nil because
@@ -67,7 +70,12 @@ final class FoundationModelSuggestionEngine {
             )
 
             let latency = Date().timeIntervalSince(startTime)
-            TabbyLogger.suggestion.debug("Foundation model generated: raw=\(rawSuggestion.count) chars, normalized=\(normalizedSuggestion.count) chars, latency=\(Int(latency * 1000))ms")
+            let rawChars = rawSuggestion.count
+            let normalizedChars = normalizedSuggestion.count
+            let latencyMs = Int(latency * 1000)
+            TabbyLogger.suggestion.debug(
+                "Foundation model generated: raw=\(rawChars) chars, normalized=\(normalizedChars) chars, latency=\(latencyMs)ms"
+            )
             return SuggestionResult(
                 generation: request.generation,
                 rawText: rawSuggestion,

--- a/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
+++ b/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
@@ -255,11 +255,23 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
     /// Waits for all in-flight `generate()` and `summarize()` calls to finish, then frees all
     /// sequences and the loaded model. Blocking is intentional: callers should dispatch this off
     /// the main thread via `Task.detached` when UI responsiveness matters.
-    func shutdown() {
+    ///
+    /// `timeoutSeconds` caps the wait for in-flight work to drain. On timeout we still proceed
+    /// with `engine.unloadModel()` so the caller (typically `applicationWillTerminate`) does not
+    /// hang the main thread on a runaway generation. A nil timeout waits indefinitely.
+    func shutdown(timeoutSeconds: TimeInterval? = nil) {
         lifecycleCondition.lock()
         isShuttingDown = true
-        while activeOperationCount > 0 {
-            lifecycleCondition.wait()
+
+        if let timeoutSeconds {
+            let deadline = Date(timeIntervalSinceNow: timeoutSeconds)
+            while activeOperationCount > 0 {
+                if !lifecycleCondition.wait(until: deadline) { break }
+            }
+        } else {
+            while activeOperationCount > 0 {
+                lifecycleCondition.wait()
+            }
         }
         lifecycleCondition.unlock()
 

--- a/Cotabby/Services/Runtime/LlamaRuntimeManager.swift
+++ b/Cotabby/Services/Runtime/LlamaRuntimeManager.swift
@@ -176,6 +176,17 @@ final class LlamaRuntimeManager: ObservableObject {
         }.value
     }
 
+    /// Synchronously releases the llama runtime on the current thread, bounded by `timeoutSeconds`.
+    /// This is the termination-time path: C++ static destructors during `exit()` tear down the Metal
+    /// device, so llama contexts must be released first to avoid `ggml_metal_rsets_free`. Returning
+    /// quickly also keeps macOS's "Quit & Reopen" TCC handshake working after a permission grant —
+    /// the previous `.terminateLater` approach delayed exit long enough that the relaunched process
+    /// never picked up the new permission.
+    func shutdownSync(timeoutSeconds: TimeInterval) {
+        prepareForStop()
+        core.shutdown(timeoutSeconds: timeoutSeconds)
+    }
+
     private func prepareForStop() {
         startupTask?.cancel()
         startupTask = nil

--- a/Cotabby/Services/Runtime/LlamaSuggestionEngine.swift
+++ b/Cotabby/Services/Runtime/LlamaSuggestionEngine.swift
@@ -44,7 +44,12 @@ final class LlamaSuggestionEngine {
             promptCacheHintTracker.recordSuccessfulRequest(request)
             let normalizedSuggestion = SuggestionTextNormalizer.normalize(rawSuggestion, for: request)
             let latency = Date().timeIntervalSince(startTime)
-            TabbyLogger.suggestion.debug("Llama generated: raw=\(rawSuggestion.count) chars, normalized=\(normalizedSuggestion.count) chars, latency=\(Int(latency * 1000))ms")
+            let rawChars = rawSuggestion.count
+            let normalizedChars = normalizedSuggestion.count
+            let latencyMs = Int(latency * 1000)
+            TabbyLogger.suggestion.debug(
+                "Llama generated: raw=\(rawChars) chars, normalized=\(normalizedChars) chars, latency=\(latencyMs)ms"
+            )
             return SuggestionResult(
                 generation: request.generation,
                 rawText: rawSuggestion,

--- a/Cotabby/Services/Visual/WindowScreenshotService.swift
+++ b/Cotabby/Services/Visual/WindowScreenshotService.swift
@@ -72,7 +72,10 @@ struct WindowScreenshotService {
             TabbyLogger.app.debug("No visible window for pid \(processIdentifier)")
             throw WindowScreenshotError.noVisibleWindowForProcess(processIdentifier)
         }
-        TabbyLogger.app.trace("Capturing window: \(matchingWindow.title ?? "untitled") (\(Int(matchingWindow.frame.width))x\(Int(matchingWindow.frame.height)))")
+        let windowTitle = matchingWindow.title ?? "untitled"
+        let windowWidth = Int(matchingWindow.frame.width)
+        let windowHeight = Int(matchingWindow.frame.height)
+        TabbyLogger.app.trace("Capturing window: \(windowTitle) (\(windowWidth)x\(windowHeight))")
 
         let sourceRect = snapshotRect(
             around: context,

--- a/Cotabby/Support/AXHelper.swift
+++ b/Cotabby/Support/AXHelper.swift
@@ -350,10 +350,8 @@ enum AXHelper {
         for scaledFlipped in DisplayCoordinateConverter.appKitRectsFromPixelRect(
             textRect,
             displays: displays
-        ) {
-            if expandedAnchor.contains(CGPoint(x: scaledFlipped.midX, y: scaledFlipped.midY)) {
-                return scaledFlipped
-            }
+        ) where expandedAnchor.contains(CGPoint(x: scaledFlipped.midX, y: scaledFlipped.midY)) {
+            return scaledFlipped
         }
 
         // Neither candidate landed near the anchor. Return unscaled as best-effort.


### PR DESCRIPTION
## Summary

The `.terminateLater` + 5s deferred-reply termination path introduced in #191 fixed the `ggml_metal_rsets_free` crash on quit but broke macOS's "Quit & Reopen" TCC handshake: after granting Accessibility / Input Monitoring / Screen Recording in System Settings and restarting through the system dialog, the relaunched process never sees the newly granted permission and the user is stuck on the permission reminder forever.

This replaces the deferred path with synchronous cleanup in `applicationWillTerminate`. `LlamaRuntimeCore.shutdown(timeoutSeconds:)` now bounds the wait for in-flight `generate()` to drain (1.5s) before forcing `engine.unloadModel()`. The C++ static destructors during `exit()` then run against an already-unloaded engine — no ggml crash, and the app dies fast enough for tccd to complete its relaunch handoff.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' test
# ** TEST SUCCEEDED **

swiftlint lint --quiet
# only pre-existing warnings; no new violations introduced
```

Manual quit-and-reopen flow needs to be verified on a machine that hits the TCC dialog after a permission grant.

## Linked issues

Follow-up to #191.

## Risk / rollout notes

- The 1.5s timeout in `LlamaRuntimeCore.shutdown(timeoutSeconds:)` is a compromise. If a generation is genuinely stuck mid-sample for >1.5s when the user quits, we proceed with `engine.unloadModel()` anyway and accept a small risk of the original ggml crash on that specific quit. In practice the autocomplete loop is short, so this should rarely fire.
- MLX is actor-isolated and cannot be drained synchronously. We fire-and-forget its shutdown via the existing `mlxRuntimeManager.stop()`; MLX has not been reported to hit the same Metal teardown crash as llama.cpp, so this is acceptable until proven otherwise.
- `LlamaRuntimeManager.stopAndWait()` and `RuntimeBootstrapModel.stopAndWait()` are kept for the documented uninstall path, even though that path doesn't actually call them today.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the `.terminateLater` deferred-reply shutdown path (introduced in #191) with a synchronous `applicationWillTerminate` path, fixing a TCC "Quit & Reopen" handshake bug where the relaunched process never received newly granted permissions. `LlamaRuntimeCore.shutdown(timeoutSeconds:)` now blocks the main thread for up to 1.5s waiting for in-flight `generate()` calls to drain before forcing `engine.unloadModel()`.

- **Core shutdown path**: `AppDelegate.applicationWillTerminate` → `RuntimeBootstrapModel.shutdownSync` → `LlamaRuntimeManager.shutdownSync` → `LlamaRuntimeCore.shutdown(timeoutSeconds: 1.5)`, replacing the previous async `Task.detached` + 5s fallback.
- **MLX path**: unchanged fire-and-forget via `mlxRuntimeManager.stop()`, acknowledged as acceptable since MLX has not exhibited the Metal teardown crash.
- **Style cleanup**: long interpolated log strings extracted to local `let` bindings; `AXHelper` for-if refactored to for-where.

<h3>Confidence Score: 3/5</h3>

Safe to merge for the common quit path; the stuck-generation edge case leaves the main thread blocking beyond the intended 1.5s window in `applicationWillTerminate`.

The synchronous shutdown path works correctly when no generation is in flight (the common case) and reliably fixes the TCC relaunch bug. The one gap is in `LlamaRuntimeCore.shutdown`: after the 1.5s condition-wait loop times out with `activeOperationCount > 0`, the code calls `resetPromptCache()`, which tries to acquire `autocompleteLock` still held by the in-flight `generate()`. In the stuck-engine scenario this code path was specifically designed to limit, the main thread in `applicationWillTerminate` can remain blocked well beyond 1.5s — potentially long enough to reintroduce the TCC timing problem the PR fixes.

Cotabby/Services/Runtime/LlamaRuntimeCore.swift — the `shutdown(timeoutSeconds:)` method's post-timeout flow.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/Services/Runtime/LlamaRuntimeCore.swift | Adds optional `timeoutSeconds` to `shutdown()` using `NSCondition.wait(until:)`. The timeout bounds the condition-wait loop but not the subsequent `resetPromptCache()` call, which blocks on `autocompleteLock` held by any in-flight `generate()` — defeating the bound in the stuck-generation case. |
| Cotabby/App/Core/AppDelegate.swift | Replaces `applicationShouldTerminate` (`.terminateLater` + deferred Task) with `applicationWillTerminate` (synchronous `shutdownSync`). The `os` import is correctly removed; comment is thorough and accurately describes the TCC tradeoff. |
| Cotabby/Models/RuntimeBootstrapModel.swift | Adds `shutdownSync(timeoutSeconds:)` that cancels `runtimeTask` and delegates to `runtimeManager.shutdownSync`. Clean delegation; mirrors the existing `stop()` and `stopAndWait()` pattern. |
| Cotabby/Services/Runtime/LlamaRuntimeManager.swift | Adds `shutdownSync(timeoutSeconds:)` that calls `prepareForStop()` then `core.shutdown(timeoutSeconds:)`. Straightforward thin wrapper; correct use of existing `prepareForStop`. |
| Cotabby/Services/Runtime/FoundationModelSuggestionEngine.swift | Style-only: interpolated log strings extracted to local `let` bindings to silence SwiftLint string-interpolation warnings. No behavioral change. |
| Cotabby/Services/Runtime/LlamaSuggestionEngine.swift | Same SwiftLint-driven log-string extraction as `FoundationModelSuggestionEngine.swift`. No behavioral change. |
| Cotabby/Services/Visual/WindowScreenshotService.swift | Same SwiftLint-driven log-string extraction. No behavioral change. |
| Cotabby/Support/AXHelper.swift | Converts `for { if … return }` to `for … where { return }` — idiomatic Swift cleanup, no semantic change. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant macOS
    participant AppDelegate
    participant RuntimeBootstrapModel
    participant LlamaRuntimeManager
    participant LlamaRuntimeCore
    participant generate as generate() thread

    macOS->>AppDelegate: applicationWillTerminate(_:)
    AppDelegate->>AppDelegate: stop UI services
    AppDelegate->>RuntimeBootstrapModel: shutdownSync(timeoutSeconds: 1.5)
    RuntimeBootstrapModel->>RuntimeBootstrapModel: runtimeTask?.cancel()
    RuntimeBootstrapModel->>LlamaRuntimeManager: shutdownSync(timeoutSeconds: 1.5)
    LlamaRuntimeManager->>LlamaRuntimeManager: prepareForStop()
    LlamaRuntimeManager->>LlamaRuntimeCore: shutdown(timeoutSeconds: 1.5)
    LlamaRuntimeCore->>LlamaRuntimeCore: "lock lifecycleCondition, isShuttingDown = true"
    alt "activeOperationCount == 0 (common case)"
        LlamaRuntimeCore->>LlamaRuntimeCore: exits loop immediately (ms)
    else "activeOperationCount > 0 within 1.5s"
        generate-->>LlamaRuntimeCore: broadcast (activeOperationCount → 0)
        LlamaRuntimeCore->>LlamaRuntimeCore: exits loop
    else "activeOperationCount > 0 after 1.5s timeout"
        LlamaRuntimeCore->>LlamaRuntimeCore: break (deadline exceeded)
        Note over LlamaRuntimeCore,generate: resetPromptCache() blocks on autocompleteLock until generate() releases it
    end
    LlamaRuntimeCore->>LlamaRuntimeCore: resetPromptCache(), engine.unloadModel()
    LlamaRuntimeCore-->>AppDelegate: returns
    AppDelegate->>AppDelegate: mlxRuntimeManager.stop()
    AppDelegate-->>macOS: applicationWillTerminate returns → exit()
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cotabby/Services/Runtime/LlamaRuntimeCore.swift`, line 266-279 ([link](https://github.com/fujacob/tabby/blob/d7875df69746f6139c372215bac9d91861e15f19/Cotabby/Services/Runtime/LlamaRuntimeCore.swift#L266-L279)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Timeout does not bound total blocking time when `generate()` holds `autocompleteLock`**

   After the 1.5s `lifecycleCondition.wait(until:)` loop breaks with `activeOperationCount > 0`, execution falls through to `resetPromptCache()`. That method tries to acquire `autocompleteLock`, which `generate()` holds for its entire sampling loop (from the `autocompleteLock.lock()` call through both its inner and outer `defer`s). If `engine.sampleNext()` is blocking inside that loop — the exact scenario this timeout is guarding against — `resetPromptCache()` will wait indefinitely on the mutex, and `applicationWillTerminate` on the main thread will not return within the intended 1.5s window. This can leave the app alive long enough to break the TCC relaunch handshake that the PR is specifically trying to fix.

   Note: `lifecycleCondition.broadcast()` fires from `generate()`'s *outer* defer, which runs after `autocompleteLock` is released. So the condition wait wakes up only when the lock is already free; `resetPromptCache()` will only block when the timeout fires *while* `generate()` still holds the mutex — i.e., the stuck case. One way to guard this: if `activeOperationCount > 0` after the loop, skip `resetPromptCache()` (the sequence state is about to be invalid after `unloadModel()` anyway) and accept the documented crash risk without additionally stalling on the lock.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22fix%2Fsync-shutdown-tcc-relaunch%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsync-shutdown-tcc-relaunch%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%0ALine%3A%20266-279%0A%0AComment%3A%0A**Timeout%20does%20not%20bound%20total%20blocking%20time%20when%20%60generate%28%29%60%20holds%20%60autocompleteLock%60**%0A%0AAfter%20the%201.5s%20%60lifecycleCondition.wait%28until%3A%29%60%20loop%20breaks%20with%20%60activeOperationCount%20%3E%200%60%2C%20execution%20falls%20through%20to%20%60resetPromptCache%28%29%60.%20That%20method%20tries%20to%20acquire%20%60autocompleteLock%60%2C%20which%20%60generate%28%29%60%20holds%20for%20its%20entire%20sampling%20loop%20%28from%20the%20%60autocompleteLock.lock%28%29%60%20call%20through%20both%20its%20inner%20and%20outer%20%60defer%60s%29.%20If%20%60engine.sampleNext%28%29%60%20is%20blocking%20inside%20that%20loop%20%E2%80%94%20the%20exact%20scenario%20this%20timeout%20is%20guarding%20against%20%E2%80%94%20%60resetPromptCache%28%29%60%20will%20wait%20indefinitely%20on%20the%20mutex%2C%20and%20%60applicationWillTerminate%60%20on%20the%20main%20thread%20will%20not%20return%20within%20the%20intended%201.5s%20window.%20This%20can%20leave%20the%20app%20alive%20long%20enough%20to%20break%20the%20TCC%20relaunch%20handshake%20that%20the%20PR%20is%20specifically%20trying%20to%20fix.%0A%0ANote%3A%20%60lifecycleCondition.broadcast%28%29%60%20fires%20from%20%60generate%28%29%60's%20*outer*%20defer%2C%20which%20runs%20after%20%60autocompleteLock%60%20is%20released.%20So%20the%20condition%20wait%20wakes%20up%20only%20when%20the%20lock%20is%20already%20free%3B%20%60resetPromptCache%28%29%60%20will%20only%20block%20when%20the%20timeout%20fires%20*while*%20%60generate%28%29%60%20still%20holds%20the%20mutex%20%E2%80%94%20i.e.%2C%20the%20stuck%20case.%20One%20way%20to%20guard%20this%3A%20if%20%60activeOperationCount%20%3E%200%60%20after%20the%20loop%2C%20skip%20%60resetPromptCache%28%29%60%20%28the%20sequence%20state%20is%20about%20to%20be%20invalid%20after%20%60unloadModel%28%29%60%20anyway%29%20and%20accept%20the%20documented%20crash%20risk%20without%20additionally%20stalling%20on%20the%20lock.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%0ALine%3A%20266-279%0A%0AComment%3A%0A**Timeout%20does%20not%20bound%20total%20blocking%20time%20when%20%60generate%28%29%60%20holds%20%60autocompleteLock%60**%0A%0AAfter%20the%201.5s%20%60lifecycleCondition.wait%28until%3A%29%60%20loop%20breaks%20with%20%60activeOperationCount%20%3E%200%60%2C%20execution%20falls%20through%20to%20%60resetPromptCache%28%29%60.%20That%20method%20tries%20to%20acquire%20%60autocompleteLock%60%2C%20which%20%60generate%28%29%60%20holds%20for%20its%20entire%20sampling%20loop%20%28from%20the%20%60autocompleteLock.lock%28%29%60%20call%20through%20both%20its%20inner%20and%20outer%20%60defer%60s%29.%20If%20%60engine.sampleNext%28%29%60%20is%20blocking%20inside%20that%20loop%20%E2%80%94%20the%20exact%20scenario%20this%20timeout%20is%20guarding%20against%20%E2%80%94%20%60resetPromptCache%28%29%60%20will%20wait%20indefinitely%20on%20the%20mutex%2C%20and%20%60applicationWillTerminate%60%20on%20the%20main%20thread%20will%20not%20return%20within%20the%20intended%201.5s%20window.%20This%20can%20leave%20the%20app%20alive%20long%20enough%20to%20break%20the%20TCC%20relaunch%20handshake%20that%20the%20PR%20is%20specifically%20trying%20to%20fix.%0A%0ANote%3A%20%60lifecycleCondition.broadcast%28%29%60%20fires%20from%20%60generate%28%29%60's%20*outer*%20defer%2C%20which%20runs%20after%20%60autocompleteLock%60%20is%20released.%20So%20the%20condition%20wait%20wakes%20up%20only%20when%20the%20lock%20is%20already%20free%3B%20%60resetPromptCache%28%29%60%20will%20only%20block%20when%20the%20timeout%20fires%20*while*%20%60generate%28%29%60%20still%20holds%20the%20mutex%20%E2%80%94%20i.e.%2C%20the%20stuck%20case.%20One%20way%20to%20guard%20this%3A%20if%20%60activeOperationCount%20%3E%200%60%20after%20the%20loop%2C%20skip%20%60resetPromptCache%28%29%60%20%28the%20sequence%20state%20is%20about%20to%20be%20invalid%20after%20%60unloadModel%28%29%60%20anyway%29%20and%20accept%20the%20documented%20crash%20risk%20without%20additionally%20stalling%20on%20the%20lock.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Ftabby&pr=225&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22fix%2Fsync-shutdown-tcc-relaunch%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsync-shutdown-tcc-relaunch%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%3A266-279%0A**Timeout%20does%20not%20bound%20total%20blocking%20time%20when%20%60generate%28%29%60%20holds%20%60autocompleteLock%60**%0A%0AAfter%20the%201.5s%20%60lifecycleCondition.wait%28until%3A%29%60%20loop%20breaks%20with%20%60activeOperationCount%20%3E%200%60%2C%20execution%20falls%20through%20to%20%60resetPromptCache%28%29%60.%20That%20method%20tries%20to%20acquire%20%60autocompleteLock%60%2C%20which%20%60generate%28%29%60%20holds%20for%20its%20entire%20sampling%20loop%20%28from%20the%20%60autocompleteLock.lock%28%29%60%20call%20through%20both%20its%20inner%20and%20outer%20%60defer%60s%29.%20If%20%60engine.sampleNext%28%29%60%20is%20blocking%20inside%20that%20loop%20%E2%80%94%20the%20exact%20scenario%20this%20timeout%20is%20guarding%20against%20%E2%80%94%20%60resetPromptCache%28%29%60%20will%20wait%20indefinitely%20on%20the%20mutex%2C%20and%20%60applicationWillTerminate%60%20on%20the%20main%20thread%20will%20not%20return%20within%20the%20intended%201.5s%20window.%20This%20can%20leave%20the%20app%20alive%20long%20enough%20to%20break%20the%20TCC%20relaunch%20handshake%20that%20the%20PR%20is%20specifically%20trying%20to%20fix.%0A%0ANote%3A%20%60lifecycleCondition.broadcast%28%29%60%20fires%20from%20%60generate%28%29%60's%20*outer*%20defer%2C%20which%20runs%20after%20%60autocompleteLock%60%20is%20released.%20So%20the%20condition%20wait%20wakes%20up%20only%20when%20the%20lock%20is%20already%20free%3B%20%60resetPromptCache%28%29%60%20will%20only%20block%20when%20the%20timeout%20fires%20*while*%20%60generate%28%29%60%20still%20holds%20the%20mutex%20%E2%80%94%20i.e.%2C%20the%20stuck%20case.%20One%20way%20to%20guard%20this%3A%20if%20%60activeOperationCount%20%3E%200%60%20after%20the%20loop%2C%20skip%20%60resetPromptCache%28%29%60%20%28the%20sequence%20state%20is%20about%20to%20be%20invalid%20after%20%60unloadModel%28%29%60%20anyway%29%20and%20accept%20the%20documented%20crash%20risk%20without%20additionally%20stalling%20on%20the%20lock.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%3A266-279%0A**Timeout%20does%20not%20bound%20total%20blocking%20time%20when%20%60generate%28%29%60%20holds%20%60autocompleteLock%60**%0A%0AAfter%20the%201.5s%20%60lifecycleCondition.wait%28until%3A%29%60%20loop%20breaks%20with%20%60activeOperationCount%20%3E%200%60%2C%20execution%20falls%20through%20to%20%60resetPromptCache%28%29%60.%20That%20method%20tries%20to%20acquire%20%60autocompleteLock%60%2C%20which%20%60generate%28%29%60%20holds%20for%20its%20entire%20sampling%20loop%20%28from%20the%20%60autocompleteLock.lock%28%29%60%20call%20through%20both%20its%20inner%20and%20outer%20%60defer%60s%29.%20If%20%60engine.sampleNext%28%29%60%20is%20blocking%20inside%20that%20loop%20%E2%80%94%20the%20exact%20scenario%20this%20timeout%20is%20guarding%20against%20%E2%80%94%20%60resetPromptCache%28%29%60%20will%20wait%20indefinitely%20on%20the%20mutex%2C%20and%20%60applicationWillTerminate%60%20on%20the%20main%20thread%20will%20not%20return%20within%20the%20intended%201.5s%20window.%20This%20can%20leave%20the%20app%20alive%20long%20enough%20to%20break%20the%20TCC%20relaunch%20handshake%20that%20the%20PR%20is%20specifically%20trying%20to%20fix.%0A%0ANote%3A%20%60lifecycleCondition.broadcast%28%29%60%20fires%20from%20%60generate%28%29%60's%20*outer*%20defer%2C%20which%20runs%20after%20%60autocompleteLock%60%20is%20released.%20So%20the%20condition%20wait%20wakes%20up%20only%20when%20the%20lock%20is%20already%20free%3B%20%60resetPromptCache%28%29%60%20will%20only%20block%20when%20the%20timeout%20fires%20*while*%20%60generate%28%29%60%20still%20holds%20the%20mutex%20%E2%80%94%20i.e.%2C%20the%20stuck%20case.%20One%20way%20to%20guard%20this%3A%20if%20%60activeOperationCount%20%3E%200%60%20after%20the%20loop%2C%20skip%20%60resetPromptCache%28%29%60%20%28the%20sequence%20state%20is%20about%20to%20be%20invalid%20after%20%60unloadModel%28%29%60%20anyway%29%20and%20accept%20the%20documented%20crash%20risk%20without%20additionally%20stalling%20on%20the%20lock.%0A%0A&repo=fujacob%2Ftabby&pr=225&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Fix pre-existing SwiftLint warnings"](https://github.com/fujacob/tabby/commit/d7875df69746f6139c372215bac9d91861e15f19) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33712648)</sub>

<!-- /greptile_comment -->