### PR TITLE
Let any key be bound as an accept shortcut

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: ship
+description: Ship the current work to main via a squash-merged PR. Branches off latest main (unless a branch is given), pushes, opens a PR using the repo template, then squash-merges with admin bypass. Use when the user says "ship it", "/ship", or wants to land changes on main end-to-end.
+---
+
+# /ship
+
+End-to-end "land this on main" workflow for Cotabby. The goal is a **single linear
+commit on main** — squash merge, never a merge commit. Cotabby's `main` ruleset
+rejects merge commits, so squashing is what keeps history clean; `--admin` bypasses
+the required-status-check protection so the owner can merge directly.
+
+`$ARGUMENTS` is optional:
+- empty → branch off the latest `origin/main` with a derived name
+- a branch name (e.g. `feat/foo`) → use/create that branch instead of deriving one
+- `from <ref>` → base the new branch on `<ref>` instead of `origin/main`
+
+## Steps
+
+1. **Establish the branch.**
+   - `git fetch origin`.
+   - If the user is already on a feature branch that holds the work, keep it.
+   - Otherwise (on `main`/detached, or a branch name was given), create the branch
+     off the latest base: `git checkout -b <name> origin/main` (or the `from <ref>`
+     base). Derive `<name>` from the change: `feat/`, `fix/`, or `chore/` + a short
+     kebab slug. Never do the work directly on `main`.
+
+2. **Commit the work.** Stage and commit anything pending. Follow the repo's
+   GitHub rules in `.claude/CLAUDE.md`: **no `Co-Authored-By` trailers.** Write a
+   concise, real commit message.
+
+3. **Validate before pushing.** Run the narrowest useful checks, broaden if shared
+   behavior changed:
+   ```bash
+   swiftlint lint --quiet
+   xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
+   ```
+   For test-affecting changes also run `build-for-testing`. Local `test` execution
+   often fails on a **Team ID / signing mismatch** — that's an environment issue, not
+   a code failure; report it and rely on `build-for-testing` succeeding.
+   - **XcodeGen:** `project.yml` is the source of truth and `Cotabby.xcodeproj` is
+     generated. New files under `Cotabby/` and `CotabbyTests/` are auto-discovered —
+     no project edit needed. Only structural changes (targets, build settings,
+     packages, scheme) require editing `project.yml` then `xcodegen generate` and
+     committing the regenerated project. Fix all lint/build errors before continuing.
+
+4. **Push.** `git push -u origin <branch>`.
+
+5. **Open the PR using the repo template.** Read `.github/PULL_REQUEST_TEMPLATE.md`
+   and fill in **every** section — Summary (what + why), Validation (what you
+   actually ran and saw), Linked issues (`Fixes #N` / `Refs #N`), Risk / rollout
+   notes. Do not invent a format. Use a heredoc body:
+   ```bash
+   gh pr create --base main --head <branch> --title "<title>" --body "$(cat <<'EOF'
+   ## Summary
+   ...
+   EOF
+   )"
+   ```
+
+6. **Confirm, then squash-merge with admin bypass.** Merging to `main` is an
+   irreversible outward action — show the PR URL and the one-line summary, and get an
+   explicit go-ahead unless the user already said to merge in this turn. Then:
+   ```bash
+   gh pr merge <branch-or-#> --squash --admin --delete-branch
+   ```
+   `--squash` keeps main linear (no merge commit → satisfies the ruleset);
+   `--admin` bypasses required checks; `--delete-branch` cleans up the remote branch.
+
+7. **Sync local main.**
+   ```bash
+   git checkout main && git pull --ff-only origin main
+   ```
+   Confirm `main` now contains the squashed commit and report the result.
+
+## Guardrails
+
+- **Never force-push `main` or rebase published history to "fix" merges.** If
+  `origin/main` moved while you worked, integrate it (rebase the branch onto the new
+  `origin/main`) and re-validate — don't clobber others' commits.
+- **Never delete or overwrite work you didn't create** without checking it first.
+- If validation fails, stop and surface the failure — don't merge red.
+- If the user named a target other than `main`, ship there instead, but keep the
+  squash-merge shape.

--- a/Cotabby/UI/KeyRecorderView.swift
+++ b/Cotabby/UI/KeyRecorderView.swift
@@ -10,16 +10,6 @@ struct KeyRecorderView: View {
 
     @State private var monitor: Any?
 
-    /// Keys that conflict with the suggestion pipeline's built-in classification.
-    /// Escape (53) is also handled above as the cancel-recording key, but lives here too
-    /// so it stays reserved even if the cancel logic changes.
-    private static let reservedKeyCodes: Set<UInt16> = [
-        36, 76,                 // Return, Enter
-        51, 117,                // Delete, Forward Delete
-        53,                     // Escape
-        123, 124, 125, 126      // Arrow keys
-    ]
-
     var body: some View {
         Text("Press a key…")
             .foregroundStyle(.secondary)
@@ -32,16 +22,19 @@ struct KeyRecorderView: View {
         monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [self] event in
             let keyCode = event.keyCode
 
-            if keyCode == 53 { // Escape cancels recording
+            // Escape cancels recording rather than binding, so it stays the universal "get me out"
+            // affordance. This is the recorder's only keyboard cancel, not a pipeline restriction.
+            if keyCode == 53 {
                 removeMonitor()
                 onCancelled?()
                 return nil
             }
 
-            guard !Self.reservedKeyCodes.contains(keyCode) else {
-                return event
-            }
-
+            // Any other key is fair game. The pipeline is key-agnostic: `InputMonitor.classify`
+            // matches the bound accept key before its behavioral branches, and acceptance only
+            // consumes the key while a suggestion is visible (otherwise it passes through and does
+            // its normal job). So even Return/Delete are safe to bind — they only intercept in the
+            // moment a suggestion is showing.
             let label = KeyCodeLabels.label(
                 for: CGKeyCode(keyCode),
                 fallback: event.charactersIgnoringModifiers


### PR DESCRIPTION
## Summary

The keybind recorder (`KeyRecorderView`) kept a reserved-key set — arrows, Return/Enter, Delete/Forward Delete, and Escape — and silently swallowed those presses, so none of them could be bound as an accept shortcut. This removes the set entirely so users can bind **any** key to "Accept Word" / "Accept Entire Suggestion".

The reservation guarded against *poor-feeling* bindings, not functional breakage. The pipeline is key-agnostic: `InputMonitor.classify` matches the bound accept key before any behavioral branch, and acceptance only consumes the key **while a suggestion is actually visible** — otherwise it passes through and performs its normal action. So a bound key is only ever intercepted in the moment a suggestion is showing.

Escape still cancels recording (it's the recorder's only keyboard cancel affordance), so it stays effectively unbindable — by UI necessity, not by reservation.

## Validation

```
swiftlint lint --quiet Cotabby/UI/KeyRecorderView.swift
# exit 0

xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby \
  -destination 'platform=macOS' \
  -skip-testing:CotabbyTests/FoundationModelDriftEvalTests CODE_SIGNING_ALLOWED=NO
# ** TEST SUCCEEDED ** — 297 tests, 0 failures (build compiled clean as part of this)
```

Not yet exercised at runtime (needs Accessibility/Input Monitoring grants on a live field). Manual check: Settings → Shortcuts → Accept Word → Change → press any key.

## Linked issues

Fixes #266

## Risk / rollout notes

- Opt-in behavior change: once a user binds a key, that key accepts the suggestion while one is visible instead of doing its normal job. With no suggestion showing it passes through normally (`acceptCurrentSuggestion` → `passTabThrough` returns `false`).
- Some bindings feel worse than others, and that's now the user's call: **Delete/Backspace** gets eaten most often (pressed constantly while typing); **Return** means a double-press to send/newline when a suggestion is up; **arrows** are the mild, originally-requested case from #266.
- **Escape** is intentionally still not bindable — it remains the recorder's cancel key.
- No schema / settings / pbxproj migration. Defaults (Tab + `` ` ``) and existing bindings are untouched.
- The accept-before-behavior ordering in `InputMonitor.classify` is what makes any bound key safe, and it's currently untested because `classify` is private. Possible follow-up: extract that ordering into a pure, testable helper.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the `reservedKeyCodes` set from `KeyRecorderView`, allowing any key except Escape to be bound as the "Accept Word" or "Accept Entire Suggestion" shortcut. The safety of this change rests on `InputMonitor.classify` matching the bound accept key before any behavioral branch, and on the event being passed through untouched when no suggestion is currently visible.

- `KeyRecorderView.swift`: The `reservedKeyCodes` static property and its guard are deleted. Escape retains its early-exit path as the recorder's only cancel affordance, making it effectively un-bindable by UI necessity.
- `.claude/skills/ship/SKILL.md`: New developer workflow skill defining the squash-merge-to-main process; no runtime impact.

<h3>Confidence Score: 4/5</h3>

Safe to merge. The key-intercept logic in InputMonitor already prioritises the accept-key match above all behavioral branches, so keys like Return and Delete pass through normally whenever no suggestion is showing.

The core change is a two-line deletion from the recorder — low surface area, well-understood semantics. One minor concern is that `acceptCurrentSuggestion` and `passTabThrough` still hardcode "Tab" in log stage names and overlay-reason strings, so debug output will misattribute accepts to Tab even when a different key triggered them. This is purely diagnostic noise and does not affect user-facing behaviour.

The `keyName: "Tab"` hardcode in `SuggestionCoordinator+Acceptance.swift` (lines 13–20) would produce misleading diagnostics for non-Tab bindings.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/KeyRecorderView.swift | Removes the `reservedKeyCodes` set so any key except Escape can now be bound as an accept shortcut; Escape still cancels recording via its early-exit check. |
| .claude/skills/ship/SKILL.md | New developer skill file defining the end-to-end squash-merge-to-main workflow; no runtime code. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User presses key in KeyRecorderView] --> B{Escape key?}
    B -- Yes --> C[Cancel recording]
    B -- No --> D[Record any key as shortcut]

    E[Key pressed in target app] --> F[InputMonitor classify]
    F --> G{Matches fullAcceptKey with no modifiers?}
    G -- Yes --> H[fullAcceptance event]
    G -- No --> I{Matches acceptKey with no modifiers?}
    I -- Yes --> J[acceptance event]
    I -- No --> K[Other: navigation / textMutation / dismissal]

    H --> L[acceptEntireSuggestion]
    J --> M[acceptCurrentSuggestion]
    L --> N{Suggestion ready?}
    M --> N
    N -- Yes --> O[Insert chunk, suppress key]
    N -- No --> P[passTabThrough: key passes through normally]
```

<sub>Reviews (1): Last reviewed commit: ["Add SKILL.md for the /ship workflow docu..."](https://github.com/fujacob/cotabby/commit/4f9374792992228b5af6c03fe8fd798bb2a16136) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34089157)</sub>

<!-- /greptile_comment -->