### PR TITLE
docs: restyle README header (logo, name, badges, sponsor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,13 @@
-# Cotabby [beta]
-
-<sub>If Cotabby is useful to you, consider supporting development:</sub>
-
-<a href='https://ko-fi.com/I2F22066MI' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://storage.ko-fi.com/cdn/kofi6.png?v=6' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
-
----
-
 <p align="center">
-  <img width="128" alt="Cotabby logo" src="https://github.com/user-attachments/assets/1e223e72-770c-417b-82e5-83f18cd5a3b2" />
+  <a href="https://cotabby.app" target="_blank">
+    <img height="200" alt="Cotabby logo" src="https://github.com/user-attachments/assets/1e223e72-770c-417b-82e5-83f18cd5a3b2" />
+  </a>
 </p>
 
-<p align="center">
-  <em>Open-source, local-first AI autocomplete for macOS.</em>
-  </p>
-  
+<h1 align="center">Cotabby [beta]</h1>
+
+<p align="center"><em>Open-source, local-first AI autocomplete for macOS.</em></p>
+
 <p align="center">
   <a href="https://cotabby.app"><strong>Visit the landing page →</strong></a>
 </p>
@@ -25,6 +19,14 @@
   <a href="https://github.com/FuJacob/cotabby/stargazers"><img alt="Stars" src="https://img.shields.io/github/stars/FuJacob/cotabby?style=flat" /></a>
   <img alt="Platform" src="https://img.shields.io/badge/platform-macOS%2015%2B-lightgrey" />
   <img alt="Visitors" src="https://visitor-badge.laobi.icu/badge?page_id=FuJacob.tabby" />
+</p>
+
+<p align="center">
+  <sub>Cotabby is free and open source. If it's useful to you, please consider supporting development for the sake of open source ✨</sub>
+</p>
+
+<p align="center">
+  <a href='https://ko-fi.com/I2F22066MI' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://storage.ko-fi.com/cdn/kofi6.png?v=6' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
 </p>
 
 ---


### PR DESCRIPTION
## Summary

Restyles the top of the README into a cleaner, centered header inspired by the Input Source Pro layout: a bigger logo, the project name, then badges, then the sponsor section. Also softens the sponsor copy to a gentler "please consider supporting … for the sake of open source" ask.

## Validation

Docs-only change. Reviewed the rendered Markdown ordering: logo (height 200, centered, links to cotabby.app) → `Cotabby [beta]` heading → tagline + landing link → badges → sponsor blurb + Ko-fi button → existing `---` divider and the rest of the README untouched. No code, no build impact.

## Linked issues

<!-- None. -->

## Risk / rollout notes

- README-only; no behavior, build, or settings impact.
- Logo, badges, landing link, and Ko-fi button all reuse the existing URLs — only ordering, logo size, and sponsor wording changed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reorders and restyls the README header section, moving from a plain Markdown heading at the top to a centered HTML layout: larger logo → `<h1>` project name → tagline → badges → sponsor blurb + Ko-fi button → `---` divider. No code, build, or configuration files are touched.

- Logo `width` attribute replaced with `height=\"200\"` and wrapped in a `cotabby.app` link; the `target=\"_blank\"` attribute is present on the wrapping `<a>` only, not on the inline landing-page link lower down (minor inconsistency, no functional impact).
- Sponsor copy relocated from the very top of the file to below the badge row and rewritten to be softer, matching the stated inspiration from Input Source Pro.

<h3>Confidence Score: 5/5</h3>

README-only cosmetic change; no code, build, or configuration files are modified.

All changes are confined to the top section of the README: logo size, ordering of elements, and sponsor copy. Every URL reused is identical to what was there before; nothing functional is altered.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Header restyled: logo enlarged (128→200px) and linked to cotabby.app, project name converted to centered `<h1>`, sponsor blurb softened and relocated after badges — rest of the document is untouched. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Before["Before (old header order)"]
        A1["# Cotabby [beta] (h1 heading)"] --> B1["Sponsor blurb + Ko-fi button"]
        B1 --> C1["--- divider"]
        C1 --> D1["Logo (width=128, no link)"]
        D1 --> E1["Tagline"]
        E1 --> F1["Landing page link"]
        F1 --> G1["Badges"]
    end

    subgraph After["After (new header order)"]
        A2["Logo (height=200, links to cotabby.app)"] --> B2["h1 Cotabby [beta] (centered HTML)"]
        B2 --> C2["Tagline"]
        C2 --> D2["Landing page link"]
        D2 --> E2["Badges"]
        E2 --> F2["Sponsor blurb (softened copy)"]
        F2 --> G2["Ko-fi button"]
        G2 --> H2["--- divider"]
    end
```

<sub>Reviews (1): Last reviewed commit: ["docs: restyle README header — bigger cen..."](https://github.com/fujacob/cotabby/commit/897929f81404389221bd128beeeeb80ffd1297b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34107736)</sub>

<!-- /greptile_comment -->