### PR TITLE
Add the HuggingFace model browser to local model settings

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		909EBE545CE644C6C57F1B5D /* SuggestionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F961F5DF2A392F6F5F94F8A /* SuggestionCoordinator.swift */; };
 		90CD3F7238E223DEBA2B4D92 /* TagChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB317C82CE2CBC69056BA4B8 /* TagChip.swift */; };
 		90DC9508F27F712EB61EEB06 /* PermissionReminderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 656F58E56FE9BC087B6F1D33 /* PermissionReminderView.swift */; };
+		91C27021750AC03AA4A0115A /* HuggingFaceAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110CB0B53016644EF7840301 /* HuggingFaceAPIClient.swift */; };
 		91D1F16B8C5DA281D4B7F699 /* CustomRulesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD752451330486FE270018B0 /* CustomRulesTests.swift */; };
 		924489CEE8171F7AD8579D71 /* FocusDebugOverlayController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5E263AB69029D5E13D5EE8 /* FocusDebugOverlayController.swift */; };
 		934885ACC2DEA20B27F10948 /* PromptContextSanitizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D80CC2CCAAFE3F23FB8C37A /* PromptContextSanitizerTests.swift */; };
@@ -104,6 +105,7 @@
 		A2B3F4D38BCB0FED452B2A3F /* FocusTrackingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D42CD456B4B3C988B148A6 /* FocusTrackingModel.swift */; };
 		A36481222BB5B2A67349D389 /* ApplicationBundleMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A168A7B6A7AD11559B60C56B /* ApplicationBundleMetadataTests.swift */; };
 		A440C596EFD9CD1E44F2579B /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E0F6AFF229D20B73CF14C6C /* SettingsView.swift */; };
+		A87978083EBE1AC294377F7C /* HuggingFaceSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F426127917FCB1096134732 /* HuggingFaceSearchService.swift */; };
 		A93A741C8C3973687D28F0B6 /* SuggestionEngineModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADBE3E6CC585C1683787C877 /* SuggestionEngineModels.swift */; };
 		A982E243A4D8BC1BF7504B3E /* SuggestionInteractionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA942A53B7C09D1F4EC57239 /* SuggestionInteractionState.swift */; };
 		A9BFE6D43DC53A3819C635B7 /* IndicatorIconImageProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBEDE359CFD99EF906FA50BC /* IndicatorIconImageProcessor.swift */; };
@@ -113,6 +115,7 @@
 		B00FDD3DEE0B73FF5136C91C /* FocusTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C9FDF029F7828CAF3FE8850 /* FocusTracker.swift */; };
 		B0828FF0D7EE110C0B23DB94 /* TagsInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C0F017699EE44C81C095CA /* TagsInputView.swift */; };
 		B0B115C6EBAC37FF6115B4BE /* SuggestionCoordinator+Lifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78E280F4F39A9D86840800D2 /* SuggestionCoordinator+Lifecycle.swift */; };
+		B2F7589B8D32ACF97BB642AB /* HuggingFaceModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A520809E71697E3BB9A8139C /* HuggingFaceModels.swift */; };
 		B93AB7E845086F6FBB068369 /* SuggestionRequestFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE94342B888A5A2CCF66BC93 /* SuggestionRequestFactoryTests.swift */; };
 		BB6325CA50F97B18B9725918 /* SuggestionTextNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B424E2AC97C99D335B0D5751 /* SuggestionTextNormalizer.swift */; };
 		BFCA7FAFDAEBF586AB615567 /* ClipboardRelevanceFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90B0D133AB77A2503FB08827 /* ClipboardRelevanceFilterTests.swift */; };
@@ -138,6 +141,7 @@
 		E9E4CC657771DF9F4C56183C /* VisualContextCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A854CAFB1F557BC4CAED8819 /* VisualContextCoordinator.swift */; };
 		ED9C51B0D7056F0753AADF2D /* GhostSuggestionLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043E8AA850F930222DD112C0 /* GhostSuggestionLayout.swift */; };
 		EDA8E8250FC2F70B206B4894 /* LlamaVisualContextSummarizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D2782B6C7BE3F56BCB22DE /* LlamaVisualContextSummarizer.swift */; };
+		EE87886AC1BFC8BB3DE09762 /* HuggingFaceModelBrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78E49BDA7F3A42455C4C5350 /* HuggingFaceModelBrowserView.swift */; };
 		F08C139B246C1EC7BB435455 /* MenuBarPresentationObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00824BDD8D0E9B3063827C78 /* MenuBarPresentationObserver.swift */; };
 		F0DEEE8A866ABB560E7A7E6A /* LaunchAtLoginService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220CD4AFA1E96A37BC4514AD /* LaunchAtLoginService.swift */; };
 		F78F594F77C26C233377E71F /* KeyCodeLabels.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAAE6B395FAB604DF059280A /* KeyCodeLabels.swift */; };
@@ -167,6 +171,7 @@
 		0D80CC2CCAAFE3F23FB8C37A /* PromptContextSanitizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptContextSanitizerTests.swift; sourceTree = "<group>"; };
 		0E0F6AFF229D20B73CF14C6C /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		0F5E263AB69029D5E13D5EE8 /* FocusDebugOverlayController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusDebugOverlayController.swift; sourceTree = "<group>"; };
+		110CB0B53016644EF7840301 /* HuggingFaceAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceAPIClient.swift; sourceTree = "<group>"; };
 		18D990E515E1AE4F312F4E95 /* BundledRuntimeLocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledRuntimeLocatorTests.swift; sourceTree = "<group>"; };
 		19DB9558F4D3AFB108D71649 /* SuggestionStateHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionStateHelperTests.swift; sourceTree = "<group>"; };
 		1CE61E74928C221B8BB261C6 /* SuggestionTextColorCodec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionTextColorCodec.swift; sourceTree = "<group>"; };
@@ -214,6 +219,7 @@
 		74BD1D4DB27D5D96D1E06096 /* DisplayCoordinateConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayCoordinateConverter.swift; sourceTree = "<group>"; };
 		77B0121E7BB173F8A2B0B108 /* WindowScreenshotService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowScreenshotService.swift; sourceTree = "<group>"; };
 		78E280F4F39A9D86840800D2 /* SuggestionCoordinator+Lifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SuggestionCoordinator+Lifecycle.swift"; sourceTree = "<group>"; };
+		78E49BDA7F3A42455C4C5350 /* HuggingFaceModelBrowserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceModelBrowserView.swift; sourceTree = "<group>"; };
 		7F4C4A7EAF886E0CC945BFEF /* TerminalAppDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAppDetector.swift; sourceTree = "<group>"; };
 		815F2ABAF6AB75DA3AFBBCEF /* WordCountFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordCountFormatter.swift; sourceTree = "<group>"; };
 		82F7F7355967725162DF2D1B /* CustomRulesEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomRulesEditor.swift; sourceTree = "<group>"; };
@@ -221,6 +227,7 @@
 		85BF316556FDA64CB8AD07B6 /* PermissionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionManager.swift; sourceTree = "<group>"; };
 		86460C747AA883FDE756BDBA /* SuggestionSettingsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionSettingsModel.swift; sourceTree = "<group>"; };
 		8724ECA8FABBC82B0A2B943B /* FoundationModelAvailabilityService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoundationModelAvailabilityService.swift; sourceTree = "<group>"; };
+		8F426127917FCB1096134732 /* HuggingFaceSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceSearchService.swift; sourceTree = "<group>"; };
 		8F961F5DF2A392F6F5F94F8A /* SuggestionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionCoordinator.swift; sourceTree = "<group>"; };
 		90B0D133AB77A2503FB08827 /* ClipboardRelevanceFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardRelevanceFilterTests.swift; sourceTree = "<group>"; };
 		92C6EB9FDA48ADF425A116A9 /* PermissionOverlayWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOverlayWindowController.swift; sourceTree = "<group>"; };
@@ -237,6 +244,7 @@
 		9D82FFC568527700EC17C07D /* PermissionModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionModels.swift; sourceTree = "<group>"; };
 		A168A7B6A7AD11559B60C56B /* ApplicationBundleMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationBundleMetadataTests.swift; sourceTree = "<group>"; };
 		A3E8E86A14090BC7BD13BA76 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		A520809E71697E3BB9A8139C /* HuggingFaceModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceModels.swift; sourceTree = "<group>"; };
 		A52D0B550E00EF173A5D157E /* LlamaRuntimeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LlamaRuntimeManager.swift; sourceTree = "<group>"; };
 		A804F4DB6FD9BC8C27B2B65F /* LlamaRuntimeModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LlamaRuntimeModels.swift; sourceTree = "<group>"; };
 		A829F28F01FAE76CA7244BBC /* ModelFileValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelFileValidatorTests.swift; sourceTree = "<group>"; };
@@ -394,6 +402,8 @@
 				9CF4FB0EC6C1BEB4EA74910A /* ClipboardContextProvider.swift */,
 				B4B4A2E2DD6733658EC05BD8 /* DownloadFileRescuer.swift */,
 				3DE1975F3B5F4A70478DBF41 /* DownloadOutcomeClassifier.swift */,
+				110CB0B53016644EF7840301 /* HuggingFaceAPIClient.swift */,
+				8F426127917FCB1096134732 /* HuggingFaceSearchService.swift */,
 				220CD4AFA1E96A37BC4514AD /* LaunchAtLoginService.swift */,
 				51020F8CD58338BD643FBF63 /* ModelDownloadManager.swift */,
 				5C4E5869D103865486AAAEEC /* ModelFileValidator.swift */,
@@ -441,6 +451,7 @@
 				E43E587E421AF544A8300CE4 /* CustomRulesCatalog.swift */,
 				0C383AE85B971A9605787358 /* FocusModels.swift */,
 				B6D42CD456B4B3C988B148A6 /* FocusTrackingModel.swift */,
+				A520809E71697E3BB9A8139C /* HuggingFaceModels.swift */,
 				5F34AE24BB7C99D66E1F3904 /* InputModels.swift */,
 				BF4BB93056F291FD24EFAD22 /* LanguageCatalog.swift */,
 				A804F4DB6FD9BC8C27B2B65F /* LlamaRuntimeModels.swift */,
@@ -498,6 +509,7 @@
 				82F7F7355967725162DF2D1B /* CustomRulesEditor.swift */,
 				BB5C2AE9A7E55495D26AD074 /* DownloadableModelCatalogView.swift */,
 				CBD5FCB8CC56AA6138382B2C /* FieldEdgeIconIndicatorView.swift */,
+				78E49BDA7F3A42455C4C5350 /* HuggingFaceModelBrowserView.swift */,
 				5A567677424A82D9EEF47495 /* KeyRecorderView.swift */,
 				9A7CDA90E128350BFF1A9D66 /* LanguageTagsEditor.swift */,
 				00824BDD8D0E9B3063827C78 /* MenuBarPresentationObserver.swift */,
@@ -731,6 +743,10 @@
 				6DD1E22151571E1A22FF22F4 /* FoundationModelSuggestionEngine.swift in Sources */,
 				42D40F37086294D0E58200C5 /* GhostFontSizeStabilizer.swift in Sources */,
 				ED9C51B0D7056F0753AADF2D /* GhostSuggestionLayout.swift in Sources */,
+				91C27021750AC03AA4A0115A /* HuggingFaceAPIClient.swift in Sources */,
+				EE87886AC1BFC8BB3DE09762 /* HuggingFaceModelBrowserView.swift in Sources */,
+				B2F7589B8D32ACF97BB642AB /* HuggingFaceModels.swift in Sources */,
+				A87978083EBE1AC294377F7C /* HuggingFaceSearchService.swift in Sources */,
 				A9BFE6D43DC53A3819C635B7 /* IndicatorIconImageProcessor.swift in Sources */,
 				5F019E5A0679FFB52F129798 /* InputModels.swift in Sources */,
 				2DF5A3826AAB99C279EBB8DE /* InputMonitor.swift in Sources */,

--- a/Cotabby/App/Coordinators/SettingsCoordinator.swift
+++ b/Cotabby/App/Coordinators/SettingsCoordinator.swift
@@ -18,6 +18,7 @@ final class SettingsCoordinator: NSObject, NSWindowDelegate {
     private let foundationModelAvailabilityService: FoundationModelAvailabilityService
     private let runtimeModel: RuntimeBootstrapModel
     private let modelDownloadManager: ModelDownloadManager
+    private let huggingFaceSearchService: HuggingFaceSearchService
     private let onShowWelcome: () -> Void
 
     private var settingsWindowController: NSWindowController?
@@ -30,6 +31,7 @@ final class SettingsCoordinator: NSObject, NSWindowDelegate {
         foundationModelAvailabilityService: FoundationModelAvailabilityService,
         runtimeModel: RuntimeBootstrapModel,
         modelDownloadManager: ModelDownloadManager,
+        huggingFaceSearchService: HuggingFaceSearchService,
         onShowWelcome: @escaping () -> Void
     ) {
         self.appUpdateManager = appUpdateManager
@@ -39,6 +41,7 @@ final class SettingsCoordinator: NSObject, NSWindowDelegate {
         self.foundationModelAvailabilityService = foundationModelAvailabilityService
         self.runtimeModel = runtimeModel
         self.modelDownloadManager = modelDownloadManager
+        self.huggingFaceSearchService = huggingFaceSearchService
         self.onShowWelcome = onShowWelcome
     }
 
@@ -61,6 +64,7 @@ final class SettingsCoordinator: NSObject, NSWindowDelegate {
                 foundationModelAvailabilityService: foundationModelAvailabilityService,
                 runtimeModel: runtimeModel,
                 modelDownloadManager: modelDownloadManager,
+                huggingFaceSearchService: huggingFaceSearchService,
                 onShowWelcome: onShowWelcome
             )
         )

--- a/Cotabby/App/Core/CotabbyAppEnvironment.swift
+++ b/Cotabby/App/Core/CotabbyAppEnvironment.swift
@@ -24,6 +24,7 @@ final class CotabbyAppEnvironment {
     let clipboardContextProvider: ClipboardContextProvider
     let suggestionCoordinator: SuggestionCoordinator
     let welcomeCoordinator: WelcomeCoordinator
+    let huggingFaceSearchService: HuggingFaceSearchService
     let settingsCoordinator: SettingsCoordinator
     let activationIndicatorController: ActivationIndicatorController
     let focusDebugOverlayController: FocusDebugOverlayController?
@@ -77,6 +78,7 @@ final class CotabbyAppEnvironment {
             suggestionSettings: suggestionSettings,
             foundationModelAvailabilityService: foundationModelAvailabilityService
         )
+        let huggingFaceSearchService = HuggingFaceSearchService()
         let settingsCoordinator = SettingsCoordinator(
             appUpdateManager: appUpdateManager,
             launchAtLoginService: launchAtLoginService,
@@ -85,6 +87,7 @@ final class CotabbyAppEnvironment {
             foundationModelAvailabilityService: foundationModelAvailabilityService,
             runtimeModel: runtimeModel,
             modelDownloadManager: modelDownloadManager,
+            huggingFaceSearchService: huggingFaceSearchService,
             onShowWelcome: { [weak welcomeCoordinator] in
                 welcomeCoordinator?.showWelcome()
             }
@@ -157,6 +160,7 @@ final class CotabbyAppEnvironment {
         self.clipboardContextProvider = clipboardContextProvider
         self.suggestionCoordinator = suggestionCoordinator
         self.welcomeCoordinator = welcomeCoordinator
+        self.huggingFaceSearchService = huggingFaceSearchService
         self.settingsCoordinator = settingsCoordinator
         self.activationIndicatorController = activationIndicatorController
         self.focusDebugOverlayController = FocusDebugOverlayController.isEnabled

--- a/Cotabby/Models/HuggingFaceModels.swift
+++ b/Cotabby/Models/HuggingFaceModels.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Codable types matching the HuggingFace REST API response shapes.
+/// These are pure value types with no business logic beyond URL construction.
+
+/// One result from `GET /api/models?filter=gguf&search=...&sort=downloads`.
+struct HFModelSearchResult: Codable, Identifiable, Equatable {
+    let id: String
+    let modelId: String
+    let downloads: Int
+    let likes: Int
+    let tags: [String]
+}
+
+/// One file entry from `GET /api/models/<repoId>/tree/main`.
+struct HFRepoFile: Codable, Equatable, Identifiable {
+    let path: String
+    let size: Int64
+    let type: String
+
+    var id: String { path }
+
+    var isGGUF: Bool {
+        path.lowercased().hasSuffix(".gguf")
+    }
+
+    var sizeInGigabytes: Double {
+        Double(size) / 1_073_741_824
+    }
+
+    var sizeLabel: String {
+        if sizeInGigabytes >= 1.0 {
+            return String(format: "%.1f GB", sizeInGigabytes)
+        }
+        let megabytes = Double(size) / 1_048_576
+        return String(format: "%.0f MB", megabytes)
+    }
+
+    func downloadURL(repoId: String) -> URL? {
+        let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? path
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = "huggingface.co"
+        components.path = "/\(repoId)/resolve/main/\(encodedPath)"
+        components.queryItems = [URLQueryItem(name: "download", value: "true")]
+        return components.url
+    }
+}

--- a/Cotabby/Services/Permission/PermissionDragSourceView.swift
+++ b/Cotabby/Services/Permission/PermissionDragSourceView.swift
@@ -133,7 +133,9 @@ final class PermissionDragSourceView: NSView, NSDraggingSource {
     private func draggingImage() -> NSImage {
         let image = NSImage(size: rowView.bounds.size)
         image.lockFocus()
-        rowView.displayIgnoringOpacity(rowView.bounds, in: NSGraphicsContext.current!)
+        if let context = NSGraphicsContext.current {
+            rowView.displayIgnoringOpacity(rowView.bounds, in: context)
+        }
         image.unlockFocus()
         return image
     }

--- a/Cotabby/Services/Utilities/HuggingFaceAPIClient.swift
+++ b/Cotabby/Services/Utilities/HuggingFaceAPIClient.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+/// Stateless client for the HuggingFace public REST API.
+/// Each call creates an ephemeral URLSession — matching the existing networking pattern
+/// in ModelDownloadManager — so no shared state or cookies persist between requests.
+enum HuggingFaceAPIClient {
+
+    enum APIError: LocalizedError {
+        case invalidURL
+        case httpError(statusCode: Int)
+        case rateLimited
+        case decodingFailed(Error)
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidURL:
+                return "Invalid HuggingFace API URL."
+            case .httpError(let statusCode):
+                return "HuggingFace returned HTTP \(statusCode)."
+            case .rateLimited:
+                return "Too many requests — please wait a moment and try again."
+            case .decodingFailed(let error):
+                return "Failed to parse HuggingFace response: \(error.localizedDescription)"
+            }
+        }
+    }
+
+    /// Search for GGUF model repositories sorted by download count.
+    static func searchModels(query: String, limit: Int = 20, offset: Int = 0) async throws -> [HFModelSearchResult] {
+        guard var components = URLComponents(string: "https://huggingface.co/api/models") else {
+            throw APIError.invalidURL
+        }
+        components.queryItems = [
+            URLQueryItem(name: "filter", value: "gguf"),
+            URLQueryItem(name: "search", value: query),
+            URLQueryItem(name: "sort", value: "downloads"),
+            URLQueryItem(name: "direction", value: "-1"),
+            URLQueryItem(name: "limit", value: String(limit)),
+            URLQueryItem(name: "offset", value: String(offset))
+        ]
+        guard let url = components.url else {
+            throw APIError.invalidURL
+        }
+
+        let data = try await performRequest(url: url)
+        do {
+            return try JSONDecoder().decode([HFModelSearchResult].self, from: data)
+        } catch {
+            throw APIError.decodingFailed(error)
+        }
+    }
+
+    /// Fetch the file tree for a repository, including exact file sizes from LFS metadata.
+    static func fetchRepoFiles(repoId: String) async throws -> [HFRepoFile] {
+        guard var components = URLComponents(string: "https://huggingface.co") else {
+            throw APIError.invalidURL
+        }
+        components.path = "/api/models/\(repoId)/tree/main"
+        guard let url = components.url else {
+            throw APIError.invalidURL
+        }
+
+        let data = try await performRequest(url: url)
+        do {
+            return try JSONDecoder().decode([HFRepoFile].self, from: data)
+        } catch {
+            throw APIError.decodingFailed(error)
+        }
+    }
+
+    private static func performRequest(url: URL) async throws -> Data {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        configuration.timeoutIntervalForRequest = 15
+        let session = URLSession(configuration: configuration)
+        defer { session.finishTasksAndInvalidate() }
+
+        let (data, response) = try await session.data(from: url)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            return data
+        }
+
+        if httpResponse.statusCode == 429 {
+            throw APIError.rateLimited
+        }
+
+        guard (200..<300).contains(httpResponse.statusCode) else {
+            throw APIError.httpError(statusCode: httpResponse.statusCode)
+        }
+
+        return data
+    }
+}

--- a/Cotabby/Services/Utilities/HuggingFaceSearchService.swift
+++ b/Cotabby/Services/Utilities/HuggingFaceSearchService.swift
@@ -1,0 +1,165 @@
+import Combine
+import Foundation
+
+/// Drives the two-step HuggingFace browse flow: search for repos, then drill into
+/// a repo to list its GGUF files. Owns cancellation and debouncing so the UI layer
+/// can bind directly to published state without managing async Tasks.
+@MainActor
+final class HuggingFaceSearchService: ObservableObject {
+
+    enum SearchState: Equatable {
+        case idle
+        case searching
+        case results([HFModelSearchResult])
+        case noResults
+        case failed(String)
+    }
+
+    enum DetailState: Equatable {
+        case idle
+        case loading
+        case loaded(repoId: String, ggufFiles: [HFRepoFile])
+        case failed(String)
+    }
+
+    @Published var searchQuery: String = ""
+    @Published private(set) var searchState: SearchState = .idle
+    @Published private(set) var detailState: DetailState = .idle
+    @Published private(set) var hasMoreResults: Bool = false
+    @Published private(set) var isLoadingMore: Bool = false
+
+    @Published private(set) var selectedRepoId: String?
+
+    private var searchTask: Task<Void, Never>?
+    private var detailTask: Task<Void, Never>?
+    private var loadMoreTask: Task<Void, Never>?
+    private var accumulatedResults: [HFModelSearchResult] = []
+
+    private static let pageSize = 20
+
+    func search() {
+        let query = searchQuery.trimmingCharacters(in: .whitespaces)
+        guard !query.isEmpty else { return }
+
+        searchTask?.cancel()
+        loadMoreTask?.cancel()
+        detailState = .idle
+        accumulatedResults = []
+
+        searchTask = Task {
+            searchState = .searching
+
+            do {
+                let results = try await HuggingFaceAPIClient.searchModels(
+                    query: query, limit: Self.pageSize, offset: 0
+                )
+                guard !Task.isCancelled else { return }
+
+                if results.isEmpty {
+                    searchState = .noResults
+                    hasMoreResults = false
+                } else {
+                    accumulatedResults = results
+                    searchState = .results(results)
+                    hasMoreResults = results.count >= Self.pageSize
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                guard !Task.isCancelled else { return }
+                searchState = .failed(error.localizedDescription)
+            }
+        }
+    }
+
+    func loadMore() {
+        let query = searchQuery.trimmingCharacters(in: .whitespaces)
+        guard !query.isEmpty, hasMoreResults, !isLoadingMore else { return }
+
+        loadMoreTask?.cancel()
+        loadMoreTask = Task {
+            isLoadingMore = true
+            defer { isLoadingMore = false }
+
+            do {
+                let nextPage = try await HuggingFaceAPIClient.searchModels(
+                    query: query, limit: Self.pageSize, offset: accumulatedResults.count
+                )
+                guard !Task.isCancelled else { return }
+
+                accumulatedResults.append(contentsOf: nextPage)
+                searchState = .results(accumulatedResults)
+                hasMoreResults = nextPage.count >= Self.pageSize
+            } catch is CancellationError {
+                return
+            } catch {
+                guard !Task.isCancelled else { return }
+                hasMoreResults = false
+                searchState = .failed(error.localizedDescription)
+            }
+        }
+    }
+
+    func fetchFiles(for repoId: String) {
+        detailTask?.cancel()
+        selectedRepoId = repoId
+
+        detailTask = Task {
+            detailState = .loading
+
+            do {
+                let allFiles = try await HuggingFaceAPIClient.fetchRepoFiles(repoId: repoId)
+                guard !Task.isCancelled else { return }
+
+                let ggufFiles = allFiles
+                    .filter(\.isGGUF)
+                    .sorted { $0.path.localizedStandardCompare($1.path) == .orderedAscending }
+
+                if ggufFiles.isEmpty {
+                    detailState = .failed("No GGUF files found in this repository.")
+                } else {
+                    detailState = .loaded(repoId: repoId, ggufFiles: ggufFiles)
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                guard !Task.isCancelled else { return }
+                detailState = .failed(error.localizedDescription)
+            }
+        }
+    }
+
+    func collapseDetail() {
+        detailTask?.cancel()
+        detailState = .idle
+        selectedRepoId = nil
+    }
+
+    func reset() {
+        searchTask?.cancel()
+        detailTask?.cancel()
+        loadMoreTask?.cancel()
+        searchQuery = ""
+        searchState = .idle
+        detailState = .idle
+        selectedRepoId = nil
+        hasMoreResults = false
+        isLoadingMore = false
+        accumulatedResults = []
+    }
+
+    func makeDownloadableModel(from file: HFRepoFile, repoId: String) -> DownloadableRuntimeModel? {
+        // HuggingFace repo paths can include subdirectories (e.g. "gguf/model-Q4.gguf").
+        // Use only the leaf filename so the download lands flat in Tabby's model directory.
+        let leafFilename = (file.path as NSString).lastPathComponent
+        guard let url = file.downloadURL(repoId: repoId) else { return nil }
+        return DownloadableRuntimeModel(
+            filename: leafFilename,
+            displayName: leafFilename,
+            downloadURL: url,
+            approximateSizeInGigabytes: file.sizeInGigabytes,
+            expectedSizeBytes: nil,
+            sha256: nil
+        )
+    }
+}

--- a/Cotabby/Services/Utilities/ModelDownloadManager.swift
+++ b/Cotabby/Services/Utilities/ModelDownloadManager.swift
@@ -2,6 +2,7 @@ import AppKit
 import Combine
 import Foundation
 import Logging
+import UniformTypeIdentifiers
 
 /// One model's current install/download lifecycle state in local storage.
 enum ModelDownloadState: Equatable {
@@ -104,6 +105,8 @@ final class ModelDownloadManager: ObservableObject {
     }
 
     func refreshModelStates() {
+        let catalogFilenames = Set(models.map(\.filename))
+
         for model in models {
             if downloadTasks[model.filename] != nil {
                 if case .downloading(let progress) = modelStates[model.filename] {
@@ -117,6 +120,30 @@ final class ModelDownloadManager: ObservableObject {
                 modelStates[model.filename] = .idle
             }
         }
+
+        var keysToRemove: [String] = []
+        for (filename, state) in modelStates where !catalogFilenames.contains(filename) {
+            if downloadTasks[filename] != nil {
+                continue
+            }
+            switch state {
+            case .downloading:
+                break
+            case .downloaded, .idle, .failed:
+                if isInstalled(filename: filename) {
+                    modelStates[filename] = .downloaded
+                } else {
+                    keysToRemove.append(filename)
+                }
+            }
+        }
+        for key in keysToRemove {
+            modelStates.removeValue(forKey: key)
+        }
+    }
+
+    func isModelInstalled(filename: String) -> Bool {
+        isInstalled(filename: filename)
     }
 
     func download(_ model: DownloadableRuntimeModel) {
@@ -181,6 +208,46 @@ final class ModelDownloadManager: ObservableObject {
         }
 
         NSWorkspace.shared.open(runtimeDirectoryURL)
+    }
+
+    func importModel() {
+        let panel = NSOpenPanel()
+        panel.title = "Select a GGUF Model"
+        if let ggufType = UTType(filenameExtension: "gguf", conformingTo: .data) {
+            panel.allowedContentTypes = [ggufType]
+        }
+        panel.allowsMultipleSelection = true
+        panel.canChooseDirectories = false
+
+        guard panel.runModal() == .OK else { return }
+
+        do {
+            try ensureRuntimeDirectoryExists()
+        } catch {
+            return
+        }
+
+        // Copy files off the main thread so multi-gigabyte GGUFs don't freeze the UI.
+        let sourceURLs = panel.urls
+        let destinationDirectory = runtimeDirectoryURL
+        Task.detached {
+            let fileManager = FileManager.default
+            for sourceURL in sourceURLs {
+                let destinationURL = destinationDirectory.appendingPathComponent(
+                    sourceURL.lastPathComponent, isDirectory: false
+                )
+                if fileManager.fileExists(atPath: destinationURL.path) { continue }
+                do {
+                    try fileManager.copyItem(at: sourceURL, to: destinationURL)
+                } catch {
+                    print("Failed to import \(sourceURL.lastPathComponent): \(error.localizedDescription)")
+                }
+            }
+            await MainActor.run { [weak self] in
+                self?.refreshModelStates()
+                self?.onModelDirectoryChanged?()
+            }
+        }
     }
 
     /// Returns `true` only when the model lives in Cotabby's user-writable model directory.

--- a/Cotabby/UI/DownloadableModelCatalogView.swift
+++ b/Cotabby/UI/DownloadableModelCatalogView.swift
@@ -14,6 +14,11 @@ struct DownloadableModelCatalogView: View {
 
     var body: some View {
         VStack(spacing: 8) {
+            Text("Recommended Models")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
             ForEach(modelDownloadManager.models) { model in
                 DownloadableModelRow(
                     model: model,
@@ -25,7 +30,8 @@ struct DownloadableModelCatalogView: View {
 
             HStack(spacing: 12) {
                 Button {
-                    modelDownloadManager.openModelsDirectory()
+                    modelDownloadManager.importModel()
+                    onRefreshModels()
                 } label: {
                     Label("Add Your Own", systemImage: "folder.badge.plus")
                         .font(.system(size: 12))
@@ -44,7 +50,7 @@ struct DownloadableModelCatalogView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
-            Text("Drop any .gguf model into the folder above.")
+            Text("Import any .gguf model from your computer.")
                 .font(.system(size: 11))
                 .foregroundStyle(.tertiary)
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/Cotabby/UI/HuggingFaceModelBrowserView.swift
+++ b/Cotabby/UI/HuggingFaceModelBrowserView.swift
@@ -1,0 +1,308 @@
+import SwiftUI
+
+/// Searchable HuggingFace GGUF model browser embedded in the Settings "Local Models" section.
+/// Users search for repos, drill into one to see available GGUF quantizations, and download
+/// directly into Tabby's model directory via the existing ModelDownloadManager.
+struct HuggingFaceModelBrowserView: View {
+    @ObservedObject var searchService: HuggingFaceSearchService
+    @ObservedObject var modelDownloadManager: ModelDownloadManager
+    let onRefreshModels: () -> Void
+
+    @State private var isExpanded = false
+
+    var body: some View {
+        DisclosureGroup("Browse HuggingFace", isExpanded: $isExpanded) {
+            VStack(alignment: .leading, spacing: 10) {
+                searchBar
+                searchResultsContent
+            }
+            .padding(.top, 4)
+        }
+        .onChange(of: isExpanded) { _, expanded in
+            if !expanded {
+                searchService.reset()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var searchBar: some View {
+        HStack(spacing: 8) {
+            TextField("Search GGUF models…", text: $searchService.searchQuery)
+                .textFieldStyle(.roundedBorder)
+                .onSubmit { searchService.search() }
+
+            Button("Search") { searchService.search() }
+                .disabled(searchService.searchQuery.trimmingCharacters(in: .whitespaces).isEmpty)
+        }
+    }
+
+    @ViewBuilder
+    private var searchResultsContent: some View {
+        switch searchService.searchState {
+        case .idle:
+            EmptyView()
+
+        case .searching:
+            HStack(spacing: 6) {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Searching…")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+        case .noResults:
+            Text("No GGUF models found.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+        case .failed(let message):
+            Label(message, systemImage: "exclamationmark.triangle.fill")
+                .font(.caption)
+                .foregroundStyle(.red)
+
+        case .results(let models):
+            ForEach(models) { model in
+                VStack(alignment: .leading, spacing: 0) {
+                    HFSearchResultRow(
+                        model: model,
+                        isSelected: isRepoSelected(model.id),
+                        onSelect: {
+                            if isRepoSelected(model.id) {
+                                searchService.collapseDetail()
+                            } else {
+                                searchService.fetchFiles(for: model.id)
+                            }
+                        }
+                    )
+                    inlineDetailContent(for: model.id)
+                }
+            }
+
+            if searchService.hasMoreResults {
+                Button {
+                    searchService.loadMore()
+                } label: {
+                    if searchService.isLoadingMore {
+                        HStack(spacing: 6) {
+                            ProgressView()
+                                .controlSize(.small)
+                            Text("Loading…")
+                                .font(.caption)
+                        }
+                    } else {
+                        Text("Load More")
+                            .font(.caption)
+                    }
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .disabled(searchService.isLoadingMore)
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.top, 4)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func inlineDetailContent(for repoId: String) -> some View {
+        if isRepoSelected(repoId) {
+            switch searchService.detailState {
+            case .loading:
+                HStack(spacing: 6) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Loading files…")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.leading, 16)
+                .padding(.top, 4)
+
+            case .failed(let message):
+                Label(message, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .padding(.leading, 16)
+                    .padding(.top, 4)
+
+            case .loaded(let loadedRepoId, let ggufFiles) where loadedRepoId == repoId:
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(ggufFiles) { file in
+                        if let model = searchService.makeDownloadableModel(from: file, repoId: repoId) {
+                            HFFileRow(
+                                file: file,
+                                repoId: repoId,
+                                state: modelDownloadManager.state(for: model),
+                                isInstalled: modelDownloadManager.isModelInstalled(filename: model.filename),
+                                onDownload: {
+                                    modelDownloadManager.download(model)
+                                },
+                                onCancel: {
+                                    modelDownloadManager.cancel(filename: model.filename)
+                                }
+                            )
+                        }
+                    }
+                }
+                .padding(.leading, 16)
+                .padding(.top, 4)
+
+            default:
+                EmptyView()
+            }
+        }
+    }
+
+    private func isRepoSelected(_ repoId: String) -> Bool {
+        searchService.selectedRepoId == repoId
+    }
+}
+
+private struct HFSearchResultRow: View {
+    let model: HFModelSearchResult
+    let isSelected: Bool
+    let onSelect: () -> Void
+
+    var body: some View {
+        Button(action: onSelect) {
+            HStack(spacing: 10) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(model.id)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+
+                    HStack(spacing: 8) {
+                        Label(formattedDownloads, systemImage: "arrow.down.circle")
+                        Label("\(model.likes)", systemImage: "heart")
+                    }
+                    .font(.system(size: 10))
+                    .foregroundStyle(.secondary)
+                }
+
+                Spacer(minLength: 0)
+
+                Image(systemName: isSelected ? "chevron.down" : "chevron.right")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.vertical, 4)
+            .padding(.horizontal, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .fill(isSelected ? Color.accentColor.opacity(0.08) : .clear)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var formattedDownloads: String {
+        if model.downloads >= 1_000_000 {
+            return String(format: "%.1fM", Double(model.downloads) / 1_000_000)
+        } else if model.downloads >= 1_000 {
+            return String(format: "%.1fK", Double(model.downloads) / 1_000)
+        }
+        return "\(model.downloads)"
+    }
+}
+
+private struct HFFileRow: View {
+    let file: HFRepoFile
+    let repoId: String
+    let state: ModelDownloadState
+    let isInstalled: Bool
+    let onDownload: () -> Void
+    let onCancel: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 10) {
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(file.path)
+                        .font(.system(size: 12, weight: .medium))
+                        .lineLimit(1)
+
+                    Text(file.sizeLabel)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer(minLength: 0)
+
+                actionButton
+            }
+
+            if state.isDownloading, let progress = state.progressFraction {
+                ProgressView(value: progress, total: 1)
+                    .progressViewStyle(.linear)
+                    .tint(.blue)
+            } else if state.isDownloading {
+                ProgressView()
+                    .progressViewStyle(.linear)
+                    .tint(.blue)
+            }
+        }
+        .padding(.vertical, 4)
+        .padding(.horizontal, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(.quaternary.opacity(0.3))
+        )
+    }
+
+    @ViewBuilder
+    private var actionButton: some View {
+        if isInstalled && !state.isDownloading {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+                .font(.system(size: 16))
+        } else {
+            switch state {
+            case .idle:
+                Button("Get") { onDownload() }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+
+            case .downloading(let progress):
+                HStack(spacing: 6) {
+                    if let progress {
+                        Text("\(Int((progress * 100).rounded()))%")
+                            .font(.system(size: 11, weight: .medium, design: .monospaced))
+                            .foregroundStyle(.blue)
+                            .frame(width: 40, alignment: .trailing)
+                    } else {
+                        ProgressView()
+                            .controlSize(.small)
+                            .frame(width: 40)
+                    }
+                    Button {
+                        onCancel()
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.system(size: 16))
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Cancel download")
+                }
+
+            case .downloaded:
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+                    .font(.system(size: 16))
+
+            case .failed:
+                Button {
+                    onDownload()
+                } label: {
+                    Label("Retry", systemImage: "arrow.counterclockwise")
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+        }
+    }
+}

--- a/Cotabby/UI/MenuBarView.swift
+++ b/Cotabby/UI/MenuBarView.swift
@@ -37,13 +37,12 @@ struct MenuBarView: View {
         .background(
             MenuBarPresentationObserver {
                 permissionManager.refresh()
+                runtimeModel.refreshAvailableModels()
             }
         )
         .onAppear {
-            // The menu is a status surface, so re-read system permissions whenever it opens.
-            // The background poll eventually catches changes too, but this avoids showing stale
-            // "Grant" rows after the user just updated System Settings.
             permissionManager.refresh()
+            runtimeModel.refreshAvailableModels()
         }
     }
 

--- a/Cotabby/UI/SettingsView.swift
+++ b/Cotabby/UI/SettingsView.swift
@@ -18,6 +18,7 @@ struct SettingsView: View {
     @ObservedObject var foundationModelAvailabilityService: FoundationModelAvailabilityService
     @ObservedObject var runtimeModel: RuntimeBootstrapModel
     @ObservedObject var modelDownloadManager: ModelDownloadManager
+    @ObservedObject var huggingFaceSearchService: HuggingFaceSearchService
 
     let onShowWelcome: () -> Void
 
@@ -458,6 +459,12 @@ struct SettingsView: View {
             }
 
             DownloadableModelCatalogView(
+                modelDownloadManager: modelDownloadManager,
+                onRefreshModels: refreshModels
+            )
+
+            HuggingFaceModelBrowserView(
+                searchService: huggingFaceSearchService,
                 modelDownloadManager: modelDownloadManager,
                 onRefreshModels: refreshModels
             )


### PR DESCRIPTION
## Summary

Brings the HuggingFace model browser to `main`. It originally landed in **#192**, but that PR merged into the `settings-reorder` branch *after* `settings-reorder` had already been merged up (#246), so the feature was stranded — its files never existed on `main`, which is why it couldn't be found in the app.

This adds a **"Browse HuggingFace"** disclosure under **Settings → Model & Engine → Local Models** (shown for the Open Source engine) that searches GGUF repositories with pagination and imports a selected model file. "Add Your Own" in the model catalog now opens an import picker, and the menu bar refreshes the model list when it opens.

The feature commit is a clean cherry-pick of #192's change (James kept as author) — it applied to current `main` with **zero conflicts and no code edits**. The only `main`-specific work was regenerating the Xcode project: the repo moved to XcodeGen (#268), so new files only enter the build target after `xcodegen generate`.

## Validation

```
xcodegen generate                          # +16 lines in project.pbxproj (the 4 new files only)

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  build CODE_SIGNING_ALLOWED=NO            # ** BUILD SUCCEEDED **
xcodebuild ... build-for-testing CODE_SIGNING_ALLOWED=NO   # ** TEST BUILD SUCCEEDED **

swiftlint lint --quiet <the 11 changed files>   # no violations
```

Verified the build *fails* before the project regen (`cannot find type 'HuggingFaceSearchService'`) and *succeeds* after — confirming the new files are now in the target. No tests were added (none came with #192), and I did not capture a runtime screenshot; the wiring is verified by compile + the entry point in `SettingsView.localModelControls`.

## Linked issues

None — no tracked issue. Restores the work from #192 onto `main`.

## Risk / rollout notes

- **Where it shows up**: the browser lives in `localModelControls`, which only renders for the **Open Source** engine. On Apple Intelligence it won't appear (same as on the original branch).
- **Generated project file**: `Cotabby.xcodeproj/project.pbxproj` is XcodeGen output. The diff is regeneration, not hand-editing — reviewers should treat it as generated. If your local XcodeGen differs from 2.45.4, a re-run may reorder lines.
- **Faithful port**: the HuggingFace source/UI/service code is byte-identical to #192 (cherry-picked, no conflicts). It carries #192's behavior as-reviewed; nothing about it was re-audited here beyond making it build on current `main`.
- **Networking**: the browser hits the public HuggingFace API at runtime (already true in #192) — worth a glance if that wasn't reviewed with networking in mind.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR cherry-picks the HuggingFace GGUF model browser from #192 onto `main`, adding search/pagination/download functionality under Settings → Local Models for the Open Source engine, and regenerates the Xcode project via XcodeGen to include the four new files.

- **New services**: `HuggingFaceAPIClient` (stateless REST client with ephemeral sessions), `HuggingFaceSearchService` (`@MainActor` ObservableObject managing search/detail/pagination state), and `HFModelSearchResult`/`HFRepoFile` model types.
- **New UI**: `HuggingFaceModelBrowserView` (disclosure group with search bar, paginated repo list, inline file drill-down, and per-file download rows wired into `ModelDownloadManager`).
- **Existing view changes**: `DownloadableModelCatalogView` replaces the \"open folder\" button with an `NSOpenPanel` import picker; `MenuBarView` now refreshes the available model list whenever the menu opens.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the new feature is isolated to the Open Source engine path and the only new defect found (double-encoding in `downloadURL`) only triggers for GGUF filenames containing spaces or other URL-special characters, which are rare on HuggingFace.

All three substantive issues flagged in previous review rounds (premature `onRefreshModels` call, `isLoadingMore` guard bypass, and `print()` vs `CotabbyLogger`) remain open, but no new blocking defects are introduced. The one new finding is a double-encoding bug in `HFRepoFile.downloadURL` that would produce malformed download URLs for filenames with spaces or brackets — uncommon in practice for GGUF files on HuggingFace, so the browser will work correctly for nearly all real-world queries.

`Cotabby/Models/HuggingFaceModels.swift` — the `downloadURL(repoId:)` method applies manual percent-encoding and then writes the result to `URLComponents.path`, causing double-encoding for any filename with URL-special characters.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Models/HuggingFaceModels.swift | New value types for HuggingFace API shapes; contains a double-encoding bug in `downloadURL(repoId:)` where a pre-encoded path is assigned to `URLComponents.path` (the decoded-path setter), causing re-encoding of `%` characters for any filename with spaces or special characters. |
| Cotabby/Services/Utilities/HuggingFaceAPIClient.swift | New stateless API client with ephemeral URLSession per request; correctly handles rate-limiting (429), HTTP errors, decoding failures, and 15 s timeouts. URL construction uses `URLComponents.path` with unencoded interpolated strings, which is correct here (no pre-encoding applied). |
| Cotabby/Services/Utilities/HuggingFaceSearchService.swift | New `@MainActor` `ObservableObject` driving search/detail/pagination state; cancellation and task lifecycle are generally correct. Known issue (per previous thread): `isLoadingMore = true` is set inside the Task body rather than before it, leaving a small window for concurrent loads. |
| Cotabby/Services/Utilities/ModelDownloadManager.swift | Adds `importModel()` (NSOpenPanel + detached copy Task) and extends `refreshModelStates()` to manage entries for non-catalog (HuggingFace-sourced) filenames. Known issues (per previous threads): premature `onRefreshModels()` call before async copy completes and copy errors using `print()` instead of `CotabbyLogger`. |
| Cotabby/UI/HuggingFaceModelBrowserView.swift | New SwiftUI browser view with disclosure group, search bar, paginated results, inline repo detail, and per-file download rows. State binding to `HuggingFaceSearchService` and `ModelDownloadManager` is correct; the accepted `onRefreshModels` closure is unused within the view but harmless. |
| Cotabby/UI/DownloadableModelCatalogView.swift | "Add Your Own" button now calls `importModel()` (open panel) instead of `openModelsDirectory()`. Known issue (per previous thread): `onRefreshModels()` fires synchronously after `importModel()` returns, before the async file copy has completed. |
| Cotabby/UI/MenuBarView.swift | Adds `runtimeModel.refreshAvailableModels()` to both `onAppear` and `MenuBarPresentationObserver` so the model list is always fresh when the menu opens. |
| Cotabby/UI/SettingsView.swift | Wires `HuggingFaceSearchService` into `SettingsView` and inserts `HuggingFaceModelBrowserView` in the local model controls section. Straightforward integration. |
| Cotabby/Services/Permission/PermissionDragSourceView.swift | Replaces a force-unwrap of `NSGraphicsContext.current!` with a safe `if let` guard in `draggingImage()`, eliminating a potential crash without changing behaviour (context is set by `lockFocus()` in practice). |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant HFBrowserView as HuggingFaceModelBrowserView
    participant SearchService as HuggingFaceSearchService
    participant APIClient as HuggingFaceAPIClient
    participant DownloadMgr as ModelDownloadManager
    participant HuggingFace as HuggingFace API

    User->>HFBrowserView: types query, taps Search
    HFBrowserView->>SearchService: search()
    SearchService->>APIClient: searchModels(query:limit:offset:)
    APIClient->>HuggingFace: "GET /api/models?filter=gguf&search=..."
    HuggingFace-->>APIClient: [HFModelSearchResult]
    APIClient-->>SearchService: results
    SearchService-->>HFBrowserView: "searchState = .results(models)"

    User->>HFBrowserView: taps repo row
    HFBrowserView->>SearchService: fetchFiles(for: repoId)
    SearchService->>APIClient: fetchRepoFiles(repoId:)
    APIClient->>HuggingFace: "GET /api/models/{repoId}/tree/main"
    HuggingFace-->>APIClient: [HFRepoFile]
    APIClient-->>SearchService: files
    SearchService-->>HFBrowserView: "detailState = .loaded(ggufFiles)"

    User->>HFBrowserView: taps Get on a file
    HFBrowserView->>DownloadMgr: download(model)
    DownloadMgr->>HuggingFace: URLSession download from HFRepoFile.downloadURL
    HuggingFace-->>DownloadMgr: file data
    DownloadMgr-->>HFBrowserView: modelStates updated to .downloaded
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22jafu%2Fhf-model-browser%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22jafu%2Fhf-model-browser%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FModels%2FHuggingFaceModels.swift%3A39-47%0ADouble-encoding%20bug%20in%20download%20URL%20construction.%20%60addingPercentEncoding%28withAllowedCharacters%3A%29%60%20returns%20a%20string%20with%20percent-encoded%20sequences%20like%20%60%2520%60%2C%20but%20%60URLComponents.path%60%20is%20the%20*decoded*%20path%20property%20%E2%80%94%20assigning%20a%20pre-encoded%20string%20to%20it%20causes%20%60URLComponents%60%20to%20re-encode%20the%20%60%25%60%20as%20%60%2525%60%2C%20turning%20%60%2520%60%20into%20%60%252520%60.%20Any%20GGUF%20filename%20containing%20a%20space%20or%20bracket%20would%20generate%20a%20URL%20that%20404s%20on%20HuggingFace.%20Either%20drop%20the%20manual%20pre-encoding%20and%20let%20%60URLComponents%60%20handle%20it%2C%20or%20use%20%60percentEncodedPath%60%20with%20a%20pre-encoded%20repoId%20too.%0A%0A%60%60%60suggestion%0A%20%20%20%20func%20downloadURL%28repoId%3A%20String%29%20-%3E%20URL%3F%20%7B%0A%20%20%20%20%20%20%20%20var%20components%20%3D%20URLComponents%28%29%0A%20%20%20%20%20%20%20%20components.scheme%20%3D%20%22https%22%0A%20%20%20%20%20%20%20%20components.host%20%3D%20%22huggingface.co%22%0A%20%20%20%20%20%20%20%20components.path%20%3D%20%22%2F%5C%28repoId%29%2Fresolve%2Fmain%2F%5C%28path%29%22%0A%20%20%20%20%20%20%20%20components.queryItems%20%3D%20%5BURLQueryItem%28name%3A%20%22download%22%2C%20value%3A%20%22true%22%29%5D%0A%20%20%20%20%20%20%20%20return%20components.url%0A%20%20%20%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FModels%2FHuggingFaceModels.swift%3A39-47%0ADouble-encoding%20bug%20in%20download%20URL%20construction.%20%60addingPercentEncoding%28withAllowedCharacters%3A%29%60%20returns%20a%20string%20with%20percent-encoded%20sequences%20like%20%60%2520%60%2C%20but%20%60URLComponents.path%60%20is%20the%20*decoded*%20path%20property%20%E2%80%94%20assigning%20a%20pre-encoded%20string%20to%20it%20causes%20%60URLComponents%60%20to%20re-encode%20the%20%60%25%60%20as%20%60%2525%60%2C%20turning%20%60%2520%60%20into%20%60%252520%60.%20Any%20GGUF%20filename%20containing%20a%20space%20or%20bracket%20would%20generate%20a%20URL%20that%20404s%20on%20HuggingFace.%20Either%20drop%20the%20manual%20pre-encoding%20and%20let%20%60URLComponents%60%20handle%20it%2C%20or%20use%20%60percentEncodedPath%60%20with%20a%20pre-encoded%20repoId%20too.%0A%0A%60%60%60suggestion%0A%20%20%20%20func%20downloadURL%28repoId%3A%20String%29%20-%3E%20URL%3F%20%7B%0A%20%20%20%20%20%20%20%20var%20components%20%3D%20URLComponents%28%29%0A%20%20%20%20%20%20%20%20components.scheme%20%3D%20%22https%22%0A%20%20%20%20%20%20%20%20components.host%20%3D%20%22huggingface.co%22%0A%20%20%20%20%20%20%20%20components.path%20%3D%20%22%2F%5C%28repoId%29%2Fresolve%2Fmain%2F%5C%28path%29%22%0A%20%20%20%20%20%20%20%20components.queryItems%20%3D%20%5BURLQueryItem%28name%3A%20%22download%22%2C%20value%3A%20%22true%22%29%5D%0A%20%20%20%20%20%20%20%20return%20components.url%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=294&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Merge main into jafu/hf-model-browser; r..."](https://github.com/fujacob/cotabby/commit/ed473b91ab4e633451aedbc3009cd96ad4ac2cea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34091989)</sub>

<!-- /greptile_comment -->