### PR TITLE
Fix double space on accept by reconciling the word boundary at insert time

### DIFF
--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
@@ -56,7 +56,19 @@ extension SuggestionCoordinator {
             return passTabThrough(reason: reason)
         }
 
-        guard suggestionInserter.insert(acceptedChunk) else {
+        // Reconcile the word boundary against the *live* preceding text instead of trusting the
+        // leading space baked into the suggestion at generation time — that decision goes stale when
+        // the user types the separating space themselves, producing a double space on accept. The
+        // session still advances by the full `acceptedChunk`; the whitespace we skip typing is the
+        // field's own, so the post-insertion consumed-suffix accounting still lines up.
+        let insertionChunk = SuggestionSessionReconciler.insertionChunk(
+            forAcceptedChunk: acceptedChunk,
+            precedingText: liveContext.precedingText
+        )
+
+        // An empty chunk means the accepted span was entirely a boundary space the field already
+        // supplies: advance the session without synthesizing a keystroke.
+        if !insertionChunk.isEmpty, !suggestionInserter.insert(insertionChunk) {
             let message = suggestionInserter.lastErrorMessage ?? "Suggestion insertion failed."
             cancelPredictionWork()
             clearSuggestion(clearDiagnostics: true)
@@ -67,7 +79,7 @@ extension SuggestionCoordinator {
                 workID: currentWorkID,
                 generation: liveContext.generation,
                 message: message,
-                normalizedOutput: acceptedChunk
+                normalizedOutput: insertionChunk
             )
             return false
         }
@@ -103,7 +115,7 @@ extension SuggestionCoordinator {
             state = .ready(text: advancedSession.remainingText, latency: advancedSession.latency)
             let isRTL = TextDirectionDetector.isRightToLeft(liveContext.precedingText)
             let predictedCaret = Self.predictedCaretRect(
-                after: acceptedChunk,
+                after: insertionChunk,
                 oldCaretRect: liveContext.caretRect,
                 caretQuality: liveContext.caretQuality,
                 observedCharWidth: liveContext.observedCharWidth,

--- a/Cotabby/Support/SuggestionSessionReconciler.swift
+++ b/Cotabby/Support/SuggestionSessionReconciler.swift
@@ -279,6 +279,30 @@ enum SuggestionSessionReconciler {
         return wordEnd
     }
 
+    /// Returns the text to actually type for an acceptance chunk, dropping its leading whitespace run
+    /// when the live text before the caret already ends in whitespace — so accepting never stacks a
+    /// second space onto a boundary the field already provides.
+    ///
+    /// This is the authoritative, accept-time counterpart to the generation-time space handling in
+    /// `SuggestionTextNormalizer`. That normalizer decides whether to keep the model's leading space
+    /// against a prefix *snapshot* taken when the request was built, which can be stale by the time
+    /// the user accepts — most often because they typed the separating space themselves after the
+    /// ghost appeared, or because AX reported the prefix before that space landed. Reconciling here
+    /// against the live preceding text makes the boundary deterministic instead of relying on the
+    /// timing-sensitive session reconciler to consume the typed space first.
+    ///
+    /// The session still advances by the full (untrimmed) chunk: the whitespace we skip typing is
+    /// exactly the whitespace already present in the field, so the consumed-suffix accounting the
+    /// reconciler does after insertion still lines up.
+    static func insertionChunk(forAcceptedChunk chunk: String, precedingText: String) -> String {
+        guard let lastScalar = precedingText.unicodeScalars.last,
+              CharacterSet.whitespaces.contains(lastScalar) else {
+            return chunk
+        }
+
+        return String(chunk.drop(while: { $0.isWhitespace }))
+    }
+
     /// Counts word-like tokens so punctuation-only accepts do not inflate productivity metrics.
     static func acceptedWordCount(in text: String) -> Int {
         text

--- a/CotabbyTests/SuggestionSessionReconcilerTests.swift
+++ b/CotabbyTests/SuggestionSessionReconcilerTests.swift
@@ -131,6 +131,64 @@ final class SuggestionSessionReconcilerTests: XCTestCase {
         )
     }
 
+    func test_insertionChunk_dropsLeadingSpaceWhenPrecedingTextAlreadyEndsInWhitespace() {
+        XCTAssertEqual(
+            SuggestionSessionReconciler.insertionChunk(forAcceptedChunk: " you", precedingText: "How are "),
+            "you"
+        )
+    }
+
+    func test_insertionChunk_keepsLeadingSpaceWhenPrecedingTextHasNoTrailingWhitespace() {
+        XCTAssertEqual(
+            SuggestionSessionReconciler.insertionChunk(forAcceptedChunk: " you", precedingText: "How are"),
+            " you"
+        )
+    }
+
+    func test_insertionChunk_collapsesAWholeLeadingRunAgainstFieldWhitespace() {
+        // The reported "bunch of spaces" case: a field that already ends in a space plus a chunk
+        // carrying its own leading space(s) must not stack them.
+        XCTAssertEqual(
+            SuggestionSessionReconciler.insertionChunk(forAcceptedChunk: "  you", precedingText: "How are "),
+            "you"
+        )
+    }
+
+    func test_insertionChunk_leavesChunkUntouchedWhenItHasNoLeadingWhitespace() {
+        XCTAssertEqual(
+            SuggestionSessionReconciler.insertionChunk(forAcceptedChunk: "you", precedingText: "How are "),
+            "you"
+        )
+    }
+
+    func test_insertionChunk_treatsTabAsBoundaryWhitespaceButNotNewline() {
+        XCTAssertEqual(
+            SuggestionSessionReconciler.insertionChunk(forAcceptedChunk: " you", precedingText: "How are\t"),
+            "you"
+        )
+        // Newlines are not horizontal whitespace, so a leading space after a line break is kept.
+        XCTAssertEqual(
+            SuggestionSessionReconciler.insertionChunk(forAcceptedChunk: " you", precedingText: "line\n"),
+            " you"
+        )
+    }
+
+    func test_insertionChunk_preservesInterWordSpaceMidSuggestion() {
+        // After "you" was already inserted, the field ends in a word, so the next chunk's space
+        // is the real boundary and must survive.
+        XCTAssertEqual(
+            SuggestionSessionReconciler.insertionChunk(forAcceptedChunk: " are", precedingText: "How are you"),
+            " are"
+        )
+    }
+
+    func test_insertionChunk_returnsChunkUnchangedForEmptyPrecedingText() {
+        XCTAssertEqual(
+            SuggestionSessionReconciler.insertionChunk(forAcceptedChunk: " you", precedingText: ""),
+            " you"
+        )
+    }
+
     func test_acceptedWordCount_countsOnlyTokensWithAlphanumerics() {
         let count = SuggestionSessionReconciler.acceptedWordCount(
             in: "hello, !!! world 123 --"


### PR DESCRIPTION
## Summary

Accepting a suggestion sometimes left **extra spaces** between the user's word and the accepted word.
The boundary space was decided once at generation time (`SuggestionTextNormalizer`, lines 90-92)
against a prefix *snapshot* and then inserted verbatim — so when that snapshot went stale by accept
time (almost always because the user typed the separating space themselves after the ghost appeared,
or AX reported the prefix before the space landed), the field's trailing space and the suggestion's
leading space both survived. The session reconciler only canceled this opportunistically, so it
slipped through on a timing race.

This moves the boundary decision to **accept time**, where it can be made deterministically against
the live field: `SuggestionSessionReconciler.insertionChunk(forAcceptedChunk:precedingText:)` drops a
chunk's leading whitespace run when the live preceding text already ends in whitespace, and
`acceptSuggestion` uses it against `liveContext.precedingText`. The session still advances by the full
accepted chunk — the whitespace we skip typing is the field's own, so the post-insertion
consumed-suffix accounting is unchanged — and caret prediction advances by what was actually typed.

## Validation

```bash
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build-for-testing
# ** TEST BUILD SUCCEEDED **
xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  -only-testing:CotabbyTests/SuggestionSessionReconcilerTests CODE_SIGNING_ALLOWED=NO
# Executed 35 tests, with 0 failures   (7 new insertionChunk cases)
swiftlint lint --quiet --config .swiftlint.yml <the 3 changed files>
# exit 0
```

New tests cover: drop leading space when the field already ends in whitespace; keep it when it
doesn't; collapse a whole leading run; leave a no-leading-space chunk untouched; tab counts as
boundary whitespace but a newline does not; inter-word spaces mid-suggestion survive; empty preceding
text is a no-op. App-hosted `test` only runs with `CODE_SIGNING_ALLOWED=NO` here (local Team ID
mismatch, per `CLAUDE.md`); I ran the affected unit suite, not the whole target.

## Linked issues

None — surfaced while investigating the recurring double-space-on-accept report.

## Risk / rollout notes

- The generation-time space handling in `SuggestionTextNormalizer` is intentionally left in place as a
  first pass for the ghost-text preview; the accept-time check is now the authoritative one for what
  actually gets typed.
- Accounting is exact in the dominant case (field has one trailing space, chunk has one leading
  space). In the rare case of a chunk with *more* leading whitespace than the field supplies (a model
  emitting multiple internal spaces, which the normalizer doesn't collapse), the result is still a
  single clean boundary but the session's consumed count can sit one ahead of the field for that
  cycle — which only triggers the existing post-insertion lag tolerance (an overlay refresh), never a
  double space. Collapsing multi-space model output is a separate, pre-existing normalizer concern.
- No change to the reconciler's own logic, so existing reconcile/acceptance tests are unaffected.
- Does not address the inverse (missing space when the user *deletes* their trailing space after
  generation); that needs the suggestion to carry the model's original leading-whitespace intent and
  is a larger change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the double-space-on-accept bug by moving the word-boundary space decision from generation time to accept time. Instead of trusting the leading space baked into a suggestion chunk (which could be stale if the user typed the separating space after the ghost appeared), the new `insertionChunk(forAcceptedChunk:precedingText:)` helper trims the chunk's leading whitespace against the live preceding text right before the keystroke is synthesized.

- **New `insertionChunk` method** in `SuggestionSessionReconciler` strips leading horizontal whitespace from the chunk when the live field already ends in whitespace, and returns the chunk unchanged otherwise; session accounting continues to advance by the full untrimmed `acceptedChunk`, keeping consumed-suffix reconciliation correct.
- **`acceptSuggestion` in `SuggestionCoordinator+Acceptance`** now inserts `insertionChunk` (trimmed) instead of `acceptedChunk`, skips the keystroke entirely for empty results (all-whitespace chunks), and uses `insertionChunk` for caret-position prediction.
- **Seven new unit tests** cover all documented cases: drop on trailing space, keep on no trailing space, multi-space collapse, tab-as-boundary, newline-as-non-boundary, inter-word space survival, and empty preceding text.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the fix is well-scoped and session accounting is unaffected. One small whitespace-definition mismatch in the new helper warrants a look before shipping to wider audiences.

The acceptance path, caret prediction, and consumed-suffix reconciliation all look correct. The only concern is that the guard in `insertionChunk` uses `CharacterSet.whitespaces` (horizontal only) to decide whether to trim, but the `drop(while:)` closure uses `Character.isWhitespace`, which also matches vertical whitespace like `
`. In the normal word-by-word acceptance path this difference is harmless, but a full-accept chunk that begins with a newline could have that newline silently stripped when the preceding text ends with a space or tab.

The `insertionChunk` method in `SuggestionSessionReconciler.swift` — specifically the `drop(while:)` predicate on line 303.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/SuggestionSessionReconciler.swift | Adds `insertionChunk(forAcceptedChunk:precedingText:)` — drops leading whitespace from a chunk when the live preceding text already ends in horizontal whitespace. Minor semantic mismatch: guard uses `CharacterSet.whitespaces` (excludes newlines) but `drop(while:)` uses `Character.isWhitespace` (includes newlines), which could silently drop a leading newline in a full-accept scenario. |
| Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift | Wires `insertionChunk` into the acceptance path: inserts `insertionChunk` (trimmed) instead of `acceptedChunk`, skips the keystroke entirely when the result is empty, and updates caret prediction to use `insertionChunk`. Session advancement and word-count accounting correctly keep using `acceptedChunk`, so consumed-suffix reconciliation is unaffected. |
| CotabbyTests/SuggestionSessionReconcilerTests.swift | Adds 7 focused unit tests for `insertionChunk`: drop on trailing space, keep on no trailing space, collapse multi-space run, untouched no-leading-space chunk, tab as boundary / newline as non-boundary, inter-word space preservation, and empty preceding text. Coverage is thorough for the documented behaviour. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Coordinator as SuggestionCoordinator
    participant Reconciler as SuggestionSessionReconciler
    participant Inserter as SuggestionInserter
    participant Session as ActiveSuggestionSession

    User->>Coordinator: Tab pressed (accept)
    Coordinator->>Coordinator: prepareAcceptance() → acceptedChunk (e.g. " you")
    Coordinator->>Reconciler: insertionChunk(forAcceptedChunk: " you", precedingText: "How are ")
    Reconciler-->>Coordinator: "you" (leading space dropped — field already ends in space)
    alt insertionChunk is non-empty
        Coordinator->>Inserter: insert("you")
        Inserter-->>Coordinator: success
    else insertionChunk is empty
        Note over Coordinator: Skip keystroke — field already supplies the whitespace
    end
    Coordinator->>Session: commitAcceptedChunk(" you") [full chunk — accounting unchanged]
    Session-->>Coordinator: .advanced / .exhausted
    Coordinator->>Coordinator: predictedCaretRect(after: "you") [trimmed chunk for caret shift]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Faccept-boundary-whitespace%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Faccept-boundary-whitespace%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FSupport%2FSuggestionSessionReconciler.swift%3A303%0AThe%20guard%20deliberately%20uses%20%60CharacterSet.whitespaces%60%20%28horizontal%20whitespace%20only%20%E2%80%94%20space%20and%20tab%29%20to%20exclude%20newlines%20from%20triggering%20the%20boundary%20trim%2C%20which%20the%20test%20comment%20explicitly%20confirms%20%28%22Newlines%20are%20not%20horizontal%20whitespace%22%29.%20However%2C%20the%20%60drop%28while%3A%29%60%20closure%20uses%20%60Character.isWhitespace%60%2C%20which%20also%20matches%20%60%0A%60%2C%20%60%0A%60%2C%20%60%0A%60%2C%20and%20other%20vertical%20whitespace.%20If%20a%20chunk%20ever%20starts%20with%20a%20newline%20%28e.g.%20a%20full-accept%20spanning%20a%20line%20break%20where%20the%20first%20character%20is%20%60%0A%60%29%2C%20and%20the%20preceding%20text%20ends%20with%20a%20space%20or%20tab%2C%20the%20guard%20passes%20and%20the%20newline%20gets%20silently%20dropped%20%E2%80%94%20potentially%20corrupting%20the%20suggestion's%20structure.%20The%20%60drop%60%20predicate%20should%20mirror%20the%20guard's%20definition%20for%20consistent%20behaviour.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20return%20String%28chunk.drop%28while%3A%20%7B%20%240.unicodeScalars.allSatisfy%20%7B%20CharacterSet.whitespaces.contains%28%240%29%20%7D%20%7D%29%29%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FSupport%2FSuggestionSessionReconciler.swift%3A303%0AThe%20guard%20deliberately%20uses%20%60CharacterSet.whitespaces%60%20%28horizontal%20whitespace%20only%20%E2%80%94%20space%20and%20tab%29%20to%20exclude%20newlines%20from%20triggering%20the%20boundary%20trim%2C%20which%20the%20test%20comment%20explicitly%20confirms%20%28%22Newlines%20are%20not%20horizontal%20whitespace%22%29.%20However%2C%20the%20%60drop%28while%3A%29%60%20closure%20uses%20%60Character.isWhitespace%60%2C%20which%20also%20matches%20%60%0A%60%2C%20%60%0A%60%2C%20%60%0A%60%2C%20and%20other%20vertical%20whitespace.%20If%20a%20chunk%20ever%20starts%20with%20a%20newline%20%28e.g.%20a%20full-accept%20spanning%20a%20line%20break%20where%20the%20first%20character%20is%20%60%0A%60%29%2C%20and%20the%20preceding%20text%20ends%20with%20a%20space%20or%20tab%2C%20the%20guard%20passes%20and%20the%20newline%20gets%20silently%20dropped%20%E2%80%94%20potentially%20corrupting%20the%20suggestion's%20structure.%20The%20%60drop%60%20predicate%20should%20mirror%20the%20guard's%20definition%20for%20consistent%20behaviour.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20return%20String%28chunk.drop%28while%3A%20%7B%20%240.unicodeScalars.allSatisfy%20%7B%20CharacterSet.whitespaces.contains%28%240%29%20%7D%20%7D%29%29%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=303&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Fix double space on accept by reconcilin..."](https://github.com/fujacob/cotabby/commit/0b8cec3ae4bb8c380928e963effdff0ad3c196d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34107828)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->