### PR TITLE
Lower macOS deployment target from 15.0 to 14.0

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -872,7 +872,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jacobfu.tabby;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -943,7 +943,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1003,7 +1003,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1029,7 +1029,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jacobfu.tabby.CotabbyTests;
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1061,7 +1061,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jacobfu.tabby;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1093,7 +1093,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jacobfu.tabby.CotabbyTests;
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME)";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/project.yml
+++ b/project.yml
@@ -3,7 +3,7 @@ options:
   bundleIdPrefix: com.jacobfu
   defaultConfig: Release
   deploymentTarget:
-    macOS: "15.0"
+    macOS: "14.0"
   developmentLanguage: en
   groupSortPosition: top
   xcodeVersion: "2600"
@@ -61,7 +61,7 @@ settings:
     GCC_WARN_UNUSED_FUNCTION: YES
     GCC_WARN_UNUSED_VARIABLE: YES
     LOCALIZATION_PREFERS_STRING_CATALOGS: YES
-    MACOSX_DEPLOYMENT_TARGET: "15.0"
+    MACOSX_DEPLOYMENT_TARGET: "14.0"
     MTL_FAST_MATH: YES
     SDKROOT: macosx
   configs:
@@ -86,7 +86,7 @@ targets:
   Cotabby:
     type: application
     platform: macOS
-    deploymentTarget: "15.0"
+    deploymentTarget: "14.0"
     sources:
       - path: Cotabby
     dependencies:
@@ -132,7 +132,7 @@ targets:
   CotabbyTests:
     type: bundle.unit-test
     platform: macOS
-    deploymentTarget: "15.0"
+    deploymentTarget: "14.0"
     sources:
       - path: CotabbyTests
     dependencies:
@@ -149,7 +149,7 @@ targets:
           - $(inherited)
           - "@executable_path/../Frameworks"
           - "@loader_path/../Frameworks"
-        MACOSX_DEPLOYMENT_TARGET: "15.0"
+        MACOSX_DEPLOYMENT_TARGET: "14.0"
         PRODUCT_BUNDLE_IDENTIFIER: com.jacobfu.tabby.CotabbyTests
         PRODUCT_MODULE_NAME: $(TARGET_NAME)
         PRODUCT_NAME: $(TARGET_NAME)


### PR DESCRIPTION
## Summary

Lowers the macOS deployment target from **15.0 to 14.0** (in `project.yml`, with the generated
`Cotabby.xcodeproj` regenerated via `xcodegen`). The 15.0 floor wasn't required by anything: the
Apple Intelligence / FoundationModels engine is independently gated behind `@available(macOS 26.0, *)`,
and no other code used a macOS 15-only API. 14.0 widens support by a full OS version at zero cost and
with no feature loss.

## Validation

Verified empirically by overriding the target and letting the compiler flag ungated APIs:

```bash
# As-is at 14.0 — clean, no source changes:
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  MACOSX_DEPLOYMENT_TARGET=14.0 build
# ** BUILD SUCCEEDED **

# After regenerating project.yml -> 14.0 and `xcodegen generate`:
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **
```

For reference, a probe at 13.0 confirmed 14.0 is the genuine floor: it fails on the two-parameter
`onChange(of:initial:_:)` (macOS 14+) and, more fundamentally, on ScreenCaptureKit's
`SCScreenshotManager` (macOS 14+) in `WindowScreenshotService.swift` — so going below 14 would require
real work in the visual-context screenshot path. 14.0 needs none.

## Linked issues

None — direct request after investigating why the floor was 15.0.

## Risk / rollout notes

- Source-only-of-truth is `project.yml`; the committed `Cotabby.xcodeproj/project.pbxproj` is the
  regenerated output (`xcodegen generate`), so the XcodeGen drift check stays green.
- No code changes — purely a build-setting change across both targets (app + tests).
- Lowering a deployment target is backward-compatible: existing macOS 15+ users are unaffected; it
  only adds macOS 14 (Sonoma) eligibility.
- Apple Intelligence remains gated at macOS 26.0 and is unaffected.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR lowers the macOS deployment target from 15.0 to 14.0 across `project.yml` (source of truth) and the regenerated `Cotabby.xcodeproj/project.pbxproj`. No source code changes are needed because every macOS 15-exclusive API is absent from the codebase — the only higher-gated code (`FoundationModels`) is already wrapped in `@available(macOS 26.0, *)`, and the actual floor is set by `SCScreenshotManager` and the two-parameter `onChange(of:)` closure form, both of which arrived in macOS 14.

- `project.yml` has the deployment target updated in three places: the global `options.deploymentTarget`, the top-level `settings.MACOSX_DEPLOYMENT_TARGET`, and the per-target `deploymentTarget` for both the app and test targets — all consistent.
- `Cotabby.xcodeproj/project.pbxproj` has all six `MACOSX_DEPLOYMENT_TARGET` entries (Debug + Release for app and tests) updated to 14.0, matching the regenerated XcodeGen output.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely a build-setting change with no source modifications.

The change is a straightforward deployment-target bump downward. Source code inspection confirms no macOS 15-only APIs are used ungated anywhere; the real API floor is macOS 14 (SCScreenshotManager, two-parameter onChange), and the only higher-versioned code (FoundationModels) is already guarded with @available(macOS 26.0, *). Both the source-of-truth (project.yml) and the generated pbxproj are internally consistent, touching all six required build configuration entries.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| project.yml | Deployment target lowered from 15.0 to 14.0 in global options, global settings, and both targets (Cotabby + CotabbyTests); consistent and correct. |
| Cotabby.xcodeproj/project.pbxproj | Generated file regenerated via xcodegen; all six MACOSX_DEPLOYMENT_TARGET entries updated from 15.0 to 14.0 (Debug + Release for app and test targets), matching project.yml. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[project.yml\ndeploymentTarget: 14.0] -->|xcodegen generate| B[Cotabby.xcodeproj/project.pbxproj]
    B --> C[Cotabby App Target\nMACOSX_DEPLOYMENT_TARGET = 14.0]
    B --> D[CotabbyTests Target\nMACOSX_DEPLOYMENT_TARGET = 14.0]
    C --> E{API Availability Gates}
    D --> E
    E -->|macOS 14+| F[SCScreenshotManager\nWindowScreenshotService.swift]
    E -->|macOS 14+| G[onChange two-param closure\nSwiftUI views]
    E -->|macOS 26.0+ @available guard| H[FoundationModels\nApple Intelligence engine]
```

<sub>Reviews (1): Last reviewed commit: ["Lower macOS deployment target from 15.0 ..."](https://github.com/fujacob/cotabby/commit/0241203994dd5f4312c9f9b0f302518680891855) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34105746)</sub>

<!-- /greptile_comment -->