### PR TITLE
Govern completion length by token budget only

### DIFF
--- a/Cotabby/Models/SuggestionModels.swift
+++ b/Cotabby/Models/SuggestionModels.swift
@@ -39,16 +39,17 @@ enum SuggestionWordCountPreset: String, CaseIterable, Equatable, Hashable, Senda
         }
     }
 
-    /// Token budget sized at ~1.5x the upper word bound. Tight enough to enforce the word cap
-    /// while leaving room for multi-token words (contractions, proper nouns, punctuation).
+    /// Token budget bumped 50% above the prior ~1.5x-upper-word-bound sizing, giving the
+    /// token-cap-only path (no in-prompt word range for the local model) room to land a clean
+    /// stopping point instead of hard-truncating mid-thought.
     var suggestedPredictionTokenBudget: Int {
         switch self {
         case .threeToSeven:
-            return 11
+            return 17
         case .sevenToTwelve:
-            return 18
+            return 27
         case .twelveToTwenty:
-            return 30
+            return 45
         }
     }
 }

--- a/Cotabby/Support/FoundationModelPromptRenderer.swift
+++ b/Cotabby/Support/FoundationModelPromptRenderer.swift
@@ -33,7 +33,9 @@ enum FoundationModelPromptRenderer {
                 + "that exact phrase and you are finishing it.",
             "Continue the existing sentence or thought — extend it, never restart it.",
             "Return exactly one continuation fragment.",
-            request.completionLengthInstruction,
+            // Experiment: the explicit word-range cue (`request.completionLengthInstruction`) is
+            // omitted here too, matching the local-model path. Length is governed solely by the
+            // shared token budget (`maximumResponseTokens` ← `request.maxPredictionTokens`).
             "Do not repeat or quote the existing text.",
             "Match the existing tone, language, casing, and punctuation.",
             "Use clipboard and screen context only when it directly helps the inline continuation.",

--- a/Cotabby/Support/LlamaPromptRenderer.swift
+++ b/Cotabby/Support/LlamaPromptRenderer.swift
@@ -77,7 +77,11 @@ enum LlamaPromptRenderer {
         if let languageInstruction, !languageInstruction.isEmpty {
             sections.append("- \(languageInstruction)")
         }
-        sections.append("- \(completionLengthInstruction)")
+        // Experiment: the explicit word-range line (`completionLengthInstruction`) is intentionally
+        // omitted from the local-model prompt so length is governed purely by the token budget
+        // (`SuggestionWordCountPreset.suggestedPredictionTokenBudget`). The parameter stays wired so
+        // re-enabling the in-prompt cue is a one-line change. Apple Intelligence still gets the cue.
+        _ = completionLengthInstruction
         sections.append("- The next line must begin directly with the continuation text.")
         sections.append("Text before caret:")
         sections.append(prefixText)

--- a/CotabbyTests/CustomRulesTests.swift
+++ b/CotabbyTests/CustomRulesTests.swift
@@ -102,7 +102,9 @@ final class CustomRulesTests: XCTestCase {
         XCTAssertTrue(instruction?.contains("Spanish") == true)
     }
 
-    func test_llamaRenderer_includesLanguageInstructionBeforeLengthCue() {
+    func test_llamaRenderer_includesLanguageInstructionInFinalBlock() {
+        // The length cue is no longer rendered (token-budget-only experiment), so this guards that
+        // the language directive still lands in the late, high-attention final-instruction block.
         let prompt = LlamaPromptRenderer.prompt(
             prefixText: "Hola",
             applicationName: "Notes",
@@ -111,12 +113,14 @@ final class CustomRulesTests: XCTestCase {
             languageInstruction: SuggestionLanguage.spanish.promptInstruction
         )
 
-        guard let langRange = prompt.range(of: "Spanish"),
-              let lenRange = prompt.range(of: "UNIQUE_LENGTH_CUE") else {
-            XCTFail("Expected language directive and length cue in the prompt")
+        XCTAssertFalse(prompt.contains("UNIQUE_LENGTH_CUE"))
+
+        guard let finalRange = prompt.range(of: "Final instruction:"),
+              let langRange = prompt.range(of: "Spanish") else {
+            XCTFail("Expected final instruction header and language directive in the prompt")
             return
         }
-        XCTAssertLessThan(langRange.lowerBound, lenRange.lowerBound)
+        XCTAssertLessThan(finalRange.lowerBound, langRange.lowerBound)
     }
 
     func test_foundationModelInstructions_includeLanguageOverride() {

--- a/CotabbyTests/LlamaPromptRendererTests.swift
+++ b/CotabbyTests/LlamaPromptRendererTests.swift
@@ -95,10 +95,12 @@ final class LlamaPromptRendererTests: XCTestCase {
         XCTAssertTrue(prompt.contains("My prefix text here"))
     }
 
-    /// The completion-length instruction is chosen from the user's word-count
-    /// preset. It must reach the prompt verbatim so the model sees the exact
-    /// guidance the UI showed the user.
-    func test_instructionPrompt_includesCompletionLengthInstructionNearPrefix() {
+    /// Length is enforced by the token budget, not by an in-prompt word range, so the
+    /// completion-length cue must never reach the local-model prompt even if a caller passes one.
+    func test_instructionPrompt_omitsCompletionLengthInstruction() {
+        // Experiment: the local-model prompt no longer carries the word-range cue; length is
+        // governed solely by the token budget. The cue must not leak into the prompt even when a
+        // caller still passes one.
         let prompt = LlamaPromptRenderer.prompt(
             prefixText: "PREFIX_BODY_XYZ",
             applicationName: "App",
@@ -106,17 +108,15 @@ final class LlamaPromptRendererTests: XCTestCase {
             userName: nil
         )
 
-        XCTAssertTrue(prompt.contains("UNIQUE_LENGTH_MARKER_7_TO_12_WORDS"))
+        XCTAssertFalse(prompt.contains("UNIQUE_LENGTH_MARKER_7_TO_12_WORDS"))
 
         guard let finalInstructionRange = prompt.range(of: "Final instruction:"),
-              let lengthRange = prompt.range(of: "UNIQUE_LENGTH_MARKER_7_TO_12_WORDS"),
               let prefixRange = prompt.range(of: "PREFIX_BODY_XYZ") else {
-            XCTFail("Expected final instruction header, length marker, and prefix in the prompt")
+            XCTFail("Expected final instruction header and prefix in the prompt")
             return
         }
 
-        XCTAssertLessThan(finalInstructionRange.lowerBound, lengthRange.lowerBound)
-        XCTAssertLessThan(lengthRange.lowerBound, prefixRange.lowerBound)
+        XCTAssertLessThan(finalInstructionRange.lowerBound, prefixRange.lowerBound)
     }
 
     func test_instructionPrompt_includesProfileContextWhenProvided() {

--- a/CotabbyTests/ModelAndPresentationValueTests.swift
+++ b/CotabbyTests/ModelAndPresentationValueTests.swift
@@ -40,13 +40,13 @@ final class SuggestionTextColorCodecTests: XCTestCase {
 final class SuggestionModelValueTests: XCTestCase {
     func test_wordCountPresetsExposeMatchingPromptInstructionsAndTokenBudgets() {
         XCTAssertEqual(SuggestionWordCountPreset.threeToSeven.promptInstruction, "Return only the next 3 to 7 words.")
-        XCTAssertEqual(SuggestionWordCountPreset.threeToSeven.suggestedPredictionTokenBudget, 11)
+        XCTAssertEqual(SuggestionWordCountPreset.threeToSeven.suggestedPredictionTokenBudget, 17)
 
         XCTAssertEqual(SuggestionWordCountPreset.sevenToTwelve.promptInstruction, "Return only the next 7 to 12 words.")
-        XCTAssertEqual(SuggestionWordCountPreset.sevenToTwelve.suggestedPredictionTokenBudget, 18)
+        XCTAssertEqual(SuggestionWordCountPreset.sevenToTwelve.suggestedPredictionTokenBudget, 27)
 
         XCTAssertEqual(SuggestionWordCountPreset.twelveToTwenty.promptInstruction, "Return only the next 12 to 20 words.")
-        XCTAssertEqual(SuggestionWordCountPreset.twelveToTwenty.suggestedPredictionTokenBudget, 30)
+        XCTAssertEqual(SuggestionWordCountPreset.twelveToTwenty.suggestedPredictionTokenBudget, 45)
     }
 
     func test_activeSuggestionSession_clampsConsumedCountAndSlicesByCharacters() {

--- a/CotabbyTests/PromptPolicyTests.swift
+++ b/CotabbyTests/PromptPolicyTests.swift
@@ -15,7 +15,8 @@ final class FoundationModelPromptRendererTests: XCTestCase {
         let instructions = FoundationModelPromptRenderer.sessionInstructions(for: request)
 
         XCTAssertTrue(instructions.contains("text-continuation engine"))
-        XCTAssertTrue(instructions.contains("UNIQUE_LENGTH_POLICY"))
+        // The word-range cue is no longer injected — length is token-budget-only on both engines.
+        XCTAssertFalse(instructions.contains("UNIQUE_LENGTH_POLICY"))
         XCTAssertTrue(instructions.contains("Do not repeat or quote the existing text."))
     }
 
@@ -99,7 +100,8 @@ final class FoundationModelPromptRendererTests: XCTestCase {
         let preview = FoundationModelPromptRenderer.promptPreview(for: request)
 
         XCTAssertTrue(preview.contains("Instructions:\n"))
-        XCTAssertTrue(preview.contains("UNIQUE_LENGTH_POLICY"))
+        // Length cue removed from the prompt; it should not surface in the diagnostics preview either.
+        XCTAssertFalse(preview.contains("UNIQUE_LENGTH_POLICY"))
         XCTAssertTrue(preview.contains("Prompt:\n"))
         XCTAssertTrue(preview.contains("UNIQUE_APPLE_SCREEN_CONTEXT"))
     }


### PR DESCRIPTION
## Summary

Completion length was enforced two ways: an in-prompt word-range cue (\"Return only the next 7 to 12 words.\") and a token cap. This makes the **token cap the single source of truth** — the word-range cue is removed from both the local-model (`LlamaPromptRenderer`) and Apple Intelligence (`FoundationModelPromptRenderer`) prompts, and `suggestedPredictionTokenBudget` is bumped ~50% (11/18/30 → 17/27/45) so the cap has room to stop on a natural boundary instead of hard-truncating mid-thought. Both engines already read the same `request.maxPredictionTokens`, so the cap stays in sync across them.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build-for-testing
# ** TEST BUILD SUCCEEDED **

swiftlint lint --quiet
# clean for changed files
```

Note: local `xcodebuild test` could not run the app-hosted bundle due to a Team ID code-signing mismatch on this machine (documented limitation); CI runs with a valid signing identity. Test logic was updated to match the new behavior:
- `LlamaPromptRendererTests` / `PromptPolicyTests` / `CustomRulesTests` now assert the word-range cue is **absent** from both prompts.
- `ModelAndPresentationValueTests` updated to the new token budgets (17/27/45).

## Linked issues

<!-- none -->

## Risk / rollout notes

- **Behavior change to an existing user flow.** With no in-prompt target, the word-count presets (`3-7`, `7-12`, `12-20`) become *ceilings* rather than *targets*. The token budgets allow roughly ~12 / ~20 / ~33 words at the top end (~0.75 words/token), so shorter presets can now overshoot their label. The model still tends to stop at sentence boundaries on its own.
- `completionLengthInstruction` stays wired through `SuggestionRequest` and both renderers (Llama via `_ =`), so re-enabling the in-prompt cue is a one-line revert in each renderer.
- No schema, settings, or pbxproj migrations.