### PR TITLE
Add a Fast Mode toggle that skips the screenshot/OCR pipeline

### DIFF
--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
@@ -36,7 +36,8 @@ extension SuggestionCoordinator {
                disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
                inputMonitoringGranted: permissionManager.inputMonitoringGranted,
                screenRecordingGranted: permissionManager.screenRecordingGranted,
-               focusSnapshot: snapshot
+               focusSnapshot: snapshot,
+               isFastModeEnabled: settingsSnapshot.isFastModeEnabled
            ) {
             visualContextCoordinator.startSessionIfNeeded(for: context)
         }
@@ -60,8 +61,19 @@ extension SuggestionCoordinator {
             return
         }
 
-        // Start capturing visual context for newly focused input.
-        visualContextCoordinator.startSessionIfNeeded(for: focusedContext)
+        // Start capturing visual context for newly focused input. Gated like the focus-change path
+        // (and skipped in fast mode) so this entry point never kicks off screenshot/OCR work that the
+        // earlier `shouldCaptureVisualContext` check already declined.
+        if SuggestionAvailabilityEvaluator.shouldCaptureVisualContext(
+            globallyEnabled: settingsSnapshot.isGloballyEnabled,
+            disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
+            inputMonitoringGranted: permissionManager.inputMonitoringGranted,
+            screenRecordingGranted: permissionManager.screenRecordingGranted,
+            focusSnapshot: snapshot,
+            isFastModeEnabled: settingsSnapshot.isFastModeEnabled
+        ) {
+            visualContextCoordinator.startSessionIfNeeded(for: focusedContext)
+        }
 
         if case .disabled = state {
             state = .idle

--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Lifecycle.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Lifecycle.swift
@@ -75,7 +75,8 @@ extension SuggestionCoordinator {
                disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
                inputMonitoringGranted: permissionManager.inputMonitoringGranted,
                screenRecordingGranted: permissionManager.screenRecordingGranted,
-               focusSnapshot: focusModel.snapshot
+               focusSnapshot: focusModel.snapshot,
+               isFastModeEnabled: settingsSnapshot.isFastModeEnabled
            ) {
             visualContextCoordinator.startSessionIfNeeded(for: focusedSnapshot)
         }

--- a/Cotabby/Models/SuggestionEngineModels.swift
+++ b/Cotabby/Models/SuggestionEngineModels.swift
@@ -69,4 +69,7 @@ struct SuggestionSettingsSnapshot: Equatable, Sendable {
     /// When true (the default), accepting a word also takes punctuation attached to it. When false,
     /// trailing punctuation is left as its own acceptance part so a single Tab takes the word alone.
     let autoAcceptTrailingPunctuation: Bool
+    /// When true, the screenshot/OCR visual-context pipeline is skipped entirely for lower-latency
+    /// suggestions. Defaults to false. Only affects visual context — predictions still run.
+    let isFastModeEnabled: Bool
 }

--- a/Cotabby/Models/SuggestionSettingsModel.swift
+++ b/Cotabby/Models/SuggestionSettingsModel.swift
@@ -26,6 +26,7 @@ final class SuggestionSettingsModel: ObservableObject {
     @Published private(set) var selectedEngine: SuggestionEngineKind
     @Published private(set) var selectedWordCountPreset: SuggestionWordCountPreset
     @Published private(set) var isClipboardContextEnabled: Bool
+    @Published private(set) var isFastModeEnabled: Bool
     @Published private(set) var userName: String
     @Published private(set) var customRules: [String]
     @Published private(set) var responseLanguages: [String]
@@ -49,6 +50,7 @@ final class SuggestionSettingsModel: ObservableObject {
     private static let selectedEngineDefaultsKey = "cotabbySelectedEngine"
     private static let selectedWordCountPresetDefaultsKey = "cotabbySelectedWordCountPreset"
     private static let clipboardContextEnabledDefaultsKey = "cotabbyClipboardContextEnabled"
+    private static let fastModeEnabledDefaultsKey = "cotabbyFastModeEnabled"
     private static let userNameDefaultsKey = "cotabbyUserName"
     private static let customRulesDefaultsKey = "cotabbyCustomRules"
     private static let responseLanguagesDefaultsKey = "cotabbyResponseLanguages"
@@ -103,6 +105,10 @@ final class SuggestionSettingsModel: ObservableObject {
             ?? configuration.defaultWordCountPreset
         let resolvedClipboardContextEnabled =
             userDefaults.object(forKey: Self.clipboardContextEnabledDefaultsKey) as? Bool ?? false
+        // Defaults to false so the visual-context pipeline keeps running for existing users; opting
+        // into fast mode turns it off.
+        let resolvedFastModeEnabled =
+            userDefaults.object(forKey: Self.fastModeEnabledDefaultsKey) as? Bool ?? false
         let resolvedUserName: String = if userDefaults.object(forKey: Self.userNameDefaultsKey) == nil {
             configuration.defaultUserName ?? ""
         } else {
@@ -174,6 +180,7 @@ final class SuggestionSettingsModel: ObservableObject {
         selectedEngine = resolvedEngine
         selectedWordCountPreset = resolvedWordCountPreset
         isClipboardContextEnabled = resolvedClipboardContextEnabled
+        isFastModeEnabled = resolvedFastModeEnabled
         userName = resolvedUserName
         customRules = resolvedCustomRules
         responseLanguages = resolvedResponseLanguages
@@ -194,6 +201,7 @@ final class SuggestionSettingsModel: ObservableObject {
         persistSelectedEngine(resolvedEngine)
         persistSelectedWordCountPreset(resolvedWordCountPreset)
         persistClipboardContextEnabled(resolvedClipboardContextEnabled)
+        persistFastModeEnabled(resolvedFastModeEnabled)
         persistUserName(resolvedUserName)
         persistCustomRules(resolvedCustomRules)
         persistResponseLanguages(resolvedResponseLanguages)
@@ -225,7 +233,8 @@ final class SuggestionSettingsModel: ObservableObject {
             debounceMilliseconds: debounceMilliseconds,
             focusPollIntervalMilliseconds: focusPollIntervalMilliseconds,
             isMultiLineEnabled: isMultiLineEnabled,
-            autoAcceptTrailingPunctuation: autoAcceptTrailingPunctuation
+            autoAcceptTrailingPunctuation: autoAcceptTrailingPunctuation,
+            isFastModeEnabled: isFastModeEnabled
         )
     }
 
@@ -254,6 +263,15 @@ final class SuggestionSettingsModel: ObservableObject {
 
         isClipboardContextEnabled = enabled
         persistClipboardContextEnabled(enabled)
+    }
+
+    func setFastModeEnabled(_ enabled: Bool) {
+        guard isFastModeEnabled != enabled else {
+            return
+        }
+
+        isFastModeEnabled = enabled
+        persistFastModeEnabled(enabled)
     }
 
     func setMultiLineEnabled(_ enabled: Bool) {
@@ -570,6 +588,10 @@ final class SuggestionSettingsModel: ObservableObject {
         userDefaults.set(enabled, forKey: Self.clipboardContextEnabledDefaultsKey)
     }
 
+    private func persistFastModeEnabled(_ enabled: Bool) {
+        userDefaults.set(enabled, forKey: Self.fastModeEnabledDefaultsKey)
+    }
+
     private func persistShowIndicator(_ show: Bool) {
         let mode: ActivationIndicatorMode = show ? .fieldEdgeIcon : .hidden
         userDefaults.set(mode.rawValue, forKey: Self.selectedIndicatorModeDefaultsKey)
@@ -707,7 +729,7 @@ extension SuggestionSettingsModel: SuggestionSettingsProviding {
                 $selectedEngine,
                 $selectedWordCountPreset
             ),
-            $isClipboardContextEnabled,
+            Publishers.CombineLatest($isClipboardContextEnabled, $isFastModeEnabled),
             Publishers.CombineLatest3($userName, $customRules, $responseLanguages),
             Publishers.CombineLatest4(
                 $debounceMilliseconds,
@@ -716,8 +738,9 @@ extension SuggestionSettingsModel: SuggestionSettingsProviding {
                 $autoAcceptTrailingPunctuation
             )
         )
-        .map { combinedSettings, clipboardContextEnabled, profile, timing in
+        .map { combinedSettings, contextToggles, profile, timing in
             let (globallyEnabled, disabledAppRules, engine, wordCountPreset) = combinedSettings
+            let (clipboardContextEnabled, fastModeEnabled) = contextToggles
             let (userName, customRules, responseLanguages) = profile
             let (debounce, focusPoll, multiLine, autoAcceptPunctuation) = timing
             return SuggestionSettingsSnapshot(
@@ -732,7 +755,8 @@ extension SuggestionSettingsModel: SuggestionSettingsProviding {
                 debounceMilliseconds: debounce,
                 focusPollIntervalMilliseconds: focusPoll,
                 isMultiLineEnabled: multiLine,
-                autoAcceptTrailingPunctuation: autoAcceptPunctuation
+                autoAcceptTrailingPunctuation: autoAcceptPunctuation,
+                isFastModeEnabled: fastModeEnabled
             )
         }
         .removeDuplicates()

--- a/Cotabby/Support/SuggestionAvailabilityEvaluator.swift
+++ b/Cotabby/Support/SuggestionAvailabilityEvaluator.swift
@@ -70,14 +70,23 @@ enum SuggestionAvailabilityEvaluator {
     /// Delegates to `disabledReason` with capability checking disabled so transient field
     /// states (text selected, secure field) are intentionally ignored — OCR should start
     /// early in those cases and be ready by the time the user begins typing.
+    ///
+    /// Fast mode is checked here, and deliberately NOT in `disabledReason`: it suppresses only the
+    /// screenshot/OCR pipeline. Predictions still run (they just go out without visual context), so
+    /// `disabledReason` / `shouldSchedulePrediction` must stay unaffected.
     static func shouldCaptureVisualContext(
         globallyEnabled: Bool = true,
         disabledAppBundleIdentifiers: Set<String> = [],
         inputMonitoringGranted: Bool,
         screenRecordingGranted: Bool,
-        focusSnapshot: FocusSnapshot
+        focusSnapshot: FocusSnapshot,
+        isFastModeEnabled: Bool = false
     ) -> Bool {
-        disabledReason(
+        guard !isFastModeEnabled else {
+            return false
+        }
+
+        return disabledReason(
             globallyEnabled: globallyEnabled,
             disabledAppBundleIdentifiers: disabledAppBundleIdentifiers,
             inputMonitoringGranted: inputMonitoringGranted,

--- a/Cotabby/UI/MenuBarView.swift
+++ b/Cotabby/UI/MenuBarView.swift
@@ -86,6 +86,11 @@ struct MenuBarView: View {
                 .toggleStyle(.switch)
                 .controlSize(.small)
 
+            Toggle("Fast Mode", isOn: fastModeEnabledBinding)
+                .toggleStyle(.switch)
+                .controlSize(.small)
+                .help("Skips capturing on-screen context (OCR) for faster, lower-overhead suggestions.")
+
             Toggle("Show Indicator", isOn: showIndicatorBinding)
                 .toggleStyle(.switch)
                 .controlSize(.small)
@@ -254,6 +259,13 @@ struct MenuBarView: View {
         Binding(
             get: { suggestionSettings.isClipboardContextEnabled },
             set: { suggestionSettings.setClipboardContextEnabled($0) }
+        )
+    }
+
+    private var fastModeEnabledBinding: Binding<Bool> {
+        Binding(
+            get: { suggestionSettings.isFastModeEnabled },
+            set: { suggestionSettings.setFastModeEnabled($0) }
         )
     }
 

--- a/Cotabby/UI/SettingsView.swift
+++ b/Cotabby/UI/SettingsView.swift
@@ -184,6 +184,9 @@ struct SettingsView: View {
 
             Toggle("Include Clipboard Context", isOn: clipboardContextEnabledBinding)
 
+            Toggle("Fast Mode", isOn: fastModeEnabledBinding)
+                .help("Skips capturing on-screen context (OCR) for faster, lower-overhead suggestions.")
+
             // Open at Login is hidden until the quarantine/SMAppService issue is resolved.
             // The toggle reports .notFound for quarantined apps and apps outside /Applications,
             // making it appear broken for most users. See LaunchAtLoginService for details.
@@ -664,6 +667,13 @@ struct SettingsView: View {
         Binding(
             get: { suggestionSettings.isClipboardContextEnabled },
             set: { suggestionSettings.setClipboardContextEnabled($0) }
+        )
+    }
+
+    private var fastModeEnabledBinding: Binding<Bool> {
+        Binding(
+            get: { suggestionSettings.isFastModeEnabled },
+            set: { suggestionSettings.setFastModeEnabled($0) }
         )
     }
 

--- a/CotabbyTests/CotabbyTestFixtures.swift
+++ b/CotabbyTests/CotabbyTestFixtures.swift
@@ -219,7 +219,8 @@ enum CotabbyTestFixtures {
         debounceMilliseconds: Int = 50,
         focusPollIntervalMilliseconds: Int = 50,
         isMultiLineEnabled: Bool = false,
-        autoAcceptTrailingPunctuation: Bool = true
+        autoAcceptTrailingPunctuation: Bool = true,
+        isFastModeEnabled: Bool = false
     ) -> SuggestionSettingsSnapshot {
         SuggestionSettingsSnapshot(
             isGloballyEnabled: isGloballyEnabled,
@@ -233,7 +234,8 @@ enum CotabbyTestFixtures {
             debounceMilliseconds: debounceMilliseconds,
             focusPollIntervalMilliseconds: focusPollIntervalMilliseconds,
             isMultiLineEnabled: isMultiLineEnabled,
-            autoAcceptTrailingPunctuation: autoAcceptTrailingPunctuation
+            autoAcceptTrailingPunctuation: autoAcceptTrailingPunctuation,
+            isFastModeEnabled: isFastModeEnabled
         )
     }
 }

--- a/CotabbyTests/SuggestionAvailabilityEvaluatorTests.swift
+++ b/CotabbyTests/SuggestionAvailabilityEvaluatorTests.swift
@@ -286,6 +286,42 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
 
         XCTAssertFalse(ok)
     }
+
+    // MARK: - shouldCaptureVisualContext + fast mode
+
+    func test_shouldCaptureVisualContext_trueWhenAllowedAndNotFastMode() {
+        let ok = SuggestionAvailabilityEvaluator.shouldCaptureVisualContext(
+            globallyEnabled: true,
+            inputMonitoringGranted: true,
+            screenRecordingGranted: true,
+            focusSnapshot: makeSnapshot(capability: .supported),
+            isFastModeEnabled: false
+        )
+
+        XCTAssertTrue(ok)
+    }
+
+    /// The core fast-mode invariant: it turns off the screenshot/OCR pipeline while leaving the
+    /// prediction gate untouched, so the user still gets (faster, context-free) completions.
+    func test_fastMode_suppressesVisualContextButNotPredictions() {
+        let snapshot = makeSnapshot(capability: .supported)
+
+        XCTAssertFalse(
+            SuggestionAvailabilityEvaluator.shouldCaptureVisualContext(
+                inputMonitoringGranted: true,
+                screenRecordingGranted: true,
+                focusSnapshot: snapshot,
+                isFastModeEnabled: true
+            )
+        )
+        XCTAssertTrue(
+            SuggestionAvailabilityEvaluator.shouldSchedulePrediction(
+                inputMonitoringGranted: true,
+                screenRecordingGranted: true,
+                focusSnapshot: snapshot
+            )
+        )
+    }
 }
 
 /// Tests for the app identity that menu-bar controls target.
@@ -491,6 +527,44 @@ final class SuggestionSettingsModelDisabledAppsTests: XCTestCase {
                 .store(in: &cancellables)
 
             model.setClipboardContextEnabled(true)
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+        _ = cancellables
+    }
+
+    func test_fastMode_defaultsToFalseAndPersists() {
+        runOnMainActor {
+            let userDefaults = makeUserDefaults()
+            let model = makeModel(userDefaults: userDefaults)
+
+            XCTAssertFalse(model.isFastModeEnabled)
+            XCTAssertFalse(model.snapshot.isFastModeEnabled)
+
+            model.setFastModeEnabled(true)
+            let reloadedModel = makeModel(userDefaults: userDefaults)
+
+            XCTAssertTrue(reloadedModel.isFastModeEnabled)
+            XCTAssertTrue(reloadedModel.snapshot.isFastModeEnabled)
+        }
+    }
+
+    func test_snapshotPublisher_emitsWhenFastModeSettingChanges() {
+        let expectation = expectation(description: "snapshot emits after fast mode setting changes")
+        var cancellables = Set<AnyCancellable>()
+
+        runOnMainActor {
+            let model = makeModel()
+
+            model.snapshotPublisher
+                .dropFirst()
+                .sink { snapshot in
+                    XCTAssertTrue(snapshot.isFastModeEnabled)
+                    expectation.fulfill()
+                }
+                .store(in: &cancellables)
+
+            model.setFastModeEnabled(true)
         }
 
         wait(for: [expectation], timeout: 1.0)


### PR DESCRIPTION
## Summary

Adds a **Fast Mode** toggle that turns off the screenshot/OCR visual-context pipeline entirely, trading screen-context accuracy for lower latency and overhead. It's surfaced in Settings → General and the menu-bar panel, and defaults **off** so existing behavior is unchanged. The gate sits at `shouldCaptureVisualContext`, *before* any capture begins, so fast mode does zero screenshot/OCR work — rather than doing the work and then discarding the result.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

xcodebuild ... test CODE_SIGNING_ALLOWED=NO \
  -only-testing:CotabbyTests/SuggestionAvailabilityEvaluatorTests \
  -only-testing:CotabbyTests/SuggestionSettingsModelDisabledAppsTests
# Executed 30 tests, with 0 failures
# New: shouldCaptureVisualContext true / false-in-fast-mode;
#      fast_mode_suppressesVisualContextButNotPredictions;
#      fastMode defaults-false + persists; snapshotPublisher emits on change.

swiftlint lint --quiet   # changed files → no new violations
```

Not verified in the running app: no manual UI walkthrough confirming the toggle renders in General + the menu bar, and no end-to-end timing check of the latency win.

## Linked issues

No tracked issue — requested directly. Happy to file one for traceability if you'd like.

## Risk / rollout notes

- **Defaults to off** (`cotabbyFastModeEnabled` absent → `false`), so existing users see no change until they opt in. New UserDefaults key; no migration needed.
- **Visual context only, never predictions.** The gate is deliberately in `shouldCaptureVisualContext` and *not* in `disabledReason` / `shouldSchedulePrediction`, so fast mode suppresses screen context while completions keep flowing (just context-free). A test pins this invariant.
- **Fixes a pre-existing gap.** `handleSupportedSnapshot` started a visual-context session unconditionally; it's now gated like the other two start paths, so fast mode can't leak OCR work through the (common) focus-change path. Behavior-preserving for non-fast-mode, since that path is only reached in already-allowed states.
- **Mid-session toggle is safe.** Turning fast mode on cancels any in-flight capture via the existing settings-change handler (`visualContextCoordinator.cancel`), so no stale excerpt reaches the next prediction.
- No pbxproj change (no files added); the committed project stays in sync with `project.yml`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a **Fast Mode** toggle that short-circuits the screenshot/OCR pipeline inside `shouldCaptureVisualContext`, while leaving prediction scheduling, permissions checks, and all other coordinator logic untouched. The gate defaults to `false` so existing users are unaffected.

- `SuggestionAvailabilityEvaluator.shouldCaptureVisualContext` gains an early-exit guard for fast mode; `disabledReason` / `shouldSchedulePrediction` are deliberately unmodified so context-free completions still flow.
- `handleSupportedSnapshot` receives the same `shouldCaptureVisualContext` gate that the other two OCR start paths already had, closing a pre-existing gap where the focus-change entry point could leak OCR work past the check.
- `SuggestionSettingsModel` adds `isFastModeEnabled` as a `@Published` property with UserDefaults persistence and folds it into the Combine snapshot publisher via a nested `CombineLatest`, so mid-session toggles propagate through the existing settings-change cancellation handler.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is additive and defaults off, so no existing user behavior is altered.

The fast-mode gate, settings wiring, and publisher chain are all correctly implemented and well-tested. The one concern is that the help text implies OCR is the only thing being skipped, but Screen Recording permission is still required for predictions to run via shouldSchedulePrediction → disabledReason → screenRecordingGranted. A user who enables fast mode expecting to work without that permission will silently get no completions and see a misleading error. Everything else — persistence, mid-session toggle cancellation, the handleSupportedSnapshot bug fix — is clean.

SettingsView.swift and MenuBarView.swift — both carry help text that may mislead users about the Screen Recording permission requirement remaining in effect.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/SuggestionAvailabilityEvaluator.swift | Adds fast-mode early-exit guard to shouldCaptureVisualContext only, deliberately leaving disabledReason and shouldSchedulePrediction untouched so predictions keep flowing context-free; design intent is clearly documented. |
| Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift | Adds isFastModeEnabled to all three shouldCaptureVisualContext call sites and gates the previously-unconditional startSessionIfNeeded call in handleSupportedSnapshot; the double-check in the handleFocusSnapshotChange→handleSupportedSnapshot path is harmless since startSessionIfNeeded is idempotent. |
| Cotabby/App/Coordinators/SuggestionCoordinator+Lifecycle.swift | Threads isFastModeEnabled into the shouldCaptureVisualContext guard inside handleSuggestionSettingsChange; mid-session toggle correctly cancels in-flight capture before conditionally restarting. |
| Cotabby/Models/SuggestionSettingsModel.swift | Adds isFastModeEnabled @Published property, UserDefaults persistence, setFastModeEnabled mutation method, and folds the new property into the Combine snapshotPublisher via a nested CombineLatest; all wiring looks correct. |
| Cotabby/Models/SuggestionEngineModels.swift | Appends isFastModeEnabled: Bool to SuggestionSettingsSnapshot; clean additive change. |
| Cotabby/UI/SettingsView.swift | Inserts Fast Mode toggle after "Include Clipboard Context" in the General section; help text may mislead users who expect fast mode to also bypass the Screen Recording permission requirement. |
| Cotabby/UI/MenuBarView.swift | Adds Fast Mode toggle with the same help text as SettingsView; carries the same help-text accuracy concern regarding Screen Recording permission still being required. |
| CotabbyTests/SuggestionAvailabilityEvaluatorTests.swift | Adds four tests covering: visual context true when not fast mode, fast mode suppresses OCR but not predictions, fast mode defaults false and persists across reloads, and snapshotPublisher emits on fast-mode change; thorough coverage of the new feature. |
| CotabbyTests/CotabbyTestFixtures.swift | Extends the snapshot factory with isFastModeEnabled defaulting to false; clean, backward-compatible change. |

</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fast-mode-toggle%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fast-mode-toggle%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FSettingsView.swift%3A187-188%0A**Help%20text%20may%20mislead%20users%20about%20Screen%20Recording**%0A%0AThe%20%60.help%28%29%60%20text%20says%20fast%20mode%20%22Skips%20capturing%20on-screen%20context%20%28OCR%29%22%2C%20but%20%60shouldSchedulePrediction%60%20still%20delegates%20to%20%60disabledReason%60%2C%20which%20gates%20on%20%60screenRecordingGranted%60.%20A%20user%20who%20enables%20fast%20mode%20expecting%20to%20avoid%20the%20Screen%20Recording%20permission%20will%20still%20see%20%22Screen%20Recording%20permission%20is%20required%20before%20Cotabby%20can%20build%20visual%20context%20for%20autocomplete%22%20and%20receive%20no%20completions%20at%20all.%20The%20same%20copy%20appears%20in%20%60MenuBarView%60.%20Consider%20adding%20a%20note%20that%20predictions%20still%20require%20the%20Screen%20Recording%20grant%2C%20or%20updating%20the%20error%20message%20in%20%60disabledReason%60%20to%20drop%20%22build%20visual%20context%22%20when%20fast%20mode%20is%20on.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FSettingsView.swift%3A187-188%0A**Help%20text%20may%20mislead%20users%20about%20Screen%20Recording**%0A%0AThe%20%60.help%28%29%60%20text%20says%20fast%20mode%20%22Skips%20capturing%20on-screen%20context%20%28OCR%29%22%2C%20but%20%60shouldSchedulePrediction%60%20still%20delegates%20to%20%60disabledReason%60%2C%20which%20gates%20on%20%60screenRecordingGranted%60.%20A%20user%20who%20enables%20fast%20mode%20expecting%20to%20avoid%20the%20Screen%20Recording%20permission%20will%20still%20see%20%22Screen%20Recording%20permission%20is%20required%20before%20Cotabby%20can%20build%20visual%20context%20for%20autocomplete%22%20and%20receive%20no%20completions%20at%20all.%20The%20same%20copy%20appears%20in%20%60MenuBarView%60.%20Consider%20adding%20a%20note%20that%20predictions%20still%20require%20the%20Screen%20Recording%20grant%2C%20or%20updating%20the%20error%20message%20in%20%60disabledReason%60%20to%20drop%20%22build%20visual%20context%22%20when%20fast%20mode%20is%20on.%0A%0A&repo=fujacob%2Fcotabby&pr=301&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add a Fast Mode toggle that skips the sc..."](https://github.com/fujacob/cotabby/commit/cb2ddbc0911e7982f80ea2dfd18be72b837269c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34107528)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->