### PR TITLE
Remove the Clear shortcut button from Settings

### DIFF
--- a/Cotabby/UI/SettingsView.swift
+++ b/Cotabby/UI/SettingsView.swift
@@ -271,13 +271,6 @@ struct SettingsView: View {
                             isRecordingKeybind = false
                         }
                     }
-
-                    if suggestionSettings.acceptanceKeyCode != SuggestionSettingsModel.disabledKeyCode {
-                        Button("Clear") {
-                            suggestionSettings.clearAcceptanceKey()
-                            isRecordingKeybind = false
-                        }
-                    }
                 }
             }
 
@@ -313,13 +306,6 @@ struct SettingsView: View {
                                 keyCode: SuggestionSettingsModel.defaultFullAcceptanceKeyCode,
                                 label: SuggestionSettingsModel.defaultFullAcceptanceKeyLabel
                             )
-                            isRecordingFullAcceptKeybind = false
-                        }
-                    }
-
-                    if suggestionSettings.fullAcceptanceKeyCode != SuggestionSettingsModel.disabledKeyCode {
-                        Button("Clear") {
-                            suggestionSettings.clearFullAcceptanceKey()
                             isRecordingFullAcceptKeybind = false
                         }
                     }


### PR DESCRIPTION
## Summary

Each row in Settings → **Shortcuts** offered both **Reset** and **Clear**. Clear unbinds the shortcut entirely, which isn't a control worth keeping. This removes the two Clear buttons so each row now shows only **Change** and **Reset**.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  build CODE_SIGNING_ALLOWED=NO
# ** BUILD SUCCEEDED **

swiftlint lint --quiet Cotabby/UI/SettingsView.swift
# exit 0
```

No screenshot attached — the only visible change is that the "Accept Word" and "Accept Entire Suggestion" rows no longer render a Clear button (Change + Reset remain).

## Linked issues

None — reported directly (see the Shortcuts screenshot). No tracked issue exists.

## Risk / rollout notes

- **UI-only**: the keybind model is untouched. `SettingsView` no longer references `disabledKeyCode` or the clear methods.
- **The model's `clearAcceptanceKey()` / `clearFullAcceptanceKey()` are intentionally kept** — `setAcceptanceKey` / `setFullAcceptanceKey` still call them to unbind the other action when both would map to the same key, and `WelcomeView` still reads `disabledKeyCode`. So they are not dead code.
- **Behavior change**: there's no longer a way to manually unbind a shortcut to "off" from Settings; only Reset (restore default) and Change (rebind) remain. A key can still end up unbound via the existing same-key conflict resolution.
