### PR TITLE
Refine Support section copy and donate button

### DIFF
--- a/Cotabby/UI/SettingsView.swift
+++ b/Cotabby/UI/SettingsView.swift
@@ -82,7 +82,7 @@ struct SettingsView: View {
                     Text("Cotabby")
                         .font(.system(size: 15, weight: .semibold, design: .rounded))
 
-                    Text("Local AI Autocomplete")
+                    Text("Local macOS AI Autocomplete")
                         .font(.system(size: 11, design: .rounded))
                         .foregroundStyle(.secondary)
                 }
@@ -414,10 +414,18 @@ struct SettingsView: View {
     private var supportSection: some View {
         Section("Support") {
             LabeledContent {
-                Link("Buy Me a Coffee", destination: URL(string: "https://buymeacoffee.com/cotabby")!)
+                Link(destination: URL(string: "https://buymeacoffee.com/cotabby")!) {
+                    Text("Support Us")
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.blue)
             } label: {
-                Text("Cotabby is free and open source. If it's useful to you, consider supporting development.")
-                    .foregroundStyle(.secondary)
+                Text(
+                    "Cotabby is free and open source, maintained by two university students. "
+                    + "If it's useful to you, consider supporting development."
+                )
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
             }
         }
     }


### PR DESCRIPTION
## Summary

Polishes the Settings Support section. Updates the blurb to mention Cotabby is maintained by two university students, replaces the plain "Buy Me a Coffee" text link with a prominent blue "Support Us" button, and clarifies the header tagline to "Local macOS AI Autocomplete". The long description now uses `fixedSize` so it wraps and stays vertically aligned next to the button.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

swiftlint lint --quiet Cotabby/UI/SettingsView.swift
# exit 0, no warnings
```

UI is copy/styling only within the existing Form `Section`.

## Linked issues

None.

## Risk / rollout notes

Cosmetic only — no behavior, settings, or schema changes. The donate URL is unchanged (https://buymeacoffee.com/cotabby).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Polishes the Settings **Support** section with copy and styling updates only — no behavior, settings, or schema changes are introduced.

- Updates the app header tagline from \"Local AI Autocomplete\" to \"Local macOS AI Autocomplete\" and expands the support blurb to mention two university students.
- Replaces the plain `Link` text with a `borderedProminent` blue \"Support Us\" button and adds `.fixedSize(horizontal: false, vertical: true)` to ensure the label text wraps correctly alongside it.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are confined to display copy and button styling within an existing Form Section.

Both hunks touch only static text values and SwiftUI view modifiers. The donate URL is unchanged and was already force-unwrapped as a compile-time constant before this PR. The `.fixedSize` modifier is applied correctly (vertical only) for multi-line label wrapping inside a `LabeledContent`. No state, settings, services, or business logic are touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/SettingsView.swift | Cosmetic-only changes: updated tagline copy, replaced plain text link with a `borderedProminent` blue button, expanded support blurb, and added `fixedSize` for correct text wrapping — no logic or behavior changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SettingsView] --> B[supportSection]
    B --> C["Section('Support')"]
    C --> D[LabeledContent]
    D --> E["label: Text — updated copy + fixedSize(horizontal: false, vertical: true)"]
    D --> F["content: Link → buymeacoffee.com/cotabby .buttonStyle(.borderedProminent) .tint(.blue)"]
    F --> G["Opens URL in browser"]
```

<sub>Reviews (1): Last reviewed commit: ["Refine Support section copy and styling"](https://github.com/fujacob/tabby/commit/c0d90e6478e279eb69af786f2bfeaefc1dbd116c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33749899)</sub>

<!-- /greptile_comment -->