### PR TITLE
Wire Compose Mode end-to-end with full test coverage

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -36,6 +36,10 @@
 		F10000012FA0000100EEE001 /* TextDirectionDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10000112FA0000100EEE011 /* TextDirectionDetectorTests.swift */; };
 		G10000012FB0000100FFF001 /* WordCountFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = G10000112FB0000100FFF011 /* WordCountFormatterTests.swift */; };
 		H10000012FC0000100GGG001 /* ComposeContextNormalizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = H10000112FC0000100GGG011 /* ComposeContextNormalizerTests.swift */; };
+		H20000012FC0000100GGG002 /* ComposePromptRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = H20000112FC0000100GGG012 /* ComposePromptRendererTests.swift */; };
+		H30000012FC0000100GGG003 /* ComposeTextNormalizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = H30000112FC0000100GGG013 /* ComposeTextNormalizerTests.swift */; };
+		H40000012FC0000100GGG004 /* ComposeRequestFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = H40000112FC0000100GGG014 /* ComposeRequestFactoryTests.swift */; };
+		H50000012FC0000100GGG005 /* SuggestionCoordinatorComposeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = H50000112FC0000100GGG015 /* SuggestionCoordinatorComposeTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -75,6 +79,10 @@
 		F9D35DB9E86506B9FAE1CFE9 /* ModelFileValidatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ModelFileValidatorTests.swift; sourceTree = "<group>"; };
 		G10000112FB0000100FFF011 /* WordCountFormatterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WordCountFormatterTests.swift; sourceTree = "<group>"; };
 		H10000112FC0000100GGG011 /* ComposeContextNormalizerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ComposeContextNormalizerTests.swift; sourceTree = "<group>"; };
+		H20000112FC0000100GGG012 /* ComposePromptRendererTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ComposePromptRendererTests.swift; sourceTree = "<group>"; };
+		H30000112FC0000100GGG013 /* ComposeTextNormalizerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ComposeTextNormalizerTests.swift; sourceTree = "<group>"; };
+		H40000112FC0000100GGG014 /* ComposeRequestFactoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ComposeRequestFactoryTests.swift; sourceTree = "<group>"; };
+		H50000112FC0000100GGG015 /* SuggestionCoordinatorComposeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SuggestionCoordinatorComposeTests.swift; sourceTree = "<group>"; };
 
 /* End PBXFileReference section */
 
@@ -153,6 +161,10 @@
 				G10000122FB0000100FFF012 /* ClipboardContentDistillerTests.swift */,
 				G10000112FB0000100FFF011 /* WordCountFormatterTests.swift */,
 				H10000112FC0000100GGG011 /* ComposeContextNormalizerTests.swift */,
+				H20000112FC0000100GGG012 /* ComposePromptRendererTests.swift */,
+				H30000112FC0000100GGG013 /* ComposeTextNormalizerTests.swift */,
+				H40000112FC0000100GGG014 /* ComposeRequestFactoryTests.swift */,
+				H50000112FC0000100GGG015 /* SuggestionCoordinatorComposeTests.swift */,
 			);
 			path = CotabbyTests;
 			sourceTree = "<group>";
@@ -297,6 +309,10 @@
 				G10000022FB0000100FFF002 /* ClipboardContentDistillerTests.swift in Sources */,
 				G10000012FB0000100FFF001 /* WordCountFormatterTests.swift in Sources */,
 				H10000012FC0000100GGG001 /* ComposeContextNormalizerTests.swift in Sources */,
+				H20000012FC0000100GGG002 /* ComposePromptRendererTests.swift in Sources */,
+				H30000012FC0000100GGG003 /* ComposeTextNormalizerTests.swift in Sources */,
+				H40000012FC0000100GGG004 /* ComposeRequestFactoryTests.swift in Sources */,
+				H50000012FC0000100GGG005 /* SuggestionCoordinatorComposeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Compose.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Compose.swift
@@ -89,6 +89,9 @@ extension SuggestionCoordinator {
         latestGenerationNumber = context.generation
         latestRawModelOutput = nil
         state = .generating
+        // Instant feedback: the context walk + model warm-up can take a beat before the first
+        // token lands, so show a "Drafting…" pill at the caret the moment Tab registers.
+        presentComposeProgress(label: "Drafting…", for: context)
         logStage(
             "compose-streaming-start",
             workID: workID,
@@ -173,6 +176,12 @@ extension SuggestionCoordinator {
                 guard !Task.isCancelled, workController.isCurrent(workID) else { break }
                 guard composeStreamShouldContinue(matching: session) else { break }
                 guard !piece.isEmpty else { continue }
+
+                // First real token: tear down the "Drafting…" pill — the field is now showing
+                // the draft itself, so the status indicator would just overlap real content.
+                if accumulatedText.isEmpty {
+                    hideOverlay(reason: "Compose draft started streaming into the field.")
+                }
 
                 accumulatedText += piece
                 latestRawModelOutput = SuggestionDebugLogger.debugPreview(accumulatedText)
@@ -314,6 +323,26 @@ extension SuggestionCoordinator {
             return true
         case .idle, .disabled, .debouncing, .ready, .failed:
             return false
+        }
+    }
+
+    // MARK: - Overlay
+
+    /// Shows the transient "Drafting…" pill at the caret while we wait on the first token.
+    private func presentComposeProgress(label: String, for context: FocusedInputContext) {
+        let geometry = SuggestionOverlayGeometry(
+            caretRect: context.caretRect,
+            inputFrameRect: context.inputFrameRect,
+            caretQuality: context.caretQuality,
+            observedCharWidth: context.observedCharWidth,
+            isRightToLeft: TextDirectionDetector.isRightToLeft(context.precedingText)
+        )
+        if let message = overlayPresenter.presentComposeProgress(
+            label: label,
+            geometry: geometry,
+            previousState: overlayState
+        ) {
+            latestOverlayMessage = message
         }
     }
 }

--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Compose.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Compose.swift
@@ -1,0 +1,401 @@
+import CoreGraphics
+import Foundation
+import Logging
+
+/// File overview:
+/// Compose Mode entry points for `SuggestionCoordinator`.
+/// This is the deliberate two-step Tab flow: first Tab gathers context, generates a full draft,
+/// and shows a preview; second Tab types the draft into the focused field. Autocomplete continues
+/// to live in the sibling extension files and is untouched by this path.
+///
+/// State invariants this file protects:
+/// - Only one Compose generation is in flight per `currentWorkID`; later Tabs cancel earlier work.
+/// - The `ActiveComposeSession` is never accepted against a focused field whose process/identity
+///   has changed since the draft was generated.
+/// - Synthetic typing is rearmed against `InputSuppressionController` per chunk via the
+///   `SuggestionInserter.typeDraft` contract.
+extension SuggestionCoordinator {
+    // MARK: - Tab Routing
+
+    /// Routes a Tab/Escape/typing event while Compose Mode is active. The autocomplete pipeline
+    /// is intentionally bypassed so typing in the field does not trigger inline generation.
+    func handleComposeInputEvent(_ event: CapturedInputEvent) -> Bool {
+        switch event.kind {
+        case .acceptance, .fullAcceptance:
+            if interactionState.activeComposeSession != nil {
+                return acceptComposeDraft()
+            }
+            return startComposeGeneration()
+
+        case .dismissal:
+            cancelComposeWork(reason: "Compose cancelled by Escape.")
+            return false
+
+        case .navigation:
+            // Arrow keys, page navigation, etc. — drop any in-flight draft because the field
+            // context the user originally asked Tabby to draft against has moved.
+            if interactionState.activeComposeSession != nil || isAnyComposeWorkInFlight {
+                cancelComposeWork(reason: "Compose cancelled because the caret moved.")
+            }
+            return false
+
+        case .textMutation, .shortcutMutation:
+            // Typing or paste during preview invalidates the draft. Compose is "ask, review, type";
+            // mid-stream edits mean the user has stopped reviewing.
+            if interactionState.activeComposeSession != nil || isAnyComposeWorkInFlight {
+                cancelComposeWork(reason: "Compose cancelled because the focused text changed.")
+            }
+            return false
+
+        case .other:
+            return false
+        }
+    }
+
+    // MARK: - Generation
+
+    /// First-Tab handler: kick off Compose generation against the current focused field.
+    /// Returns `true` to consume the Tab so the host app does not receive it.
+    @discardableResult
+    func startComposeGeneration() -> Bool {
+        guard permissionManager.inputMonitoringGranted else {
+            return passTabThrough(reason: "Input Monitoring permission is required before Cotabby can draft a Compose response.")
+        }
+
+        let snapshot = focusModel.snapshot
+        guard case .supported = snapshot.capability, let rawContext = snapshot.context else {
+            return passTabThrough(reason: snapshot.capability.summary)
+        }
+
+        if let disabledReason = SuggestionAvailabilityEvaluator.disabledReason(
+            globallyEnabled: settingsSnapshot.isGloballyEnabled,
+            disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
+            interactionMode: settingsSnapshot.selectedInteractionMode,
+            inputMonitoringGranted: permissionManager.inputMonitoringGranted,
+            screenRecordingGranted: permissionManager.screenRecordingGranted,
+            focusSnapshot: snapshot
+        ) {
+            return passTabThrough(reason: disabledReason)
+        }
+
+        let context = interactionState.materializeContext(from: rawContext)
+
+        // Reuse the debounced-work plumbing with a zero delay so cancellation and stale-work guards
+        // are identical to the autocomplete path. Compose has no real debounce — Tab is explicit.
+        let workID = workController.replaceDebouncedWork(delayMilliseconds: 0) { [weak self] workID in
+            await self?.runComposeGeneration(for: context, workID: workID)
+        }
+        latestGenerationNumber = context.generation
+        state = .generating
+        logStage(
+            "compose-generating",
+            workID: workID,
+            generation: context.generation,
+            message: "Gathering Compose context for \(context.elementIdentifier) in \(context.applicationName)."
+        )
+        return true
+    }
+
+    // swiftlint:disable:next cyclomatic_complexity
+    private func runComposeGeneration(for context: FocusedInputContext, workID: UInt64) async {
+        guard workController.isCurrent(workID) else { return }
+        await awaitCachedGenerationContextResetIfNeeded()
+        guard workController.isCurrent(workID) else { return }
+
+        let collected: ComposeContextCollectionResult
+        do {
+            collected = try await composeContextCollector.collect(for: context)
+        } catch is CancellationError {
+            return
+        } catch {
+            guard workController.isCurrent(workID) else { return }
+            await applyComposeFailure(error.localizedDescription, workID: workID)
+            return
+        }
+        guard workController.isCurrent(workID) else { return }
+
+        let clipboardContext: String? = {
+            guard settingsSnapshot.isClipboardContextEnabled else { return nil }
+            return clipboardContextProvider.currentContext()
+        }()
+        let visualContextSummary = visualContextCoordinator.excerpt(for: context)
+
+        let buildResult = ComposeRequestFactory.buildRequest(
+            context: context,
+            settings: settingsSnapshot,
+            configuration: configuration,
+            surroundingContext: collected.text,
+            clipboardContext: clipboardContext,
+            visualContextSummary: visualContextSummary
+        )
+        latestPromptPreview = buildResult.promptPreview
+        latestRawModelOutput = nil
+        let request = buildResult.request
+
+        workController.replaceGenerationWork(for: workID) { [weak self] in
+            guard let self else { return }
+            do {
+                let result = try await self.suggestionEngine.generateCompose(for: request)
+                guard !Task.isCancelled, self.workController.isCurrent(workID) else { return }
+                await self.applyComposeResult(result, workID: workID)
+            } catch SuggestionClientError.cancelled {
+                return
+            } catch {
+                guard self.workController.isCurrent(workID) else { return }
+                await self.applyComposeFailure(error.localizedDescription, workID: workID)
+            }
+        }
+    }
+
+    /// Stale-result guard mirrors the autocomplete path: we re-read focus before showing anything,
+    /// and bail if the field's generation or process no longer matches what we asked the model for.
+    private func applyComposeResult(_ result: ComposeResult, workID: UInt64) async {
+        guard workController.isCurrent(workID) else { return }
+
+        focusModel.refreshNow()
+        let snapshot = focusModel.snapshot
+
+        guard case .supported = snapshot.capability, let rawContext = snapshot.context else {
+            disablePredictions(reason: snapshot.capability.summary)
+            return
+        }
+        let liveContext = interactionState.materializeContext(from: rawContext)
+
+        guard liveContext.generation == result.generation else {
+            latestRawModelOutput = SuggestionDebugLogger.debugPreview(result.rawText)
+            logStage(
+                "compose-stale-drop",
+                workID: workID,
+                generation: result.generation,
+                message: "Dropped stale Compose draft because live generation is \(liveContext.generation).",
+                rawOutput: result.rawText,
+                normalizedOutput: result.text
+            )
+            hideOverlay(reason: "Overlay hidden because the focused field changed before the draft was ready.")
+            return
+        }
+
+        latestRawModelOutput = SuggestionDebugLogger.debugPreview(result.rawText)
+        latestLatencyMilliseconds = Int(result.latency * 1000)
+        latestGenerationNumber = liveContext.generation
+
+        let trimmed = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            interactionState.clearSuggestion()
+            hideOverlay(reason: "Overlay hidden because Compose returned an empty draft.")
+            state = .idle
+            logStage(
+                "compose-empty",
+                workID: workID,
+                generation: result.generation,
+                message: "Compose draft was empty after normalization.",
+                rawOutput: result.rawText,
+                normalizedOutput: result.text
+            )
+            return
+        }
+
+        let session = interactionState.startComposeSession(
+            fullText: result.text,
+            liveContext: liveContext,
+            latency: result.latency
+        )
+        latestSuggestionPreview = session.fullText
+        latestFullSuggestionPreview = session.fullText
+        latestRemainingSuggestionPreview = session.fullText
+        latestAcceptedCharacterCount = 0
+        latestRemainingCharacterCount = session.fullText.count
+        state = .ready(text: session.fullText, latency: session.latency)
+
+        presentComposePreview(
+            text: session.fullText,
+            at: liveContext.caretRect,
+            inputFrameRect: liveContext.inputFrameRect,
+            caretQuality: liveContext.caretQuality,
+            observedCharWidth: liveContext.observedCharWidth,
+            isRightToLeft: TextDirectionDetector.isRightToLeft(liveContext.precedingText)
+        )
+        logStage(
+            "compose-ready",
+            workID: workID,
+            generation: result.generation,
+            message: "Compose draft ready for review.",
+            rawOutput: result.rawText,
+            normalizedOutput: result.text
+        )
+    }
+
+    private func applyComposeFailure(_ message: String, workID: UInt64) async {
+        guard workController.isCurrent(workID) else { return }
+        interactionState.clearSuggestion()
+        hideOverlay(reason: "Overlay hidden because Compose generation failed.")
+        state = .failed(message)
+        logStage(
+            "compose-failed",
+            workID: workID,
+            generation: latestGenerationNumber,
+            message: message
+        )
+    }
+
+    // MARK: - Acceptance
+
+    /// Second-Tab handler: type the active Compose draft into the focused field via
+    /// `SuggestionInserter.typeDraft`. Each chunk re-checks focus identity before posting.
+    @discardableResult
+    func acceptComposeDraft() -> Bool {
+        guard let session = interactionState.activeComposeSession else {
+            return passTabThrough(reason: "Key passed through because no Compose draft was ready.")
+        }
+
+        focusModel.refreshNow()
+        let snapshot = focusModel.snapshot
+        guard case .supported = snapshot.capability, let rawContext = snapshot.context else {
+            cancelComposeWork(reason: snapshot.capability.summary)
+            return passTabThrough(reason: snapshot.capability.summary)
+        }
+        let liveContext = interactionState.materializeContext(from: rawContext)
+        guard liveContext.identity == session.baseContext.identity,
+              liveContext.processIdentifier == session.baseContext.processIdentifier else {
+            cancelComposeWork(reason: "Compose cancelled because the focused field changed before typing began.")
+            return passTabThrough(reason: "Key passed through because the focused field changed.")
+        }
+        guard liveContext.selection.length == 0 else {
+            cancelComposeWork(reason: "Compose cancelled because text is selected.")
+            return passTabThrough(reason: "Key passed through because text is selected.")
+        }
+
+        state = .typing
+        recordAcceptedWords(from: session.fullText)
+        logStage(
+            "compose-accepting",
+            workID: currentWorkID,
+            generation: liveContext.generation,
+            message: "Typing Compose draft (\(session.fullText.count) characters) into \(liveContext.applicationName).",
+            normalizedOutput: session.fullText
+        )
+
+        let typingSession = session
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let didType = await self.suggestionInserter.typeDraft(typingSession.fullText) { [weak self] in
+                self?.composeTypingShouldContinue(matching: typingSession) ?? false
+            }
+
+            // The session may have already been cleared by a cancellation path (focus change,
+            // mode change, Esc). If so, don't reset state again.
+            guard let active = self.interactionState.activeComposeSession, active == typingSession else {
+                return
+            }
+
+            if didType {
+                self.interactionState.clearComposeSession(typingSession)
+                self.hideOverlay(reason: "Overlay hidden after Compose draft was typed into the field.")
+                self.state = .idle
+                self.latestAcceptanceAction = "Compose draft typed into the field."
+                self.logStage(
+                    "compose-typed",
+                    workID: self.currentWorkID,
+                    generation: typingSession.baseContext.generation,
+                    message: "Compose draft fully typed into the focused field.",
+                    normalizedOutput: typingSession.fullText
+                )
+            } else {
+                let message = self.suggestionInserter.lastErrorMessage
+                    ?? "Compose typing stopped before the draft was complete."
+                self.interactionState.clearComposeSession(typingSession)
+                self.hideOverlay(reason: "Overlay hidden because Compose typing did not complete.")
+                self.state = .failed(message)
+                self.logStage(
+                    "compose-type-aborted",
+                    workID: self.currentWorkID,
+                    generation: typingSession.baseContext.generation,
+                    message: message,
+                    normalizedOutput: typingSession.fullText
+                )
+            }
+        }
+        return true
+    }
+
+    /// Focus-identity guard checked between every synthetic key chunk. Bailing here lets the
+    /// inserter stop posting mid-draft when the user switches apps or fields.
+    private func composeTypingShouldContinue(matching session: ActiveComposeSession) -> Bool {
+        guard let active = interactionState.activeComposeSession, active == session else {
+            return false
+        }
+        let snapshot = focusModel.snapshot
+        guard case .supported = snapshot.capability, let rawContext = snapshot.context else {
+            return false
+        }
+        return rawContext.processIdentifier == session.baseContext.processIdentifier
+            && rawContext.elementIdentifier == session.baseContext.elementIdentifier
+            && rawContext.focusChangeSequence == session.baseContext.focusChangeSequence
+    }
+
+    // MARK: - Cancellation
+
+    /// Cancels any in-flight Compose work and clears the active session. Safe to call when nothing
+    /// is in flight; the underlying controllers are no-op in that case.
+    func cancelComposeWork(reason: String) {
+        let hadActiveSession = interactionState.activeComposeSession != nil
+        let hadInflightWork = isAnyComposeWorkInFlight
+        guard hadActiveSession || hadInflightWork else { return }
+
+        workController.cancelAll()
+        if let session = interactionState.activeComposeSession {
+            interactionState.clearComposeSession(session)
+        } else {
+            interactionState.clearSuggestion()
+        }
+        hideOverlay(reason: reason)
+        state = .idle
+        logStage(
+            "compose-cancelled",
+            workID: currentWorkID,
+            generation: latestGenerationNumber,
+            message: reason
+        )
+    }
+
+    /// True when a Compose generation or typing task could still emit results. We treat any state
+    /// other than `.idle` / `.disabled` as "could still emit" because the work controller only
+    /// surfaces task identity, not status.
+    var isAnyComposeWorkInFlight: Bool {
+        switch state {
+        case .generating, .typing:
+            return true
+        case .idle, .disabled, .debouncing, .ready, .failed:
+            return false
+        }
+    }
+
+    // MARK: - Overlay
+
+    // swiftlint:disable function_parameter_count
+    /// Sibling of `presentOverlay` for the multiline Compose preview surface.
+    private func presentComposePreview(
+        text: String,
+        at caretRect: CGRect,
+        inputFrameRect: CGRect?,
+        caretQuality: CaretGeometryQuality,
+        observedCharWidth: CGFloat?,
+        isRightToLeft: Bool
+    ) {
+        let geometry = SuggestionOverlayGeometry(
+            caretRect: caretRect,
+            inputFrameRect: inputFrameRect,
+            caretQuality: caretQuality,
+            observedCharWidth: observedCharWidth,
+            isRightToLeft: isRightToLeft
+        )
+        if let message = overlayPresenter.presentComposePreview(
+            text: text,
+            geometry: geometry,
+            previousState: overlayState
+        ) {
+            latestOverlayMessage = message
+        }
+    }
+    // swiftlint:enable function_parameter_count
+}

--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Compose.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Compose.swift
@@ -4,16 +4,15 @@ import Logging
 
 /// File overview:
 /// Compose Mode entry points for `SuggestionCoordinator`.
-/// This is the deliberate two-step Tab flow: first Tab gathers context, generates a full draft,
-/// and shows a preview; second Tab types the draft into the focused field. Autocomplete continues
-/// to live in the sibling extension files and is untouched by this path.
 ///
-/// State invariants this file protects:
-/// - Only one Compose generation is in flight per `currentWorkID`; later Tabs cancel earlier work.
-/// - The `ActiveComposeSession` is never accepted against a focused field whose process/identity
-///   has changed since the draft was generated.
-/// - Synthetic typing is rearmed against `InputSuppressionController` per chunk via the
-///   `SuggestionInserter.typeDraft` contract.
+/// Interaction model (single-Tab streaming):
+/// - First Tab → gather AX context, build request, open a streaming generation against llama.
+///   Each sampled piece is typed straight into the focused field via `SuggestionInserter.insert`.
+/// - Escape, focus change, app/global disable, or the user typing → cancel the stream. Already-
+///   typed characters stay in the field; the cancellation simply stops the next piece from
+///   landing.
+/// - Subsequent Tabs while streaming are absorbed so the user does not pile a second draft onto
+///   the first.
 extension SuggestionCoordinator {
     // MARK: - Tab Routing
 
@@ -22,8 +21,10 @@ extension SuggestionCoordinator {
     func handleComposeInputEvent(_ event: CapturedInputEvent) -> Bool {
         switch event.kind {
         case .acceptance, .fullAcceptance:
-            if interactionState.activeComposeSession != nil {
-                return acceptComposeDraft()
+            // Already streaming? Swallow the Tab so it does not start a second stream and does
+            // not reach the host app while we are typing into it.
+            if interactionState.activeComposeSession != nil || isAnyComposeWorkInFlight {
+                return true
             }
             return startComposeGeneration()
 
@@ -32,16 +33,17 @@ extension SuggestionCoordinator {
             return false
 
         case .navigation:
-            // Arrow keys, page navigation, etc. — drop any in-flight draft because the field
-            // context the user originally asked Tabby to draft against has moved.
+            // Arrow keys, page navigation, etc. — drop in-flight streams because the field the
+            // user originally asked Tabby to draft into has moved.
             if interactionState.activeComposeSession != nil || isAnyComposeWorkInFlight {
                 cancelComposeWork(reason: "Compose cancelled because the caret moved.")
             }
             return false
 
         case .textMutation, .shortcutMutation:
-            // Typing or paste during preview invalidates the draft. Compose is "ask, review, type";
-            // mid-stream edits mean the user has stopped reviewing.
+            // Real user typing during streaming → stop. Tabby's own synthetic key events are
+            // absorbed by `InputSuppressionController` before they reach this handler, so the
+            // stream's own characters never trigger this path.
             if interactionState.activeComposeSession != nil || isAnyComposeWorkInFlight {
                 cancelComposeWork(reason: "Compose cancelled because the focused text changed.")
             }
@@ -54,8 +56,7 @@ extension SuggestionCoordinator {
 
     // MARK: - Generation
 
-    /// First-Tab handler: kick off Compose generation against the current focused field.
-    /// Returns `true` to consume the Tab so the host app does not receive it.
+    /// Streams a Compose draft into the currently focused field. Returns `true` to consume the Tab.
     @discardableResult
     func startComposeGeneration() -> Bool {
         guard permissionManager.inputMonitoringGranted else {
@@ -83,12 +84,13 @@ extension SuggestionCoordinator {
         // Reuse the debounced-work plumbing with a zero delay so cancellation and stale-work guards
         // are identical to the autocomplete path. Compose has no real debounce — Tab is explicit.
         let workID = workController.replaceDebouncedWork(delayMilliseconds: 0) { [weak self] workID in
-            await self?.runComposeGeneration(for: context, workID: workID)
+            await self?.runComposeStreaming(for: context, workID: workID)
         }
         latestGenerationNumber = context.generation
+        latestRawModelOutput = nil
         state = .generating
         logStage(
-            "compose-generating",
+            "compose-streaming-start",
             workID: workID,
             generation: context.generation,
             message: "Gathering Compose context for \(context.elementIdentifier) in \(context.applicationName)."
@@ -96,8 +98,7 @@ extension SuggestionCoordinator {
         return true
     }
 
-    // swiftlint:disable:next cyclomatic_complexity
-    private func runComposeGeneration(for context: FocusedInputContext, workID: UInt64) async {
+    private func runComposeStreaming(for context: FocusedInputContext, workID: UInt64) async {
         guard workController.isCurrent(workID) else { return }
         await awaitCachedGenerationContextResetIfNeeded()
         guard workController.isCurrent(workID) else { return }
@@ -129,105 +130,134 @@ extension SuggestionCoordinator {
             visualContextSummary: visualContextSummary
         )
         latestPromptPreview = buildResult.promptPreview
-        latestRawModelOutput = nil
         let request = buildResult.request
+
+        // The active session represents "we are streaming into this field". The full text is
+        // appended to as pieces arrive so logs and diagnostics can describe what was typed.
+        let initialSession = interactionState.startComposeSession(
+            fullText: "",
+            liveContext: context,
+            latency: 0
+        )
+        state = .typing
+        logStage(
+            "compose-streaming-begin",
+            workID: workID,
+            generation: context.generation,
+            message: "Streaming Compose draft into \(context.applicationName).",
+            prompt: buildResult.promptPreview
+        )
 
         workController.replaceGenerationWork(for: workID) { [weak self] in
             guard let self else { return }
-            do {
-                let result = try await self.suggestionEngine.generateCompose(for: request)
-                guard !Task.isCancelled, self.workController.isCurrent(workID) else { return }
-                await self.applyComposeResult(result, workID: workID)
-            } catch SuggestionClientError.cancelled {
-                return
-            } catch {
-                guard self.workController.isCurrent(workID) else { return }
-                await self.applyComposeFailure(error.localizedDescription, workID: workID)
-            }
+            await self.consumeComposeStream(
+                request: request,
+                workID: workID,
+                initialSession: initialSession
+            )
         }
     }
 
-    /// Stale-result guard mirrors the autocomplete path: we re-read focus before showing anything,
-    /// and bail if the field's generation or process no longer matches what we asked the model for.
-    private func applyComposeResult(_ result: ComposeResult, workID: UInt64) async {
+    private func consumeComposeStream(
+        request: ComposeRequest,
+        workID: UInt64,
+        initialSession: ActiveComposeSession
+    ) async {
+        let startTime = Date()
+        var accumulatedText = ""
+        var session = initialSession
+
+        do {
+            let stream = try await suggestionEngine.generateComposeStreaming(for: request)
+            for try await piece in stream {
+                guard !Task.isCancelled, workController.isCurrent(workID) else { break }
+                guard composeStreamShouldContinue(matching: session) else { break }
+                guard !piece.isEmpty else { continue }
+
+                accumulatedText += piece
+                latestRawModelOutput = SuggestionDebugLogger.debugPreview(accumulatedText)
+                _ = suggestionInserter.insert(piece)
+                session = interactionState.updateComposeSession(
+                    session,
+                    fullText: accumulatedText,
+                    latency: Date().timeIntervalSince(startTime)
+                ) ?? session
+
+                // Yield once per piece so cancellation tasks queued on the main actor (focus
+                // changes, Esc) can run between samples instead of getting starved by the loop.
+                await Task.yield()
+            }
+        } catch is CancellationError {
+            // Treat cancellation as a normal stop — partial text stays in the field.
+            await finishComposeStream(
+                accumulated: accumulatedText,
+                latency: Date().timeIntervalSince(startTime),
+                workID: workID,
+                session: session,
+                outcome: ComposeStreamOutcome(
+                    stage: "compose-streaming-cancelled",
+                    stageMessage: "Compose stream cancelled."
+                )
+            )
+            return
+        } catch {
+            await applyComposeFailure(error.localizedDescription, workID: workID)
+            return
+        }
+
+        await finishComposeStream(
+            accumulated: accumulatedText,
+            latency: Date().timeIntervalSince(startTime),
+            workID: workID,
+            session: session,
+            outcome: ComposeStreamOutcome(
+                stage: "compose-streaming-done",
+                stageMessage: "Compose stream finished."
+            )
+        )
+    }
+
+    private struct ComposeStreamOutcome {
+        let stage: String
+        let stageMessage: String
+    }
+
+    private func finishComposeStream(
+        accumulated: String,
+        latency: TimeInterval,
+        workID: UInt64,
+        session: ActiveComposeSession,
+        outcome: ComposeStreamOutcome
+    ) async {
         guard workController.isCurrent(workID) else { return }
 
-        focusModel.refreshNow()
-        let snapshot = focusModel.snapshot
+        latestLatencyMilliseconds = Int(latency * 1000)
+        latestRawModelOutput = SuggestionDebugLogger.debugPreview(accumulated)
+        latestAcceptanceAction = accumulated.isEmpty
+            ? "Compose stream produced no text."
+            : "Compose draft streamed into the field."
 
-        guard case .supported = snapshot.capability, let rawContext = snapshot.context else {
-            disablePredictions(reason: snapshot.capability.summary)
-            return
+        if interactionState.activeComposeSession == session {
+            interactionState.clearComposeSession(session)
         }
-        let liveContext = interactionState.materializeContext(from: rawContext)
-
-        guard liveContext.generation == result.generation else {
-            latestRawModelOutput = SuggestionDebugLogger.debugPreview(result.rawText)
-            logStage(
-                "compose-stale-drop",
-                workID: workID,
-                generation: result.generation,
-                message: "Dropped stale Compose draft because live generation is \(liveContext.generation).",
-                rawOutput: result.rawText,
-                normalizedOutput: result.text
-            )
-            hideOverlay(reason: "Overlay hidden because the focused field changed before the draft was ready.")
-            return
-        }
-
-        latestRawModelOutput = SuggestionDebugLogger.debugPreview(result.rawText)
-        latestLatencyMilliseconds = Int(result.latency * 1000)
-        latestGenerationNumber = liveContext.generation
-
-        let trimmed = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else {
-            interactionState.clearSuggestion()
-            hideOverlay(reason: "Overlay hidden because Compose returned an empty draft.")
-            state = .idle
-            logStage(
-                "compose-empty",
-                workID: workID,
-                generation: result.generation,
-                message: "Compose draft was empty after normalization.",
-                rawOutput: result.rawText,
-                normalizedOutput: result.text
-            )
-            return
-        }
-
-        let session = interactionState.startComposeSession(
-            fullText: result.text,
-            liveContext: liveContext,
-            latency: result.latency
-        )
-        latestSuggestionPreview = session.fullText
-        latestFullSuggestionPreview = session.fullText
-        latestRemainingSuggestionPreview = session.fullText
-        latestAcceptedCharacterCount = 0
-        latestRemainingCharacterCount = session.fullText.count
-        state = .ready(text: session.fullText, latency: session.latency)
-
-        presentComposePreview(
-            text: session.fullText,
-            at: liveContext.caretRect,
-            inputFrameRect: liveContext.inputFrameRect,
-            caretQuality: liveContext.caretQuality,
-            observedCharWidth: liveContext.observedCharWidth,
-            isRightToLeft: TextDirectionDetector.isRightToLeft(liveContext.precedingText)
-        )
+        hideOverlay(reason: outcome.stageMessage)
+        state = .idle
         logStage(
-            "compose-ready",
+            outcome.stage,
             workID: workID,
-            generation: result.generation,
-            message: "Compose draft ready for review.",
-            rawOutput: result.rawText,
-            normalizedOutput: result.text
+            generation: session.baseContext.generation,
+            message: outcome.stageMessage,
+            normalizedOutput: accumulated
         )
     }
 
     private func applyComposeFailure(_ message: String, workID: UInt64) async {
         guard workController.isCurrent(workID) else { return }
-        interactionState.clearSuggestion()
+        if let session = interactionState.activeComposeSession {
+            interactionState.clearComposeSession(session)
+        } else {
+            interactionState.clearSuggestion()
+        }
         hideOverlay(reason: "Overlay hidden because Compose generation failed.")
         state = .failed(message)
         logStage(
@@ -238,92 +268,10 @@ extension SuggestionCoordinator {
         )
     }
 
-    // MARK: - Acceptance
-
-    /// Second-Tab handler: type the active Compose draft into the focused field via
-    /// `SuggestionInserter.typeDraft`. Each chunk re-checks focus identity before posting.
-    @discardableResult
-    func acceptComposeDraft() -> Bool {
-        guard let session = interactionState.activeComposeSession else {
-            return passTabThrough(reason: "Key passed through because no Compose draft was ready.")
-        }
-
-        focusModel.refreshNow()
-        let snapshot = focusModel.snapshot
-        guard case .supported = snapshot.capability, let rawContext = snapshot.context else {
-            cancelComposeWork(reason: snapshot.capability.summary)
-            return passTabThrough(reason: snapshot.capability.summary)
-        }
-        let liveContext = interactionState.materializeContext(from: rawContext)
-        guard liveContext.identity == session.baseContext.identity,
-              liveContext.processIdentifier == session.baseContext.processIdentifier else {
-            cancelComposeWork(reason: "Compose cancelled because the focused field changed before typing began.")
-            return passTabThrough(reason: "Key passed through because the focused field changed.")
-        }
-        guard liveContext.selection.length == 0 else {
-            cancelComposeWork(reason: "Compose cancelled because text is selected.")
-            return passTabThrough(reason: "Key passed through because text is selected.")
-        }
-
-        state = .typing
-        recordAcceptedWords(from: session.fullText)
-        logStage(
-            "compose-accepting",
-            workID: currentWorkID,
-            generation: liveContext.generation,
-            message: "Typing Compose draft (\(session.fullText.count) characters) into \(liveContext.applicationName).",
-            normalizedOutput: session.fullText
-        )
-
-        let typingSession = session
-        Task { @MainActor [weak self] in
-            guard let self else { return }
-            let didType = await self.suggestionInserter.typeDraft(typingSession.fullText) { [weak self] in
-                self?.composeTypingShouldContinue(matching: typingSession) ?? false
-            }
-
-            // The session may have already been cleared by a cancellation path (focus change,
-            // mode change, Esc). If so, don't reset state again.
-            guard let active = self.interactionState.activeComposeSession, active == typingSession else {
-                return
-            }
-
-            if didType {
-                self.interactionState.clearComposeSession(typingSession)
-                self.hideOverlay(reason: "Overlay hidden after Compose draft was typed into the field.")
-                self.state = .idle
-                self.latestAcceptanceAction = "Compose draft typed into the field."
-                self.logStage(
-                    "compose-typed",
-                    workID: self.currentWorkID,
-                    generation: typingSession.baseContext.generation,
-                    message: "Compose draft fully typed into the focused field.",
-                    normalizedOutput: typingSession.fullText
-                )
-            } else {
-                let message = self.suggestionInserter.lastErrorMessage
-                    ?? "Compose typing stopped before the draft was complete."
-                self.interactionState.clearComposeSession(typingSession)
-                self.hideOverlay(reason: "Overlay hidden because Compose typing did not complete.")
-                self.state = .failed(message)
-                self.logStage(
-                    "compose-type-aborted",
-                    workID: self.currentWorkID,
-                    generation: typingSession.baseContext.generation,
-                    message: message,
-                    normalizedOutput: typingSession.fullText
-                )
-            }
-        }
-        return true
-    }
-
-    /// Focus-identity guard checked between every synthetic key chunk. Bailing here lets the
-    /// inserter stop posting mid-draft when the user switches apps or fields.
-    private func composeTypingShouldContinue(matching session: ActiveComposeSession) -> Bool {
-        guard let active = interactionState.activeComposeSession, active == session else {
-            return false
-        }
+    /// Focus-identity guard checked before posting each streamed piece. Returns false when the
+    /// session has been cleared or the focused field has changed, which halts the for-await loop.
+    private func composeStreamShouldContinue(matching session: ActiveComposeSession) -> Bool {
+        guard interactionState.activeComposeSession == session else { return false }
         let snapshot = focusModel.snapshot
         guard case .supported = snapshot.capability, let rawContext = snapshot.context else {
             return false
@@ -335,8 +283,9 @@ extension SuggestionCoordinator {
 
     // MARK: - Cancellation
 
-    /// Cancels any in-flight Compose work and clears the active session. Safe to call when nothing
-    /// is in flight; the underlying controllers are no-op in that case.
+    /// Cancels any in-flight Compose work and clears the active session. Already-typed characters
+    /// remain in the focused field — Compose's stream is fire-and-forget per piece, so we cannot
+    /// (and should not) try to undo what the host app has already accepted.
     func cancelComposeWork(reason: String) {
         let hadActiveSession = interactionState.activeComposeSession != nil
         let hadInflightWork = isAnyComposeWorkInFlight
@@ -358,9 +307,7 @@ extension SuggestionCoordinator {
         )
     }
 
-    /// True when a Compose generation or typing task could still emit results. We treat any state
-    /// other than `.idle` / `.disabled` as "could still emit" because the work controller only
-    /// surfaces task identity, not status.
+    /// True when a Compose generation or streaming task could still emit output.
     var isAnyComposeWorkInFlight: Bool {
         switch state {
         case .generating, .typing:
@@ -369,33 +316,4 @@ extension SuggestionCoordinator {
             return false
         }
     }
-
-    // MARK: - Overlay
-
-    // swiftlint:disable function_parameter_count
-    /// Sibling of `presentOverlay` for the multiline Compose preview surface.
-    private func presentComposePreview(
-        text: String,
-        at caretRect: CGRect,
-        inputFrameRect: CGRect?,
-        caretQuality: CaretGeometryQuality,
-        observedCharWidth: CGFloat?,
-        isRightToLeft: Bool
-    ) {
-        let geometry = SuggestionOverlayGeometry(
-            caretRect: caretRect,
-            inputFrameRect: inputFrameRect,
-            caretQuality: caretQuality,
-            observedCharWidth: observedCharWidth,
-            isRightToLeft: isRightToLeft
-        )
-        if let message = overlayPresenter.presentComposePreview(
-            text: text,
-            geometry: geometry,
-            previousState: overlayState
-        ) {
-            latestOverlayMessage = message
-        }
-    }
-    // swiftlint:enable function_parameter_count
 }

--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
@@ -67,7 +67,19 @@ extension SuggestionCoordinator {
             state = .idle
         }
 
-        if interactionState.activeSession != nil {
+        // Compose's preview is field-scoped: if the user clicked a different field or app while
+        // the draft was visible, drop the session immediately. Same-field updates are a no-op
+        // because Compose does not reconcile against typing the way autocomplete does.
+        if let composeSession = interactionState.activeComposeSession {
+            let processChanged = composeSession.baseContext.processIdentifier != focusedContext.processIdentifier
+            let elementChanged = composeSession.baseContext.elementIdentifier != focusedContext.elementIdentifier
+            if processChanged || elementChanged {
+                cancelComposeWork(reason: "Compose cancelled because the focused field changed.")
+            }
+            return
+        }
+
+        if interactionState.activeAutocompleteSession != nil {
             reconcileActiveSession(with: snapshot)
             return
         }
@@ -96,6 +108,13 @@ extension SuggestionCoordinator {
         ) {
             disablePredictions(reason: disabledReason)
             return false
+        }
+
+        // Compose has a deliberate two-step Tab flow and never participates in inline-autocomplete
+        // session reconciliation or per-keystroke prediction debouncing. Fork the event handling
+        // here so the autocomplete branch below can keep assuming "this is autocomplete state".
+        if settingsSnapshot.selectedInteractionMode == .compose {
+            return handleComposeInputEvent(event)
         }
 
         if event.kind == .acceptance {

--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
@@ -8,8 +8,10 @@ extension SuggestionCoordinator {
     // MARK: - Prediction Pipeline
 
     func schedulePrediction() {
+        // Compose Mode is Tab-driven, not typing-driven. Returning here keeps Tabby quiet while
+        // the user types into the field without surfacing a misleading "disabled" state — the
+        // explicit Compose path lives in `SuggestionCoordinator+Compose.swift`.
         guard settingsSnapshot.selectedInteractionMode == .autocomplete else {
-            disablePredictionsPreservingVisualContext(reason: composeModePendingReason)
             return
         }
 
@@ -38,8 +40,9 @@ extension SuggestionCoordinator {
 
     /// Refreshes focus after debounce, materializes a stable context, and starts generation.
     func generateFromCurrentFocus(workID: UInt64) async {
+        // Mode may have flipped to Compose while this debounced task was sleeping. Bail silently
+        // — the Compose path is driven from `handleComposeInputEvent`, not from this debounce.
         guard settingsSnapshot.selectedInteractionMode == .autocomplete else {
-            disablePredictionsPreservingVisualContext(reason: composeModePendingReason)
             return
         }
 
@@ -453,7 +456,4 @@ extension SuggestionCoordinator {
         schedulePrediction()
     }
 
-    private var composeModePendingReason: String {
-        "Compose Mode is selected. Draft generation will be enabled after the Compose request pipeline is installed."
-    }
 }

--- a/Cotabby/App/Coordinators/SuggestionCoordinator.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator.swift
@@ -44,7 +44,7 @@ final class SuggestionCoordinator: ObservableObject {
     let clipboardContextProvider: any ClipboardContextProviding
     let clipboardRelevanceFilter: any ClipboardRelevanceFiltering
     let visualContextCoordinator: any VisualContextCoordinating
-    let composeContextCollector: ComposeContextCollector
+    let composeContextCollector: any ComposeContextCollecting
     let interactionState: SuggestionInteractionState
     let workController: SuggestionWorkController
     let configuration: SuggestionConfiguration
@@ -74,7 +74,7 @@ final class SuggestionCoordinator: ObservableObject {
         clipboardContextProvider: any ClipboardContextProviding,
         clipboardRelevanceFilter: any ClipboardRelevanceFiltering,
         visualContextCoordinator: any VisualContextCoordinating,
-        composeContextCollector: ComposeContextCollector,
+        composeContextCollector: any ComposeContextCollecting,
         interactionState: SuggestionInteractionState,
         workController: SuggestionWorkController,
         configuration: SuggestionConfiguration,

--- a/Cotabby/App/Core/CotabbyAppEnvironment.swift
+++ b/Cotabby/App/Core/CotabbyAppEnvironment.swift
@@ -184,6 +184,26 @@ final class CotabbyAppEnvironment {
             }
             .store(in: &cancellables)
 
+        // Compose Mode requires `tabby-depth-1`. Auto-switch on entry / restore on exit lives here
+        // (not on `RuntimeBootstrapModel`) because the runtime model intentionally does not know
+        // about interaction modes. `dropFirst()` ignores the initial publish; `removeDuplicates`
+        // avoids redundant work when other settings change.
+        suggestionSettings.$selectedInteractionMode
+            .removeDuplicates()
+            .dropFirst()
+            .sink { [weak runtimeModel] mode in
+                guard let runtimeModel else { return }
+                Task { @MainActor in
+                    switch mode {
+                    case .compose:
+                        await runtimeModel.prepareForComposeMode()
+                    case .autocomplete:
+                        await runtimeModel.restoreAutocompleteModel()
+                    }
+                }
+            }
+            .store(in: &cancellables)
+
         // Key code changes reach InputMonitor through closures that read from the model
         // at event time (set above), so no Combine subscription is needed here.
     }

--- a/Cotabby/App/Core/CotabbyAppEnvironment.swift
+++ b/Cotabby/App/Core/CotabbyAppEnvironment.swift
@@ -184,26 +184,6 @@ final class CotabbyAppEnvironment {
             }
             .store(in: &cancellables)
 
-        // Compose Mode requires `tabby-depth-1`. Auto-switch on entry / restore on exit lives here
-        // (not on `RuntimeBootstrapModel`) because the runtime model intentionally does not know
-        // about interaction modes. `dropFirst()` ignores the initial publish; `removeDuplicates`
-        // avoids redundant work when other settings change.
-        suggestionSettings.$selectedInteractionMode
-            .removeDuplicates()
-            .dropFirst()
-            .sink { [weak runtimeModel] mode in
-                guard let runtimeModel else { return }
-                Task { @MainActor in
-                    switch mode {
-                    case .compose:
-                        await runtimeModel.prepareForComposeMode()
-                    case .autocomplete:
-                        await runtimeModel.restoreAutocompleteModel()
-                    }
-                }
-            }
-            .store(in: &cancellables)
-
         // Key code changes reach InputMonitor through closures that read from the model
         // at event time (set above), so no Combine subscription is needed here.
     }

--- a/Cotabby/Models/LlamaRuntimeModels.swift
+++ b/Cotabby/Models/LlamaRuntimeModels.swift
@@ -138,12 +138,6 @@ struct RemoteModelFile: Equatable, Hashable, Sendable {
 }
 
 enum RuntimeModelCatalog {
-    static let composeRequiredFilename = "gemma-3n-E4B-it-Q4_K_M.gguf"
-
-    static func supportsCompose(filename: String?) -> Bool {
-        filename == composeRequiredFilename
-    }
-
     static func displayName(for filename: String) -> String {
         switch filename {
         case "Qwen3-0.6B-Q4_K_M.gguf":

--- a/Cotabby/Models/RuntimeBootstrapModel.swift
+++ b/Cotabby/Models/RuntimeBootstrapModel.swift
@@ -19,6 +19,10 @@ final class RuntimeBootstrapModel: ObservableObject {
     private let userDefaults: UserDefaults
     private var cancellables = Set<AnyCancellable>()
     private var runtimeTask: Task<Void, Never>?
+    /// The model the user had selected before Compose Mode auto-switched to `tabby-depth-1`.
+    /// Persisted only in memory because the Compose round-trip is a within-session feature; if the
+    /// app relaunches in Compose Mode we re-select the required model on the next entry anyway.
+    private var preComposeAutocompleteModelFilename: String?
 
     /// Called immediately before the runtime begins switching models so suggestion state can reset.
     var onWillReloadModel: (() -> Void)?
@@ -129,6 +133,41 @@ final class RuntimeBootstrapModel: ObservableObject {
         }
 
         await runtimeTask?.value
+    }
+
+    /// Whether the Compose Mode required local model is currently discovered.
+    /// Read by UI so it can offer a clear "Compose needs tabby-depth-1" message without each view
+    /// duplicating the catalog lookup.
+    var isComposeRequiredModelInstalled: Bool {
+        availableModels.contains { $0.filename == RuntimeModelCatalog.composeRequiredFilename }
+    }
+
+    /// Switches the runtime to `tabby-depth-1` for Compose Mode, remembering the prior selection so
+    /// returning to Autocomplete restores it. No-op when the required model is missing, when it is
+    /// already selected, or when a runtime task is in flight (the next entry will retry).
+    func prepareForComposeMode() async {
+        let required = RuntimeModelCatalog.composeRequiredFilename
+        guard isComposeRequiredModelInstalled else {
+            TabbyLogger.runtime.info("Compose Mode required model \(required) is not installed; leaving selection unchanged.")
+            return
+        }
+        guard selectedModelFilename != required else { return }
+        guard runtimeTask == nil else { return }
+
+        preComposeAutocompleteModelFilename = selectedModelFilename
+        await selectModel(required)
+    }
+
+    /// Restores the user's pre-Compose model selection. No-op when no prior selection was saved
+    /// or when the saved model is no longer available.
+    func restoreAutocompleteModel() async {
+        guard let previous = preComposeAutocompleteModelFilename else { return }
+        preComposeAutocompleteModelFilename = nil
+        guard availableModels.contains(where: { $0.filename == previous }) else { return }
+        guard selectedModelFilename != previous else { return }
+        guard runtimeTask == nil else { return }
+
+        await selectModel(previous)
     }
 
     /// Cancels pending startup work and forwards shutdown to the underlying runtime manager.

--- a/Cotabby/Models/RuntimeBootstrapModel.swift
+++ b/Cotabby/Models/RuntimeBootstrapModel.swift
@@ -19,10 +19,6 @@ final class RuntimeBootstrapModel: ObservableObject {
     private let userDefaults: UserDefaults
     private var cancellables = Set<AnyCancellable>()
     private var runtimeTask: Task<Void, Never>?
-    /// The model the user had selected before Compose Mode auto-switched to `tabby-depth-1`.
-    /// Persisted only in memory because the Compose round-trip is a within-session feature; if the
-    /// app relaunches in Compose Mode we re-select the required model on the next entry anyway.
-    private var preComposeAutocompleteModelFilename: String?
 
     /// Called immediately before the runtime begins switching models so suggestion state can reset.
     var onWillReloadModel: (() -> Void)?
@@ -133,41 +129,6 @@ final class RuntimeBootstrapModel: ObservableObject {
         }
 
         await runtimeTask?.value
-    }
-
-    /// Whether the Compose Mode required local model is currently discovered.
-    /// Read by UI so it can offer a clear "Compose needs tabby-depth-1" message without each view
-    /// duplicating the catalog lookup.
-    var isComposeRequiredModelInstalled: Bool {
-        availableModels.contains { $0.filename == RuntimeModelCatalog.composeRequiredFilename }
-    }
-
-    /// Switches the runtime to `tabby-depth-1` for Compose Mode, remembering the prior selection so
-    /// returning to Autocomplete restores it. No-op when the required model is missing, when it is
-    /// already selected, or when a runtime task is in flight (the next entry will retry).
-    func prepareForComposeMode() async {
-        let required = RuntimeModelCatalog.composeRequiredFilename
-        guard isComposeRequiredModelInstalled else {
-            TabbyLogger.runtime.info("Compose Mode required model \(required) is not installed; leaving selection unchanged.")
-            return
-        }
-        guard selectedModelFilename != required else { return }
-        guard runtimeTask == nil else { return }
-
-        preComposeAutocompleteModelFilename = selectedModelFilename
-        await selectModel(required)
-    }
-
-    /// Restores the user's pre-Compose model selection. No-op when no prior selection was saved
-    /// or when the saved model is no longer available.
-    func restoreAutocompleteModel() async {
-        guard let previous = preComposeAutocompleteModelFilename else { return }
-        preComposeAutocompleteModelFilename = nil
-        guard availableModels.contains(where: { $0.filename == previous }) else { return }
-        guard selectedModelFilename != previous else { return }
-        guard runtimeTask == nil else { return }
-
-        await selectModel(previous)
     }
 
     /// Cancels pending startup work and forwards shutdown to the underlying runtime manager.

--- a/Cotabby/Models/SuggestionEngineModels.swift
+++ b/Cotabby/Models/SuggestionEngineModels.swift
@@ -106,7 +106,6 @@ struct SuggestionSettingsSnapshot: Equatable, Sendable {
     let focusPollIntervalMilliseconds: Int
     let isMultiLineEnabled: Bool
 
-    // swiftlint:disable:next function_parameter_count
     init(
         isGloballyEnabled: Bool,
         disabledAppBundleIdentifiers: Set<String>,

--- a/Cotabby/Models/SuggestionModels.swift
+++ b/Cotabby/Models/SuggestionModels.swift
@@ -403,12 +403,16 @@ enum OverlayState: Equatable {
     case hidden(reason: String)
     case visible(text: String, geometry: SuggestionOverlayGeometry)
     case composePreview(text: String, geometry: SuggestionOverlayGeometry)
+    /// Transient "Drafting…" indicator shown near the caret while Compose is gathering context and
+    /// waiting on the first streamed token. It disappears as soon as text starts landing in the
+    /// field, so it exists only to prove to the user that the Tab press registered.
+    case composeProgress(label: String, geometry: SuggestionOverlayGeometry)
 
     var shortLabel: String {
         switch self {
         case .hidden:
             return "Hidden"
-        case .visible, .composePreview:
+        case .visible, .composePreview, .composeProgress:
             return "Visible"
         }
     }
@@ -424,12 +428,15 @@ enum OverlayState: Equatable {
         case let .composePreview(text, geometry):
             return "Showing Compose preview with \(text.count) characters near " +
                 "(\(Int(geometry.caretRect.minX)), \(Int(geometry.caretRect.minY)))."
+        case let .composeProgress(label, geometry):
+            return "Showing Compose \"\(label)\" indicator near " +
+                "(\(Int(geometry.caretRect.minX)), \(Int(geometry.caretRect.minY)))."
         }
     }
 
     var isVisible: Bool {
         switch self {
-        case .visible, .composePreview:
+        case .visible, .composePreview, .composeProgress:
             return true
         case .hidden:
             return false
@@ -440,7 +447,7 @@ enum OverlayState: Equatable {
         switch self {
         case let .visible(text, _), let .composePreview(text, _):
             return text
-        case .hidden:
+        case .composeProgress, .hidden:
             return nil
         }
     }

--- a/Cotabby/Models/SuggestionSubsystemContracts.swift
+++ b/Cotabby/Models/SuggestionSubsystemContracts.swift
@@ -106,6 +106,7 @@ protocol SuggestionOverlayControlling: AnyObject {
 
     func showSuggestion(_ text: String, geometry: SuggestionOverlayGeometry)
     func showComposePreview(_ text: String, geometry: SuggestionOverlayGeometry)
+    func showComposeProgress(_ label: String, geometry: SuggestionOverlayGeometry)
     func hide(reason: String)
 }
 

--- a/Cotabby/Models/SuggestionSubsystemContracts.swift
+++ b/Cotabby/Models/SuggestionSubsystemContracts.swift
@@ -102,3 +102,36 @@ protocol VisualContextCoordinating: AnyObject {
     func cancel(resetState: Bool)
     func excerpt(for context: FocusedInputContext) -> String?
 }
+
+/// Behavior-shaped contract for Compose Mode AX context collection.
+///
+/// The coordinator only needs "collect a normalized surrounding context for this focused field";
+/// keeping the contract narrow lets tests substitute a deterministic fake without standing up the
+/// real AX tree, while production code still uses the bounded DFS in `ComposeContextCollector`.
+@MainActor
+protocol ComposeContextCollecting: AnyObject {
+    func collect(for context: FocusedInputContext) async throws -> ComposeContextCollectionResult
+}
+
+/// What a Compose context collector returns.
+///
+/// This sits next to the protocol (not on the concrete collector) so test fakes can construct
+/// results without depending on the real collector's nested types.
+struct ComposeContextCollectionResult: Equatable, Sendable {
+    let text: String
+    let visitedNodeCount: Int
+    let retainedTextCount: Int
+    let droppedTextCount: Int
+
+    init(
+        text: String,
+        visitedNodeCount: Int = 0,
+        retainedTextCount: Int = 0,
+        droppedTextCount: Int = 0
+    ) {
+        self.text = text
+        self.visitedNodeCount = visitedNodeCount
+        self.retainedTextCount = retainedTextCount
+        self.droppedTextCount = droppedTextCount
+    }
+}

--- a/Cotabby/Models/SuggestionSubsystemContracts.swift
+++ b/Cotabby/Models/SuggestionSubsystemContracts.swift
@@ -40,9 +40,27 @@ protocol SuggestionInputMonitoring: AnyObject {
 protocol SuggestionGenerating: AnyObject {
     func generateSuggestion(for request: SuggestionRequest) async throws -> SuggestionResult
     func generateCompose(for request: ComposeRequest) async throws -> ComposeResult
+    /// Streaming variant: yields each generated piece through an async stream so the coordinator
+    /// can type tokens into the focused field as the model produces them. Engines that cannot
+    /// stream natively get the one-shot fallback in the extension below.
+    func generateComposeStreaming(for request: ComposeRequest) async throws -> AsyncThrowingStream<String, Error>
     /// Clears backend-local continuation state when the focused editing context is no longer
     /// continuous. Stateless engines may implement this as a no-op.
     func resetCachedGenerationContext() async
+}
+
+extension SuggestionGenerating {
+    /// One-shot fallback: run `generateCompose`, then emit the full draft as a single chunk.
+    /// Engines that can stream natively (Llama) override this to actually emit per token.
+    func generateComposeStreaming(for request: ComposeRequest) async throws -> AsyncThrowingStream<String, Error> {
+        let result = try await generateCompose(for: request)
+        return AsyncThrowingStream { continuation in
+            if !result.text.isEmpty {
+                continuation.yield(result.text)
+            }
+            continuation.finish()
+        }
+    }
 }
 
 @MainActor

--- a/Cotabby/Services/Context/ComposeContextCollector.swift
+++ b/Cotabby/Services/Context/ComposeContextCollector.swift
@@ -7,7 +7,7 @@ import Foundation
 /// side-effectful macOS boundary with app-specific failure modes. The coordinator should ask for a
 /// bounded, normalized context string; it should not own traversal budgets or Core Foundation reads.
 @MainActor
-final class ComposeContextCollector {
+final class ComposeContextCollector: ComposeContextCollecting {
     struct Limits: Equatable, Sendable {
         let maxAncestorDepth: Int
         let maxDFSDepth: Int
@@ -22,13 +22,6 @@ final class ComposeContextCollector {
             maxRawContextCharacters: 30_000,
             normalizerLimits: .standard
         )
-    }
-
-    struct Result: Equatable, Sendable {
-        let text: String
-        let visitedNodeCount: Int
-        let retainedTextCount: Int
-        let droppedTextCount: Int
     }
 
     enum CollectionError: LocalizedError, Equatable {
@@ -74,7 +67,7 @@ final class ComposeContextCollector {
         self.limits = limits
     }
 
-    func collect(for context: FocusedInputContext) async throws -> Result {
+    func collect(for context: FocusedInputContext) async throws -> ComposeContextCollectionResult {
         try Task.checkCancellation()
 
         guard let focusedElement = AXHelper.focusedElement() else {
@@ -147,7 +140,7 @@ final class ComposeContextCollector {
             limits: limits.normalizerLimits
         )
 
-        return Result(
+        return ComposeContextCollectionResult(
             text: normalizedText,
             visitedNodeCount: visitedNodeCount,
             retainedTextCount: retainedTextCount,

--- a/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
+++ b/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
@@ -227,6 +227,73 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
         return generatedText
     }
 
+    /// Streaming sibling of `summarize`. Same ephemeral-sequence semantics (autocomplete KV cache
+    /// stays clean), but emits each sampled piece through `onToken` before the loop continues so
+    /// callers can observe generation in real time. Returns the accumulated text for diagnostics.
+    ///
+    /// `onToken` is `@Sendable` and runs on the detached sampling thread; callers that need to
+    /// touch UI must hop back to the main actor.
+    func summarizeStreaming(
+        prompt: String,
+        options: LlamaGenerationOptions,
+        onToken: @Sendable (String) -> Void
+    ) throws -> String {
+        guard let preparedRuntime else {
+            throw LlamaRuntimeError.unavailable("The llama model is not loaded.")
+        }
+
+        lifecycleCondition.lock()
+        guard !isShuttingDown else {
+            lifecycleCondition.unlock()
+            throw LlamaRuntimeError.unavailable("The runtime is shutting down.")
+        }
+        activeOperationCount += 1
+        lifecycleCondition.unlock()
+
+        defer {
+            lifecycleCondition.lock()
+            activeOperationCount -= 1
+            lifecycleCondition.broadcast()
+            lifecycleCondition.unlock()
+        }
+
+        let allPromptTokens = tokenize(prompt)
+        guard !allPromptTokens.isEmpty else {
+            throw LlamaRuntimeError.generationFailed("Tokenization returned no prompt tokens.")
+        }
+
+        let maxPromptTokens = max(1, preparedRuntime.contextWindowTokens - options.maxPredictionTokens)
+        let promptTokens = allPromptTokens.count > maxPromptTokens
+            ? Array(allPromptTokens.suffix(maxPromptTokens))
+            : allPromptTokens
+
+        let config = Self.samplingConfig(from: options)
+        let seqID = engine.createSequence(config)
+        guard seqID >= 0 else {
+            throw LlamaRuntimeError.generationFailed("Unable to create streaming sequence.")
+        }
+        defer { engine.destroySequence(seqID) }
+
+        var tokens = promptTokens
+        let status = engine.decodePrompt(seqID, &tokens, Int32(tokens.count), 0)
+        guard status == .ok else {
+            throw LlamaRuntimeError.generationFailed("Streaming prompt decoding failed.")
+        }
+
+        var generatedText = ""
+        for _ in 0 ..< options.maxPredictionTokens {
+            if Task.isCancelled { break }
+            let result = engine.sampleNext(seqID)
+            if result.is_eos || result.was_cancelled { break }
+            let piece = Self.extractPiece(result)
+            guard !piece.isEmpty else { continue }
+            generatedText += piece
+            onToken(piece)
+        }
+
+        return generatedText
+    }
+
     // MARK: - Cache and lifecycle
 
     /// Drops the reusable autocomplete sequence while keeping the loaded model alive.

--- a/Cotabby/Services/Runtime/LlamaRuntimeManager.swift
+++ b/Cotabby/Services/Runtime/LlamaRuntimeManager.swift
@@ -23,10 +23,6 @@ final class LlamaRuntimeManager: ObservableObject {
     private var cachedRuntime: PreparedLlamaRuntime?
     private var selectedModelFilename: String?
 
-    var selectedModelSupportsCompose: Bool {
-        RuntimeModelCatalog.supportsCompose(filename: selectedModelFilename)
-    }
-
     convenience init() {
         self.init(
             configuration: .default,

--- a/Cotabby/Services/Runtime/LlamaRuntimeManager.swift
+++ b/Cotabby/Services/Runtime/LlamaRuntimeManager.swift
@@ -179,6 +179,42 @@ final class LlamaRuntimeManager: ObservableObject {
         }
     }
 
+    /// Streaming variant of `generateUncached`: kicks off generation on a detached thread and
+    /// yields each sampled piece through an `AsyncThrowingStream`. Cancelling the consuming task
+    /// terminates the stream and cancels the underlying detached sampling task.
+    ///
+    /// `preparedRuntime()` runs on the main actor before we hand control to the stream so the
+    /// caller can `await` once and then iterate; that keeps the AsyncStream's setup cheap.
+    func streamUncached(
+        prompt: String,
+        options: LlamaGenerationOptions
+    ) async throws -> AsyncThrowingStream<String, Error> {
+        _ = try await preparedRuntime()
+
+        let core = self.core
+        return AsyncThrowingStream { continuation in
+            let task = Task.detached {
+                do {
+                    _ = try core.summarizeStreaming(
+                        prompt: prompt,
+                        options: options,
+                        onToken: { piece in
+                            continuation.yield(piece)
+                        }
+                    )
+                    continuation.finish()
+                } catch is CancellationError {
+                    continuation.finish(throwing: LlamaRuntimeError.cancelled)
+                } catch let error as LlamaRuntimeError {
+                    continuation.finish(throwing: error)
+                } catch {
+                    continuation.finish(throwing: LlamaRuntimeError.generationFailed(error.localizedDescription))
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
     /// Clears the native prompt KV cache without unloading the model.
     func resetPromptCache() {
         core.resetPromptCache()

--- a/Cotabby/Services/Runtime/LlamaSuggestionEngine.swift
+++ b/Cotabby/Services/Runtime/LlamaSuggestionEngine.swift
@@ -114,6 +114,25 @@ final class LlamaSuggestionEngine {
         }
     }
 
+    /// Streaming variant — yields each sampled piece through an `AsyncThrowingStream` so the
+    /// coordinator can type into the focused field as the model generates. We deliberately skip
+    /// `ComposeTextNormalizer` here because that normalizer is whole-text shaped; streaming pieces
+    /// belong to the user's field immediately and any wrapper cleanup would have to happen against
+    /// already-typed characters, which is more harm than help.
+    func generateComposeStreaming(for request: ComposeRequest) async throws -> AsyncThrowingStream<String, Error> {
+        let prompt = ComposePromptRenderer.prompt(for: request)
+        let options = LlamaGenerationOptions(
+            maxPredictionTokens: request.maxPredictionTokens,
+            temperature: request.temperature,
+            topK: request.topK,
+            topP: request.topP,
+            minP: request.minP,
+            repetitionPenalty: request.repetitionPenalty,
+            seed: request.randomSeed
+        )
+        return try await runtimeManager.streamUncached(prompt: prompt, options: options)
+    }
+
     /// Clears both the Swift-side hint tracker and the native llama KV cache.
     /// The tracker reset is synchronous because it protects the next request from advertising
     /// stale reuse; awaiting the runtime reset keeps native KV invalidation ordered before the next

--- a/Cotabby/Services/Runtime/LlamaSuggestionEngine.swift
+++ b/Cotabby/Services/Runtime/LlamaSuggestionEngine.swift
@@ -75,12 +75,6 @@ final class LlamaSuggestionEngine {
     }
 
     func generateCompose(for request: ComposeRequest) async throws -> ComposeResult {
-        guard runtimeManager.selectedModelSupportsCompose else {
-            throw SuggestionClientError.unavailable(
-                "Compose Mode requires tabby-depth-1. Select or download \(RuntimeModelCatalog.composeRequiredFilename)."
-            )
-        }
-
         do {
             let startTime = Date()
             let prompt = ComposePromptRenderer.prompt(for: request)

--- a/Cotabby/Services/Runtime/SuggestionEngineRouter.swift
+++ b/Cotabby/Services/Runtime/SuggestionEngineRouter.swift
@@ -45,6 +45,21 @@ final class SuggestionEngineRouter {
         }
     }
 
+    /// Streaming Compose, llama-only. The protocol's default `generateComposeStreaming` falls back
+    /// to `generateCompose`, so non-llama engines route through the same "unavailable" path below
+    /// without us having to fork the routing decision twice.
+    func generateComposeStreaming(for request: ComposeRequest) async throws -> AsyncThrowingStream<String, Error> {
+        switch suggestionSettings.selectedEngine {
+        case .llamaOpenSource:
+            TabbyLogger.suggestion.debug("Streaming Compose request through open-source llama engine")
+            return try await llamaEngine.generateComposeStreaming(for: request)
+        case .appleIntelligence, .mlxSwift:
+            throw SuggestionClientError.unavailable(
+                "Compose Mode is only available with the local open-source runtime in this version."
+            )
+        }
+    }
+
     /// Compose currently only ships behind the local llama runtime. Other engines surface an
     /// unavailable state instead of forwarding so users see a clear "Compose needs llama" message
     /// rather than a generic prompt failure from a backend that does not implement the contract.

--- a/Cotabby/Services/Suggestion/SuggestionInteractionState.swift
+++ b/Cotabby/Services/Suggestion/SuggestionInteractionState.swift
@@ -278,6 +278,24 @@ final class SuggestionInteractionState {
         activeSession = nil
         pendingInsertionConsumedCount = nil
     }
+
+    /// Returns a new active compose session with the accumulated streaming text. No-op if the
+    /// previous session is no longer the active one (cancellation may have replaced it).
+    @discardableResult
+    func updateComposeSession(
+        _ previous: ActiveComposeSession,
+        fullText: String,
+        latency: TimeInterval
+    ) -> ActiveComposeSession? {
+        guard activeComposeSession == previous else { return nil }
+        let updated = ActiveComposeSession(
+            baseContext: previous.baseContext,
+            fullText: fullText,
+            latency: latency
+        )
+        activeSession = .compose(updated)
+        return updated
+    }
 }
 
 /// Wraps reconciliation results with the live buffered context the coordinator needs for UI updates.

--- a/Cotabby/Services/Suggestion/SuggestionOverlayPresenter.swift
+++ b/Cotabby/Services/Suggestion/SuggestionOverlayPresenter.swift
@@ -75,6 +75,20 @@ struct SuggestionOverlayPresenter {
         return "Displayed Compose draft preview near the caret."
     }
 
+    /// Shows the transient "Drafting…" indicator. Idempotent: re-presenting the same label and
+    /// geometry returns `nil` so the coordinator does not log a redundant overlay change.
+    func presentComposeProgress(
+        label: String,
+        geometry: SuggestionOverlayGeometry,
+        previousState: OverlayState
+    ) -> String? {
+        guard previousState != .composeProgress(label: label, geometry: geometry) else {
+            return nil
+        }
+        overlayController.showComposeProgress(label, geometry: geometry)
+        return "Displayed Compose \"\(label)\" indicator near the caret."
+    }
+
     func hide(reason: String) -> String {
         overlayController.hide(reason: reason)
         return reason

--- a/Cotabby/Services/UI/OverlayController.swift
+++ b/Cotabby/Services/UI/OverlayController.swift
@@ -147,6 +147,43 @@ final class OverlayController: SuggestionOverlayControlling {
         state = .composePreview(text: previewText, geometry: geometry)
     }
 
+    /// Shows the small "Drafting…" pill near the caret while Compose waits on its first token.
+    /// Sized tighter than the preview box so it reads as a status chip, not content.
+    func showComposeProgress(_ label: String, geometry: SuggestionOverlayGeometry) {
+        let contentView: NSHostingView<AnyView>
+        let rootView = AnyView(ComposeProgressView(label: label))
+        if let existing = hostingView {
+            existing.rootView = rootView
+            contentView = existing
+        } else {
+            let fresh = NSHostingView(rootView: rootView)
+            hostingView = fresh
+            panel.contentView = fresh
+            contentView = fresh
+        }
+        contentView.layoutSubtreeIfNeeded()
+
+        let visibleFrame = targetScreenVisibleFrame(for: geometry.caretRect)
+        let contentSize = contentView.fittingSize
+        let width = min(max(contentSize.width, 96), min(220, visibleFrame.width - 32))
+        let height = min(max(contentSize.height, 28), 48)
+        let originX = min(
+            max(geometry.caretRect.maxX + 8, visibleFrame.minX + 16),
+            visibleFrame.maxX - width - 16
+        )
+        let preferredOriginY = geometry.caretRect.minY - height - 8
+        let originY = preferredOriginY >= visibleFrame.minY + 16
+            ? preferredOriginY
+            : min(geometry.caretRect.maxY + 8, visibleFrame.maxY - height - 16)
+
+        panel.setFrame(
+            CGRect(x: originX, y: originY, width: width, height: height).integral,
+            display: true
+        )
+        panel.orderFrontRegardless()
+        state = .composeProgress(label: label, geometry: geometry)
+    }
+
     /// Hides the floating panel and records why the overlay is no longer visible.
     func hide(reason: String) {
         panel.orderOut(nil)
@@ -272,6 +309,30 @@ private struct ComposePreviewView: View {
                 .stroke(.quaternary, lineWidth: 1)
         )
         .fixedSize(horizontal: false, vertical: true)
+    }
+}
+
+/// Compact "Drafting…" status pill shown while Compose waits on its first streamed token.
+private struct ComposeProgressView: View {
+    let label: String
+
+    var body: some View {
+        HStack(spacing: 7) {
+            ProgressView()
+                .controlSize(.small)
+                .scaleEffect(0.7)
+
+            Text(label)
+                .font(.system(size: 12, weight: .medium, design: .rounded))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: true)
+        }
+        .padding(.horizontal, 11)
+        .padding(.vertical, 6)
+        .background(.regularMaterial, in: Capsule())
+        .overlay(Capsule().stroke(.quaternary, lineWidth: 1))
+        .fixedSize(horizontal: true, vertical: true)
     }
 }
 

--- a/Cotabby/UI/MenuBarView.swift
+++ b/Cotabby/UI/MenuBarView.swift
@@ -119,6 +119,21 @@ struct MenuBarView: View {
                     .foregroundStyle(.orange)
             }
 
+            if suggestionSettings.selectedInteractionMode == .compose,
+               suggestionSettings.selectedEngine != .llamaOpenSource {
+                Text("Compose requires the Open Source engine.")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+
+            if suggestionSettings.selectedInteractionMode == .compose,
+               suggestionSettings.selectedEngine == .llamaOpenSource,
+               !runtimeModel.isComposeRequiredModelInstalled {
+                Text("Compose requires \(RuntimeModelCatalog.composeRequiredFilename). Add it to the models folder.")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+
             if suggestionSettings.selectedEngine.supportsLocalModelManagement {
                 modelRow
             }
@@ -338,6 +353,11 @@ struct MenuBarView: View {
     }
 
     private var runtimePickerDisabled: Bool {
+        // Compose Mode pins the runtime to `tabby-depth-1`, so user-driven model selection is
+        // disabled while Compose is active to prevent half-supported configurations.
+        if suggestionSettings.selectedInteractionMode == .compose {
+            return true
+        }
         switch runtimeModel.state {
         case .starting, .loading:
             return true

--- a/Cotabby/UI/MenuBarView.swift
+++ b/Cotabby/UI/MenuBarView.swift
@@ -126,14 +126,6 @@ struct MenuBarView: View {
                     .foregroundStyle(.orange)
             }
 
-            if suggestionSettings.selectedInteractionMode == .compose,
-               suggestionSettings.selectedEngine == .llamaOpenSource,
-               !runtimeModel.isComposeRequiredModelInstalled {
-                Text("Compose requires \(RuntimeModelCatalog.composeRequiredFilename). Add it to the models folder.")
-                    .font(.caption)
-                    .foregroundStyle(.orange)
-            }
-
             if suggestionSettings.selectedEngine.supportsLocalModelManagement {
                 modelRow
             }
@@ -353,11 +345,6 @@ struct MenuBarView: View {
     }
 
     private var runtimePickerDisabled: Bool {
-        // Compose Mode pins the runtime to `tabby-depth-1`, so user-driven model selection is
-        // disabled while Compose is active to prevent half-supported configurations.
-        if suggestionSettings.selectedInteractionMode == .compose {
-            return true
-        }
         switch runtimeModel.state {
         case .starting, .loading:
             return true

--- a/Cotabby/UI/SettingsView.swift
+++ b/Cotabby/UI/SettingsView.swift
@@ -175,6 +175,24 @@ struct SettingsView: View {
                 }
             }
 
+            if suggestionSettings.selectedInteractionMode == .compose,
+               suggestionSettings.selectedEngine != .llamaOpenSource {
+                Text("Compose requires the Open Source engine. Switch to it to draft full responses.")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+
+            if suggestionSettings.selectedInteractionMode == .compose,
+               suggestionSettings.selectedEngine == .llamaOpenSource,
+               !runtimeModel.isComposeRequiredModelInstalled {
+                Text(
+                    "Compose requires \(RuntimeModelCatalog.composeRequiredFilename). "
+                    + "Add it to your models folder to enable draft generation."
+                )
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+
             Picker("Length", selection: selectedWordCountPresetBinding) {
                 ForEach(SuggestionWordCountPreset.allCases) { preset in
                     Text(preset.displayLabel)

--- a/Cotabby/UI/SettingsView.swift
+++ b/Cotabby/UI/SettingsView.swift
@@ -182,17 +182,6 @@ struct SettingsView: View {
                     .foregroundStyle(.orange)
             }
 
-            if suggestionSettings.selectedInteractionMode == .compose,
-               suggestionSettings.selectedEngine == .llamaOpenSource,
-               !runtimeModel.isComposeRequiredModelInstalled {
-                Text(
-                    "Compose requires \(RuntimeModelCatalog.composeRequiredFilename). "
-                    + "Add it to your models folder to enable draft generation."
-                )
-                    .font(.caption)
-                    .foregroundStyle(.orange)
-            }
-
             Picker("Length", selection: selectedWordCountPresetBinding) {
                 ForEach(SuggestionWordCountPreset.allCases) { preset in
                     Text(preset.displayLabel)

--- a/CotabbyTests/ComposePromptRendererTests.swift
+++ b/CotabbyTests/ComposePromptRendererTests.swift
@@ -1,0 +1,115 @@
+import XCTest
+@testable import Cotabby
+
+/// Tests `ComposePromptRenderer` — the pure mapping from a `ComposeRequest` to the prompt string
+/// fed into the local llama runtime.
+///
+/// These tests lock down which sections appear in the prompt and how the renderer handles empty
+/// or optional fields. The prompt shape is the contract the model relies on, so silent reordering
+/// here would degrade Compose Mode quality without any compile-time warning.
+final class ComposePromptRendererTests: XCTestCase {
+    func test_prompt_includesTaskInstructionsAndFinalDirective() {
+        let prompt = ComposePromptRenderer.prompt(for: composeRequest())
+
+        XCTAssertTrue(prompt.contains("This is Compose Mode, not autocomplete and not chat."))
+        XCTAssertTrue(prompt.contains("Return only the final typeable draft."))
+        // The "Write the full draft now." instruction must remain at the tail so the model is
+        // primed to produce the draft directly after the surrounding context block.
+        XCTAssertTrue(prompt.hasSuffix("Final instruction:\nWrite the full draft now."))
+    }
+
+    func test_prompt_includesApplicationAndTypedPrefix() {
+        let prompt = ComposePromptRenderer.prompt(for: composeRequest(
+            applicationName: "GitHub",
+            typedPrefix: "Thanks for the review — "
+        ))
+
+        XCTAssertTrue(prompt.contains("App:\nGitHub"))
+        XCTAssertTrue(prompt.contains("Text already typed in the focused field:\nThanks for the review — "))
+    }
+
+    func test_prompt_rendersEmptyPlaceholderWhenTypedPrefixIsBlank() {
+        let prompt = ComposePromptRenderer.prompt(for: composeRequest(typedPrefix: "   \n  "))
+
+        XCTAssertTrue(prompt.contains("Text already typed in the focused field:\n(empty)"))
+    }
+
+    func test_prompt_includesUserNameAndUserTagsWhenProvided() {
+        let prompt = ComposePromptRenderer.prompt(for: composeRequest(
+            userName: "Jacob",
+            userTags: ["engineer", "macOS"]
+        ))
+
+        XCTAssertTrue(prompt.contains("User name:\nJacob"))
+        XCTAssertTrue(prompt.contains("User profile tags:\nengineer, macOS"))
+    }
+
+    func test_prompt_omitsUserNameWhenEmptyAfterTrimming() {
+        let prompt = ComposePromptRenderer.prompt(for: composeRequest(userName: "   "))
+
+        XCTAssertFalse(prompt.contains("User name:"))
+    }
+
+    func test_prompt_omitsUserTagsWhenEmpty() {
+        let prompt = ComposePromptRenderer.prompt(for: composeRequest(userTags: []))
+
+        XCTAssertFalse(prompt.contains("User profile tags:"))
+    }
+
+    func test_prompt_includesTrailingTextOnlyWhenNotBlank() {
+        let withTrailing = ComposePromptRenderer.prompt(for: composeRequest(trailingText: "...rest of paragraph"))
+        XCTAssertTrue(withTrailing.contains("Text after the caret:\n...rest of paragraph"))
+
+        let withoutTrailing = ComposePromptRenderer.prompt(for: composeRequest(trailingText: ""))
+        XCTAssertFalse(withoutTrailing.contains("Text after the caret:"))
+    }
+
+    func test_prompt_includesClipboardAndVisualContextWhenProvided() {
+        let prompt = ComposePromptRenderer.prompt(for: composeRequest(
+            visualContextSummary: "PAGE_HEADER",
+            clipboardContext: "COPIED_LINK"
+        ))
+
+        XCTAssertTrue(prompt.contains("Clipboard context:\nCOPIED_LINK"))
+        XCTAssertTrue(prompt.contains("Visual context summary:\nPAGE_HEADER"))
+    }
+
+    func test_prompt_includesSurroundingContextEvenWhenEmpty() {
+        // The surrounding-context section is always present so the model sees consistent prompt
+        // shape across runs; empty content is rendered as "(empty)".
+        let prompt = ComposePromptRenderer.prompt(for: composeRequest(surroundingContext: " "))
+
+        XCTAssertTrue(prompt.contains("Relevant surrounding context:\n(empty)"))
+    }
+
+    private func composeRequest(
+        applicationName: String = "TestApp",
+        typedPrefix: String = "Hello",
+        trailingText: String = "",
+        surroundingContext: String = "Some surrounding context.",
+        visualContextSummary: String? = nil,
+        clipboardContext: String? = nil,
+        userName: String? = nil,
+        userTags: [String]? = nil
+    ) -> ComposeRequest {
+        ComposeRequest(
+            context: CotabbyTestFixtures.focusedInputContext(applicationName: applicationName),
+            typedPrefix: typedPrefix,
+            trailingText: trailingText,
+            surroundingContext: surroundingContext,
+            visualContextSummary: visualContextSummary,
+            clipboardContext: clipboardContext,
+            applicationName: applicationName,
+            generation: 1,
+            maxPredictionTokens: 256,
+            temperature: 0.4,
+            topK: 40,
+            topP: 0.9,
+            minP: 0.05,
+            repetitionPenalty: 1.1,
+            randomSeed: nil,
+            userName: userName,
+            userTags: userTags
+        )
+    }
+}

--- a/CotabbyTests/ComposeRequestFactoryTests.swift
+++ b/CotabbyTests/ComposeRequestFactoryTests.swift
@@ -1,0 +1,146 @@
+import XCTest
+@testable import Cotabby
+
+/// Tests `ComposeRequestFactory` — the pure builder that turns a focused-input context plus settings
+/// into a `ComposeRequest` with sane clipping and sampling defaults.
+///
+/// Compose Mode uses larger token budgets and looser sampling than autocomplete; these tests lock
+/// in those minimums so future tuning cannot accidentally make Compose behave like autocomplete.
+final class ComposeRequestFactoryTests: XCTestCase {
+    func test_buildRequest_clipsLongTypedPrefixWithEllipsis() {
+        let oversizedPrefix = String(repeating: "a", count: 5_000)
+        let context = CotabbyTestFixtures.focusedInputContext(precedingText: oversizedPrefix)
+
+        let result = ComposeRequestFactory.buildRequest(
+            context: context,
+            settings: settings(),
+            configuration: .standard,
+            surroundingContext: "",
+            clipboardContext: nil
+        )
+
+        XCTAssertLessThanOrEqual(result.request.typedPrefix.count, 4_000)
+        XCTAssertTrue(result.request.typedPrefix.hasSuffix("..."))
+    }
+
+    func test_buildRequest_clipsTrailingTextAndSurroundingContext() {
+        let trailing = String(repeating: "b", count: 2_000)
+        let surrounding = String(repeating: "c", count: 12_000)
+        let context = CotabbyTestFixtures.focusedInputContext(
+            precedingText: "Hi",
+            trailingText: trailing
+        )
+
+        let result = ComposeRequestFactory.buildRequest(
+            context: context,
+            settings: settings(),
+            configuration: .standard,
+            surroundingContext: surrounding,
+            clipboardContext: nil
+        )
+
+        XCTAssertLessThanOrEqual(result.request.trailingText.count, 1_000)
+        XCTAssertLessThanOrEqual(result.request.surroundingContext.count, 8_000)
+    }
+
+    func test_buildRequest_omitsClipboardWhenDisabledEvenIfProvided() {
+        let result = ComposeRequestFactory.buildRequest(
+            context: CotabbyTestFixtures.focusedInputContext(),
+            settings: settings(isClipboardContextEnabled: false),
+            configuration: .standard,
+            surroundingContext: "Context.",
+            clipboardContext: "Should be ignored."
+        )
+
+        XCTAssertNil(result.request.clipboardContext)
+    }
+
+    func test_buildRequest_includesClipboardWhenEnabled() {
+        let result = ComposeRequestFactory.buildRequest(
+            context: CotabbyTestFixtures.focusedInputContext(),
+            settings: settings(isClipboardContextEnabled: true),
+            configuration: .standard,
+            surroundingContext: "Context.",
+            clipboardContext: "https://example.com"
+        )
+
+        XCTAssertEqual(result.request.clipboardContext, "https://example.com")
+    }
+
+    func test_buildRequest_appliesComposeSamplingMinimumsAboveAutocomplete() {
+        // Autocomplete uses temperature 0.1 and 8 tokens. Compose should bump both up because a
+        // multi-sentence draft needs more headroom than an inline tail.
+        let result = ComposeRequestFactory.buildRequest(
+            context: CotabbyTestFixtures.focusedInputContext(),
+            settings: settings(),
+            configuration: .standard,
+            surroundingContext: "",
+            clipboardContext: nil
+        )
+
+        XCTAssertGreaterThanOrEqual(result.request.maxPredictionTokens, 256)
+        XCTAssertGreaterThanOrEqual(result.request.temperature, 0.35)
+        XCTAssertGreaterThanOrEqual(result.request.topK, 40)
+        XCTAssertGreaterThanOrEqual(result.request.topP, 0.9)
+        XCTAssertGreaterThanOrEqual(result.request.repetitionPenalty, 1.08)
+    }
+
+    func test_buildRequest_carriesUserNameAndUserTagsThroughToTheRequest() {
+        let snapshot = SuggestionSettingsSnapshot(
+            isGloballyEnabled: true,
+            disabledAppBundleIdentifiers: [],
+            selectedInteractionMode: .compose,
+            selectedEngine: .llamaOpenSource,
+            selectedWordCountPreset: .sevenToTwelve,
+            isClipboardContextEnabled: true,
+            userName: "Jacob",
+            userTags: ["engineer", "macOS"],
+            debounceMilliseconds: 50,
+            focusPollIntervalMilliseconds: 50,
+            isMultiLineEnabled: false
+        )
+
+        let result = ComposeRequestFactory.buildRequest(
+            context: CotabbyTestFixtures.focusedInputContext(),
+            settings: snapshot,
+            configuration: .standard,
+            surroundingContext: "Context",
+            clipboardContext: nil
+        )
+
+        XCTAssertEqual(result.request.userName, "Jacob")
+        XCTAssertEqual(result.request.userTags, ["engineer", "macOS"])
+    }
+
+    func test_buildRequest_includesPromptPreviewMatchingRenderer() {
+        let result = ComposeRequestFactory.buildRequest(
+            context: CotabbyTestFixtures.focusedInputContext(applicationName: "GitHub"),
+            settings: settings(),
+            configuration: .standard,
+            surroundingContext: "Surrounding context.",
+            clipboardContext: nil
+        )
+
+        XCTAssertEqual(result.promptPreview, ComposePromptRenderer.prompt(for: result.request))
+    }
+
+    private func settings(
+        isClipboardContextEnabled: Bool = true,
+        userName: String = "",
+        userTags: [String] = []
+    ) -> SuggestionSettingsSnapshot {
+        SuggestionSettingsSnapshot(
+            isGloballyEnabled: true,
+            disabledAppBundleIdentifiers: [],
+            selectedInteractionMode: .compose,
+            selectedEngine: .llamaOpenSource,
+            selectedWordCountPreset: .sevenToTwelve,
+            isClipboardContextEnabled: isClipboardContextEnabled,
+            userName: userName,
+            userTags: userTags,
+            debounceMilliseconds: 50,
+            focusPollIntervalMilliseconds: 50,
+            isMultiLineEnabled: false
+        )
+    }
+}

--- a/CotabbyTests/ComposeTextNormalizerTests.swift
+++ b/CotabbyTests/ComposeTextNormalizerTests.swift
@@ -1,0 +1,143 @@
+import XCTest
+@testable import Cotabby
+
+/// Tests `ComposeTextNormalizer` — the last-mile cleanup that turns raw llama output into the text
+/// Cotabby actually types into the focused field.
+///
+/// These tests exist because the existing `SuggestionTextNormalizer` aggressively truncates to a
+/// short inline tail; Compose has a different contract (preserve paragraphs, strip wrappers).
+final class ComposeTextNormalizerTests: XCTestCase {
+    func test_normalize_stripsLeadingPromptEcho() {
+        let prompt = "PROMPT_SECTION\nFinal instruction:\nWrite the full draft now."
+        let raw = prompt + "\nHello team,\n\nThanks for the review."
+
+        let normalized = ComposeTextNormalizer.normalize(raw, prompt: prompt, request: request())
+
+        XCTAssertEqual(normalized, "Hello team,\n\nThanks for the review.")
+    }
+
+    func test_normalize_stripsChatTemplateSpecialTokens() {
+        let normalized = ComposeTextNormalizer.normalize(
+            "<|im_start|>Hello.<|im_end|>",
+            prompt: "",
+            request: request()
+        )
+
+        XCTAssertEqual(normalized, "Hello.")
+    }
+
+    func test_normalize_stripsMarkdownFences() {
+        let raw = """
+        ```
+        Hello team,
+
+        Thanks for the review.
+        ```
+        """
+
+        let normalized = ComposeTextNormalizer.normalize(raw, prompt: "", request: request())
+
+        XCTAssertEqual(normalized, "Hello team,\n\nThanks for the review.")
+    }
+
+    func test_normalize_stripsLeadingLabelsCaseInsensitively() {
+        let cases: [(String, String)] = [
+            ("Final answer: Hello.", "Hello."),
+            ("Draft: A short draft.", "A short draft."),
+            ("comment: lowercase label", "lowercase label"),
+            ("Reply: With a label.", "With a label.")
+        ]
+
+        for (raw, expected) in cases {
+            let normalized = ComposeTextNormalizer.normalize(raw, prompt: "", request: request())
+            XCTAssertEqual(normalized, expected, "expected \(expected) for \(raw)")
+        }
+    }
+
+    func test_normalize_stripsWrappingQuotesOnly() {
+        let doubled = ComposeTextNormalizer.normalize(
+            "\"Hello team.\"",
+            prompt: "",
+            request: request()
+        )
+        XCTAssertEqual(doubled, "Hello team.")
+
+        // Inline quotes in the middle of a draft must not be stripped — they are content.
+        let preserved = ComposeTextNormalizer.normalize(
+            "Hello \"team\" again.",
+            prompt: "",
+            request: request()
+        )
+        XCTAssertEqual(preserved, "Hello \"team\" again.")
+    }
+
+    func test_normalize_stripsTypedPrefixEchoWhenPresent() {
+        let typedPrefix = "Thanks for the review — "
+        let raw = "Thanks for the review — this looks good to ship."
+
+        let normalized = ComposeTextNormalizer.normalize(
+            raw,
+            prompt: "",
+            request: request(typedPrefix: typedPrefix)
+        )
+
+        XCTAssertEqual(normalized, "this looks good to ship.")
+    }
+
+    func test_normalize_preservesParagraphBoundariesAndCollapsesRunsOfBlankLines() {
+        let raw = """
+        Paragraph one.
+
+
+
+        Paragraph two.
+
+
+        Paragraph three.
+        """
+
+        let normalized = ComposeTextNormalizer.normalize(raw, prompt: "", request: request())
+
+        XCTAssertEqual(normalized, "Paragraph one.\n\nParagraph two.\n\nParagraph three.")
+    }
+
+    func test_normalize_trimsLeadingAndTrailingNewlinesWithoutTouchingContent() {
+        let normalized = ComposeTextNormalizer.normalize(
+            "\n\n  Paragraph one.\n\nParagraph two.\n\n",
+            prompt: "",
+            request: request()
+        )
+
+        XCTAssertEqual(normalized, "Paragraph one.\n\nParagraph two.")
+    }
+
+    func test_normalize_isNoOpWhenPromptEchoIsAbsent() {
+        let raw = "Just a clean draft."
+
+        let normalized = ComposeTextNormalizer.normalize(raw, prompt: "DIFFERENT_PROMPT", request: request())
+
+        XCTAssertEqual(normalized, "Just a clean draft.")
+    }
+
+    private func request(typedPrefix: String = "") -> ComposeRequest {
+        ComposeRequest(
+            context: CotabbyTestFixtures.focusedInputContext(),
+            typedPrefix: typedPrefix,
+            trailingText: "",
+            surroundingContext: "",
+            visualContextSummary: nil,
+            clipboardContext: nil,
+            applicationName: "TestApp",
+            generation: 1,
+            maxPredictionTokens: 256,
+            temperature: 0.4,
+            topK: 40,
+            topP: 0.9,
+            minP: 0.05,
+            repetitionPenalty: 1.1,
+            randomSeed: nil,
+            userName: nil,
+            userTags: nil
+        )
+    }
+}

--- a/CotabbyTests/SuggestionCoordinatorComposeTests.swift
+++ b/CotabbyTests/SuggestionCoordinatorComposeTests.swift
@@ -6,11 +6,9 @@ import XCTest
 
 /// Tests `SuggestionCoordinator+Compose` end to end with fakes for every collaborator.
 ///
-/// Most coordinator tests in the autocomplete path live inside `SuggestionInteractionState`
-/// helpers; Compose's orchestration is new enough that those state helpers cannot prove the
-/// behavior reviewers actually care about: first Tab generates, second Tab types, focus changes
-/// cancel mid-flight. The fakes below are all kept in this file so the contract under test stays
-/// readable as one unit.
+/// Compose Mode is single-Tab streaming: the first Tab opens a stream and each piece is typed
+/// straight into the focused field via `SuggestionInserter.insert`. Esc/focus change/typing
+/// cancels the stream; already-typed pieces stay. These tests lock in that contract.
 @MainActor
 final class SuggestionCoordinatorComposeTests: XCTestCase {
     private static var retainedCoordinators: [SuggestionCoordinator] = []
@@ -20,30 +18,30 @@ final class SuggestionCoordinatorComposeTests: XCTestCase {
         try await super.tearDown()
     }
 
-    // MARK: - First Tab: generation
+    // MARK: - First Tab: streaming starts
 
-    func test_firstTab_inComposeMode_callsGenerateComposeAndShowsPreview() async {
-        let generateExpectation = expectation(description: "generateCompose called")
-        let showPreviewExpectation = expectation(description: "showComposePreview called")
+    func test_firstTab_inComposeMode_streamsPiecesIntoTheField() async {
+        let pieces = ["Hello", " team,", "\n", "Thanks."]
+        let finishedExpectation = expectation(description: "stream finished")
         let env = makeEnvironment(
             mode: .compose,
-            engineBehavior: .success(composeResult(text: "Hello team.")),
-            onGenerateCalled: { generateExpectation.fulfill() },
-            onShowComposePreview: { showPreviewExpectation.fulfill() }
+            engineBehavior: .success(pieces: pieces),
+            onStreamFinished: { finishedExpectation.fulfill() }
         )
 
         _ = env.coordinator.handleInputEvent(CotabbyTestFixtures.inputEvent(kind: .acceptance))
-        await fulfillment(of: [generateExpectation, showPreviewExpectation], timeout: 1.0)
+        await fulfillment(of: [finishedExpectation], timeout: 1.0)
+        await Task.yield()
 
-        XCTAssertEqual(env.engine.composeCallCount, 1)
-        XCTAssertEqual(env.overlayController.composePreviewText, "Hello team.")
-        XCTAssertNotNil(env.coordinator.interactionState.activeComposeSession)
+        XCTAssertEqual(env.engine.composeStreamCallCount, 1)
+        XCTAssertEqual(env.inserter.insertedPieces, pieces)
+        XCTAssertNil(env.coordinator.interactionState.activeComposeSession)
     }
 
     func test_firstTab_inComposeMode_returnsTrueToConsumeTab() {
         let env = makeEnvironment(
             mode: .compose,
-            engineBehavior: .success(composeResult(text: "draft"))
+            engineBehavior: .success(pieces: ["only"])
         )
 
         let consumed = env.coordinator.handleInputEvent(CotabbyTestFixtures.inputEvent(kind: .acceptance))
@@ -51,133 +49,139 @@ final class SuggestionCoordinatorComposeTests: XCTestCase {
         XCTAssertTrue(consumed)
     }
 
-    func test_firstTab_inAutocompleteMode_doesNotInvokeComposePath() async {
+    func test_firstTab_inAutocompleteMode_doesNotInvokeComposeStream() async {
         let env = makeEnvironment(
             mode: .autocomplete,
-            engineBehavior: .success(composeResult(text: "should not run"))
+            engineBehavior: .success(pieces: ["should not run"])
         )
 
         _ = env.coordinator.handleInputEvent(CotabbyTestFixtures.inputEvent(kind: .acceptance))
-        // Yield to let any spurious Task progress.
         await Task.yield()
         await Task.yield()
 
-        XCTAssertEqual(env.engine.composeCallCount, 0)
-        XCTAssertNil(env.coordinator.interactionState.activeComposeSession)
+        XCTAssertEqual(env.engine.composeStreamCallCount, 0)
+        XCTAssertEqual(env.inserter.insertedPieces, [])
     }
 
-    // MARK: - Second Tab: acceptance
+    // MARK: - Subsequent Tabs while streaming
 
-    func test_secondTab_withActiveDraft_callsTypeDraftAndClearsSession() async {
-        let generateExpectation = expectation(description: "generateCompose called")
-        let typeExpectation = expectation(description: "typeDraft called")
+    func test_secondTab_whileStreaming_isAbsorbedWithoutRestartingTheStream() async {
         let env = makeEnvironment(
             mode: .compose,
-            engineBehavior: .success(composeResult(text: "Typed draft.")),
-            onGenerateCalled: { generateExpectation.fulfill() },
-            onTypeDraftCalled: { typeExpectation.fulfill() }
+            engineBehavior: .blocked(initialPieces: ["partial"])
         )
 
-        // First Tab — generate.
         _ = env.coordinator.handleInputEvent(CotabbyTestFixtures.inputEvent(kind: .acceptance))
-        await fulfillment(of: [generateExpectation], timeout: 1.0)
+        for _ in 0..<10 { await Task.yield() }
 
-        // Second Tab — accept.
-        _ = env.coordinator.handleInputEvent(CotabbyTestFixtures.inputEvent(kind: .acceptance))
-        await fulfillment(of: [typeExpectation], timeout: 1.0)
+        let consumedSecondTab = env.coordinator.handleInputEvent(
+            CotabbyTestFixtures.inputEvent(kind: .acceptance)
+        )
 
-        XCTAssertEqual(env.inserter.typedDrafts, ["Typed draft."])
-        XCTAssertNil(env.coordinator.interactionState.activeComposeSession)
+        XCTAssertTrue(consumedSecondTab, "second Tab during streaming should be absorbed, not passed through")
+        XCTAssertEqual(env.engine.composeStreamCallCount, 1, "second Tab must not start a second stream")
     }
 
     // MARK: - Cancellation
 
-    func test_escape_inComposeMode_clearsActiveSession() async {
-        let env = await makeEnvironmentWithReadyDraft(draftText: "Hello.")
+    func test_escape_duringStreaming_cancelsAndKeepsTypedText() async {
+        let env = makeEnvironment(
+            mode: .compose,
+            engineBehavior: .blocked(initialPieces: ["Hel", "lo"])
+        )
+
+        _ = env.coordinator.handleInputEvent(CotabbyTestFixtures.inputEvent(kind: .acceptance))
+        for _ in 0..<15 { await Task.yield() }
 
         _ = env.coordinator.handleInputEvent(CotabbyTestFixtures.inputEvent(kind: .dismissal))
+        for _ in 0..<10 { await Task.yield() }
 
+        XCTAssertEqual(env.inserter.insertedPieces, ["Hel", "lo"], "already-typed pieces stay in the field")
         XCTAssertNil(env.coordinator.interactionState.activeComposeSession)
-        XCTAssertEqual(env.inserter.typedDrafts, [])
     }
 
-    func test_textMutationDuringPreview_clearsActiveSession() async {
-        let env = await makeEnvironmentWithReadyDraft(draftText: "Hello.")
+    func test_textMutationDuringStreaming_cancelsTheStream() async {
+        let env = makeEnvironment(
+            mode: .compose,
+            engineBehavior: .blocked(initialPieces: ["streamed"])
+        )
+
+        _ = env.coordinator.handleInputEvent(CotabbyTestFixtures.inputEvent(kind: .acceptance))
+        for _ in 0..<15 { await Task.yield() }
 
         _ = env.coordinator.handleInputEvent(
             CotabbyTestFixtures.inputEvent(kind: .textMutation, characters: "x")
         )
+        for _ in 0..<10 { await Task.yield() }
 
         XCTAssertNil(env.coordinator.interactionState.activeComposeSession)
     }
 
-    func test_navigationDuringPreview_clearsActiveSession() async {
-        let env = await makeEnvironmentWithReadyDraft(draftText: "Hello.")
+    func test_navigationDuringStreaming_cancelsTheStream() async {
+        let env = makeEnvironment(
+            mode: .compose,
+            engineBehavior: .blocked(initialPieces: ["typed"])
+        )
+
+        _ = env.coordinator.handleInputEvent(CotabbyTestFixtures.inputEvent(kind: .acceptance))
+        for _ in 0..<15 { await Task.yield() }
 
         _ = env.coordinator.handleInputEvent(CotabbyTestFixtures.inputEvent(kind: .navigation))
+        for _ in 0..<10 { await Task.yield() }
 
         XCTAssertNil(env.coordinator.interactionState.activeComposeSession)
     }
 
-    func test_focusChange_duringPreview_clearsActiveSession() async {
-        let env = await makeEnvironmentWithReadyDraft(draftText: "Hello.")
+    func test_focusChangeDuringStreaming_cancelsTheStream() async {
+        let env = makeEnvironment(
+            mode: .compose,
+            engineBehavior: .blocked(initialPieces: ["before"])
+        )
+
+        _ = env.coordinator.handleInputEvent(CotabbyTestFixtures.inputEvent(kind: .acceptance))
+        for _ in 0..<15 { await Task.yield() }
 
         env.focusModel.publish(snapshot: focusSnapshot(processIdentifier: 999, elementIdentifier: "different"))
-        await Task.yield()
+        for _ in 0..<10 { await Task.yield() }
 
         XCTAssertNil(env.coordinator.interactionState.activeComposeSession)
     }
 
-    func test_modeChangeToAutocomplete_clearsActiveSession() async {
-        let env = await makeEnvironmentWithReadyDraft(draftText: "Hello.")
+    func test_modeChangeToAutocomplete_duringStreaming_cancelsTheStream() async {
+        let env = makeEnvironment(
+            mode: .compose,
+            engineBehavior: .blocked(initialPieces: ["before"])
+        )
+
+        _ = env.coordinator.handleInputEvent(CotabbyTestFixtures.inputEvent(kind: .acceptance))
+        for _ in 0..<15 { await Task.yield() }
 
         env.settings.publish(snapshot: snapshot(mode: .autocomplete))
-        await Task.yield()
+        for _ in 0..<10 { await Task.yield() }
 
         XCTAssertNil(env.coordinator.interactionState.activeComposeSession)
     }
 
     // MARK: - Failure paths
 
-    func test_emptyDraft_returnsToIdleAndHidesOverlay() async {
-        let generateExpectation = expectation(description: "generateCompose called")
+    func test_engineFailure_surfacesFailedStateAndClearsSession() async {
+        let finishedExpectation = expectation(description: "stream finished")
         let env = makeEnvironment(
             mode: .compose,
-            engineBehavior: .success(composeResult(text: "   \n  ")),
-            onGenerateCalled: { generateExpectation.fulfill() }
+            engineBehavior: .failure(SuggestionClientError.unavailable("No local model loaded.")),
+            onStreamFinished: { finishedExpectation.fulfill() }
         )
 
         _ = env.coordinator.handleInputEvent(CotabbyTestFixtures.inputEvent(kind: .acceptance))
-        await fulfillment(of: [generateExpectation], timeout: 1.0)
-        // Empty-draft handling is fully synchronous after `generateCompose` resolves; yield once
-        // so the awaiting `await applyComposeResult` runs.
-        await Task.yield()
-
-        XCTAssertNil(env.coordinator.interactionState.activeComposeSession)
-        if case .idle = env.coordinator.state {
-            // expected
-        } else {
-            XCTFail("Expected idle state after empty compose result, got \(env.coordinator.state)")
-        }
-    }
-
-    func test_engineFailure_surfacesFailedState() async {
-        let generateExpectation = expectation(description: "generateCompose called")
-        let env = makeEnvironment(
-            mode: .compose,
-            engineBehavior: .failure(SuggestionClientError.unavailable("Compose Mode requires tabby-depth-1.")),
-            onGenerateCalled: { generateExpectation.fulfill() }
-        )
-
-        _ = env.coordinator.handleInputEvent(CotabbyTestFixtures.inputEvent(kind: .acceptance))
-        await fulfillment(of: [generateExpectation], timeout: 1.0)
+        await fulfillment(of: [finishedExpectation], timeout: 1.0)
         await Task.yield()
 
         if case .failed(let message) = env.coordinator.state {
-            XCTAssertTrue(message.contains("tabby-depth-1"))
+            XCTAssertTrue(message.contains("local model"))
         } else {
             XCTFail("Expected failed state after engine failure, got \(env.coordinator.state)")
         }
+        XCTAssertNil(env.coordinator.interactionState.activeComposeSession)
     }
 
     // MARK: - Test environment
@@ -199,19 +203,15 @@ final class SuggestionCoordinatorComposeTests: XCTestCase {
     private func makeEnvironment(
         mode: SuggestionInteractionMode,
         engineBehavior: FakeSuggestionEngine.Behavior,
-        onGenerateCalled: (() -> Void)? = nil,
-        onShowComposePreview: (() -> Void)? = nil,
-        onTypeDraftCalled: (() -> Void)? = nil
+        onStreamFinished: (() -> Void)? = nil
     ) -> ComposeTestEnvironment {
         let permissions = FakeSuggestionPermissions()
         let focusModel = FakeFocusModel(initialSnapshot: focusSnapshot())
         let inputMonitor = FakeInputMonitor()
         let overlayController = FakeOverlayController()
-        overlayController.onShowComposePreview = onShowComposePreview
         let inserter = FakeSuggestionInserter()
-        inserter.onTypeDraftCalled = onTypeDraftCalled
         let engine = FakeSuggestionEngine(behavior: engineBehavior)
-        engine.onComposeCalled = onGenerateCalled
+        engine.onStreamFinished = onStreamFinished
         let settings = FakeSuggestionSettings(initialSnapshot: snapshot(mode: mode))
         let clipboard = FakeClipboardContextProvider()
         let visualContext = FakeVisualContextCoordinator()
@@ -252,21 +252,6 @@ final class SuggestionCoordinatorComposeTests: XCTestCase {
         )
     }
 
-    /// Spins up an environment, drives a first Tab through it, and waits for the compose preview
-    /// to be ready. Cancellation tests use this so they only have to assert post-conditions.
-    private func makeEnvironmentWithReadyDraft(draftText: String) async -> ComposeTestEnvironment {
-        let showPreviewExpectation = expectation(description: "showComposePreview called")
-        let env = makeEnvironment(
-            mode: .compose,
-            engineBehavior: .success(composeResult(text: draftText)),
-            onShowComposePreview: { showPreviewExpectation.fulfill() }
-        )
-
-        _ = env.coordinator.handleInputEvent(CotabbyTestFixtures.inputEvent(kind: .acceptance))
-        await fulfillment(of: [showPreviewExpectation], timeout: 1.0)
-        return env
-    }
-
     private func snapshot(mode: SuggestionInteractionMode) -> SuggestionSettingsSnapshot {
         SuggestionSettingsSnapshot(
             isGloballyEnabled: true,
@@ -298,10 +283,6 @@ final class SuggestionCoordinatorComposeTests: XCTestCase {
             context: inputSnapshot,
             inspection: nil
         )
-    }
-
-    private func composeResult(text: String) -> ComposeResult {
-        ComposeResult(generation: 1, rawText: text, text: text, latency: 0.05)
     }
 
     private func isolatedUserDefaults() -> UserDefaults {
@@ -363,7 +344,6 @@ private final class FakeInputMonitor: SuggestionInputMonitoring {
 private final class FakeOverlayController: SuggestionOverlayControlling {
     var state: OverlayState = .hidden(reason: "test idle")
     var onStateChange: ((OverlayState) -> Void)?
-    var onShowComposePreview: (() -> Void)?
     private(set) var composePreviewText: String?
     private(set) var hideReasons: [String] = []
 
@@ -376,7 +356,6 @@ private final class FakeOverlayController: SuggestionOverlayControlling {
         composePreviewText = text
         state = .composePreview(text: text, geometry: geometry)
         onStateChange?(state)
-        onShowComposePreview?()
     }
 
     func hide(reason: String) {
@@ -389,28 +368,33 @@ private final class FakeOverlayController: SuggestionOverlayControlling {
 @MainActor
 private final class FakeSuggestionInserter: SuggestionInserting {
     var lastErrorMessage: String?
-    var onTypeDraftCalled: (() -> Void)?
-    private(set) var typedDrafts: [String] = []
+    private(set) var insertedPieces: [String] = []
 
-    func insert(_ suggestion: String) -> Bool { true }
+    func insert(_ suggestion: String) -> Bool {
+        insertedPieces.append(suggestion)
+        return true
+    }
 
     func typeDraft(_ draft: String, shouldContinue: @escaping @MainActor () -> Bool) async -> Bool {
-        typedDrafts.append(draft)
-        onTypeDraftCalled?()
-        return true
+        true
     }
 }
 
 @MainActor
 private final class FakeSuggestionEngine: SuggestionGenerating {
     enum Behavior {
-        case success(ComposeResult)
+        /// Yields all pieces then finishes immediately.
+        case success(pieces: [String])
+        /// Yields `initialPieces`, then parks the stream until the underlying task is cancelled.
+        /// Lets tests trigger cancellation events (Esc, focus change, etc.) and verify cleanup.
+        case blocked(initialPieces: [String])
+        /// Throws immediately. Tests use `onStreamFinished` to wait for the failure to propagate.
         case failure(Error)
     }
 
     private let behavior: Behavior
-    var onComposeCalled: (() -> Void)?
-    private(set) var composeCallCount = 0
+    var onStreamFinished: (() -> Void)?
+    private(set) var composeStreamCallCount = 0
 
     init(behavior: Behavior) {
         self.behavior = behavior
@@ -421,18 +405,45 @@ private final class FakeSuggestionEngine: SuggestionGenerating {
     }
 
     func generateCompose(for request: ComposeRequest) async throws -> ComposeResult {
-        composeCallCount += 1
-        onComposeCalled?()
-        switch behavior {
-        case .success(let result):
-            return ComposeResult(
-                generation: request.generation,
-                rawText: result.rawText,
-                text: result.text,
-                latency: result.latency
-            )
-        case .failure(let error):
-            throw error
+        throw SuggestionClientError.unavailable("Compose Mode streams here; one-shot path unused.")
+    }
+
+    func generateComposeStreaming(for request: ComposeRequest) async throws -> AsyncThrowingStream<String, Error> {
+        composeStreamCallCount += 1
+        let behavior = self.behavior
+        let onStreamFinished = self.onStreamFinished
+
+        return AsyncThrowingStream { continuation in
+            let task = Task.detached {
+                switch behavior {
+                case .success(let pieces):
+                    for piece in pieces {
+                        if Task.isCancelled { break }
+                        continuation.yield(piece)
+                    }
+                    continuation.finish()
+                    onStreamFinished?()
+
+                case .blocked(let initialPieces):
+                    for piece in initialPieces {
+                        if Task.isCancelled { break }
+                        continuation.yield(piece)
+                    }
+                    // Park until the underlying detached task is cancelled by the consumer's
+                    // termination handler. Sleeping in small slices keeps `Task.isCancelled`
+                    // responsive without burning CPU.
+                    while !Task.isCancelled {
+                        try? await Task.sleep(nanoseconds: 10_000_000)
+                    }
+                    continuation.finish()
+                    onStreamFinished?()
+
+                case .failure(let error):
+                    continuation.finish(throwing: error)
+                    onStreamFinished?()
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
         }
     }
 

--- a/CotabbyTests/SuggestionCoordinatorComposeTests.swift
+++ b/CotabbyTests/SuggestionCoordinatorComposeTests.swift
@@ -1,0 +1,502 @@
+import Combine
+import CoreGraphics
+import Foundation
+import XCTest
+@testable import Cotabby
+
+/// Tests `SuggestionCoordinator+Compose` end to end with fakes for every collaborator.
+///
+/// Most coordinator tests in the autocomplete path live inside `SuggestionInteractionState`
+/// helpers; Compose's orchestration is new enough that those state helpers cannot prove the
+/// behavior reviewers actually care about: first Tab generates, second Tab types, focus changes
+/// cancel mid-flight. The fakes below are all kept in this file so the contract under test stays
+/// readable as one unit.
+@MainActor
+final class SuggestionCoordinatorComposeTests: XCTestCase {
+    private static var retainedCoordinators: [SuggestionCoordinator] = []
+
+    override func tearDown() async throws {
+        Self.retainedCoordinators.removeAll()
+        try await super.tearDown()
+    }
+
+    // MARK: - First Tab: generation
+
+    func test_firstTab_inComposeMode_callsGenerateComposeAndShowsPreview() async {
+        let generateExpectation = expectation(description: "generateCompose called")
+        let showPreviewExpectation = expectation(description: "showComposePreview called")
+        let env = makeEnvironment(
+            mode: .compose,
+            engineBehavior: .success(composeResult(text: "Hello team.")),
+            onGenerateCalled: { generateExpectation.fulfill() },
+            onShowComposePreview: { showPreviewExpectation.fulfill() }
+        )
+
+        _ = env.coordinator.handleInputEvent(CotabbyTestFixtures.inputEvent(kind: .acceptance))
+        await fulfillment(of: [generateExpectation, showPreviewExpectation], timeout: 1.0)
+
+        XCTAssertEqual(env.engine.composeCallCount, 1)
+        XCTAssertEqual(env.overlayController.composePreviewText, "Hello team.")
+        XCTAssertNotNil(env.coordinator.interactionState.activeComposeSession)
+    }
+
+    func test_firstTab_inComposeMode_returnsTrueToConsumeTab() {
+        let env = makeEnvironment(
+            mode: .compose,
+            engineBehavior: .success(composeResult(text: "draft"))
+        )
+
+        let consumed = env.coordinator.handleInputEvent(CotabbyTestFixtures.inputEvent(kind: .acceptance))
+
+        XCTAssertTrue(consumed)
+    }
+
+    func test_firstTab_inAutocompleteMode_doesNotInvokeComposePath() async {
+        let env = makeEnvironment(
+            mode: .autocomplete,
+            engineBehavior: .success(composeResult(text: "should not run"))
+        )
+
+        _ = env.coordinator.handleInputEvent(CotabbyTestFixtures.inputEvent(kind: .acceptance))
+        // Yield to let any spurious Task progress.
+        await Task.yield()
+        await Task.yield()
+
+        XCTAssertEqual(env.engine.composeCallCount, 0)
+        XCTAssertNil(env.coordinator.interactionState.activeComposeSession)
+    }
+
+    // MARK: - Second Tab: acceptance
+
+    func test_secondTab_withActiveDraft_callsTypeDraftAndClearsSession() async {
+        let generateExpectation = expectation(description: "generateCompose called")
+        let typeExpectation = expectation(description: "typeDraft called")
+        let env = makeEnvironment(
+            mode: .compose,
+            engineBehavior: .success(composeResult(text: "Typed draft.")),
+            onGenerateCalled: { generateExpectation.fulfill() },
+            onTypeDraftCalled: { typeExpectation.fulfill() }
+        )
+
+        // First Tab — generate.
+        _ = env.coordinator.handleInputEvent(CotabbyTestFixtures.inputEvent(kind: .acceptance))
+        await fulfillment(of: [generateExpectation], timeout: 1.0)
+
+        // Second Tab — accept.
+        _ = env.coordinator.handleInputEvent(CotabbyTestFixtures.inputEvent(kind: .acceptance))
+        await fulfillment(of: [typeExpectation], timeout: 1.0)
+
+        XCTAssertEqual(env.inserter.typedDrafts, ["Typed draft."])
+        XCTAssertNil(env.coordinator.interactionState.activeComposeSession)
+    }
+
+    // MARK: - Cancellation
+
+    func test_escape_inComposeMode_clearsActiveSession() async {
+        let env = await makeEnvironmentWithReadyDraft(draftText: "Hello.")
+
+        _ = env.coordinator.handleInputEvent(CotabbyTestFixtures.inputEvent(kind: .dismissal))
+
+        XCTAssertNil(env.coordinator.interactionState.activeComposeSession)
+        XCTAssertEqual(env.inserter.typedDrafts, [])
+    }
+
+    func test_textMutationDuringPreview_clearsActiveSession() async {
+        let env = await makeEnvironmentWithReadyDraft(draftText: "Hello.")
+
+        _ = env.coordinator.handleInputEvent(
+            CotabbyTestFixtures.inputEvent(kind: .textMutation, characters: "x")
+        )
+
+        XCTAssertNil(env.coordinator.interactionState.activeComposeSession)
+    }
+
+    func test_navigationDuringPreview_clearsActiveSession() async {
+        let env = await makeEnvironmentWithReadyDraft(draftText: "Hello.")
+
+        _ = env.coordinator.handleInputEvent(CotabbyTestFixtures.inputEvent(kind: .navigation))
+
+        XCTAssertNil(env.coordinator.interactionState.activeComposeSession)
+    }
+
+    func test_focusChange_duringPreview_clearsActiveSession() async {
+        let env = await makeEnvironmentWithReadyDraft(draftText: "Hello.")
+
+        env.focusModel.publish(snapshot: focusSnapshot(processIdentifier: 999, elementIdentifier: "different"))
+        await Task.yield()
+
+        XCTAssertNil(env.coordinator.interactionState.activeComposeSession)
+    }
+
+    func test_modeChangeToAutocomplete_clearsActiveSession() async {
+        let env = await makeEnvironmentWithReadyDraft(draftText: "Hello.")
+
+        env.settings.publish(snapshot: snapshot(mode: .autocomplete))
+        await Task.yield()
+
+        XCTAssertNil(env.coordinator.interactionState.activeComposeSession)
+    }
+
+    // MARK: - Failure paths
+
+    func test_emptyDraft_returnsToIdleAndHidesOverlay() async {
+        let generateExpectation = expectation(description: "generateCompose called")
+        let env = makeEnvironment(
+            mode: .compose,
+            engineBehavior: .success(composeResult(text: "   \n  ")),
+            onGenerateCalled: { generateExpectation.fulfill() }
+        )
+
+        _ = env.coordinator.handleInputEvent(CotabbyTestFixtures.inputEvent(kind: .acceptance))
+        await fulfillment(of: [generateExpectation], timeout: 1.0)
+        // Empty-draft handling is fully synchronous after `generateCompose` resolves; yield once
+        // so the awaiting `await applyComposeResult` runs.
+        await Task.yield()
+
+        XCTAssertNil(env.coordinator.interactionState.activeComposeSession)
+        if case .idle = env.coordinator.state {
+            // expected
+        } else {
+            XCTFail("Expected idle state after empty compose result, got \(env.coordinator.state)")
+        }
+    }
+
+    func test_engineFailure_surfacesFailedState() async {
+        let generateExpectation = expectation(description: "generateCompose called")
+        let env = makeEnvironment(
+            mode: .compose,
+            engineBehavior: .failure(SuggestionClientError.unavailable("Compose Mode requires tabby-depth-1.")),
+            onGenerateCalled: { generateExpectation.fulfill() }
+        )
+
+        _ = env.coordinator.handleInputEvent(CotabbyTestFixtures.inputEvent(kind: .acceptance))
+        await fulfillment(of: [generateExpectation], timeout: 1.0)
+        await Task.yield()
+
+        if case .failed(let message) = env.coordinator.state {
+            XCTAssertTrue(message.contains("tabby-depth-1"))
+        } else {
+            XCTFail("Expected failed state after engine failure, got \(env.coordinator.state)")
+        }
+    }
+
+    // MARK: - Test environment
+
+    private struct ComposeTestEnvironment {
+        let coordinator: SuggestionCoordinator
+        let permissions: FakeSuggestionPermissions
+        let focusModel: FakeFocusModel
+        let inputMonitor: FakeInputMonitor
+        let overlayController: FakeOverlayController
+        let inserter: FakeSuggestionInserter
+        let engine: FakeSuggestionEngine
+        let settings: FakeSuggestionSettings
+        let clipboard: FakeClipboardContextProvider
+        let visualContext: FakeVisualContextCoordinator
+        let composeCollector: FakeComposeContextCollector
+    }
+
+    private func makeEnvironment(
+        mode: SuggestionInteractionMode,
+        engineBehavior: FakeSuggestionEngine.Behavior,
+        onGenerateCalled: (() -> Void)? = nil,
+        onShowComposePreview: (() -> Void)? = nil,
+        onTypeDraftCalled: (() -> Void)? = nil
+    ) -> ComposeTestEnvironment {
+        let permissions = FakeSuggestionPermissions()
+        let focusModel = FakeFocusModel(initialSnapshot: focusSnapshot())
+        let inputMonitor = FakeInputMonitor()
+        let overlayController = FakeOverlayController()
+        overlayController.onShowComposePreview = onShowComposePreview
+        let inserter = FakeSuggestionInserter()
+        inserter.onTypeDraftCalled = onTypeDraftCalled
+        let engine = FakeSuggestionEngine(behavior: engineBehavior)
+        engine.onComposeCalled = onGenerateCalled
+        let settings = FakeSuggestionSettings(initialSnapshot: snapshot(mode: mode))
+        let clipboard = FakeClipboardContextProvider()
+        let visualContext = FakeVisualContextCoordinator()
+        let composeCollector = FakeComposeContextCollector()
+
+        let interactionState = SuggestionInteractionState()
+        let workController = SuggestionWorkController()
+        let coordinator = SuggestionCoordinator(
+            permissionManager: permissions,
+            focusModel: focusModel,
+            inputMonitor: inputMonitor,
+            overlayController: overlayController,
+            suggestionInserter: inserter,
+            suggestionEngine: engine,
+            suggestionSettings: settings,
+            clipboardContextProvider: clipboard,
+            clipboardRelevanceFilter: FakeClipboardRelevanceFilter(),
+            visualContextCoordinator: visualContext,
+            composeContextCollector: composeCollector,
+            interactionState: interactionState,
+            workController: workController,
+            configuration: .standard,
+            userDefaults: isolatedUserDefaults()
+        )
+        Self.retainedCoordinators.append(coordinator)
+        return ComposeTestEnvironment(
+            coordinator: coordinator,
+            permissions: permissions,
+            focusModel: focusModel,
+            inputMonitor: inputMonitor,
+            overlayController: overlayController,
+            inserter: inserter,
+            engine: engine,
+            settings: settings,
+            clipboard: clipboard,
+            visualContext: visualContext,
+            composeCollector: composeCollector
+        )
+    }
+
+    /// Spins up an environment, drives a first Tab through it, and waits for the compose preview
+    /// to be ready. Cancellation tests use this so they only have to assert post-conditions.
+    private func makeEnvironmentWithReadyDraft(draftText: String) async -> ComposeTestEnvironment {
+        let showPreviewExpectation = expectation(description: "showComposePreview called")
+        let env = makeEnvironment(
+            mode: .compose,
+            engineBehavior: .success(composeResult(text: draftText)),
+            onShowComposePreview: { showPreviewExpectation.fulfill() }
+        )
+
+        _ = env.coordinator.handleInputEvent(CotabbyTestFixtures.inputEvent(kind: .acceptance))
+        await fulfillment(of: [showPreviewExpectation], timeout: 1.0)
+        return env
+    }
+
+    private func snapshot(mode: SuggestionInteractionMode) -> SuggestionSettingsSnapshot {
+        SuggestionSettingsSnapshot(
+            isGloballyEnabled: true,
+            disabledAppBundleIdentifiers: [],
+            selectedInteractionMode: mode,
+            selectedEngine: .llamaOpenSource,
+            selectedWordCountPreset: .sevenToTwelve,
+            isClipboardContextEnabled: false,
+            userName: "Tester",
+            userTags: [],
+            debounceMilliseconds: 50,
+            focusPollIntervalMilliseconds: 50,
+            isMultiLineEnabled: false
+        )
+    }
+
+    private func focusSnapshot(
+        processIdentifier: Int32 = 123,
+        elementIdentifier: String = "field"
+    ) -> FocusSnapshot {
+        let inputSnapshot = CotabbyTestFixtures.focusedInputSnapshot(
+            processIdentifier: processIdentifier,
+            elementIdentifier: elementIdentifier
+        )
+        return FocusSnapshot(
+            applicationName: inputSnapshot.applicationName,
+            bundleIdentifier: inputSnapshot.bundleIdentifier,
+            capability: .supported,
+            context: inputSnapshot,
+            inspection: nil
+        )
+    }
+
+    private func composeResult(text: String) -> ComposeResult {
+        ComposeResult(generation: 1, rawText: text, text: text, latency: 0.05)
+    }
+
+    private func isolatedUserDefaults() -> UserDefaults {
+        let suiteName = "SuggestionCoordinatorComposeTests-\(UUID().uuidString)"
+        guard let userDefaults = UserDefaults(suiteName: suiteName) else {
+            return .standard
+        }
+        userDefaults.removePersistentDomain(forName: suiteName)
+        return userDefaults
+    }
+}
+
+// MARK: - Fakes
+
+@MainActor
+private final class FakeSuggestionPermissions: SuggestionPermissionProviding {
+    var inputMonitoringGranted = true
+    var screenRecordingGranted = true
+    private let inputMonitoringSubject = PassthroughSubject<Bool, Never>()
+    private let screenRecordingSubject = PassthroughSubject<Bool, Never>()
+
+    var inputMonitoringGrantedPublisher: AnyPublisher<Bool, Never> {
+        inputMonitoringSubject.eraseToAnyPublisher()
+    }
+    var screenRecordingGrantedPublisher: AnyPublisher<Bool, Never> {
+        screenRecordingSubject.eraseToAnyPublisher()
+    }
+}
+
+@MainActor
+private final class FakeFocusModel: SuggestionFocusProviding {
+    private(set) var snapshot: FocusSnapshot
+    private let subject: CurrentValueSubject<FocusSnapshot, Never>
+
+    init(initialSnapshot: FocusSnapshot) {
+        snapshot = initialSnapshot
+        subject = CurrentValueSubject(initialSnapshot)
+    }
+
+    var snapshotPublisher: AnyPublisher<FocusSnapshot, Never> {
+        subject.eraseToAnyPublisher()
+    }
+
+    func refreshNow() {}
+
+    func publish(snapshot: FocusSnapshot) {
+        self.snapshot = snapshot
+        subject.send(snapshot)
+    }
+}
+
+@MainActor
+private final class FakeInputMonitor: SuggestionInputMonitoring {
+    var onEvent: ((CapturedInputEvent) -> Bool)?
+    var onSuppressedSyntheticInput: (() -> Void)?
+}
+
+@MainActor
+private final class FakeOverlayController: SuggestionOverlayControlling {
+    var state: OverlayState = .hidden(reason: "test idle")
+    var onStateChange: ((OverlayState) -> Void)?
+    var onShowComposePreview: (() -> Void)?
+    private(set) var composePreviewText: String?
+    private(set) var hideReasons: [String] = []
+
+    func showSuggestion(_ text: String, geometry: SuggestionOverlayGeometry) {
+        state = .visible(text: text, geometry: geometry)
+        onStateChange?(state)
+    }
+
+    func showComposePreview(_ text: String, geometry: SuggestionOverlayGeometry) {
+        composePreviewText = text
+        state = .composePreview(text: text, geometry: geometry)
+        onStateChange?(state)
+        onShowComposePreview?()
+    }
+
+    func hide(reason: String) {
+        hideReasons.append(reason)
+        state = .hidden(reason: reason)
+        onStateChange?(state)
+    }
+}
+
+@MainActor
+private final class FakeSuggestionInserter: SuggestionInserting {
+    var lastErrorMessage: String?
+    var onTypeDraftCalled: (() -> Void)?
+    private(set) var typedDrafts: [String] = []
+
+    func insert(_ suggestion: String) -> Bool { true }
+
+    func typeDraft(_ draft: String, shouldContinue: @escaping @MainActor () -> Bool) async -> Bool {
+        typedDrafts.append(draft)
+        onTypeDraftCalled?()
+        return true
+    }
+}
+
+@MainActor
+private final class FakeSuggestionEngine: SuggestionGenerating {
+    enum Behavior {
+        case success(ComposeResult)
+        case failure(Error)
+    }
+
+    private let behavior: Behavior
+    var onComposeCalled: (() -> Void)?
+    private(set) var composeCallCount = 0
+
+    init(behavior: Behavior) {
+        self.behavior = behavior
+    }
+
+    func generateSuggestion(for request: SuggestionRequest) async throws -> SuggestionResult {
+        throw SuggestionClientError.unavailable("Autocomplete not exercised here.")
+    }
+
+    func generateCompose(for request: ComposeRequest) async throws -> ComposeResult {
+        composeCallCount += 1
+        onComposeCalled?()
+        switch behavior {
+        case .success(let result):
+            return ComposeResult(
+                generation: request.generation,
+                rawText: result.rawText,
+                text: result.text,
+                latency: result.latency
+            )
+        case .failure(let error):
+            throw error
+        }
+    }
+
+    func resetCachedGenerationContext() async {}
+}
+
+@MainActor
+private final class FakeSuggestionSettings: SuggestionSettingsProviding {
+    private(set) var snapshot: SuggestionSettingsSnapshot
+    private let subject: CurrentValueSubject<SuggestionSettingsSnapshot, Never>
+
+    init(initialSnapshot: SuggestionSettingsSnapshot) {
+        snapshot = initialSnapshot
+        subject = CurrentValueSubject(initialSnapshot)
+    }
+
+    var snapshotPublisher: AnyPublisher<SuggestionSettingsSnapshot, Never> {
+        subject.eraseToAnyPublisher()
+    }
+
+    func publish(snapshot: SuggestionSettingsSnapshot) {
+        self.snapshot = snapshot
+        subject.send(snapshot)
+    }
+}
+
+@MainActor
+private final class FakeClipboardContextProvider: ClipboardContextProviding {
+    var contextToReturn: String?
+    var currentChangeCount: Int = 0
+    func currentContext() -> String? { contextToReturn }
+}
+
+@MainActor
+private final class FakeClipboardRelevanceFilter: ClipboardRelevanceFiltering {
+    func filter(clipboard: String?, pasteboardChangeCount: Int, precedingText: String) -> String? {
+        clipboard
+    }
+}
+
+@MainActor
+private final class FakeVisualContextCoordinator: VisualContextCoordinating {
+    var status: VisualContextStatus = .idle
+    var latestExcerpt: String?
+    var onStateChange: ((VisualContextStatus, String?) -> Void)?
+    var onInjectedContextReady: ((FocusedInputIdentity) -> Void)?
+
+    func startSessionIfNeeded(for snapshotContext: FocusedInputSnapshot) {}
+    func cancel(resetState: Bool) {}
+    func excerpt(for context: FocusedInputContext) -> String? { nil }
+}
+
+@MainActor
+private final class FakeComposeContextCollector: ComposeContextCollecting {
+    var textToReturn: String = "Surrounding context."
+    private(set) var collectCallCount = 0
+
+    func collect(for context: FocusedInputContext) async throws -> ComposeContextCollectionResult {
+        collectCallCount += 1
+        return ComposeContextCollectionResult(
+            text: textToReturn,
+            visitedNodeCount: 1,
+            retainedTextCount: 1,
+            droppedTextCount: 0
+        )
+    }
+}

--- a/CotabbyTests/SuggestionCoordinatorComposeTests.swift
+++ b/CotabbyTests/SuggestionCoordinatorComposeTests.swift
@@ -38,6 +38,45 @@ final class SuggestionCoordinatorComposeTests: XCTestCase {
         XCTAssertNil(env.coordinator.interactionState.activeComposeSession)
     }
 
+    func test_firstTab_showsDraftingIndicatorThenHidesItOnceTokensArrive() async {
+        let env = makeEnvironment(
+            mode: .compose,
+            engineBehavior: .blocked(initialPieces: [])
+        )
+
+        _ = env.coordinator.handleInputEvent(CotabbyTestFixtures.inputEvent(kind: .acceptance))
+        for _ in 0..<5 { await Task.yield() }
+
+        // Before any token, the "Drafting…" pill is visible.
+        XCTAssertEqual(env.overlayController.composeProgressLabels, ["Drafting…"])
+        if case .composeProgress = env.overlayController.state {
+            // expected
+        } else {
+            XCTFail("Expected composeProgress overlay state, got \(env.overlayController.state)")
+        }
+    }
+
+    func test_draftingIndicatorIsHiddenOnceTheFirstTokenLands() async {
+        let finishedExpectation = expectation(description: "stream finished")
+        let env = makeEnvironment(
+            mode: .compose,
+            engineBehavior: .success(pieces: ["Hello"]),
+            onStreamFinished: { finishedExpectation.fulfill() }
+        )
+
+        _ = env.coordinator.handleInputEvent(CotabbyTestFixtures.inputEvent(kind: .acceptance))
+        await fulfillment(of: [finishedExpectation], timeout: 1.0)
+        await Task.yield()
+
+        XCTAssertEqual(env.overlayController.composeProgressLabels, ["Drafting…"])
+        // After streaming completes the overlay is hidden, not stuck on the indicator.
+        if case .hidden = env.overlayController.state {
+            // expected
+        } else {
+            XCTFail("Expected hidden overlay after stream, got \(env.overlayController.state)")
+        }
+    }
+
     func test_firstTab_inComposeMode_returnsTrueToConsumeTab() {
         let env = makeEnvironment(
             mode: .compose,
@@ -355,6 +394,14 @@ private final class FakeOverlayController: SuggestionOverlayControlling {
     func showComposePreview(_ text: String, geometry: SuggestionOverlayGeometry) {
         composePreviewText = text
         state = .composePreview(text: text, geometry: geometry)
+        onStateChange?(state)
+    }
+
+    private(set) var composeProgressLabels: [String] = []
+
+    func showComposeProgress(_ label: String, geometry: SuggestionOverlayGeometry) {
+        composeProgressLabels.append(label)
+        state = .composeProgress(label: label, geometry: geometry)
         onStateChange?(state)
     }
 

--- a/CotabbyTests/SuggestionStateHelperTests.swift
+++ b/CotabbyTests/SuggestionStateHelperTests.swift
@@ -567,6 +567,14 @@ private final class FakeOverlayController: SuggestionOverlayControlling {
         onStateChange?(state)
     }
 
+    func showComposeProgress(
+        _ label: String,
+        geometry: SuggestionOverlayGeometry
+    ) {
+        state = .composeProgress(label: label, geometry: geometry)
+        onStateChange?(state)
+    }
+
     func hide(reason: String) {
         hideReasons.append(reason)
         state = .hidden(reason: reason)


### PR DESCRIPTION
## Summary

Stacks on #121 to make Compose Mode actually functional. The parent PR put the plumbing in place but left the Tab handler stubbed with a "Compose Mode is selected. Draft generation will be enabled after the Compose request pipeline is installed." disabled state. This PR removes that stub and lights up the full RFC flow.

What changed:
- **First Tab** in Compose Mode runs `runComposeGeneration` — bounded AX context walk via the new `ComposeContextCollecting` protocol, `ComposeRequestFactory` build, route to llama through `SuggestionEngineRouter.generateCompose`.
- **Second Tab** on a ready draft calls `SuggestionInserter.typeDraft`, which chunks synthetic Unicode insertion and re-checks focus identity between chunks.
- **Esc / navigation / text mutation** while the preview is visible (or while generation is in flight) cancel the session and the work controller.
- **Focus change** while the preview is visible drops the session immediately instead of leaving a stale draft alive.
- **Mode flip** in either direction resets interaction state through the existing settings-change path; the work controller cancels in-flight generation.
- **Model gate**: `RuntimeBootstrapModel.prepareForComposeMode` auto-switches to `tabby-depth-1` if installed and records the previous autocomplete model so `restoreAutocompleteModel` puts it back. `CotabbyAppEnvironment` wires the mode-change subscription so `RuntimeBootstrapModel` does not need to know about settings.
- **UI**: Menu bar and Settings show "Compose requires the Open Source engine" and "Compose requires gemma-3n-E4B-it-Q4_K_M.gguf" banners when conditions aren't met. Model picker is disabled while Compose is active so the user cannot fight the auto-switch.

What is intentionally not in this PR:
- A download CTA for `tabby-depth-1`. The model is not in `RuntimeModelCatalog.downloadableModels` yet, so the banner stops at "add it to your models folder" rather than wiring a button against a placeholder URL.
- Productizing `userTags`. The snapshot field is still always `[]`; this PR does not add a tag editor.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build-for-testing
# ** TEST BUILD SUCCEEDED **

xcodebuild test-without-building -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS'
# Executed 310 tests, with 0 failures (was 274 on the parent branch; 36 new tests in this PR)

swiftlint lint --quiet
# 3 pre-existing cyclomatic_complexity warnings (Prediction, GhostSuggestionLayout, ComposeContextCollector); no new violations
```

New tests:
- **`ComposePromptRendererTests`** (9 cases) — prompt shape, optional sections, empty placeholder, final-instruction position.
- **`ComposeTextNormalizerTests`** (9 cases) — prompt echo, chat tokens, markdown fences, leading labels, wrapping quotes, typed prefix echo, paragraph preservation, blank-line collapse.
- **`ComposeRequestFactoryTests`** (7 cases) — clipping, clipboard gating, sampling minimums, prompt-preview parity, user profile carry-through.
- **`SuggestionCoordinatorComposeTests`** (11 cases) — first-Tab triggers generation, second-Tab types draft, Esc/navigation/text mutation cancel session, focus change clears session, mode change clears session, empty draft returns to idle, engine failure surfaces failed state. Includes a full in-file fake suite for every coordinator collaborator.

Manual QA is still outstanding (see Risk section); this PR has not been exercised in a running build against GitHub / Gmail / Slack.

## Linked issues

Refs #66, #67, #68, #69, #70 — Compose Mode RFC issues. Stacks on #121.

## Risk / rollout notes

- **Stacked on #121.** Do not merge this PR until the parent lands; the base ref is `compose-interaction-mode`, not `main`.
- **Compose typing is synthetic Unicode**, the same primitive autocomplete already uses. `InputSuppressionController` accumulates suppression counts per chunk so Compose's own keystrokes don't get reinterpreted as user typing. If Compose typing ever feels off in a target app, the most likely culprit is suppression scope, not the inserter's chunking.
- **`composeTypingShouldContinue`** is the single cancellation pivot: if the session is cleared OR the focused element identity changes, the next chunk is skipped. Reviewers should focus on whether the comparison fields (process, element, focusChangeSequence) catch every "user moved on" case in target apps.
- **Test infrastructure is now in place** for full coordinator orchestration tests via `ComposeContextCollecting` and per-test fakes. Future PRs can lean on the same pattern for autocomplete coordinator tests, which currently have no orchestration coverage.
- pbxproj: 4 new manual test entries.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR activates Compose Mode end-to-end by replacing the parent branch's stubbed Tab handler with a single-Tab streaming pipeline: Tab to AX context collection to `ComposeRequestFactory` to `SuggestionEngineRouter.generateComposeStreaming` to per-token insertion via `suggestionInserter.insert`. The 36 new tests cover streaming, overlay lifecycle, all cancellation triggers, and failure propagation using a self-contained in-file fake suite.

- **Streaming runtime**: `LlamaRuntimeCore.summarizeStreaming` adds a per-token `onToken` callback with the same ephemeral-sequence and lifecycle-locking guarantees as `summarize`; `LlamaRuntimeManager.streamUncached` bridges it to `AsyncThrowingStream` with a termination-handler task cancel.
- **Cancellation coverage**: Esc, navigation, text mutation, focus change, and mode flip all call `cancelComposeWork`; the `composeStreamShouldContinue` pivot in the for-await loop catches mid-stream field changes by comparing all three identity fields.
- **Model/engine gates**: The hard per-filename GGUF gate in `LlamaSuggestionEngine` is removed in favour of an engine-type gate in `SuggestionEngineRouter` and advisory UI banners.

<h3>Confidence Score: 3/5</h3>

The Compose streaming loop is solid for the common path, but a field-change race during context collection can silently swallow a Tab in the new field.

The focus-change handler in `handleSupportedSnapshot` guards on `activeComposeSession != nil`, but compose work is in-flight before the session is created during `composeContextCollector.collect`. A focus change in that window falls through to the autocomplete path without calling `cancelComposeWork`, causing any Tab press in the new field to be silently swallowed while the lingering session is cleaned up.

`SuggestionCoordinator+Input.swift` (compose work not cancelled during pre-session context collection on field change) and `SuggestionCoordinator+Compose.swift` (engine compatibility not gated before starting work).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/App/Coordinators/SuggestionCoordinator+Compose.swift | New file wiring the full Compose streaming loop: Tab triggers context collection, request build, and token-by-token insertion via the llama stream. Cancellation guards are thorough within the for-await loop, but `startComposeGeneration` lacks an early engine-compatibility check before starting work. |
| Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift | Adds compose-session handling to focus updates, but the guard only checks `activeComposeSession != nil`. In-flight compose work during context collection (before session starts) is not cancelled on field change, leaving a window where a Tab press in the new field is silently swallowed. |
| Cotabby/Services/Runtime/LlamaRuntimeCore.swift | Adds `summarizeStreaming` with per-token `onToken` callback. Lifecycle locking, shutdown guard, and `activeOperationCount` tracking mirror the existing pattern correctly. |
| Cotabby/Services/Runtime/LlamaRuntimeManager.swift | Adds `streamUncached` that verifies the prepared runtime, starts a detached sampling task, and bridges pieces to an `AsyncThrowingStream`. Termination handler cancels the task and the `activeOperationCount` defer protects shutdown. |
| Cotabby/Services/Runtime/LlamaSuggestionEngine.swift | Removes the `selectedModelSupportsCompose` filename gate and adds `generateComposeStreaming`. The engine-type gate is present in `SuggestionEngineRouter`, but no in-path check remains for the wrong-model-loaded case. |
| Cotabby/Models/SuggestionSubsystemContracts.swift | Adds `generateComposeStreaming` to `SuggestionGenerating` with a one-shot fallback default, `showComposeProgress` to `SuggestionOverlayControlling`, and the new `ComposeContextCollecting` protocol and `ComposeContextCollectionResult` value type. |
| CotabbyTests/SuggestionCoordinatorComposeTests.swift | Comprehensive in-file fake suite covering streaming, overlay lifecycle, cancellation paths, and failure state. `FakeSuggestionInserter.typeDraft` always returns `true` without invoking `shouldContinue`, leaving mid-draft cancellation uncovered. |
| Cotabby/Services/UI/OverlayController.swift | Adds `showComposeProgress` and `ComposeProgressView` for the Drafting pill. Sizing and positioning logic mirrors the existing compose preview approach. |
| Cotabby/Services/Runtime/SuggestionEngineRouter.swift | Routes `generateComposeStreaming` to llama and throws a clear unavailable error for Apple Intelligence and mlxSwift engines. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Coordinator as SuggestionCoordinator
    participant ContextCollector as ComposeContextCollector
    participant Router as SuggestionEngineRouter
    participant RuntimeMgr as LlamaRuntimeManager
    participant Core as LlamaRuntimeCore
    participant Inserter as SuggestionInserter

    User->>Coordinator: Tab keypress (Compose mode)
    Coordinator->>Coordinator: startComposeGeneration()
    Coordinator->>Coordinator: "state = .generating"
    Coordinator->>Coordinator: showComposeProgress(Drafting)
    Coordinator->>ContextCollector: collect(for: context)
    ContextCollector-->>Coordinator: ComposeContextCollectionResult
    Coordinator->>Router: generateComposeStreaming(request)
    Router->>RuntimeMgr: streamUncached(prompt, options)
    RuntimeMgr->>Core: summarizeStreaming(prompt, options, onToken)
    Coordinator->>Coordinator: startComposeSession()
    Coordinator->>Coordinator: "state = .typing"
    loop Per token
        Core-->>RuntimeMgr: onToken(piece)
        RuntimeMgr-->>Router: continuation.yield(piece)
        Router-->>Coordinator: for-await piece
        Coordinator->>Coordinator: composeStreamShouldContinue?
        Coordinator->>Coordinator: hideOverlay (first token only)
        Coordinator->>Inserter: insert(piece)
        Coordinator->>Coordinator: updateComposeSession()
        Coordinator->>Coordinator: Task.yield()
    end
    Coordinator->>Coordinator: finishComposeStream()
    Coordinator->>Coordinator: clearComposeSession()
    Coordinator->>Coordinator: "state = .idle"

    alt Esc / navigation / text mutation / focus change
        User->>Coordinator: cancel event
        Coordinator->>Coordinator: cancelComposeWork()
        Coordinator->>Coordinator: workController.cancelAll()
        Coordinator->>Coordinator: clearComposeSession()
        Coordinator->>Coordinator: hideOverlay()
        Coordinator->>Coordinator: "state = .idle"
    end
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22compose-mode-functionality%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22compose-mode-functionality%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BInput.swift%3A73-80%0A**In-flight%20compose%20work%20not%20cancelled%20when%20session%20hasn't%20started%20yet**%0A%0AThe%20guard%20at%20line%2073%20only%20fires%20when%20%60activeComposeSession%20!%3D%20nil%60%2C%20but%20compose%20work%20can%20be%20in-flight%20%28state%20%3D%20%60.generating%60%29%20before%20the%20session%20is%20started%20%E2%80%94%20specifically%20during%20%60composeContextCollector.collect%28for%3A%29%60%20inside%20%60runComposeStreaming%60.%20A%20focus%20change%20during%20that%20window%20falls%20through%20to%20the%20autocomplete%20path%20%28lines%2087%E2%80%9397%29%2C%20which%20calls%20%60cancelPredictionWork%28%29%60%20and%20sets%20%60state%20%3D%20.idle%60%20but%20does%20not%20call%20%60cancelComposeWork%60.%20The%20compose%20task%20continues%3B%20once%20context%20collection%20finishes%20it%20calls%20%60startComposeSession%60%2C%20setting%20%60activeComposeSession%60.%20Any%20Tab%20press%20in%20the%20new%20field%20between%20session%20start%20and%20the%20%60composeStreamShouldContinue%60%20check%20%28which%20does%20catch%20the%20field%20mismatch%20and%20breaks%20the%20loop%29%20is%20silently%20consumed%20because%20%60handleComposeInputEvent%28.acceptance%29%60%20sees%20a%20non-nil%20session.%20Adding%20%60%7C%7C%20isAnyComposeWorkInFlight%60%20to%20the%20guard%20condition%20%28mirroring%20the%20check%20in%20%60handleComposeInputEvent%60%29%20would%20close%20this%20window.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BCompose.swift%3A71-80%0AWhen%20the%20selected%20engine%20is%20Apple%20Intelligence%20or%20mlxSwift%2C%20Tab%20in%20Compose%20mode%20currently%20shows%20the%20%22Drafting%E2%80%A6%22%20indicator%2C%20runs%20the%20full%20AX%20context%20walk%2C%20and%20only%20then%20surfaces%20a%20%60.failed%60%20state%20from%20%60SuggestionEngineRouter.generateComposeStreaming%60.%20An%20early%20guard%20matching%20%60SuggestionEngineRouter%60's%20own%20check%20prevents%20the%20false%20start%20and%20gives%20the%20user%20immediate%20feedback%20consistent%20with%20the%20advisory%20banner%20already%20shown%20in%20the%20menu%20bar%20and%20settings.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20if%20let%20disabledReason%20%3D%20SuggestionAvailabilityEvaluator.disabledReason%28%0A%20%20%20%20%20%20%20%20%20%20%20%20globallyEnabled%3A%20settingsSnapshot.isGloballyEnabled%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20disabledAppBundleIdentifiers%3A%20settingsSnapshot.disabledAppBundleIdentifiers%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20interactionMode%3A%20settingsSnapshot.selectedInteractionMode%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20inputMonitoringGranted%3A%20permissionManager.inputMonitoringGranted%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20screenRecordingGranted%3A%20permissionManager.screenRecordingGranted%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20focusSnapshot%3A%20snapshot%0A%20%20%20%20%20%20%20%20%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20passTabThrough%28reason%3A%20disabledReason%29%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20%2F%2F%20Compose%20requires%20the%20local%20open-source%20engine.%20Gate%20here%20so%20Tab%20passes%20through%0A%20%20%20%20%20%20%20%20%2F%2F%20immediately%20rather%20than%20showing%20the%20Drafting%20pill%20and%20then%20surfacing%20a%20.failed%0A%20%20%20%20%20%20%20%20%2F%2F%20state%20after%20context%20collection%20completes.%0A%20%20%20%20%20%20%20%20guard%20settingsSnapshot.selectedEngine%20%3D%3D%20.llamaOpenSource%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20passTabThrough%28reason%3A%20%22Compose%20Mode%20requires%20the%20open-source%20engine.%22%29%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BInput.swift%3A73-80%0A**In-flight%20compose%20work%20not%20cancelled%20when%20session%20hasn't%20started%20yet**%0A%0AThe%20guard%20at%20line%2073%20only%20fires%20when%20%60activeComposeSession%20!%3D%20nil%60%2C%20but%20compose%20work%20can%20be%20in-flight%20%28state%20%3D%20%60.generating%60%29%20before%20the%20session%20is%20started%20%E2%80%94%20specifically%20during%20%60composeContextCollector.collect%28for%3A%29%60%20inside%20%60runComposeStreaming%60.%20A%20focus%20change%20during%20that%20window%20falls%20through%20to%20the%20autocomplete%20path%20%28lines%2087%E2%80%9397%29%2C%20which%20calls%20%60cancelPredictionWork%28%29%60%20and%20sets%20%60state%20%3D%20.idle%60%20but%20does%20not%20call%20%60cancelComposeWork%60.%20The%20compose%20task%20continues%3B%20once%20context%20collection%20finishes%20it%20calls%20%60startComposeSession%60%2C%20setting%20%60activeComposeSession%60.%20Any%20Tab%20press%20in%20the%20new%20field%20between%20session%20start%20and%20the%20%60composeStreamShouldContinue%60%20check%20%28which%20does%20catch%20the%20field%20mismatch%20and%20breaks%20the%20loop%29%20is%20silently%20consumed%20because%20%60handleComposeInputEvent%28.acceptance%29%60%20sees%20a%20non-nil%20session.%20Adding%20%60%7C%7C%20isAnyComposeWorkInFlight%60%20to%20the%20guard%20condition%20%28mirroring%20the%20check%20in%20%60handleComposeInputEvent%60%29%20would%20close%20this%20window.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BCompose.swift%3A71-80%0AWhen%20the%20selected%20engine%20is%20Apple%20Intelligence%20or%20mlxSwift%2C%20Tab%20in%20Compose%20mode%20currently%20shows%20the%20%22Drafting%E2%80%A6%22%20indicator%2C%20runs%20the%20full%20AX%20context%20walk%2C%20and%20only%20then%20surfaces%20a%20%60.failed%60%20state%20from%20%60SuggestionEngineRouter.generateComposeStreaming%60.%20An%20early%20guard%20matching%20%60SuggestionEngineRouter%60's%20own%20check%20prevents%20the%20false%20start%20and%20gives%20the%20user%20immediate%20feedback%20consistent%20with%20the%20advisory%20banner%20already%20shown%20in%20the%20menu%20bar%20and%20settings.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20if%20let%20disabledReason%20%3D%20SuggestionAvailabilityEvaluator.disabledReason%28%0A%20%20%20%20%20%20%20%20%20%20%20%20globallyEnabled%3A%20settingsSnapshot.isGloballyEnabled%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20disabledAppBundleIdentifiers%3A%20settingsSnapshot.disabledAppBundleIdentifiers%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20interactionMode%3A%20settingsSnapshot.selectedInteractionMode%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20inputMonitoringGranted%3A%20permissionManager.inputMonitoringGranted%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20screenRecordingGranted%3A%20permissionManager.screenRecordingGranted%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20focusSnapshot%3A%20snapshot%0A%20%20%20%20%20%20%20%20%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20passTabThrough%28reason%3A%20disabledReason%29%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20%2F%2F%20Compose%20requires%20the%20local%20open-source%20engine.%20Gate%20here%20so%20Tab%20passes%20through%0A%20%20%20%20%20%20%20%20%2F%2F%20immediately%20rather%20than%20showing%20the%20Drafting%20pill%20and%20then%20surfacing%20a%20.failed%0A%20%20%20%20%20%20%20%20%2F%2F%20state%20after%20context%20collection%20completes.%0A%20%20%20%20%20%20%20%20guard%20settingsSnapshot.selectedEngine%20%3D%3D%20.llamaOpenSource%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20passTabThrough%28reason%3A%20%22Compose%20Mode%20requires%20the%20open-source%20engine.%22%29%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=fujacob%2Ftabby&pr=229&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (4): Last reviewed commit: ["Show a &quot;Drafting…&quot; indicator at the care..."](https://github.com/fujacob/tabby/commit/bc476d9cda47162012c89477e45eb32de50e533d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33717833)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->