### PR TITLE
Stabilize ghost-text size per focus session

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		E10000012F93000100DDD001 /* PromptContextSanitizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10000112F93000100DDD011 /* PromptContextSanitizerTests.swift */; };
 		E10000022F93000100DDD002 /* PermissionAndContextModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10000122F93000100DDD012 /* PermissionAndContextModelTests.swift */; };
 		E10000032F93000100DDD003 /* GhostSuggestionLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10000132F93000100DDD013 /* GhostSuggestionLayoutTests.swift */; };
+		E10000992F93000100DDD099 /* GhostFontSizeStabilizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10000A92F93000100DDD0A9 /* GhostFontSizeStabilizerTests.swift */; };
 		E10000042F93000100DDD004 /* BundledRuntimeLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10000142F93000100DDD014 /* BundledRuntimeLocatorTests.swift */; };
 		E10000052F93000100DDD005 /* DisplayCoordinateConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10000152F93000100DDD015 /* DisplayCoordinateConverterTests.swift */; };
 		F10000012FA0000100EEE001 /* TextDirectionDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10000112FA0000100EEE011 /* TextDirectionDetectorTests.swift */; };
@@ -69,6 +70,7 @@
 		E10000112F93000100DDD011 /* PromptContextSanitizerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PromptContextSanitizerTests.swift; sourceTree = "<group>"; };
 		E10000122F93000100DDD012 /* PermissionAndContextModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PermissionAndContextModelTests.swift; sourceTree = "<group>"; };
 		E10000132F93000100DDD013 /* GhostSuggestionLayoutTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GhostSuggestionLayoutTests.swift; sourceTree = "<group>"; };
+		E10000A92F93000100DDD0A9 /* GhostFontSizeStabilizerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GhostFontSizeStabilizerTests.swift; sourceTree = "<group>"; };
 		E10000142F93000100DDD014 /* BundledRuntimeLocatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BundledRuntimeLocatorTests.swift; sourceTree = "<group>"; };
 		E10000152F93000100DDD015 /* DisplayCoordinateConverterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DisplayCoordinateConverterTests.swift; sourceTree = "<group>"; };
 		F10000112FA0000100EEE011 /* TextDirectionDetectorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TextDirectionDetectorTests.swift; sourceTree = "<group>"; };
@@ -151,6 +153,7 @@
 				E10000112F93000100DDD011 /* PromptContextSanitizerTests.swift */,
 				E10000122F93000100DDD012 /* PermissionAndContextModelTests.swift */,
 				E10000132F93000100DDD013 /* GhostSuggestionLayoutTests.swift */,
+				E10000A92F93000100DDD0A9 /* GhostFontSizeStabilizerTests.swift */,
 				E10000142F93000100DDD014 /* BundledRuntimeLocatorTests.swift */,
 				E10000152F93000100DDD015 /* DisplayCoordinateConverterTests.swift */,
 				F10000112FA0000100EEE011 /* TextDirectionDetectorTests.swift */,
@@ -296,6 +299,7 @@
 				E10000012F93000100DDD001 /* PromptContextSanitizerTests.swift in Sources */,
 				E10000022F93000100DDD002 /* PermissionAndContextModelTests.swift in Sources */,
 				E10000032F93000100DDD003 /* GhostSuggestionLayoutTests.swift in Sources */,
+				E10000992F93000100DDD099 /* GhostFontSizeStabilizerTests.swift in Sources */,
 				E10000042F93000100DDD004 /* BundledRuntimeLocatorTests.swift in Sources */,
 				E10000052F93000100DDD005 /* DisplayCoordinateConverterTests.swift in Sources */,
 				F10000012FA0000100EEE001 /* TextDirectionDetectorTests.swift in Sources */,

--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
@@ -108,9 +108,7 @@ extension SuggestionCoordinator {
             presentOverlay(
                 text: advancedSession.remainingText,
                 at: predictedCaret,
-                inputFrameRect: liveContext.inputFrameRect,
-                caretQuality: liveContext.caretQuality,
-                observedCharWidth: liveContext.observedCharWidth,
+                context: liveContext,
                 isRightToLeft: isRTL
             )
             schedulePostInsertionRefresh()
@@ -170,9 +168,7 @@ extension SuggestionCoordinator {
         presentOverlay(
             text: advancedSession.remainingText,
             at: session.baseContext.caretRect,
-            inputFrameRect: session.baseContext.inputFrameRect,
-            caretQuality: session.baseContext.caretQuality,
-            observedCharWidth: session.baseContext.observedCharWidth
+            context: session.baseContext
         )
         logStage(
             "typed-match-advanced",
@@ -314,17 +310,16 @@ extension SuggestionCoordinator {
     func presentOverlay(
         text: String,
         at caretRect: CGRect,
-        inputFrameRect: CGRect?,
-        caretQuality: CaretGeometryQuality,
-        observedCharWidth: CGFloat?,
+        context: FocusedInputContext,
         isRightToLeft: Bool = false
     ) {
         let geometry = SuggestionOverlayGeometry(
             caretRect: caretRect,
-            inputFrameRect: inputFrameRect,
-            caretQuality: caretQuality,
-            observedCharWidth: observedCharWidth,
-            isRightToLeft: isRightToLeft
+            inputFrameRect: context.inputFrameRect,
+            caretQuality: context.caretQuality,
+            observedCharWidth: context.observedCharWidth,
+            isRightToLeft: isRightToLeft,
+            focusChangeSequence: context.focusChangeSequence
         )
         if let message = overlayPresenter.present(
             text: text,

--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
@@ -224,9 +224,7 @@ extension SuggestionCoordinator {
         presentOverlay(
             text: session.remainingText,
             at: liveContext.caretRect,
-            inputFrameRect: liveContext.inputFrameRect,
-            caretQuality: liveContext.caretQuality,
-            observedCharWidth: liveContext.observedCharWidth,
+            context: liveContext,
             isRightToLeft: TextDirectionDetector.isRightToLeft(liveContext.precedingText)
         )
         logStage(
@@ -319,9 +317,7 @@ extension SuggestionCoordinator {
             presentOverlay(
                 text: reconciledSession.remainingText,
                 at: liveContext.caretRect,
-                inputFrameRect: liveContext.inputFrameRect,
-                caretQuality: liveContext.caretQuality,
-                observedCharWidth: liveContext.observedCharWidth,
+                context: liveContext,
                 isRightToLeft: TextDirectionDetector.isRightToLeft(liveContext.precedingText)
             )
             if let advancement {

--- a/Cotabby/Models/SuggestionModels.swift
+++ b/Cotabby/Models/SuggestionModels.swift
@@ -39,16 +39,17 @@ enum SuggestionWordCountPreset: String, CaseIterable, Equatable, Hashable, Senda
         }
     }
 
-    /// Token budget sized at ~1.5x the upper word bound. Tight enough to enforce the word cap
-    /// while leaving room for multi-token words (contractions, proper nouns, punctuation).
+    /// Token budget bumped 50% above the prior ~1.5x-upper-word-bound sizing, giving the
+    /// token-cap-only path (no in-prompt word range for the local model) room to land a clean
+    /// stopping point instead of hard-truncating mid-thought.
     var suggestedPredictionTokenBudget: Int {
         switch self {
         case .threeToSeven:
-            return 11
+            return 17
         case .sevenToTwelve:
-            return 18
+            return 27
         case .twelveToTwenty:
-            return 30
+            return 45
         }
     }
 }

--- a/Cotabby/Models/SuggestionModels.swift
+++ b/Cotabby/Models/SuggestionModels.swift
@@ -353,6 +353,26 @@ struct SuggestionOverlayGeometry: Equatable, Sendable {
     /// When `true`, the text near the caret is Right-to-Left (Arabic, Hebrew, etc.) and the ghost
     /// text overlay should appear to the left of the caret instead of the right.
     let isRightToLeft: Bool
+    /// Identifies the focus session that produced this geometry. `OverlayController` keys its
+    /// per-session font-size stabilization on this value, so a field switch (or focus loss) starts
+    /// a fresh size baseline. Defaults to 0 for tests that do not exercise session-scoped behavior.
+    let focusChangeSequence: UInt64
+
+    init(
+        caretRect: CGRect,
+        inputFrameRect: CGRect?,
+        caretQuality: CaretGeometryQuality,
+        observedCharWidth: CGFloat?,
+        isRightToLeft: Bool,
+        focusChangeSequence: UInt64 = 0
+    ) {
+        self.caretRect = caretRect
+        self.inputFrameRect = inputFrameRect
+        self.caretQuality = caretQuality
+        self.observedCharWidth = observedCharWidth
+        self.isRightToLeft = isRightToLeft
+        self.focusChangeSequence = focusChangeSequence
+    }
 }
 
 /// The overlay is intentionally modeled as data so diagnostics can reason about visibility

--- a/Cotabby/Services/UI/OverlayController.swift
+++ b/Cotabby/Services/UI/OverlayController.swift
@@ -32,6 +32,11 @@ final class OverlayController: SuggestionOverlayControlling {
     /// instead of a full view rebuild + layout pass.
     private var hostingView: NSHostingView<GhostSuggestionView>?
 
+    /// Per-focus-session floor for caret-derived font size. Caret height flickers between the real
+    /// line height and the coarse field-height fallback from poll to poll; stabilizing keeps ghost
+    /// text from ballooning when the fallback wins. See `GhostFontSizeStabilizer`.
+    private var ghostFontStabilizer = GhostFontSizeStabilizer()
+
     init(suggestionSettings: SuggestionSettingsModel) {
         self.suggestionSettings = suggestionSettings
     }
@@ -66,8 +71,12 @@ final class OverlayController: SuggestionOverlayControlling {
             return
         }
 
+        let stabilizedCaretHeight = ghostFontStabilizer.stabilizedCaretHeight(
+            geometry.caretRect.height,
+            focusSessionKey: geometry.focusChangeSequence
+        )
         let fontSize = resolvedGhostFontSize(
-            for: geometry.caretRect,
+            forCaretHeight: stabilizedCaretHeight,
             caretQuality: geometry.caretQuality
         )
         let layout = GhostSuggestionLayout.make(
@@ -118,14 +127,15 @@ final class OverlayController: SuggestionOverlayControlling {
     /// Exact and derived caret rects usually reflect the real text line height, so they may scale
     /// up in larger editors. Estimated rects are much less trustworthy because some apps only
     /// expose the full field frame; the extra ceiling prevents one bad estimate from rendering
-    /// comically oversized ghost text.
+    /// comically oversized ghost text. `caretHeight` is already floored to the per-session minimum
+    /// by `ghostFontStabilizer`, so this only applies the static floor and quality ceilings.
     private func resolvedGhostFontSize(
-        for caretRect: CGRect,
+        forCaretHeight caretHeight: CGFloat,
         caretQuality: CaretGeometryQuality
     ) -> CGFloat {
         let proposedSize = max(
             Layout.minimumGhostFontSize,
-            caretRect.height * Layout.fontToLineHeightRatio
+            caretHeight * Layout.fontToLineHeightRatio
         )
         let qualityCap = caretQuality == .estimated
             ? Layout.maximumEstimatedGhostFontSize

--- a/Cotabby/Support/FoundationModelPromptRenderer.swift
+++ b/Cotabby/Support/FoundationModelPromptRenderer.swift
@@ -33,7 +33,9 @@ enum FoundationModelPromptRenderer {
                 + "that exact phrase and you are finishing it.",
             "Continue the existing sentence or thought — extend it, never restart it.",
             "Return exactly one continuation fragment.",
-            request.completionLengthInstruction,
+            // Experiment: the explicit word-range cue (`request.completionLengthInstruction`) is
+            // omitted here too, matching the local-model path. Length is governed solely by the
+            // shared token budget (`maximumResponseTokens` ← `request.maxPredictionTokens`).
             "Do not repeat or quote the existing text.",
             "Match the existing tone, language, casing, and punctuation.",
             "Use clipboard and screen context only when it directly helps the inline continuation.",

--- a/Cotabby/Support/GhostFontSizeStabilizer.swift
+++ b/Cotabby/Support/GhostFontSizeStabilizer.swift
@@ -1,0 +1,43 @@
+import CoreGraphics
+import Foundation
+
+/// Floors ghost-text size to the smallest caret line height observed during one focus session.
+///
+/// AX caret geometry is eventually consistent and app-specific. The same field can yield a tight
+/// line-height caret on one poll (zero-length `BoundsForRange`) and the full field-height `AXFrame`
+/// fallback on the next, when the precise branches happen to fail. Because `OverlayController`
+/// derives ghost font size from caret height, that fluctuation renders the suggestion comically
+/// oversized whenever the coarse fallback wins a poll.
+///
+/// Within a single focus session the real line height does not grow, so we treat the smallest
+/// height we have seen as the truth and clamp larger readings down to it. The baseline is keyed by
+/// `FocusTracker`'s `focusChangeSequence`, so switching fields — or leaving and re-entering the same
+/// field — starts a fresh measurement instead of inheriting a stale ceiling.
+///
+/// This intentionally biases toward the smaller reading: an over-tall fallback is the observed
+/// failure mode, and the downstream `minimumGhostFontSize` floor bounds how small a spurious low
+/// reading can make the text.
+struct GhostFontSizeStabilizer {
+    private var sessionKey: UInt64?
+    private var minCaretHeight: CGFloat?
+
+    /// Returns the caret height to derive font size from: the running per-session minimum.
+    ///
+    /// Non-positive heights (empty rects) pass through untouched so a transient bad poll can't pin
+    /// the session minimum to zero and force every later suggestion to the font-size floor.
+    mutating func stabilizedCaretHeight(_ caretHeight: CGFloat, focusSessionKey: UInt64) -> CGFloat {
+        guard caretHeight > 0 else {
+            return caretHeight
+        }
+
+        if sessionKey != focusSessionKey {
+            sessionKey = focusSessionKey
+            minCaretHeight = caretHeight
+            return caretHeight
+        }
+
+        let stabilized = min(caretHeight, minCaretHeight ?? caretHeight)
+        minCaretHeight = stabilized
+        return stabilized
+    }
+}

--- a/Cotabby/Support/LlamaPromptRenderer.swift
+++ b/Cotabby/Support/LlamaPromptRenderer.swift
@@ -77,7 +77,11 @@ enum LlamaPromptRenderer {
         if let languageInstruction, !languageInstruction.isEmpty {
             sections.append("- \(languageInstruction)")
         }
-        sections.append("- \(completionLengthInstruction)")
+        // Experiment: the explicit word-range line (`completionLengthInstruction`) is intentionally
+        // omitted from the local-model prompt so length is governed purely by the token budget
+        // (`SuggestionWordCountPreset.suggestedPredictionTokenBudget`). The parameter stays wired so
+        // re-enabling the in-prompt cue is a one-line change. Apple Intelligence still gets the cue.
+        _ = completionLengthInstruction
         sections.append("- The next line must begin directly with the continuation text.")
         sections.append("Text before caret:")
         sections.append(prefixText)

--- a/CotabbyTests/CustomRulesTests.swift
+++ b/CotabbyTests/CustomRulesTests.swift
@@ -102,7 +102,9 @@ final class CustomRulesTests: XCTestCase {
         XCTAssertTrue(instruction?.contains("Spanish") == true)
     }
 
-    func test_llamaRenderer_includesLanguageInstructionBeforeLengthCue() {
+    func test_llamaRenderer_includesLanguageInstructionInFinalBlock() {
+        // The length cue is no longer rendered (token-budget-only experiment), so this guards that
+        // the language directive still lands in the late, high-attention final-instruction block.
         let prompt = LlamaPromptRenderer.prompt(
             prefixText: "Hola",
             applicationName: "Notes",
@@ -111,12 +113,14 @@ final class CustomRulesTests: XCTestCase {
             languageInstruction: SuggestionLanguage.spanish.promptInstruction
         )
 
-        guard let langRange = prompt.range(of: "Spanish"),
-              let lenRange = prompt.range(of: "UNIQUE_LENGTH_CUE") else {
-            XCTFail("Expected language directive and length cue in the prompt")
+        XCTAssertFalse(prompt.contains("UNIQUE_LENGTH_CUE"))
+
+        guard let finalRange = prompt.range(of: "Final instruction:"),
+              let langRange = prompt.range(of: "Spanish") else {
+            XCTFail("Expected final instruction header and language directive in the prompt")
             return
         }
-        XCTAssertLessThan(langRange.lowerBound, lenRange.lowerBound)
+        XCTAssertLessThan(finalRange.lowerBound, langRange.lowerBound)
     }
 
     func test_foundationModelInstructions_includeLanguageOverride() {

--- a/CotabbyTests/GhostFontSizeStabilizerTests.swift
+++ b/CotabbyTests/GhostFontSizeStabilizerTests.swift
@@ -1,0 +1,57 @@
+import CoreGraphics
+import XCTest
+@testable import Cotabby
+
+final class GhostFontSizeStabilizerTests: XCTestCase {
+
+    func test_firstReadingEstablishesBaseline() {
+        var stabilizer = GhostFontSizeStabilizer()
+        XCTAssertEqual(stabilizer.stabilizedCaretHeight(18, focusSessionKey: 1), 18)
+    }
+
+    func test_largerReadingInSameSessionClampsToMinimum() {
+        var stabilizer = GhostFontSizeStabilizer()
+        _ = stabilizer.stabilizedCaretHeight(18, focusSessionKey: 1)
+        // A later poll falls back to the full field height; we keep the smaller real line height.
+        XCTAssertEqual(stabilizer.stabilizedCaretHeight(120, focusSessionKey: 1), 18)
+    }
+
+    func test_smallerReadingLowersMinimumForRestOfSession() {
+        var stabilizer = GhostFontSizeStabilizer()
+        _ = stabilizer.stabilizedCaretHeight(40, focusSessionKey: 7)
+        XCTAssertEqual(stabilizer.stabilizedCaretHeight(22, focusSessionKey: 7), 22)
+        // The new lower floor sticks even when a tall reading returns later in the session.
+        XCTAssertEqual(stabilizer.stabilizedCaretHeight(90, focusSessionKey: 7), 22)
+    }
+
+    func test_sessionChangeResetsBaseline() {
+        var stabilizer = GhostFontSizeStabilizer()
+        _ = stabilizer.stabilizedCaretHeight(16, focusSessionKey: 1)
+        // Switching fields must not pin a tall field to the previous field's short line height.
+        XCTAssertEqual(stabilizer.stabilizedCaretHeight(48, focusSessionKey: 2), 48)
+    }
+
+    func test_reentryWithNewSessionKeyResetsEvenWhenLarger() {
+        var stabilizer = GhostFontSizeStabilizer()
+        _ = stabilizer.stabilizedCaretHeight(18, focusSessionKey: 3)
+        _ = stabilizer.stabilizedCaretHeight(18, focusSessionKey: 3)
+        // focusChangeSequence increments on focus loss + re-entry, so the larger reading is honored.
+        XCTAssertEqual(stabilizer.stabilizedCaretHeight(30, focusSessionKey: 4), 30)
+    }
+
+    func test_nonPositiveHeightPassesThroughWithoutPoisoningCache() {
+        var stabilizer = GhostFontSizeStabilizer()
+        _ = stabilizer.stabilizedCaretHeight(20, focusSessionKey: 5)
+        // A transient empty rect should not become the session minimum.
+        XCTAssertEqual(stabilizer.stabilizedCaretHeight(0, focusSessionKey: 5), 0)
+        XCTAssertEqual(stabilizer.stabilizedCaretHeight(20, focusSessionKey: 5), 20)
+    }
+
+    func test_genuinelyLargeFieldStaysLarge() {
+        var stabilizer = GhostFontSizeStabilizer()
+        // Every poll agrees the line is tall; nothing should shrink it.
+        XCTAssertEqual(stabilizer.stabilizedCaretHeight(60, focusSessionKey: 9), 60)
+        XCTAssertEqual(stabilizer.stabilizedCaretHeight(60, focusSessionKey: 9), 60)
+        XCTAssertEqual(stabilizer.stabilizedCaretHeight(62, focusSessionKey: 9), 60)
+    }
+}

--- a/CotabbyTests/LlamaPromptRendererTests.swift
+++ b/CotabbyTests/LlamaPromptRendererTests.swift
@@ -95,10 +95,12 @@ final class LlamaPromptRendererTests: XCTestCase {
         XCTAssertTrue(prompt.contains("My prefix text here"))
     }
 
-    /// The completion-length instruction is chosen from the user's word-count
-    /// preset. It must reach the prompt verbatim so the model sees the exact
-    /// guidance the UI showed the user.
-    func test_instructionPrompt_includesCompletionLengthInstructionNearPrefix() {
+    /// Length is enforced by the token budget, not by an in-prompt word range, so the
+    /// completion-length cue must never reach the local-model prompt even if a caller passes one.
+    func test_instructionPrompt_omitsCompletionLengthInstruction() {
+        // Experiment: the local-model prompt no longer carries the word-range cue; length is
+        // governed solely by the token budget. The cue must not leak into the prompt even when a
+        // caller still passes one.
         let prompt = LlamaPromptRenderer.prompt(
             prefixText: "PREFIX_BODY_XYZ",
             applicationName: "App",
@@ -106,17 +108,15 @@ final class LlamaPromptRendererTests: XCTestCase {
             userName: nil
         )
 
-        XCTAssertTrue(prompt.contains("UNIQUE_LENGTH_MARKER_7_TO_12_WORDS"))
+        XCTAssertFalse(prompt.contains("UNIQUE_LENGTH_MARKER_7_TO_12_WORDS"))
 
         guard let finalInstructionRange = prompt.range(of: "Final instruction:"),
-              let lengthRange = prompt.range(of: "UNIQUE_LENGTH_MARKER_7_TO_12_WORDS"),
               let prefixRange = prompt.range(of: "PREFIX_BODY_XYZ") else {
-            XCTFail("Expected final instruction header, length marker, and prefix in the prompt")
+            XCTFail("Expected final instruction header and prefix in the prompt")
             return
         }
 
-        XCTAssertLessThan(finalInstructionRange.lowerBound, lengthRange.lowerBound)
-        XCTAssertLessThan(lengthRange.lowerBound, prefixRange.lowerBound)
+        XCTAssertLessThan(finalInstructionRange.lowerBound, prefixRange.lowerBound)
     }
 
     func test_instructionPrompt_includesProfileContextWhenProvided() {

--- a/CotabbyTests/ModelAndPresentationValueTests.swift
+++ b/CotabbyTests/ModelAndPresentationValueTests.swift
@@ -40,13 +40,13 @@ final class SuggestionTextColorCodecTests: XCTestCase {
 final class SuggestionModelValueTests: XCTestCase {
     func test_wordCountPresetsExposeMatchingPromptInstructionsAndTokenBudgets() {
         XCTAssertEqual(SuggestionWordCountPreset.threeToSeven.promptInstruction, "Return only the next 3 to 7 words.")
-        XCTAssertEqual(SuggestionWordCountPreset.threeToSeven.suggestedPredictionTokenBudget, 11)
+        XCTAssertEqual(SuggestionWordCountPreset.threeToSeven.suggestedPredictionTokenBudget, 17)
 
         XCTAssertEqual(SuggestionWordCountPreset.sevenToTwelve.promptInstruction, "Return only the next 7 to 12 words.")
-        XCTAssertEqual(SuggestionWordCountPreset.sevenToTwelve.suggestedPredictionTokenBudget, 18)
+        XCTAssertEqual(SuggestionWordCountPreset.sevenToTwelve.suggestedPredictionTokenBudget, 27)
 
         XCTAssertEqual(SuggestionWordCountPreset.twelveToTwenty.promptInstruction, "Return only the next 12 to 20 words.")
-        XCTAssertEqual(SuggestionWordCountPreset.twelveToTwenty.suggestedPredictionTokenBudget, 30)
+        XCTAssertEqual(SuggestionWordCountPreset.twelveToTwenty.suggestedPredictionTokenBudget, 45)
     }
 
     func test_activeSuggestionSession_clampsConsumedCountAndSlicesByCharacters() {

--- a/CotabbyTests/PromptPolicyTests.swift
+++ b/CotabbyTests/PromptPolicyTests.swift
@@ -15,7 +15,8 @@ final class FoundationModelPromptRendererTests: XCTestCase {
         let instructions = FoundationModelPromptRenderer.sessionInstructions(for: request)
 
         XCTAssertTrue(instructions.contains("text-continuation engine"))
-        XCTAssertTrue(instructions.contains("UNIQUE_LENGTH_POLICY"))
+        // The word-range cue is no longer injected — length is token-budget-only on both engines.
+        XCTAssertFalse(instructions.contains("UNIQUE_LENGTH_POLICY"))
         XCTAssertTrue(instructions.contains("Do not repeat or quote the existing text."))
     }
 
@@ -99,7 +100,8 @@ final class FoundationModelPromptRendererTests: XCTestCase {
         let preview = FoundationModelPromptRenderer.promptPreview(for: request)
 
         XCTAssertTrue(preview.contains("Instructions:\n"))
-        XCTAssertTrue(preview.contains("UNIQUE_LENGTH_POLICY"))
+        // Length cue removed from the prompt; it should not surface in the diagnostics preview either.
+        XCTAssertFalse(preview.contains("UNIQUE_LENGTH_POLICY"))
         XCTAssertTrue(preview.contains("Prompt:\n"))
         XCTAssertTrue(preview.contains("UNIQUE_APPLE_SCREEN_CONTEXT"))
     }

--- a/CotabbyTests/SuggestionRequestFactoryTests.swift
+++ b/CotabbyTests/SuggestionRequestFactoryTests.swift
@@ -119,7 +119,7 @@ final class SuggestionRequestFactoryTests: XCTestCase {
             result.request.completionLengthInstruction,
             "Return only the next 12 to 20 words."
         )
-        XCTAssertEqual(result.request.maxPredictionTokens, 30)
+        XCTAssertEqual(result.request.maxPredictionTokens, 45)
         XCTAssertEqual(result.promptPreview, result.request.prompt)
     }
 


### PR DESCRIPTION
## Summary

Ghost text occasionally rendered comically oversized. Font size is derived from the resolved caret height, but AX caret geometry is eventually consistent: the same field returns a tight line-height caret on one poll and the full field-height `AXFrame` fallback on the next, so the suggestion ballooned whenever the coarse fallback won a poll. This tracks the smallest caret height seen during a focus session and clamps larger readings down to it, so ghost text stays the size of the real text line. The baseline is keyed by `FocusTracker`'s `focusChangeSequence`, so it resets on field switch or focus loss.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby \
  -destination 'platform=macOS' \
  -skip-testing:CotabbyTests/FoundationModelDriftEvalTests \
  CODE_SIGNING_ALLOWED=NO
# ** TEST SUCCEEDED **  (0 failures, incl. 7 new GhostFontSizeStabilizerTests)

swiftlint lint --quiet
# exit 0 — no new warnings from this change
```

Local test execution needs `CODE_SIGNING_ALLOWED=NO` (dev-cert Team ID mismatch on the app-hosted bundle), matching `.github/workflows/tests.yml`.

The 7 new unit tests cover: first reading establishes the baseline, larger readings clamp to the session minimum, smaller readings lower it for the rest of the session, session-key change resets the baseline, re-entry with a new key resets even when larger, non-positive heights pass through without poisoning the cache, and a genuinely tall field stays tall.

## Linked issues

None.

## Risk / rollout notes

- **Behavior change:** ghost-text **size** only. Vertical positioning is intentionally unchanged — the existing `minimumGhostFontSize` floor also bounds how small a spurious low reading can make the text.
- **pbxproj:** registers the new `CotabbyTests/GhostFontSizeStabilizerTests.swift` (manual `CotabbyTests` group entry, per the repo convention).
- **Refactor (no behavior change):** `presentOverlay`'s loose geometry parameters were collapsed into the `FocusedInputContext` they already came from, which also threads `focusChangeSequence` to the overlay and keeps the function under the SwiftLint parameter-count rule.
- **Unrelated fix included as a separate commit:** `SuggestionRequestFactoryTests` asserted the pre-bump `maxPredictionTokens == 30` for the 12–20 word preset while the budget is now `45`; it was already failing on `main`, so it is corrected here to unblock the suite.
