### PR TITLE
Fix README badge + clone URLs (repo is still FuJacob/tabby)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@
 
 <p align="center">
   <a href="LICENSE"><img alt="License: AGPL v3" src="https://img.shields.io/badge/license-AGPL--3.0-blue.svg" /></a>
-  <a href="https://github.com/FuJacob/Cotabby/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/FuJacob/Cotabby" /></a>
-  <a href="https://github.com/FuJacob/Cotabby/releases"><img alt="Downloads" src="https://img.shields.io/github/downloads/FuJacob/Cotabby/total" /></a>
-  <a href="https://github.com/FuJacob/Cotabby/stargazers"><img alt="Stars" src="https://img.shields.io/github/stars/FuJacob/Cotabby?style=flat" /></a>
+  <a href="https://github.com/FuJacob/tabby/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/FuJacob/tabby" /></a>
+  <a href="https://github.com/FuJacob/tabby/releases"><img alt="Downloads" src="https://img.shields.io/github/downloads/FuJacob/tabby/total" /></a>
+  <a href="https://github.com/FuJacob/tabby/stargazers"><img alt="Stars" src="https://img.shields.io/github/stars/FuJacob/tabby?style=flat" /></a>
   <img alt="Platform" src="https://img.shields.io/badge/platform-macOS%2015%2B-lightgrey" />
-  <img alt="Visitors" src="https://visitor-badge.laobi.icu/badge?page_id=FuJacob.Cotabby" />
+  <img alt="Visitors" src="https://visitor-badge.laobi.icu/badge?page_id=FuJacob.tabby" />
 </p>
 
 ---
@@ -107,7 +107,7 @@ If macOS blocks first launch, right-click `Cotabby.app` → `Open`, or allow it 
 Requires Xcode and Command Line Tools. Apple Silicon is strongly recommended for local model performance. For setup, build, test, and contribution workflow details, start with [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ```bash
-git clone https://github.com/FuJacob/Cotabby.git
+git clone https://github.com/FuJacob/tabby.git Cotabby
 cd Cotabby
 open Cotabby.xcodeproj
 ```


### PR DESCRIPTION
## Summary

The GitHub repo is still named `tabby` — the rename to Cotabby only touched the project, app bundle, and xcodeproj on disk; the remote repo was never renamed. Badge URLs pointing at `FuJacob/Cotabby` are 404ing against shields.io and the visitor counter is keyed on a string that does not exist. Same issue for the `git clone` URL in the install section.

This PR flips all repo URLs back to `FuJacob/tabby` and explicitly clones into `Cotabby` so the next `cd Cotabby` step still works (otherwise `git clone` would default the folder to `tabby`).

Product-name references (`Cotabby.app`, `Cotabby.xcodeproj`, "open Cotabby.xcodeproj") are intentionally left alone — those are the actual on-disk artifacts.

## Validation

Diff is README-only, 5 changed lines.

## Linked issues

None.

## Risk / rollout notes

- The visitor-counter badge resets if `laobi.icu` deleted the old `FuJacob.tabby` bucket when nobody hit it during the Cotabby period. Acceptable — visitor count is decorative.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes five broken README URLs that referenced the non-existent `FuJacob/Cotabby` GitHub repo slug — reverting them to the real `FuJacob/tabby` slug and adding an explicit clone-directory argument so the `cd Cotabby` step in the Local Development section still works.

- Badge links (latest release, downloads, stars) and the shields.io image sources are updated from `/FuJacob/Cotabby` to `/FuJacob/tabby`, and the visitor-badge `page_id` is updated from `FuJacob.Cotabby` to `FuJacob.tabby`.
- The `git clone` command gains a trailing `Cotabby` argument so the checked-out directory is named `Cotabby` rather than the default `tabby`, keeping the following `cd Cotabby` and `open Cotabby.xcodeproj` instructions intact.

<h3>Confidence Score: 5/5</h3>

README-only change with no code, logic, or configuration affected — safe to merge.

All five changed lines are URL strings in documentation. Each replacement is a direct, verifiable correction from the never-created Cotabby slug to the actual tabby remote. The explicit clone-directory argument preserves the downstream cd Cotabby step exactly as intended. No application code, build files, or configuration is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Corrects five broken URLs: three shield.io badge hrefs/srcs, the visitor-badge page_id, and the git clone URL; adds an explicit target-directory argument so the subsequent `cd Cotabby` step continues to work |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["README badge/clone URLs"] --> B{Repo slug used}
    B -- "Before (broken)" --> C["FuJacob/Cotabby ❌\n(repo never existed)"]
    B -- "After (this PR)" --> D["FuJacob/tabby ✅\n(actual remote name)"]
    C --> E["shields.io → 404\nvisitor badge → wrong bucket\ngit clone → not found"]
    D --> F["shields.io → live stats\nvisitor badge → correct bucket\ngit clone → clones into Cotabby/"]
```

<sub>Reviews (1): Last reviewed commit: ["Point README badges and clone URL at the..."](https://github.com/fujacob/tabby/commit/d76e696c69c085b2926be2695e19a85013525bbd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33725263)</sub>

<!-- /greptile_comment -->