### PR TITLE
Add two more downloadable models (four defaults)

### DIFF
--- a/Cotabby/Models/LlamaRuntimeModels.swift
+++ b/Cotabby/Models/LlamaRuntimeModels.swift
@@ -86,13 +86,13 @@ enum RuntimeModelCatalog {
     static func displayName(for filename: String) -> String {
         switch filename {
         case "Qwen3-0.6B-Q4_K_M.gguf":
-            return "Cotabby-Swift-1"
+            return "cotabby-swift-1"
         case "Qwen3.5-0.8B-Q4_K_M.gguf":
-            return "Cotabby-Swift+-1"
+            return "cotabby-swift-pro-1"
         case "gemma-3-1b-it-Q4_K_M.gguf":
-            return "Cotabby-Balanced-1"
+            return "cotabby-balanced-1"
         case "gemma-4-E2B-it-Q4_K_M.gguf":
-            return "Cotabby-Careful-1"
+            return "cotabby-careful-1"
         default:
             return filename
         }

--- a/Cotabby/Models/LlamaRuntimeModels.swift
+++ b/Cotabby/Models/LlamaRuntimeModels.swift
@@ -87,8 +87,12 @@ enum RuntimeModelCatalog {
         switch filename {
         case "Qwen3-0.6B-Q4_K_M.gguf":
             return "Cotabby-fast-1"
+        case "Qwen3.5-0.8B-Q4_K_M.gguf":
+            return "Cotabby-fast-2"
         case "gemma-3-1b-it-Q4_K_M.gguf":
             return "Cotabby-balanced-1"
+        case "gemma-4-E2B-it-Q4_K_M.gguf":
+            return "Cotabby-quality-1"
         default:
             return filename
         }
@@ -114,6 +118,17 @@ enum RuntimeModelCatalog {
             sha256: "ac2d97712095a558e31573f62f466a3f9d93990898b0ec79d7c974c1780d524a"
         ),
         DownloadableRuntimeModel(
+            filename: "Qwen3.5-0.8B-Q4_K_M.gguf",
+            displayName: displayName(for: "Qwen3.5-0.8B-Q4_K_M.gguf"),
+            downloadURL: URL(
+                string:
+                    "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/Qwen3.5-0.8B-Q4_K_M.gguf?download=true"
+            )!,
+            approximateSizeInGigabytes: 0.5,
+            expectedSizeBytes: 532_517_120,
+            sha256: "bd258782e35f7f458f8aced1adc053e6e92e89bc735ba3be89d38a06121dc517"
+        ),
+        DownloadableRuntimeModel(
             filename: "gemma-3-1b-it-Q4_K_M.gguf",
             displayName: displayName(for: "gemma-3-1b-it-Q4_K_M.gguf"),
             downloadURL: URL(
@@ -123,6 +138,17 @@ enum RuntimeModelCatalog {
             approximateSizeInGigabytes: 0.8,
             expectedSizeBytes: 806_058_272,
             sha256: "8270790f3ab69fdfe860b7b64008d9a19986d8df7e407bb018184caa08798ebd"
+        ),
+        DownloadableRuntimeModel(
+            filename: "gemma-4-E2B-it-Q4_K_M.gguf",
+            displayName: displayName(for: "gemma-4-E2B-it-Q4_K_M.gguf"),
+            downloadURL: URL(
+                string:
+                    "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/gemma-4-E2B-it-Q4_K_M.gguf?download=true"
+            )!,
+            approximateSizeInGigabytes: 3.1,
+            expectedSizeBytes: 3_106_736_256,
+            sha256: "9378bc471710229ef165709b62e34bfb62231420ddaf6d729e727305b5b8672d"
         )
     ]
 }

--- a/Cotabby/Models/LlamaRuntimeModels.swift
+++ b/Cotabby/Models/LlamaRuntimeModels.swift
@@ -86,13 +86,13 @@ enum RuntimeModelCatalog {
     static func displayName(for filename: String) -> String {
         switch filename {
         case "Qwen3-0.6B-Q4_K_M.gguf":
-            return "Cotabby-fast-1"
+            return "Cotabby-Swift-1"
         case "Qwen3.5-0.8B-Q4_K_M.gguf":
-            return "Cotabby-fast-2"
+            return "Cotabby-Swift+-1"
         case "gemma-3-1b-it-Q4_K_M.gguf":
-            return "Cotabby-balanced-1"
+            return "Cotabby-Balanced-1"
         case "gemma-4-E2B-it-Q4_K_M.gguf":
-            return "Cotabby-quality-1"
+            return "Cotabby-Careful-1"
         default:
             return filename
         }

--- a/CotabbyTests/ModelAndPresentationValueTests.swift
+++ b/CotabbyTests/ModelAndPresentationValueTests.swift
@@ -143,11 +143,19 @@ final class RuntimeAndInputModelValueTests: XCTestCase {
     func test_runtimeModelCatalogMapsKnownNamesAndLeavesCustomNamesAlone() {
         XCTAssertEqual(
             RuntimeModelCatalog.displayName(for: "Qwen3-0.6B-Q4_K_M.gguf"),
-            "Cotabby-fast-1"
+            "Cotabby-Swift-1"
+        )
+        XCTAssertEqual(
+            RuntimeModelCatalog.displayName(for: "Qwen3.5-0.8B-Q4_K_M.gguf"),
+            "Cotabby-Swift+-1"
         )
         XCTAssertEqual(
             RuntimeModelCatalog.displayName(for: "gemma-3-1b-it-Q4_K_M.gguf"),
-            "Cotabby-balanced-1"
+            "Cotabby-Balanced-1"
+        )
+        XCTAssertEqual(
+            RuntimeModelCatalog.displayName(for: "gemma-4-E2B-it-Q4_K_M.gguf"),
+            "Cotabby-Careful-1"
         )
         XCTAssertEqual(
             RuntimeModelCatalog.displayName(for: "custom-local-model.gguf"),

--- a/CotabbyTests/ModelAndPresentationValueTests.swift
+++ b/CotabbyTests/ModelAndPresentationValueTests.swift
@@ -143,19 +143,19 @@ final class RuntimeAndInputModelValueTests: XCTestCase {
     func test_runtimeModelCatalogMapsKnownNamesAndLeavesCustomNamesAlone() {
         XCTAssertEqual(
             RuntimeModelCatalog.displayName(for: "Qwen3-0.6B-Q4_K_M.gguf"),
-            "Cotabby-Swift-1"
+            "cotabby-swift-1"
         )
         XCTAssertEqual(
             RuntimeModelCatalog.displayName(for: "Qwen3.5-0.8B-Q4_K_M.gguf"),
-            "Cotabby-Swift+-1"
+            "cotabby-swift-pro-1"
         )
         XCTAssertEqual(
             RuntimeModelCatalog.displayName(for: "gemma-3-1b-it-Q4_K_M.gguf"),
-            "Cotabby-Balanced-1"
+            "cotabby-balanced-1"
         )
         XCTAssertEqual(
             RuntimeModelCatalog.displayName(for: "gemma-4-E2B-it-Q4_K_M.gguf"),
-            "Cotabby-Careful-1"
+            "cotabby-careful-1"
         )
         XCTAssertEqual(
             RuntimeModelCatalog.displayName(for: "custom-local-model.gguf"),

--- a/README.md
+++ b/README.md
@@ -89,10 +89,12 @@ Everything runs on-device. No hosted API, no cloud round-trip.
 
 **Open Source**: runs local GGUF models in-process through llama.cpp via `llama.swift`. Built-in downloadable models suggested for use:
 
-| Model              | File                            | Size    |
-| ------------------ | ------------------------------- | ------- |
-| `Cotabby-fast-1`     | `Qwen3-0.6B-Q4_K_M.gguf`       | ~0.4 GB |
-| `Cotabby-balanced-1` | `gemma-3-1b-it-Q4_K_M.gguf`    | ~0.8 GB |
+| Model                | File                          | Size    |
+| -------------------- | ----------------------------- | ------- |
+| `Cotabby-fast-1`     | `Qwen3-0.6B-Q4_K_M.gguf`      | ~0.4 GB |
+| `Cotabby-fast-2`     | `Qwen3.5-0.8B-Q4_K_M.gguf`    | ~0.5 GB |
+| `Cotabby-balanced-1` | `gemma-3-1b-it-Q4_K_M.gguf`   | ~0.8 GB |
+| `Cotabby-quality-1`  | `gemma-4-E2B-it-Q4_K_M.gguf`  | ~3.1 GB |
 
 You can also drop your own `.gguf` files into Cotabby's models folder and refresh the model list.
 

--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ Everything runs on-device. No hosted API, no cloud round-trip.
 
 | Model                | File                          | Size    |
 | -------------------- | ----------------------------- | ------- |
-| `Cotabby-Swift-1`    | `Qwen3-0.6B-Q4_K_M.gguf`      | ~0.4 GB |
-| `Cotabby-Swift+-1`   | `Qwen3.5-0.8B-Q4_K_M.gguf`    | ~0.5 GB |
-| `Cotabby-Balanced-1` | `gemma-3-1b-it-Q4_K_M.gguf`   | ~0.8 GB |
-| `Cotabby-Careful-1`  | `gemma-4-E2B-it-Q4_K_M.gguf`  | ~3.1 GB |
+| `cotabby-swift-1`     | `Qwen3-0.6B-Q4_K_M.gguf`     | ~0.4 GB |
+| `cotabby-swift-pro-1` | `Qwen3.5-0.8B-Q4_K_M.gguf`   | ~0.5 GB |
+| `cotabby-balanced-1`  | `gemma-3-1b-it-Q4_K_M.gguf`  | ~0.8 GB |
+| `cotabby-careful-1`   | `gemma-4-E2B-it-Q4_K_M.gguf` | ~3.1 GB |
 
 You can also drop your own `.gguf` files into Cotabby's models folder and refresh the model list.
 

--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ Everything runs on-device. No hosted API, no cloud round-trip.
 
 | Model                | File                          | Size    |
 | -------------------- | ----------------------------- | ------- |
-| `Cotabby-fast-1`     | `Qwen3-0.6B-Q4_K_M.gguf`      | ~0.4 GB |
-| `Cotabby-fast-2`     | `Qwen3.5-0.8B-Q4_K_M.gguf`    | ~0.5 GB |
-| `Cotabby-balanced-1` | `gemma-3-1b-it-Q4_K_M.gguf`   | ~0.8 GB |
-| `Cotabby-quality-1`  | `gemma-4-E2B-it-Q4_K_M.gguf`  | ~3.1 GB |
+| `Cotabby-Swift-1`    | `Qwen3-0.6B-Q4_K_M.gguf`      | ~0.4 GB |
+| `Cotabby-Swift+-1`   | `Qwen3.5-0.8B-Q4_K_M.gguf`    | ~0.5 GB |
+| `Cotabby-Balanced-1` | `gemma-3-1b-it-Q4_K_M.gguf`   | ~0.8 GB |
+| `Cotabby-Careful-1`  | `gemma-4-E2B-it-Q4_K_M.gguf`  | ~3.1 GB |
 
 You can also drop your own `.gguf` files into Cotabby's models folder and refresh the model list.
 


### PR DESCRIPTION
## Summary

Activates the two "newer models" that were sitting commented-out on the inference-engine branch, so the built-in downloadable catalog now offers four GGUF models across fast/balanced/quality tiers:

| Model | File | Size |
|---|---|---|
| `Cotabby-fast-1` | `Qwen3-0.6B-Q4_K_M.gguf` | ~0.4 GB (existing) |
| `Cotabby-fast-2` | `Qwen3.5-0.8B-Q4_K_M.gguf` | ~0.5 GB (new) |
| `Cotabby-balanced-1` | `gemma-3-1b-it-Q4_K_M.gguf` | ~0.8 GB (existing) |
| `Cotabby-quality-1` | `gemma-4-E2B-it-Q4_K_M.gguf` | ~3.1 GB (new) |

Display names route through `displayName(for:)` for consistency; `expectedSizeBytes`/`sha256` carried over from the captured HuggingFace CDN headers.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build   # ** BUILD SUCCEEDED **
```

Both new download URLs verified live (HTTP 200) via `curl -sIL`. No test asserts the catalog count, so none needed updating. README model table updated to match.

## Linked issues

<!-- none -->

## Risk / rollout notes

- Additive only — existing two models unchanged; download/validation pipeline already handles arbitrary catalog entries (size + SHA-256 gate).
- `Cotabby-quality-1` is ~3.1 GB; it's opt-in to download like the others.
- `LlamaRuntimeConfiguration.preferredModelNames` (runtime auto-load priority) left as-is; the new models are downloadable but not forced as the auto-load default.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands the built-in downloadable model catalog from two entries to four by activating two previously commented-out models (`Qwen3.5-0.8B-Q4_K_M.gguf` and `gemma-4-E2B-it-Q4_K_M.gguf`), and renames all display names to a consistent lowercase `cotabby-*` scheme.

- **New catalog entries**: Both new `DownloadableRuntimeModel` structs include `expectedSizeBytes` and `sha256` fields populated from HuggingFace CDN headers, which the existing size + SHA-256 validation gate will enforce on download.
- **Display name rename**: All four display names are now lowercase (e.g. `cotabby-swift-1`, `cotabby-balanced-1`); since model identity uses `filename` as `id`, not the display string, existing user selections are unaffected.
- **`LlamaRuntimeConfiguration.preferredModelNames`** is intentionally left with only the original two entries — the new models are opt-in downloads, not auto-load defaults.

<h3>Confidence Score: 5/5</h3>

Additive catalog change only — no existing behavior altered, download validation gate unchanged, and model identity relies on filenames not display strings.

The two new catalog entries follow the exact same pattern as the two existing ones, with expectedSizeBytes and sha256 populated so the validation gate will reject corrupt or wrong downloads. The display name rename from title-case to lowercase is cosmetic and safe because id is always the raw filename. Tests are updated to match, and preferredModelNames is left intentionally narrow.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/Models/LlamaRuntimeModels.swift | Adds two new DownloadableRuntimeModel entries (Qwen3.5-0.8B and gemma-4-E2B) and renames all four display names to lowercase cotabby-* aliases; LlamaRuntimeConfiguration.preferredModelNames intentionally left unchanged. |
| CotabbyTests/ModelAndPresentationValueTests.swift | Adds two new XCTAssertEqual assertions for the new filenames and updates existing assertions to match the renamed lowercase display names. |
| README.md | Model table updated to list all four models with their new lowercase display names and correct sizes. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[RuntimeModelCatalog.downloadableModels] --> B[Qwen3-0.6B-Q4_K_M.gguf\ncotabby-swift-1 ~0.4 GB]
    A --> C[Qwen3.5-0.8B-Q4_K_M.gguf\ncotabby-swift-pro-1 ~0.5 GB\nNEW]
    A --> D[gemma-3-1b-it-Q4_K_M.gguf\ncotabby-balanced-1 ~0.8 GB]
    A --> E[gemma-4-E2B-it-Q4_K_M.gguf\ncotabby-careful-1 ~3.1 GB\nNEW]
    B & C & D & E --> F[displayName for filename]
    F --> G[DownloadableRuntimeModel\nfilename · displayName · downloadURL\nexpectedSizeBytes · sha256]
    G --> H[Download Manager]
    H --> I{Size + SHA-256 gate}
    I -->|pass| J[Install to models folder]
    I -->|fail| K[Reject staged file]
    L[LlamaRuntimeConfiguration.preferredModelNames] --> M[gemma-3-1b-it-Q4_K_M.gguf\nQwen3-0.6B-Q4_K_M.gguf]
    M --> N[Auto-load priority\nnew models excluded intentionally]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cotabby/Models/LlamaRuntimeModels.swift`, line 88-99 ([link](https://github.com/fujacob/tabby/blob/d4f67c0e2c0778b935c3ea9d4814103b4f37d029/Cotabby/Models/LlamaRuntimeModels.swift#L88-L99)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **PR description lists different display names than the implementation**

   The PR summary table uses `Cotabby-fast-1`, `Cotabby-fast-2`, `Cotabby-balanced-1`, and `Cotabby-quality-1`, but the code (and README) now uses `Cotabby-Swift-1`, `Cotabby-Swift+-1`, `Cotabby-Balanced-1`, and `Cotabby-Careful-1`. This is only a description inconsistency and won't affect runtime behaviour, but it may confuse reviewers or anyone searching for the names later.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22add-four-default-models%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22add-four-default-models%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FModels%2FLlamaRuntimeModels.swift%0ALine%3A%2088-99%0A%0AComment%3A%0A**PR%20description%20lists%20different%20display%20names%20than%20the%20implementation**%0A%0AThe%20PR%20summary%20table%20uses%20%60Cotabby-fast-1%60%2C%20%60Cotabby-fast-2%60%2C%20%60Cotabby-balanced-1%60%2C%20and%20%60Cotabby-quality-1%60%2C%20but%20the%20code%20%28and%20README%29%20now%20uses%20%60Cotabby-Swift-1%60%2C%20%60Cotabby-Swift%2B-1%60%2C%20%60Cotabby-Balanced-1%60%2C%20and%20%60Cotabby-Careful-1%60.%20This%20is%20only%20a%20description%20inconsistency%20and%20won't%20affect%20runtime%20behaviour%2C%20but%20it%20may%20confuse%20reviewers%20or%20anyone%20searching%20for%20the%20names%20later.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FModels%2FLlamaRuntimeModels.swift%0ALine%3A%2088-99%0A%0AComment%3A%0A**PR%20description%20lists%20different%20display%20names%20than%20the%20implementation**%0A%0AThe%20PR%20summary%20table%20uses%20%60Cotabby-fast-1%60%2C%20%60Cotabby-fast-2%60%2C%20%60Cotabby-balanced-1%60%2C%20and%20%60Cotabby-quality-1%60%2C%20but%20the%20code%20%28and%20README%29%20now%20uses%20%60Cotabby-Swift-1%60%2C%20%60Cotabby-Swift%2B-1%60%2C%20%60Cotabby-Balanced-1%60%2C%20and%20%60Cotabby-Careful-1%60.%20This%20is%20only%20a%20description%20inconsistency%20and%20won't%20affect%20runtime%20behaviour%2C%20but%20it%20may%20confuse%20reviewers%20or%20anyone%20searching%20for%20the%20names%20later.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Ftabby&pr=245&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Rename model tiers to lowercase; swift+ ..."](https://github.com/fujacob/tabby/commit/c6a53e6b8b998a4d356cb2dd4c0d7c903938e808) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33756802)</sub>

<!-- /greptile_comment -->