### PR TITLE
Add tabby-nano-1 and tabby-max-1 default models

### DIFF
--- a/Cotabby/Models/LlamaRuntimeModels.swift
+++ b/Cotabby/Models/LlamaRuntimeModels.swift
@@ -89,6 +89,10 @@ enum RuntimeModelCatalog {
             return "tabby-fast-1"
         case "gemma-4-E2B-it-Q4_K_M.gguf":
             return "tabby-balanced-1"
+        case "gemma-4-E4B-it-Q4_K_M.gguf":
+            return "tabby-max-1"
+        case "SmolLM-360M-Instruct.Q8_0.gguf":
+            return "tabby-nano-1"
         default:
             return filename
         }
@@ -102,6 +106,17 @@ enum RuntimeModelCatalog {
     ///
     ///   curl -sIL "<URL>" | grep -iE "^(x-linked-size|x-linked-etag):"
     static let downloadableModels: [DownloadableRuntimeModel] = [
+        DownloadableRuntimeModel(
+            filename: "SmolLM-360M-Instruct.Q8_0.gguf",
+            displayName: displayName(for: "SmolLM-360M-Instruct.Q8_0.gguf"),
+            downloadURL: URL(
+                string:
+                    "https://huggingface.co/QuantFactory/SmolLM-360M-Instruct-GGUF/resolve/main/SmolLM-360M-Instruct.Q8_0.gguf?download=true"
+            )!,
+            approximateSizeInGigabytes: 0.4,
+            expectedSizeBytes: 386_404_800,
+            sha256: "24ca4b7c7a5eb3673af7eb313fb2c68ab778f1d2a10c545ef23193faef706ca0"
+        ),
         DownloadableRuntimeModel(
             filename: "Qwen3-0.6B-Q4_K_M.gguf",
             displayName: displayName(for: "Qwen3-0.6B-Q4_K_M.gguf"),
@@ -123,6 +138,17 @@ enum RuntimeModelCatalog {
             approximateSizeInGigabytes: 3.1,
             expectedSizeBytes: 3_106_736_256,
             sha256: "9378bc471710229ef165709b62e34bfb62231420ddaf6d729e727305b5b8672d"
+        ),
+        DownloadableRuntimeModel(
+            filename: "gemma-4-E4B-it-Q4_K_M.gguf",
+            displayName: displayName(for: "gemma-4-E4B-it-Q4_K_M.gguf"),
+            downloadURL: URL(
+                string:
+                    "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/main/gemma-4-E4B-it-Q4_K_M.gguf?download=true"
+            )!,
+            approximateSizeInGigabytes: 5.0,
+            expectedSizeBytes: 4_977_169_568,
+            sha256: "519b9793ed6ce0ff530f1b7c96e848e08e49e7af4d57bb97f76215963a54146d"
         )
     ]
 }
@@ -140,8 +166,10 @@ struct LlamaRuntimeConfiguration: Equatable, Sendable {
     static let `default` = LlamaRuntimeConfiguration(
         runtimeDirectoryPath: nil,
         preferredModelNames: [
+            "gemma-4-E4B-it-Q4_K_M.gguf",
             "gemma-4-E2B-it-Q4_K_M.gguf",
-            "Qwen3-0.6B-Q4_K_M.gguf"
+            "Qwen3-0.6B-Q4_K_M.gguf",
+            "SmolLM-360M-Instruct.Q8_0.gguf"
         ],
         contextWindowTokens: 2048,
         batchSize: 512,

--- a/README.md
+++ b/README.md
@@ -80,21 +80,18 @@ Everything runs on-device. No hosted API, no cloud round-trip.
 
 **Apple Intelligence**: uses Apple's on-device `FoundationModels` runtime on macOS 26 or later, no download required.
 
-**Open Source**: runs local GGUF models in-process through llama.cpp via `llama.swift`. Cotabby ships with two built-in downloadable models:
+**Open Source**: runs local GGUF models in-process through llama.cpp via `llama.swift`. Cotabby ships with four built-in downloadable models:
 
-| Model              | File                         | Size    | Source                                                                                              |
-| ------------------ | ---------------------------- | ------- | --------------------------------------------------------------------------------------------------- |
-| `tabby-fast-1`     | `Qwen3-0.6B-Q4_K_M.gguf`     | ~0.4 GB | [unsloth/Qwen3-0.6B-GGUF](https://huggingface.co/unsloth/Qwen3-0.6B-GGUF)                           |
-| `tabby-balanced-1` | `gemma-4-E2B-it-Q4_K_M.gguf` | ~3.1 GB | [unsloth/gemma-4-E2B-it-GGUF](https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF)                   |
+| Model              | File                             | Size    | Source                                                                                                  |
+| ------------------ | -------------------------------- | ------- | ------------------------------------------------------------------------------------------------------- |
+| `tabby-nano-1`     | `SmolLM-360M-Instruct.Q8_0.gguf` | ~0.4 GB | [QuantFactory/SmolLM-360M-Instruct-GGUF](https://huggingface.co/QuantFactory/SmolLM-360M-Instruct-GGUF) |
+| `tabby-fast-1`     | `Qwen3-0.6B-Q4_K_M.gguf`         | ~0.4 GB | [unsloth/Qwen3-0.6B-GGUF](https://huggingface.co/unsloth/Qwen3-0.6B-GGUF)                               |
+| `tabby-balanced-1` | `gemma-4-E2B-it-Q4_K_M.gguf`     | ~3.1 GB | [unsloth/gemma-4-E2B-it-GGUF](https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF)                       |
+| `tabby-max-1`      | `gemma-4-E4B-it-Q4_K_M.gguf`     | ~5.0 GB | [unsloth/gemma-4-E4B-it-GGUF](https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF)                       |
 
 ### Bring your own model
 
-Any GGUF small enough to run on-device works. Drop a `.gguf` file into Cotabby's models folder and refresh the model list from the menu bar. Community models we've tested with Cotabby:
-
-| Model                   | File                        | Size    | Source                                                                          |
-| ----------------------- | --------------------------- | ------- | ------------------------------------------------------------------------------- |
-| Qwen3.5-0.8B (instruct) | `Qwen3.5-0.8B-Q4_K_M.gguf`  | ~0.5 GB | [unsloth/Qwen3.5-0.8B-GGUF](https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF)   |
-| Gemma 3 1B (instruct)   | `gemma-3-1b-it-Q4_K_M.gguf` | ~0.8 GB | [unsloth/gemma-3-1b-it-GGUF](https://huggingface.co/unsloth/gemma-3-1b-it-GGUF) |
+Any GGUF small enough to run on-device works. Drop a `.gguf` file into Cotabby's models folder and refresh the model list from the menu bar.
 
 Browse the [unsloth GGUF collection on Hugging Face](https://huggingface.co/unsloth) for more variants. Smaller quants (`Q3_K_M`, `Q4_K_S`) trade quality for size; larger models give better completions at the cost of memory and per-token latency.
 


### PR DESCRIPTION
## Summary

Adds two built-in downloadable models, rounding the lineup out to four:

| Name | Model | Size | Role |
|---|---|---|---|
| `tabby-nano-1` | SmolLM-360M-Instruct Q8_0 | ~0.4 GB | smallest / fastest (new) |
| `tabby-fast-1` | Qwen3-0.6B Q4_K_M | ~0.4 GB | unchanged |
| `tabby-balanced-1` | gemma-4-E2B Q4_K_M | ~3.1 GB | unchanged |
| `tabby-max-1` | gemma-4-E4B Q4_K_M | ~5.0 GB | most capable (new) |

`displayName(for:)` maps both new filenames; each gets a `downloadableModels` entry. The catalog lists models **lightest-first**; `preferredModelNames` prefers the **most capable present** model (`max > balanced > fast > nano`), extending the existing balanced-over-fast ordering. `tabby-fast-1` / `tabby-balanced-1` names are untouched (already public).

## Validation

```
# size + sha256 for each captured from HuggingFace and cross-checked against the LFS oid:
#   SmolLM-360M Q8_0  -> 386,404,800 B   sha256 24ca4b7c…ca0   (header == API oid ✓)
#   gemma-4-E4B Q4_K_M -> 4,977,169,568 B sha256 519b9793…46d  (header == API oid ✓)

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  build CODE_SIGNING_ALLOWED=NO          # ** BUILD SUCCEEDED **
swiftlint lint --quiet Cotabby/Models/LlamaRuntimeModels.swift   # exit 0
```

Metadata-only catalog entries; the download + `ModelFileValidator` size/sha256 check is existing, exercised code. I did not download the GGUFs or load them at runtime.

## Linked issues

None — direct request.

## Risk / rollout notes

- **Load priority**: `preferredModelNames` now prefers `max` over everything when present. It never forces a download and has no effect on users who haven't fetched a given model — a user only gets `max` auto-selected if they downloaded it. Reorder the list if you'd rather a lighter model stay the auto-default.
- **`tabby-nano-1` vs `tabby-fast-1` are the same size on disk** (~0.4 GB); nano is the lower rung because it has fewer params (360M vs 600M) → faster/lighter at runtime, lower quality.
- Branch is still named `jafu/add-tabby-depth-model` from when this PR was just the E4B model (originally proposed as `tabby-depth-1`); the model is now `tabby-max-1`. Cosmetic only — squash-merge controls the final commit message.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `tabby-nano-1` (SmolLM-360M-Instruct Q8_0) and `tabby-max-1` (gemma-4-E4B Q4_K_M) to the built-in downloadable model catalog, rounding the lineup to four models, and updates `preferredModelNames` to prefer the most capable model present at startup.

- **`displayName(for:)`** gains two new cases and **`downloadableModels`** gains the corresponding entries — each with verified `expectedSizeBytes` and `sha256` metadata — following the existing pattern exactly.
- **`preferredModelNames`** is now ordered max → balanced → fast → nano, so a user who has downloaded `tabby-max-1` gets it auto-selected; users without it are unaffected.
- **README.md** updates the model table to all four entries and drops the now-redundant "community models" tested list.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are additive catalog entries that cannot affect users who haven't downloaded the new models.

Both new model entries follow the existing pattern exactly: displayName, downloadableModels, and preferredModelNames are updated consistently. The size/sha256 metadata is provided for the download validator. The preferredModelNames ordering is opt-in by download, so no existing user's auto-selected model changes unless they explicitly fetch tabby-max-1.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Models/LlamaRuntimeModels.swift | Adds two new model entries (tabby-nano-1 and tabby-max-1) to displayName(), downloadableModels, and preferredModelNames, following the established pattern with verified size/sha256 metadata. |
| README.md | Updates model table to list all four built-in models and removes the community-tested models section. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[App startup] --> B{Scan models directory}
    B --> C[Iterate preferredModelNames in order]
    C --> D{gemma-4-E4B-it-Q4_K_M.gguf present?}
    D -- yes --> E[Load tabby-max-1]
    D -- no --> F{gemma-4-E2B-it-Q4_K_M.gguf present?}
    F -- yes --> G[Load tabby-balanced-1]
    F -- no --> H{Qwen3-0.6B-Q4_K_M.gguf present?}
    H -- yes --> I[Load tabby-fast-1]
    H -- no --> J{SmolLM-360M-Instruct.Q8_0.gguf present?}
    J -- yes --> K[Load tabby-nano-1]
    J -- no --> L[Fallback: any discovered GGUF]

    M[User opens onboarding/menu] --> N[Show downloadableModels list]
    N --> O[tabby-nano-1 ~0.4 GB]
    N --> P[tabby-fast-1 ~0.4 GB]
    N --> Q[tabby-balanced-1 ~3.1 GB]
    N --> R[tabby-max-1 ~5.0 GB]
```

<sub>Reviews (3): Last reviewed commit: ["Update README model lineup for tabby-nan..."](https://github.com/fujacob/cotabby/commit/be7db53594870beebb7d4e1b5891c02e5e781b97) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34107314)</sub>

<!-- /greptile_comment -->