### PR TITLE
Add tabby-pico-1 (SmolLM2-135M) as the smallest default model

### DIFF
--- a/Cotabby/Models/LlamaRuntimeModels.swift
+++ b/Cotabby/Models/LlamaRuntimeModels.swift
@@ -93,6 +93,8 @@ enum RuntimeModelCatalog {
             return "tabby-max-1"
         case "SmolLM-360M-Instruct.Q8_0.gguf":
             return "tabby-nano-1"
+        case "SmolLM2-135M-Instruct-q8_0.gguf":
+            return "tabby-pico-1"
         default:
             return filename
         }
@@ -106,6 +108,17 @@ enum RuntimeModelCatalog {
     ///
     ///   curl -sIL "<URL>" | grep -iE "^(x-linked-size|x-linked-etag):"
     static let downloadableModels: [DownloadableRuntimeModel] = [
+        DownloadableRuntimeModel(
+            filename: "SmolLM2-135M-Instruct-q8_0.gguf",
+            displayName: displayName(for: "SmolLM2-135M-Instruct-q8_0.gguf"),
+            downloadURL: URL(
+                string:
+                    "https://huggingface.co/Mungert/SmolLM2-135M-Instruct-GGUF/resolve/main/SmolLM2-135M-Instruct-q8_0.gguf?download=true"
+            )!,
+            approximateSizeInGigabytes: 0.1,
+            expectedSizeBytes: 144_811_552,
+            sha256: "bc64cce8e1c11e4ed870633b557e04af718249c817c4cf8a6784116144ec3e28"
+        ),
         DownloadableRuntimeModel(
             filename: "SmolLM-360M-Instruct.Q8_0.gguf",
             displayName: displayName(for: "SmolLM-360M-Instruct.Q8_0.gguf"),
@@ -169,7 +182,8 @@ struct LlamaRuntimeConfiguration: Equatable, Sendable {
             "gemma-4-E4B-it-Q4_K_M.gguf",
             "gemma-4-E2B-it-Q4_K_M.gguf",
             "Qwen3-0.6B-Q4_K_M.gguf",
-            "SmolLM-360M-Instruct.Q8_0.gguf"
+            "SmolLM-360M-Instruct.Q8_0.gguf",
+            "SmolLM2-135M-Instruct-q8_0.gguf"
         ],
         contextWindowTokens: 2048,
         batchSize: 512,

--- a/README.md
+++ b/README.md
@@ -82,14 +82,15 @@ Everything runs on-device. No hosted API, no cloud round-trip.
 
 **Apple Intelligence**: uses Apple's on-device `FoundationModels` runtime on macOS 26 or later, no download required.
 
-**Open Source**: runs local GGUF models in-process through llama.cpp via `llama.swift`. Cotabby ships with four built-in downloadable models:
+**Open Source**: runs local GGUF models in-process through llama.cpp via `llama.swift`. Cotabby ships with five built-in downloadable models:
 
-| Model              | File                             | Size    | Source                                                                                                  |
-| ------------------ | -------------------------------- | ------- | ------------------------------------------------------------------------------------------------------- |
-| `tabby-nano-1`     | `SmolLM-360M-Instruct.Q8_0.gguf` | ~0.4 GB | [QuantFactory/SmolLM-360M-Instruct-GGUF](https://huggingface.co/QuantFactory/SmolLM-360M-Instruct-GGUF) |
-| `tabby-fast-1`     | `Qwen3-0.6B-Q4_K_M.gguf`         | ~0.4 GB | [unsloth/Qwen3-0.6B-GGUF](https://huggingface.co/unsloth/Qwen3-0.6B-GGUF)                               |
-| `tabby-balanced-1` | `gemma-4-E2B-it-Q4_K_M.gguf`     | ~3.1 GB | [unsloth/gemma-4-E2B-it-GGUF](https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF)                       |
-| `tabby-max-1`      | `gemma-4-E4B-it-Q4_K_M.gguf`     | ~5.0 GB | [unsloth/gemma-4-E4B-it-GGUF](https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF)                       |
+| Model              | File                              | Size    | Source                                                                                                  |
+| ------------------ | --------------------------------- | ------- | ------------------------------------------------------------------------------------------------------- |
+| `tabby-pico-1`     | `SmolLM2-135M-Instruct-q8_0.gguf` | ~0.1 GB | [Mungert/SmolLM2-135M-Instruct-GGUF](https://huggingface.co/Mungert/SmolLM2-135M-Instruct-GGUF)         |
+| `tabby-nano-1`     | `SmolLM-360M-Instruct.Q8_0.gguf`  | ~0.4 GB | [QuantFactory/SmolLM-360M-Instruct-GGUF](https://huggingface.co/QuantFactory/SmolLM-360M-Instruct-GGUF) |
+| `tabby-fast-1`     | `Qwen3-0.6B-Q4_K_M.gguf`          | ~0.4 GB | [unsloth/Qwen3-0.6B-GGUF](https://huggingface.co/unsloth/Qwen3-0.6B-GGUF)                               |
+| `tabby-balanced-1` | `gemma-4-E2B-it-Q4_K_M.gguf`      | ~3.1 GB | [unsloth/gemma-4-E2B-it-GGUF](https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF)                       |
+| `tabby-max-1`      | `gemma-4-E4B-it-Q4_K_M.gguf`      | ~5.0 GB | [unsloth/gemma-4-E4B-it-GGUF](https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF)                       |
 
 ### Bring your own model
 


### PR DESCRIPTION
## Summary

Adds **`tabby-pico-1`** (SmolLM2-135M-Instruct Q8_0, ~0.1 GB, 135M params) — the new smallest/fastest model, one rung below `tabby-nano-1`. The name continues the metric-prefix scale (`pico` is the SI prefix directly below `nano`), so the floor reads `pico → nano → fast → balanced → max`.

- `displayName(for:)` maps `SmolLM2-135M-Instruct-q8_0.gguf` → `tabby-pico-1`.
- New `downloadableModels` entry, listed **first** (catalog is lightest-first).
- Added **last** in `preferredModelNames` (load-priority is most-capable-first, so pico only auto-loads when it's the only/most-preferred model present).
- README built-in table updated to **five** models.

## Validation

```
# size + sha256 from HuggingFace, cross-checked against the LFS oid:
#   SmolLM2-135M Q8_0 -> 144,811,552 B   sha256 bc64cce8…e28   (header == API oid ✓)

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  build CODE_SIGNING_ALLOWED=NO          # ** BUILD SUCCEEDED **
swiftlint lint --quiet Cotabby/Models/LlamaRuntimeModels.swift   # exit 0
```

Metadata-only catalog entry; the download + `ModelFileValidator` size/sha256 check is existing, exercised code. Did not download the GGUF or load it at runtime.

## Linked issues

None — direct request.

## Risk / rollout notes

- **Smallest/fastest, lowest quality**: 135M params is well below the others; expect noticeably weaker completions in exchange for the lowest latency/RAM. It's opt-in (a download), and `preferredModelNames` ranks it last, so it never displaces a more capable model a user already has.
- The lineup is now five models: `tabby-pico-1`, `tabby-nano-1`, `tabby-fast-1`, `tabby-balanced-1`, `tabby-max-1`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `tabby-pico-1` (SmolLM2-135M-Instruct Q8_0, ~145 MB) as the smallest model in the catalog, continuing the SI-prefix naming scheme below `tabby-nano-1`.

- New `DownloadableRuntimeModel` entry placed first in `downloadableModels` (lightest-first order) with `expectedSizeBytes: 144_811_552` and a 64-char SHA-256 hash, consistent with all other catalog entries.
- Added last in `preferredModelNames` so it is only auto-selected when no higher-capability model is present; README model table updated from four to five rows with correct size and source link.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a pure metadata-only catalog addition that follows every existing pattern in the file.

The new entry mirrors the structure of the four existing models exactly: a displayName switch-case, a DownloadableRuntimeModel with a 64-character SHA-256 and exact byte count, correct placement in both the lightest-first download list and the most-capable-first preferredModelNames array, and a matching README row. No logic, validation, or download code was changed.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Models/LlamaRuntimeModels.swift | Adds tabby-pico-1 catalog entry: displayName mapping, DownloadableRuntimeModel with size/SHA-256, and preferredModelNames placement. Follows all existing patterns correctly. |
| README.md | Updates model count ("four" → "five") and adds tabby-pico-1 as the first row in the built-in models table, consistent with the lightest-first ordering in the catalog. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Add tabby-pico-1 (SmolLM2-135M) as the s..."](https://github.com/fujacob/cotabby/commit/e435f16f68557649037c03b3d57d92f71dbe3d5c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34114022)</sub>

<!-- /greptile_comment -->