### PR TITLE
Group the menu bar popover into divider-separated sections

### DIFF
--- a/Cotabby/UI/MenuBarView.swift
+++ b/Cotabby/UI/MenuBarView.swift
@@ -71,61 +71,79 @@ struct MenuBarView: View {
     @ViewBuilder
     private var controlsSection: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Toggle("Enable Globally", isOn: globallyEnabledBinding)
-                .toggleStyle(.switch)
-                .controlSize(.small)
-
-            if let application = focusModel.latestExternalApplication,
-               !TerminalAppDetector.isTerminal(bundleIdentifier: application.bundleIdentifier) {
-                Toggle("Enable in \(application.applicationName)", isOn: appEnabledBinding(for: application))
-                    .toggleStyle(.switch)
-                    .controlSize(.small)
-            }
-
-            Toggle("Include Clipboard Context", isOn: clipboardContextEnabledBinding)
-                .toggleStyle(.switch)
-                .controlSize(.small)
-
             Toggle("Fast Mode", isOn: fastModeEnabledBinding)
                 .toggleStyle(.switch)
                 .controlSize(.small)
                 .help("Skips capturing on-screen context (OCR) for faster, lower-overhead suggestions.")
 
-            Toggle("Allow Multi-line Suggestions", isOn: multiLineEnabledBinding)
-                .toggleStyle(.switch)
-                .controlSize(.small)
+            Divider()
 
-            MenuBarPickerRow(title: "Engine") {
-                Picker("Engine", selection: selectedEngineBinding) {
-                    ForEach(SuggestionEngineKind.allCases) { engine in
-                        Text(engine.displayLabel)
-                            .tag(engine)
-                    }
+            // Activation lives in its own band: the global switch plus the per-app override for
+            // whatever app currently has focus.
+            Group {
+                Toggle("Enable Globally", isOn: globallyEnabledBinding)
+                    .toggleStyle(.switch)
+                    .controlSize(.small)
+
+                if let application = focusModel.latestExternalApplication,
+                   !TerminalAppDetector.isTerminal(bundleIdentifier: application.bundleIdentifier) {
+                    Toggle("Enable in \(application.applicationName)", isOn: appEnabledBinding(for: application))
+                        .toggleStyle(.switch)
+                        .controlSize(.small)
                 }
-                .labelsHidden()
-                .pickerStyle(.menu)
             }
 
-            if suggestionSettings.selectedEngine == .appleIntelligence,
-               !foundationModelAvailabilityService.isAvailable {
-                Text(foundationModelAvailabilityService.userVisibleMessage)
-                    .font(.caption)
-                    .foregroundStyle(.orange)
+            Divider()
+
+            // Context-shaping toggles that change what the model is fed.
+            Group {
+                Toggle("Include Clipboard Context", isOn: clipboardContextEnabledBinding)
+                    .toggleStyle(.switch)
+                    .controlSize(.small)
+
+                Toggle("Allow Multi-line Suggestions", isOn: multiLineEnabledBinding)
+                    .toggleStyle(.switch)
+                    .controlSize(.small)
             }
 
-            if suggestionSettings.selectedEngine.supportsLocalModelManagement {
-                modelRow
-            }
+            Divider()
 
-            MenuBarPickerRow(title: "Length") {
-                Picker("Length", selection: selectedWordCountPresetBinding) {
-                    ForEach(SuggestionWordCountPreset.allCases) { preset in
-                        Text(preset.displayLabel)
-                            .tag(preset)
+            // Generation setup: which engine/model produces completions and how long they run.
+            // Wrapped in a Group so the four rows plus the toggles and dividers above stay under
+            // SwiftUI's 10-child ViewBuilder limit for the enclosing VStack.
+            Group {
+                MenuBarPickerRow(title: "Engine") {
+                    Picker("Engine", selection: selectedEngineBinding) {
+                        ForEach(SuggestionEngineKind.allCases) { engine in
+                            Text(engine.displayLabel)
+                                .tag(engine)
+                        }
                     }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
                 }
-                .labelsHidden()
-                .pickerStyle(.menu)
+
+                if suggestionSettings.selectedEngine == .appleIntelligence,
+                   !foundationModelAvailabilityService.isAvailable {
+                    Text(foundationModelAvailabilityService.userVisibleMessage)
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                }
+
+                if suggestionSettings.selectedEngine.supportsLocalModelManagement {
+                    modelRow
+                }
+
+                MenuBarPickerRow(title: "Length") {
+                    Picker("Length", selection: selectedWordCountPresetBinding) {
+                        ForEach(SuggestionWordCountPreset.allCases) { preset in
+                            Text(preset.displayLabel)
+                                .tag(preset)
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                }
             }
         }
         .padding(.bottom, 12)


### PR DESCRIPTION
## Summary

Reorders the menu bar popover controls into four divider-separated bands so the panel reads as
distinct zones instead of one long stack:

1. **Fast Mode**
2. **Activation** — Enable Globally + Enable in ⟨current app⟩
3. **Context** — Include Clipboard Context + Allow Multi-line Suggestions
4. **Generation** — Engine / Model / Length

No items added or removed — same controls, regrouped with `Divider()`s between bands (the header and
footer keep their existing dividers).

## Validation

```bash
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **
swiftlint lint --quiet --config .swiftlint.yml Cotabby/UI/MenuBarView.swift
# exit 0
```

UI verified by build only — no manual app run.

## Linked issues

None — follow-up from the popover layout discussion.

## Risk / rollout notes

- Pure layout change in `MenuBarView.controlsSection`; no bindings, settings, or behavior touched.
- The multi-row bands are wrapped in `Group { }` specifically so the three new `Divider()`s don't push
  the enclosing `VStack` past SwiftUI's 10-child `ViewBuilder` limit. `Group` is layout-transparent in
  a stack, so the `VStack(spacing: 8)` still spaces every row and divider uniformly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reorganises `MenuBarView.controlsSection` into four visually distinct bands separated by `Divider()`s — **Fast Mode**, **Activation**, **Context**, and **Generation** — without adding, removing, or altering any control, binding, or business logic.

- Controls are wrapped in `Group {}` blocks to keep the enclosing `VStack`'s direct-child count below SwiftUI's 10-child `ViewBuilder` limit; the groups are layout-transparent so spacing is unaffected.
- The only minor gap is a stale doc comment on `controlsSection` that still describes only the generation-related controls rather than the full set of items now in the section.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are cosmetic layout reordering with no touched bindings, models, or logic.

Every control, binding, and piece of business logic is identical to before. The only changes are the insertion of three Divider() views and the wrapping of control groups into Group {} blocks, which are layout-transparent. The Group usage is correct and necessary to stay within SwiftUI's ViewBuilder child limit. The single finding is a stale doc comment with no runtime impact.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/UI/MenuBarView.swift | Pure layout reorder — Fast Mode promoted to top, three Divider-separated Groups added for Activation / Context / Generation bands; no bindings or logic changed. One stale doc comment on controlsSection. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[controlsSection VStack] --> B[Toggle: Fast Mode]
    B --> D1[Divider]
    D1 --> G1["Group — Activation"]
    G1 --> T1[Toggle: Enable Globally]
    G1 --> T2["[conditional] Toggle: Enable in app"]
    G1 --> D2[Divider]
    D2 --> G2["Group — Context"]
    G2 --> T3[Toggle: Include Clipboard Context]
    G2 --> T4[Toggle: Allow Multi-line Suggestions]
    G2 --> D3[Divider]
    D3 --> G3["Group — Generation"]
    G3 --> P1[MenuBarPickerRow: Engine]
    G3 --> C1["[conditional] Apple Intelligence warning"]
    G3 --> C2["[conditional] modelRow"]
    G3 --> P2[MenuBarPickerRow: Length]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cotabby/UI/MenuBarView.swift`, line 69-70 ([link](https://github.com/fujacob/cotabby/blob/57c536c775aa4920807c972dabb767b953df6e59/Cotabby/UI/MenuBarView.swift#L69-L70)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The doc comment on `controlsSection` still lists only engine choice, model selection, and completion length. After this PR the section now also contains Fast Mode, Enable Globally, per-app enable, clipboard context, and multi-line toggles — so the comment is misleading for anyone landing here later.

   

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22chore%2Freorder-popover-sections%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2Freorder-popover-sections%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FMenuBarView.swift%0ALine%3A%2069-70%0A%0AComment%3A%0AThe%20doc%20comment%20on%20%60controlsSection%60%20still%20lists%20only%20engine%20choice%2C%20model%20selection%2C%20and%20completion%20length.%20After%20this%20PR%20the%20section%20now%20also%20contains%20Fast%20Mode%2C%20Enable%20Globally%2C%20per-app%20enable%2C%20clipboard%20context%2C%20and%20multi-line%20toggles%20%E2%80%94%20so%20the%20comment%20is%20misleading%20for%20anyone%20landing%20here%20later.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Session-level%20preferences%20that%20users%20reach%20for%20mid-work%3A%20activation%20toggles%0A%20%20%20%20%2F%2F%2F%20%28global%20%2B%20per-app%29%2C%20context%20shaping%20%28clipboard%2C%20multi-line%29%2C%20and%20generation%0A%20%20%20%20%2F%2F%2F%20settings%20%28engine%2C%20model%2C%20completion%20length%29.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FMenuBarView.swift%0ALine%3A%2069-70%0A%0AComment%3A%0AThe%20doc%20comment%20on%20%60controlsSection%60%20still%20lists%20only%20engine%20choice%2C%20model%20selection%2C%20and%20completion%20length.%20After%20this%20PR%20the%20section%20now%20also%20contains%20Fast%20Mode%2C%20Enable%20Globally%2C%20per-app%20enable%2C%20clipboard%20context%2C%20and%20multi-line%20toggles%20%E2%80%94%20so%20the%20comment%20is%20misleading%20for%20anyone%20landing%20here%20later.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Session-level%20preferences%20that%20users%20reach%20for%20mid-work%3A%20activation%20toggles%0A%20%20%20%20%2F%2F%2F%20%28global%20%2B%20per-app%29%2C%20context%20shaping%20%28clipboard%2C%20multi-line%29%2C%20and%20generation%0A%20%20%20%20%2F%2F%2F%20settings%20%28engine%2C%20model%2C%20completion%20length%29.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=306&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22chore%2Freorder-popover-sections%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2Freorder-popover-sections%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FMenuBarView.swift%3A69-70%0AThe%20doc%20comment%20on%20%60controlsSection%60%20still%20lists%20only%20engine%20choice%2C%20model%20selection%2C%20and%20completion%20length.%20After%20this%20PR%20the%20section%20now%20also%20contains%20Fast%20Mode%2C%20Enable%20Globally%2C%20per-app%20enable%2C%20clipboard%20context%2C%20and%20multi-line%20toggles%20%E2%80%94%20so%20the%20comment%20is%20misleading%20for%20anyone%20landing%20here%20later.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Session-level%20preferences%20that%20users%20reach%20for%20mid-work%3A%20activation%20toggles%0A%20%20%20%20%2F%2F%2F%20%28global%20%2B%20per-app%29%2C%20context%20shaping%20%28clipboard%2C%20multi-line%29%2C%20and%20generation%0A%20%20%20%20%2F%2F%2F%20settings%20%28engine%2C%20model%2C%20completion%20length%29.%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FMenuBarView.swift%3A69-70%0AThe%20doc%20comment%20on%20%60controlsSection%60%20still%20lists%20only%20engine%20choice%2C%20model%20selection%2C%20and%20completion%20length.%20After%20this%20PR%20the%20section%20now%20also%20contains%20Fast%20Mode%2C%20Enable%20Globally%2C%20per-app%20enable%2C%20clipboard%20context%2C%20and%20multi-line%20toggles%20%E2%80%94%20so%20the%20comment%20is%20misleading%20for%20anyone%20landing%20here%20later.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Session-level%20preferences%20that%20users%20reach%20for%20mid-work%3A%20activation%20toggles%0A%20%20%20%20%2F%2F%2F%20%28global%20%2B%20per-app%29%2C%20context%20shaping%20%28clipboard%2C%20multi-line%29%2C%20and%20generation%0A%20%20%20%20%2F%2F%2F%20settings%20%28engine%2C%20model%2C%20completion%20length%29.%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=306&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Group the menu bar popover into divider-..."](https://github.com/fujacob/cotabby/commit/57c536c775aa4920807c972dabb767b953df6e59) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34116188)</sub>

<!-- /greptile_comment -->