### PR TITLE
Update the Homebrew cask on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,10 @@ jobs:
     name: Build, notarize, sign, and publish
     runs-on: macos-26
     timeout-minutes: 180
+    outputs:
+      release_version: ${{ steps.metadata.outputs.release_version }}
+      publish: ${{ steps.metadata.outputs.publish }}
+      dmg_sha256: ${{ steps.dmg-sha.outputs.dmg_sha256 }}
     environment:
       name: github-pages
       url: ${{ steps.deploy-pages.outputs.page_url }}
@@ -568,6 +572,18 @@ jobs:
           xcrun stapler staple "${dmg_path}"
           xcrun stapler validate "${dmg_path}"
 
+      - name: Compute DMG SHA-256
+        id: dmg-sha
+        run: |
+          set -euo pipefail
+
+          # Checksum the stapled DMG that gets uploaded to the release so the
+          # Homebrew cask points at the exact bytes users download. Computed
+          # after stapling because stapling rewrites the DMG in place.
+          dmg_sha256="$(shasum -a 256 "build/${DMG_NAME}" | awk '{ print $1 }')"
+          echo "dmg_sha256=${dmg_sha256}" >> "$GITHUB_OUTPUT"
+          echo "Cotabby.dmg SHA-256: ${dmg_sha256}"
+
       - name: Generate signed appcast
         if: steps.sparkle-key.outputs.has_key == 'true'
         env:
@@ -691,3 +707,39 @@ jobs:
             build/appcast.xml
             build/notarization/**
           if-no-files-found: ignore
+
+  # Tell the Homebrew tap to point at the DMG this run just published. The tap's
+  # own update-cask.yml workflow listens for this repository_dispatch and rewrites
+  # Casks/cotabby.rb from the payload, so the cask-editing logic stays in the tap.
+  # Runs only after a real publish so dry-run validation builds never bump the cask.
+  update-homebrew-cask:
+    name: Update Homebrew cask
+    needs: release
+    if: needs.release.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch cask update to the tap
+        env:
+          # PAT with contents:write on FuJacob/homebrew-cotabby — the built-in
+          # GITHUB_TOKEN cannot reach another repository.
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          VERSION: ${{ needs.release.outputs.release_version }}
+          DMG_SHA256: ${{ needs.release.outputs.dmg_sha256 }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${DMG_SHA256}" ]]; then
+            echo "The release job did not produce a DMG checksum." >&2
+            exit 1
+          fi
+
+          # version + sha256 are the client_payload contract expected by
+          # FuJacob/homebrew-cotabby's update-cask.yml. jq builds the body so the
+          # values are JSON-escaped instead of string-spliced into the request.
+          jq -nc \
+            --arg version "${VERSION}" \
+            --arg sha256 "${DMG_SHA256}" \
+            '{event_type: "update-cask", client_payload: {version: $version, sha256: $sha256}}' \
+            | gh api repos/FuJacob/homebrew-cotabby/dispatches --method POST --input -
+
+          echo "Dispatched update-cask to FuJacob/homebrew-cotabby for ${VERSION}."

--- a/README.md
+++ b/README.md
@@ -100,13 +100,29 @@ Browse the [unsloth GGUF collection on Hugging Face](https://huggingface.co/unsl
 
 ## Install
 
+### Homebrew
+
+```sh
+brew tap FuJacob/cotabby
+brew install --cask cotabby
+```
+
+Upgrade later with `brew upgrade --cask cotabby`. The tap repo is [FuJacob/homebrew-cotabby](https://github.com/FuJacob/homebrew-cotabby).
+
+### Manual download
+
 1. Download the latest `Cotabby.dmg` from GitHub Releases.
 2. Drag `Cotabby.app` into `Applications` and launch it.
-3. Grant **Accessibility**, **Input Monitoring**, and **Screen Recording** when prompted.
-4. Pick an engine. Apple Intelligence if available, otherwise Open Source plus a model.
-5. Start typing in any supported editable field.
 
 If macOS blocks first launch, right-click `Cotabby.app` → `Open`, or allow it in `System Settings → Privacy & Security`.
+
+### Set up
+
+After installing with either method:
+
+1. Grant **Accessibility**, **Input Monitoring**, and **Screen Recording** when prompted.
+2. Pick an engine. Apple Intelligence if available, otherwise Open Source plus a model.
+3. Start typing in any supported editable field.
 
 ### Why those permissions?
 


### PR DESCRIPTION
## Summary

Keeps the Homebrew cask in [FuJacob/homebrew-cotabby](https://github.com/FuJacob/homebrew-cotabby) in sync with every published release. After the release job finishes, a new `update-homebrew-cask` job sends a `repository_dispatch` (`event_type: update-cask`) to the tap carrying the release `version` and the stapled DMG's `sha256`. The tap's existing `update-cask.yml` already listens for that payload and rewrites `Casks/cotabby.rb`, so this PR just wires the main repo up to it (authenticated with the `HOMEBREW_TAP_TOKEN` secret, since the built-in `GITHUB_TOKEN` can't reach another repo). The README also gains a Homebrew install section.

## Validation

```
# YAML + workflow lint
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"   # OK
actionlint .github/workflows/release.yml                                          # exit 0

# The dispatch payload matches the tap receiver's contract (version + sha256):
jq -nc --arg version 0.0.7-beta --arg sha256 <64-hex> \
  '{event_type:"update-cask", client_payload:{version:$version, sha256:$sha256}}'
# => {"event_type":"update-cask","client_payload":{"version":"0.0.7-beta","sha256":"..."}}
```

The job itself can't be exercised without pushing a real tag + the production secrets, so it's verified statically (YAML, actionlint, payload shape, job `needs`/`if`/outputs wiring). The DMG checksum is computed *after* stapling so it matches the bytes uploaded to the release.

## Linked issues

None — requested directly. (The `HOMEBREW_TAP_TOKEN` secret and the tap's `update-cask.yml` receiver were already set up; this connects the main repo to them.)

## Risk / rollout notes

- **Blocker for the cask to actually install — needs a one-time fix in the tap repo.** The tap's committed `Casks/cotabby.rb` is stale from before the tabby→cotabby rename: it still has `url ".../tabby.dmg"` and `app "tabby.app"`. The receiver only `sed`s the `version`/`sha256` lines, so after a dispatch the cask will carry the right version + checksum but still point at a non-existent `tabby.dmg` asset (releases now ship `Cotabby.dmg` containing `Cotabby.app`). The cask won't install correctly until that base file is corrected in `FuJacob/homebrew-cotabby` (`url` → `Cotabby.dmg`, `app` → `Cotabby.app`). I can open that follow-up PR to the tap — it's out of this repo's scope.
- **Gating**: the job runs only when `needs.release.outputs.publish == 'true'`, so dry-run `workflow_dispatch` validation builds never bump the cask. It fires for every published release, including prereleases (matching the current beta cask); restricting to stable later is a one-line `if` change.
- **Secret/permissions**: `HOMEBREW_TAP_TOKEN` must have `contents: write` on the tap repo — for both this dispatch call and the tap workflow's own commit/push.
- New `release` job outputs (`release_version`, `publish`, `dmg_sha256`) are additive; no existing step changes behavior.
