### PR TITLE
Polish: menu-bar language picker, Apple Intelligence drift fix, drop beta labels

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,9 +54,13 @@ jobs:
       # it, xcodebuild would refuse to embed the test xctest bundle into the
       # host app's Contents/PlugIns for loading.
       - name: Run tests
+        # FoundationModelDriftEvalTests is excluded here: it drives the real on-device Apple
+        # Intelligence model (absent on CI runners) and is non-deterministic. It self-skips via
+        # RUN_FM_EVAL too, but skipping it explicitly keeps the CI intent visible.
         run: |
           xcodebuild test \
             -project Cotabby.xcodeproj \
             -scheme Cotabby \
             -destination 'platform=macOS' \
+            -skip-testing:CotabbyTests/FoundationModelDriftEvalTests \
             CODE_SIGNING_ALLOWED=NO

--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		E10000042F93000100DDD004 /* BundledRuntimeLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10000142F93000100DDD014 /* BundledRuntimeLocatorTests.swift */; };
 		E10000052F93000100DDD005 /* DisplayCoordinateConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10000152F93000100DDD015 /* DisplayCoordinateConverterTests.swift */; };
 		F10000012FA0000100EEE001 /* TextDirectionDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10000112FA0000100EEE011 /* TextDirectionDetectorTests.swift */; };
+		FA0000012FA4000100FFF001 /* FoundationModelDriftEvalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0000112FA4000100FFF011 /* FoundationModelDriftEvalTests.swift */; };
 		G10000012FB0000100FFF001 /* WordCountFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = G10000112FB0000100FFF011 /* WordCountFormatterTests.swift */; };
 		G10000022FB0000100FFF002 /* ClipboardContentDistillerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = G10000122FB0000100FFF012 /* ClipboardContentDistillerTests.swift */; };
 		G20000012FB0000100FFF001 /* ClipboardRelevanceFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = G20000112FB0000100FFF011 /* ClipboardRelevanceFilterTests.swift */; };
@@ -71,6 +72,7 @@
 		F10000112FA0000100EEE011 /* TextDirectionDetectorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TextDirectionDetectorTests.swift; sourceTree = "<group>"; };
 		F29623C5C0A67B992D383A3C /* LlamaPromptRendererTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LlamaPromptRendererTests.swift; sourceTree = "<group>"; };
 		F9D35DB9E86506B9FAE1CFE9 /* ModelFileValidatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ModelFileValidatorTests.swift; sourceTree = "<group>"; };
+		FA0000112FA4000100FFF011 /* FoundationModelDriftEvalTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FoundationModelDriftEvalTests.swift; sourceTree = "<group>"; };
 		G10000112FB0000100FFF011 /* WordCountFormatterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WordCountFormatterTests.swift; sourceTree = "<group>"; };
 		G10000122FB0000100FFF012 /* ClipboardContentDistillerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ClipboardContentDistillerTests.swift; sourceTree = "<group>"; };
 		G20000112FB0000100FFF011 /* ClipboardRelevanceFilterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ClipboardRelevanceFilterTests.swift; sourceTree = "<group>"; };
@@ -130,6 +132,7 @@
 				C10000112F91000100BBB011 /* CotabbyTestFixtures.swift */,
 				F29623C5C0A67B992D383A3C /* LlamaPromptRendererTests.swift */,
 				C10000302F91000100BBB030 /* CustomRulesTests.swift */,
+				FA0000112FA4000100FFF011 /* FoundationModelDriftEvalTests.swift */,
 				C10000152F91000100BBB015 /* PromptPolicyTests.swift */,
 				5A39EC1A44E9160E13E2AE77 /* SuggestionAvailabilityEvaluatorTests.swift */,
 				8B1121FFDAD30C7F62E15289 /* SuggestionRequestFactoryTests.swift */,
@@ -273,6 +276,7 @@
 			files = (
 				A404828463CADB2ECDAE7AF3 /* LlamaPromptRendererTests.swift in Sources */,
 				C10000312F91000100BBB031 /* CustomRulesTests.swift in Sources */,
+				FA0000012FA4000100FFF001 /* FoundationModelDriftEvalTests.swift in Sources */,
 				B053492719F6106E48290C32 /* SuggestionAvailabilityEvaluatorTests.swift in Sources */,
 				ADEFEE12C197DB6C990E3812 /* SuggestionRequestFactoryTests.swift in Sources */,
 				C10000022F91000100BBB002 /* SuggestionTextNormalizerTests.swift in Sources */,
@@ -435,7 +439,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
@@ -446,6 +450,7 @@
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = CotabbyInfo.plist;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -470,7 +475,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
@@ -481,6 +486,7 @@
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = CotabbyInfo.plist;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",

--- a/Cotabby/Models/SuggestionEngineModels.swift
+++ b/Cotabby/Models/SuggestionEngineModels.swift
@@ -16,7 +16,7 @@ enum SuggestionEngineKind: String, CaseIterable, Equatable, Hashable, Sendable, 
     var displayLabel: String {
         switch self {
         case .appleIntelligence:
-            return "Apple Intelligence [BETA]"
+            return "Apple Intelligence"
         case .llamaOpenSource:
             return "Open Source"
         }

--- a/Cotabby/Support/FoundationModelPromptRenderer.swift
+++ b/Cotabby/Support/FoundationModelPromptRenderer.swift
@@ -14,18 +14,31 @@ enum FoundationModelPromptRenderer {
     /// Session instructions define the model's role and output contract.
     /// Apple documents that instructions have higher priority than the prompt itself, which makes
     /// them the right place to say "this is autocomplete, not chat."
+    ///
+    /// The framing is deliberately *text continuation*, not *assist the user*. Apple's system model
+    /// is chat-tuned, so any second-person/assistant framing ("complete the user's text", a stated
+    /// user name) pulls it toward greetings and replies ("Jacob, how are you", "Hope it's going
+    /// well"). We replace negative "don't chat" rules with a positive identity plus few-shot
+    /// examples, which steer the chat prior far more reliably than prohibitions.
     static func sessionInstructions(for request: SuggestionRequest) -> String {
         var lines = [
-            "You are Cotabby's inline autocomplete engine for a macOS text field.",
-            "Complete the user's existing text at the current caret position.",
-            "This is not a chatbot.",
-            "Do not answer the user as an assistant or begin a conversation.",
+            "You are a text-continuation engine. Output only the text that comes immediately after "
+                + "the existing text, as if the same person kept typing in the same field.",
+            "You are not a chatbot or assistant. Never greet, introduce yourself, address the reader, "
+                + "ask a question, or start a new message.",
+            "There is no request to fulfill — you only continue text. Never refuse, apologize, or say "
+                + "you cannot help; always produce a continuation of the existing text.",
+            "Do not open your output with a person's name or with words like \"Hi\", \"Hey\", "
+                + "\"Hello\", \"Hope\", \"Thanks\", or \"Dear\" unless the existing text already began "
+                + "that exact phrase and you are finishing it.",
+            "Continue the existing sentence or thought — extend it, never restart it.",
             "Return exactly one continuation fragment.",
             request.completionLengthInstruction,
             "Do not repeat or quote the existing text.",
             "Match the existing tone, language, casing, and punctuation.",
-            "Use clipboard context only when it directly helps the inline continuation.",
-            "Use plain text only with no labels, bullets, markdown, or explanation."
+            "Use clipboard and screen context only when it directly helps the inline continuation.",
+            "Output plain text only: no labels, bullets, markdown, surrounding quotation marks, "
+                + "or explanation."
         ]
 
         // A language override supersedes the "match the existing language" base rule above, so it
@@ -34,15 +47,16 @@ enum FoundationModelPromptRenderer {
             lines.append(languageInstruction)
         }
 
-        var profileSections: [String] = []
-        if let name = request.userName, !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            profileSections.append("The user's name is \(name).")
-        }
-        if !profileSections.isEmpty {
-            lines.append("User Profile Context:")
-            lines.append(contentsOf: profileSections)
-            lines.append("Use this context only when it fits naturally into the continuation.")
-        }
+        // We intentionally do NOT inject the user's name here. On the chat-tuned system model a
+        // stated name is the single biggest trigger for breaking character ("Jacob, how are
+        // you"). The llama backend still personalizes via `LlamaPromptRenderer`; Apple's model
+        // does not get the name until we can scope it to contexts that actually need it.
+
+        // Few-shot examples are the strongest signal that the task is "keep typing", not "reply".
+        // They deliberately include openers that tempt a greeting (a name, "Hey", "Thanks") and show
+        // the model finishing the thought instead.
+        lines.append("Examples (quotes only mark the text boundaries — never output the quotes):")
+        lines.append(contentsOf: Self.continuationExampleLines)
 
         // Style rules live in the high-priority instructions channel like the base rules, but are
         // appended last with an explicit subordination line so they cannot override the output
@@ -58,6 +72,23 @@ enum FoundationModelPromptRenderer {
 
         return lines.joined(separator: "\n")
     }
+
+    /// Demonstrations that lock the "continue, don't converse" behavior. Each pairs the text already
+    /// in the field with the bare continuation. Cases target the observed failure modes: re-greeting
+    /// when a name is present, adding pleasantries, and restarting the sentence. Kept single-line so
+    /// they don't fragment the newline-joined instructions block.
+    private static let continuationExampleLines: [String] = [
+        "Existing text: \"I just wanted to follow up on the \"",
+        "Continuation: proposal we discussed last week.",
+        "Existing text: \"Thanks Priya — I'll look over the \"",
+        "Continuation: draft and send notes tomorrow.",
+        "Existing text: \"Hi team,\n\nQuick update — we \"",
+        "Continuation: finished the migration ahead of schedule.",
+        "Existing text: \"lol yeah I totally \"",
+        "Continuation: forgot we had that meeting today.",
+        "Existing text: \"def total(items): return \"",
+        "Continuation: sum(item.price for item in items)"
+    ]
 
     /// The request prompt stays short and concrete.
     /// Foundation Models tends to behave more reliably when the prompt describes the immediate task

--- a/Cotabby/UI/MenuBarView.swift
+++ b/Cotabby/UI/MenuBarView.swift
@@ -126,6 +126,17 @@ struct MenuBarView: View {
                 .labelsHidden()
                 .pickerStyle(.menu)
             }
+
+            MenuBarPickerRow(title: "Language") {
+                Picker("Language", selection: selectedLanguageBinding) {
+                    ForEach(SuggestionLanguage.allCases) { language in
+                        Text(language.displayLabel)
+                            .tag(language)
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.menu)
+            }
         }
         .padding(.bottom, 12)
     }
@@ -298,6 +309,15 @@ struct MenuBarView: View {
             get: { suggestionSettings.selectedWordCountPreset },
             set: { preset in
                 suggestionSettings.selectWordCountPreset(preset)
+            }
+        )
+    }
+
+    private var selectedLanguageBinding: Binding<SuggestionLanguage> {
+        Binding(
+            get: { suggestionSettings.responseLanguage },
+            set: { language in
+                suggestionSettings.setResponseLanguage(language)
             }
         )
     }

--- a/Cotabby/UI/WelcomeView.swift
+++ b/Cotabby/UI/WelcomeView.swift
@@ -192,7 +192,7 @@ extension WelcomeView {
 
         return EngineCard(
             artworkName: "apple_intelligence",
-            title: "Apple Intelligence [BETA]",
+            title: "Apple Intelligence",
             subtitle: isAvailable
                 ? "Built into macOS. No download needed."
                 : "Requires Apple Silicon and macOS 26.",

--- a/CotabbyTests/FoundationModelDriftEvalTests.swift
+++ b/CotabbyTests/FoundationModelDriftEvalTests.swift
@@ -1,0 +1,115 @@
+import XCTest
+@testable import Cotabby
+
+#if canImport(FoundationModels)
+
+/// Live Apple Intelligence drift eval — deliberately NOT a CI test.
+///
+/// Apple's system model is chat-tuned and used to break character on plain prefixes: greeting the
+/// user ("Jacob, how are you"), tacking on pleasantries ("Hope it's going well"), or replying like
+/// an assistant. This harness runs real on-device generations against the prefixes that historically
+/// drifted and reports how many still do, so prompt changes can be measured instead of guessed at.
+///
+/// It is gated behind the `RUN_FM_EVAL` compilation condition because it (a) needs the on-device
+/// model, which CI runners do not have, and (b) is non-deterministic, so it is a local tuning tool
+/// rather than a hard gate. xcodebuild does not forward shell env vars to the macOS test host, so a
+/// compile flag (which *is* passable on the command line) is the reliable switch. CI never sets it
+/// — and `tests.yml` also `-skip-testing`s this class — so it is a no-op there.
+///
+/// Run locally with:
+///   xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
+///     -only-testing:CotabbyTests/FoundationModelDriftEvalTests \
+///     SWIFT_ACTIVE_COMPILATION_CONDITIONS='$(inherited) RUN_FM_EVAL' CODE_SIGNING_ALLOWED=NO
+@available(macOS 26.0, *)
+@MainActor
+final class FoundationModelDriftEvalTests: XCTestCase {
+#if RUN_FM_EVAL
+    /// Prefixes that previously pulled the model into assistant/chat replies. Each ends mid-thought,
+    /// where the correct behavior is to keep typing, not to greet or reply.
+    private static let cases: [String] = [
+        "Hey Jacob, ",
+        "Hi Sarah,\n\n",
+        "Thanks for ",
+        "I wanted to reach out about ",
+        "Good morning team, ",
+        "Let me know if ",
+        "lol yeah ",
+        "The quarterly numbers are ",
+        "Please review the ",
+        "Hello! "
+    ]
+
+    /// Phrases that mark a continuation as out-of-character: assistant replies, greetings, or the
+    /// pleasantries the user flagged. Matched case-insensitively anywhere in the output.
+    private static let driftTells: [String] = [
+        "how are you", "how's it going", "hows it going", "hope you", "hope it", "hope this",
+        "as an ai", "i'm here to", "i am here to", "let me know if you", "feel free to",
+        "happy to help", "how can i help", "is there anything i", "i'd be happy", "i would be happy",
+        // Assistant refusals / apologies — the model treating the prefix as a request to decline.
+        "i'm sorry", "i am sorry", "i cannot assist", "i can't assist", "cannot assist with",
+        "cannot help with", "unable to assist", "i cannot help", "i can't help"
+    ]
+
+    func test_reportAssistantDriftRate() async throws {
+        let availability = FoundationModelAvailabilityService()
+        availability.refresh()
+        try XCTSkipUnless(
+            availability.isAvailable,
+            "Apple Intelligence is unavailable here: \(availability.userVisibleMessage)"
+        )
+
+        let engine = FoundationModelSuggestionEngine(availabilityService: availability)
+
+        var driftCount = 0
+        var report = "\n=== FM drift eval ===\n"
+        for (index, prefix) in Self.cases.enumerated() {
+            let request = CotabbyTestFixtures.suggestionRequest(
+                prefixText: prefix,
+                maxPredictionTokens: 32
+            )
+            let result = try await engine.generateSuggestion(for: request)
+            let drifted = Self.isDrift(prefix: prefix, output: result.text)
+            if drifted { driftCount += 1 }
+            report += "[\(index + 1)] \(drifted ? "DRIFT" : "ok   ") prefix=\(prefix.debugDescription)\n"
+            report += "        norm=\(result.text.debugDescription)\n"
+            report += "        raw =\(result.rawText.debugDescription)\n"
+        }
+        report += "drift: \(driftCount)/\(Self.cases.count)\n"
+        print(report)
+
+        XCTAssertLessThanOrEqual(
+            driftCount,
+            2,
+            "Too many out-of-character continuations.\(report)"
+        )
+    }
+
+    /// A continuation drifts if it contains an assistant tell, or opens with a greeting word that the
+    /// prefix had not already started (so finishing "Hi Sa…" → "rah" is fine, but a bare "Hi there"
+    /// after a mid-sentence prefix is drift).
+    private static func isDrift(prefix: String, output: String) -> Bool {
+        let lower = output.lowercased()
+        if driftTells.contains(where: { lower.contains($0) }) {
+            return true
+        }
+
+        // Greeting openers only — "thanks" is omitted because continuing the user's own message with
+        // a thank-you ("Hey Jacob, " -> "thanks for the update") is correct, not assistant drift.
+        let openers = ["hi ", "hey ", "hello", "dear ", "good morning", "good afternoon"]
+        let trimmed = lower.trimmingCharacters(in: .whitespacesAndNewlines)
+        let prefixLower = prefix.lowercased()
+        return openers.contains { opener in
+            trimmed.hasPrefix(opener) && !prefixLower.contains(opener)
+        }
+    }
+#else
+    func test_reportAssistantDriftRate() throws {
+        throw XCTSkip(
+            "Live FM eval is local-only. Run with "
+                + "SWIFT_ACTIVE_COMPILATION_CONDITIONS='$(inherited) RUN_FM_EVAL' (see file header)."
+        )
+    }
+#endif
+}
+
+#endif

--- a/CotabbyTests/PromptPolicyTests.swift
+++ b/CotabbyTests/PromptPolicyTests.swift
@@ -14,10 +14,29 @@ final class FoundationModelPromptRendererTests: XCTestCase {
 
         let instructions = FoundationModelPromptRenderer.sessionInstructions(for: request)
 
-        XCTAssertTrue(instructions.contains("inline autocomplete engine"))
+        XCTAssertTrue(instructions.contains("text-continuation engine"))
         XCTAssertTrue(instructions.contains("UNIQUE_LENGTH_POLICY"))
-        XCTAssertTrue(instructions.contains("UNIQUE_PROFILE_NAME"))
         XCTAssertTrue(instructions.contains("Do not repeat or quote the existing text."))
+    }
+
+    /// The user's name is deliberately withheld from Apple's chat-tuned model: a stated name is the
+    /// main trigger for breaking character ("Jacob, how are you"). Personalization stays on llama.
+    func test_sessionInstructions_omitTheUserName() {
+        let request = CotabbyTestFixtures.suggestionRequest(userName: "UNIQUE_PROFILE_NAME")
+
+        let instructions = FoundationModelPromptRenderer.sessionInstructions(for: request)
+
+        XCTAssertFalse(instructions.contains("UNIQUE_PROFILE_NAME"))
+    }
+
+    /// Few-shot examples are the primary anti-drift mechanism, so guard their presence.
+    func test_sessionInstructions_includeContinuationExamples() {
+        let request = CotabbyTestFixtures.suggestionRequest()
+
+        let instructions = FoundationModelPromptRenderer.sessionInstructions(for: request)
+
+        XCTAssertTrue(instructions.contains("Examples ("))
+        XCTAssertTrue(instructions.contains("Continuation:"))
     }
 
     func test_prompt_includesApplicationNameAndPreservesPrefixText() {

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Everything runs on-device. No hosted API, no cloud round-trip.
 
 ## Engines
 
-**Apple Intelligence [EXPERIMENTAL]**: uses Apple's on-device `FoundationModels` runtime on macOS 26 or later, no download required. Currently does not perform as well as the Open Source models. We're actively working on improving it.
+**Apple Intelligence**: uses Apple's on-device `FoundationModels` runtime on macOS 26 or later, no download required.
 
 **Open Source**: runs local GGUF models in-process through llama.cpp via `llama.swift`. Built-in downloadable models suggested for use:
 


### PR DESCRIPTION
## Summary

Follow-up to #239 carrying three commits that landed on the branch after that PR was squash-merged, so they never reached `main`:
- Menu-bar response-language picker (parity with the Settings picker).
- Reduce Apple Intelligence (Foundation Models) assistant drift: reframe instructions as a text-continuation engine, drop the user's name from FM instructions (top trigger for "Jacob, how are you"; llama still personalizes), forbid refusals/apologies, and add few-shot continuation examples. Adds a flag-gated live eval (`FoundationModelDriftEvalTests`) that is `-skip-testing`'d in CI.
- Drop the `[BETA]`/`[EXPERIMENTAL]` labels and the "does not perform as well" disclaimer for Apple Intelligence (app + README).

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build   # ** BUILD SUCCEEDED **
xcodebuild test ... -only-testing:CotabbyTests/FoundationModelPromptRendererTests             # ** TEST SUCCEEDED **
```

Local FM drift eval (RUN_FM_EVAL compile flag): assistant drift down to 1/10; the holdout is an Apple guardrail refusal on an empty-body greeting, not a prompt issue. The eval needs the on-device model and is non-deterministic, so it self-skips without the flag and is `-skip-testing`'d in CI.

## Linked issues

Refs #239.

## Risk / rollout notes

- Prompt-only change for Apple Intelligence behavior; llama path unchanged (still uses the name).
- New test file registered in `project.pbxproj`; excluded from CI via `-skip-testing` + a compile-flag gate.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers three follow-up changes after #239: a Language picker in the menu bar (matching the existing Settings picker), a prompt-engineering overhaul for Apple Intelligence to reduce assistant drift (text-continuation identity + five few-shot examples, dropping the username injection), and removal of the `[BETA]`/`[EXPERIMENTAL]` labels and performance disclaimer. A flag-gated local drift eval harness (`FoundationModelDriftEvalTests`) is also added and correctly excluded from CI.

- **Menu-bar language picker**: mirrors the Settings picker pattern exactly; the new `selectedLanguageBinding` follows the same `Binding(get:set:)` shape as all other bindings in `MenuBarView`.
- **FM prompt rewrite**: replaces negative prohibitions with a positive text-continuation identity and five few-shot examples targeting the specific failure modes (greeting prefixes, pleasantries, re-starting sentences); username injection is removed with a clear comment linking to why and where personalization still lives.
- **Project changes outside the stated scope**: `CODE_SIGN_IDENTITY` is changed from ad-hoc (`\"-\"`) to `\"Apple Development\"` in both Debug and Release configs, and `LSApplicationCategoryType` is added — the signing change could affect local builds for contributors without an Apple Developer certificate.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the prompt and UI changes are well-scoped, the new eval test is correctly double-gated, and CI is unaffected by any of the changes.

The functional changes (language picker, prompt rewrite, label removal) are clean and well-tested. The only concerns are a false-negative edge case in the local-only drift eval harness and an unrelated signing identity change in the project file that could surprise contributors building locally without an Apple Developer certificate.

Cotabby.xcodeproj/project.pbxproj — the CODE_SIGN_IDENTITY change is unrelated to the stated PR scope and worth a quick second look. CotabbyTests/FoundationModelDriftEvalTests.swift — the isDrift helper has a minor false-negative edge case in the greeting-opener check.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby.xcodeproj/project.pbxproj | Registers FoundationModelDriftEvalTests.swift; also changes CODE_SIGN_IDENTITY from ad-hoc to Apple Development in both Debug and Release, and adds LSApplicationCategoryType — both unrelated to the PR scope and potentially breaking for contributors without Apple Developer certs. |
| Cotabby/Support/FoundationModelPromptRenderer.swift | Rewrites session instructions with a text-continuation identity, drops username injection, and appends five few-shot examples targeting observed drift failure modes; well-commented and backed by new unit tests. |
| Cotabby/UI/MenuBarView.swift | Adds a Language picker row (MenuBarPickerRow + selectedLanguageBinding) matching the existing Settings picker pattern; implementation is clean and consistent with the surrounding binding style. |
| CotabbyTests/FoundationModelDriftEvalTests.swift | New flag-gated local eval harness for FM drift; correctly double-gated and excluded from CI, but isDrift has a false-negative edge case when the prefix starts with a greeting opener and uses contains instead of hasPrefix for the exclusion check. |
| CotabbyTests/PromptPolicyTests.swift | Tests updated to reflect new prompt contract: checks for text-continuation identity, asserts username is omitted, and guards presence of few-shot examples; all three new/modified tests are precise and meaningful. |
| .github/workflows/tests.yml | Adds -skip-testing:CotabbyTests/FoundationModelDriftEvalTests with an explanatory comment; CI intent is clear and the change is correct. |
| Cotabby/Models/SuggestionEngineModels.swift | Removes [BETA] suffix from Apple Intelligence display label; one-line change, no issues. |
| Cotabby/UI/WelcomeView.swift | Removes [BETA] from the engine card title; clean one-line change. |
| README.md | Drops [EXPERIMENTAL] label and does-not-perform-as-well disclaimer for Apple Intelligence; accurate given the prompt improvements. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SuggestionRequest] --> B[sessionInstructions]
    B --> C[Base rules block\ntext-continuation identity\nno greet / no refuse / no repeat]
    C --> D{Language override?}
    D -- yes --> E[Append languageInstruction]
    D -- no --> F[Skip]
    E --> G[Append few-shot\ncontinuationExampleLines]
    F --> G
    G --> H{Custom style rules?}
    H -- yes --> I[Append style rules\nsubordinated to contract]
    H -- no --> J[Skip]
    I --> K[lines.joined separator newline]
    J --> K
    K --> L[Instructions string to Apple Foundation Models]

    M[MenuBarView] --> N[Language Picker]
    N --> O[selectedLanguageBinding\nget: suggestionSettings.responseLanguage\nset: setResponseLanguage]
    O --> P[SuggestionSettingsModel]
    P --> Q[Persisted to UserDefaults]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22ai-polish-followup%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ai-polish-followup%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabbyTests%2FFoundationModelDriftEvalTests.swift%3A100-103%0A**Drift%20detection%20has%20false%20negatives%20for%20greeting-opener%20prefixes**%0A%0A%60prefixLower.contains%28opener%29%60%20is%20used%20to%20exempt%20continuations%20when%20the%20prefix%20already%20includes%20the%20opener%2C%20but%20%60contains%60%20is%20broader%20than%20%60hasPrefix%60.%20For%20the%20test%20case%20%60%22Hey%20Jacob%2C%20%22%60%2C%20%60prefixLower.contains%28%22hey%20%22%29%60%20is%20%60true%60%2C%20so%20a%20re-greeting%20output%20that%20starts%20with%20%60%22hey%20%22%60%20%28e.g.%20%22hey%20there%2C%20how%20are%20you%22%29%20bypasses%20the%20opener%20check%20entirely%20and%20is%20only%20caught%20if%20its%20content%20happens%20to%20match%20a%20%60driftTells%60%20phrase.%20The%20exclusion%20was%20intended%20to%20handle%20%22finishing%20Hi%20Sa%E2%80%A6%20%E2%86%92%20rah%22%2C%20which%20only%20requires%20checking%20whether%20the%20prefix%20**starts**%20with%20the%20opener.%20Switching%20to%20%60prefixLower.hasPrefix%28opener%29%60%20would%20correctly%20allow%20completion%20of%20an%20in-progress%20greeting%20while%20still%20flagging%20a%20fresh%20one.%0A%0AA%20second%20minor%20inconsistency%3A%20%60%22hello%22%60%20in%20%60openers%60%20has%20no%20trailing%20space%2C%20while%20all%20other%20entries%20%28%60%22hi%20%22%60%2C%20%60%22hey%20%22%60%2C%20%60%22dear%20%22%60%2C%20etc.%29%20do.%20This%20means%20a%20continuation%20like%20%60%22helloooo%22%60%20would%20be%20flagged%20as%20drift%2C%20which%20is%20a%20false%20positive%20unlikely%20to%20occur%20in%20practice%20but%20asymmetric%20with%20the%20rest%20of%20the%20list.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby.xcodeproj%2Fproject.pbxproj%3A439-443%0A**Unrelated%20signing%20identity%20change%20may%20break%20local%20builds%20without%20Apple%20Developer%20cert**%0A%0ABoth%20Debug%20and%20Release%20configurations%20for%20the%20Cotabby%20app%20target%20are%20changed%20from%20ad-hoc%20signing%20%28%60%22-%22%60%29%20to%20%60%22Apple%20Development%22%60.%20This%20change%20is%20unrelated%20to%20the%20PR's%20stated%20scope%20and%2C%20with%20%60CODE_SIGN_STYLE%20%3D%20Automatic%60%2C%20will%20cause%20Xcode%20to%20look%20up%20an%20Apple%20Developer%20identity%20in%20the%20keychain%3B%20contributors%20without%20a%20paid%20or%20free%20Apple%20Developer%20account%20enrolled%20in%20Xcode%20would%20see%20a%20%22No%20signing%20certificate%20found%22%20error.%20CI%20is%20unaffected%20because%20%60CODE_SIGNING_ALLOWED%3DNO%60%20is%20passed%20in%20%60tests.yml%60.%20If%20this%20change%20is%20intentional%20%28e.g.%20to%20support%20entitlements%20that%20require%20a%20provisioning%20profile%29%2C%20a%20brief%20note%20in%20the%20PR%20description%20or%20a%20comment%20in%20the%20%60.pbxproj%60%20would%20help%20future%20contributors%20understand%20the%20requirement.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabbyTests%2FFoundationModelDriftEvalTests.swift%3A100-103%0A**Drift%20detection%20has%20false%20negatives%20for%20greeting-opener%20prefixes**%0A%0A%60prefixLower.contains%28opener%29%60%20is%20used%20to%20exempt%20continuations%20when%20the%20prefix%20already%20includes%20the%20opener%2C%20but%20%60contains%60%20is%20broader%20than%20%60hasPrefix%60.%20For%20the%20test%20case%20%60%22Hey%20Jacob%2C%20%22%60%2C%20%60prefixLower.contains%28%22hey%20%22%29%60%20is%20%60true%60%2C%20so%20a%20re-greeting%20output%20that%20starts%20with%20%60%22hey%20%22%60%20%28e.g.%20%22hey%20there%2C%20how%20are%20you%22%29%20bypasses%20the%20opener%20check%20entirely%20and%20is%20only%20caught%20if%20its%20content%20happens%20to%20match%20a%20%60driftTells%60%20phrase.%20The%20exclusion%20was%20intended%20to%20handle%20%22finishing%20Hi%20Sa%E2%80%A6%20%E2%86%92%20rah%22%2C%20which%20only%20requires%20checking%20whether%20the%20prefix%20**starts**%20with%20the%20opener.%20Switching%20to%20%60prefixLower.hasPrefix%28opener%29%60%20would%20correctly%20allow%20completion%20of%20an%20in-progress%20greeting%20while%20still%20flagging%20a%20fresh%20one.%0A%0AA%20second%20minor%20inconsistency%3A%20%60%22hello%22%60%20in%20%60openers%60%20has%20no%20trailing%20space%2C%20while%20all%20other%20entries%20%28%60%22hi%20%22%60%2C%20%60%22hey%20%22%60%2C%20%60%22dear%20%22%60%2C%20etc.%29%20do.%20This%20means%20a%20continuation%20like%20%60%22helloooo%22%60%20would%20be%20flagged%20as%20drift%2C%20which%20is%20a%20false%20positive%20unlikely%20to%20occur%20in%20practice%20but%20asymmetric%20with%20the%20rest%20of%20the%20list.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby.xcodeproj%2Fproject.pbxproj%3A439-443%0A**Unrelated%20signing%20identity%20change%20may%20break%20local%20builds%20without%20Apple%20Developer%20cert**%0A%0ABoth%20Debug%20and%20Release%20configurations%20for%20the%20Cotabby%20app%20target%20are%20changed%20from%20ad-hoc%20signing%20%28%60%22-%22%60%29%20to%20%60%22Apple%20Development%22%60.%20This%20change%20is%20unrelated%20to%20the%20PR's%20stated%20scope%20and%2C%20with%20%60CODE_SIGN_STYLE%20%3D%20Automatic%60%2C%20will%20cause%20Xcode%20to%20look%20up%20an%20Apple%20Developer%20identity%20in%20the%20keychain%3B%20contributors%20without%20a%20paid%20or%20free%20Apple%20Developer%20account%20enrolled%20in%20Xcode%20would%20see%20a%20%22No%20signing%20certificate%20found%22%20error.%20CI%20is%20unaffected%20because%20%60CODE_SIGNING_ALLOWED%3DNO%60%20is%20passed%20in%20%60tests.yml%60.%20If%20this%20change%20is%20intentional%20%28e.g.%20to%20support%20entitlements%20that%20require%20a%20provisioning%20profile%29%2C%20a%20brief%20note%20in%20the%20PR%20description%20or%20a%20comment%20in%20the%20%60.pbxproj%60%20would%20help%20future%20contributors%20understand%20the%20requirement.%0A%0A&repo=fujacob%2Ftabby&pr=244&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Drop Apple Intelligence beta/experimenta..."](https://github.com/fujacob/tabby/commit/3a2f31b189a09c8d0db85434159fc9f18c04dc5f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33752867)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->