### PR TITLE
Fix Sparkle pin verification path after project rename

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,14 @@ jobs:
           xcodebuild -version
           swift --version
 
+      # Package.resolved is gitignored, so SwiftPM must materialize it before
+      # the Sparkle pin check can compare against it.
+      - name: Resolve Swift package dependencies
+        run: |
+          xcodebuild \
+            -project Cotabby.xcodeproj \
+            -resolvePackageDependencies
+
       - name: Verify Sparkle version pin
         run: |
           set -euo pipefail

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
           # Sparkle must use exactVersion pinning. upToNextMajorVersion lets
           # Xcode silently upgrade the framework, which drifts the signing
           # tools hash and breaks releases.
-          sparkle_block="$(sed -n '/XCRemoteSwiftPackageReference "Sparkle" \*\/ = {/,/};/p' tabby.xcodeproj/project.pbxproj)"
+          sparkle_block="$(sed -n '/XCRemoteSwiftPackageReference "Sparkle" \*\/ = {/,/};/p' Cotabby.xcodeproj/project.pbxproj)"
 
           if ! echo "${sparkle_block}" | grep -q 'kind = exactVersion'; then
             echo "Sparkle must use exactVersion pinning in project.pbxproj." >&2
@@ -64,7 +64,7 @@ jobs:
           pbxproj_version="$(echo "${sparkle_block}" | grep -A1 'kind = exactVersion' | grep 'version' | sed 's/.*= //;s/;.*//' | tr -d '[:space:]')"
           resolved_version="$(python3 -c "
           import json, sys
-          resolved = json.load(open('tabby.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved'))
+          resolved = json.load(open('Cotabby.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved'))
           pins = {p['identity']: p for p in resolved['pins']}
           if 'sparkle' not in pins:
               print('sparkle not found in Package.resolved. Available: ' + ', '.join(sorted(pins.keys())), file=sys.stderr)


### PR DESCRIPTION
## Summary

The Sparkle exact-version pin check in \`.github/workflows/build.yml\`
still reads from \`tabby.xcodeproj/project.pbxproj\` and
\`tabby.xcodeproj/.../Package.resolved\`. After the rename to
\`Cotabby.xcodeproj\`, every Build job on main fails with:

\`\`\`
sed: tabby.xcodeproj/project.pbxproj: No such file or directory
\`\`\`

Point both reads at \`Cotabby.xcodeproj\`.

## Validation

Ran the exact verification logic locally against the renamed project:

\`\`\`
sparkle_block="$(sed -n '/XCRemoteSwiftPackageReference "Sparkle" \*\/ = {/,/};/p' Cotabby.xcodeproj/project.pbxproj)"
# kind = exactVersion present
# pbxproj=2.9.1  resolved=2.9.1  → PASS
\`\`\`

## Linked issues

None.

## Risk / rollout notes

- Workflow-only change; touches no app code.
- Unblocks every future push to \`main\` (Build job has been red since
  the rename merged).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two stale `tabby.xcodeproj` path references in the Sparkle pin verification step after the project was renamed to `Cotabby.xcodeproj`, and adds a `xcodebuild -resolvePackageDependencies` step to materialize `Package.resolved` (which is gitignored) before the verification logic reads it.

- Renames `tabby.xcodeproj` → `Cotabby.xcodeproj` in both the `sed` call on `project.pbxproj` and the Python `json.load(open(...))` call on `Package.resolved`.
- Inserts a new \"Resolve Swift package dependencies\" step before \"Verify Sparkle version pin\" so that `Cotabby.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved` exists at verification time, addressing the `FileNotFoundError` that was raised on every CI run because the file is gitignored.

<h3>Confidence Score: 5/5</h3>

Safe to merge — workflow-only change that unblocks CI without touching any app code.

Both path renames are mechanical and correct. The new xcodebuild -resolvePackageDependencies step writes Package.resolved to exactly the path the subsequent Python script reads, cleanly resolving the gitignore problem flagged in the previous review round. No app logic is affected.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/build.yml | Renames two tabby.xcodeproj path references to Cotabby.xcodeproj and adds a dependency-resolution step so Package.resolved is present before the Sparkle pin check runs; no logic changes to the verification itself. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub Actions
    participant XC as xcodebuild
    participant FS as Filesystem
    participant Verify as Verify Step

    GH->>XC: -project Cotabby.xcodeproj -resolvePackageDependencies
    XC->>FS: write Cotabby.xcodeproj/.../swiftpm/Package.resolved
    GH->>Verify: Verify Sparkle version pin
    Verify->>FS: sed read Cotabby.xcodeproj/project.pbxproj
    FS-->>Verify: sparkle_block (kind + version)
    Verify->>FS: python3 open(Cotabby.xcodeproj/.../Package.resolved)
    FS-->>Verify: resolved version
    Verify->>Verify: "compare pbxproj_version == resolved_version"
    Verify-->>GH: PASS / FAIL
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/build.yml`, line 65-73 ([link](https://github.com/fujacob/tabby/blob/1887e949b241c7f9d2b469132f83a5ff2006f0c7/.github/workflows/build.yml#L65-L73)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`Package.resolved` is gitignored — this step will still fail on CI**

   `.gitignore` contains `**/xcshareddata/swiftpm/Package.resolved`, so `actions/checkout` will never produce this file. The Python call on line 67 will raise `FileNotFoundError` in every CI run regardless of the renamed path, because the file simply doesn't exist in the working tree after checkout. The `sed`/`pbxproj` read on line 56 is fixed correctly, but the `Package.resolved` check cannot pass until the file is either committed (by removing it from `.gitignore`) or this step is replaced with an alternative that sources the version from a tracked artifact.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22fix-sparkle-pin-pbxproj-path%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix-sparkle-pin-pbxproj-path%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fbuild.yml%0ALine%3A%2065-73%0A%0AComment%3A%0A**%60Package.resolved%60%20is%20gitignored%20%E2%80%94%20this%20step%20will%20still%20fail%20on%20CI**%0A%0A%60.gitignore%60%20contains%20%60**%2Fxcshareddata%2Fswiftpm%2FPackage.resolved%60%2C%20so%20%60actions%2Fcheckout%60%20will%20never%20produce%20this%20file.%20The%20Python%20call%20on%20line%2067%20will%20raise%20%60FileNotFoundError%60%20in%20every%20CI%20run%20regardless%20of%20the%20renamed%20path%2C%20because%20the%20file%20simply%20doesn't%20exist%20in%20the%20working%20tree%20after%20checkout.%20The%20%60sed%60%2F%60pbxproj%60%20read%20on%20line%2056%20is%20fixed%20correctly%2C%20but%20the%20%60Package.resolved%60%20check%20cannot%20pass%20until%20the%20file%20is%20either%20committed%20%28by%20removing%20it%20from%20%60.gitignore%60%29%20or%20this%20step%20is%20replaced%20with%20an%20alternative%20that%20sources%20the%20version%20from%20a%20tracked%20artifact.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fbuild.yml%0ALine%3A%2065-73%0A%0AComment%3A%0A**%60Package.resolved%60%20is%20gitignored%20%E2%80%94%20this%20step%20will%20still%20fail%20on%20CI**%0A%0A%60.gitignore%60%20contains%20%60**%2Fxcshareddata%2Fswiftpm%2FPackage.resolved%60%2C%20so%20%60actions%2Fcheckout%60%20will%20never%20produce%20this%20file.%20The%20Python%20call%20on%20line%2067%20will%20raise%20%60FileNotFoundError%60%20in%20every%20CI%20run%20regardless%20of%20the%20renamed%20path%2C%20because%20the%20file%20simply%20doesn't%20exist%20in%20the%20working%20tree%20after%20checkout.%20The%20%60sed%60%2F%60pbxproj%60%20read%20on%20line%2056%20is%20fixed%20correctly%2C%20but%20the%20%60Package.resolved%60%20check%20cannot%20pass%20until%20the%20file%20is%20either%20committed%20%28by%20removing%20it%20from%20%60.gitignore%60%29%20or%20this%20step%20is%20replaced%20with%20an%20alternative%20that%20sources%20the%20version%20from%20a%20tracked%20artifact.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Ftabby&pr=231&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Resolve SwiftPM packages before Sparkle ..."](https://github.com/fujacob/tabby/commit/ec6c87fdf874d8bc8b9f61f7209fa482817d5618) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33720578)</sub>

<!-- /greptile_comment -->