### PR TITLE
Add menu-bar busy indicator and ghost-text color/opacity controls

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		4B54ACE1255873955414CD06 /* PermissionGuidanceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F2C764D29C8D50D0C854FF8 /* PermissionGuidanceController.swift */; };
 		4CAFD8F3444FEDC9ACAFF529 /* LlamaRuntimeModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A804F4DB6FD9BC8C27B2B65F /* LlamaRuntimeModels.swift */; };
 		4F369F5284DDCEABF082E59B /* SuggestionAvailabilityEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3609CC88A5280B3AA40414DF /* SuggestionAvailabilityEvaluator.swift */; };
+		4FBAB0D00E46C40B40B3C65B /* MenuBarActivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8178B8E7DE4936C6A09066B /* MenuBarActivityTests.swift */; };
 		51C069603DA16830868F1628 /* LanguageTagsEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7CDA90E128350BFF1A9D66 /* LanguageTagsEditor.swift */; };
 		52518CF0760DFEE9AF7C786C /* SuggestionEngineRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384FBCF5D7A3A446C5BE2B8D /* SuggestionEngineRouter.swift */; };
 		53FB56A095BCF0389DAC0A56 /* SuggestionTextColorCodec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CE61E74928C221B8BB261C6 /* SuggestionTextColorCodec.swift */; };
@@ -65,6 +66,7 @@
 		5E10EFC426217CB7218A5847 /* CotabbyTestFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF1E065C7FFB697FCEB2FA5C /* CotabbyTestFixtures.swift */; };
 		5E92E3C1EB41D482FC06BC52 /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA0117B322C625F6D4BBEAB /* MenuBarView.swift */; };
 		5F019E5A0679FFB52F129798 /* InputModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F34AE24BB7C99D66E1F3904 /* InputModels.swift */; };
+		6014B31E2570EFFE45557E33 /* TickMarkSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67586807ACE8EB13C9014535 /* TickMarkSlider.swift */; };
 		61EC9D635D416115E7C96E0F /* PermissionOverlayWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C6EB9FDA48ADF425A116A9 /* PermissionOverlayWindowController.swift */; };
 		644EEF959D07D54CC779BBF6 /* SettingsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3350EDE01ED5125520C79D53 /* SettingsCoordinator.swift */; };
 		65478B0DABF5460C32D4C458 /* ModelFileValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A829F28F01FAE76CA7244BBC /* ModelFileValidatorTests.swift */; };
@@ -77,6 +79,7 @@
 		6E01052209B73D7361C12CEF /* ClipboardContentDistiller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96495E4147D828C0B1B22765 /* ClipboardContentDistiller.swift */; };
 		6E49ADEB31D04DC77A47DEB0 /* FileLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8C2569A8217EE9BD3B197F /* FileLogHandler.swift */; };
 		744B06C2488156B178675615 /* PermissionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85BF316556FDA64CB8AD07B6 /* PermissionManager.swift */; };
+		754311C25953763E2B43298D /* MenuBarActivityModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A267E49747B2EEEFD3D88AB5 /* MenuBarActivityModel.swift */; };
 		7B6A63F5DCC2C163CDFD2A5C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BC4F887528AE74AC0DD30314 /* Assets.xcassets */; };
 		7D6BB9AF72F7076A4E5EE96F /* DownloadableModelCatalogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5C2AE9A7E55495D26AD074 /* DownloadableModelCatalogView.swift */; };
 		7E9413CE7C999C4612348248 /* SuggestionSessionReconcilerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C8F07AC52C7A482F5FE34C5 /* SuggestionSessionReconcilerTests.swift */; };
@@ -138,8 +141,10 @@
 		E9E4CC657771DF9F4C56183C /* VisualContextCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A854CAFB1F557BC4CAED8819 /* VisualContextCoordinator.swift */; };
 		ED9C51B0D7056F0753AADF2D /* GhostSuggestionLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043E8AA850F930222DD112C0 /* GhostSuggestionLayout.swift */; };
 		EDA8E8250FC2F70B206B4894 /* LlamaVisualContextSummarizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D2782B6C7BE3F56BCB22DE /* LlamaVisualContextSummarizer.swift */; };
+		EE0A5A7EBDB3982C8F7F7ECF /* MenuBarActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AE4622EF5D4CD9068482A33 /* MenuBarActivity.swift */; };
 		F08C139B246C1EC7BB435455 /* MenuBarPresentationObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00824BDD8D0E9B3063827C78 /* MenuBarPresentationObserver.swift */; };
 		F0DEEE8A866ABB560E7A7E6A /* LaunchAtLoginService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220CD4AFA1E96A37BC4514AD /* LaunchAtLoginService.swift */; };
+		F4EEE6291095B0BF2D3FBA21 /* GhostTextColorPreset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E44E393DD58B978B1EAB6CF /* GhostTextColorPreset.swift */; };
 		F78F594F77C26C233377E71F /* KeyCodeLabels.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAAE6B395FAB604DF059280A /* KeyCodeLabels.swift */; };
 		F8E86FA4D6CEEBFA7FB55F8D /* KeyRecorderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A567677424A82D9EEF47495 /* KeyRecorderView.swift */; };
 		FAC7FFC78BEBF62D5B7A2EFB /* DownloadOutcomeClassifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E217A66717D78E1E49350EC8 /* DownloadOutcomeClassifierTests.swift */; };
@@ -206,6 +211,7 @@
 		5F34AE24BB7C99D66E1F3904 /* InputModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputModels.swift; sourceTree = "<group>"; };
 		60629DFE309C1A4BD8A7FB3B /* RuntimeBootstrapModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimeBootstrapModel.swift; sourceTree = "<group>"; };
 		656F58E56FE9BC087B6F1D33 /* PermissionReminderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionReminderView.swift; sourceTree = "<group>"; };
+		67586807ACE8EB13C9014535 /* TickMarkSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TickMarkSlider.swift; sourceTree = "<group>"; };
 		6B2D97BAA3618A7D0357AC44 /* SuggestionWorkController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionWorkController.swift; sourceTree = "<group>"; };
 		6C4565D64DF64A2AA0DB1532 /* WelcomeProfileStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeProfileStepView.swift; sourceTree = "<group>"; };
 		70367FCC1E0F08EE3B8EB26F /* FocusCapabilityResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusCapabilityResolver.swift; sourceTree = "<group>"; };
@@ -214,6 +220,8 @@
 		74BD1D4DB27D5D96D1E06096 /* DisplayCoordinateConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayCoordinateConverter.swift; sourceTree = "<group>"; };
 		77B0121E7BB173F8A2B0B108 /* WindowScreenshotService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowScreenshotService.swift; sourceTree = "<group>"; };
 		78E280F4F39A9D86840800D2 /* SuggestionCoordinator+Lifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SuggestionCoordinator+Lifecycle.swift"; sourceTree = "<group>"; };
+		7AE4622EF5D4CD9068482A33 /* MenuBarActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarActivity.swift; sourceTree = "<group>"; };
+		7E44E393DD58B978B1EAB6CF /* GhostTextColorPreset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostTextColorPreset.swift; sourceTree = "<group>"; };
 		7F4C4A7EAF886E0CC945BFEF /* TerminalAppDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAppDetector.swift; sourceTree = "<group>"; };
 		815F2ABAF6AB75DA3AFBBCEF /* WordCountFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordCountFormatter.swift; sourceTree = "<group>"; };
 		82F7F7355967725162DF2D1B /* CustomRulesEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomRulesEditor.swift; sourceTree = "<group>"; };
@@ -236,6 +244,7 @@
 		9D598CC3134879999D567455 /* SuggestionOverlayPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionOverlayPresenter.swift; sourceTree = "<group>"; };
 		9D82FFC568527700EC17C07D /* PermissionModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionModels.swift; sourceTree = "<group>"; };
 		A168A7B6A7AD11559B60C56B /* ApplicationBundleMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationBundleMetadataTests.swift; sourceTree = "<group>"; };
+		A267E49747B2EEEFD3D88AB5 /* MenuBarActivityModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarActivityModel.swift; sourceTree = "<group>"; };
 		A3E8E86A14090BC7BD13BA76 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A52D0B550E00EF173A5D157E /* LlamaRuntimeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LlamaRuntimeManager.swift; sourceTree = "<group>"; };
 		A804F4DB6FD9BC8C27B2B65F /* LlamaRuntimeModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LlamaRuntimeModels.swift; sourceTree = "<group>"; };
@@ -288,6 +297,7 @@
 		EE94342B888A5A2CCF66BC93 /* SuggestionRequestFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionRequestFactoryTests.swift; sourceTree = "<group>"; };
 		EFD89799BB82AF7A92559AEB /* ClipboardContentDistillerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardContentDistillerTests.swift; sourceTree = "<group>"; };
 		F308F6E274CC645E27CB651F /* OverlayController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayController.swift; sourceTree = "<group>"; };
+		F8178B8E7DE4936C6A09066B /* MenuBarActivityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarActivityTests.swift; sourceTree = "<group>"; };
 		FA4B45B91D4DEAC979C3113E /* PromptContextSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptContextSanitizer.swift; sourceTree = "<group>"; };
 		FB317C82CE2CBC69056BA4B8 /* TagChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagChip.swift; sourceTree = "<group>"; };
 		FC24FD54860CE6737E65EF65 /* TextDirectionDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextDirectionDetectorTests.swift; sourceTree = "<group>"; };
@@ -475,6 +485,7 @@
 				B097727248B5B32885D99036 /* IndicatorIconImageProcessorTests.swift */,
 				4793D4EA5D36D7E5CC216C27 /* LanguageSupportTests.swift */,
 				3009812A35A1CDEF16295AB7 /* LlamaPromptRendererTests.swift */,
+				F8178B8E7DE4936C6A09066B /* MenuBarActivityTests.swift */,
 				03766F6253FF17639230C0F6 /* ModelAndPresentationValueTests.swift */,
 				A829F28F01FAE76CA7244BBC /* ModelFileValidatorTests.swift */,
 				E7F42112F14026E6253BB865 /* PermissionAndContextModelTests.swift */,
@@ -500,6 +511,7 @@
 				CBD5FCB8CC56AA6138382B2C /* FieldEdgeIconIndicatorView.swift */,
 				5A567677424A82D9EEF47495 /* KeyRecorderView.swift */,
 				9A7CDA90E128350BFF1A9D66 /* LanguageTagsEditor.swift */,
+				A267E49747B2EEEFD3D88AB5 /* MenuBarActivityModel.swift */,
 				00824BDD8D0E9B3063827C78 /* MenuBarPresentationObserver.swift */,
 				83A810F9D28A18BA6F2066C7 /* MenuBarSections.swift */,
 				BD42C7E2852F59BEF7972663 /* MenuBarStatusLabelView.swift */,
@@ -509,6 +521,7 @@
 				0E0F6AFF229D20B73CF14C6C /* SettingsView.swift */,
 				FB317C82CE2CBC69056BA4B8 /* TagChip.swift */,
 				58C0F017699EE44C81C095CA /* TagsInputView.swift */,
+				67586807ACE8EB13C9014535 /* TickMarkSlider.swift */,
 				D5D6C2318E405AA717D1C256 /* WelcomePermissionStepView.swift */,
 				6C4565D64DF64A2AA0DB1532 /* WelcomeProfileStepView.swift */,
 				264CA64B2AB1611F82E5B760 /* WelcomeView.swift */,
@@ -565,9 +578,11 @@
 				FE7BF162A12703249726F20A /* FoundationModelPromptRenderer.swift */,
 				9458F0820B3161FE9CF1DDAF /* GhostFontSizeStabilizer.swift */,
 				043E8AA850F930222DD112C0 /* GhostSuggestionLayout.swift */,
+				7E44E393DD58B978B1EAB6CF /* GhostTextColorPreset.swift */,
 				EBEDE359CFD99EF906FA50BC /* IndicatorIconImageProcessor.swift */,
 				EAAE6B395FAB604DF059280A /* KeyCodeLabels.swift */,
 				B5679E08C9A09065531C37B5 /* LlamaPromptRenderer.swift */,
+				7AE4622EF5D4CD9068482A33 /* MenuBarActivity.swift */,
 				FA4B45B91D4DEAC979C3113E /* PromptContextSanitizer.swift */,
 				3609CC88A5280B3AA40414DF /* SuggestionAvailabilityEvaluator.swift */,
 				DDE858CB1E687E3CEB8FDD5B /* SuggestionRequestFactory.swift */,
@@ -731,6 +746,7 @@
 				6DD1E22151571E1A22FF22F4 /* FoundationModelSuggestionEngine.swift in Sources */,
 				42D40F37086294D0E58200C5 /* GhostFontSizeStabilizer.swift in Sources */,
 				ED9C51B0D7056F0753AADF2D /* GhostSuggestionLayout.swift in Sources */,
+				F4EEE6291095B0BF2D3FBA21 /* GhostTextColorPreset.swift in Sources */,
 				A9BFE6D43DC53A3819C635B7 /* IndicatorIconImageProcessor.swift in Sources */,
 				5F019E5A0679FFB52F129798 /* InputModels.swift in Sources */,
 				2DF5A3826AAB99C279EBB8DE /* InputMonitor.swift in Sources */,
@@ -746,6 +762,8 @@
 				4CAFD8F3444FEDC9ACAFF529 /* LlamaRuntimeModels.swift in Sources */,
 				2197B68F1E4D0C3497DAC061 /* LlamaSuggestionEngine.swift in Sources */,
 				EDA8E8250FC2F70B206B4894 /* LlamaVisualContextSummarizer.swift in Sources */,
+				EE0A5A7EBDB3982C8F7F7ECF /* MenuBarActivity.swift in Sources */,
+				754311C25953763E2B43298D /* MenuBarActivityModel.swift in Sources */,
 				F08C139B246C1EC7BB435455 /* MenuBarPresentationObserver.swift in Sources */,
 				0333B3CE8F189DD1BEC4AD26 /* MenuBarSections.swift in Sources */,
 				AECC7289DA796B071B4FE3C0 /* MenuBarStatusLabelView.swift in Sources */,
@@ -792,6 +810,7 @@
 				B0828FF0D7EE110C0B23DB94 /* TagsInputView.swift in Sources */,
 				AB9C9C001F97F9D14F8B192A /* TerminalAppDetector.swift in Sources */,
 				96782E57CA26A16409368B69 /* TextDirectionDetector.swift in Sources */,
+				6014B31E2570EFFE45557E33 /* TickMarkSlider.swift in Sources */,
 				E9E4CC657771DF9F4C56183C /* VisualContextCoordinator.swift in Sources */,
 				4190F8A76196B16ED94D0A55 /* VisualContextModels.swift in Sources */,
 				4AC255BE2D0CCC67B8882C7A /* WelcomeCoordinator.swift in Sources */,
@@ -824,6 +843,7 @@
 				9B086C44BEE317231CE2AD45 /* IndicatorIconImageProcessorTests.swift in Sources */,
 				E912D4617AE1376061DF1F00 /* LanguageSupportTests.swift in Sources */,
 				190C571B3CDFE117F4D15484 /* LlamaPromptRendererTests.swift in Sources */,
+				4FBAB0D00E46C40B40B3C65B /* MenuBarActivityTests.swift in Sources */,
 				25D4FC8D191A50F63E6391F9 /* ModelAndPresentationValueTests.swift in Sources */,
 				65478B0DABF5460C32D4C458 /* ModelFileValidatorTests.swift in Sources */,
 				15FA56CEF6FB5FF54C2FBA6F /* PermissionAndContextModelTests.swift in Sources */,

--- a/Cotabby/App/Core/AppDelegate.swift
+++ b/Cotabby/App/Core/AppDelegate.swift
@@ -25,6 +25,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let suggestionSettings: SuggestionSettingsModel
     let foundationModelAvailabilityService: FoundationModelAvailabilityService
     let suggestionCoordinator: SuggestionCoordinator
+    let menuBarActivityModel: MenuBarActivityModel
     let welcomeCoordinator: WelcomeCoordinator
     let settingsCoordinator: SettingsCoordinator
 
@@ -50,6 +51,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         suggestionSettings = environment.suggestionSettings
         foundationModelAvailabilityService = environment.foundationModelAvailabilityService
         suggestionCoordinator = environment.suggestionCoordinator
+        menuBarActivityModel = environment.menuBarActivityModel
         welcomeCoordinator = environment.welcomeCoordinator
         settingsCoordinator = environment.settingsCoordinator
         activationIndicatorController = environment.activationIndicatorController

--- a/Cotabby/App/Core/CotabbyApp.swift
+++ b/Cotabby/App/Core/CotabbyApp.swift
@@ -32,7 +32,7 @@ struct CotabbyApp: App {
                 }
             )
         } label: {
-            MenuBarStatusLabelView(suggestionCoordinator: appDelegate.suggestionCoordinator)
+            MenuBarStatusLabelView(activityModel: appDelegate.menuBarActivityModel)
         }
         .menuBarExtraStyle(.window)
     }

--- a/Cotabby/App/Core/CotabbyAppEnvironment.swift
+++ b/Cotabby/App/Core/CotabbyAppEnvironment.swift
@@ -23,6 +23,7 @@ final class CotabbyAppEnvironment {
     let foundationModelAvailabilityService: FoundationModelAvailabilityService
     let clipboardContextProvider: ClipboardContextProvider
     let suggestionCoordinator: SuggestionCoordinator
+    let menuBarActivityModel: MenuBarActivityModel
     let welcomeCoordinator: WelcomeCoordinator
     let settingsCoordinator: SettingsCoordinator
     let activationIndicatorController: ActivationIndicatorController
@@ -143,6 +144,10 @@ final class CotabbyAppEnvironment {
             workController: workController,
             configuration: configuration
         )
+        let menuBarActivityModel = MenuBarActivityModel(
+            runtimeModel: runtimeModel,
+            suggestionCoordinator: suggestionCoordinator
+        )
 
         self.permissionManager = permissionManager
         self.runtimeModel = runtimeModel
@@ -156,6 +161,7 @@ final class CotabbyAppEnvironment {
         self.foundationModelAvailabilityService = foundationModelAvailabilityService
         self.clipboardContextProvider = clipboardContextProvider
         self.suggestionCoordinator = suggestionCoordinator
+        self.menuBarActivityModel = menuBarActivityModel
         self.welcomeCoordinator = welcomeCoordinator
         self.settingsCoordinator = settingsCoordinator
         self.activationIndicatorController = activationIndicatorController

--- a/Cotabby/Models/SuggestionSettingsModel.swift
+++ b/Cotabby/Models/SuggestionSettingsModel.swift
@@ -23,6 +23,7 @@ final class SuggestionSettingsModel: ObservableObject {
     @Published private(set) var customIndicatorImage: NSImage?
     @Published private(set) var disabledAppRules: [DisabledApplicationRule]
     @Published private(set) var customSuggestionTextColorHex: String?
+    @Published private(set) var ghostTextOpacity: Double
     @Published private(set) var selectedEngine: SuggestionEngineKind
     @Published private(set) var selectedWordCountPreset: SuggestionWordCountPreset
     @Published private(set) var isClipboardContextEnabled: Bool
@@ -47,6 +48,7 @@ final class SuggestionSettingsModel: ObservableObject {
     private static let showAcceptanceHintDefaultsKey = "cotabbyShowAcceptanceHint"
     private static let customIndicatorImageDataDefaultsKey = "cotabbyCustomIndicatorImageData"
     private static let customSuggestionTextColorHexDefaultsKey = "cotabbyCustomSuggestionTextColorHex"
+    private static let ghostTextOpacityDefaultsKey = "cotabbyGhostTextOpacity"
     private static let selectedEngineDefaultsKey = "cotabbySelectedEngine"
     private static let selectedWordCountPresetDefaultsKey = "cotabbySelectedWordCountPreset"
     private static let clipboardContextEnabledDefaultsKey = "cotabbyClipboardContextEnabled"
@@ -76,6 +78,13 @@ final class SuggestionSettingsModel: ObservableObject {
     static let defaultFullAcceptanceKeyCode: CGKeyCode = 50
     static let defaultFullAcceptanceKeyLabel = "`"
 
+    /// Floor kept above zero so ghost text can be faded but never made fully invisible (which would
+    /// look like the suggestion engine is broken). 100% is the out-of-box default.
+    static let minimumGhostTextOpacity: Double = 0.3
+    static let maximumGhostTextOpacity: Double = 1.0
+    static let defaultGhostTextOpacity: Double = 1.0
+    static let ghostTextOpacityStep: Double = 0.1
+
     init(
         configuration: SuggestionConfiguration,
         userDefaults: UserDefaults = .standard
@@ -95,6 +104,11 @@ final class SuggestionSettingsModel: ObservableObject {
         let resolvedCustomSuggestionTextColorHex = Self.normalizedHexString(
             userDefaults.string(forKey: Self.customSuggestionTextColorHexDefaultsKey)
         )
+        let resolvedGhostTextOpacity: Double = if userDefaults.object(forKey: Self.ghostTextOpacityDefaultsKey) == nil {
+            Self.defaultGhostTextOpacity
+        } else {
+            Self.clampedGhostTextOpacity(userDefaults.double(forKey: Self.ghostTextOpacityDefaultsKey))
+        }
         let resolvedEngine = userDefaults
             .string(forKey: Self.selectedEngineDefaultsKey)
             .flatMap(SuggestionEngineKind.init(rawValue:))
@@ -177,6 +191,7 @@ final class SuggestionSettingsModel: ObservableObject {
         showAcceptanceHint = resolvedShowAcceptanceHint
         customIndicatorImage = Self.loadCustomIndicatorImage(from: userDefaults)
         customSuggestionTextColorHex = resolvedCustomSuggestionTextColorHex
+        ghostTextOpacity = resolvedGhostTextOpacity
         selectedEngine = resolvedEngine
         selectedWordCountPreset = resolvedWordCountPreset
         isClipboardContextEnabled = resolvedClipboardContextEnabled
@@ -198,6 +213,7 @@ final class SuggestionSettingsModel: ObservableObject {
         persistShowIndicator(resolvedShowIndicator)
         userDefaults.set(resolvedShowAcceptanceHint, forKey: Self.showAcceptanceHintDefaultsKey)
         persistCustomSuggestionTextColorHex(resolvedCustomSuggestionTextColorHex)
+        userDefaults.set(resolvedGhostTextOpacity, forKey: Self.ghostTextOpacityDefaultsKey)
         persistSelectedEngine(resolvedEngine)
         persistSelectedWordCountPreset(resolvedWordCountPreset)
         persistClipboardContextEnabled(resolvedClipboardContextEnabled)
@@ -476,6 +492,16 @@ final class SuggestionSettingsModel: ObservableObject {
         persistCustomSuggestionTextColorHex(normalizedHex)
     }
 
+    func setGhostTextOpacity(_ opacity: Double) {
+        let clamped = Self.clampedGhostTextOpacity(opacity)
+        guard ghostTextOpacity != clamped else {
+            return
+        }
+
+        ghostTextOpacity = clamped
+        userDefaults.set(clamped, forKey: Self.ghostTextOpacityDefaultsKey)
+    }
+
     func setUserName(_ name: String) {
         guard userName != name else {
             return
@@ -675,6 +701,14 @@ final class SuggestionSettingsModel: ObservableObject {
     ) -> String {
         let trimmed = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? fallbackBundleIdentifier : trimmed
+    }
+
+    private static func clampedGhostTextOpacity(_ value: Double) -> Double {
+        guard value.isFinite else {
+            return defaultGhostTextOpacity
+        }
+
+        return min(maximumGhostTextOpacity, max(minimumGhostTextOpacity, value))
     }
 
     private static func normalizedHexString(_ hex: String?) -> String? {

--- a/Cotabby/Services/UI/OverlayController.swift
+++ b/Cotabby/Services/UI/OverlayController.swift
@@ -92,13 +92,15 @@ final class OverlayController: SuggestionOverlayControlling {
         let customGhostColor = SuggestionTextColorCodec.color(
             fromHex: suggestionSettings.customSuggestionTextColorHex
         )
+        let ghostOpacity = suggestionSettings.ghostTextOpacity
         let contentView: NSHostingView<GhostSuggestionView>
         if let existing = hostingView {
             existing.rootView = GhostSuggestionView(
                 layout: layout,
                 fontSize: fontSize,
                 customColor: customGhostColor,
-                keycapLabel: acceptanceHintLabel
+                keycapLabel: acceptanceHintLabel,
+                opacity: ghostOpacity
             )
             contentView = existing
         } else {
@@ -107,7 +109,8 @@ final class OverlayController: SuggestionOverlayControlling {
                     layout: layout,
                     fontSize: fontSize,
                     customColor: customGhostColor,
-                    keycapLabel: acceptanceHintLabel
+                    keycapLabel: acceptanceHintLabel,
+                    opacity: ghostOpacity
                 )
             )
             hostingView = fresh
@@ -181,14 +184,18 @@ private struct GhostSuggestionView: View {
     /// The accept key to print inside the keycap pill, or `nil` when the hint is suppressed. Pairs
     /// with `layout.lines`, where `showsKeycap` is already false on every line when this is `nil`.
     let keycapLabel: String?
+    /// User-controlled fade for the suggestion text, in [0.3, 1.0]. Applied only to the ghost text,
+    /// not the keycap, so the acceptance hint stays legible at low opacities.
+    let opacity: Double
 
     var ghostColor: Color {
-        customColor
+        let baseColor = customColor
             ?? (
                 colorScheme == .dark
                     ? Color(red: 0.65, green: 0.65, blue: 0.65)
                     : Color(red: 0.45, green: 0.45, blue: 0.45)
             )
+        return baseColor.opacity(opacity)
     }
 
     var body: some View {

--- a/Cotabby/Support/GhostTextColorPreset.swift
+++ b/Cotabby/Support/GhostTextColorPreset.swift
@@ -17,14 +17,19 @@ struct GhostTextColorPreset: Identifiable, Equatable {
 
     static let automatic = GhostTextColorPreset(id: "automatic", name: "Automatic", hex: nil)
 
-    /// Automatic plus five distinct accent hues. Order is the swatch order shown in Settings.
+    /// Automatic plus ten distinct accent hues. Order is the swatch order shown in Settings.
     static let all: [GhostTextColorPreset] = [
         automatic,
         GhostTextColorPreset(id: "blue", name: "Blue", hex: "3B82F6"),
         GhostTextColorPreset(id: "green", name: "Green", hex: "22C55E"),
         GhostTextColorPreset(id: "purple", name: "Purple", hex: "A855F7"),
         GhostTextColorPreset(id: "orange", name: "Orange", hex: "F97316"),
-        GhostTextColorPreset(id: "pink", name: "Pink", hex: "EC4899")
+        GhostTextColorPreset(id: "pink", name: "Pink", hex: "EC4899"),
+        GhostTextColorPreset(id: "red", name: "Red", hex: "EF4444"),
+        GhostTextColorPreset(id: "yellow", name: "Yellow", hex: "EAB308"),
+        GhostTextColorPreset(id: "teal", name: "Teal", hex: "14B8A6"),
+        GhostTextColorPreset(id: "cyan", name: "Cyan", hex: "06B6D4"),
+        GhostTextColorPreset(id: "indigo", name: "Indigo", hex: "6366F1")
     ]
 
     /// Matches a persisted hex back to its preset so the UI can highlight the active swatch. Falls

--- a/Cotabby/Support/GhostTextColorPreset.swift
+++ b/Cotabby/Support/GhostTextColorPreset.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// File overview:
+/// The curated set of ghost-text colors offered in Settings.
+///
+/// Why this file exists:
+/// Users asked to recolor the inline suggestion, but a free `ColorPicker` makes it easy to land on
+/// illegible or jarring colors. Exposing a small fixed palette keeps every choice readable against
+/// real editors while still satisfying the request. Each preset is just the hex string the settings
+/// model already persists (`nil` for the adaptive "Automatic" gray the overlay falls back to), so no
+/// new persistence format is introduced.
+struct GhostTextColorPreset: Identifiable, Equatable {
+    let id: String
+    let name: String
+    /// Persisted hex (uppercased, 6 digits), or `nil` for the adaptive automatic gray.
+    let hex: String?
+
+    static let automatic = GhostTextColorPreset(id: "automatic", name: "Automatic", hex: nil)
+
+    /// Automatic plus five distinct accent hues. Order is the swatch order shown in Settings.
+    static let all: [GhostTextColorPreset] = [
+        automatic,
+        GhostTextColorPreset(id: "blue", name: "Blue", hex: "3B82F6"),
+        GhostTextColorPreset(id: "green", name: "Green", hex: "22C55E"),
+        GhostTextColorPreset(id: "purple", name: "Purple", hex: "A855F7"),
+        GhostTextColorPreset(id: "orange", name: "Orange", hex: "F97316"),
+        GhostTextColorPreset(id: "pink", name: "Pink", hex: "EC4899")
+    ]
+
+    /// Matches a persisted hex back to its preset so the UI can highlight the active swatch. Falls
+    /// back to `automatic` when the stored value is absent or no longer in the palette.
+    static func matching(hex: String?) -> GhostTextColorPreset {
+        guard let hex else {
+            return automatic
+        }
+
+        let normalized = hex.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+        return all.first { $0.hex?.uppercased() == normalized } ?? automatic
+    }
+}

--- a/Cotabby/Support/MenuBarActivity.swift
+++ b/Cotabby/Support/MenuBarActivity.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// File overview:
+/// Pure rule that collapses Cotabby's three independent "working" pipelines into a single menu-bar
+/// busy signal.
+///
+/// Why this file exists:
+/// The menu bar shows one indicator meaning "Cotabby is doing something" rather than three separate
+/// per-pipeline states (runtime/model load, on-screen context OCR, completion generation). Keeping
+/// the "what counts as busy" mapping here — separate from the debounce timing in
+/// `MenuBarActivityModel` — makes the decision trivial to read and unit test, and the exhaustive
+/// switches force a compile error if any pipeline adds a state we forgot to classify.
+enum MenuBarActivity {
+    /// `.debouncing` is deliberately excluded: it means "the user is still typing", not "Cotabby is
+    /// working", and surfacing it would strobe the menu bar on every keystroke. The leading-edge
+    /// delay in `MenuBarActivityModel` further hides any generation that finishes near-instantly.
+    static func isBusy(
+        runtime: RuntimeBootstrapState,
+        completion: SuggestionDebugState,
+        visual: VisualContextStatus
+    ) -> Bool {
+        isRuntimeBusy(runtime) || isCompletionBusy(completion) || isVisualBusy(visual)
+    }
+
+    private static func isRuntimeBusy(_ state: RuntimeBootstrapState) -> Bool {
+        switch state {
+        case .starting, .loading:
+            return true
+        case .idle, .ready, .failed:
+            return false
+        }
+    }
+
+    private static func isCompletionBusy(_ state: SuggestionDebugState) -> Bool {
+        switch state {
+        case .generating:
+            return true
+        case .idle, .disabled, .debouncing, .ready, .failed:
+            return false
+        }
+    }
+
+    private static func isVisualBusy(_ status: VisualContextStatus) -> Bool {
+        switch status {
+        case .capturing, .extractingText, .summarizingText:
+            return true
+        case .idle, .ready, .unavailable, .failed:
+            return false
+        }
+    }
+}

--- a/Cotabby/UI/MenuBarActivityModel.swift
+++ b/Cotabby/UI/MenuBarActivityModel.swift
@@ -1,0 +1,93 @@
+import Combine
+import Foundation
+
+/// File overview:
+/// View model behind the menu-bar busy indicator. It watches the three pipeline states, collapses
+/// them with `MenuBarActivity.isBusy`, and applies hysteresis so the indicator never flickers.
+///
+/// Why the hysteresis:
+/// Completions cycle through `.generating` on nearly every typing burst and a local generation can
+/// finish in tens of milliseconds. Binding the spinner straight to the raw busy flag would strobe
+/// the menu bar. Two guards fix that:
+///   - a leading delay (`showDelay`): work must stay busy this long before the spinner appears, so
+///     sub-threshold completions never show anything;
+///   - a minimum on-time (`minimumVisibleDuration`): once shown, the spinner stays up at least this
+///     long so a quick busy → idle → busy bounce doesn't blink it off and back on.
+@MainActor
+final class MenuBarActivityModel: ObservableObject {
+    @Published private(set) var isBusy = false
+
+    private let showDelay: Duration
+    private let minimumVisibleDuration: Duration
+    private var cancellable: AnyCancellable?
+    private var pendingShow: Task<Void, Never>?
+    private var pendingHide: Task<Void, Never>?
+    private var shownAt: ContinuousClock.Instant?
+
+    init(
+        runtimeModel: RuntimeBootstrapModel,
+        suggestionCoordinator: SuggestionCoordinator,
+        showDelay: Duration = .milliseconds(250),
+        minimumVisibleDuration: Duration = .milliseconds(500)
+    ) {
+        self.showDelay = showDelay
+        self.minimumVisibleDuration = minimumVisibleDuration
+
+        // All three sources are @MainActor @Published, so CombineLatest delivers on the main actor
+        // and the derived flag is safe to drive UI directly. `removeDuplicates` avoids re-running the
+        // debounce logic for state churn that doesn't change the collapsed busy verdict.
+        cancellable = runtimeModel.$state
+            .combineLatest(
+                suggestionCoordinator.$state,
+                suggestionCoordinator.$visualContextStatus
+            )
+            .map { MenuBarActivity.isBusy(runtime: $0, completion: $1, visual: $2) }
+            .removeDuplicates()
+            .sink { [weak self] rawBusy in
+                self?.updateRawBusy(rawBusy)
+            }
+    }
+
+    /// Drives the debounced `isBusy` from the collapsed raw signal. `internal` (not `private`) so
+    /// unit tests can exercise the hysteresis directly with short thresholds.
+    func updateRawBusy(_ rawBusy: Bool) {
+        if rawBusy {
+            // A fresh burst of work cancels any pending hide so the spinner stays up continuously.
+            pendingHide?.cancel()
+            pendingHide = nil
+            guard !isBusy, pendingShow == nil else {
+                return
+            }
+            pendingShow = Task { [weak self] in
+                guard let self else { return }
+                try? await Task.sleep(for: showDelay)
+                guard !Task.isCancelled else { return }
+                pendingShow = nil
+                isBusy = true
+                shownAt = .now
+            }
+        } else {
+            // Work stopped before the spinner ever appeared: drop the pending show silently.
+            pendingShow?.cancel()
+            pendingShow = nil
+            guard isBusy, pendingHide == nil else {
+                return
+            }
+            let elapsed = shownAt.map { ContinuousClock.now - $0 } ?? minimumVisibleDuration
+            let remaining = minimumVisibleDuration - elapsed
+            guard remaining > .zero else {
+                isBusy = false
+                shownAt = nil
+                return
+            }
+            pendingHide = Task { [weak self] in
+                guard let self else { return }
+                try? await Task.sleep(for: remaining)
+                guard !Task.isCancelled else { return }
+                pendingHide = nil
+                isBusy = false
+                shownAt = nil
+            }
+        }
+    }
+}

--- a/Cotabby/UI/MenuBarStatusLabelView.swift
+++ b/Cotabby/UI/MenuBarStatusLabelView.swift
@@ -22,13 +22,15 @@ struct MenuBarStatusLabelView: View {
                 .scaledToFit()
                 .frame(height: 16)
 
-            if activityModel.isBusy {
-                ProgressView()
-                    .progressViewStyle(.circular)
-                    .controlSize(.small)
-                    .scaleEffect(0.7)
-                    .frame(width: 14, height: 16)
-            }
+            // Always reserve the spinner slot and toggle it with opacity. Inserting/removing the
+            // ProgressView would change the label view's width, which makes MenuBarExtra resize the
+            // status item and shove neighboring menu-bar icons sideways on every busy transition.
+            ProgressView()
+                .progressViewStyle(.circular)
+                .controlSize(.small)
+                .scaleEffect(0.7)
+                .frame(width: 14, height: 16)
+                .opacity(activityModel.isBusy ? 1 : 0)
         }
     }
 }

--- a/Cotabby/UI/MenuBarStatusLabelView.swift
+++ b/Cotabby/UI/MenuBarStatusLabelView.swift
@@ -5,24 +5,29 @@ import SwiftUI
 /// the larger menu content so the menu-bar extra can stay minimal even as the panel layout evolves.
 ///
 /// This label lives in its own view because `MenuBarExtra` does not automatically observe
-/// plain properties hanging off `AppDelegate`. By observing the coordinator directly here,
-/// SwiftUI knows when to redraw the menu bar item as the accepted word count changes.
+/// plain properties hanging off `AppDelegate`. By observing the activity model directly here,
+/// SwiftUI knows when to redraw the menu bar item as Cotabby starts and finishes work.
+///
+/// The accepted word-count badge that used to live here is hidden for now; its source
+/// (`SuggestionCoordinator.totalTabAcceptedWordCount`) and `WordCountFormatter` are intentionally
+/// left intact so it can be restored — possibly as a count-when-idle, spinner-when-busy pairing.
 struct MenuBarStatusLabelView: View {
-    @ObservedObject var suggestionCoordinator: SuggestionCoordinator
+    @ObservedObject var activityModel: MenuBarActivityModel
 
     var body: some View {
-        HStack(spacing: 2) {
+        HStack(spacing: 3) {
             Image("MenuBarCatIcon")
                 .renderingMode(.template)
                 .resizable()
                 .scaledToFit()
                 .frame(height: 16)
 
-            if let label = WordCountFormatter.compactLabel(
-                for: suggestionCoordinator.totalTabAcceptedWordCount
-            ) {
-                Text(label)
-                    .font(.system(size: 10, weight: .medium).monospacedDigit())
+            if activityModel.isBusy {
+                ProgressView()
+                    .progressViewStyle(.circular)
+                    .controlSize(.small)
+                    .scaleEffect(0.7)
+                    .frame(width: 14, height: 16)
             }
         }
     }

--- a/Cotabby/UI/SettingsView.swift
+++ b/Cotabby/UI/SettingsView.swift
@@ -187,6 +187,32 @@ struct SettingsView: View {
             Toggle("Fast Mode", isOn: fastModeEnabledBinding)
                 .help("Skips capturing on-screen context (OCR) for faster, lower-overhead suggestions.")
 
+            LabeledContent("Ghost Text Color") {
+                HStack(spacing: 8) {
+                    ForEach(GhostTextColorPreset.all) { preset in
+                        ghostColorSwatch(for: preset)
+                    }
+                }
+            }
+
+            LabeledContent("Ghost Text Opacity") {
+                HStack(spacing: 10) {
+                    TickMarkSlider(
+                        value: ghostTextOpacityBinding,
+                        range: SuggestionSettingsModel.minimumGhostTextOpacity
+                            ... SuggestionSettingsModel.maximumGhostTextOpacity,
+                        step: SuggestionSettingsModel.ghostTextOpacityStep
+                    )
+                    .frame(width: 180)
+
+                    Text(ghostTextOpacityLabel)
+                        .font(.callout)
+                        .monospacedDigit()
+                        .foregroundStyle(.secondary)
+                        .frame(width: 42, alignment: .trailing)
+                }
+            }
+
             // Open at Login is hidden until the quarantine/SMAppService issue is resolved.
             // The toggle reports .notFound for quarantined apps and apps outside /Applications,
             // making it appear broken for most users. See LaunchAtLoginService for details.
@@ -722,25 +748,10 @@ struct SettingsView: View {
     //     )
     // }
 
-    /// The color picker always needs a concrete color. When the user has not picked one yet we feed
-    /// it the current automatic fallback so the control still previews something sensible. The first
-    /// user interaction promotes that preview into a persisted custom color.
-    private var customSuggestionTextColorBinding: Binding<Color> {
+    private var ghostTextOpacityBinding: Binding<Double> {
         Binding(
-            get: {
-                SuggestionTextColorCodec.color(
-                    fromHex: suggestionSettings.customSuggestionTextColorHex)
-                    ?? automaticGhostTextColor
-            },
-            set: { color in
-                guard let nsColor = NSColor(color).usingColorSpace(.sRGB),
-                    let hex = SuggestionTextColorCodec.hexString(from: nsColor)
-                else {
-                    return
-                }
-
-                suggestionSettings.setCustomSuggestionTextColorHex(hex)
-            }
+            get: { suggestionSettings.ghostTextOpacity },
+            set: { suggestionSettings.setGhostTextOpacity($0) }
         )
     }
 
@@ -777,18 +788,52 @@ struct SettingsView: View {
         )
     }
 
+    /// Mirrors the overlay's automatic fallback (`GhostSuggestionView.ghostColor`) so the Automatic
+    /// swatch previews the same gray the user will actually see.
     private var automaticGhostTextColor: Color {
         colorScheme == .dark
             ? Color(red: 0.65, green: 0.65, blue: 0.65)
             : Color(red: 0.45, green: 0.45, blue: 0.45)
     }
 
-    private var ghostTextColorDescription: String {
-        if suggestionSettings.customSuggestionTextColorHex == nil {
-            return "Automatic adapts to light and dark editors with Cotabby's default subtle gray."
+    private var ghostTextOpacityLabel: String {
+        "\(Int((suggestionSettings.ghostTextOpacity * 100).rounded()))%"
+    }
+
+    /// A tappable color chip. `nil` hex selects the adaptive Automatic gray. The active preset gets a
+    /// heavier ring so the current choice reads at a glance.
+    @ViewBuilder
+    private func ghostColorSwatch(for preset: GhostTextColorPreset) -> some View {
+        let isSelected = GhostTextColorPreset.matching(
+            hex: suggestionSettings.customSuggestionTextColorHex
+        ) == preset
+
+        Button {
+            suggestionSettings.setCustomSuggestionTextColorHex(preset.hex)
+        } label: {
+            Circle()
+                .fill(swatchFill(for: preset))
+                .frame(width: 18, height: 18)
+                .overlay(
+                    Circle()
+                        .strokeBorder(
+                            Color.primary.opacity(isSelected ? 0.9 : 0.18),
+                            lineWidth: isSelected ? 2 : 1
+                        )
+                )
+        }
+        .buttonStyle(.plain)
+        .help(preset.name)
+    }
+
+    private func swatchFill(for preset: GhostTextColorPreset) -> Color {
+        guard let hex = preset.hex,
+              let color = SuggestionTextColorCodec.color(fromHex: hex)
+        else {
+            return automaticGhostTextColor
         }
 
-        return "Custom ghost text color is active."
+        return color
     }
 
     private var localModelsDescription: String {

--- a/Cotabby/UI/TickMarkSlider.swift
+++ b/Cotabby/UI/TickMarkSlider.swift
@@ -28,6 +28,21 @@ struct TickMarkSlider: NSViewRepresentable {
 
     func updateNSView(_ slider: NSSlider, context: Context) {
         context.coordinator.value = $value
+
+        // Re-apply the range-derived configuration so a caller passing dynamic range/step values
+        // doesn't leave the slider with stale tick marks or snap bounds. Guarded so we only touch
+        // AppKit state when it actually changed.
+        let expectedTickCount = tickCount
+        if slider.numberOfTickMarks != expectedTickCount {
+            slider.numberOfTickMarks = expectedTickCount
+        }
+        if slider.minValue != range.lowerBound {
+            slider.minValue = range.lowerBound
+        }
+        if slider.maxValue != range.upperBound {
+            slider.maxValue = range.upperBound
+        }
+
         // Avoid feeding the slider its own in-flight value back as an external update.
         if slider.doubleValue != value {
             slider.doubleValue = value

--- a/Cotabby/UI/TickMarkSlider.swift
+++ b/Cotabby/UI/TickMarkSlider.swift
@@ -1,0 +1,64 @@
+import AppKit
+import SwiftUI
+
+/// A macOS slider with evenly spaced, visible tick marks that the knob snaps to.
+///
+/// SwiftUI's `Slider` can snap to a `step` but cannot draw tick marks on macOS, and the ghost-text
+/// opacity control is specced with visible notches. Wrapping `NSSlider` gives native ticks plus
+/// `allowsTickMarkValuesOnly` snapping in one control.
+struct TickMarkSlider: NSViewRepresentable {
+    @Binding var value: Double
+    let range: ClosedRange<Double>
+    let step: Double
+
+    func makeNSView(context: Context) -> NSSlider {
+        let slider = NSSlider(
+            value: value,
+            minValue: range.lowerBound,
+            maxValue: range.upperBound,
+            target: context.coordinator,
+            action: #selector(Coordinator.valueChanged(_:))
+        )
+        slider.numberOfTickMarks = tickCount
+        slider.allowsTickMarkValuesOnly = true
+        slider.tickMarkPosition = .below
+        slider.controlSize = .small
+        return slider
+    }
+
+    func updateNSView(_ slider: NSSlider, context: Context) {
+        context.coordinator.value = $value
+        // Avoid feeding the slider its own in-flight value back as an external update.
+        if slider.doubleValue != value {
+            slider.doubleValue = value
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(value: $value)
+    }
+
+    /// Inclusive of both endpoints, e.g. 0.3...1.0 at 0.1 yields 8 ticks.
+    private var tickCount: Int {
+        guard step > 0 else {
+            return 2
+        }
+
+        let span = range.upperBound - range.lowerBound
+        return Int((span / step).rounded()) + 1
+    }
+
+    @MainActor
+    final class Coordinator: NSObject {
+        var value: Binding<Double>
+
+        init(value: Binding<Double>) {
+            self.value = value
+        }
+
+        @objc
+        func valueChanged(_ sender: NSSlider) {
+            value.wrappedValue = sender.doubleValue
+        }
+    }
+}

--- a/CotabbyTests/MenuBarActivityTests.swift
+++ b/CotabbyTests/MenuBarActivityTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+@testable import Cotabby
+
+/// Verifies which pipeline states collapse into the single menu-bar busy signal. The debounce timing
+/// lives in `MenuBarActivityModel`; these cover only the pure classification, which is the part most
+/// likely to drift as the underlying state enums gain cases.
+final class MenuBarActivityTests: XCTestCase {
+    func test_allPipelinesIdleIsNotBusy() {
+        XCTAssertFalse(MenuBarActivity.isBusy(runtime: .idle, completion: .idle, visual: .idle))
+    }
+
+    func test_runtimeStartingOrLoadingIsBusy() {
+        XCTAssertTrue(MenuBarActivity.isBusy(runtime: .starting("…"), completion: .idle, visual: .idle))
+        XCTAssertTrue(MenuBarActivity.isBusy(runtime: .loading("…"), completion: .idle, visual: .idle))
+    }
+
+    func test_runtimeReadyIdleFailedAreNotBusy() {
+        XCTAssertFalse(MenuBarActivity.isBusy(runtime: .ready("…"), completion: .idle, visual: .idle))
+        XCTAssertFalse(MenuBarActivity.isBusy(runtime: .failed("…"), completion: .idle, visual: .idle))
+    }
+
+    func test_completionGeneratingIsBusy() {
+        XCTAssertTrue(MenuBarActivity.isBusy(runtime: .idle, completion: .generating, visual: .idle))
+    }
+
+    func test_completionDebouncingIsNotBusy() {
+        // Debouncing means "still typing", not "working" — surfacing it would strobe the menu bar.
+        XCTAssertFalse(MenuBarActivity.isBusy(runtime: .idle, completion: .debouncing, visual: .idle))
+    }
+
+    func test_completionTerminalStatesAreNotBusy() {
+        XCTAssertFalse(MenuBarActivity.isBusy(runtime: .idle, completion: .disabled("…"), visual: .idle))
+        XCTAssertFalse(
+            MenuBarActivity.isBusy(runtime: .idle, completion: .ready(text: "x", latency: 0), visual: .idle)
+        )
+        XCTAssertFalse(MenuBarActivity.isBusy(runtime: .idle, completion: .failed("…"), visual: .idle))
+    }
+
+    func test_visualCaptureExtractSummarizeAreBusy() {
+        XCTAssertTrue(MenuBarActivity.isBusy(runtime: .idle, completion: .idle, visual: .capturing))
+        XCTAssertTrue(MenuBarActivity.isBusy(runtime: .idle, completion: .idle, visual: .extractingText))
+        XCTAssertTrue(MenuBarActivity.isBusy(runtime: .idle, completion: .idle, visual: .summarizingText))
+    }
+
+    func test_visualTerminalStatesAreNotBusy() {
+        XCTAssertFalse(MenuBarActivity.isBusy(runtime: .idle, completion: .idle, visual: .ready))
+        XCTAssertFalse(MenuBarActivity.isBusy(runtime: .idle, completion: .idle, visual: .unavailable("…")))
+        XCTAssertFalse(MenuBarActivity.isBusy(runtime: .idle, completion: .idle, visual: .failed("…")))
+    }
+
+    func test_anyBusyPipelineWinsOverIdleOthers() {
+        XCTAssertTrue(MenuBarActivity.isBusy(runtime: .loading("…"), completion: .debouncing, visual: .ready))
+    }
+}

--- a/CotabbyTests/ModelAndPresentationValueTests.swift
+++ b/CotabbyTests/ModelAndPresentationValueTests.swift
@@ -176,3 +176,105 @@ final class RuntimeAndInputModelValueTests: XCTestCase {
         XCTAssertFalse(CotabbyTestFixtures.inputEvent(kind: .other).shouldClearSuggestion)
     }
 }
+
+final class GhostTextColorPresetTests: XCTestCase {
+    func test_matching_nilHexResolvesToAutomatic() {
+        XCTAssertEqual(GhostTextColorPreset.matching(hex: nil), .automatic)
+    }
+
+    func test_matching_isCaseInsensitiveAndIgnoresWhitespace() {
+        XCTAssertEqual(GhostTextColorPreset.matching(hex: "  3b82f6 ").id, "blue")
+        XCTAssertEqual(GhostTextColorPreset.matching(hex: "EC4899").id, "pink")
+    }
+
+    func test_matching_unknownHexFallsBackToAutomatic() {
+        XCTAssertEqual(GhostTextColorPreset.matching(hex: "010203"), .automatic)
+    }
+
+    func test_allPresetHexesAreValidAndDecodable() {
+        for preset in GhostTextColorPreset.all where preset.hex != nil {
+            XCTAssertNotNil(
+                SuggestionTextColorCodec.nsColor(fromHex: preset.hex),
+                "Preset \(preset.id) has an undecodable hex"
+            )
+        }
+    }
+}
+
+final class GhostTextOpacitySettingsTests: XCTestCase {
+    /// Hosted macOS tests crash while deallocating short-lived `SuggestionSettingsModel` instances,
+    /// so we retain them for the process lifetime and drive each test through `MainActor`. This
+    /// mirrors `SuggestionSettingsModelDisabledAppsTests`, which quarantines the same runtime issue.
+    private static var retainedModels: [SuggestionSettingsModel] = []
+
+    private var userDefaultsSuites: [(suiteName: String, userDefaults: UserDefaults)] = []
+
+    override func tearDown() {
+        for suite in userDefaultsSuites {
+            suite.userDefaults.removePersistentDomain(forName: suite.suiteName)
+        }
+        userDefaultsSuites.removeAll()
+        super.tearDown()
+    }
+
+    func test_defaultOpacityIsFullyOpaqueOnFreshInstall() {
+        runOnMainActor {
+            XCTAssertEqual(makeModel().ghostTextOpacity, SuggestionSettingsModel.defaultGhostTextOpacity)
+        }
+    }
+
+    func test_setOpacityClampsBelowMinimumAndAboveMaximum() {
+        runOnMainActor {
+            let model = makeModel()
+
+            model.setGhostTextOpacity(0.0)
+            XCTAssertEqual(model.ghostTextOpacity, SuggestionSettingsModel.minimumGhostTextOpacity)
+
+            model.setGhostTextOpacity(5.0)
+            XCTAssertEqual(model.ghostTextOpacity, SuggestionSettingsModel.maximumGhostTextOpacity)
+        }
+    }
+
+    func test_opacityPersistsAcrossModelReload() {
+        runOnMainActor {
+            let userDefaults = makeUserDefaults()
+            makeModel(userDefaults: userDefaults).setGhostTextOpacity(0.5)
+
+            XCTAssertEqual(makeModel(userDefaults: userDefaults).ghostTextOpacity, 0.5)
+        }
+    }
+
+    @MainActor
+    private func makeModel(userDefaults: UserDefaults? = nil) -> SuggestionSettingsModel {
+        let model = SuggestionSettingsModel(
+            configuration: .standard,
+            userDefaults: userDefaults ?? makeUserDefaults()
+        )
+        Self.retainedModels.append(model)
+        return model
+    }
+
+    private func makeUserDefaults() -> UserDefaults {
+        let suiteName = "GhostTextOpacitySettingsTests-\(UUID().uuidString)"
+        guard let userDefaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Expected an isolated UserDefaults suite")
+            return .standard
+        }
+
+        userDefaults.removePersistentDomain(forName: suiteName)
+        userDefaultsSuites.append((suiteName: suiteName, userDefaults: userDefaults))
+        return userDefaults
+    }
+
+    private func runOnMainActor<Result>(
+        _ body: @MainActor () throws -> Result
+    ) rethrows -> Result {
+        if Thread.isMainThread {
+            return try MainActor.assumeIsolated(body)
+        }
+
+        return try DispatchQueue.main.sync {
+            try MainActor.assumeIsolated(body)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a refine.sh-style menu-bar busy indicator and resurfaces user control over ghost-text appearance. The menu bar gains a single spinner that shows whenever Cotabby is actually working (model load/switch, screenshot+OCR context, or completion generation), and the General settings gain a preset ghost-text color palette plus a notched opacity slider. These were repeatedly requested, and the custom-color plumbing already existed but was disabled.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED ** (deployment target macOS 14.0)

xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby \
  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO \
  -only-testing:CotabbyTests/MenuBarActivityTests \
  -only-testing:CotabbyTests/GhostTextColorPresetTests \
  -only-testing:CotabbyTests/GhostTextOpacitySettingsTests
# ** TEST SUCCEEDED **  Executed 16 tests, 0 failures

swiftlint lint --quiet   # exit 0 on all changed files
```

Not yet verified end-to-end in the running app: the **menu-bar spinner animation**. SwiftUI animations inside a `MenuBarExtra` label can be unreliable because the status-item label isn't redrawn like a normal view. The busy/idle *state* and debounce logic are unit-tested and correct; if the `ProgressView` spinner turns out not to animate in the live menu bar, the fallback is a static "busy" glyph (e.g. an SF Symbol) that simply appears/disappears — same plumbing, no logic change. Worth a manual smoke test on a real menu bar before merge.

## Linked issues

<!-- None linked; opened from internal feature requests. -->

## Risk / rollout notes

- **New project files (pbxproj migration):** five new sources added via `xcodegen generate` (`MenuBarActivity`, `MenuBarActivityModel`, `GhostTextColorPreset`, `TickMarkSlider`, `MenuBarActivityTests`). `project.yml` is unchanged.
- **Settings/UserDefaults:** new persisted key `cotabbyGhostTextOpacity` (Double, default 1.0, clamped 0.3–1.0). The existing `cotabbyCustomSuggestionTextColorHex` key is reused — color presets just write known hexes into it, so existing custom colors keep working.
- **Behavior change:** the accepted-word-count badge no longer renders in the menu bar (replaced by the busy indicator). Its source (`totalTabAcceptedWordCount`) and `WordCountFormatter` are intentionally left intact for easy restoration or a count-when-idle / spinner-when-busy pairing later.
- **Debounce tuning:** very fast completions (under the 250ms leading delay) intentionally show no spinner, to avoid strobing the menu bar on every keystroke. The spinner also stays visible for a 500ms minimum once shown.
- **Two features in one PR** (menu-bar indicator + ghost-text color/opacity) bundled per request; they're independent and could be split if preferred.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two independent features: a debounced menu-bar busy spinner (replacing the word-count badge) and user-facing ghost-text color/opacity controls in General Settings. Previous review concerns — menu-bar resize on busy transitions and stale `updateNSView` in `TickMarkSlider` — are both addressed in this revision.

- **Menu-bar activity indicator**: `MenuBarActivity` (pure classifier) + `MenuBarActivityModel` (`@MainActor` view model with 250 ms leading-edge delay and 500 ms minimum on-time) collapse three pipeline states into a single `isBusy` flag; the `ProgressView` slot is always present and toggled with `.opacity()` to keep the status-item width fixed.
- **Ghost-text color presets**: 11-swatch fixed palette writes known hex strings into the existing `cotabbyCustomSuggestionTextColorHex` key; the \"Automatic\" preset writes `nil`, restoring the adaptive fallback — no new persistence format.
- **Ghost-text opacity**: new `cotabbyGhostTextOpacity` UserDefaults key (Double, clamped 0.3–1.0, default 1.0) surfaced through a `TickMarkSlider`; opacity is baked into `ghostColor` rather than applied as a view modifier so the keycap acceptance hint stays fully opaque.

<h3>Confidence Score: 5/5</h3>

Safe to merge. Both features touch only UI presentation and UserDefaults persistence; no data model migrations, no new permissions, and the existing cotabbyCustomSuggestionTextColorHex key is reused without format changes.

The busy-indicator hysteresis logic is straightforward and unit-tested; the ghost-text opacity and color-preset wiring are narrow, well-guarded additions that follow established patterns in the codebase. Previous reviewer concerns about menu-bar resize and stale TickMarkSlider updateNSView are both resolved in this revision. No new persistence format is introduced for color presets, and the opacity key has a correct isFinite guard against corrupt stored values.

No files require special attention. The one unverified item — whether ProgressView actually animates inside MenuBarExtra — is acknowledged in the PR description and has no correctness impact on the busy/idle state logic.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/MenuBarActivityModel.swift | New @MainActor view model implementing debounced busy indicator with leading-edge delay (250 ms) and minimum on-time (500 ms); hysteresis logic is correct and Tasks use [weak self] safely. |
| Cotabby/Support/MenuBarActivity.swift | Pure stateless classifier that maps three pipeline states to a single busy bool; exhaustive switches ensure compile-time safety if new states are added. |
| Cotabby/UI/MenuBarStatusLabelView.swift | Replaced word-count badge with opacity-toggled ProgressView; spinner slot is always reserved to avoid menu-bar resize jitter (previous thread concern addressed). |
| Cotabby/UI/TickMarkSlider.swift | NSViewRepresentable NSSlider wrapper; updateNSView now re-applies tickCount/minValue/maxValue when they change (previous thread concern addressed). |
| Cotabby/Models/SuggestionSettingsModel.swift | Adds ghostTextOpacity (Double, persisted, clamped 0.3–1.0) with correct isFinite guard against NaN/Inf and consistent read-on-absent-key logic mirroring existing settings. |
| Cotabby/Services/UI/OverlayController.swift | Reads ghostTextOpacity from settings and passes it to GhostSuggestionView; opacity is baked into ghostColor (not the whole view) so the keycap hint stays fully opaque. |
| Cotabby/UI/SettingsView.swift | Adds color swatch row and TickMarkSlider opacity row; automaticGhostTextColor mirrors the overlay's fallback exactly; old ColorPicker binding removed cleanly. |
| Cotabby/Support/GhostTextColorPreset.swift | 11-color preset palette reusing the existing hex-string persistence format; matching() is case-insensitive and whitespace-tolerant, with correct automatic fallback. |
| Cotabby/App/Core/CotabbyAppEnvironment.swift | Constructs MenuBarActivityModel and wires runtimeModel + suggestionCoordinator; dependency injection is consistent with existing env pattern. |
| CotabbyTests/MenuBarActivityTests.swift | Full coverage of the busy-classification logic including edge cases like debouncing-is-not-busy and multi-pipeline interactions. |
| CotabbyTests/ModelAndPresentationValueTests.swift | New GhostTextColorPresetTests and GhostTextOpacitySettingsTests appended; opacity tests correctly use process-lifetime model retention workaround to avoid known dealloc crash. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    R["runtimeModel state"]
    C["suggestionCoordinator state"]
    V["visualContextStatus"]

    IB["MenuBarActivity.isBusy\nstarting/loading → busy\ngenerating → busy\ncapturing/extracting/summarizing → busy"]

    UD["updateRawBusy"]
    PS["pendingShow Task\n250ms leading delay"]
    PH["pendingHide Task\n500ms min on-time"]
    IS["@Published isBusy"]
    PV["ProgressView\nopacity toggled"]

    R --> IB
    C --> IB
    V --> IB
    IB --> UD
    UD -->|"rawBusy=true, spinner hidden"| PS
    UD -->|"rawBusy=false, spinner visible"| PH
    PS -->|"delay elapsed"| IS
    PH -->|"remaining elapsed"| IS
    IS --> PV
```

<sub>Reviews (4): Last reviewed commit: ["Add 5 ghost-text colors and address Grep..."](https://github.com/fujacob/cotabby/commit/f6add827850e6f58a455971024ec54bc8e95b25c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34106153)</sub>

<!-- /greptile_comment -->