### PR TITLE
Materialize Package.resolved before reading the Sparkle pin in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,14 @@ jobs:
           xcodebuild -version
           swift --version
 
+      # Package.resolved is gitignored, so SwiftPM must materialize it before
+      # the next step can read the Sparkle pin out of it (mirrors build.yml).
+      - name: Resolve Swift package dependencies
+        run: |
+          xcodebuild \
+            -project "${PROJECT_PATH}" \
+            -resolvePackageDependencies
+
       - name: Install DMG packaging dependencies
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

The Release workflow resolved the Sparkle version by reading `Cotabby.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved` directly. That file is gitignored, so a clean tag checkout does not contain it — the **Resolve Sparkle version** step died with `FileNotFoundError` before any build ran, failing every release (most recently the `v0.1.0-beta` run).

This adds a **Resolve Swift package dependencies** step (`xcodebuild -resolvePackageDependencies`) ahead of it so SwiftPM regenerates `Package.resolved` first. It mirrors the step `build.yml` already uses for its Sparkle pin check.

## Validation

- **Reproduced:** release run `26405022300` (`v0.1.0-beta`) failed with `FileNotFoundError: [Errno 2] ... Package.resolved` at *Resolve Sparkle version*.
- **Root cause:** `Package.resolved` is gitignored (`.gitignore:14`) and untracked (`git ls-files` empty), absent on `origin/main`.
- **YAML:** `ruby -ryaml -e "YAML.load_file(...)"` parses OK.
- **Pattern match:** identical to the working *Resolve Swift package dependencies* step in `build.yml`, which materializes the same file on every run.
- **No later breakage:** verified `SPARKLE_SHA256` equals the SHA-256 of `Sparkle-2.9.1.tar.xz`, so the downstream *Download Sparkle tools* check still passes.

## Linked issues

None — surfaced from the failing `v0.1.0-beta` Release run.

## Risk / rollout notes

- CI-only; no application code changes.
- The Release workflow is **tag-triggered**, so this PR's Build/Lint/Tests checks exercise the same `-resolvePackageDependencies` path but not the full signing/notarization flow.
- **Follow-up to actually ship the release:** once merged, the `v0.1.0-beta` tag must be re-pointed at the new `main` HEAD (delete + re-push the tag) to re-trigger the Release workflow with this fix.
