### PR TITLE
Left-align README support block and drop top divider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,8 @@
 # Cotabby
 
----
+<sub>If Cotabby is useful to you, consider supporting development:</sub>
 
-<p align="center">
-  <sub>If Cotabby is useful to you, consider supporting development:</sub>
-</p>
-
-<p align="center">
-  <a href='https://ko-fi.com/I2F22066MI' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://storage.ko-fi.com/cdn/kofi6.png?v=6' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
-</p>
+<a href='https://ko-fi.com/I2F22066MI' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://storage.ko-fi.com/cdn/kofi6.png?v=6' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
 
 ---
 


### PR DESCRIPTION
## Summary

The support block under the title rendered center-aligned with a heavy horizontal rule directly above it, making the top of the README feel cluttered. This removes that top divider and unwraps the `<p align="center">` wrappers so the support copy and Ko-fi button render left-aligned under the title.

## Validation

Markdown-only change; rendered the README locally to confirm the support copy and button are now left-aligned and the divider above them is gone.

## Linked issues

None.

## Risk / rollout notes

Documentation only — no code, settings, or build changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a documentation-only change to `README.md` that removes the horizontal rule above the Ko-fi support block and strips the `<p align="center">` wrappers so the support text and button render left-aligned directly under the project title.

- Removes the `---` divider that appeared immediately after the `# Cotabby` heading, reducing visual clutter at the top of the README.
- Unwraps both the `<sub>` support copy and the Ko-fi `<a>`/`<img>` tag from their `<p align="center">` containers, making them flow left like the rest of the prose content.

<h3>Confidence Score: 5/5</h3>

Safe to merge — only two HTML wrapper tags and one horizontal rule are removed from the README, with no impact on code, configuration, or build artifacts.

The change touches a single Markdown file and removes three lines of presentational HTML along with a decorative divider. There is no logic, no configuration, and no user-facing behaviour beyond how the top of the README renders on GitHub.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Removes the top `---` divider and unwraps `<p align="center">` around the Ko-fi support block, leaving content left-aligned under the title. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph before["Before"]
        direction TB
        A1["# Cotabby"] --> DIV["--- (removed)"]
        DIV --> PC1["p align=center: sub text"]
        PC1 --> PC2["p align=center: Ko-fi button"]
        PC2 --> DIV2["---"]
    end

    subgraph after["After"]
        direction TB
        A2["# Cotabby"] --> SUB["sub text (left-aligned)"]
        SUB --> BTN["Ko-fi button (left-aligned)"]
        BTN --> DIV3["---"]
    end
```

<sub>Reviews (1): Last reviewed commit: ["Left-align README support block and drop..."](https://github.com/fujacob/tabby/commit/22ce4b4d7d8d20614783c394065aaf4d90a0ba36) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33759371)</sub>

<!-- /greptile_comment -->