### PR TITLE
Reorganize settings by task and reconcile with the menu bar

### DIFF
--- a/Cotabby/UI/MenuBarView.swift
+++ b/Cotabby/UI/MenuBarView.swift
@@ -86,7 +86,7 @@ struct MenuBarView: View {
                 .toggleStyle(.switch)
                 .controlSize(.small)
 
-            Toggle("Show Cotabby Indicator", isOn: showIndicatorBinding)
+            Toggle("Show Indicator", isOn: showIndicatorBinding)
                 .toggleStyle(.switch)
                 .controlSize(.small)
 

--- a/Cotabby/UI/SettingsView.swift
+++ b/Cotabby/UI/SettingsView.swift
@@ -118,6 +118,9 @@ struct SettingsView: View {
         } else if suggestionSettings.selectedEngine == .appleIntelligence,
                   !foundationModelAvailabilityService.isAvailable {
             attentionRow(foundationModelAvailabilityService.userVisibleMessage)
+        } else if suggestionSettings.selectedEngine == .llamaOpenSource,
+                  case .failed(let detail) = runtimeModel.state {
+            attentionRow("\(detail) See Model & Engine below.")
         }
     }
 

--- a/Cotabby/UI/SettingsView.swift
+++ b/Cotabby/UI/SettingsView.swift
@@ -29,20 +29,23 @@ struct SettingsView: View {
 
     var body: some View {
         Form {
+            // Header keeps the app identity and the (important, frequently-checked) update
+            // control pinned at the very top; Support stays directly beneath it.
             settingsHeader
             supportSection
-            updatesSection
-            uninstallSection
+            // Surfaces broken state (missing permission / unavailable engine) high up so the
+            // user doesn't have to scroll to discover why autocomplete isn't working.
+            attentionBanner
             generalSection
-            autocompleteSection
-            keybindSection
+            modelEngineSection
+            writingSection
+            shortcutsSection
             // performanceSection — hidden until these controls are productized.
             // Both suggestion delay and focus poll interval are developer-facing
             // tuning knobs that invite misconfiguration for end users.
-            disabledAppsSection
-            profileSection
+            appsSection
             permissionsSection
-            localModelsSection
+            uninstallSection
         }
         .formStyle(.grouped)
         .frame(minWidth: 620, minHeight: 560)
@@ -86,13 +89,64 @@ struct SettingsView: View {
                         .font(.system(size: 11, design: .rounded))
                         .foregroundStyle(.secondary)
                 }
+
+                Spacer(minLength: 12)
+
+                // Updates are important enough to stay visible without scrolling, but compact
+                // enough to ride along in the title bar instead of owning a whole section.
+                VStack(alignment: .trailing, spacing: 4) {
+                    Text(appVersionText)
+                        .font(.system(size: 11, design: .rounded))
+                        .foregroundStyle(.secondary)
+
+                    Button("Check for Updates") {
+                        appUpdateManager.checkForUpdates()
+                    }
+                    .controlSize(.small)
+                }
             }
         }
     }
 
+    /// Conditional banner that only renders when something is preventing autocomplete from
+    /// working. Detailed remediation still lives in the Permissions / Model sections below;
+    /// this just makes the problem impossible to miss.
+    @ViewBuilder
+    private var attentionBanner: some View {
+        if !permissionManager.requiredPermissionsGranted {
+            attentionRow("Cotabby needs more access to run. See Permissions below to grant it.")
+        } else if suggestionSettings.selectedEngine == .appleIntelligence,
+                  !foundationModelAvailabilityService.isAvailable {
+            attentionRow(foundationModelAvailabilityService.userVisibleMessage)
+        }
+    }
+
+    @ViewBuilder
+    private func attentionRow(_ message: String) -> some View {
+        Section {
+            HStack(spacing: 10) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+
+                Text(message)
+                    .font(.callout)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    /// Everyday on/off behavior the user reaches for most often, plus the onboarding re-entry.
     @ViewBuilder
     private var generalSection: some View {
         Section("General") {
+            Toggle("Enable Globally", isOn: globallyEnabledBinding)
+
+            Toggle("Show Indicator", isOn: showIndicatorBinding)
+
+            Toggle("Allow Multi-line Suggestions", isOn: multiLineEnabledBinding)
+
+            Toggle("Include Clipboard Context", isOn: clipboardContextEnabledBinding)
+
             // Open at Login is hidden until the quarantine/SMAppService issue is resolved.
             // The toggle reports .notFound for quarantined apps and apps outside /Applications,
             // making it appear broken for most users. See LaunchAtLoginService for details.
@@ -105,36 +159,11 @@ struct SettingsView: View {
         }
     }
 
+    /// Which brain runs (engine + availability) and the local model files it uses. Merged so the
+    /// engine choice and the models that back it are no longer separated by unrelated sections.
     @ViewBuilder
-    private var autocompleteSection: some View {
-        Section("Autocomplete") {
-            Toggle("Enable Globally", isOn: globallyEnabledBinding)
-
-            Toggle("Include Clipboard Context", isOn: clipboardContextEnabledBinding)
-
-            Toggle("Show Indicator", isOn: showIndicatorBinding)
-
-            // TODO: Re-enable ghost text color customization once the inline overlay is stable.
-            // LabeledContent("Ghost Text Color") {
-            //     HStack(spacing: 8) {
-            //         ColorPicker(
-            //             "Ghost Text Color",
-            //             selection: customSuggestionTextColorBinding,
-            //             supportsOpacity: false
-            //         )
-            //         .labelsHidden()
-            //
-            //         Button("Use Automatic") {
-            //             suggestionSettings.setCustomSuggestionTextColorHex(nil)
-            //         }
-            //         .disabled(suggestionSettings.customSuggestionTextColorHex == nil)
-            //     }
-            // }
-            //
-            // Text(ghostTextColorDescription)
-            //     .font(.caption)
-            //     .foregroundStyle(.secondary)
-
+    private var modelEngineSection: some View {
+        Section("Model & Engine") {
             Picker("Engine", selection: selectedEngineBinding) {
                 ForEach(SuggestionEngineKind.allCases) { engine in
                     Text(engine.displayLabel)
@@ -155,6 +184,16 @@ struct SettingsView: View {
                 }
             }
 
+            if suggestionSettings.selectedEngine.supportsLocalModelManagement {
+                localModelControls
+            }
+        }
+    }
+
+    /// How the completion reads: length, language, custom directives, and who the user is.
+    @ViewBuilder
+    private var writingSection: some View {
+        Section("Writing") {
             Picker("Length", selection: selectedWordCountPresetBinding) {
                 ForEach(SuggestionWordCountPreset.allCases) { preset in
                     Text(preset.displayLabel)
@@ -168,12 +207,32 @@ struct SettingsView: View {
                         .tag(language)
                 }
             }
+
+            VStack(alignment: .leading, spacing: 16) {
+                Text("This information is passed to the AI to help personalize your completions.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Name")
+                        .font(.system(size: 13, weight: .medium))
+
+                    TextField("What should Cotabby call you?", text: Binding(
+                        get: { suggestionSettings.userName },
+                        set: { suggestionSettings.setUserName($0) }
+                    ))
+                    .textFieldStyle(.roundedBorder)
+                }
+
+                CustomRulesEditor(suggestionSettings: suggestionSettings)
+            }
+            .padding(.vertical, 4)
         }
     }
 
     @ViewBuilder
-    private var keybindSection: some View {
-        Section("Keybind") {
+    private var shortcutsSection: some View {
+        Section("Shortcuts") {
             LabeledContent("Accept Word") {
                 HStack(spacing: 8) {
                     Text(suggestionSettings.acceptanceKeyLabel)
@@ -278,8 +337,8 @@ struct SettingsView: View {
     }
 
     @ViewBuilder
-    private var disabledAppsSection: some View {
-        Section("Disabled Apps") {
+    private var appsSection: some View {
+        Section("Apps") {
             if suggestionSettings.disabledAppRules.isEmpty {
                 Text("No apps are disabled. Apps you turn off from the menu bar will appear here.")
                     .font(.caption)
@@ -289,31 +348,6 @@ struct SettingsView: View {
                     disabledAppRuleRow(rule)
                 }
             }
-        }
-    }
-
-    @ViewBuilder
-    private var profileSection: some View {
-        Section("Profile") {
-            VStack(alignment: .leading, spacing: 16) {
-                Text("This information is passed to the AI to help personalize your completions.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("Name")
-                        .font(.system(size: 13, weight: .medium))
-
-                    TextField("What should Cotabby call you?", text: Binding(
-                        get: { suggestionSettings.userName },
-                        set: { suggestionSettings.setUserName($0) }
-                    ))
-                    .textFieldStyle(.roundedBorder)
-                }
-
-                CustomRulesEditor(suggestionSettings: suggestionSettings)
-            }
-            .padding(.vertical, 4)
         }
     }
 
@@ -344,9 +378,11 @@ struct SettingsView: View {
         }
     }
 
+    /// Local model rows nested inside the Model & Engine section (no `Section` wrapper of its
+    /// own). Only shown for engines that manage local GGUF files.
     @ViewBuilder
-    private var localModelsSection: some View {
-        Section("Local Models") {
+    private var localModelControls: some View {
+        Group {
             Text(localModelsDescription)
                 .font(.caption)
                 .foregroundStyle(.secondary)
@@ -434,22 +470,6 @@ struct SettingsView: View {
                 )
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
-            }
-        }
-    }
-
-    @ViewBuilder
-    private var updatesSection: some View {
-        Section("Updates") {
-            LabeledContent("Version", value: appVersionText)
-
-            LabeledContent {
-                Button("Check for Updates") {
-                    appUpdateManager.checkForUpdates()
-                }
-            } label: {
-                Text("Check GitHub Releases for updates.")
-                    .foregroundStyle(.secondary)
             }
         }
     }
@@ -593,6 +613,13 @@ struct SettingsView: View {
         Binding(
             get: { suggestionSettings.showIndicator },
             set: { suggestionSettings.setShowIndicator($0) }
+        )
+    }
+
+    private var multiLineEnabledBinding: Binding<Bool> {
+        Binding(
+            get: { suggestionSettings.isMultiLineEnabled },
+            set: { suggestionSettings.setMultiLineEnabled($0) }
         )
     }
 


### PR DESCRIPTION
## Summary

Refactors the settings window so users can find what they need faster, without changing any underlying settings or persistence. Stays a single flat grouped `Form` (no tabs/sidebar) — just reordered, regrouped, and aligned with the menu bar.

Key changes:
- **Updates folded into the title header**, right-aligned (version + Check for Updates), with **Support pinned directly below** — both kept at the top as requested.
- **Needs-attention banner** near the top, shown only when a required permission is missing or the selected engine is unavailable, so the cause of "it's not working" isn't buried at the bottom.
- **Task-based regrouping** of the previously scattered sections:
  - General — Enable Globally, Show Indicator, Allow Multi-line Suggestions, Include Clipboard Context, Open Welcome Guide
  - Model & Engine — engine picker + availability/runtime status **merged with** the formerly-distant Local Models block
  - Writing — Length, Language, Custom Rules, Name (was split across "Autocomplete" + "Profile")
  - Shortcuts (was "Keybind"), Apps (was "Disabled Apps"), Permissions, Uninstall
- **Menu ↔ Settings parity:** added the multi-line toggle to Settings and aligned the indicator label to "Show Indicator" in both surfaces.

## Validation

```
swiftlint lint --quiet Cotabby/UI/SettingsView.swift Cotabby/UI/MenuBarView.swift
# exit 0

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **
```

Presentation-only; no `SuggestionSettingsModel` or persistence changes. Worth an eyeball in the running app to confirm the header layout and banner read well.

## Linked issues

_None._

## Risk / rollout notes

UI-only reorganization. The per-app blocklist/allowlist polarity was intentionally left as-is (out of scope), and the prefix-autocorrect feature is not referenced here since it isn't on `main` yet.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a presentation-only reorganization of the settings window — no persistence, no model changes — that regroups controls by task, merges previously scattered sections, and adds a top-of-screen attention banner for blocked-autocomplete states.

- **Section consolidation:** The old `Autocomplete`, `Profile`, and `Local Models` sections are merged into `General`, `Writing`, and a `localModelControls` group nested inside `Model & Engine`; `Keybind` → `Shortcuts` and `Disabled Apps` → `Apps` are pure renames.
- **Header + banner rework:** The Updates section is dissolved into a compact trailing widget in the header row, and a new `attentionBanner` surfaces the three blocking states (missing permissions, Apple Intelligence unavailable, llama runtime failure) near the top without scrolling.
- **Menu-bar parity:** `multiLineEnabledBinding` is added to wire the new "Allow Multi-line Suggestions" toggle in Settings, and the menu-bar label is trimmed from "Show Cotabby Indicator" to "Show Indicator" to match.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely presentation reorganization with no persistence, model, or behavioral changes.

Every changed line is SwiftUI layout: section renames, view moves, a new conditional banner, and one label string. No settings model mutations, no new side effects, no new async paths. The attention banner correctly covers all three blocking states (permissions, Apple Intelligence, llama failure). The new multiLineEnabledBinding follows the same pattern as every other binding in the file and hooks into a pre-existing model property. Nothing here can regress autocomplete behavior.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/UI/SettingsView.swift | Major section restructuring — new attentionBanner, merged modelEngineSection/localModelControls, writingSection absorbs profile content, header hosts version+update button. No logic changes; bindings follow existing patterns correctly. |
| Cotabby/UI/MenuBarView.swift | Single label change: 'Show Cotabby Indicator' → 'Show Indicator' for parity with SettingsView. No behavioral or binding changes. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SettingsView body] --> B[settingsHeader\nversion + Check for Updates]
    A --> C[supportSection]
    A --> D{attentionBanner\nconditions}
    D -- permissions missing --> E[attentionRow: grant permissions]
    D -- appleIntelligence unavailable --> F[attentionRow: foundation model message]
    D -- llamaOpenSource failed --> G[attentionRow: runtime failure detail]
    D -- all OK --> H[EmptyView]
    A --> I[generalSection\nEnable / Indicator / Multi-line / Clipboard / Onboarding]
    A --> J[modelEngineSection\nEngine picker + availability/runtime status]
    J -- supportsLocalModelManagement --> K[localModelControls Group\ndescription / picker / catalog / folder]
    A --> L[writingSection\nLength / Language / Name / CustomRules]
    A --> M[shortcutsSection]
    A --> N[appsSection]
    A --> O[permissionsSection]
    A --> P[uninstallSection]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cotabby/UI/SettingsView.swift`, line 721-728 ([link](https://github.com/fujacob/tabby/blob/af6c15772ec22d43be164ffc12f4d750c25f4d67/Cotabby/UI/SettingsView.swift#L721-L728)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `.appleIntelligence` branch of `localModelsDescription` is now unreachable. `localModelControls` — the only caller — is guarded by `suggestionSettings.selectedEngine.supportsLocalModelManagement`, which is almost certainly `false` for `.appleIntelligence`. As a result the string "These models are used when Engine is set to Open Source." can never appear in the UI, and the hint that local models exist (useful when a user is deciding whether to switch engines) is silently dropped. Consider removing the dead branch or restructuring the `modelEngineSection` to surface this hint another way.

   

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Ftabby%22%20on%20the%20existing%20branch%20%22settings-reorder%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22settings-reorder%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FSettingsView.swift%0ALine%3A%20721-728%0A%0AComment%3A%0AThe%20%60.appleIntelligence%60%20branch%20of%20%60localModelsDescription%60%20is%20now%20unreachable.%20%60localModelControls%60%20%E2%80%94%20the%20only%20caller%20%E2%80%94%20is%20guarded%20by%20%60suggestionSettings.selectedEngine.supportsLocalModelManagement%60%2C%20which%20is%20almost%20certainly%20%60false%60%20for%20%60.appleIntelligence%60.%20As%20a%20result%20the%20string%20%22These%20models%20are%20used%20when%20Engine%20is%20set%20to%20Open%20Source.%22%20can%20never%20appear%20in%20the%20UI%2C%20and%20the%20hint%20that%20local%20models%20exist%20%28useful%20when%20a%20user%20is%20deciding%20whether%20to%20switch%20engines%29%20is%20silently%20dropped.%20Consider%20removing%20the%20dead%20branch%20or%20restructuring%20the%20%60modelEngineSection%60%20to%20surface%20this%20hint%20another%20way.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20var%20localModelsDescription%3A%20String%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20Only%20called%20when%20supportsLocalModelManagement%20is%20true%2C%20which%20is%20.llamaOpenSource%20only.%0A%20%20%20%20%20%20%20%20return%20%22Download%20a%20model%20or%20add%20your%20own%20below.%20Models%20are%20stored%20locally%20on%20your%20Mac.%22%0A%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FSettingsView.swift%0ALine%3A%20721-728%0A%0AComment%3A%0AThe%20%60.appleIntelligence%60%20branch%20of%20%60localModelsDescription%60%20is%20now%20unreachable.%20%60localModelControls%60%20%E2%80%94%20the%20only%20caller%20%E2%80%94%20is%20guarded%20by%20%60suggestionSettings.selectedEngine.supportsLocalModelManagement%60%2C%20which%20is%20almost%20certainly%20%60false%60%20for%20%60.appleIntelligence%60.%20As%20a%20result%20the%20string%20%22These%20models%20are%20used%20when%20Engine%20is%20set%20to%20Open%20Source.%22%20can%20never%20appear%20in%20the%20UI%2C%20and%20the%20hint%20that%20local%20models%20exist%20%28useful%20when%20a%20user%20is%20deciding%20whether%20to%20switch%20engines%29%20is%20silently%20dropped.%20Consider%20removing%20the%20dead%20branch%20or%20restructuring%20the%20%60modelEngineSection%60%20to%20surface%20this%20hint%20another%20way.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20var%20localModelsDescription%3A%20String%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20Only%20called%20when%20supportsLocalModelManagement%20is%20true%2C%20which%20is%20.llamaOpenSource%20only.%0A%20%20%20%20%20%20%20%20return%20%22Download%20a%20model%20or%20add%20your%20own%20below.%20Models%20are%20stored%20locally%20on%20your%20Mac.%22%0A%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Ftabby&pr=246&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Surface the attention banner when the op..."](https://github.com/fujacob/tabby/commit/617f7d579469e9872f5788903112ef5cb3fb3424) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33757759)</sub>

<!-- /greptile_comment -->