### PR TITLE
Cache caret geometry sources to cut per-keystroke AX walks

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -113,6 +113,7 @@
 		B00FDD3DEE0B73FF5136C91C /* FocusTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C9FDF029F7828CAF3FE8850 /* FocusTracker.swift */; };
 		B0828FF0D7EE110C0B23DB94 /* TagsInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C0F017699EE44C81C095CA /* TagsInputView.swift */; };
 		B0B115C6EBAC37FF6115B4BE /* SuggestionCoordinator+Lifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78E280F4F39A9D86840800D2 /* SuggestionCoordinator+Lifecycle.swift */; };
+		B2CABC9F92368B4FCB7BF2C4 /* CaretGeometrySourceCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED63EBDD04B6E9EBF7E7D411 /* CaretGeometrySourceCache.swift */; };
 		B93AB7E845086F6FBB068369 /* SuggestionRequestFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE94342B888A5A2CCF66BC93 /* SuggestionRequestFactoryTests.swift */; };
 		BB6325CA50F97B18B9725918 /* SuggestionTextNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B424E2AC97C99D335B0D5751 /* SuggestionTextNormalizer.swift */; };
 		BFCA7FAFDAEBF586AB615567 /* ClipboardRelevanceFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90B0D133AB77A2503FB08827 /* ClipboardRelevanceFilterTests.swift */; };
@@ -284,6 +285,7 @@
 		E7F42112F14026E6253BB865 /* PermissionAndContextModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionAndContextModelTests.swift; sourceTree = "<group>"; };
 		EAAE6B395FAB604DF059280A /* KeyCodeLabels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyCodeLabels.swift; sourceTree = "<group>"; };
 		EBEDE359CFD99EF906FA50BC /* IndicatorIconImageProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndicatorIconImageProcessor.swift; sourceTree = "<group>"; };
+		ED63EBDD04B6E9EBF7E7D411 /* CaretGeometrySourceCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaretGeometrySourceCache.swift; sourceTree = "<group>"; };
 		ED8672B87CEC72BE3978C6BB /* CotabbyTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CotabbyTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		EE94342B888A5A2CCF66BC93 /* SuggestionRequestFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionRequestFactoryTests.swift; sourceTree = "<group>"; };
 		EFD89799BB82AF7A92559AEB /* ClipboardContentDistillerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardContentDistillerTests.swift; sourceTree = "<group>"; };
@@ -405,6 +407,7 @@
 			isa = PBXGroup;
 			children = (
 				CB58035EFFD65B767949BAE6 /* AXTextGeometryResolver.swift */,
+				ED63EBDD04B6E9EBF7E7D411 /* CaretGeometrySourceCache.swift */,
 				04E25414C307A20B6F9F20EC /* FocusSnapshotResolver.swift */,
 				5C9FDF029F7828CAF3FE8850 /* FocusTracker.swift */,
 			);
@@ -705,6 +708,7 @@
 				C4C6734678797669055988E0 /* AppUpdateManager.swift in Sources */,
 				66C23A7C2FCDE0266FF425F8 /* ApplicationBundleMetadata.swift in Sources */,
 				3CBBC3BFAC0DC8952EE24EF7 /* BundledRuntimeLocator.swift in Sources */,
+				B2CABC9F92368B4FCB7BF2C4 /* CaretGeometrySourceCache.swift in Sources */,
 				6E01052209B73D7361C12CEF /* ClipboardContentDistiller.swift in Sources */,
 				D2CAA59F69BCBC07DDA2B0D8 /* ClipboardContextProvider.swift in Sources */,
 				157A55EB796BEB7819B90D5D /* ClipboardRelevanceFilter.swift in Sources */,

--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		258EAFB0292290C88520E915 /* SystemSettingsWindowLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5976600F428C1265121D4C0C /* SystemSettingsWindowLocator.swift */; };
 		25D4FC8D191A50F63E6391F9 /* ModelAndPresentationValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03766F6253FF17639230C0F6 /* ModelAndPresentationValueTests.swift */; };
 		26E0331E9E2F92FAE531BDEE /* ActivationIndicatorController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84D4528EEC9EFEB8AE8E318 /* ActivationIndicatorController.swift */; };
+		29A11716A212C8E66202D527 /* CaretGeometrySourceCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6ECC3A26862471FAAF1F906 /* CaretGeometrySourceCacheTests.swift */; };
 		2C6159231472A849F15BD0AE /* ScreenFrameReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5484C8A04B9C00CF79D589EB /* ScreenFrameReader.swift */; };
 		2DF5A3826AAB99C279EBB8DE /* InputMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B81DD30EB657368AACE9625A /* InputMonitor.swift */; };
 		2EE05B312C990104BE934772 /* GhostFontSizeStabilizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335BF59EE80F3A0143B79740 /* GhostFontSizeStabilizerTests.swift */; };
@@ -264,6 +265,7 @@
 		C046CB4F3CB4BFE9391DB5DE /* AXTextGeometryResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AXTextGeometryResolverTests.swift; sourceTree = "<group>"; };
 		C05B0439348261163B37C508 /* SuggestionAvailabilityEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionAvailabilityEvaluatorTests.swift; sourceTree = "<group>"; };
 		C1C5DE0F3FF63545000E2453 /* DisplayCoordinateConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayCoordinateConverterTests.swift; sourceTree = "<group>"; };
+		C6ECC3A26862471FAAF1F906 /* CaretGeometrySourceCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaretGeometrySourceCacheTests.swift; sourceTree = "<group>"; };
 		C7B2D34A6F3AC9DFD61350F7 /* CotabbyDebugOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CotabbyDebugOptions.swift; sourceTree = "<group>"; };
 		CA942A53B7C09D1F4EC57239 /* SuggestionInteractionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionInteractionState.swift; sourceTree = "<group>"; };
 		CB58035EFFD65B767949BAE6 /* AXTextGeometryResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AXTextGeometryResolver.swift; sourceTree = "<group>"; };
@@ -464,6 +466,7 @@
 				A168A7B6A7AD11559B60C56B /* ApplicationBundleMetadataTests.swift */,
 				C046CB4F3CB4BFE9391DB5DE /* AXTextGeometryResolverTests.swift */,
 				18D990E515E1AE4F312F4E95 /* BundledRuntimeLocatorTests.swift */,
+				C6ECC3A26862471FAAF1F906 /* CaretGeometrySourceCacheTests.swift */,
 				EFD89799BB82AF7A92559AEB /* ClipboardContentDistillerTests.swift */,
 				90B0D133AB77A2503FB08827 /* ClipboardRelevanceFilterTests.swift */,
 				AF1E065C7FFB697FCEB2FA5C /* CotabbyTestFixtures.swift */,
@@ -814,6 +817,7 @@
 				6D0E79CF3C1A8CE53046FCE5 /* AXTextGeometryResolverTests.swift in Sources */,
 				A36481222BB5B2A67349D389 /* ApplicationBundleMetadataTests.swift in Sources */,
 				58AC3193D846FDE88513377D /* BundledRuntimeLocatorTests.swift in Sources */,
+				29A11716A212C8E66202D527 /* CaretGeometrySourceCacheTests.swift in Sources */,
 				8865B95FE84198D70390DF80 /* ClipboardContentDistillerTests.swift in Sources */,
 				BFCA7FAFDAEBF586AB615567 /* ClipboardRelevanceFilterTests.swift in Sources */,
 				5E10EFC426217CB7218A5847 /* CotabbyTestFixtures.swift in Sources */,

--- a/Cotabby/Services/Focus/AXTextGeometryResolver.swift
+++ b/Cotabby/Services/Focus/AXTextGeometryResolver.swift
@@ -33,7 +33,11 @@ struct CaretGeometryResult {
 struct AXTextGeometryResolver {
     /// Remembers the text-run leaves of the focused field so per-keystroke caret resolution can
     /// re-read them instead of re-walking the tree. Nil disables caching (tests, non-focus callers).
-    private let cache: CaretGeometrySourceCache?
+    ///
+    /// Exposed (not private) so `FocusSnapshotResolver` can adopt this exact instance for its own
+    /// deep-walk fast path. If the two types held separate caches, an injected resolver would
+    /// silently lose run-walk caching while deep-walk caching kept working.
+    let cache: CaretGeometrySourceCache?
 
     init(cache: CaretGeometrySourceCache? = nil) {
         self.cache = cache
@@ -304,16 +308,45 @@ struct AXTextGeometryResolver {
             return result
         }
 
-        // Slow path: discover the leaves with a bounded walk, cache them, then map.
+        // Slow path: discover the leaves with a bounded walk, then map. The resolved field's leaves
+        // are cached once after candidate selection by `cacheTextRunSources` — deliberately not here
+        // — so a non-winning candidate probed on the same poll cannot evict the focused field's entry
+        // and force a re-walk every keystroke.
         let elements = collectStaticTextElements(from: element)
         guard !elements.isEmpty,
             let runs = textRuns(fromElements: elements), !runs.isEmpty else {
             return nil
         }
-        if let fieldKey, let cache {
-            cache.store(textRunElements: elements, for: fieldKey)
-        }
         return caretResult(fromRuns: runs, caretOffset: parentSelection.location)
+    }
+
+    /// Populates the text-run cache for the resolved field once candidate selection is done.
+    ///
+    /// `FocusSnapshotResolver` probes every candidate with the run cache read-only: each candidate
+    /// has a distinct cache identity and the cache holds a single field, so letting every probe write
+    /// would let a non-winning candidate evict the focused field's leaves on the same poll and force
+    /// a re-walk every keystroke. The resolver instead calls this once for the winner. Already-warm
+    /// fields are a no-op; the walk runs only when the entry is cold (first poll on a field) or a
+    /// line change moved the caret off the cached leaves.
+    func cacheTextRunSources(for element: AXUIElement, focusChangeSequence: UInt64) {
+        guard let cache else {
+            return
+        }
+
+        let fieldKey = CaretGeometrySourceCache.FieldKey(
+            containerIdentifier: AXHelper.elementIdentity(for: element),
+            focusChangeSequence: focusChangeSequence
+        )
+        guard cache.textRunElements(for: fieldKey) == nil else {
+            return
+        }
+
+        let elements = collectStaticTextElements(from: element)
+        guard !elements.isEmpty,
+            let runs = textRuns(fromElements: elements), !runs.isEmpty else {
+            return
+        }
+        cache.store(textRunElements: elements, for: fieldKey)
     }
 
     /// Maps a caret offset onto ordered text runs: walk cumulative text length to find the

--- a/Cotabby/Services/Focus/AXTextGeometryResolver.swift
+++ b/Cotabby/Services/Focus/AXTextGeometryResolver.swift
@@ -31,6 +31,14 @@ struct CaretGeometryResult {
 
 @MainActor
 struct AXTextGeometryResolver {
+    /// Remembers the text-run leaves of the focused field so per-keystroke caret resolution can
+    /// re-read them instead of re-walking the tree. Nil disables caching (tests, non-focus callers).
+    private let cache: CaretGeometrySourceCache?
+
+    init(cache: CaretGeometrySourceCache? = nil) {
+        self.cache = cache
+    }
+
     /// Resolves the full input frame for workflows that need the whole field bounds, such as
     /// screenshot cropping and field-level diagnostics. This stays separate from caret resolution
     /// because not every consumer wants the same geometry contract.
@@ -53,7 +61,8 @@ struct AXTextGeometryResolver {
         supportsBoundsForRange: Bool,
         supportsFrame: Bool,
         cocoaAnchorFrame: CGRect?,
-        textValue: String? = nil
+        textValue: String? = nil,
+        focusChangeSequence: UInt64? = nil
     ) -> CaretGeometryResult? {
         // Branch 1: Zero-length BoundsForRange at the caret position — ideal case.
         // Gated on `supportsBoundsForRange` because the API is a synchronous cross-process
@@ -146,7 +155,8 @@ struct AXTextGeometryResolver {
             if let result = resolveCaretFromChildTextRuns(
                 element: element,
                 parentSelection: selection,
-                parentText: parentText
+                parentText: parentText,
+                focusChangeSequence: focusChangeSequence
             ) {
                 return result
             }
@@ -265,20 +275,57 @@ struct AXTextGeometryResolver {
     private func resolveCaretFromChildTextRuns(
         element: AXUIElement,
         parentSelection: NSRange,
-        parentText: String
+        parentText: String,
+        focusChangeSequence: UInt64?
     ) -> CaretGeometryResult? {
         let parentTextLength = (parentText as NSString).length
         guard parentSelection.location <= parentTextLength else {
             return nil
         }
 
-        let textRuns = collectStaticTextRuns(from: element)
+        let fieldKey: CaretGeometrySourceCache.FieldKey?
+        if let focusChangeSequence, cache != nil {
+            fieldKey = CaretGeometrySourceCache.FieldKey(
+                containerIdentifier: AXHelper.elementIdentity(for: element),
+                focusChangeSequence: focusChangeSequence
+            )
+        } else {
+            fieldKey = nil
+        }
 
-        guard !textRuns.isEmpty else { return nil }
+        // Fast path: re-read the cached line leaves instead of re-walking the tree. A successful
+        // caret map means the field's line structure is intact — including after the caret jumped
+        // lines, since the offset simply maps to a different cached run. A nil map (e.g. a line the
+        // cache predates) falls through to a fresh walk that refreshes the cache.
+        if let fieldKey, let cache,
+            let cachedElements = cache.textRunElements(for: fieldKey),
+            let runs = textRuns(fromElements: cachedElements), !runs.isEmpty,
+            let result = caretResult(fromRuns: runs, caretOffset: parentSelection.location) {
+            return result
+        }
 
-        // Derive the average character width from the child frames — this is a direct measurement
-        // of the actual rendered font, not a guess. We aggregate across all children so a single
-        // short run doesn't skew the estimate.
+        // Slow path: discover the leaves with a bounded walk, cache them, then map.
+        let elements = collectStaticTextElements(from: element)
+        guard !elements.isEmpty,
+            let runs = textRuns(fromElements: elements), !runs.isEmpty else {
+            return nil
+        }
+        if let fieldKey, let cache {
+            cache.store(textRunElements: elements, for: fieldKey)
+        }
+        return caretResult(fromRuns: runs, caretOffset: parentSelection.location)
+    }
+
+    /// Maps a caret offset onto ordered text runs: walk cumulative text length to find the
+    /// containing run, then interpolate proportionally inside its frame. Returns nil when the offset
+    /// overshoots the runs by more than a small tolerance — the signal that the run list is stale or
+    /// incomplete, so the caller should re-walk rather than anchor the overlay to an unrelated tail.
+    private func caretResult(
+        fromRuns textRuns: [(text: String, frame: CGRect)],
+        caretOffset: Int
+    ) -> CaretGeometryResult? {
+        // Average character width measured directly from the child frames — the actual rendered
+        // font, not a guess. Aggregated across runs so one short run doesn't skew it.
         var totalChars = 0
         var totalWidth: CGFloat = 0
         for run in textRuns {
@@ -287,9 +334,7 @@ struct AXTextGeometryResolver {
         }
         let charWidth: CGFloat? = totalChars > 0 ? totalWidth / CGFloat(totalChars) : nil
 
-        // Find which child contains the caret by matching parent selection against cumulative
-        // text lengths. AX selections use UTF-16 offsets, so we match on NSString length.
-        let caretOffset = parentSelection.location
+        // AX selections use UTF-16 offsets, so match on NSString length.
         var cumulative = 0
         for run in textRuns {
             let runLen = (run.text as NSString).length
@@ -308,16 +353,16 @@ struct AXTextGeometryResolver {
             cumulative += runLen
         }
 
-        // A tiny overrun can happen when browsers omit newline glue from child text runs.
-        // A large overrun means the descendant list is incomplete or polluted by non-editor labels
-        // (Gmail tracking banners are exposed this way), so anchoring to the last child would jump
-        // the overlay to unrelated UI.
+        // A tiny overrun can happen when browsers omit newline glue from child text runs. A large
+        // overrun means the run list is incomplete or polluted by non-editor labels (Gmail tracking
+        // banners are exposed this way), so anchoring to the last run would jump the overlay to
+        // unrelated UI.
         let missingTextTolerance = 2
-        guard caretOffset <= cumulative + missingTextTolerance else {
+        guard caretOffset <= cumulative + missingTextTolerance, let lastRun = textRuns.last else {
             return nil
         }
 
-        let lastFrame = AXHelper.cocoaRect(fromAccessibilityRect: textRuns.last!.frame)
+        let lastFrame = AXHelper.cocoaRect(fromAccessibilityRect: lastRun.frame)
         return CaretGeometryResult(
             rect: CGRect(x: lastFrame.maxX, y: lastFrame.minY, width: 2, height: lastFrame.height),
             quality: .derived,
@@ -329,12 +374,12 @@ struct AXTextGeometryResolver {
     /// anonymous containers, etc.). Walking only one child level misses those runs and forces
     /// Branch 3 (`AXFrame`) fallback. We scan descendants in pre-order so cumulative text length
     /// still tracks visual reading order in most editor trees.
-    private func collectStaticTextRuns(from root: AXUIElement) -> [(text: String, frame: CGRect)] {
+    private func collectStaticTextElements(from root: AXUIElement) -> [AXUIElement] {
         let maxDepth = 8
         let maxNodes = 300
         var visitedNodes = 0
         var seen = Set<String>()
-        var runs: [(text: String, frame: CGRect)] = []
+        var elements: [AXUIElement] = []
 
         func walk(_ element: AXUIElement, depth: Int) {
             guard depth <= maxDepth, visitedNodes < maxNodes else {
@@ -354,7 +399,7 @@ struct AXTextGeometryResolver {
                 !text.isEmpty,
                 let frame = AXHelper.rectValue(for: "AXFrame" as CFString, on: element),
                 !frame.isEmpty {
-                runs.append((text, frame))
+                elements.append(element)
             }
 
             guard depth < maxDepth else {
@@ -368,6 +413,29 @@ struct AXTextGeometryResolver {
 
         for child in AXHelper.childElements(of: root) {
             walk(child, depth: 1)
+        }
+
+        return elements
+    }
+
+    /// Reads the current text and frame of each leaf and returns them in visual reading order.
+    /// Returns nil when a leaf no longer reports the static-text role — the signal that a cached
+    /// element list is stale and the caller must re-walk. Leaves that read empty are skipped rather
+    /// than treated as stale, since a line can be momentarily empty mid-edit.
+    private func textRuns(fromElements elements: [AXUIElement]) -> [(text: String, frame: CGRect)]? {
+        var runs: [(text: String, frame: CGRect)] = []
+        for element in elements {
+            guard AXHelper.stringValue(for: kAXRoleAttribute as CFString, on: element)
+                == kAXStaticTextRole as String else {
+                return nil
+            }
+            guard let text = AXHelper.stringValue(for: kAXValueAttribute as CFString, on: element),
+                !text.isEmpty,
+                let frame = AXHelper.rectValue(for: "AXFrame" as CFString, on: element),
+                !frame.isEmpty else {
+                continue
+            }
+            runs.append((text, frame))
         }
 
         return runs.sorted { lhs, rhs in
@@ -385,6 +453,11 @@ struct AXTextGeometryResolver {
             }
             return lhsFrame.minX < rhsFrame.minX
         }
+    }
+
+    /// One-shot run collection for callers that don't cache (e.g. line-height estimation).
+    private func collectStaticTextRuns(from root: AXUIElement) -> [(text: String, frame: CGRect)] {
+        textRuns(fromElements: collectStaticTextElements(from: root)) ?? []
     }
 
     /// Confirms a BoundsForRange result actually belongs to the focused field's neighborhood.

--- a/Cotabby/Services/Focus/CaretGeometrySourceCache.swift
+++ b/Cotabby/Services/Focus/CaretGeometrySourceCache.swift
@@ -1,0 +1,51 @@
+import ApplicationServices
+import Foundation
+
+/// File overview:
+/// Remembers the AX leaf elements that produced caret geometry for the currently focused field so
+/// the resolver can re-read them directly instead of re-discovering them with a fresh tree walk on
+/// every keystroke.
+///
+/// Why this exists: in Chromium editors the caret rect comes from per-line `AXStaticText` leaves,
+/// and finding them means a bounded-but-real BFS (`collectStaticTextRuns`) on each focus poll. The
+/// leaf *elements* are stable across keystrokes within a field even though their text and frames
+/// change, so caching the element references turns the per-keystroke crawl into a handful of
+/// attribute reads. The cache is intentionally a reference type: the resolvers are value-type
+/// structs, so their own state cannot survive across calls.
+///
+/// Correctness contract: the cache is keyed by `(container identity, focusChangeSequence)`. The
+/// sequence is the authoritative field-switch signal (`elementIdentifier` alone is `CFHash`-based
+/// and can collide across recycled nodes), so a key match guarantees "same field, same focus." Even
+/// on a match, callers must re-validate the cached elements before trusting them — a stale element
+/// read simply misses and forces a re-walk.
+@MainActor
+final class CaretGeometrySourceCache {
+    struct FieldKey: Equatable {
+        let containerIdentifier: String
+        let focusChangeSequence: UInt64
+    }
+
+    private var key: FieldKey?
+    private var textRunElements: [AXUIElement]?
+
+    /// Returns the cached ordered text-run leaves for `key`, or nil when the focused field changed
+    /// (key mismatch) or nothing has been cached yet.
+    func textRunElements(for key: FieldKey) -> [AXUIElement]? {
+        guard self.key == key else {
+            return nil
+        }
+        return textRunElements
+    }
+
+    /// Replaces the cached leaves for `key`. Storing under a new key implicitly drops the previous
+    /// field's entry, so the cache never holds more than one field at a time.
+    func store(textRunElements elements: [AXUIElement], for key: FieldKey) {
+        self.key = key
+        self.textRunElements = elements
+    }
+
+    func invalidate() {
+        key = nil
+        textRunElements = nil
+    }
+}

--- a/Cotabby/Services/Focus/CaretGeometrySourceCache.swift
+++ b/Cotabby/Services/Focus/CaretGeometrySourceCache.swift
@@ -25,13 +25,16 @@ final class CaretGeometrySourceCache {
         let focusChangeSequence: UInt64
     }
 
-    private var key: FieldKey?
+    private var runKey: FieldKey?
     private var textRunElements: [AXUIElement]?
+
+    private var deepKey: FieldKey?
+    private var deepSourceElement: AXUIElement?
 
     /// Returns the cached ordered text-run leaves for `key`, or nil when the focused field changed
     /// (key mismatch) or nothing has been cached yet.
     func textRunElements(for key: FieldKey) -> [AXUIElement]? {
-        guard self.key == key else {
+        guard runKey == key else {
             return nil
         }
         return textRunElements
@@ -40,12 +43,29 @@ final class CaretGeometrySourceCache {
     /// Replaces the cached leaves for `key`. Storing under a new key implicitly drops the previous
     /// field's entry, so the cache never holds more than one field at a time.
     func store(textRunElements elements: [AXUIElement], for key: FieldKey) {
-        self.key = key
-        self.textRunElements = elements
+        runKey = key
+        textRunElements = elements
+    }
+
+    /// Returns the cached deep geometry source leaf — the element whose zero-length selection range
+    /// produced the caret rect last time — so the resolver can read it directly instead of BFS-ing
+    /// the subtree again. Nil on field change or cold cache.
+    func deepSource(for key: FieldKey) -> AXUIElement? {
+        guard deepKey == key else {
+            return nil
+        }
+        return deepSourceElement
+    }
+
+    func store(deepSource element: AXUIElement, for key: FieldKey) {
+        deepKey = key
+        deepSourceElement = element
     }
 
     func invalidate() {
-        key = nil
+        runKey = nil
         textRunElements = nil
+        deepKey = nil
+        deepSourceElement = nil
     }
 }

--- a/Cotabby/Services/Focus/FocusSnapshotResolver.swift
+++ b/Cotabby/Services/Focus/FocusSnapshotResolver.swift
@@ -16,8 +16,11 @@ struct FocusSnapshotResolver {
     private static let dumpAXTree = false
     private static var lastDumpedElementID: String?
 
-    init(geometryResolver: AXTextGeometryResolver? = nil) {
-        self.geometryResolver = geometryResolver ?? AXTextGeometryResolver()
+    init(
+        geometryResolver: AXTextGeometryResolver? = nil,
+        caretGeometryCache: CaretGeometrySourceCache? = nil
+    ) {
+        self.geometryResolver = geometryResolver ?? AXTextGeometryResolver(cache: caretGeometryCache)
     }
 
     /// Resolves the best editable candidate around the focused AX node and materializes a focus snapshot.
@@ -47,7 +50,11 @@ struct FocusSnapshotResolver {
         }
 
         let candidates = candidateElements(around: focusedElement).map {
-            candidateSnapshot(for: $0, bundleIdentifier: bundleIdentifier)
+            candidateSnapshot(
+                for: $0,
+                bundleIdentifier: bundleIdentifier,
+                focusChangeSequence: focusChangeSequence
+            )
         }
         let resolution = FocusCapabilityResolver.resolve(
             candidates: candidates.map(\.resolverCandidate))
@@ -131,7 +138,8 @@ struct FocusSnapshotResolver {
             : resolveDeepGeometrySource(
                 focusedElement: focusedElement,
                 resolvedElement: resolvedCandidate.element,
-                cocoaAnchorFrame: resolvedCandidate.inputFrameRect
+                cocoaAnchorFrame: resolvedCandidate.inputFrameRect,
+                focusChangeSequence: focusChangeSequence
             )
 
         guard let caret = Self.selectCaretGeometry(
@@ -474,11 +482,13 @@ struct FocusSnapshotResolver {
     private func resolveDeepGeometrySource(
         focusedElement: AXUIElement,
         resolvedElement: AXUIElement,
-        cocoaAnchorFrame: CGRect?
+        cocoaAnchorFrame: CGRect?,
+        focusChangeSequence: UInt64
     ) -> CaretGeometryResult? {
         if let result = findDeepGeometrySource(
             from: resolvedElement,
-            cocoaAnchorFrame: cocoaAnchorFrame
+            cocoaAnchorFrame: cocoaAnchorFrame,
+            focusChangeSequence: focusChangeSequence
         ) {
             return result
         }
@@ -492,7 +502,8 @@ struct FocusSnapshotResolver {
 
         return findDeepGeometrySource(
             from: focusedElement,
-            cocoaAnchorFrame: cocoaAnchorFrame
+            cocoaAnchorFrame: cocoaAnchorFrame,
+            focusChangeSequence: focusChangeSequence
         )
     }
 
@@ -503,7 +514,8 @@ struct FocusSnapshotResolver {
     /// We only read position from these nodes; the input target (where we type) stays unchanged.
     private func findDeepGeometrySource(
         from root: AXUIElement,
-        cocoaAnchorFrame: CGRect?
+        cocoaAnchorFrame: CGRect?,
+        focusChangeSequence: UInt64
     ) -> CaretGeometryResult? {
         var queue: [(element: AXUIElement, depth: Int)] = [(root, 0)]
         let maxDepth = 10
@@ -538,7 +550,8 @@ struct FocusSnapshotResolver {
                     ),
                     supportsFrame: attrs.contains("AXFrame"),
                     cocoaAnchorFrame: cocoaAnchorFrame,
-                    textValue: textValue
+                    textValue: textValue,
+                    focusChangeSequence: focusChangeSequence
                 )
 
                 if let result, result.quality == .exact || result.quality == .derived {
@@ -595,8 +608,11 @@ struct FocusSnapshotResolver {
     }
 
     /// Extracts the AX properties Cotabby needs from one candidate element near the current focus.
-    private func candidateSnapshot(for element: AXUIElement, bundleIdentifier: String)
-        -> AXFocusCandidate {
+    private func candidateSnapshot(
+        for element: AXUIElement,
+        bundleIdentifier: String,
+        focusChangeSequence: UInt64
+    ) -> AXFocusCandidate {
         let role = AXHelper.stringValue(for: kAXRoleAttribute as CFString, on: element) ?? "Unknown"
         let subrole = AXHelper.stringValue(for: kAXSubroleAttribute as CFString, on: element)
         let supportedAttributes = Set(AXHelper.attributeNames(on: element))
@@ -654,7 +670,8 @@ struct FocusSnapshotResolver {
                     kAXBoundsForRangeParameterizedAttribute as String),
                 supportsFrame: supportedAttributes.contains("AXFrame"),
                 cocoaAnchorFrame: inputFrameRect,
-                textValue: textValue
+                textValue: textValue,
+                focusChangeSequence: focusChangeSequence
             )
         }
         let caretRect = caretResult?.rect

--- a/Cotabby/Services/Focus/FocusSnapshotResolver.swift
+++ b/Cotabby/Services/Focus/FocusSnapshotResolver.swift
@@ -23,8 +23,12 @@ struct FocusSnapshotResolver {
         geometryResolver: AXTextGeometryResolver? = nil,
         caretGeometryCache: CaretGeometrySourceCache? = nil
     ) {
-        self.geometryResolver = geometryResolver ?? AXTextGeometryResolver(cache: caretGeometryCache)
-        self.caretGeometryCache = caretGeometryCache
+        let resolver = geometryResolver ?? AXTextGeometryResolver(cache: caretGeometryCache)
+        self.geometryResolver = resolver
+        // Adopt the resolver's own cache so the deep-walk fast path (this type) and the run-walk fast
+        // path (inside the resolver) always key off one memo. When a caller injects a custom resolver,
+        // its cache wins; the `caretGeometryCache` argument only seeds the default resolver.
+        self.caretGeometryCache = resolver.cache
     }
 
     /// Resolves the best editable candidate around the focused AX node and materializes a focus snapshot.
@@ -119,6 +123,18 @@ struct FocusSnapshotResolver {
                 capability: .unsupported("Selection range exceeds the current field value."),
                 context: nil,
                 inspection: inspection
+            )
+        }
+
+        // Populate the focused field's text-run cache once, for the resolved winner. The candidate
+        // probe above resolves caret geometry with the run cache read-only so a non-winning candidate
+        // can't evict the focused field's leaves on the same poll. `observedCharWidth` is non-nil only
+        // when the winner's caret came from the child-text-run path, so native / BoundsForRange fields
+        // that never use the run cache skip the walk entirely.
+        if resolvedCandidate.observedCharWidth != nil {
+            geometryResolver.cacheTextRunSources(
+                for: resolvedCandidate.element,
+                focusChangeSequence: focusChangeSequence
             )
         }
 

--- a/Cotabby/Services/Focus/FocusSnapshotResolver.swift
+++ b/Cotabby/Services/Focus/FocusSnapshotResolver.swift
@@ -10,6 +10,9 @@ import Logging
 @MainActor
 struct FocusSnapshotResolver {
     private let geometryResolver: AXTextGeometryResolver
+    /// Shared with `geometryResolver` so the deep-walk fast path and the run-walk fast path key off
+    /// the same per-field memo. Nil disables caching (tests, callers that inject a bare resolver).
+    private let caretGeometryCache: CaretGeometrySourceCache?
 
     // MARK: - Debug AX tree dump (temporary — remove after caret placement is fixed)
     /// Set to true to print the AX tree every time focus changes. Check Xcode console.
@@ -21,6 +24,7 @@ struct FocusSnapshotResolver {
         caretGeometryCache: CaretGeometrySourceCache? = nil
     ) {
         self.geometryResolver = geometryResolver ?? AXTextGeometryResolver(cache: caretGeometryCache)
+        self.caretGeometryCache = caretGeometryCache
     }
 
     /// Resolves the best editable candidate around the focused AX node and materializes a focus snapshot.
@@ -517,12 +521,28 @@ struct FocusSnapshotResolver {
         cocoaAnchorFrame: CGRect?,
         focusChangeSequence: UInt64
     ) -> CaretGeometryResult? {
+        let fieldKey = CaretGeometrySourceCache.FieldKey(
+            containerIdentifier: AXHelper.elementIdentity(for: root),
+            focusChangeSequence: focusChangeSequence
+        )
+
+        // Fast path: the leaf that held the caret last keystroke almost always still does, so try it
+        // directly before BFS-ing the subtree. A line change moves the active zero-length selection
+        // to a different leaf, so the cached one yields nil here and we fall through to a re-walk.
+        if let cache = caretGeometryCache,
+            let cached = cache.deepSource(for: fieldKey),
+            let result = caretGeometry(
+                at: cached, cocoaAnchorFrame: cocoaAnchorFrame, focusChangeSequence: focusChangeSequence
+            ) {
+            return result
+        }
+
         var queue: [(element: AXUIElement, depth: Int)] = [(root, 0)]
         let maxDepth = 10
         let maxNodes = 200
         var visited = 0
         var seen = Set<String>()
-        var bestResult: (result: CaretGeometryResult, depth: Int)?
+        var best: DeepGeometryCandidate?
 
         while !queue.isEmpty, visited < maxNodes {
             let (element, depth) = queue.removeFirst()
@@ -531,38 +551,10 @@ struct FocusSnapshotResolver {
             guard seen.insert(identity).inserted else { continue }
             visited += 1
 
-            // Look for any node with an active caret (zero-length selection).
-            // Don't filter by role — Chrome uses AXStaticText for editable text runs.
-            if let range = AXHelper.rangeValue(
-                for: kAXSelectedTextRangeAttribute as CFString, on: element
-            ), range.length == 0 {
-                let paramAttrs = Set(AXHelper.parameterizedAttributeNames(on: element))
-                let attrs = Set(AXHelper.attributeNames(on: element))
-                let textValue =
-                    attrs.contains(kAXValueAttribute as String)
-                    ? AXHelper.stringValue(for: kAXValueAttribute as CFString, on: element)
-                    : nil
-                let result = geometryResolver.resolveCaretRect(
-                    for: element,
-                    selection: range,
-                    supportsBoundsForRange: paramAttrs.contains(
-                        kAXBoundsForRangeParameterizedAttribute as String
-                    ),
-                    supportsFrame: attrs.contains("AXFrame"),
-                    cocoaAnchorFrame: cocoaAnchorFrame,
-                    textValue: textValue,
-                    focusChangeSequence: focusChangeSequence
-                )
-
-                if let result, result.quality == .exact || result.quality == .derived {
-                    if shouldPreferDeepResult(
-                        result,
-                        at: depth,
-                        over: bestResult
-                    ) {
-                        bestResult = (result, depth)
-                    }
-                }
+            if let result = caretGeometry(
+                at: element, cocoaAnchorFrame: cocoaAnchorFrame, focusChangeSequence: focusChangeSequence
+            ), shouldPreferDeepResult(result, at: depth, over: best.map { ($0.result, $0.depth) }) {
+                best = DeepGeometryCandidate(result: result, depth: depth, element: element)
             }
 
             guard depth < maxDepth else { continue }
@@ -571,7 +563,57 @@ struct FocusSnapshotResolver {
             }
         }
 
-        return bestResult?.result
+        if let cache = caretGeometryCache, let best {
+            cache.store(deepSource: best.element, for: fieldKey)
+        }
+        return best?.result
+    }
+
+    /// The winning deep-walk leaf plus the metadata `shouldPreferDeepResult` ranks it by, and the
+    /// element reference so the result can be cached as the field's deep geometry source.
+    private struct DeepGeometryCandidate {
+        let result: CaretGeometryResult
+        let depth: Int
+        let element: AXUIElement
+    }
+
+    /// Resolves caret geometry from a single candidate leaf, returning a result only when the leaf
+    /// holds an active caret (zero-length selection) and produces exact/derived geometry. Shared by
+    /// the deep-walk BFS and its cached fast path so both apply identical acceptance rules.
+    /// Don't filter by role — Chrome exposes editable text runs as `AXStaticText`.
+    private func caretGeometry(
+        at element: AXUIElement,
+        cocoaAnchorFrame: CGRect?,
+        focusChangeSequence: UInt64
+    ) -> CaretGeometryResult? {
+        guard let range = AXHelper.rangeValue(
+            for: kAXSelectedTextRangeAttribute as CFString, on: element
+        ), range.length == 0 else {
+            return nil
+        }
+
+        let paramAttrs = Set(AXHelper.parameterizedAttributeNames(on: element))
+        let attrs = Set(AXHelper.attributeNames(on: element))
+        let textValue =
+            attrs.contains(kAXValueAttribute as String)
+            ? AXHelper.stringValue(for: kAXValueAttribute as CFString, on: element)
+            : nil
+        let result = geometryResolver.resolveCaretRect(
+            for: element,
+            selection: range,
+            supportsBoundsForRange: paramAttrs.contains(
+                kAXBoundsForRangeParameterizedAttribute as String
+            ),
+            supportsFrame: attrs.contains("AXFrame"),
+            cocoaAnchorFrame: cocoaAnchorFrame,
+            textValue: textValue,
+            focusChangeSequence: focusChangeSequence
+        )
+
+        guard let result, result.quality == .exact || result.quality == .derived else {
+            return nil
+        }
+        return result
     }
 
     /// Prefers exact marker/range geometry before depth. Browser AX wrappers can expose

--- a/Cotabby/Services/Focus/FocusTracker.swift
+++ b/Cotabby/Services/Focus/FocusTracker.swift
@@ -42,7 +42,11 @@ final class FocusTracker {
         self.ignoredBundleIdentifier = ignoredBundleIdentifier
         // Default resolver construction must happen inside the actor-isolated initializer body.
         // Swift evaluates default parameter expressions before entering the `@MainActor` context.
-        self.snapshotResolver = snapshotResolver ?? FocusSnapshotResolver()
+        // The caret-geometry cache is owned here so its lifetime matches the tracker's; it memoizes
+        // the focused field's text-run leaves so per-keystroke caret resolution can re-read them
+        // instead of re-walking the AX tree.
+        self.snapshotResolver = snapshotResolver
+            ?? FocusSnapshotResolver(caretGeometryCache: CaretGeometrySourceCache())
     }
 
     /// Starts periodic AX polling and immediately captures an initial snapshot.

--- a/CotabbyTests/CaretGeometrySourceCacheTests.swift
+++ b/CotabbyTests/CaretGeometrySourceCacheTests.swift
@@ -43,6 +43,15 @@ final class CaretGeometrySourceCacheTests: XCTestCase {
         XCTAssertEqual(cache.textRunElements(for: key("b", 1))?.count, 1)
     }
 
+    func testStoringDeepSourceNewKeyEvictsPrevious() {
+        let cache = CaretGeometrySourceCache()
+        cache.store(deepSource: element, for: key("a", 1))
+        cache.store(deepSource: element, for: key("b", 1))
+        // The deep-source slot shares the run slot's one-entry contract: a new key drops the old one.
+        XCTAssertNil(cache.deepSource(for: key("a", 1)))
+        XCTAssertNotNil(cache.deepSource(for: key("b", 1)))
+    }
+
     func testRunAndDeepEntriesAreIndependent() {
         let cache = CaretGeometrySourceCache()
         cache.store(textRunElements: [element], for: key("field", 1))

--- a/CotabbyTests/CaretGeometrySourceCacheTests.swift
+++ b/CotabbyTests/CaretGeometrySourceCacheTests.swift
@@ -1,0 +1,67 @@
+import ApplicationServices
+import XCTest
+@testable import Cotabby
+
+/// Tests for `CaretGeometrySourceCache` key matching and invalidation.
+///
+/// The cache stores live `AXUIElement` references, so these tests use a real system-wide element as
+/// an opaque stand-in — the behavior under test is the per-field keying and eviction, not the AX
+/// content of the elements themselves.
+@MainActor
+final class CaretGeometrySourceCacheTests: XCTestCase {
+    private let element = AXUIElementCreateSystemWide()
+
+    private func key(_ identifier: String, _ sequence: UInt64) -> CaretGeometrySourceCache.FieldKey {
+        CaretGeometrySourceCache.FieldKey(containerIdentifier: identifier, focusChangeSequence: sequence)
+    }
+
+    func testColdCacheReturnsNil() {
+        let cache = CaretGeometrySourceCache()
+        XCTAssertNil(cache.textRunElements(for: key("field", 1)))
+        XCTAssertNil(cache.deepSource(for: key("field", 1)))
+    }
+
+    func testRunElementsHitOnMatchingKey() {
+        let cache = CaretGeometrySourceCache()
+        cache.store(textRunElements: [element], for: key("field", 1))
+        XCTAssertEqual(cache.textRunElements(for: key("field", 1))?.count, 1)
+    }
+
+    func testRunElementsMissOnDifferentSequence() {
+        let cache = CaretGeometrySourceCache()
+        cache.store(textRunElements: [element], for: key("field", 1))
+        // A focus change bumps the sequence, which must invalidate the previous field's entry even
+        // though the container identifier (a CFHash) could collide across recycled nodes.
+        XCTAssertNil(cache.textRunElements(for: key("field", 2)))
+    }
+
+    func testStoringNewKeyEvictsPrevious() {
+        let cache = CaretGeometrySourceCache()
+        cache.store(textRunElements: [element], for: key("a", 1))
+        cache.store(textRunElements: [element], for: key("b", 1))
+        XCTAssertNil(cache.textRunElements(for: key("a", 1)))
+        XCTAssertEqual(cache.textRunElements(for: key("b", 1))?.count, 1)
+    }
+
+    func testRunAndDeepEntriesAreIndependent() {
+        let cache = CaretGeometrySourceCache()
+        cache.store(textRunElements: [element], for: key("field", 1))
+        // Caching runs must not imply a deep-source entry, and vice versa.
+        XCTAssertNil(cache.deepSource(for: key("field", 1)))
+
+        cache.store(deepSource: element, for: key("field", 1))
+        XCTAssertNotNil(cache.deepSource(for: key("field", 1)))
+        XCTAssertEqual(cache.textRunElements(for: key("field", 1))?.count, 1)
+    }
+
+    func testInvalidateClearsBoth() {
+        let cache = CaretGeometrySourceCache()
+        cache.store(textRunElements: [element], for: key("field", 1))
+        cache.store(deepSource: element, for: key("field", 1))
+
+        cache.invalidate()
+
+        XCTAssertNil(cache.textRunElements(for: key("field", 1)))
+        XCTAssertNil(cache.deepSource(for: key("field", 1)))
+    }
+}


### PR DESCRIPTION
## Summary

In Chromium editors the caret rect is derived from per-line `AXStaticText` leaves located by bounded tree walks (`collectStaticTextElements` ≤300 nodes, `findDeepGeometrySource` ≤200 nodes) run on every focus poll — the heavy part of the per-keystroke resolve. The leaf *elements* are stable across keystrokes even as their text/frames change, so this caches them and re-reads directly next time, keyed by `(container identity, focusChangeSequence)`. Stacked on #265.

- **Run-leaf cache**: caches the ordered text-run leaves of the focused field; re-reads + re-maps the caret offset on the next resolve. Caching all line leaves keeps line changes free (the offset maps to a different cached run). Stale leaf or offset overshoot falls back to a fresh walk.
- **Deep-source cache**: caches the leaf whose zero-length selection produced the caret rect; tries it directly before the BFS. A line change moves the active selection, so the cached leaf fails the zero-length check and we re-walk + re-cache.

This is **placement-neutral**: it re-serves the same runs through the same mapping, just memoized — it changes performance, not where the caret lands.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build-for-testing
# ** TEST BUILD SUCCEEDED **
swiftlint lint --quiet   # clean for changed files
```

Added `CaretGeometrySourceCacheTests` (key hit/miss, sequence-bump eviction, run/deep independence, invalidate). Local test *execution* is blocked by a Team ID / signing mismatch (environment, not code) — CI runs them. Per-keystroke smoothness verified by live typing in Chrome/Gmail.

## Linked issues

Refs #265 (stacked on its branch).

## Risk / rollout notes

- Cache is a `@MainActor` class owned by `FocusTracker`, shared into the resolvers (which are value-type structs and can't hold surviving state). Holds at most one field's entry.
- Correctness rests on `focusChangeSequence` incrementing on every real field switch — true today; the key combines it with container identity precisely because `elementIdentifier` is `CFHash`-based and can collide across recycled nodes.
- No behavior change when the cache misses: it falls back to the existing walk, so worst case is the pre-PR cost, never a wrong caret.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `CaretGeometrySourceCache` to memoize the `AXStaticText` leaf elements used for caret geometry in Chromium editors, replacing per-keystroke bounded AX tree walks with a handful of attribute reads on cached element references. The cache is keyed by `(containerIdentifier, focusChangeSequence)` and holds at most one field entry, with separate slots for the run-walk and deep-walk paths.

- **Run-leaf cache**: `resolveCaretFromChildTextRuns` tries cached elements first; the winner's elements are stored by `cacheTextRunSources` after candidate selection to prevent non-winning candidates from evicting the focused field's entry mid-poll.
- **Deep-source cache**: `findDeepGeometrySource` tries the previously winning leaf directly before BFS; on a line change the zero-length selection check fails and the BFS re-runs with the new winner cached.
- **`cacheTextRunSources` stale-entry gap**: the \"skip if non-nil\" guard that prevents candidate-eviction also blocks recovery when `textRuns(fromElements:)` detects a recycled AX node (role changed), permanently defeating the optimization for that focus session.

<h3>Confidence Score: 4/5</h3>

Safe to merge if the stale run-cache recovery gap is acceptable as a deferred fix; caret placement is never wrong, only the performance optimization is permanently bypassed for recycled AX nodes.

The caching logic has one gap: once `textRuns(fromElements:)` detects a recycled AX node, the skip-if-non-nil guard in `cacheTextRunSources` treats the stale entry as warm and skips the re-walk indefinitely. The PR's own contract says stale leaf falls back to a fresh walk, but that fresh walk's result is never re-cached, so every subsequent keystroke in that session pays the full walk cost without recovery. Correctness is unaffected — the caret lands in the right place — but the optimization is silently defeated for the remainder of the focus session when this case occurs.

AXTextGeometryResolver.swift — specifically the interaction between resolveCaretFromChildTextRuns (staleness detection) and cacheTextRunSources (the skip-if-non-nil guard that prevents re-caching after a stale miss).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Services/Focus/CaretGeometrySourceCache.swift | New single-entry cache keyed by (containerIdentifier, focusChangeSequence), with independent run and deep-source slots; invalidate() is defined but not called from production code. |
| Cotabby/Services/Focus/AXTextGeometryResolver.swift | Refactored to separate element collection from run reading; adds run-cache fast path — but cacheTextRunSources' skip-if-non-nil guard permanently blocks cache refresh once a stale entry is detected, and the cold-cache path pays two full AX walks per poll. |
| Cotabby/Services/Focus/FocusSnapshotResolver.swift | Passes focusChangeSequence through candidate probes and caches the winner's run elements only after selection; deep-walk fast path correctly uses the shared cache; DeepGeometryCandidate struct cleanly captures element reference for post-walk caching. |
| Cotabby/Services/Focus/FocusTracker.swift | Minimal change: creates CaretGeometrySourceCache() and passes it to FocusSnapshotResolver so the cache lifetime matches the tracker. |
| CotabbyTests/CaretGeometrySourceCacheTests.swift | 6 focused unit tests cover cold cache, hit/miss on matching/different sequences, single-entry eviction for both slots, slot independence, and invalidate. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant FT as FocusTracker
    participant FSR as FocusSnapshotResolver
    participant ATGR as AXTextGeometryResolver
    participant Cache as CaretGeometrySourceCache

    FT->>FSR: resolve(focusedElement, focusChangeSequence)
    FSR->>FSR: candidateSnapshot(element, focusChangeSequence)
    FSR->>ATGR: resolveCaretRect(..., focusChangeSequence)

    alt Run-cache fast path (warm)
        ATGR->>Cache: textRunElements(for: fieldKey)
        Cache-->>ATGR: [cachedElements]
        ATGR->>ATGR: textRuns(fromElements:) → runs
        ATGR-->>FSR: CaretGeometryResult
    else Run-cache miss or cold
        ATGR->>Cache: textRunElements(for: fieldKey)
        Cache-->>ATGR: nil
        ATGR->>ATGR: collectStaticTextElements() [AX walk 1]
        ATGR-->>FSR: CaretGeometryResult
    end

    FSR->>FSR: select winning candidate
    FSR->>ATGR: cacheTextRunSources(winner, focusChangeSequence)
    ATGR->>Cache: "textRunElements(for: fieldKey) == nil?"
    alt Cache cold
        Cache-->>ATGR: nil
        ATGR->>ATGR: collectStaticTextElements() [AX walk 2]
        ATGR->>Cache: store(textRunElements:, for:)
    else Cache warm or stale
        Cache-->>ATGR: non-nil
        Note over ATGR,Cache: stale entry also non-nil → skips re-walk
    end

    FSR->>FSR: resolveDeepGeometrySource(..., focusChangeSequence)
    alt Deep-source fast path
        FSR->>Cache: deepSource(for: fieldKey)
        Cache-->>FSR: cachedLeaf
        FSR-->>FT: FocusSnapshot
    else BFS walk
        FSR->>FSR: BFS ≤200 nodes
        FSR->>Cache: store(deepSource: winner, for: fieldKey)
        FSR-->>FT: FocusSnapshot
    end
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22perf%2Fcaret-geometry-cache%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22perf%2Fcaret-geometry-cache%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FServices%2FFocus%2FAXTextGeometryResolver.swift%3A340-350%0A**Stale%20run-cache%20entry%20is%20never%20refreshed%20after%20role-change%20detection**%0A%0A%60cacheTextRunSources%60%20guards%20with%20%60cache.textRunElements%28for%3A%20fieldKey%29%20%3D%3D%20nil%60%20before%20walking.%20When%20%60textRuns%28fromElements%3A%20cachedElements%29%60%20detects%20a%20stale%20element%20%28role%20changed%20from%20%60kAXStaticTextRole%60%29%20it%20returns%20%60nil%60%2C%20the%20fast%20path%20misses%2C%20and%20the%20slow%20path%20succeeds%20%E2%80%94%20but%20%60cacheTextRunSources%60%20then%20finds%20the%20old%20entry%20is%20non-nil%20and%20returns%20early%20without%20updating.%20The%20cache%20is%20permanently%20stuck%20with%20stale%20elements%20for%20the%20remainder%20of%20that%20%60%28identity%2C%20sequence%29%60%20key's%20lifetime.%20Every%20subsequent%20keystroke%20repeats%3A%20fast%20path%20detects%20staleness%20%E2%86%92%20slow%20path%20walks%20%E2%86%92%20%60cacheTextRunSources%60%20skips%20%E2%86%92%20no%20recovery.%20The%20fix%20is%20to%20drop%20the%20stale%20entry%20in%20%60resolveCaretFromChildTextRuns%60%20before%20falling%20through%2C%20so%20%60cacheTextRunSources%60%20sees%20a%20nil%20entry%20and%20re-populates%20it.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FServices%2FFocus%2FAXTextGeometryResolver.swift%3A331-349%0A**Double%20AX%20tree%20walk%20on%20first%20contact%20per%20field**%0A%0AOn%20the%20cold-cache%20path%2C%20%60resolveCaretFromChildTextRuns%60%20calls%20%60collectStaticTextElements%60%20%28walk%201%29%20and%20returns%20the%20caret%20result.%20Then%20%60cacheTextRunSources%60%20is%20called%20for%20the%20winner%2C%20finds%20the%20cache%20cold%2C%20and%20calls%20%60collectStaticTextElements%60%20again%20%28walk%202%29%20for%20the%20same%20element%20in%20the%20same%20poll.%20This%20doubles%20the%20AX%20walk%20cost%20on%20the%20first%20keystroke%20per%20field.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FServices%2FFocus%2FAXTextGeometryResolver.swift%3A340-350%0A**Stale%20run-cache%20entry%20is%20never%20refreshed%20after%20role-change%20detection**%0A%0A%60cacheTextRunSources%60%20guards%20with%20%60cache.textRunElements%28for%3A%20fieldKey%29%20%3D%3D%20nil%60%20before%20walking.%20When%20%60textRuns%28fromElements%3A%20cachedElements%29%60%20detects%20a%20stale%20element%20%28role%20changed%20from%20%60kAXStaticTextRole%60%29%20it%20returns%20%60nil%60%2C%20the%20fast%20path%20misses%2C%20and%20the%20slow%20path%20succeeds%20%E2%80%94%20but%20%60cacheTextRunSources%60%20then%20finds%20the%20old%20entry%20is%20non-nil%20and%20returns%20early%20without%20updating.%20The%20cache%20is%20permanently%20stuck%20with%20stale%20elements%20for%20the%20remainder%20of%20that%20%60%28identity%2C%20sequence%29%60%20key's%20lifetime.%20Every%20subsequent%20keystroke%20repeats%3A%20fast%20path%20detects%20staleness%20%E2%86%92%20slow%20path%20walks%20%E2%86%92%20%60cacheTextRunSources%60%20skips%20%E2%86%92%20no%20recovery.%20The%20fix%20is%20to%20drop%20the%20stale%20entry%20in%20%60resolveCaretFromChildTextRuns%60%20before%20falling%20through%2C%20so%20%60cacheTextRunSources%60%20sees%20a%20nil%20entry%20and%20re-populates%20it.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FServices%2FFocus%2FAXTextGeometryResolver.swift%3A331-349%0A**Double%20AX%20tree%20walk%20on%20first%20contact%20per%20field**%0A%0AOn%20the%20cold-cache%20path%2C%20%60resolveCaretFromChildTextRuns%60%20calls%20%60collectStaticTextElements%60%20%28walk%201%29%20and%20returns%20the%20caret%20result.%20Then%20%60cacheTextRunSources%60%20is%20called%20for%20the%20winner%2C%20finds%20the%20cache%20cold%2C%20and%20calls%20%60collectStaticTextElements%60%20again%20%28walk%202%29%20for%20the%20same%20element%20in%20the%20same%20poll.%20This%20doubles%20the%20AX%20walk%20cost%20on%20the%20first%20keystroke%20per%20field.%0A%0A&repo=fujacob%2Fcotabby&pr=297&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Address Greptile review on caret geometr..."](https://github.com/fujacob/cotabby/commit/c596ba6f5c75cd6770da3a74202f0101ef2cefd9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34104677)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->