### PR TITLE
Add a toggle to hide the suggestion accept-key hint

### DIFF
--- a/Cotabby/Models/SuggestionSettingsModel.swift
+++ b/Cotabby/Models/SuggestionSettingsModel.swift
@@ -14,6 +14,8 @@ import Foundation
 final class SuggestionSettingsModel: ObservableObject {
     @Published private(set) var isGloballyEnabled: Bool
     @Published private(set) var showIndicator: Bool
+    /// Whether the keycap hint (the small pill that teaches the accept key) is drawn after ghost text.
+    @Published private(set) var showAcceptanceHint: Bool
     @Published private(set) var disabledAppRules: [DisabledApplicationRule]
     @Published private(set) var customSuggestionTextColorHex: String?
     @Published private(set) var selectedEngine: SuggestionEngineKind
@@ -35,6 +37,7 @@ final class SuggestionSettingsModel: ObservableObject {
     private static let disabledAppRulesDefaultsKey = "cotabbyDisabledAppRules"
     private static let showCaretIndicatorDefaultsKey = "cotabbyShowCaretIndicator"
     private static let selectedIndicatorModeDefaultsKey = "cotabbySelectedIndicatorMode"
+    private static let showAcceptanceHintDefaultsKey = "cotabbyShowAcceptanceHint"
     private static let customSuggestionTextColorHexDefaultsKey = "cotabbyCustomSuggestionTextColorHex"
     private static let selectedEngineDefaultsKey = "cotabbySelectedEngine"
     private static let selectedWordCountPresetDefaultsKey = "cotabbySelectedWordCountPreset"
@@ -76,6 +79,7 @@ final class SuggestionSettingsModel: ObservableObject {
         } else {
             userDefaults.object(forKey: Self.showCaretIndicatorDefaultsKey) as? Bool ?? true
         }
+        let resolvedShowAcceptanceHint = userDefaults.object(forKey: Self.showAcceptanceHintDefaultsKey) as? Bool ?? true
         let resolvedCustomSuggestionTextColorHex = Self.normalizedHexString(
             userDefaults.string(forKey: Self.customSuggestionTextColorHexDefaultsKey)
         )
@@ -145,6 +149,7 @@ final class SuggestionSettingsModel: ObservableObject {
         isGloballyEnabled = resolvedGloballyEnabled
         disabledAppRules = resolvedDisabledAppRules
         showIndicator = resolvedShowIndicator
+        showAcceptanceHint = resolvedShowAcceptanceHint
         customSuggestionTextColorHex = resolvedCustomSuggestionTextColorHex
         selectedEngine = resolvedEngine
         selectedWordCountPreset = resolvedWordCountPreset
@@ -163,6 +168,7 @@ final class SuggestionSettingsModel: ObservableObject {
         userDefaults.set(resolvedGloballyEnabled, forKey: Self.isGloballyEnabledDefaultsKey)
         persistDisabledAppRules(resolvedDisabledAppRules)
         persistShowIndicator(resolvedShowIndicator)
+        userDefaults.set(resolvedShowAcceptanceHint, forKey: Self.showAcceptanceHintDefaultsKey)
         persistCustomSuggestionTextColorHex(resolvedCustomSuggestionTextColorHex)
         persistSelectedEngine(resolvedEngine)
         persistSelectedWordCountPreset(resolvedWordCountPreset)
@@ -349,6 +355,33 @@ final class SuggestionSettingsModel: ObservableObject {
 
         showIndicator = show
         persistShowIndicator(show)
+    }
+
+    func setShowAcceptanceHint(_ show: Bool) {
+        guard showAcceptanceHint != show else {
+            return
+        }
+
+        showAcceptanceHint = show
+        userDefaults.set(show, forKey: Self.showAcceptanceHintDefaultsKey)
+    }
+
+    /// The label the ghost-text keycap should display, or `nil` when no hint should be drawn —
+    /// either the user turned it off or no key is currently bound to accept a suggestion. Prefers
+    /// the word-accept key (the historical "tab" pill) and falls back to the full-accept key so the
+    /// hint still teaches a working gesture after the word-accept key has been cleared.
+    var acceptanceHintLabel: String? {
+        guard showAcceptanceHint else {
+            return nil
+        }
+
+        if acceptanceKeyCode != Self.disabledKeyCode {
+            return acceptanceKeyLabel
+        }
+        if fullAcceptanceKeyCode != Self.disabledKeyCode {
+            return fullAcceptanceKeyLabel
+        }
+        return nil
     }
 
     func setCustomSuggestionTextColorHex(_ hex: String?) {

--- a/Cotabby/Services/UI/OverlayController.swift
+++ b/Cotabby/Services/UI/OverlayController.swift
@@ -79,11 +79,15 @@ final class OverlayController: SuggestionOverlayControlling {
             forCaretHeight: stabilizedCaretHeight,
             caretQuality: geometry.caretQuality
         )
+        // `nil` when the user disabled the hint or no accept key is bound — in that case the layout
+        // drops the keycap and its reserved width so ghost text can use the full line.
+        let acceptanceHintLabel = suggestionSettings.acceptanceHintLabel
         let layout = GhostSuggestionLayout.make(
             text: text,
             geometry: geometry,
             fontSize: fontSize,
-            visibleFrame: targetScreenVisibleFrame(for: geometry.caretRect)
+            visibleFrame: targetScreenVisibleFrame(for: geometry.caretRect),
+            showsAcceptanceHint: acceptanceHintLabel != nil
         )
         let customGhostColor = SuggestionTextColorCodec.color(
             fromHex: suggestionSettings.customSuggestionTextColorHex
@@ -93,7 +97,8 @@ final class OverlayController: SuggestionOverlayControlling {
             existing.rootView = GhostSuggestionView(
                 layout: layout,
                 fontSize: fontSize,
-                customColor: customGhostColor
+                customColor: customGhostColor,
+                keycapLabel: acceptanceHintLabel
             )
             contentView = existing
         } else {
@@ -101,7 +106,8 @@ final class OverlayController: SuggestionOverlayControlling {
                 rootView: GhostSuggestionView(
                     layout: layout,
                     fontSize: fontSize,
-                    customColor: customGhostColor
+                    customColor: customGhostColor,
+                    keycapLabel: acceptanceHintLabel
                 )
             )
             hostingView = fresh
@@ -172,6 +178,9 @@ private struct GhostSuggestionView: View {
     let layout: GhostSuggestionLayout
     let fontSize: CGFloat
     let customColor: Color?
+    /// The accept key to print inside the keycap pill, or `nil` when the hint is suppressed. Pairs
+    /// with `layout.lines`, where `showsKeycap` is already false on every line when this is `nil`.
+    let keycapLabel: String?
 
     var ghostColor: Color {
         customColor
@@ -186,9 +195,10 @@ private struct GhostSuggestionView: View {
         let alignment: HorizontalAlignment = layout.isRightToLeft ? .trailing : .leading
         VStack(alignment: alignment, spacing: 0) {
             ForEach(layout.lines) { line in
-                HStack(alignment: .firstTextBaseline, spacing: line.showsKeycap ? 6 : 0) {
-                    if layout.isRightToLeft && line.showsKeycap {
-                        GhostTabKeycap()
+                let showsKeycap = line.showsKeycap && keycapLabel != nil
+                HStack(alignment: .firstTextBaseline, spacing: showsKeycap ? 6 : 0) {
+                    if layout.isRightToLeft, showsKeycap, let keycapLabel {
+                        GhostKeycap(label: keycapLabel)
                     }
 
                     Text(line.text)
@@ -197,8 +207,8 @@ private struct GhostSuggestionView: View {
                         .lineLimit(1)
                         .fixedSize(horizontal: true, vertical: true)
 
-                    if !layout.isRightToLeft && line.showsKeycap {
-                        GhostTabKeycap()
+                    if !layout.isRightToLeft, showsKeycap, let keycapLabel {
+                        GhostKeycap(label: keycapLabel)
                     }
                 }
                 .padding(layout.isRightToLeft ? .trailing : .leading, line.leadingIndent)
@@ -209,9 +219,11 @@ private struct GhostSuggestionView: View {
     }
 }
 
-/// Visual hint that teaches the user which key accepts the suggestion.
-private struct GhostTabKeycap: View {
+/// Visual hint that teaches the user which key accepts the suggestion. The label tracks the user's
+/// configured accept keybind, so rebinding away from Tab updates the pill instead of lying about it.
+private struct GhostKeycap: View {
     @Environment(\.colorScheme) var colorScheme
+    let label: String
 
     var textColor: Color {
         colorScheme == .dark ? Color(white: 0.65) : Color(white: 0.45)
@@ -226,7 +238,7 @@ private struct GhostTabKeycap: View {
     }
 
     var body: some View {
-        Text("tab")
+        Text(label)
             .font(.system(size: 10, weight: .medium, design: .rounded))
             .foregroundStyle(textColor)
             .padding(.horizontal, 5)

--- a/Cotabby/Support/GhostSuggestionLayout.swift
+++ b/Cotabby/Support/GhostSuggestionLayout.swift
@@ -39,11 +39,14 @@ struct GhostSuggestionLayout: Equatable {
         text: String,
         geometry: SuggestionOverlayGeometry,
         fontSize: CGFloat,
-        visibleFrame: CGRect
+        visibleFrame: CGRect,
+        showsAcceptanceHint: Bool = true
     ) -> GhostSuggestionLayout {
         let normalizedText = normalizedDisplayText(text)
         let lineHeight = ceil(fontSize * Metrics.lineHeightMultiplier)
         let isRTL = geometry.isRightToLeft
+        // When the keycap is hidden the text can use the full width, so we stop reserving room for it.
+        let keycapReservation = showsAcceptanceHint ? Metrics.estimatedKeycapAndSpacingWidth : 0
         let usableFrame = usableTextFrame(
             geometry: geometry,
             visibleFrame: visibleFrame
@@ -61,7 +64,7 @@ struct GhostSuggestionLayout: Equatable {
             )
             firstLineBudget = max(
                 0,
-                firstLineAnchor - usableFrame.minX - Metrics.estimatedKeycapAndSpacingWidth
+                firstLineAnchor - usableFrame.minX - keycapReservation
             )
         } else {
             firstLineAnchor = min(
@@ -70,13 +73,13 @@ struct GhostSuggestionLayout: Equatable {
             )
             firstLineBudget = max(
                 0,
-                usableFrame.maxX - firstLineAnchor - Metrics.estimatedKeycapAndSpacingWidth
+                usableFrame.maxX - firstLineAnchor - keycapReservation
             )
         }
 
         let overflowBudget = max(
             Metrics.minimumLineWidth,
-            usableFrame.width - Metrics.estimatedKeycapAndSpacingWidth
+            usableFrame.width - keycapReservation
         )
 
         let singleLineFits = !normalizedText.contains("\n") && measuredWidth(
@@ -88,7 +91,7 @@ struct GhostSuggestionLayout: Equatable {
         if singleLineFits {
             return GhostSuggestionLayout(
                 lines: [
-                    Line(index: 0, text: normalizedText, leadingIndent: 0, showsKeycap: true)
+                    Line(index: 0, text: normalizedText, leadingIndent: 0, showsKeycap: showsAcceptanceHint)
                 ],
                 panelOriginX: firstLineAnchor,
                 lineHeight: lineHeight,
@@ -152,7 +155,7 @@ struct GhostSuggestionLayout: Equatable {
                 index: offset,
                 text: rawLine.text,
                 leadingIndent: rawLine.leadingIndent,
-                showsKeycap: offset == rawLines.count - 1
+                showsKeycap: showsAcceptanceHint && offset == rawLines.count - 1
             )
         }
 

--- a/Cotabby/Support/GhostSuggestionLayout.swift
+++ b/Cotabby/Support/GhostSuggestionLayout.swift
@@ -250,31 +250,13 @@ struct GhostSuggestionLayout: Equatable {
 
         // Explicit newline: force a line break at the first one.
         if let newlineIndex = source.firstIndex(of: "\n") {
-            let segment = String(source[..<newlineIndex]).trimmingCharacters(in: .whitespaces)
-            let afterIndex = source.index(after: newlineIndex)
-            let afterNewline = afterIndex < source.endIndex
-                ? String(source[afterIndex...]).trimmingCharacters(in: .whitespaces)
-                : ""
-
-            guard !segment.isEmpty else {
-                return splitPrefix(from: afterNewline, maxWidth: maxWidth, fontSize: fontSize, observedCharWidth: observedCharWidth)
-            }
-
-            if measuredWidth(of: segment, fontSize: fontSize, observedCharWidth: observedCharWidth) <= safeMaxWidth {
-                return (segment, afterNewline)
-            }
-
-            // Segment before newline is too wide — width-wrap it, keep post-newline as remainder.
-            let widthSplit = splitPrefix(from: segment, maxWidth: maxWidth, fontSize: fontSize, observedCharWidth: observedCharWidth)
-            let combined: String
-            if widthSplit.remainder.isEmpty {
-                combined = afterNewline
-            } else if afterNewline.isEmpty {
-                combined = widthSplit.remainder
-            } else {
-                combined = widthSplit.remainder + "\n" + afterNewline
-            }
-            return (widthSplit.line, combined)
+            return splitAtNewline(
+                source: source,
+                newlineIndex: newlineIndex,
+                maxWidth: maxWidth,
+                fontSize: fontSize,
+                observedCharWidth: observedCharWidth
+            )
         }
 
         if measuredWidth(of: source, fontSize: fontSize, observedCharWidth: observedCharWidth) <= safeMaxWidth {
@@ -309,6 +291,42 @@ struct GhostSuggestionLayout: Equatable {
         }
 
         return (text.trimmingCharacters(in: .whitespaces), "")
+    }
+
+    /// Splits `source` at its first explicit newline, width-wrapping the leading segment if it overflows.
+    private static func splitAtNewline(
+        source: String,
+        newlineIndex: String.Index,
+        maxWidth: CGFloat,
+        fontSize: CGFloat,
+        observedCharWidth: CGFloat?
+    ) -> (line: String, remainder: String) {
+        let safeMaxWidth = max(maxWidth, Metrics.minimumLineWidth)
+        let segment = String(source[..<newlineIndex]).trimmingCharacters(in: .whitespaces)
+        let afterIndex = source.index(after: newlineIndex)
+        let afterNewline = afterIndex < source.endIndex
+            ? String(source[afterIndex...]).trimmingCharacters(in: .whitespaces)
+            : ""
+
+        guard !segment.isEmpty else {
+            return splitPrefix(from: afterNewline, maxWidth: maxWidth, fontSize: fontSize, observedCharWidth: observedCharWidth)
+        }
+
+        if measuredWidth(of: segment, fontSize: fontSize, observedCharWidth: observedCharWidth) <= safeMaxWidth {
+            return (segment, afterNewline)
+        }
+
+        // Segment before newline is too wide — width-wrap it, keep post-newline as remainder.
+        let widthSplit = splitPrefix(from: segment, maxWidth: maxWidth, fontSize: fontSize, observedCharWidth: observedCharWidth)
+        let combined: String
+        if widthSplit.remainder.isEmpty {
+            combined = afterNewline
+        } else if afterNewline.isEmpty {
+            combined = widthSplit.remainder
+        } else {
+            combined = widthSplit.remainder + "\n" + afterNewline
+        }
+        return (widthSplit.line, combined)
     }
 
     private static func measuredWidth(

--- a/Cotabby/UI/MenuBarView.swift
+++ b/Cotabby/UI/MenuBarView.swift
@@ -90,6 +90,10 @@ struct MenuBarView: View {
                 .toggleStyle(.switch)
                 .controlSize(.small)
 
+            Toggle("Show Accept Hint", isOn: showAcceptanceHintBinding)
+                .toggleStyle(.switch)
+                .controlSize(.small)
+
             Toggle("Allow Multi-line Suggestions", isOn: multiLineEnabledBinding)
                 .toggleStyle(.switch)
                 .controlSize(.small)
@@ -285,6 +289,13 @@ struct MenuBarView: View {
         Binding(
             get: { suggestionSettings.showIndicator },
             set: { suggestionSettings.setShowIndicator($0) }
+        )
+    }
+
+    private var showAcceptanceHintBinding: Binding<Bool> {
+        Binding(
+            get: { suggestionSettings.showAcceptanceHint },
+            set: { suggestionSettings.setShowAcceptanceHint($0) }
         )
     }
 

--- a/Cotabby/UI/SettingsView.swift
+++ b/Cotabby/UI/SettingsView.swift
@@ -146,6 +146,8 @@ struct SettingsView: View {
 
             Toggle("Show Indicator", isOn: showIndicatorBinding)
 
+            Toggle("Show Accept Hint", isOn: showAcceptanceHintBinding)
+
             Toggle("Allow Multi-line Suggestions", isOn: multiLineEnabledBinding)
 
             Toggle("Include Clipboard Context", isOn: clipboardContextEnabledBinding)
@@ -626,6 +628,13 @@ struct SettingsView: View {
         Binding(
             get: { suggestionSettings.showIndicator },
             set: { suggestionSettings.setShowIndicator($0) }
+        )
+    }
+
+    private var showAcceptanceHintBinding: Binding<Bool> {
+        Binding(
+            get: { suggestionSettings.showAcceptanceHint },
+            set: { suggestionSettings.setShowAcceptanceHint($0) }
         )
     }
 

--- a/CotabbyTests/GhostSuggestionLayoutTests.swift
+++ b/CotabbyTests/GhostSuggestionLayoutTests.swift
@@ -48,6 +48,61 @@ final class GhostSuggestionLayoutTests: XCTestCase {
         XCTAssertEqual(layout.lines.last?.showsKeycap, true)
     }
 
+    // MARK: - Acceptance hint suppression
+
+    func test_make_hidesKeycapOnEveryLineWhenAcceptanceHintDisabled() {
+        let geometry = CotabbyTestFixtures.overlayGeometry(
+            caretRect: CGRect(x: 10, y: 80, width: 2, height: 18),
+            inputFrameRect: CGRect(x: 0, y: 70, width: 200, height: 30),
+            observedCharWidth: 7
+        )
+
+        let layout = GhostSuggestionLayout.make(
+            text: " alpha beta gamma delta epsilon zeta eta theta iota",
+            geometry: geometry,
+            fontSize: 14,
+            visibleFrame: CGRect(x: 0, y: 0, width: 500, height: 300),
+            showsAcceptanceHint: false
+        )
+
+        XCTAssertGreaterThan(layout.lines.count, 1, "Should still wrap to multiple lines")
+        for line in layout.lines {
+            XCTAssertFalse(line.showsKeycap, "No line should show a keycap when the hint is disabled")
+        }
+    }
+
+    func test_make_reclaimsKeycapWidthForTextWhenAcceptanceHintDisabled() {
+        // Text width (44 chars * 10pt = 440) is tuned to sit between the first-line budget with the
+        // keycap reserved (492 - 28 - 36 = 428) and without it (492 - 28 = 464). So the same text
+        // overflows and wraps while the hint is shown, but fits on a single line once hiding the
+        // hint hands its reserved width back to the text.
+        let geometry = CotabbyTestFixtures.overlayGeometry(
+            caretRect: CGRect(x: 20, y: 80, width: 2, height: 18),
+            inputFrameRect: CGRect(x: 0, y: 70, width: 500, height: 30),
+            observedCharWidth: 10
+        )
+        let text = "aaaa bbbb cccc dddd eeee ffff gggg hhhh iiii"
+        let visibleFrame = CGRect(x: 0, y: 0, width: 1000, height: 600)
+
+        let withHint = GhostSuggestionLayout.make(
+            text: text,
+            geometry: geometry,
+            fontSize: 14,
+            visibleFrame: visibleFrame,
+            showsAcceptanceHint: true
+        )
+        let withoutHint = GhostSuggestionLayout.make(
+            text: text,
+            geometry: geometry,
+            fontSize: 14,
+            visibleFrame: visibleFrame,
+            showsAcceptanceHint: false
+        )
+
+        XCTAssertGreaterThan(withHint.lines.count, 1, "Keycap reservation should force a wrap here")
+        XCTAssertEqual(withoutHint.lines.count, 1, "Reclaimed keycap width should fit the text on one line")
+    }
+
     // MARK: - Word boundary splitting
 
     func test_make_splitsAtWordBoundaryWhenTextExceedsBudget() {

--- a/CotabbyTests/SuggestionAvailabilityEvaluatorTests.swift
+++ b/CotabbyTests/SuggestionAvailabilityEvaluatorTests.swift
@@ -497,6 +497,45 @@ final class SuggestionSettingsModelDisabledAppsTests: XCTestCase {
         _ = cancellables
     }
 
+    func test_acceptanceHint_defaultsToOnAndShowsWordAcceptLabel() {
+        runOnMainActor {
+            let model = makeModel()
+
+            XCTAssertTrue(model.showAcceptanceHint)
+            XCTAssertEqual(model.acceptanceHintLabel, SuggestionSettingsModel.defaultAcceptanceKeyLabel)
+        }
+    }
+
+    func test_showAcceptanceHint_persistsAcrossModelRecreation() {
+        runOnMainActor {
+            let userDefaults = makeUserDefaults()
+            let model = makeModel(userDefaults: userDefaults)
+
+            model.setShowAcceptanceHint(false)
+            let reloadedModel = makeModel(userDefaults: userDefaults)
+
+            XCTAssertFalse(reloadedModel.showAcceptanceHint)
+            XCTAssertNil(reloadedModel.acceptanceHintLabel, "Disabled hint should resolve to no label")
+        }
+    }
+
+    func test_acceptanceHintLabel_tracksRebindAndFallsBackWhenWordAcceptCleared() {
+        runOnMainActor {
+            let model = makeModel()
+
+            model.setAcceptanceKey(keyCode: 49, label: "Space")
+            XCTAssertEqual(model.acceptanceHintLabel, "Space", "Hint should follow the rebound word-accept key")
+
+            // Clearing word-accept should fall back to the still-bound full-accept key.
+            model.clearAcceptanceKey()
+            XCTAssertEqual(model.acceptanceHintLabel, model.fullAcceptanceKeyLabel)
+
+            // With no accept key bound at all, there is nothing to teach.
+            model.clearFullAcceptanceKey()
+            XCTAssertNil(model.acceptanceHintLabel)
+        }
+    }
+
     @MainActor
     private func makeModel(
         userDefaults: UserDefaults? = nil


### PR DESCRIPTION
## Summary

Issue #275 asks for an option to hide the "tab" pill drawn after a suggestion — it
feels clunky and, worse, kept saying "tab" even after the accept shortcut was rebound.

This adds a `showAcceptanceHint` setting (default on, so existing users are unaffected)
exposed in both **Settings → General** and the **menu bar popup**, next to "Show Indicator".
It also makes the keycap render the user's *actual* accept keybind instead of a hardcoded
"tab": it follows a rebind, falls back to the full-accept key if the word-accept key is
cleared, and disappears when no accept key is bound at all. When hidden, the layout stops
reserving the keycap's width so the suggestion text can use the full line.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build-for-testing
# ** TEST BUILD SUCCEEDED **

xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  CODE_SIGNING_ALLOWED=NO \
  -only-testing:CotabbyTests/GhostSuggestionLayoutTests \
  -only-testing:CotabbyTests/SuggestionSettingsModelDisabledAppsTests
# ** TEST SUCCEEDED ** — Executed 22 tests, 0 failures

swiftlint lint --quiet   # changed files
# 0 new violations (two pre-existing warnings remain in untouched code:
#   GhostSuggestionLayout.splitPrefix cyclomatic complexity; a long test type name)
```

New tests: keycap is hidden on every line when the hint is off; hiding it reclaims width so
text that otherwise wraps fits on one line; the resolved hint label defaults on and tracks a
rebind, falls back to the full-accept key when word-accept is cleared, and is nil when both
are unbound, persisting across model reloads.

UI note: the two toggles were verified by build, not captured in a running app — the live
overlay needs Accessibility permission, a focused field, and a loaded model to render ghost
text, which isn't reproducible as a screenshot here.

## Linked issues

Fixes #275

## Risk / rollout notes

- New persisted UserDefaults key `cotabbyShowAcceptanceHint` (default `true` → no behavior
  change until the user toggles it).
- Presentation-only: intentionally **not** added to `SuggestionSettingsSnapshot`, so it has no
  effect on generation/engine routing — same treatment as "Show Indicator" and ghost text color.
- `GhostSuggestionLayout.make` gained a defaulted `showsAcceptanceHint` parameter; all existing
  call sites and tests keep the prior behavior.
- The keycap now renders the live accept-key label, so a long rebind (e.g. "Right Arrow") makes a
  wider pill; the panel grows to fit it, so there's no clipping.
- No `project.pbxproj` change — tests were added to already-registered files.
