### PR TITLE
Check for updates on launch + pin daily Sparkle interval

### DIFF
--- a/Cotabby/Services/Utilities/AppUpdateManager.swift
+++ b/Cotabby/Services/Utilities/AppUpdateManager.swift
@@ -47,6 +47,15 @@ final class AppUpdateManager {
         isStarted = true
         log("Sparkle updater started.")
 
+        // Check once on every launch. Sparkle's scheduled check only fires on launch when the
+        // interval has already elapsed, so frequent users (who reopen within a day) would never
+        // see a check on open. This is a *background* check: it silently does nothing when the app
+        // is up to date and only surfaces UI when an update is actually available — unlike
+        // `checkForUpdates()`, which always shows a result dialog and is reserved for the manual
+        // "Check for Updates" button. The daily `SUScheduledCheckInterval` then covers long-running
+        // sessions where the app stays open for days.
+        updaterController.updater.checkForUpdatesInBackground()
+
         #if DEBUG
         if ProcessInfo.processInfo.arguments.contains(Self.debugCheckForUpdatesOnLaunchArgument) {
             log("Debug launch argument requested an immediate update check.")

--- a/CotabbyInfo.plist
+++ b/CotabbyInfo.plist
@@ -30,6 +30,8 @@
 	<false/>
 	<key>SUEnableAutomaticChecks</key>
 	<true/>
+	<key>SUScheduledCheckInterval</key>
+	<integer>86400</integer>
 	<key>SUFeedURL</key>
 	<string>https://updates.cotabby.app/appcast.xml</string>
     <key>SUPublicEDKey</key>


### PR DESCRIPTION
## Summary

Fixes auto-updates not appearing for users on open. Sparkle was configured for automatic checks (valid `SUFeedURL` + `SUPublicEDKey`, `SUEnableAutomaticChecks=true`), but nothing actually triggered a check on launch in release builds — `start()` only checked in DEBUG behind a launch argument. So release relied entirely on Sparkle's *scheduled* check, which only runs on launch once the interval has already elapsed. Anyone reopening the app within a day never saw an update prompt.

## Changes

- `AppUpdateManager.start()` now calls `updater.checkForUpdatesInBackground()` on every launch. This is a **background** check: silent when up to date, surfaces UI only when an update is available — so it won't show an "up to date" dialog on every open (that stays reserved for the manual "Check for Updates" button via `checkForUpdates()`).
- Pin `SUScheduledCheckInterval` to `86400` (1 day) in `CotabbyInfo.plist` so long-running sessions get a daily check instead of relying on Sparkle's implicit default.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build   # BUILD SUCCEEDED
swiftlint lint --quiet Cotabby/Services/Utilities/AppUpdateManager.swift                     # exit 0
plutil -lint CotabbyInfo.plist                                                               # OK
```

End-to-end update delivery (real appcast → prompt) can't be exercised from a dev build; verified the build links `checkForUpdatesInBackground()` (Sparkle 2.9.1) and the plist is valid. Recommend a manual smoke test against a release-signed build pointed at the live appcast.

## Risk / rollout notes

- **No silent auto-install.** `SUAutomaticallyUpdate` / `SUAllowsAutomaticUpdates` stay `false`, so users are *prompted* when an update is found — behavior unchanged, just actually triggered now.
- A background check now hits `updates.cotabby.app/appcast.xml` once per launch (plus daily while open). Negligible load; standard Sparkle usage.
- Info.plist change ships in the app bundle — takes effect for users only after they're on a build containing it (so the very next release establishes the on-open behavior going forward).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a gap where release builds never triggered an update check on launch — Sparkle's scheduled check only fires on open once the interval has already elapsed, so users reopening the app within 24 hours never saw a prompt. The fix adds an unconditional `checkForUpdatesInBackground()` call in `start()` and pins `SUScheduledCheckInterval` to 86400 seconds in the plist.

- `AppUpdateManager.start()` now calls `checkForUpdatesInBackground()` on every launch outside any `#if DEBUG` guard; the call is silent when the app is already up to date and only surfaces UI when an update is found.
- `CotabbyInfo.plist` gains `SUScheduledCheckInterval = 86400` so long-running sessions get a daily background re-check without relying on Sparkle's implicit default.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the on-launch background check is non-intrusive and the plist change is straightforward.

The core fix is correct and well-guarded — `hasUsableConfiguration` prevents the call from firing in dev builds with the placeholder key. The one rough edge is that DEBUG builds with the `-Cotabby-check-for-updates-on-launch` argument now fire two Sparkle checks back-to-back (background + foreground dialog), which adds noise to that test path but doesn't affect production behavior at all.

The DEBUG block in `AppUpdateManager.start()` is worth a second look — the unconditional background check slightly undermines the isolation that the debug launch argument was designed to provide.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/Services/Utilities/AppUpdateManager.swift | Adds `checkForUpdatesInBackground()` call on every launch (outside DEBUG guard). In DEBUG builds with the launch argument set, both a background check and a foreground dialog check now fire in sequence. |
| CotabbyInfo.plist | Adds `SUScheduledCheckInterval = 86400` to pin the daily scheduled-check interval. Valid plist syntax; value is consistent with the PR intent. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App
    participant AppUpdateManager
    participant Sparkle
    participant Appcast as updates.cotabby.app

    App->>AppUpdateManager: start()
    AppUpdateManager->>Sparkle: startUpdater()
    AppUpdateManager->>Sparkle: checkForUpdatesInBackground()
    Sparkle->>Appcast: GET /appcast.xml
    alt Update available
        Appcast-->>Sparkle: new version entry
        Sparkle-->>App: Show update prompt (UI)
    else Up to date
        Appcast-->>Sparkle: current version
        Sparkle-->>App: silent (no UI)
    end

    Note over Sparkle: SUScheduledCheckInterval=86400
    loop Every 24 h (app stays open)
        Sparkle->>Appcast: GET /appcast.xml
        Appcast-->>Sparkle: response
    end

    App->>AppUpdateManager: checkForUpdates() (manual)
    AppUpdateManager->>Sparkle: checkForUpdates(nil)
    Sparkle->>Appcast: GET /appcast.xml
    Appcast-->>Sparkle: response
    Sparkle-->>App: Always shows result dialog
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cotabby/Services/Utilities/AppUpdateManager.swift`, line 57-64 ([link](https://github.com/fujacob/cotabby/blob/6493f56600b2e8cba44638870e504929956506b8/Cotabby/Services/Utilities/AppUpdateManager.swift#L57-L64)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> In DEBUG builds where the `-Cotabby-check-for-updates-on-launch` argument is present, `checkForUpdatesInBackground()` is now called unconditionally first, then `checkForUpdates()` (the foreground dialog check) fires immediately after. Two Sparkle checks are in-flight simultaneously. Sparkle serialises them internally so it won't crash, but the debug flag was designed to exercise the foreground dialog path in isolation; the preceding background check adds noise to that test scenario. Moving the background call inside an `else` branch (or skipping it when the debug argument is present) keeps the two test paths clean.

   

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fsparkle-check-on-launch-and-daily%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsparkle-check-on-launch-and-daily%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FServices%2FUtilities%2FAppUpdateManager.swift%0ALine%3A%2057-64%0A%0AComment%3A%0AIn%20DEBUG%20builds%20where%20the%20%60-Cotabby-check-for-updates-on-launch%60%20argument%20is%20present%2C%20%60checkForUpdatesInBackground%28%29%60%20is%20now%20called%20unconditionally%20first%2C%20then%20%60checkForUpdates%28%29%60%20%28the%20foreground%20dialog%20check%29%20fires%20immediately%20after.%20Two%20Sparkle%20checks%20are%20in-flight%20simultaneously.%20Sparkle%20serialises%20them%20internally%20so%20it%20won't%20crash%2C%20but%20the%20debug%20flag%20was%20designed%20to%20exercise%20the%20foreground%20dialog%20path%20in%20isolation%3B%20the%20preceding%20background%20check%20adds%20noise%20to%20that%20test%20scenario.%20Moving%20the%20background%20call%20inside%20an%20%60else%60%20branch%20%28or%20skipping%20it%20when%20the%20debug%20argument%20is%20present%29%20keeps%20the%20two%20test%20paths%20clean.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%23if%20DEBUG%0A%20%20%20%20%20%20%20%20if%20ProcessInfo.processInfo.arguments.contains%28Self.debugCheckForUpdatesOnLaunchArgument%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20log%28%22Debug%20launch%20argument%20requested%20an%20immediate%20update%20check.%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20checkForUpdates%28%29%0A%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20updaterController.updater.checkForUpdatesInBackground%28%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%23else%0A%20%20%20%20%20%20%20%20updaterController.updater.checkForUpdatesInBackground%28%29%0A%20%20%20%20%20%20%20%20%23endif%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FServices%2FUtilities%2FAppUpdateManager.swift%0ALine%3A%2057-64%0A%0AComment%3A%0AIn%20DEBUG%20builds%20where%20the%20%60-Cotabby-check-for-updates-on-launch%60%20argument%20is%20present%2C%20%60checkForUpdatesInBackground%28%29%60%20is%20now%20called%20unconditionally%20first%2C%20then%20%60checkForUpdates%28%29%60%20%28the%20foreground%20dialog%20check%29%20fires%20immediately%20after.%20Two%20Sparkle%20checks%20are%20in-flight%20simultaneously.%20Sparkle%20serialises%20them%20internally%20so%20it%20won't%20crash%2C%20but%20the%20debug%20flag%20was%20designed%20to%20exercise%20the%20foreground%20dialog%20path%20in%20isolation%3B%20the%20preceding%20background%20check%20adds%20noise%20to%20that%20test%20scenario.%20Moving%20the%20background%20call%20inside%20an%20%60else%60%20branch%20%28or%20skipping%20it%20when%20the%20debug%20argument%20is%20present%29%20keeps%20the%20two%20test%20paths%20clean.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%23if%20DEBUG%0A%20%20%20%20%20%20%20%20if%20ProcessInfo.processInfo.arguments.contains%28Self.debugCheckForUpdatesOnLaunchArgument%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20log%28%22Debug%20launch%20argument%20requested%20an%20immediate%20update%20check.%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20checkForUpdates%28%29%0A%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20updaterController.updater.checkForUpdatesInBackground%28%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%23else%0A%20%20%20%20%20%20%20%20updaterController.updater.checkForUpdatesInBackground%28%29%0A%20%20%20%20%20%20%20%20%23endif%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=310&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fsparkle-check-on-launch-and-daily%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsparkle-check-on-launch-and-daily%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FServices%2FUtilities%2FAppUpdateManager.swift%3A57-64%0AIn%20DEBUG%20builds%20where%20the%20%60-Cotabby-check-for-updates-on-launch%60%20argument%20is%20present%2C%20%60checkForUpdatesInBackground%28%29%60%20is%20now%20called%20unconditionally%20first%2C%20then%20%60checkForUpdates%28%29%60%20%28the%20foreground%20dialog%20check%29%20fires%20immediately%20after.%20Two%20Sparkle%20checks%20are%20in-flight%20simultaneously.%20Sparkle%20serialises%20them%20internally%20so%20it%20won't%20crash%2C%20but%20the%20debug%20flag%20was%20designed%20to%20exercise%20the%20foreground%20dialog%20path%20in%20isolation%3B%20the%20preceding%20background%20check%20adds%20noise%20to%20that%20test%20scenario.%20Moving%20the%20background%20call%20inside%20an%20%60else%60%20branch%20%28or%20skipping%20it%20when%20the%20debug%20argument%20is%20present%29%20keeps%20the%20two%20test%20paths%20clean.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%23if%20DEBUG%0A%20%20%20%20%20%20%20%20if%20ProcessInfo.processInfo.arguments.contains%28Self.debugCheckForUpdatesOnLaunchArgument%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20log%28%22Debug%20launch%20argument%20requested%20an%20immediate%20update%20check.%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20checkForUpdates%28%29%0A%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20updaterController.updater.checkForUpdatesInBackground%28%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%23else%0A%20%20%20%20%20%20%20%20updaterController.updater.checkForUpdatesInBackground%28%29%0A%20%20%20%20%20%20%20%20%23endif%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FServices%2FUtilities%2FAppUpdateManager.swift%3A57-64%0AIn%20DEBUG%20builds%20where%20the%20%60-Cotabby-check-for-updates-on-launch%60%20argument%20is%20present%2C%20%60checkForUpdatesInBackground%28%29%60%20is%20now%20called%20unconditionally%20first%2C%20then%20%60checkForUpdates%28%29%60%20%28the%20foreground%20dialog%20check%29%20fires%20immediately%20after.%20Two%20Sparkle%20checks%20are%20in-flight%20simultaneously.%20Sparkle%20serialises%20them%20internally%20so%20it%20won't%20crash%2C%20but%20the%20debug%20flag%20was%20designed%20to%20exercise%20the%20foreground%20dialog%20path%20in%20isolation%3B%20the%20preceding%20background%20check%20adds%20noise%20to%20that%20test%20scenario.%20Moving%20the%20background%20call%20inside%20an%20%60else%60%20branch%20%28or%20skipping%20it%20when%20the%20debug%20argument%20is%20present%29%20keeps%20the%20two%20test%20paths%20clean.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%23if%20DEBUG%0A%20%20%20%20%20%20%20%20if%20ProcessInfo.processInfo.arguments.contains%28Self.debugCheckForUpdatesOnLaunchArgument%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20log%28%22Debug%20launch%20argument%20requested%20an%20immediate%20update%20check.%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20checkForUpdates%28%29%0A%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20updaterController.updater.checkForUpdatesInBackground%28%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%23else%0A%20%20%20%20%20%20%20%20updaterController.updater.checkForUpdatesInBackground%28%29%0A%20%20%20%20%20%20%20%20%23endif%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=310&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Check for updates on launch and pin dail..."](https://github.com/fujacob/cotabby/commit/6493f56600b2e8cba44638870e504929956506b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34118495)</sub>

<!-- /greptile_comment -->