### PR TITLE
Run visual-context summarizer on a reduced CPU thread budget

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -1173,7 +1173,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/FuJacob/cotabbyinference.git";
 			requirement = {
-				branch = main;
+				branch = "feat/per-sequence-thread-budget";
 				kind = branch;
 			};
 		};

--- a/Cotabby/Models/LlamaRuntimeModels.swift
+++ b/Cotabby/Models/LlamaRuntimeModels.swift
@@ -204,6 +204,11 @@ struct LlamaGenerationOptions: Equatable, Sendable {
     let minP: Double
     let repetitionPenalty: Double
     var seed: UInt32?
+    /// CPU threads the sequence's context may use. 0 means "the runtime default" (all hardware
+    /// threads). Autocomplete leaves this at 0 to stay as fast as possible; the background
+    /// summarizer sets a smaller budget so it decodes concurrently with autocomplete instead of
+    /// oversubscribing every core. Does not affect sampling output, only execution width.
+    var threadCount: Int = 0
 
     static func summary(maxPredictionTokens: Int, temperature: Double) -> LlamaGenerationOptions {
         LlamaGenerationOptions(
@@ -214,8 +219,16 @@ struct LlamaGenerationOptions: Equatable, Sendable {
             minP: 0.05,
             // Higher penalty than autocomplete (1.05) because summaries span more tokens and
             // are more prone to looping when OCR input contains repeated phrases.
-            repetitionPenalty: 1.4
+            repetitionPenalty: 1.4,
+            // Background work: cap to roughly a quarter of the cores (min 2) so the summarizer
+            // runs alongside latency-critical autocomplete rather than fighting it for every core.
+            threadCount: Self.backgroundThreadBudget
         )
+    }
+
+    /// ~1/4 of the machine's cores, floored at 2, used for background (summary) sequences.
+    static var backgroundThreadBudget: Int {
+        max(2, ProcessInfo.processInfo.activeProcessorCount / 4)
     }
 }
 

--- a/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
+++ b/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
@@ -381,7 +381,8 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
             top_p: Float(options.topP),
             min_p: Float(options.minP),
             repetition_penalty: Float(options.repetitionPenalty),
-            seed: options.seed ?? 0
+            seed: options.seed ?? 0,
+            thread_count: Int32(options.threadCount)
         )
     }
 

--- a/project.yml
+++ b/project.yml
@@ -13,7 +13,9 @@ packages:
     exactVersion: 2.9.1
   CotabbyInference:
     url: https://github.com/FuJacob/cotabbyinference.git
-    branch: main
+    # Temporarily tracks the per-sequence thread-budget branch (cotabbyinference#1).
+    # Move back to `branch: main` once that PR merges.
+    branch: feat/per-sequence-thread-budget
   swift-log:
     url: https://github.com/apple/swift-log.git
     from: 1.12.1


### PR DESCRIPTION
## Summary

Makes the OCR/visual-context summarizer actually decode *alongside* autocomplete on CPU-only machines instead of stalling it. The two already run on independent llama sequences with no shared lock, but every `llama_context` was created with `n_threads = all cores`, so a background summary spun up a second full set of compute threads that oversubscribed the cores and starved latency-critical autocomplete. This caps the summarizer's sequence to a smaller thread budget so the two share cores instead of fighting for them.

## Validation

```
xcodegen generate
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build   # BUILD SUCCEEDED
swiftlint lint --quiet                                                                       # exit 0, 0 violations
xcodebuild test … CODE_SIGNING_ALLOWED=NO                                                     # 354 tests, 0 failures, 1 skipped
```

Behavioral tuning (autocomplete tokens/sec **solo** vs **while OCR runs**) is not yet measured — shipping the default split and leaving the knob easy to tune.

## Linked issues

Depends on FuJacob/cotabbyinference#1 (adds the per-sequence `thread_count` field this PR sets).

## Risk / rollout notes

- **Dependency pinned to a branch:** `project.yml` temporarily points `CotabbyInference` at `feat/per-sequence-thread-budget` (`c58a938`). **Move it back to `branch: main` once cotabbyinference#1 merges**, then regenerate. Do not merge this before that dependency lands on the middleware's main.
- **Thread split:** autocomplete keeps `0` (all cores); the summarizer uses `max(2, activeProcessorCount / 4)` via `LlamaGenerationOptions.backgroundThreadBudget`. One-line tuning point if measurements say otherwise.
- **Expectation:** this is about *latency hiding*, not a 2× speedup — memory bandwidth still caps total CPU tokens/sec. The win is the background summary no longer degrading autocomplete latency. Tune the split after measuring solo-vs-concurrent autocomplete throughput.
- No change to sampling output or KV-cache logic; `thread_count` only sets a context's execution width, and `0` reproduces prior behavior.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR caps the OCR/visual-context summarizer to a reduced CPU thread budget (`max(2, activeProcessorCount / 4)`) so it decodes concurrently with autocomplete instead of oversubscribing every core. The change adds `threadCount` to `LlamaGenerationOptions`, wires it through to `SamplingConfig`, and introduces a `backgroundThreadBudget` static property on the model; `CotabbyInference` is temporarily pinned to a feature branch that supplies the new `thread_count` field.

- `LlamaGenerationOptions` gains a `threadCount: Int = 0` field; the `summary` factory sets it via `backgroundThreadBudget`, while autocomplete leaves it at `0` (runtime default = all cores).
- `LlamaRuntimeCore.samplingConfig` passes `thread_count: Int32(options.threadCount)` to the downstream `SamplingConfig`; the summary path uses an ephemeral sequence so no KV-cache interactions are introduced.
- Both `project.yml` and `project.pbxproj` are temporarily pinned to `feat/per-sequence-thread-budget` and must be restored to `main` after `cotabbyinference#1` merges — this is the only hard prerequisite before landing.

<h3>Confidence Score: 4/5</h3>

Safe to merge only after the `CotabbyInference` upstream PR lands on `main` and both `project.yml` and `project.pbxproj` are updated back to `branch: main`; the code changes themselves are correct and well-scoped.

The thread-budget split logic is straightforward and the summary sequence already uses an ephemeral context, so there is no KV-cache interaction to worry about. The one real concern is the pinned feature-branch dependency: merging before the upstream lands would ship a ref that could disappear or change, breaking the build. Everything else — the `backgroundThreadBudget` computation, the `Int32` conversion, the `SamplingFingerprint` intentionally omitting `threadCount` — is correct as written.

`project.yml` and `Cotabby.xcodeproj/project.pbxproj` both need their branch reference updated before this PR can be safely merged.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/Models/LlamaRuntimeModels.swift | Adds `threadCount` to `LlamaGenerationOptions` with a default of 0 (all cores) and a `backgroundThreadBudget` static computed property that caps the summarizer to `max(2, activeProcessorCount / 4)` threads; logic is clean, though `SamplingFingerprint` silently omits `threadCount` without a comment. |
| Cotabby/Services/Runtime/LlamaRuntimeCore.swift | Passes `thread_count: Int32(options.threadCount)` through to `SamplingConfig`; the summary path uses an ephemeral sequence so no KV-cache concerns arise; autocomplete continues to use 0 (runtime default). |
| project.yml | Pins `CotabbyInference` to `feat/per-sequence-thread-budget` — this is a hard merge-order dependency; restoring `branch: main` after the upstream PR lands is a required step before this PR can be safely merged. |
| Cotabby.xcodeproj/project.pbxproj | Updates the Xcode package reference to match the `project.yml` branch change; must be reverted to `main` alongside `project.yml` once the upstream dependency merges. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant AC as Autocomplete
    participant SC as Summarizer
    participant Core as LlamaRuntimeCore
    participant Inf as CotabbyInference

    AC->>Core: "generate(options: threadCount=0)"
    Core->>Inf: "createSequence(SamplingConfig(thread_count=0))"
    Note over Inf: Uses all CPU cores

    SC->>Core: "summarize(options: threadCount=backgroundThreadBudget)"
    Core->>Inf: "createSequence(SamplingConfig(thread_count=max(2, cores/4)))"
    Note over Inf: Uses reduced thread budget

    par Concurrent execution
        Core-->>AC: decode tokens (full cores)
        Core-->>SC: decode tokens (capped cores)
    end

    Inf-->>Core: destroySequence (summary ephemeral)
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `Cotabby/Models/LlamaRuntimeModels.swift`, line 413-421 ([link](https://github.com/fujacob/cotabby/blob/cded4bd481919f270985d5841458bad647af10d1/Cotabby/Models/LlamaRuntimeModels.swift#L413-L421)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`SamplingFingerprint` silently drops `threadCount` from the KV-cache key**

   `SamplingFingerprint.init` copies every field from `LlamaGenerationOptions` except `threadCount`. Since the fingerprint is the sole guard for KV-state reuse in `obtainAutocompleteSequence`, a future caller that passes different `threadCount` values across successive autocomplete requests would happily reuse cached KV state built under a different execution-width context. Today this is safe because autocomplete always uses the default `0`, but the omission isn't documented — a comment noting that `threadCount` is intentionally excluded (it doesn't affect KV state or token probabilities) would prevent a future maintainer from accidentally treating a budget change as a safe no-op for the cache.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fconcurrent-summary-thread-budget%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fconcurrent-summary-thread-budget%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FModels%2FLlamaRuntimeModels.swift%0ALine%3A%20413-421%0A%0AComment%3A%0A**%60SamplingFingerprint%60%20silently%20drops%20%60threadCount%60%20from%20the%20KV-cache%20key**%0A%0A%60SamplingFingerprint.init%60%20copies%20every%20field%20from%20%60LlamaGenerationOptions%60%20except%20%60threadCount%60.%20Since%20the%20fingerprint%20is%20the%20sole%20guard%20for%20KV-state%20reuse%20in%20%60obtainAutocompleteSequence%60%2C%20a%20future%20caller%20that%20passes%20different%20%60threadCount%60%20values%20across%20successive%20autocomplete%20requests%20would%20happily%20reuse%20cached%20KV%20state%20built%20under%20a%20different%20execution-width%20context.%20Today%20this%20is%20safe%20because%20autocomplete%20always%20uses%20the%20default%20%600%60%2C%20but%20the%20omission%20isn't%20documented%20%E2%80%94%20a%20comment%20noting%20that%20%60threadCount%60%20is%20intentionally%20excluded%20%28it%20doesn't%20affect%20KV%20state%20or%20token%20probabilities%29%20would%20prevent%20a%20future%20maintainer%20from%20accidentally%20treating%20a%20budget%20change%20as%20a%20safe%20no-op%20for%20the%20cache.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FModels%2FLlamaRuntimeModels.swift%0ALine%3A%20413-421%0A%0AComment%3A%0A**%60SamplingFingerprint%60%20silently%20drops%20%60threadCount%60%20from%20the%20KV-cache%20key**%0A%0A%60SamplingFingerprint.init%60%20copies%20every%20field%20from%20%60LlamaGenerationOptions%60%20except%20%60threadCount%60.%20Since%20the%20fingerprint%20is%20the%20sole%20guard%20for%20KV-state%20reuse%20in%20%60obtainAutocompleteSequence%60%2C%20a%20future%20caller%20that%20passes%20different%20%60threadCount%60%20values%20across%20successive%20autocomplete%20requests%20would%20happily%20reuse%20cached%20KV%20state%20built%20under%20a%20different%20execution-width%20context.%20Today%20this%20is%20safe%20because%20autocomplete%20always%20uses%20the%20default%20%600%60%2C%20but%20the%20omission%20isn't%20documented%20%E2%80%94%20a%20comment%20noting%20that%20%60threadCount%60%20is%20intentionally%20excluded%20%28it%20doesn't%20affect%20KV%20state%20or%20token%20probabilities%29%20would%20prevent%20a%20future%20maintainer%20from%20accidentally%20treating%20a%20budget%20change%20as%20a%20safe%20no-op%20for%20the%20cache.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=309&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>


2. `Cotabby/Services/Runtime/LlamaRuntimeCore.swift`, line 403-404 ([link](https://github.com/fujacob/cotabby/blob/cded4bd481919f270985d5841458bad647af10d1/Cotabby/Services/Runtime/LlamaRuntimeCore.swift#L403-L404)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `SamplingFingerprint` omits `threadCount` because it intentionally only captures fields that affect KV state and token probabilities. A small note here makes the exclusion explicit and guards against a future maintainer accidentally adding it.

   

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fconcurrent-summary-thread-budget%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fconcurrent-summary-thread-budget%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%0ALine%3A%20403-404%0A%0AComment%3A%0A%60SamplingFingerprint%60%20omits%20%60threadCount%60%20because%20it%20intentionally%20only%20captures%20fields%20that%20affect%20KV%20state%20and%20token%20probabilities.%20A%20small%20note%20here%20makes%20the%20exclusion%20explicit%20and%20guards%20against%20a%20future%20maintainer%20accidentally%20adding%20it.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Generation%20knobs%20that%20intentionally%20break%20KV%20reuse%20when%20changed.%0A%20%20%20%20%2F%2F%2F%20Note%3A%20%60threadCount%60%20is%20intentionally%20excluded%20%E2%80%94%20it%20controls%20execution%20width%2C%20not%20KV%20state%0A%20%20%20%20%2F%2F%2F%20or%20sampling%20probabilities%2C%20so%20changing%20it%20does%20not%20invalidate%20a%20cached%20autocomplete%20sequence.%0A%20%20%20%20private%20struct%20SamplingFingerprint%3A%20Equatable%20%7B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%0ALine%3A%20403-404%0A%0AComment%3A%0A%60SamplingFingerprint%60%20omits%20%60threadCount%60%20because%20it%20intentionally%20only%20captures%20fields%20that%20affect%20KV%20state%20and%20token%20probabilities.%20A%20small%20note%20here%20makes%20the%20exclusion%20explicit%20and%20guards%20against%20a%20future%20maintainer%20accidentally%20adding%20it.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Generation%20knobs%20that%20intentionally%20break%20KV%20reuse%20when%20changed.%0A%20%20%20%20%2F%2F%2F%20Note%3A%20%60threadCount%60%20is%20intentionally%20excluded%20%E2%80%94%20it%20controls%20execution%20width%2C%20not%20KV%20state%0A%20%20%20%20%2F%2F%2F%20or%20sampling%20probabilities%2C%20so%20changing%20it%20does%20not%20invalidate%20a%20cached%20autocomplete%20sequence.%0A%20%20%20%20private%20struct%20SamplingFingerprint%3A%20Equatable%20%7B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=309&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fconcurrent-summary-thread-budget%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fconcurrent-summary-thread-budget%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aproject.yml%3A15-17%0A**Upstream%20branch%20dependency%20must%20land%20before%20merge**%0A%0A%60CotabbyInference%60%20is%20currently%20pinned%20to%20%60feat%2Fper-sequence-thread-budget%60%20at%20commit%20%60c58a938%60.%20If%20%60cotabbyinference%231%60%20is%20force-pushed%2C%20rebased%2C%20or%20deleted%20before%20this%20PR%20merges%2C%20CI%20will%20resolve%20a%20different%20%28or%20missing%29%20tree%20%E2%80%94%20and%20the%20%60thread_count%60%20field%20this%20PR%20depends%20on%20would%20disappear%2C%20breaking%20the%20build%20silently.%20The%20same%20pinned%20ref%20appears%20in%20%60project.pbxproj%60.%20Make%20sure%20to%20restore%20%60branch%3A%20main%60%20in%20both%20files%20after%20the%20upstream%20dependency%20merges%2C%20and%20treat%20those%20edits%20as%20a%20hard%20merge-order%20gate.%0A%0A%23%23%23%20Issue%202%20of%203%0ACotabby%2FModels%2FLlamaRuntimeModels.swift%3A413-421%0A**%60SamplingFingerprint%60%20silently%20drops%20%60threadCount%60%20from%20the%20KV-cache%20key**%0A%0A%60SamplingFingerprint.init%60%20copies%20every%20field%20from%20%60LlamaGenerationOptions%60%20except%20%60threadCount%60.%20Since%20the%20fingerprint%20is%20the%20sole%20guard%20for%20KV-state%20reuse%20in%20%60obtainAutocompleteSequence%60%2C%20a%20future%20caller%20that%20passes%20different%20%60threadCount%60%20values%20across%20successive%20autocomplete%20requests%20would%20happily%20reuse%20cached%20KV%20state%20built%20under%20a%20different%20execution-width%20context.%20Today%20this%20is%20safe%20because%20autocomplete%20always%20uses%20the%20default%20%600%60%2C%20but%20the%20omission%20isn't%20documented%20%E2%80%94%20a%20comment%20noting%20that%20%60threadCount%60%20is%20intentionally%20excluded%20%28it%20doesn't%20affect%20KV%20state%20or%20token%20probabilities%29%20would%20prevent%20a%20future%20maintainer%20from%20accidentally%20treating%20a%20budget%20change%20as%20a%20safe%20no-op%20for%20the%20cache.%0A%0A%23%23%23%20Issue%203%20of%203%0ACotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%3A403-404%0A%60SamplingFingerprint%60%20omits%20%60threadCount%60%20because%20it%20intentionally%20only%20captures%20fields%20that%20affect%20KV%20state%20and%20token%20probabilities.%20A%20small%20note%20here%20makes%20the%20exclusion%20explicit%20and%20guards%20against%20a%20future%20maintainer%20accidentally%20adding%20it.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Generation%20knobs%20that%20intentionally%20break%20KV%20reuse%20when%20changed.%0A%20%20%20%20%2F%2F%2F%20Note%3A%20%60threadCount%60%20is%20intentionally%20excluded%20%E2%80%94%20it%20controls%20execution%20width%2C%20not%20KV%20state%0A%20%20%20%20%2F%2F%2F%20or%20sampling%20probabilities%2C%20so%20changing%20it%20does%20not%20invalidate%20a%20cached%20autocomplete%20sequence.%0A%20%20%20%20private%20struct%20SamplingFingerprint%3A%20Equatable%20%7B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aproject.yml%3A15-17%0A**Upstream%20branch%20dependency%20must%20land%20before%20merge**%0A%0A%60CotabbyInference%60%20is%20currently%20pinned%20to%20%60feat%2Fper-sequence-thread-budget%60%20at%20commit%20%60c58a938%60.%20If%20%60cotabbyinference%231%60%20is%20force-pushed%2C%20rebased%2C%20or%20deleted%20before%20this%20PR%20merges%2C%20CI%20will%20resolve%20a%20different%20%28or%20missing%29%20tree%20%E2%80%94%20and%20the%20%60thread_count%60%20field%20this%20PR%20depends%20on%20would%20disappear%2C%20breaking%20the%20build%20silently.%20The%20same%20pinned%20ref%20appears%20in%20%60project.pbxproj%60.%20Make%20sure%20to%20restore%20%60branch%3A%20main%60%20in%20both%20files%20after%20the%20upstream%20dependency%20merges%2C%20and%20treat%20those%20edits%20as%20a%20hard%20merge-order%20gate.%0A%0A%23%23%23%20Issue%202%20of%203%0ACotabby%2FModels%2FLlamaRuntimeModels.swift%3A413-421%0A**%60SamplingFingerprint%60%20silently%20drops%20%60threadCount%60%20from%20the%20KV-cache%20key**%0A%0A%60SamplingFingerprint.init%60%20copies%20every%20field%20from%20%60LlamaGenerationOptions%60%20except%20%60threadCount%60.%20Since%20the%20fingerprint%20is%20the%20sole%20guard%20for%20KV-state%20reuse%20in%20%60obtainAutocompleteSequence%60%2C%20a%20future%20caller%20that%20passes%20different%20%60threadCount%60%20values%20across%20successive%20autocomplete%20requests%20would%20happily%20reuse%20cached%20KV%20state%20built%20under%20a%20different%20execution-width%20context.%20Today%20this%20is%20safe%20because%20autocomplete%20always%20uses%20the%20default%20%600%60%2C%20but%20the%20omission%20isn't%20documented%20%E2%80%94%20a%20comment%20noting%20that%20%60threadCount%60%20is%20intentionally%20excluded%20%28it%20doesn't%20affect%20KV%20state%20or%20token%20probabilities%29%20would%20prevent%20a%20future%20maintainer%20from%20accidentally%20treating%20a%20budget%20change%20as%20a%20safe%20no-op%20for%20the%20cache.%0A%0A%23%23%23%20Issue%203%20of%203%0ACotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%3A403-404%0A%60SamplingFingerprint%60%20omits%20%60threadCount%60%20because%20it%20intentionally%20only%20captures%20fields%20that%20affect%20KV%20state%20and%20token%20probabilities.%20A%20small%20note%20here%20makes%20the%20exclusion%20explicit%20and%20guards%20against%20a%20future%20maintainer%20accidentally%20adding%20it.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Generation%20knobs%20that%20intentionally%20break%20KV%20reuse%20when%20changed.%0A%20%20%20%20%2F%2F%2F%20Note%3A%20%60threadCount%60%20is%20intentionally%20excluded%20%E2%80%94%20it%20controls%20execution%20width%2C%20not%20KV%20state%0A%20%20%20%20%2F%2F%2F%20or%20sampling%20probabilities%2C%20so%20changing%20it%20does%20not%20invalidate%20a%20cached%20autocomplete%20sequence.%0A%20%20%20%20private%20struct%20SamplingFingerprint%3A%20Equatable%20%7B%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=309&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Run visual-context summarizer on a reduc..."](https://github.com/fujacob/cotabby/commit/cded4bd481919f270985d5841458bad647af10d1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34118126)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->