### PR TITLE
Stop the guided-permission helper from flickering during the granting flow

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		4B54ACE1255873955414CD06 /* PermissionGuidanceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F2C764D29C8D50D0C854FF8 /* PermissionGuidanceController.swift */; };
 		4CAFD8F3444FEDC9ACAFF529 /* LlamaRuntimeModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A804F4DB6FD9BC8C27B2B65F /* LlamaRuntimeModels.swift */; };
 		4F369F5284DDCEABF082E59B /* SuggestionAvailabilityEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3609CC88A5280B3AA40414DF /* SuggestionAvailabilityEvaluator.swift */; };
+		4F38CE1C2602CF4F41323032 /* PermissionOverlayTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12DD19BCE610808F1E38702D /* PermissionOverlayTrackerTests.swift */; };
 		51C069603DA16830868F1628 /* LanguageTagsEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7CDA90E128350BFF1A9D66 /* LanguageTagsEditor.swift */; };
 		52518CF0760DFEE9AF7C786C /* SuggestionEngineRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384FBCF5D7A3A446C5BE2B8D /* SuggestionEngineRouter.swift */; };
 		53FB56A095BCF0389DAC0A56 /* SuggestionTextColorCodec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CE61E74928C221B8BB261C6 /* SuggestionTextColorCodec.swift */; };
@@ -67,6 +68,7 @@
 		5E92E3C1EB41D482FC06BC52 /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA0117B322C625F6D4BBEAB /* MenuBarView.swift */; };
 		5F019E5A0679FFB52F129798 /* InputModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F34AE24BB7C99D66E1F3904 /* InputModels.swift */; };
 		6014B31E2570EFFE45557E33 /* TickMarkSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67586807ACE8EB13C9014535 /* TickMarkSlider.swift */; };
+		6106B16C0DBA94EBF838D93E /* PermissionOverlayTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6423D6CC8CC371D2DA899DE /* PermissionOverlayTracker.swift */; };
 		61EC9D635D416115E7C96E0F /* PermissionOverlayWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C6EB9FDA48ADF425A116A9 /* PermissionOverlayWindowController.swift */; };
 		644EEF959D07D54CC779BBF6 /* SettingsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3350EDE01ED5125520C79D53 /* SettingsCoordinator.swift */; };
 		65478B0DABF5460C32D4C458 /* ModelFileValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A829F28F01FAE76CA7244BBC /* ModelFileValidatorTests.swift */; };
@@ -176,6 +178,7 @@
 		0E0F6AFF229D20B73CF14C6C /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		0F5E263AB69029D5E13D5EE8 /* FocusDebugOverlayController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusDebugOverlayController.swift; sourceTree = "<group>"; };
 		110CB0B53016644EF7840301 /* HuggingFaceAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceAPIClient.swift; sourceTree = "<group>"; };
+		12DD19BCE610808F1E38702D /* PermissionOverlayTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOverlayTrackerTests.swift; sourceTree = "<group>"; };
 		18D990E515E1AE4F312F4E95 /* BundledRuntimeLocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledRuntimeLocatorTests.swift; sourceTree = "<group>"; };
 		19DB9558F4D3AFB108D71649 /* SuggestionStateHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionStateHelperTests.swift; sourceTree = "<group>"; };
 		1CE61E74928C221B8BB261C6 /* SuggestionTextColorCodec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionTextColorCodec.swift; sourceTree = "<group>"; };
@@ -296,6 +299,7 @@
 		E1D2782B6C7BE3F56BCB22DE /* LlamaVisualContextSummarizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LlamaVisualContextSummarizer.swift; sourceTree = "<group>"; };
 		E217A66717D78E1E49350EC8 /* DownloadOutcomeClassifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadOutcomeClassifierTests.swift; sourceTree = "<group>"; };
 		E43E587E421AF544A8300CE4 /* CustomRulesCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomRulesCatalog.swift; sourceTree = "<group>"; };
+		E6423D6CC8CC371D2DA899DE /* PermissionOverlayTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOverlayTracker.swift; sourceTree = "<group>"; };
 		E7F42112F14026E6253BB865 /* PermissionAndContextModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionAndContextModelTests.swift; sourceTree = "<group>"; };
 		EAAE6B395FAB604DF059280A /* KeyCodeLabels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyCodeLabels.swift; sourceTree = "<group>"; };
 		EBEDE359CFD99EF906FA50BC /* IndicatorIconImageProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndicatorIconImageProcessor.swift; sourceTree = "<group>"; };
@@ -499,6 +503,7 @@
 				03766F6253FF17639230C0F6 /* ModelAndPresentationValueTests.swift */,
 				A829F28F01FAE76CA7244BBC /* ModelFileValidatorTests.swift */,
 				E7F42112F14026E6253BB865 /* PermissionAndContextModelTests.swift */,
+				12DD19BCE610808F1E38702D /* PermissionOverlayTrackerTests.swift */,
 				0D80CC2CCAAFE3F23FB8C37A /* PromptContextSanitizerTests.swift */,
 				4696A84D17890B154533A08F /* PromptPolicyTests.swift */,
 				C05B0439348261163B37C508 /* SuggestionAvailabilityEvaluatorTests.swift */,
@@ -592,6 +597,7 @@
 				EBEDE359CFD99EF906FA50BC /* IndicatorIconImageProcessor.swift */,
 				EAAE6B395FAB604DF059280A /* KeyCodeLabels.swift */,
 				B5679E08C9A09065531C37B5 /* LlamaPromptRenderer.swift */,
+				E6423D6CC8CC371D2DA899DE /* PermissionOverlayTracker.swift */,
 				FA4B45B91D4DEAC979C3113E /* PromptContextSanitizer.swift */,
 				3609CC88A5280B3AA40414DF /* SuggestionAvailabilityEvaluator.swift */,
 				DDE858CB1E687E3CEB8FDD5B /* SuggestionRequestFactory.swift */,
@@ -788,6 +794,7 @@
 				E17CAA453B1F534D284F0D89 /* PermissionHostApp.swift in Sources */,
 				744B06C2488156B178675615 /* PermissionManager.swift in Sources */,
 				CCC83DC5AE51C17F153D5A6A /* PermissionModels.swift in Sources */,
+				6106B16C0DBA94EBF838D93E /* PermissionOverlayTracker.swift in Sources */,
 				61EC9D635D416115E7C96E0F /* PermissionOverlayWindowController.swift in Sources */,
 				90DC9508F27F712EB61EEB06 /* PermissionReminderView.swift in Sources */,
 				98E2E14A069384C1088CDB44 /* PromptContextSanitizer.swift in Sources */,
@@ -859,6 +866,7 @@
 				25D4FC8D191A50F63E6391F9 /* ModelAndPresentationValueTests.swift in Sources */,
 				65478B0DABF5460C32D4C458 /* ModelFileValidatorTests.swift in Sources */,
 				15FA56CEF6FB5FF54C2FBA6F /* PermissionAndContextModelTests.swift in Sources */,
+				4F38CE1C2602CF4F41323032 /* PermissionOverlayTrackerTests.swift in Sources */,
 				934885ACC2DEA20B27F10948 /* PromptContextSanitizerTests.swift in Sources */,
 				3CF1A4E39F24917DF0470A7D /* PromptPolicyTests.swift in Sources */,
 				88BCD795A14E1C9308F7BB31 /* SuggestionAvailabilityEvaluatorTests.swift in Sources */,

--- a/Cotabby/Services/Permission/PermissionGuidanceController.swift
+++ b/Cotabby/Services/Permission/PermissionGuidanceController.swift
@@ -17,7 +17,9 @@ final class PermissionGuidanceController {
     private var activationObserver: NSObjectProtocol?
     private var activePermission: CotabbyPermissionKind?
     private var pendingSourceFrameInScreen: CGRect?
-    private var didPresentCurrentOverlay = false
+    private var hasPresentedOverlay = false
+    private var isOverlayVisible = false
+    private var lastSettingsFrame: CGRect?
 
     init(
         permissionManager: PermissionManager,
@@ -72,7 +74,9 @@ final class PermissionGuidanceController {
         overlayController = nil
         activePermission = nil
         pendingSourceFrameInScreen = nil
-        didPresentCurrentOverlay = false
+        hasPresentedOverlay = false
+        isOverlayVisible = false
+        lastSettingsFrame = nil
     }
 
     private func presentGuidance(for permission: CotabbyPermissionKind, sourceFrameInScreen: CGRect?) {
@@ -98,7 +102,7 @@ final class PermissionGuidanceController {
 
     private func startTracking() {
         trackingTimer?.invalidate()
-        trackingTimer = Timer.scheduledTimer(withTimeInterval: 0.15, repeats: true) { [weak self] _ in
+        trackingTimer = Timer.scheduledTimer(withTimeInterval: 0.3, repeats: true) { [weak self] _ in
             guard let self else {
                 return
             }
@@ -138,24 +142,44 @@ final class PermissionGuidanceController {
             return
         }
 
-        guard let snapshot = SystemSettingsWindowLocator.frontmostWindow() else {
-            overlayController?.hide()
-            return
-        }
+        // The tracker fires on a timer *and* on every app activation. Route the decision through a
+        // pure rule and only touch the window when the action actually changes — re-ordering or
+        // hiding on every tick is what made the helper flicker as focus moved between System
+        // Settings, the macOS permission dialog, and Cotabby's own windows.
+        let snapshot = SystemSettingsWindowLocator.frontmostWindow()
+        switch PermissionOverlayTracker.transition(
+            settingsFrame: snapshot?.frame,
+            hasPresented: hasPresentedOverlay,
+            isVisible: isOverlayVisible,
+            lastFrame: lastSettingsFrame
+        ) {
+        case .present:
+            guard let snapshot else { return }
+            overlayController?.present(
+                from: pendingSourceFrameInScreen,
+                settingsFrame: snapshot.frame,
+                visibleFrame: snapshot.visibleFrame
+            )
+            hasPresentedOverlay = true
+            isOverlayVisible = true
+            lastSettingsFrame = snapshot.frame
 
-        if didPresentCurrentOverlay {
+        case .reposition:
+            guard let snapshot else { return }
             overlayController?.updatePosition(
                 with: snapshot.frame,
                 visibleFrame: snapshot.visibleFrame
             )
-            return
-        }
+            isOverlayVisible = true
+            lastSettingsFrame = snapshot.frame
 
-        overlayController?.present(
-            from: pendingSourceFrameInScreen,
-            settingsFrame: snapshot.frame,
-            visibleFrame: snapshot.visibleFrame
-        )
-        didPresentCurrentOverlay = true
+        case .hide:
+            overlayController?.hide()
+            isOverlayVisible = false
+            lastSettingsFrame = nil
+
+        case .none:
+            break
+        }
     }
 }

--- a/Cotabby/Support/PermissionOverlayTracker.swift
+++ b/Cotabby/Support/PermissionOverlayTracker.swift
@@ -1,0 +1,54 @@
+import CoreGraphics
+
+/// File overview:
+/// Pure decision rule for the guided-permission helper overlay that floats over System Settings.
+///
+/// `PermissionGuidanceController` re-evaluates the overlay very often — a short repeating timer plus
+/// an app-activation observer — so "what should the overlay do now?" must collapse to a no-op
+/// whenever nothing actually changed. The previous controller logic hid the overlay and re-ordered
+/// the window on *every* tick, so the helper flickered as focus bounced between System Settings, the
+/// macOS permission dialog, and Cotabby's own windows. Keeping the rule pure makes the no-op paths
+/// cheap to test.
+enum PermissionOverlayTracker {
+    enum Transition: Equatable {
+        /// First appearance this session — the controller plays the fly-in animation.
+        case present
+        /// Move to / ensure visible at a new frame, without replaying the animation.
+        case reposition
+        case hide
+        case none
+    }
+
+    /// Decides the next overlay action from the current state.
+    ///
+    /// - Parameters:
+    ///   - settingsFrame: the frontmost System Settings window frame, or `nil` when System Settings
+    ///     is not frontmost (e.g. the macOS permission dialog or Cotabby is in front).
+    ///   - hasPresented: whether the overlay has been shown at least once since tracking started.
+    ///   - isVisible: whether the overlay is currently on screen.
+    ///   - lastFrame: the System Settings frame the overlay was last positioned against.
+    static func transition(
+        settingsFrame: CGRect?,
+        hasPresented: Bool,
+        isVisible: Bool,
+        lastFrame: CGRect?
+    ) -> Transition {
+        guard let settingsFrame else {
+            // System Settings isn't frontmost. Only act if we're actually showing something —
+            // hiding an already-hidden overlay every tick is exactly what caused the flicker.
+            return isVisible ? .hide : .none
+        }
+
+        guard hasPresented else {
+            return .present
+        }
+
+        // Re-show after a hide, or follow the window when it moves — but never re-animate, and
+        // never touch the window when it's already parked at the right spot.
+        if !isVisible || settingsFrame != lastFrame {
+            return .reposition
+        }
+
+        return .none
+    }
+}

--- a/CotabbyTests/PermissionOverlayTrackerTests.swift
+++ b/CotabbyTests/PermissionOverlayTrackerTests.swift
@@ -1,0 +1,57 @@
+import CoreGraphics
+import XCTest
+@testable import Cotabby
+
+/// Tests for the pure overlay-transition rule that keeps the guided-permission helper from
+/// flickering as window focus bounces during the granting flow.
+final class PermissionOverlayTrackerTests: XCTestCase {
+    private let frameA = CGRect(x: 100, y: 100, width: 800, height: 600)
+    private let frameB = CGRect(x: 140, y: 120, width: 800, height: 600)
+
+    func test_noSettingsWindow_whileHidden_isNoOp() {
+        XCTAssertEqual(
+            PermissionOverlayTracker.transition(settingsFrame: nil, hasPresented: false, isVisible: false, lastFrame: nil),
+            .none
+        )
+        // Already presented earlier but currently hidden — still a no-op, not a redundant hide.
+        XCTAssertEqual(
+            PermissionOverlayTracker.transition(settingsFrame: nil, hasPresented: true, isVisible: false, lastFrame: nil),
+            .none
+        )
+    }
+
+    func test_noSettingsWindow_whileVisible_hides() {
+        XCTAssertEqual(
+            PermissionOverlayTracker.transition(settingsFrame: nil, hasPresented: true, isVisible: true, lastFrame: frameA),
+            .hide
+        )
+    }
+
+    func test_firstAppearance_presents() {
+        XCTAssertEqual(
+            PermissionOverlayTracker.transition(settingsFrame: frameA, hasPresented: false, isVisible: false, lastFrame: nil),
+            .present
+        )
+    }
+
+    func test_alreadyParkedAtSameFrame_isNoOp() {
+        XCTAssertEqual(
+            PermissionOverlayTracker.transition(settingsFrame: frameA, hasPresented: true, isVisible: true, lastFrame: frameA),
+            .none
+        )
+    }
+
+    func test_settingsWindowMoved_repositions() {
+        XCTAssertEqual(
+            PermissionOverlayTracker.transition(settingsFrame: frameB, hasPresented: true, isVisible: true, lastFrame: frameA),
+            .reposition
+        )
+    }
+
+    func test_reshowAfterHide_repositionsWithoutReanimating() {
+        XCTAssertEqual(
+            PermissionOverlayTracker.transition(settingsFrame: frameA, hasPresented: true, isVisible: false, lastFrame: nil),
+            .reposition
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the flickering seen while granting permissions. `PermissionGuidanceController` re-evaluated the
helper overlay on a **0.15s timer *and* on every app activation**, and on each tick it
unconditionally hid the overlay when System Settings wasn't frontmost and re-ordered it when it was.
During granting, focus legitimately bounces between System Settings, the macOS "would like to control
this computer" dialog, and Cotabby's own windows — so the overlay hid/re-showed many times a second.

The decision is now a pure, tested rule (`PermissionOverlayTracker.transition(...)`) and
`refreshPosition` is idempotent: present once (animated), reposition only when the System Settings
frame actually moves or after a real hide (never re-animating), hide only on an actual
visible→hidden change, and no-op otherwise. The timer is also calmed from 0.15s → 0.3s (the
app-activation observer still handles immediate repositioning).

## Validation

```bash
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build-for-testing
# ** TEST BUILD SUCCEEDED **
xcodebuild test ... -only-testing:CotabbyTests/PermissionOverlayTrackerTests CODE_SIGNING_ALLOWED=NO
# Executed 6 tests, with 0 failures
swiftlint lint --quiet --config .swiftlint.yml <changed files>
# exit 0
```

`PermissionOverlayTrackerTests` covers: no-Settings-window while hidden (no-op) vs while visible
(hide); first appearance (present); already parked at same frame (no-op); Settings window moved
(reposition); re-show after hide (reposition, not re-animate). Window behavior itself verified by
build — the AppKit controller isn't unit-tested, but its decision logic now is.

## Linked issues

None — reported directly ("permission window keeps flashing open").

## Risk / rollout notes

- Behavior-preserving: the overlay still appears over System Settings, follows it when dragged, and
  hides when you leave — it just stops doing redundant hide/re-order work every tick.
- New `Cotabby/Support/PermissionOverlayTracker.swift` and its test are registered via
  `xcodegen generate` (committed `project.pbxproj` regenerated; no drift).
- **Scope:** this fixes the confirmed cause — the guided-overlay tracking loop during the granting
  flow. It does **not** address the unconfirmed possibility that the *big* permission reminder
  window re-opens on plain app launch; the reminder is presented once and guarded, so if that's also
  happening it points at macOS's TCC "Quit & Reopen" relaunch (called out in `AppDelegate`) and
  needs a console-log repro to confirm — happy to chase it as a follow-up.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the flickering guided-permission overlay by replacing the unconditional hide/re-order logic that ran on every timer tick with a pure, idempotent state machine (`PermissionOverlayTracker`) that only triggers a window operation when something actually changes. The timer interval is also relaxed from 0.15 s to 0.3 s, and app-activation notifications continue to handle immediate repositioning.

- **`PermissionOverlayTracker.transition`** is a pure, side-effect-free function that maps `(settingsFrame, hasPresented, isVisible, lastFrame)` to one of four actions: `.present`, `.reposition`, `.hide`, or `.none`.
- **`PermissionGuidanceController`** now tracks three pieces of state and delegates every decision to the tracker, touching `PermissionOverlayWindowController` only when the action is non-`.none`.
- Six unit tests cover all key state paths; project file is regenerated via xcodegen with both new files correctly registered.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is behavior-preserving and the new decision logic is fully unit-tested.

The refactor is clean and well-contained: the pure transition function covers every realistic state combination, all three state variables are consistently reset in dismiss(), and MainActor isolation is correctly applied throughout. The only finding is a style concern — the Transition.none case name shadows Optional.none, which could cause confusion in future call sites that wrap the return type in an optional.

No files require special attention beyond the minor naming note in PermissionOverlayTracker.swift.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/PermissionOverlayTracker.swift | New pure-function state machine that decides the overlay action; well-structured, but the Transition.none case name can shadow Optional.none in certain call sites. |
| Cotabby/Services/Permission/PermissionGuidanceController.swift | Refactored to delegate overlay decisions to PermissionOverlayTracker; state variables are consistently reset in dismiss(), timer calmed to 0.3s, and MainActor isolation is correct throughout. |
| CotabbyTests/PermissionOverlayTrackerTests.swift | Six tests cover all realistic state transitions (no-op, first present, reposition, hide, re-show after hide); all passing per PR description. |
| Cotabby.xcodeproj/project.pbxproj | Generated by xcodegen; correctly registers both new source files in the app target and test target. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Timer as Timer (0.3s) / AppActivation
    participant PGC as PermissionGuidanceController
    participant POT as PermissionOverlayTracker
    participant POWC as PermissionOverlayWindowController
    participant SSL as SystemSettingsWindowLocator

    Timer->>PGC: refreshPosition()
    PGC->>PGC: guard activePermission, !isGranted
    PGC->>SSL: frontmostWindow()
    SSL-->>PGC: snapshot (frame) or nil
    PGC->>POT: transition(settingsFrame, hasPresented, isVisible, lastFrame)
    alt .present (first time)
        POT-->>PGC: .present
        PGC->>POWC: present(from:settingsFrame:visibleFrame:)
        PGC->>PGC: "hasPresentedOverlay=true, isOverlayVisible=true"
    else .reposition (frame changed or re-show after hide)
        POT-->>PGC: .reposition
        PGC->>POWC: updatePosition(with:visibleFrame:)
        PGC->>PGC: "isOverlayVisible=true, lastSettingsFrame=frame"
    else .hide (Settings not frontmost while overlay visible)
        POT-->>PGC: .hide
        PGC->>POWC: hide()
        PGC->>PGC: "isOverlayVisible=false, lastSettingsFrame=nil"
    else .none (no state change)
        POT-->>PGC: .none
        PGC->>PGC: break (no window ops)
    end
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fpermission-overlay-flicker%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpermission-overlay-flicker%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FSupport%2FPermissionOverlayTracker.swift%3A18-20%0AThe%20%60none%60%20case%20name%20shadows%20%60Optional.none%60%2C%20which%20can%20cause%20subtle%20surprises.%20For%20example%2C%20%60let%20t%3A%20Transition%3F%20%3D%20.none%60%20silently%20resolves%20to%20%60Optional.none%60%20%28nil%29%20rather%20than%20%60Transition.none%60%2C%20and%20any%20function%20returning%20%60Transition%3F%60%20will%20have%20ambiguous%20nil-vs-no-op%20semantics%20at%20the%20call%20site.%20A%20more%20distinct%20name%20keeps%20the%20intent%20unambiguous.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20case%20hide%0A%20%20%20%20%20%20%20%20case%20noAction%0A%20%20%20%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FSupport%2FPermissionOverlayTracker.swift%3A18-20%0AThe%20%60none%60%20case%20name%20shadows%20%60Optional.none%60%2C%20which%20can%20cause%20subtle%20surprises.%20For%20example%2C%20%60let%20t%3A%20Transition%3F%20%3D%20.none%60%20silently%20resolves%20to%20%60Optional.none%60%20%28nil%29%20rather%20than%20%60Transition.none%60%2C%20and%20any%20function%20returning%20%60Transition%3F%60%20will%20have%20ambiguous%20nil-vs-no-op%20semantics%20at%20the%20call%20site.%20A%20more%20distinct%20name%20keeps%20the%20intent%20unambiguous.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20case%20hide%0A%20%20%20%20%20%20%20%20case%20noAction%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=312&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Stop the guided-permission helper from f..."](https://github.com/fujacob/cotabby/commit/8ad0e02866860ff899fef2d5ce2f7339c3405583) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34120174)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->