### PR TITLE
Add setting to accept a word without its trailing punctuation

### DIFF
--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
@@ -37,7 +37,11 @@ extension SuggestionCoordinator {
 
         let preparation = fullText
             ? interactionState.prepareFullAcceptance(from: rawContext, overlayState: overlayState)
-            : interactionState.prepareAcceptance(from: rawContext, overlayState: overlayState)
+            : interactionState.prepareAcceptance(
+                from: rawContext,
+                overlayState: overlayState,
+                autoAcceptTrailingPunctuation: settingsSnapshot.autoAcceptTrailingPunctuation
+            )
 
         let liveContext: FocusedInputContext
         let sessionForAcceptance: ActiveSuggestionSession

--- a/Cotabby/Models/SuggestionEngineModels.swift
+++ b/Cotabby/Models/SuggestionEngineModels.swift
@@ -64,4 +64,7 @@ struct SuggestionSettingsSnapshot: Equatable, Sendable {
     let debounceMilliseconds: Int
     let focusPollIntervalMilliseconds: Int
     let isMultiLineEnabled: Bool
+    /// When true (the default), accepting a word also takes punctuation attached to it. When false,
+    /// trailing punctuation is left as its own acceptance part so a single Tab takes the word alone.
+    let autoAcceptTrailingPunctuation: Bool
 }

--- a/Cotabby/Models/SuggestionSettingsModel.swift
+++ b/Cotabby/Models/SuggestionSettingsModel.swift
@@ -25,6 +25,7 @@ final class SuggestionSettingsModel: ObservableObject {
     @Published private(set) var debounceMilliseconds: Int
     @Published private(set) var focusPollIntervalMilliseconds: Int
     @Published private(set) var isMultiLineEnabled: Bool
+    @Published private(set) var autoAcceptTrailingPunctuation: Bool
     @Published private(set) var acceptanceKeyCode: CGKeyCode
     @Published private(set) var acceptanceKeyLabel: String
     @Published private(set) var fullAcceptanceKeyCode: CGKeyCode
@@ -45,6 +46,7 @@ final class SuggestionSettingsModel: ObservableObject {
     private static let debounceMillisecondsDefaultsKey = "cotabbyDebounceMilliseconds"
     private static let focusPollIntervalMillisecondsDefaultsKey = "cotabbyFocusPollIntervalMilliseconds"
     private static let multiLineEnabledDefaultsKey = "cotabbyMultiLineEnabled"
+    private static let autoAcceptTrailingPunctuationDefaultsKey = "cotabbyAutoAcceptTrailingPunctuation"
     private static let acceptanceKeyCodeDefaultsKey = "cotabbyAcceptanceKeyCode"
     private static let acceptanceKeyLabelDefaultsKey = "cotabbyAcceptanceKeyLabel"
     private static let fullAcceptanceKeyCodeDefaultsKey = "cotabbyFullAcceptanceKeyCode"
@@ -127,6 +129,8 @@ final class SuggestionSettingsModel: ObservableObject {
         }()
 
         let resolvedMultiLineEnabled = userDefaults.object(forKey: Self.multiLineEnabledDefaultsKey) as? Bool ?? false
+        let resolvedAutoAcceptTrailingPunctuation =
+            userDefaults.object(forKey: Self.autoAcceptTrailingPunctuationDefaultsKey) as? Bool ?? true
 
         let resolvedAcceptanceKeyCode = CGKeyCode(
             userDefaults.object(forKey: Self.acceptanceKeyCodeDefaultsKey) as? Int
@@ -155,6 +159,7 @@ final class SuggestionSettingsModel: ObservableObject {
         debounceMilliseconds = resolvedDebounceMilliseconds
         focusPollIntervalMilliseconds = resolvedFocusPollIntervalMilliseconds
         isMultiLineEnabled = resolvedMultiLineEnabled
+        autoAcceptTrailingPunctuation = resolvedAutoAcceptTrailingPunctuation
         acceptanceKeyCode = resolvedAcceptanceKeyCode
         acceptanceKeyLabel = resolvedAcceptanceKeyLabel
         fullAcceptanceKeyCode = resolvedFullAcceptanceKeyCode
@@ -173,6 +178,7 @@ final class SuggestionSettingsModel: ObservableObject {
         userDefaults.set(resolvedDebounceMilliseconds, forKey: Self.debounceMillisecondsDefaultsKey)
         userDefaults.set(resolvedFocusPollIntervalMilliseconds, forKey: Self.focusPollIntervalMillisecondsDefaultsKey)
         userDefaults.set(resolvedMultiLineEnabled, forKey: Self.multiLineEnabledDefaultsKey)
+        userDefaults.set(resolvedAutoAcceptTrailingPunctuation, forKey: Self.autoAcceptTrailingPunctuationDefaultsKey)
         userDefaults.set(Int(resolvedAcceptanceKeyCode), forKey: Self.acceptanceKeyCodeDefaultsKey)
         userDefaults.set(resolvedAcceptanceKeyLabel, forKey: Self.acceptanceKeyLabelDefaultsKey)
         userDefaults.set(Int(resolvedFullAcceptanceKeyCode), forKey: Self.fullAcceptanceKeyCodeDefaultsKey)
@@ -196,7 +202,8 @@ final class SuggestionSettingsModel: ObservableObject {
             responseLanguage: responseLanguage,
             debounceMilliseconds: debounceMilliseconds,
             focusPollIntervalMilliseconds: focusPollIntervalMilliseconds,
-            isMultiLineEnabled: isMultiLineEnabled
+            isMultiLineEnabled: isMultiLineEnabled,
+            autoAcceptTrailingPunctuation: autoAcceptTrailingPunctuation
         )
     }
 
@@ -233,6 +240,14 @@ final class SuggestionSettingsModel: ObservableObject {
         }
         isMultiLineEnabled = enabled
         userDefaults.set(enabled, forKey: Self.multiLineEnabledDefaultsKey)
+    }
+
+    func setAutoAcceptTrailingPunctuation(_ enabled: Bool) {
+        guard autoAcceptTrailingPunctuation != enabled else {
+            return
+        }
+        autoAcceptTrailingPunctuation = enabled
+        userDefaults.set(enabled, forKey: Self.autoAcceptTrailingPunctuationDefaultsKey)
     }
 
     func setDebounceMilliseconds(_ value: Int) {
@@ -583,12 +598,17 @@ extension SuggestionSettingsModel: SuggestionSettingsProviding {
             ),
             $isClipboardContextEnabled,
             Publishers.CombineLatest3($userName, $customRules, $responseLanguage),
-            Publishers.CombineLatest3($debounceMilliseconds, $focusPollIntervalMilliseconds, $isMultiLineEnabled)
+            Publishers.CombineLatest4(
+                $debounceMilliseconds,
+                $focusPollIntervalMilliseconds,
+                $isMultiLineEnabled,
+                $autoAcceptTrailingPunctuation
+            )
         )
         .map { combinedSettings, clipboardContextEnabled, profile, timing in
             let (globallyEnabled, disabledAppRules, engine, wordCountPreset) = combinedSettings
             let (userName, customRules, responseLanguage) = profile
-            let (debounce, focusPoll, multiLine) = timing
+            let (debounce, focusPoll, multiLine, autoAcceptPunctuation) = timing
             return SuggestionSettingsSnapshot(
                 isGloballyEnabled: globallyEnabled,
                 disabledAppBundleIdentifiers: Set(disabledAppRules.map(\.bundleIdentifier)),
@@ -600,7 +620,8 @@ extension SuggestionSettingsModel: SuggestionSettingsProviding {
                 responseLanguage: responseLanguage,
                 debounceMilliseconds: debounce,
                 focusPollIntervalMilliseconds: focusPoll,
-                isMultiLineEnabled: multiLine
+                isMultiLineEnabled: multiLine,
+                autoAcceptTrailingPunctuation: autoAcceptPunctuation
             )
         }
         .removeDuplicates()

--- a/Cotabby/Services/Suggestion/SuggestionInteractionState.swift
+++ b/Cotabby/Services/Suggestion/SuggestionInteractionState.swift
@@ -106,14 +106,18 @@ final class SuggestionInteractionState {
     /// use for diagnostics and overlay updates.
     func prepareAcceptance(
         from snapshot: FocusedInputSnapshot,
-        overlayState: OverlayState
+        overlayState: OverlayState,
+        autoAcceptTrailingPunctuation: Bool = true
     ) -> SuggestionAcceptancePreparation {
         let validated = validateSessionForAcceptance(from: snapshot, overlayState: overlayState)
         guard let (liveContext, session) = validated.session else {
             return .invalid(validated.failureReason ?? "Key passed through.")
         }
 
-        let chunk = SuggestionSessionReconciler.nextAcceptanceChunk(from: session.remainingText)
+        let chunk = SuggestionSessionReconciler.nextAcceptanceChunk(
+            from: session.remainingText,
+            autoAcceptTrailingPunctuation: autoAcceptTrailingPunctuation
+        )
         guard !chunk.isEmpty else {
             return .invalid("Key passed through because no remaining suggestion chunk was available.")
         }

--- a/Cotabby/Support/SuggestionSessionReconciler.swift
+++ b/Cotabby/Support/SuggestionSessionReconciler.swift
@@ -220,8 +220,19 @@ enum SuggestionSessionReconciler {
     }
 
     /// Accepts optional leading whitespace plus the next visible token.
+    ///
+    /// When `autoAcceptTrailingPunctuation` is false, punctuation that trails a word is treated as
+    /// its own acceptance part: the chunk stops after the word's last alphanumeric character so a
+    /// user can accept "you" without being forced to also take the "?" in "you?". The leftover
+    /// punctuation is returned whole on the next call. Punctuation that sits inside a word
+    /// (the apostrophe in "don't", the interior dots in "U.S.A") is preserved because it is not
+    /// trailing.
+    ///
     /// This is intentionally a user-facing chunking rule rather than a model-token rule.
-    static func nextAcceptanceChunk(from remainingText: String) -> String {
+    static func nextAcceptanceChunk(
+        from remainingText: String,
+        autoAcceptTrailingPunctuation: Bool = true
+    ) -> String {
         guard !remainingText.isEmpty else {
             return ""
         }
@@ -231,11 +242,41 @@ enum SuggestionSessionReconciler {
             index = remainingText.index(after: index)
         }
 
+        let tokenStart = index
         while index < remainingText.endIndex, !remainingText[index].isWhitespace {
             index = remainingText.index(after: index)
         }
 
+        if !autoAcceptTrailingPunctuation,
+           let wordEnd = wordEndTrimmingTrailingPunctuation(in: remainingText, from: tokenStart, to: index) {
+            index = wordEnd
+        }
+
         return String(remainingText[..<index])
+    }
+
+    /// Returns the index just past a word token's final alphanumeric character when that token has
+    /// trailing punctuation worth splitting off. Returns `nil` — meaning "accept the whole token" —
+    /// for punctuation-only tokens and for words that already end in an alphanumeric character.
+    private static func wordEndTrimmingTrailingPunctuation(
+        in text: String,
+        from tokenStart: String.Index,
+        to tokenEnd: String.Index
+    ) -> String.Index? {
+        var lastWordCharacterEnd: String.Index?
+        var cursor = tokenStart
+        while cursor < tokenEnd {
+            if text[cursor].isAcceptanceWordCharacter {
+                lastWordCharacterEnd = text.index(after: cursor)
+            }
+            cursor = text.index(after: cursor)
+        }
+
+        guard let wordEnd = lastWordCharacterEnd, wordEnd < tokenEnd else {
+            return nil
+        }
+
+        return wordEnd
     }
 
     /// Counts word-like tokens so punctuation-only accepts do not inflate productivity metrics.
@@ -281,5 +322,13 @@ private extension String {
         }
 
         return unicodeScalars.allSatisfy { !CharacterSet.controlCharacters.contains($0) }
+    }
+}
+
+private extension Character {
+    /// Alphanumerics form the core of a "word"; everything else trailing a word is punctuation that
+    /// can be peeled into its own acceptance part when auto-accept is disabled.
+    var isAcceptanceWordCharacter: Bool {
+        isLetter || isNumber
     }
 }

--- a/Cotabby/UI/SettingsView.swift
+++ b/Cotabby/UI/SettingsView.swift
@@ -148,6 +148,9 @@ struct SettingsView: View {
 
             Toggle("Allow Multi-line Suggestions", isOn: multiLineEnabledBinding)
 
+            Toggle("Accept Punctuation With Word", isOn: autoAcceptTrailingPunctuationBinding)
+                .help("When on, accepting a word also takes punctuation attached to it, like the \"?\" in \"you?\".")
+
             Toggle("Include Clipboard Context", isOn: clipboardContextEnabledBinding)
 
             // Open at Login is hidden until the quarantine/SMAppService issue is resolved.
@@ -280,9 +283,6 @@ struct SettingsView: View {
                     }
                 }
             }
-
-            Toggle("Accept Punctuation With Word", isOn: autoAcceptTrailingPunctuationBinding)
-                .help("When on, accepting a word also takes punctuation attached to it, like the \"?\" in \"you?\".")
 
             LabeledContent("Accept Entire Suggestion") {
                 HStack(spacing: 8) {

--- a/Cotabby/UI/SettingsView.swift
+++ b/Cotabby/UI/SettingsView.swift
@@ -281,6 +281,9 @@ struct SettingsView: View {
                 }
             }
 
+            Toggle("Accept Punctuation With Word", isOn: autoAcceptTrailingPunctuationBinding)
+                .help("When on, accepting a word also takes punctuation attached to it, like the \"?\" in \"you?\".")
+
             LabeledContent("Accept Entire Suggestion") {
                 HStack(spacing: 8) {
                     Text(suggestionSettings.fullAcceptanceKeyLabel)
@@ -633,6 +636,13 @@ struct SettingsView: View {
         Binding(
             get: { suggestionSettings.isMultiLineEnabled },
             set: { suggestionSettings.setMultiLineEnabled($0) }
+        )
+    }
+
+    private var autoAcceptTrailingPunctuationBinding: Binding<Bool> {
+        Binding(
+            get: { suggestionSettings.autoAcceptTrailingPunctuation },
+            set: { suggestionSettings.setAutoAcceptTrailingPunctuation($0) }
         )
     }
 

--- a/CotabbyTests/CotabbyTestFixtures.swift
+++ b/CotabbyTests/CotabbyTestFixtures.swift
@@ -218,7 +218,8 @@ enum CotabbyTestFixtures {
         responseLanguage: SuggestionLanguage = .default,
         debounceMilliseconds: Int = 50,
         focusPollIntervalMilliseconds: Int = 50,
-        isMultiLineEnabled: Bool = false
+        isMultiLineEnabled: Bool = false,
+        autoAcceptTrailingPunctuation: Bool = true
     ) -> SuggestionSettingsSnapshot {
         SuggestionSettingsSnapshot(
             isGloballyEnabled: isGloballyEnabled,
@@ -231,7 +232,8 @@ enum CotabbyTestFixtures {
             responseLanguage: responseLanguage,
             debounceMilliseconds: debounceMilliseconds,
             focusPollIntervalMilliseconds: focusPollIntervalMilliseconds,
-            isMultiLineEnabled: isMultiLineEnabled
+            isMultiLineEnabled: isMultiLineEnabled,
+            autoAcceptTrailingPunctuation: autoAcceptTrailingPunctuation
         )
     }
 }

--- a/CotabbyTests/SuggestionSessionReconcilerTests.swift
+++ b/CotabbyTests/SuggestionSessionReconcilerTests.swift
@@ -59,6 +59,78 @@ final class SuggestionSessionReconcilerTests: XCTestCase {
         XCTAssertEqual(SuggestionSessionReconciler.nextAcceptanceChunk(from: ""), "")
     }
 
+    func test_nextAcceptanceChunk_defaultsToAcceptingTrailingPunctuation() {
+        XCTAssertEqual(SuggestionSessionReconciler.nextAcceptanceChunk(from: "you?"), "you?")
+    }
+
+    func test_nextAcceptanceChunk_keepsTrailingPunctuationWhenAutoAcceptEnabled() {
+        XCTAssertEqual(
+            SuggestionSessionReconciler.nextAcceptanceChunk(from: "you?", autoAcceptTrailingPunctuation: true),
+            "you?"
+        )
+    }
+
+    func test_nextAcceptanceChunk_splitsTrailingPunctuationWhenAutoAcceptDisabled() {
+        XCTAssertEqual(
+            SuggestionSessionReconciler.nextAcceptanceChunk(from: "you?", autoAcceptTrailingPunctuation: false),
+            "you"
+        )
+    }
+
+    func test_nextAcceptanceChunk_returnsLeftoverPunctuationAsItsOwnPart() {
+        // After "you" is accepted, the remaining tail is the bare punctuation, taken whole next.
+        XCTAssertEqual(
+            SuggestionSessionReconciler.nextAcceptanceChunk(from: "?", autoAcceptTrailingPunctuation: false),
+            "?"
+        )
+    }
+
+    func test_nextAcceptanceChunk_splitsMultipleTrailingMarksAsOnePart() {
+        XCTAssertEqual(
+            SuggestionSessionReconciler.nextAcceptanceChunk(from: "you?!", autoAcceptTrailingPunctuation: false),
+            "you"
+        )
+        XCTAssertEqual(
+            SuggestionSessionReconciler.nextAcceptanceChunk(from: "?!", autoAcceptTrailingPunctuation: false),
+            "?!"
+        )
+    }
+
+    func test_nextAcceptanceChunk_preservesInternalPunctuationWhenSplitting() {
+        // Apostrophes and interior dots are not trailing, so the word stays whole.
+        XCTAssertEqual(
+            SuggestionSessionReconciler.nextAcceptanceChunk(from: "don't", autoAcceptTrailingPunctuation: false),
+            "don't"
+        )
+        XCTAssertEqual(
+            SuggestionSessionReconciler.nextAcceptanceChunk(from: "U.S.A", autoAcceptTrailingPunctuation: false),
+            "U.S.A"
+        )
+    }
+
+    func test_nextAcceptanceChunk_splitsOnlyFinalPeriodAfterInteriorDots() {
+        XCTAssertEqual(
+            SuggestionSessionReconciler.nextAcceptanceChunk(from: "U.S.A.", autoAcceptTrailingPunctuation: false),
+            "U.S.A"
+        )
+    }
+
+    func test_nextAcceptanceChunk_keepsLeadingWhitespaceWhenSplittingPunctuation() {
+        XCTAssertEqual(
+            SuggestionSessionReconciler.nextAcceptanceChunk(from: " world!", autoAcceptTrailingPunctuation: false),
+            " world"
+        )
+    }
+
+    func test_nextAcceptanceChunk_splittingStopsAtFirstWhitespaceBoundary() {
+        // The first token has no trailing punctuation, so splitting leaves it whole and never
+        // reaches the punctuation on the following word.
+        XCTAssertEqual(
+            SuggestionSessionReconciler.nextAcceptanceChunk(from: "hello world?", autoAcceptTrailingPunctuation: false),
+            "hello"
+        )
+    }
+
     func test_acceptedWordCount_countsOnlyTokensWithAlphanumerics() {
         let count = SuggestionSessionReconciler.acceptedWordCount(
             in: "hello, !!! world 123 --"


### PR DESCRIPTION
## Summary

Adds an **Accept Punctuation With Word** setting (default **on**) so a user can accept a
suggested word without being forced to take the punctuation attached to it. This resolves the
case in #274 where a `"you?"` suggestion took the `?` on the same Tab even when the user only
wanted `you`.

With the setting **off**, `nextAcceptanceChunk` treats trailing punctuation as its own acceptance
part: the first Tab inserts `you`, a second Tab inserts `?`. Default-on preserves today's behavior,
so existing users see no change until they opt in.

## Validation

What I actually ran and saw:

```bash
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build-for-testing
# ** TEST BUILD SUCCEEDED **

xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  -only-testing:CotabbyTests/SuggestionSessionReconcilerTests \
  -only-testing:CotabbyTests/SuggestionInteractionStateTests CODE_SIGNING_ALLOWED=NO
# SuggestionSessionReconcilerTests: Executed 28 tests, with 0 failures
# SuggestionInteractionStateTests:  Executed 8 tests, with 0 failures

swiftlint lint --quiet --config .swiftlint.yml <the 8 changed files>
# exit 0
```

Added 9 `nextAcceptanceChunk` cases covering split-on/off, the leftover punctuation-only tail,
multiple trailing marks, internal punctuation (`don't`, `U.S.A`), only-final-period splitting,
leading whitespace, and the whitespace boundary.

Notes:
- App-hosted tests do not launch under the default scheme on this machine because of a local
  Team ID / code-signing mismatch (called out in `CLAUDE.md`); re-running with
  `CODE_SIGNING_ALLOWED=NO` loads the bundle and the suites pass.
- I ran the two affected unit suites, not the entire test target. UI was verified by compilation
  only — I did not capture a screenshot. The new control is a single `Toggle("Accept Punctuation
  With Word")` in the **Shortcuts** settings section, beneath the **Accept Word** keybind.

## Linked issues

Fixes #274

## Risk / rollout notes

- **New persisted setting** `cotabbyAutoAcceptTrailingPunctuation` (UserDefaults `Bool`), defaults
  to `true`, so existing installs keep the current behavior.
- **Scope:** only word-by-word (Tab) acceptance is affected. "Accept Entire Suggestion"
  (full accept) is intentionally unchanged and still inserts trailing punctuation, because a
  one-shot full accept has nowhere to leave a trailing remainder.
- **Snapshot change:** `SuggestionSettingsSnapshot` gained a field; `CotabbyTestFixtures.settingsSnapshot`
  was updated with a defaulted parameter. No `.pbxproj` changes (tests were added to an existing file).
- When the setting is off, accepting the punctuation-only part records 0 words, so the productivity
  counter is not inflated (existing `acceptedWordCount` rule already handles this).
