### PR TITLE
Reorder menu bar toggles and clarify their labels

### DIFF
--- a/Cotabby/UI/MenuBarView.swift
+++ b/Cotabby/UI/MenuBarView.swift
@@ -75,10 +75,6 @@ struct MenuBarView: View {
                 .toggleStyle(.switch)
                 .controlSize(.small)
 
-            Toggle("Include Clipboard Context", isOn: clipboardContextEnabledBinding)
-                .toggleStyle(.switch)
-                .controlSize(.small)
-
             if let application = focusModel.latestExternalApplication,
                !TerminalAppDetector.isTerminal(bundleIdentifier: application.bundleIdentifier) {
                 Toggle("Enable in \(application.applicationName)", isOn: appEnabledBinding(for: application))
@@ -86,7 +82,15 @@ struct MenuBarView: View {
                     .controlSize(.small)
             }
 
-            Toggle("Show Indicator", isOn: showIndicatorBinding)
+            Toggle("Include Clipboard Context", isOn: clipboardContextEnabledBinding)
+                .toggleStyle(.switch)
+                .controlSize(.small)
+
+            Toggle("Show Cotabby Indicator", isOn: showIndicatorBinding)
+                .toggleStyle(.switch)
+                .controlSize(.small)
+
+            Toggle("Allow Multi-line Suggestions", isOn: multiLineEnabledBinding)
                 .toggleStyle(.switch)
                 .controlSize(.small)
 
@@ -122,10 +126,6 @@ struct MenuBarView: View {
                 .labelsHidden()
                 .pickerStyle(.menu)
             }
-
-            Toggle("Multi-line", isOn: multiLineEnabledBinding)
-                .toggleStyle(.switch)
-                .controlSize(.small)
         }
         .padding(.bottom, 12)
     }


### PR DESCRIPTION
## Summary

Tightens the menu bar quick-controls layout. The per-app enable/disable toggle now sits directly beneath **Enable Globally** so the two scope controls are adjacent. **Show Indicator** is renamed to **Show Cotabby Indicator**, and the multi-line switch is relabeled **Allow Multi-line Suggestions** and moved up next to the other behavior toggles instead of trailing the engine/model/length pickers.

Note: the per-app toggle (`Enable in <app>`) is conditional on a focused non-terminal external app, so it only renders when Cotabby has tracked one — it was never removed, just positioned below the clipboard toggle.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

swiftlint lint --quiet Cotabby/UI/MenuBarView.swift
# exit 0
```

UI-only change to existing toggles; behavior of each setting is unchanged.

## Linked issues

_None._

## Risk / rollout notes

Pure presentation change — toggle order and labels only. No settings, schema, or persistence changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reorders the toggle controls in the menu bar panel and clarifies two toggle labels. No bindings, settings persistence, or behavioral logic is changed.

- Moves "Enable in \<app\>" directly below "Enable Globally" so the two scope controls are adjacent, then groups clipboard, indicator, and multi-line toggles together before the engine/model/length pickers.
- Renames "Show Indicator" → "Show Cotabby Indicator" and "Multi-line" → "Allow Multi-line Suggestions" for clarity.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely reorders existing toggles and updates two labels with no functional changes.

Every toggle retains its original binding and behavior. The two renamed labels are purely cosmetic strings. The new ordering groups scope controls together and places all toggles before the pickers, which is a sensible UX improvement with no risk of breakage.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/MenuBarView.swift | Toggle reorder and two label renames; all bindings and logic are unchanged. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Enable Globally] --> B{latestExternalApplication\nnon-terminal?}
    B -- yes --> C[Enable in app]
    B -- no --> D[Include Clipboard Context]
    C --> D
    D --> E[Show Cotabby Indicator]
    E --> F[Allow Multi-line Suggestions]
    F --> G[Engine picker]
    G --> H{selectedEngine ==\nappleIntelligence\n&& unavailable?}
    H -- yes --> I[Availability warning]
    H -- no --> J{supportsLocal\nModelManagement?}
    I --> J
    J -- yes --> K[Model picker]
    J -- no --> L[Length picker]
    K --> L
```

<sub>Reviews (1): Last reviewed commit: ["Reorder menu bar toggles and clarify the..."](https://github.com/fujacob/tabby/commit/af6c9a2d34075a2253cde82303a05fa0bfd8f8ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33746677)</sub>

<!-- /greptile_comment -->