### PR TITLE
Guard XcodeGen project against drift + document workflow

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -65,9 +65,12 @@ change as shipping to end users, not as an exercise.
 ## Contributing Workflow
 
 - External contributors open PRs against `main`. Greptile reviews automatically.
-- New test files in `CotabbyTests/` must be manually registered in
-  `Cotabby.xcodeproj/project.pbxproj` (the `Cotabby/` source group auto-discovers
-  files, but `CotabbyTests/` uses manual PBXGroup entries).
+- `Cotabby.xcodeproj` is generated from `project.yml` by XcodeGen and committed to the
+  repo. `project.yml` is the source of truth. Sources under `Cotabby/` and `CotabbyTests/`
+  are auto-discovered by folder, so a new file (including a new test) needs no project edit.
+  Only structural changes (targets, build settings, package dependencies, scheme) require
+  editing `project.yml` followed by `xcodegen generate`. The `XcodeGen` CI workflow fails the
+  PR if the committed project drifts from `project.yml`.
 - Run SwiftLint before pushing: `swiftlint lint --quiet`. The project config is
   in `.swiftlint.yml` (line length 140/200, trailing commas disallowed).
 - Wiki lives at https://github.com/FuJacob/Cotabby/wiki for contributor onboarding.

--- a/.github/workflows/xcodegen.yml
+++ b/.github/workflows/xcodegen.yml
@@ -1,0 +1,52 @@
+# XcodeGen drift gate.
+#
+# The .xcodeproj is generated from `project.yml` but committed to the repo so
+# contributors can `open Cotabby.xcodeproj` without installing XcodeGen first.
+# That convenience only holds if the committed project stays byte-identical to
+# what `xcodegen generate` produces. This job regenerates on every PR and fails
+# if the result differs from what's checked in — catching the case where
+# someone edits the project in Xcode (or hand-edits the pbxproj) without
+# mirroring the change into `project.yml`.
+#
+# Sibling to Build/Lint/Tests: one gate, one file, one clear failure mode.
+
+name: XcodeGen
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: xcodegen-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  drift:
+    name: project.yml matches Cotabby.xcodeproj
+    runs-on: macos-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install / verify XcodeGen
+        run: |
+          if ! command -v xcodegen >/dev/null; then
+            brew install xcodegen
+          fi
+          xcodegen --version
+
+      - name: Regenerate project
+        run: xcodegen generate
+
+      # XcodeGen only rewrites the tracked project files (pbxproj + shared
+      # schemes); Package.resolved is gitignored and untouched here. Scope the
+      # check to the project so unrelated working-tree noise can't fail it.
+      - name: Verify no drift
+        run: |
+          if ! git diff --exit-code -- Cotabby.xcodeproj; then
+            echo "::error::Cotabby.xcodeproj is out of sync with project.yml." \
+              "Run 'xcodegen generate' and commit the result." >&2
+            exit 1
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,8 @@ You need:
 - A local Apple development team configured in Xcode if you want to launch the signed app from the
   IDE.
 - SwiftLint for local lint checks. CI installs it with Homebrew when needed.
+- XcodeGen if you need to change the project structure (targets, build settings, dependencies,
+  or scheme). Install it with `brew install xcodegen`. CI installs it the same way.
 
 Apple Silicon is strongly recommended for local model-runtime work.
 
@@ -47,6 +49,26 @@ open Cotabby.xcodeproj
 
 In Xcode, select the `Cotabby` scheme. If you run from Xcode, set your signing team under
 `Signing & Capabilities`.
+
+## The Xcode Project Is Generated
+
+`Cotabby.xcodeproj` is generated from `project.yml` by [XcodeGen](https://github.com/yonaskolb/XcodeGen).
+It is committed to the repo so you can clone and `open Cotabby.xcodeproj` without any extra tooling,
+but **`project.yml` is the source of truth**.
+
+Source files under `Cotabby/` and `CotabbyTests/` are auto-discovered by folder, so adding a new
+file (including a new test) needs no project edit — just create it and regenerate. Only structural
+changes (targets, build settings, package dependencies, scheme) require editing `project.yml`.
+
+After any structural change, regenerate and commit the result:
+
+```sh
+xcodegen generate
+```
+
+CI runs the `XcodeGen` workflow on every PR and fails if the committed `Cotabby.xcodeproj` differs
+from what `project.yml` produces. If that check is red, run `xcodegen generate` and commit the diff.
+Avoid hand-editing the project in Xcode without mirroring the change into `project.yml`.
 
 ## How To Navigate The Repo
 

--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -823,6 +823,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
@@ -1011,6 +1012,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;

--- a/project.yml
+++ b/project.yml
@@ -101,6 +101,7 @@ targets:
     settings:
       base:
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+        ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS: YES
         ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: AccentColor
         CODE_SIGN_IDENTITY[sdk=macosx*]: Apple Development
         CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
## Summary

Follow-ups to #268, which adopted XcodeGen and committed the generated `Cotabby.xcodeproj` but left nothing to keep it in sync with `project.yml`. This adds the missing guard rails:

- **CI drift gate** (`.github/workflows/xcodegen.yml`): regenerates the project on every PR and fails if the committed `Cotabby.xcodeproj` differs from what `project.yml` produces — catching hand-edits or Xcode edits that aren't mirrored into `project.yml`.
- **Docs**: a "The Xcode Project Is Generated" section in `CONTRIBUTING.md` (plus XcodeGen in prerequisites), and an updated note in `.claude/CLAUDE.md` that replaces the now-stale "manually register new test files in project.pbxproj" instruction — sources are auto-discovered by folder now.
- **Fidelity fix**: restore `ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES`, the one build setting the initial regeneration in #268 silently dropped from the original project.

## Validation

- `xcodegen generate` is idempotent against the committed project (two consecutive runs produce a byte-identical `project.pbxproj`), so the new drift gate is green on this branch.
- `xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build`
  `** BUILD SUCCEEDED **`
- `swiftlint lint --quiet` — no new warnings (pre-existing `GhostSuggestionLayout.swift:235` complexity warning unchanged).

## Linked issues

Refs #268.

## Risk / rollout notes

- The drift gate installs XcodeGen via Homebrew on `macos-latest`, mirroring how the Lint workflow installs SwiftLint.
- Restoring the asset-symbol setting is the only behavioral change to the build; it matches the original pre-XcodeGen project and the app builds clean with it.
- Contributors now need `brew install xcodegen` only when changing project structure; everyday source edits still need no project changes.
