### PR TITLE
Add file log handler gated behind -cotabby-debug

### DIFF
--- a/Cotabby/Support/CotabbyDebugOptions.swift
+++ b/Cotabby/Support/CotabbyDebugOptions.swift
@@ -32,13 +32,19 @@ enum CotabbyDebugOptions {
 
 /// Provides subsystem-scoped loggers for the entire app.
 ///
-/// All loggers route through `OSLogHandler`, so messages appear in Console.app
-/// with the subsystem as a filterable column. Open Console.app and filter by
-/// process "tabby" or subsystem "com.tabby.*" to see structured output.
+/// All loggers route through `OSLogHandler` so messages appear in Console.app with the
+/// subsystem as a filterable column. When the `-cotabby-debug` launch argument is set we
+/// additionally fan out to `FileLogHandler`, which writes JSONL to
+/// `~/Library/Logs/Cotabby/cotabby.jsonl` for AI-assisted debugging without copy-paste.
 enum TabbyLogger {
     private static let bootstrapOnce: Void = {
+        // The debug-flag check happens once, at bootstrap time. Toggling it requires a relaunch,
+        // which matches how every other launch-arg in the app behaves.
+        let installFileHandler = CotabbyDebugOptions.isEnabled
         LoggingSystem.bootstrap { label in
-            OSLogHandler(label: label)
+            let osHandler = OSLogHandler(label: label)
+            guard installFileHandler else { return osHandler }
+            return MultiplexLogHandler([osHandler, FileLogHandler(label: label)])
         }
     }()
 

--- a/Cotabby/Support/FileLogHandler.swift
+++ b/Cotabby/Support/FileLogHandler.swift
@@ -47,13 +47,15 @@ final class FileLogWriter: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
 
-        guard let handle else { return }
-
         // Wiping when *already over* the cap means the line that pushes us past gets stored
         // in the new file rather than the old one. That keeps the file's tail readable.
+        // The wipe replaces `self.handle`, so we must read it AFTER the check — binding it
+        // before would write the first post-cap line into a closed descriptor and drop it.
         if currentByteOffset >= effectiveCap {
             wipeLocked()
         }
+
+        guard let handle else { return }
 
         do {
             try handle.write(contentsOf: data)

--- a/Cotabby/Support/FileLogHandler.swift
+++ b/Cotabby/Support/FileLogHandler.swift
@@ -1,0 +1,199 @@
+import Foundation
+import Logging
+
+/// File overview:
+/// A swift-log `LogHandler` that appends one JSON record per line to a file under
+/// `~/Library/Logs/Cotabby/`. This is the on-disk sink an AI debugging agent can read
+/// directly without copy-pasting from Console.app.
+///
+/// The handler is only installed when `-cotabby-debug` is passed at launch (see
+/// `TabbyLogger.bootstrap`). When the file grows past `sizeCapBytes` it is wiped to zero
+/// and a fresh tail begins — the user opted into "everything since the last cap" semantics
+/// rather than rotation, which is simpler to reason about and to ingest.
+
+/// Shared writer that owns the on-disk file handle. swift-log can call handlers from any
+/// thread, so an `NSLock` serializes writes and the size check that may trigger a wipe.
+///
+/// `@unchecked Sendable`: the only mutable state is `handle` and `currentByteOffset`,
+/// both guarded by `lock`. FileHandle itself is not Sendable so we cannot mark it cleanly.
+final class FileLogWriter: @unchecked Sendable {
+    static let shared = FileLogWriter()
+
+    /// Default cap of 10 MB. Large enough for hours of debug output without ballooning disk.
+    private let sizeCapBytes: UInt64 = 10 * 1024 * 1024
+
+    private let lock = NSLock()
+    private let logFileURL: URL?
+    private var handle: FileHandle?
+    private var currentByteOffset: UInt64 = 0
+
+    init(sizeCapBytes: UInt64? = nil) {
+        self.sizeCapBytesOverride = sizeCapBytes
+        self.logFileURL = Self.makeLogFileURL()
+        openHandle()
+    }
+
+    private let sizeCapBytesOverride: UInt64?
+    private var effectiveCap: UInt64 { sizeCapBytesOverride ?? sizeCapBytes }
+
+    /// Returns the on-disk path the handler writes to, if available. Useful for surfacing in
+    /// settings and for tests.
+    var fileURL: URL? { logFileURL }
+
+    /// Appends one already-rendered line. Caller is responsible for the trailing newline.
+    func write(_ line: String) {
+        guard let data = line.data(using: .utf8) else { return }
+
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard let handle else { return }
+
+        // Wiping when *already over* the cap means the line that pushes us past gets stored
+        // in the new file rather than the old one. That keeps the file's tail readable.
+        if currentByteOffset >= effectiveCap {
+            wipeLocked()
+        }
+
+        do {
+            try handle.write(contentsOf: data)
+            currentByteOffset += UInt64(data.count)
+        } catch {
+            // Failing to write a debug log line must never disrupt the app. Swallow.
+        }
+    }
+
+    /// Test-only hook to force a wipe.
+    func wipeForTesting() {
+        lock.lock()
+        defer { lock.unlock() }
+        wipeLocked()
+    }
+
+    private func wipeLocked() {
+        guard let logFileURL else { return }
+        do {
+            try handle?.close()
+        } catch {
+            // Closing a stale handle should not block re-opening a fresh one.
+        }
+        handle = nil
+        // Truncating to zero is cheaper than delete-and-recreate and keeps any open `tail -f`
+        // following the same inode.
+        FileManager.default.createFile(atPath: logFileURL.path, contents: nil)
+        openHandleLocked()
+    }
+
+    private func openHandle() {
+        lock.lock()
+        defer { lock.unlock() }
+        openHandleLocked()
+    }
+
+    private func openHandleLocked() {
+        guard let logFileURL else { return }
+        let fileManager = FileManager.default
+        let directory = logFileURL.deletingLastPathComponent()
+        try? fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        if !fileManager.fileExists(atPath: logFileURL.path) {
+            fileManager.createFile(atPath: logFileURL.path, contents: nil)
+        }
+        handle = try? FileHandle(forWritingTo: logFileURL)
+        currentByteOffset = (try? handle?.seekToEnd()) ?? 0
+    }
+
+    private static func makeLogFileURL() -> URL? {
+        let fileManager = FileManager.default
+        guard let libraryURL = fileManager.urls(for: .libraryDirectory, in: .userDomainMask).first else {
+            return nil
+        }
+        let bundleName = (Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String) ?? "Cotabby"
+        let directory = libraryURL
+            .appendingPathComponent("Logs", isDirectory: true)
+            .appendingPathComponent(bundleName, isDirectory: true)
+        try? fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory.appendingPathComponent("cotabby.jsonl")
+    }
+}
+
+/// swift-log handler that serializes each event to one JSON object per line and forwards it
+/// to a shared `FileLogWriter`. Metadata fields (e.g. `prompt`, `raw_output`) are emitted as
+/// top-level keys so they can be filtered with `jq` without unpacking strings.
+struct FileLogHandler: LogHandler {
+    var metadata: Logging.Logger.Metadata = [:]
+    var logLevel: Logging.Logger.Level = .trace
+
+    private let label: String
+    private let writer: FileLogWriter
+
+    init(label: String, writer: FileLogWriter = .shared) {
+        self.label = label
+        self.writer = writer
+    }
+
+    subscript(metadataKey key: String) -> Logging.Logger.Metadata.Value? {
+        get { metadata[key] }
+        set { metadata[key] = newValue }
+    }
+
+    func log(event: borrowing Logging.LogEvent) {
+        let category = Self.category(from: label)
+        let timestamp = ISO8601DateFormatter.shared.string(from: Date())
+
+        var record: [String: Any] = [
+            "timestamp": timestamp,
+            "level": "\(event.level)",
+            "category": category,
+            "message": "\(event.message)"
+        ]
+
+        if let eventMetadata = event.metadata {
+            for (key, value) in eventMetadata {
+                record[key] = Self.jsonValue(of: value)
+            }
+        }
+        for (key, value) in metadata where record[key] == nil {
+            record[key] = Self.jsonValue(of: value)
+        }
+
+        guard JSONSerialization.isValidJSONObject(record),
+              let data = try? JSONSerialization.data(withJSONObject: record, options: [.sortedKeys, .withoutEscapingSlashes]),
+              let json = String(data: data, encoding: .utf8) else {
+            return
+        }
+        writer.write(json + "\n")
+    }
+
+    /// `com.tabby.runtime` → `runtime`. Matches `OSLogHandler`'s category convention so the
+    /// JSON `category` field lines up with what Console.app shows.
+    private static func category(from label: String) -> String {
+        let parts = label.split(separator: ".", maxSplits: 2)
+        return parts.count > 2 ? String(parts[2]) : label
+    }
+
+    private static func jsonValue(of value: Logging.Logger.Metadata.Value) -> Any {
+        switch value {
+        case .string(let stringValue):
+            return stringValue
+        case .stringConvertible(let stringConvertible):
+            return "\(stringConvertible)"
+        case .dictionary(let dictionary):
+            var nested: [String: Any] = [:]
+            for (key, value) in dictionary {
+                nested[key] = jsonValue(of: value)
+            }
+            return nested
+        case .array(let array):
+            return array.map(jsonValue(of:))
+        }
+    }
+}
+
+private extension ISO8601DateFormatter {
+    /// Shared formatter avoids allocating a new one per log line. ISO8601 is thread-safe.
+    static let shared: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+}


### PR DESCRIPTION
## Summary

Adds a swift-log handler that writes one JSON record per line to `~/Library/Logs/Cotabby/cotabby.jsonl` whenever the app is launched with `-cotabby-debug`. The file is the on-disk sink an AI debugging agent can `Read` / `tail` directly — no Console.app copy-paste.

When the file crosses a 10 MB cap it is wiped to zero (truncated in place so any open `tail -f` keeps following) and a fresh tail begins. This is a deliberate "everything since the last wipe" semantic — simpler than rotation and easier to ingest.

Bootstrapping fans out via `MultiplexLogHandler` so Console.app and unified-log behavior is unchanged; the file handler is only installed when the debug flag is on.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' test
# ** TEST SUCCEEDED **

swiftlint lint --quiet
# (no output)
```

Manual: launch with `-cotabby-debug`, trigger any suggestion, then `cat ~/Library/Logs/Cotabby/cotabby.jsonl` — each line is a JSON object with `timestamp`, `level`, `category`, `message`, plus any swift-log metadata fields the call site passed.

## Linked issues

Refs #200.

## Risk / rollout notes

- Default behavior (no debug flag) is byte-identical to today — only `OSLogHandler` is registered, no file I/O.
- File path is `~/Library/Logs/Cotabby/cotabby.jsonl`. Bundle name comes from `CFBundleName` so a rename does not strand old logs in the wrong folder.
- Writes are serialized through an `NSLock` on a shared `FileLogWriter`. Write failures are swallowed so a disk-full or permission error never disrupts the app.
- Size cap is hard-coded at 10 MB. Easy to surface as a setting later if needed, but a constant keeps the first iteration boring.
- Follow-up worth flagging: `SuggestionDebugLogger` still emits its prompt/output payload as a pre-formatted multi-line block via the `message` field. The file handler renders it fine, but routing those payloads as structured `metadata` would produce cleaner JSON for `jq`. Left for a separate PR.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `FileLogHandler` (writing JSONL to `~/Library/Logs/Cotabby/cotabby.jsonl`) that is only installed when the app is launched with `-cotabby-debug`, fanning out via `MultiplexLogHandler` so Console.app behavior is unchanged for all other users. The 10 MB size cap wipes the file rather than rotating it, and the guard-after-wipe ordering (fixing the stale-handle bug from the previous thread) is correctly in place.

- `FileLogWriter` serializes all writes through `NSLock`, tracks the byte offset incrementally, and wipes by truncating then reopening the handle; the wipe path would more reliably preserve the inode for `tail -f` users with `FileHandle.truncate(atOffset:)` instead of `FileManager.createFile`.
- `FileLogHandler.log(event:)` merges event metadata into the JSON record unconditionally, which allows call-site keys like `\"timestamp\"` or `\"level\"` to shadow the system-generated fields silently.
- The category-parsing logic (`split(separator: \".\", maxSplits: 2)`) is duplicated verbatim from `OSLogHandler` and would benefit from extraction into a shared helper.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the debug file handler is fully gated behind a launch argument and has zero effect on normal users.

All changes are additive and isolated to the -cotabby-debug path. The stale-handle ordering bug called out in the previous thread is already addressed. The remaining observations (inode-preservation semantics in wipeLocked, event metadata shadowing reserved keys, duplicated category parsing) are behavioral edge cases or style issues that do not affect correctness in the typical debug workflow.

No files require special attention; FileLogHandler.swift has minor edge-case concerns noted in the comments but none affect the happy path.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/FileLogHandler.swift | New file implementing a thread-safe JSONL file log handler gated behind -cotabby-debug; minor concerns around inode preservation in wipeLocked(), event metadata shadowing reserved JSON keys, and duplicated category-parsing logic. |
| Cotabby/Support/CotabbyDebugOptions.swift | Bootstrapping updated to fan out to MultiplexLogHandler with FileLogHandler when the debug flag is set; the installFileHandler capture-once pattern is clean and correct. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App
    participant TabbyLogger
    participant LoggingSystem
    participant MultiplexLogHandler
    participant OSLogHandler
    participant FileLogHandler
    participant FileLogWriter
    participant Disk

    App->>TabbyLogger: bootstrap()
    TabbyLogger->>TabbyLogger: check CotabbyDebugOptions.isEnabled (once)
    TabbyLogger->>LoggingSystem: "bootstrap { label in ... }"

    alt -cotabby-debug is set
        LoggingSystem-->>MultiplexLogHandler: create([OSLogHandler, FileLogHandler])
    else no debug flag
        LoggingSystem-->>OSLogHandler: create OSLogHandler only
    end

    App->>TabbyLogger: logger.info("msg", metadata: [...])
    TabbyLogger->>MultiplexLogHandler: log(event:)
    MultiplexLogHandler->>OSLogHandler: log(event:)
    OSLogHandler-->>App: appears in Console.app

    MultiplexLogHandler->>FileLogHandler: log(event:)
    FileLogHandler->>FileLogHandler: build JSON record (timestamp, level, category, message + metadata)
    FileLogHandler->>FileLogWriter: write(json + newline)
    FileLogWriter->>FileLogWriter: lock.lock()
    alt "currentByteOffset >= 10 MB cap"
        FileLogWriter->>FileLogWriter: wipeLocked() - truncate - reopen handle
    end
    FileLogWriter->>Disk: handle.write(contentsOf: data)
    FileLogWriter->>FileLogWriter: "currentByteOffset += data.count"
    FileLogWriter->>FileLogWriter: lock.unlock()
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22feat%2Ffile-log-handler%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Ffile-log-handler%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0ACotabby%2FSupport%2FFileLogHandler.swift%3A152-158%0A**Event%20metadata%20can%20silently%20shadow%20reserved%20JSON%20keys**%0A%0A%60event.metadata%60%20is%20written%20into%20%60record%60%20unconditionally%2C%20so%20any%20call%20site%20that%20passes%20a%20metadata%20key%20matching%20%60%22timestamp%22%60%2C%20%60%22level%22%60%2C%20%60%22category%22%60%2C%20or%20%60%22message%22%60%20will%20overwrite%20the%20system-generated%20value.%20An%20AI%20agent%20reading%20the%20JSONL%20would%20then%20see%20incorrect%20or%20missing%20level%2Ftimestamp%20fields%20without%20any%20indication%20of%20the%20collision.%20A%20simple%20guard%20against%20the%20reserved%20key%20set%20%28or%20applying%20call-site%20metadata%20only%20for%20keys%20not%20already%20present%2C%20as%20is%20done%20for%20handler%20metadata%20on%20line%20157%29%20would%20prevent%20the%20ambiguity.%0A%0A%23%23%23%20Issue%202%20of%203%0ACotabby%2FSupport%2FFileLogHandler.swift%3A77-86%0A**%60FileManager.createFile%60%20does%20not%20guarantee%20inode%20preservation%20for%20%60tail%20-f%60**%0A%0AThe%20comment%20on%20line%2083%20says%20this%20truncates%20in-place%20to%20keep%20the%20inode%20stable%20for%20an%20open%20%60tail%20-f%60%2C%20but%20%60FileManager.createFile%28atPath%3Acontents%3Anil%29%60%20on%20an%20existing%20path%20is%20not%20documented%20to%20preserve%20the%20inode%20%E2%80%94%20its%20underlying%20implementation%20may%20unlink%20and%20recreate.%20The%20reliable%2C%20explicit%20way%20to%20zero-truncate%20an%20open%20descriptor%20while%20keeping%20the%20inode%20is%20%60FileHandle.truncate%28atOffset%3A%200%29%60%20followed%20by%20a%20seek%20to%20position%200%2C%20which%20avoids%20closing%20and%20reopening%20the%20handle%20at%20all.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Truncate%20the%20existing%20file%20to%20zero%20bytes%20in%20place.%20Using%20truncate%28atOffset%3A%200%29%0A%20%20%20%20%20%20%20%20%2F%2F%20preserves%20the%20inode%2C%20so%20any%20open%20%60tail%20-f%60%20continues%20following%20without%20restart.%0A%20%20%20%20%20%20%20%20do%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20try%20handle%3F.truncate%28atOffset%3A%200%29%0A%20%20%20%20%20%20%20%20%20%20%20%20handle%3F.seek%28toFileOffset%3A%200%29%0A%20%20%20%20%20%20%20%20%20%20%20%20currentByteOffset%20%3D%200%0A%20%20%20%20%20%20%20%20%7D%20catch%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20If%20truncation%20fails%2C%20fall%20back%20to%20close-and-recreate.%0A%20%20%20%20%20%20%20%20%20%20%20%20do%20%7B%20try%20handle%3F.close%28%29%20%7D%20catch%20%7B%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20handle%20%3D%20nil%0A%20%20%20%20%20%20%20%20%20%20%20%20FileManager.default.createFile%28atPath%3A%20logFileURL.path%2C%20contents%3A%20nil%29%0A%20%20%20%20%20%20%20%20%20%20%20%20openHandleLocked%28%29%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0ACotabby%2FSupport%2FFileLogHandler.swift%3A171-173%0A**Category-parsing%20logic%20is%20duplicated%20from%20%60OSLogHandler%60**%0A%0AThe%20identical%20three-line%20pattern%20%28%60split%28separator%3A%20%22.%22%2C%20maxSplits%3A%202%29%60%2C%20%60count%20%3E%202%20%3F%20parts%5B2%5D%20%3A%20label%60%29%20already%20exists%20in%20%60OSLogHandler.init%60.%20Extracting%20it%20to%20a%20static%20helper%20on%20%60TabbyLogger%60%20or%20a%20free%20function%20in%20the%20same%20file%20would%20give%20both%20handlers%20a%20single%20authoritative%20source%20and%20make%20future%20label-format%20changes%20a%20one-line%20fix.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0ACotabby%2FSupport%2FFileLogHandler.swift%3A152-158%0A**Event%20metadata%20can%20silently%20shadow%20reserved%20JSON%20keys**%0A%0A%60event.metadata%60%20is%20written%20into%20%60record%60%20unconditionally%2C%20so%20any%20call%20site%20that%20passes%20a%20metadata%20key%20matching%20%60%22timestamp%22%60%2C%20%60%22level%22%60%2C%20%60%22category%22%60%2C%20or%20%60%22message%22%60%20will%20overwrite%20the%20system-generated%20value.%20An%20AI%20agent%20reading%20the%20JSONL%20would%20then%20see%20incorrect%20or%20missing%20level%2Ftimestamp%20fields%20without%20any%20indication%20of%20the%20collision.%20A%20simple%20guard%20against%20the%20reserved%20key%20set%20%28or%20applying%20call-site%20metadata%20only%20for%20keys%20not%20already%20present%2C%20as%20is%20done%20for%20handler%20metadata%20on%20line%20157%29%20would%20prevent%20the%20ambiguity.%0A%0A%23%23%23%20Issue%202%20of%203%0ACotabby%2FSupport%2FFileLogHandler.swift%3A77-86%0A**%60FileManager.createFile%60%20does%20not%20guarantee%20inode%20preservation%20for%20%60tail%20-f%60**%0A%0AThe%20comment%20on%20line%2083%20says%20this%20truncates%20in-place%20to%20keep%20the%20inode%20stable%20for%20an%20open%20%60tail%20-f%60%2C%20but%20%60FileManager.createFile%28atPath%3Acontents%3Anil%29%60%20on%20an%20existing%20path%20is%20not%20documented%20to%20preserve%20the%20inode%20%E2%80%94%20its%20underlying%20implementation%20may%20unlink%20and%20recreate.%20The%20reliable%2C%20explicit%20way%20to%20zero-truncate%20an%20open%20descriptor%20while%20keeping%20the%20inode%20is%20%60FileHandle.truncate%28atOffset%3A%200%29%60%20followed%20by%20a%20seek%20to%20position%200%2C%20which%20avoids%20closing%20and%20reopening%20the%20handle%20at%20all.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Truncate%20the%20existing%20file%20to%20zero%20bytes%20in%20place.%20Using%20truncate%28atOffset%3A%200%29%0A%20%20%20%20%20%20%20%20%2F%2F%20preserves%20the%20inode%2C%20so%20any%20open%20%60tail%20-f%60%20continues%20following%20without%20restart.%0A%20%20%20%20%20%20%20%20do%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20try%20handle%3F.truncate%28atOffset%3A%200%29%0A%20%20%20%20%20%20%20%20%20%20%20%20handle%3F.seek%28toFileOffset%3A%200%29%0A%20%20%20%20%20%20%20%20%20%20%20%20currentByteOffset%20%3D%200%0A%20%20%20%20%20%20%20%20%7D%20catch%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20If%20truncation%20fails%2C%20fall%20back%20to%20close-and-recreate.%0A%20%20%20%20%20%20%20%20%20%20%20%20do%20%7B%20try%20handle%3F.close%28%29%20%7D%20catch%20%7B%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20handle%20%3D%20nil%0A%20%20%20%20%20%20%20%20%20%20%20%20FileManager.default.createFile%28atPath%3A%20logFileURL.path%2C%20contents%3A%20nil%29%0A%20%20%20%20%20%20%20%20%20%20%20%20openHandleLocked%28%29%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0ACotabby%2FSupport%2FFileLogHandler.swift%3A171-173%0A**Category-parsing%20logic%20is%20duplicated%20from%20%60OSLogHandler%60**%0A%0AThe%20identical%20three-line%20pattern%20%28%60split%28separator%3A%20%22.%22%2C%20maxSplits%3A%202%29%60%2C%20%60count%20%3E%202%20%3F%20parts%5B2%5D%20%3A%20label%60%29%20already%20exists%20in%20%60OSLogHandler.init%60.%20Extracting%20it%20to%20a%20static%20helper%20on%20%60TabbyLogger%60%20or%20a%20free%20function%20in%20the%20same%20file%20would%20give%20both%20handlers%20a%20single%20authoritative%20source%20and%20make%20future%20label-format%20changes%20a%20one-line%20fix.%0A%0A&repo=fujacob%2Ftabby&pr=227&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Re-bind FileHandle after wipe so post-ca..."](https://github.com/fujacob/tabby/commit/bc9ae9de0f331f7691a26dcdfe7b303da07a042f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33715102)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=45fae5fd-3007-4631-a2b0-92b2beb3df2a))

<!-- /greptile_comment -->