### PR TITLE
Add an app picker to disable Cotabby in unreachable apps

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		G10000012FB0000100FFF001 /* WordCountFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = G10000112FB0000100FFF011 /* WordCountFormatterTests.swift */; };
 		G10000022FB0000100FFF002 /* ClipboardContentDistillerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = G10000122FB0000100FFF012 /* ClipboardContentDistillerTests.swift */; };
 		G20000012FB0000100FFF001 /* ClipboardRelevanceFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = G20000112FB0000100FFF011 /* ClipboardRelevanceFilterTests.swift */; };
+		G30000012FB0000100FFF001 /* ApplicationBundleMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = G30000112FB0000100FFF011 /* ApplicationBundleMetadataTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -80,6 +81,7 @@
 		G10000112FB0000100FFF011 /* WordCountFormatterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WordCountFormatterTests.swift; sourceTree = "<group>"; };
 		G10000122FB0000100FFF012 /* ClipboardContentDistillerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ClipboardContentDistillerTests.swift; sourceTree = "<group>"; };
 		G20000112FB0000100FFF011 /* ClipboardRelevanceFilterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ClipboardRelevanceFilterTests.swift; sourceTree = "<group>"; };
+		G30000112FB0000100FFF011 /* ApplicationBundleMetadataTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ApplicationBundleMetadataTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -160,6 +162,7 @@
 				G20000112FB0000100FFF011 /* ClipboardRelevanceFilterTests.swift */,
 				G10000122FB0000100FFF012 /* ClipboardContentDistillerTests.swift */,
 				G10000112FB0000100FFF011 /* WordCountFormatterTests.swift */,
+				G30000112FB0000100FFF011 /* ApplicationBundleMetadataTests.swift */,
 			);
 			path = CotabbyTests;
 			sourceTree = "<group>";
@@ -307,6 +310,7 @@
 				G20000012FB0000100FFF001 /* ClipboardRelevanceFilterTests.swift in Sources */,
 				G10000022FB0000100FFF002 /* ClipboardContentDistillerTests.swift in Sources */,
 				G10000012FB0000100FFF001 /* WordCountFormatterTests.swift in Sources */,
+				G30000012FB0000100FFF001 /* ApplicationBundleMetadataTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Cotabby/Services/Focus/FocusTracker.swift
+++ b/Cotabby/Services/Focus/FocusTracker.swift
@@ -123,7 +123,21 @@ final class FocusTracker {
             )
         }
 
-        guard let application = NSWorkspace.shared.frontmostApplication else {
+        guard let focusedElement = AXHelper.focusedElement() else {
+            let frontmost = NSWorkspace.shared.frontmostApplication
+            return inactiveCapture(
+                applicationName: frontmost?.localizedName ?? "No active application",
+                bundleIdentifier: frontmost?.bundleIdentifier,
+                capability: .unsupported("No focused Accessibility element.")
+            )
+        }
+
+        // Identity must come from the app that owns the focused element, not from
+        // `frontmostApplication`. Accessory apps with non-activating panels (Raycast, Spotlight,
+        // Alfred) leave the previous app frontmost while owning the focused field, so trusting
+        // frontmost there would attribute typing to the wrong app and defeat per-app disabling.
+        guard let application = AXHelper.owningApplication(of: focusedElement)
+            ?? NSWorkspace.shared.frontmostApplication else {
             return inactiveCapture(
                 applicationName: "No active application",
                 bundleIdentifier: nil,
@@ -136,14 +150,6 @@ final class FocusTracker {
                 applicationName: application.localizedName ?? "Cotabby",
                 bundleIdentifier: application.bundleIdentifier,
                 capability: .blocked("Cotabby is focused.")
-            )
-        }
-
-        guard let focusedElement = AXHelper.focusedElement() else {
-            return inactiveCapture(
-                applicationName: application.localizedName ?? "Unknown",
-                bundleIdentifier: application.bundleIdentifier,
-                capability: .unsupported("No focused Accessibility element.")
             )
         }
 

--- a/Cotabby/Support/AXHelper.swift
+++ b/Cotabby/Support/AXHelper.swift
@@ -213,6 +213,20 @@ enum AXHelper {
         return unsafeBitCast(element, to: AXUIElement.self)
     }
 
+    /// Returns the running application that owns the given AX element.
+    ///
+    /// This matters for accessory apps (Raycast, Spotlight, Alfred) that show non-activating
+    /// panels: they keep the previously active app as `NSWorkspace.frontmostApplication` while
+    /// actually owning the focused text element. Resolving identity from the element's pid is the
+    /// only way to attribute the focused field to the real owner.
+    static func owningApplication(of element: AXUIElement) -> NSRunningApplication? {
+        var pid: pid_t = 0
+        guard AXUIElementGetPid(element, &pid) == .success, pid > 0 else {
+            return nil
+        }
+        return NSRunningApplication(processIdentifier: pid)
+    }
+
     /// Returns the parent AX node when the current element exposes one.
     static func parentElement(of element: AXUIElement) -> AXUIElement? {
         guard let value = copyAttributeValue(kAXParentAttribute as CFString, on: element) else {

--- a/Cotabby/Support/ApplicationBundleMetadata.swift
+++ b/Cotabby/Support/ApplicationBundleMetadata.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// File overview:
+/// Resolves the durable identity of an application bundle the user picked from disk so Settings can
+/// turn it into a disabled-app rule.
+///
+/// Why this exists: the "Add App" open panel hands back a file URL, but disable rules are keyed by
+/// bundle identifier with a human-facing display name. Choosing that display name has a small
+/// fallback order (Info.plist display name, then bundle name, then the file name on disk), and a
+/// bundle without an identifier can never match a focused app, so it must be rejected. Keeping that
+/// logic here — out of the SwiftUI view — makes the fallback order pure and unit-testable.
+struct ApplicationBundleMetadata: Equatable {
+    let bundleIdentifier: String
+    let displayName: String
+}
+
+extension ApplicationBundleMetadata {
+    /// Reads metadata from an on-disk application bundle. Returns `nil` when the URL is not a
+    /// readable bundle or carries no bundle identifier, because a disable rule without a bundle
+    /// identifier can never match the focused app the suggestion pipeline reports.
+    init?(appURL: URL) {
+        guard let bundle = Bundle(url: appURL) else {
+            return nil
+        }
+
+        self.init(
+            bundleIdentifier: bundle.bundleIdentifier,
+            infoDisplayName: bundle.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String,
+            infoBundleName: bundle.object(forInfoDictionaryKey: "CFBundleName") as? String,
+            fileName: appURL.deletingPathExtension().lastPathComponent
+        )
+    }
+
+    /// Pure resolution from already-extracted values, split out from `init(appURL:)` so the fallback
+    /// order can be tested without a real bundle on disk.
+    ///
+    /// `CFBundleDisplayName` is the name shown in Finder and the Dock, so it wins; some apps ship
+    /// only `CFBundleName`; a few ship neither, where the file name (minus `.app`) is the closest
+    /// thing to what the user clicked. The bundle identifier is the last-resort label.
+    init?(
+        bundleIdentifier: String?,
+        infoDisplayName: String?,
+        infoBundleName: String?,
+        fileName: String
+    ) {
+        guard let bundleIdentifier = Self.nonEmpty(bundleIdentifier) else {
+            return nil
+        }
+
+        self.bundleIdentifier = bundleIdentifier
+        displayName = Self.nonEmpty(infoDisplayName)
+            ?? Self.nonEmpty(infoBundleName)
+            ?? Self.nonEmpty(fileName)
+            ?? bundleIdentifier
+    }
+
+    /// Trims surrounding whitespace and collapses an empty result to `nil` so the fallback chain can
+    /// skip blank Info.plist values instead of surfacing them as the display name.
+    private static func nonEmpty(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty
+        else {
+            return nil
+        }
+
+        return trimmed
+    }
+}

--- a/Cotabby/UI/SettingsView.swift
+++ b/Cotabby/UI/SettingsView.swift
@@ -352,14 +352,17 @@ struct SettingsView: View {
     @ViewBuilder
     private var appsSection: some View {
         Section("Apps") {
-            if suggestionSettings.disabledAppRules.isEmpty {
-                Text("No apps are disabled. Apps you turn off from the menu bar will appear here.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            } else {
-                ForEach(suggestionSettings.disabledAppRules) { rule in
-                    disabledAppRuleRow(rule)
-                }
+            Text("Cotabby won't autocomplete in these apps. Add an app you can't disable from the "
+                + "menu bar — like a launcher that closes the moment it loses focus.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            ForEach(suggestionSettings.disabledAppRules) { rule in
+                disabledAppRuleRow(rule)
+            }
+
+            Button("Add App…") {
+                presentDisabledAppPicker()
             }
         }
     }
@@ -801,6 +804,36 @@ struct SettingsView: View {
     private func refreshModels() {
         modelDownloadManager.refreshModelStates()
         runtimeModel.refreshAvailableModels()
+    }
+
+    /// Lets the user disable Cotabby in an app they can't reach from the menu bar. The menu-bar
+    /// "Enable in <app>" switch only targets the frontmost app, so a launcher like Raycast or
+    /// Spotlight — which dismisses itself the instant the menu bar is clicked — can never be turned
+    /// off that way. An open panel names any installed app whether or not it is running.
+    private func presentDisabledAppPicker() {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.application]
+        panel.allowsMultipleSelection = true
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.directoryURL = URL(fileURLWithPath: "/Applications", isDirectory: true)
+        panel.prompt = "Disable"
+        panel.message = "Choose apps where Cotabby should not autocomplete."
+
+        guard panel.runModal() == .OK else {
+            return
+        }
+
+        for url in panel.urls {
+            guard let metadata = ApplicationBundleMetadata(appURL: url) else {
+                continue
+            }
+
+            suggestionSettings.disableApplication(
+                bundleIdentifier: metadata.bundleIdentifier,
+                displayName: metadata.displayName
+            )
+        }
     }
 
 }

--- a/CotabbyTests/ApplicationBundleMetadataTests.swift
+++ b/CotabbyTests/ApplicationBundleMetadataTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+@testable import Cotabby
+
+/// Tests for the picker-to-rule resolution that backs "Add App" in Settings.
+///
+/// These exercise the pure initializer — the one that does not touch disk — so the display-name
+/// fallback order and the bundle-identifier requirement are locked independently of whatever apps
+/// happen to be installed on the machine running the suite.
+final class ApplicationBundleMetadataTests: XCTestCase {
+    func test_init_returnsNilWhenBundleIdentifierIsMissing() {
+        XCTAssertNil(
+            ApplicationBundleMetadata(
+                bundleIdentifier: nil,
+                infoDisplayName: "Raycast",
+                infoBundleName: "Raycast",
+                fileName: "Raycast"
+            )
+        )
+    }
+
+    func test_init_returnsNilWhenBundleIdentifierIsBlank() {
+        XCTAssertNil(
+            ApplicationBundleMetadata(
+                bundleIdentifier: "   ",
+                infoDisplayName: "Raycast",
+                infoBundleName: nil,
+                fileName: "Raycast"
+            )
+        )
+    }
+
+    func test_init_prefersDisplayNameOverBundleNameAndFileName() {
+        let metadata = ApplicationBundleMetadata(
+            bundleIdentifier: "com.raycast.macos",
+            infoDisplayName: "Raycast",
+            infoBundleName: "RaycastBundle",
+            fileName: "Raycast 1.2.3"
+        )
+
+        XCTAssertEqual(metadata?.bundleIdentifier, "com.raycast.macos")
+        XCTAssertEqual(metadata?.displayName, "Raycast")
+    }
+
+    func test_init_fallsBackToBundleNameWhenDisplayNameIsMissing() {
+        let metadata = ApplicationBundleMetadata(
+            bundleIdentifier: "com.microsoft.VSCode",
+            infoDisplayName: nil,
+            infoBundleName: "Code",
+            fileName: "Visual Studio Code"
+        )
+
+        XCTAssertEqual(metadata?.displayName, "Code")
+    }
+
+    func test_init_fallsBackToFileNameWhenInfoNamesAreEmpty() {
+        let metadata = ApplicationBundleMetadata(
+            bundleIdentifier: "com.example.app",
+            infoDisplayName: "  ",
+            infoBundleName: nil,
+            fileName: "Example"
+        )
+
+        XCTAssertEqual(metadata?.displayName, "Example")
+    }
+
+    func test_init_fallsBackToBundleIdentifierWhenEveryNameIsEmpty() {
+        let metadata = ApplicationBundleMetadata(
+            bundleIdentifier: "com.example.app",
+            infoDisplayName: nil,
+            infoBundleName: "",
+            fileName: "   "
+        )
+
+        XCTAssertEqual(metadata?.displayName, "com.example.app")
+    }
+
+    func test_init_trimsResolvedBundleIdentifierAndDisplayName() {
+        let metadata = ApplicationBundleMetadata(
+            bundleIdentifier: "  com.example.app  ",
+            infoDisplayName: "  Example App  ",
+            infoBundleName: nil,
+            fileName: "Example"
+        )
+
+        XCTAssertEqual(metadata?.bundleIdentifier, "com.example.app")
+        XCTAssertEqual(metadata?.displayName, "Example App")
+    }
+}


### PR DESCRIPTION
## Summary

The menu-bar "Enable in &lt;app&gt;" toggle only targets the frontmost app, so apps that take focus away from the menu bar — launchers like Raycast or Spotlight — can never be disabled that way. This adds an **"Add App…"** button to Settings → **Apps** that opens a standard open panel, letting users disable Cotabby in any installed app whether or not it's running. The picked app flows through the existing `disableApplication(bundleIdentifier:displayName:)` API, so persistence and the suggestion-pipeline enforcement are unchanged.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  build-for-testing CODE_SIGNING_ALLOWED=NO
# ** BUILD SUCCEEDED **

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  test -only-testing:CotabbyTests/ApplicationBundleMetadataTests CODE_SIGNING_ALLOWED=NO
# ** TEST SUCCEEDED **  7 tests, 0 failures

swiftlint lint --config .swiftlint.yml --quiet
# no warnings on changed files (one pre-existing cyclomatic_complexity warning in
# GhostSuggestionLayout.swift, untouched here)
```

The new `ApplicationBundleMetadata` helper is covered by 7 unit tests (display-name fallback order + the bundle-identifier requirement). No screenshot attached: the new control is a single button that presents the system open panel; selecting an app routes through the already-shipping disabled-apps list and row UI.

## Linked issues

Fixes #273

## Risk / rollout notes

- **pbxproj migration**: registers `ApplicationBundleMetadataTests.swift` in the `CotabbyTests` target (manual `PBXGroup`/`PBXBuildFile` entries, per the repo convention since the tests group isn't file-system-synchronized). The `Cotabby/` source file is picked up automatically.
- **Additive behavior**: the menu-bar per-app toggle and the existing disabled-apps list/remove UI are unchanged — this only adds a second way to populate the same list. The empty-state caption in the Apps section was reworded to mention the new button.
- **No schema/settings migration**: reuses the existing `disabledAppRules` persistence and snapshot.
