### PR TITLE
Trim the menu bar popover: drop Show Indicator and Show Accept Hint toggles

### DIFF
--- a/Cotabby/UI/MenuBarView.swift
+++ b/Cotabby/UI/MenuBarView.swift
@@ -91,14 +91,6 @@ struct MenuBarView: View {
                 .controlSize(.small)
                 .help("Skips capturing on-screen context (OCR) for faster, lower-overhead suggestions.")
 
-            Toggle("Show Indicator", isOn: showIndicatorBinding)
-                .toggleStyle(.switch)
-                .controlSize(.small)
-
-            Toggle("Show Accept Hint", isOn: showAcceptanceHintBinding)
-                .toggleStyle(.switch)
-                .controlSize(.small)
-
             Toggle("Allow Multi-line Suggestions", isOn: multiLineEnabledBinding)
                 .toggleStyle(.switch)
                 .controlSize(.small)
@@ -283,20 +275,6 @@ struct MenuBarView: View {
                     disabled: !enabled
                 )
             }
-        )
-    }
-
-    private var showIndicatorBinding: Binding<Bool> {
-        Binding(
-            get: { suggestionSettings.showIndicator },
-            set: { suggestionSettings.setShowIndicator($0) }
-        )
-    }
-
-    private var showAcceptanceHintBinding: Binding<Bool> {
-        Binding(
-            get: { suggestionSettings.showAcceptanceHint },
-            set: { suggestionSettings.setShowAcceptanceHint($0) }
         )
     }
 


### PR DESCRIPTION
## Summary

The menu bar popover had grown to seven toggles and was drifting into a second Settings window.
**Show Indicator** and **Show Accept Hint** are set-once display preferences — not momentary or
context-dependent controls — so they don't earn a spot in a frequently-opened quick panel. This
removes both from the popover (and their now-dead `Binding` helpers). Both remain fully available in
**Settings › General**, where they already lived, so nothing becomes unreachable.

This is the first, smallest cut of the popover de-clutter: keep the popover for glanceable status and
momentary/contextual switches (Enable Globally, Enable in ⟨app⟩, Fast Mode, Multi-line, Clipboard),
and let durable display prefs live in Settings.

## Validation

```bash
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **
swiftlint lint --quiet --config .swiftlint.yml Cotabby/UI/MenuBarView.swift
# exit 0
```

Confirmed no dangling references to the removed toggles/bindings in `MenuBarView`, and confirmed both
toggles + their bindings still exist in `SettingsView` (lines 160 / 178). UI verified by build only —
no manual app run.

## Linked issues

None — follow-up from a discussion about the popover getting crowded.

## Risk / rollout notes

- Pure UI removal from the popover: the underlying `showIndicator` / `showAcceptanceHint` settings,
  their setters, and persistence are untouched, and both toggles remain in Settings.
- No behavior change to the indicator or accept-hint features themselves — only where you toggle them.
- Scoped intentionally to these two. The other "set-once" candidates (Multi-line, Clipboard Context)
  were left in the popover pending a decision on how far to trim.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes "Show Indicator" and "Show Accept Hint" toggles from the menu-bar popover, along with their two `Binding` helper properties in `MenuBarView`. Both toggles are preserved in `Settings › General`, the underlying model properties, setters, and UserDefaults persistence are fully intact.

- Two `Toggle` views and two `private var …Binding` helpers are deleted from `MenuBarView.swift`; no other files are touched.
- `SuggestionSettingsModel`, `SettingsView`, `AppDelegate`, and the test suite are all unaffected and continue to reference `showIndicator` / `showAcceptanceHint` as before.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a pure UI removal with no behavioral change.

The change deletes two Toggle views and two Binding helpers from the popover. Both settings remain fully accessible in SettingsView, the model layer is untouched, persistence is unaffected, and a grep across the repo confirms no dangling references to the removed symbols.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/MenuBarView.swift | Removes two Toggle rows and their corresponding Binding helpers; remaining bindings and view structure are untouched. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[MenuBarView popover] --> B[Enable Globally]
    A --> C[Enable in App]
    A --> D[Include Clipboard Context]
    A --> E[Fast Mode]
    A --> F[Allow Multi-line Suggestions]
    A --> G[Engine Picker]
    A --> H[Length Picker]

    I[Settings › General] --> J[Show Indicator kept here]
    I --> K[Show Accept Hint kept here]

    subgraph Removed from popover
        direction LR
        X[Show Indicator Toggle]
        Y[Show Accept Hint Toggle]
        X2[showIndicatorBinding]
        Y2[showAcceptanceHintBinding]
    end

    style X fill:#ffcccc,stroke:#cc0000
    style Y fill:#ffcccc,stroke:#cc0000
    style X2 fill:#ffcccc,stroke:#cc0000
    style Y2 fill:#ffcccc,stroke:#cc0000
    style J fill:#ccffcc,stroke:#007700
    style K fill:#ccffcc,stroke:#007700
```

<sub>Reviews (1): Last reviewed commit: ["Remove Show Indicator and Show Accept Hi..."](https://github.com/fujacob/cotabby/commit/91b94379e0e2a7415e7d239d3a6675d322166276) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34109960)</sub>

<!-- /greptile_comment -->