### PR TITLE
Tighten token-cap completion-length budgets (#271)

### DIFF
--- a/Cotabby/Models/SuggestionModels.swift
+++ b/Cotabby/Models/SuggestionModels.swift
@@ -39,17 +39,19 @@ enum SuggestionWordCountPreset: String, CaseIterable, Equatable, Hashable, Senda
         }
     }
 
-    /// Token budget bumped 50% above the prior ~1.5x-upper-word-bound sizing, giving the
-    /// token-cap-only path (no in-prompt word range for the local model) room to land a clean
-    /// stopping point instead of hard-truncating mid-thought.
+    /// Token budget is the sole governor of completion length on the local model (the in-prompt
+    /// word-range cue was removed), so it must track the upper word bound closely. Sized at
+    /// ~1.5x the upper word count to leave headroom for multi-token words (contractions, proper
+    /// nouns, punctuation) without overrunning the preset. The earlier 50% bump (17/27/45) let
+    /// completions blow past the setting — e.g. ~12 words on the 3-7 preset (#271).
     var suggestedPredictionTokenBudget: Int {
         switch self {
         case .threeToSeven:
-            return 17
+            return 11
         case .sevenToTwelve:
-            return 27
+            return 18
         case .twelveToTwenty:
-            return 45
+            return 30
         }
     }
 }

--- a/CotabbyTests/ModelAndPresentationValueTests.swift
+++ b/CotabbyTests/ModelAndPresentationValueTests.swift
@@ -40,13 +40,13 @@ final class SuggestionTextColorCodecTests: XCTestCase {
 final class SuggestionModelValueTests: XCTestCase {
     func test_wordCountPresetsExposeMatchingPromptInstructionsAndTokenBudgets() {
         XCTAssertEqual(SuggestionWordCountPreset.threeToSeven.promptInstruction, "Return only the next 3 to 7 words.")
-        XCTAssertEqual(SuggestionWordCountPreset.threeToSeven.suggestedPredictionTokenBudget, 17)
+        XCTAssertEqual(SuggestionWordCountPreset.threeToSeven.suggestedPredictionTokenBudget, 11)
 
         XCTAssertEqual(SuggestionWordCountPreset.sevenToTwelve.promptInstruction, "Return only the next 7 to 12 words.")
-        XCTAssertEqual(SuggestionWordCountPreset.sevenToTwelve.suggestedPredictionTokenBudget, 27)
+        XCTAssertEqual(SuggestionWordCountPreset.sevenToTwelve.suggestedPredictionTokenBudget, 18)
 
         XCTAssertEqual(SuggestionWordCountPreset.twelveToTwenty.promptInstruction, "Return only the next 12 to 20 words.")
-        XCTAssertEqual(SuggestionWordCountPreset.twelveToTwenty.suggestedPredictionTokenBudget, 45)
+        XCTAssertEqual(SuggestionWordCountPreset.twelveToTwenty.suggestedPredictionTokenBudget, 30)
     }
 
     func test_activeSuggestionSession_clampsConsumedCountAndSlicesByCharacters() {

--- a/CotabbyTests/SuggestionRequestFactoryTests.swift
+++ b/CotabbyTests/SuggestionRequestFactoryTests.swift
@@ -119,7 +119,7 @@ final class SuggestionRequestFactoryTests: XCTestCase {
             result.request.completionLengthInstruction,
             "Return only the next 12 to 20 words."
         )
-        XCTAssertEqual(result.request.maxPredictionTokens, 45)
+        XCTAssertEqual(result.request.maxPredictionTokens, 30)
         XCTAssertEqual(result.promptPreview, result.request.prompt)
     }
 


### PR DESCRIPTION
## Summary

Completion length runs past the user's word-count setting because, with the token-cap-only experiment (#251), `suggestedPredictionTokenBudget` is the *sole* governor of length on the local model — and that experiment also bumped it 50% (11/18/30 → 17/27/45). The looser cap lets the model emit ~12 words on a 3-7 setting and spill onto multiple lines (#271). This keeps the token-cap-only design (the in-prompt word-range cue stays removed on both engines) and just returns the caps to 11/18/30 (~1.5× the upper word bound) so the limit lands close to the selected range.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build-for-testing
# ** TEST BUILD SUCCEEDED **
```

App-hosted test *execution* fails locally only on the known Team ID code-signing mismatch (`CotabbyTests` bundle won't load); the updated budget assertions compile under `build-for-testing`.

## Linked issues

Fixes #271

## Risk / rollout notes

- Number-only change to `suggestedPredictionTokenBudget`; the token-cap-only behavior from #251 is unchanged (no completion-length cue is reintroduced into either prompt).
- Tighter caps mean slightly shorter completions across all three presets, matching the labeled word ranges.
