### PR TITLE
Add tooltips across Settings and the menu-bar quick controls

### DIFF
--- a/Cotabby/UI/CustomRulesEditor.swift
+++ b/Cotabby/UI/CustomRulesEditor.swift
@@ -30,6 +30,8 @@ struct CustomRulesEditor: View {
             HStack {
                 Text("Rules")
                     .font(.system(size: 13, weight: .medium))
+                    .help("Short style instructions added to every prompt, like \"no em dashes\" "
+                        + "or \"prefer short sentences\". Stored only on your Mac.")
                 Spacer()
                 if canClear {
                     Button("Clear") {
@@ -38,12 +40,9 @@ struct CustomRulesEditor: View {
                     .buttonStyle(.plain)
                     .font(.system(size: 12))
                     .foregroundStyle(.secondary)
+                    .help("Remove all custom rules.")
                 }
             }
-
-            Text("Short style instructions for your completions. Stored only on your Mac.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
 
             if !rules.isEmpty {
                 TagFlowLayout(spacing: 10) {

--- a/Cotabby/UI/LanguageTagsEditor.swift
+++ b/Cotabby/UI/LanguageTagsEditor.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// File overview:
 /// Editor for the languages the user writes in. Mirrors `CustomRulesEditor`: declared languages are
 /// removable chips, added by tapping a suggestion (shown with its native name) or typing a custom
-/// one. "Clear" removes them all — the baseline is empty, which means "just follow the surrounding
+/// one. "Clear" removes them all. The baseline is empty, which means "just follow the surrounding
 /// text." The chip and flow-layout primitives are shared via `TagChip.swift`.
 struct LanguageTagsEditor: View {
     @ObservedObject var suggestionSettings: SuggestionSettingsModel
@@ -29,6 +29,9 @@ struct LanguageTagsEditor: View {
             HStack {
                 Text("Languages")
                     .font(.system(size: 13, weight: .medium))
+                    .help("Languages you write in. Cotabby matches what you're currently typing; "
+                        + "these help when a field is empty or too short to tell. "
+                        + "Leave empty to always follow the surrounding text.")
                 Spacer()
                 if canClear {
                     Button("Clear") {
@@ -37,14 +40,9 @@ struct LanguageTagsEditor: View {
                     .buttonStyle(.plain)
                     .font(.system(size: 12))
                     .foregroundStyle(.secondary)
+                    .help("Remove all language tags.")
                 }
             }
-
-            Text("The languages you write in. Cotabby matches the language you're already typing; "
-                + "these help when a field is empty or too short to tell. Leave empty to always "
-                + "follow the surrounding text.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
 
             if !languages.isEmpty {
                 TagFlowLayout(spacing: 10) {
@@ -86,7 +84,7 @@ struct LanguageTagsEditor: View {
 
             // The hint can only ask the model to use a language; whether it actually can depends on
             // the chosen engine, so we say so plainly rather than implying universal support.
-            Text("Language support depends on your selected model — Apple Intelligence covers a fixed "
+            Text("Language support depends on your selected model. Apple Intelligence covers a fixed "
                 + "set of languages, and local models vary, so some languages may not work.")
                 .font(.caption2)
                 .foregroundStyle(.tertiary)

--- a/Cotabby/UI/MenuBarView.swift
+++ b/Cotabby/UI/MenuBarView.swift
@@ -73,7 +73,7 @@ struct MenuBarView: View {
             Toggle("Fast Mode", isOn: fastModeEnabledBinding)
                 .toggleStyle(.switch)
                 .controlSize(.small)
-                .help("Skips capturing on-screen context (OCR) for faster, lower-overhead suggestions.")
+                .help("Skip on-screen OCR context for faster, lower-overhead suggestions. Predictions still run.")
 
             Divider()
 
@@ -83,12 +83,14 @@ struct MenuBarView: View {
                 Toggle("Enable Globally", isOn: globallyEnabledBinding)
                     .toggleStyle(.switch)
                     .controlSize(.small)
+                    .help("Master switch. Turn off to silence Cotabby in every app.")
 
                 if let application = focusModel.latestExternalApplication,
                    !TerminalAppDetector.isTerminal(bundleIdentifier: application.bundleIdentifier) {
                     Toggle("Enable in \(application.applicationName)", isOn: appEnabledBinding(for: application))
                         .toggleStyle(.switch)
                         .controlSize(.small)
+                        .help("Disable Cotabby just in this app. Overrides Enable Globally.")
                 }
             }
 
@@ -99,10 +101,12 @@ struct MenuBarView: View {
                 Toggle("Include Clipboard Context", isOn: clipboardContextEnabledBinding)
                     .toggleStyle(.switch)
                     .controlSize(.small)
+                    .help("Include your latest clipboard contents in the prompt so completions can reference what you copied.")
 
                 Toggle("Allow Multi-line Suggestions", isOn: multiLineEnabledBinding)
                     .toggleStyle(.switch)
                     .controlSize(.small)
+                    .help("Let suggestions span more than one line. Off keeps them to a single line.")
             }
 
             Divider()
@@ -120,6 +124,7 @@ struct MenuBarView: View {
                     }
                     .labelsHidden()
                     .pickerStyle(.menu)
+                    .help("Apple Intelligence runs on-device through macOS. Llama runs a local GGUF model you pick below.")
                 }
 
                 if suggestionSettings.selectedEngine == .appleIntelligence,
@@ -142,6 +147,7 @@ struct MenuBarView: View {
                     }
                     .labelsHidden()
                     .pickerStyle(.menu)
+                    .help("How long completions tend to be. Shorter is faster and less likely to overreach.")
                 }
             }
         }

--- a/Cotabby/UI/SettingsView.swift
+++ b/Cotabby/UI/SettingsView.swift
@@ -157,8 +157,10 @@ struct SettingsView: View {
     private var generalSection: some View {
         Section("General") {
             Toggle("Enable Globally", isOn: globallyEnabledBinding)
+                .help("Master switch. Turn off to silence Cotabby in every app.")
 
             Toggle("Show Indicator", isOn: showIndicatorBinding)
+                .help("Show a small icon next to the cursor when Cotabby is active in a field.")
 
             LabeledContent("Indicator Icon") {
                 HStack(spacing: 8) {
@@ -172,21 +174,26 @@ struct SettingsView: View {
                         Button("Reset") {
                             suggestionSettings.clearCustomIndicatorImage()
                         }
+                        .help("Go back to the default indicator icon.")
                     }
                 }
             }
+            .help("Custom image used in place of the default indicator. PNG or JPEG.")
 
             Toggle("Show Accept Hint", isOn: showAcceptanceHintBinding)
+                .help("Show a small label near the ghost text reminding you which key accepts it.")
 
             Toggle("Allow Multi-line Suggestions", isOn: multiLineEnabledBinding)
+                .help("Let suggestions span more than one line. Off keeps them to a single line.")
 
             Toggle("Accept Punctuation With Word", isOn: autoAcceptTrailingPunctuationBinding)
-                .help("When on, accepting a word also takes punctuation attached to it, like the \"?\" in \"you?\".")
+                .help("With this on, accepting a word also takes punctuation attached to it, like the \"?\" in \"you?\".")
 
             Toggle("Include Clipboard Context", isOn: clipboardContextEnabledBinding)
+                .help("Include your latest clipboard contents in the prompt so completions can reference what you copied.")
 
             Toggle("Fast Mode", isOn: fastModeEnabledBinding)
-                .help("Skips capturing on-screen context (OCR) for faster, lower-overhead suggestions.")
+                .help("Skip on-screen OCR context for faster, lower-overhead suggestions. Predictions still run.")
 
             LabeledContent("Ghost Text Color") {
                 HStack(spacing: 8) {
@@ -195,6 +202,7 @@ struct SettingsView: View {
                     }
                 }
             }
+            .help("Color of the ghost text shown before you accept it.")
 
             LabeledContent("Ghost Text Opacity") {
                 HStack(spacing: 10) {
@@ -213,6 +221,7 @@ struct SettingsView: View {
                         .frame(width: 42, alignment: .trailing)
                 }
             }
+            .help("How visible the ghost text is. Lower values are subtler but harder to read.")
 
             // Open at Login is hidden until the quarantine/SMAppService issue is resolved.
             // The toggle reports .notFound for quarantined apps and apps outside /Applications,
@@ -280,6 +289,7 @@ struct SettingsView: View {
                         .tag(preset)
                 }
             }
+            .help("How long completions tend to be. Shorter is faster and less likely to overreach.")
 
             VStack(alignment: .leading, spacing: 24) {
                 Text("This information is passed to the AI to help personalize your completions.")
@@ -295,6 +305,7 @@ struct SettingsView: View {
                         set: { suggestionSettings.setUserName($0) }
                     ))
                     .textFieldStyle(.roundedBorder)
+                    .help("How Cotabby refers to you when it matters, like signing off an email.")
                 }
 
                 LanguageTagsEditor(suggestionSettings: suggestionSettings)
@@ -332,6 +343,7 @@ struct SettingsView: View {
                         Button("Change") {
                             isRecordingKeybind = true
                         }
+                        .help("Record a new key. Press any key to bind it; Escape to cancel.")
                     }
 
                     if suggestionSettings.acceptanceKeyCode != SuggestionSettingsModel.defaultAcceptanceKeyCode {
@@ -342,6 +354,7 @@ struct SettingsView: View {
                             )
                             isRecordingKeybind = false
                         }
+                        .help("Restore the default key.")
                     }
 
                     if suggestionSettings.acceptanceKeyCode != SuggestionSettingsModel.disabledKeyCode {
@@ -349,9 +362,11 @@ struct SettingsView: View {
                             suggestionSettings.clearAcceptanceKey()
                             isRecordingKeybind = false
                         }
+                        .help("Unbind this shortcut. No key will accept word-by-word.")
                     }
                 }
             }
+            .help("Key that accepts the next word of the suggestion.")
 
             LabeledContent("Accept Entire Suggestion") {
                 HStack(spacing: 8) {
@@ -377,6 +392,7 @@ struct SettingsView: View {
                         Button("Change") {
                             isRecordingFullAcceptKeybind = true
                         }
+                        .help("Record a new key. Press any key to bind it; Escape to cancel.")
                     }
 
                     if suggestionSettings.fullAcceptanceKeyCode != SuggestionSettingsModel.defaultFullAcceptanceKeyCode {
@@ -387,6 +403,7 @@ struct SettingsView: View {
                             )
                             isRecordingFullAcceptKeybind = false
                         }
+                        .help("Restore the default key.")
                     }
 
                     if suggestionSettings.fullAcceptanceKeyCode != SuggestionSettingsModel.disabledKeyCode {
@@ -394,9 +411,11 @@ struct SettingsView: View {
                             suggestionSettings.clearFullAcceptanceKey()
                             isRecordingFullAcceptKeybind = false
                         }
+                        .help("Unbind this shortcut. No key will accept the whole suggestion at once.")
                     }
                 }
             }
+            .help("Key that accepts the whole suggestion at once.")
         }
     }
 
@@ -409,10 +428,7 @@ struct SettingsView: View {
                 in: 10...500,
                 step: 10
             )
-
-            Text("How long to wait after typing before generating a suggestion.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
+            .help("How long Cotabby waits after you stop typing before generating. Higher saves CPU; lower feels snappier.")
 
             // Focus poll interval is intentionally hidden from the UI. The default (50 ms)
             // is tuned for the best balance of responsiveness and CPU usage. Exposing it

--- a/Cotabby/UI/SettingsView.swift
+++ b/Cotabby/UI/SettingsView.swift
@@ -259,6 +259,7 @@ struct SettingsView: View {
                         .tag(engine)
                 }
             }
+            .help("Apple Intelligence runs on-device through macOS. Llama runs a local GGUF model you pick below.")
 
             switch suggestionSettings.selectedEngine {
             case .appleIntelligence:
@@ -452,6 +453,7 @@ struct SettingsView: View {
             Button("Add App…") {
                 presentDisabledAppPicker()
             }
+            .help("Pick an app to disable Cotabby in.")
         }
     }
 
@@ -501,6 +503,7 @@ struct SettingsView: View {
                             .tag(model.filename)
                     }
                 }
+                .help("Which GGUF file Cotabby loads. Larger models are smarter but slower and use more memory.")
             }
 
             DownloadableModelCatalogView(
@@ -524,14 +527,18 @@ struct SettingsView: View {
                     HStack(spacing: 8) {
                         let lmStudioURL = FileManager.default.homeDirectoryForCurrentUser
                             .appendingPathComponent(".lmstudio/models")
+                        let lmStudioAvailable = FileManager.default.fileExists(atPath: lmStudioURL.path)
                         let isUsingCustomPath = BundledRuntimeLocator.customModelDirectoryURL() != nil
                         Button("Use LM Studio") {
                             BundledRuntimeLocator.setCustomModelDirectory(lmStudioURL)
                             modelDownloadManager.refreshSearchDirectories()
                             refreshModels()
                         }
-                        .disabled(
-                            !FileManager.default.fileExists(atPath: lmStudioURL.path)
+                        .disabled(!lmStudioAvailable)
+                        .help(
+                            lmStudioAvailable
+                                ? "Point Cotabby at LM Studio's models folder (~/.lmstudio/models) so you don't keep two copies."
+                                : "Install LM Studio with at least one model first. Cotabby couldn't find ~/.lmstudio/models."
                         )
 
                         Button("Reset Path") {
@@ -540,6 +547,7 @@ struct SettingsView: View {
                             refreshModels()
                         }
                         .disabled(!isUsingCustomPath)
+                        .help("Go back to Cotabby's default models folder.")
 
                         Button("Open Folder") {
                             modelDownloadManager.openModelsDirectory()
@@ -548,9 +556,11 @@ struct SettingsView: View {
                         Button("Refresh") {
                             refreshModels()
                         }
+                        .help("Re-scan the folder for newly added or removed model files.")
                     }
                 }
             }
+            .help("Where Cotabby looks for GGUF model files.")
 
             if !runtimeModel.availableModels.isEmpty {
                 Text("Installed")
@@ -692,6 +702,7 @@ struct SettingsView: View {
                     action()
                 }
                 .controlSize(.small)
+                .help("Open System Settings to Privacy & Security so you can grant this permission.")
             }
         }
     }


### PR DESCRIPTION
## Summary

Every interactive control in Settings and the menu-bar quick-controls panel now has a `.help("...")` tooltip explaining what it does, with the trade-off named when there is one (latency vs. context, CPU vs. snappiness, etc.). Self-explanatory buttons (Open Folder, Quit, Open Welcome Guide) are intentionally left untipped to avoid noise. The redundant description paragraphs above the Languages, Custom Rules, and Suggestion Delay controls have been removed, since the new tooltips carry their copy and the body text was hurting density.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

swiftlint lint --quiet
# 3 pre-existing warnings in SuggestionCoordinator+Input.swift and FocusTracker.swift;
# 0 violations in any file touched by this PR.

awk 'length > 140' on the four edited files
# no lines exceed the 140-char line-length limit
```

Not verified in the running app: I did not manually hover every control to read the rendered tooltip popovers, since tooltip strings are inert at compile time and the failure mode for a typo is just bad copy on hover, not a crash.

## Linked issues

No tracked issue. Direct request.

## Risk / rollout notes

- Tooltips are additive `.help(...)` calls on existing controls. No behavior changes, no settings migrations, no pbxproj edits.
- One real semantic change: the `Use LM Studio` button now picks its tooltip based on whether `~/.lmstudio/models` exists. Reuses the same `FileManager.default.fileExists` check that already drives `.disabled(...)`, so no extra IO. Worst case if that check ever drifts, the tooltip wording disagrees with the disabled state, which is purely cosmetic.
- Existing tooltip copy on `Accept Punctuation With Word` and `Fast Mode` was rewritten for consistent voice (no em dashes, lead with the verb / outcome). The Fast Mode change appears in both Settings and the menu-bar panel so they stay in sync.
- Three caption-style `Text(...)` rows were removed (`LanguageTagsEditor` line 43, `CustomRulesEditor` line 44, `SettingsView` Performance section). If you'd rather keep that copy visible without hovering, easy to put back.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `.help(...)` tooltip strings to every interactive control in `SettingsView`, `MenuBarView`, `CustomRulesEditor`, and `LanguageTagsEditor`, and removes three now-redundant caption `Text` rows whose copy has been folded into the new tooltips.

- Tooltips are purely additive `.help()` modifiers; no logic, state, or layout is changed beyond extracting `lmStudioAvailable` as a local `let` so the existing `FileManager.default.fileExists` check is shared between `.disabled()` and the new conditional `.help()` (net I/O is unchanged).
- Three caption `Text` views (`LanguageTagsEditor`, `CustomRulesEditor`, `SettingsView` Performance section) are removed; their content is preserved in the tooltip copy, at the cost of requiring a hover to read it.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all changes are additive tooltip strings with no behavioral side effects.

Every change is a `.help(...)` string or a cosmetic copy tweak. The one structural change — extracting `lmStudioAvailable` — is a clean refactor that reduces the number of `fileExists` calls from one-per-modifier to one-per-render. The three removed caption `Text` views are matched by equivalent tooltip copy, so no information is lost. No logic, state, navigation, or persistence is altered.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/SettingsView.swift | Adds .help() tooltips throughout all settings sections; extracts lmStudioAvailable local var to reuse for both .disabled() and .help(); replaces one caption Text with a tooltip. |
| Cotabby/UI/MenuBarView.swift | Adds .help() tooltips to Fast Mode, Enable Globally, per-app toggle, clipboard context, multi-line, engine picker, and length picker; rewrites Fast Mode tooltip for consistent imperative voice. |
| Cotabby/UI/CustomRulesEditor.swift | Adds tooltips to the Rules label and Clear button; removes the now-redundant caption Text below the header. |
| Cotabby/UI/LanguageTagsEditor.swift | Adds tooltips to the Languages label and Clear button; removes caption Text; replaces em dashes with periods in the file comment and footer disclaimer. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User hovers control] --> B{Has .help modifier?}
    B -- Yes --> C[Show tooltip popover]
    B -- No --> D[No tooltip shown]

    subgraph LM Studio Path
        E[Render LabeledContent Folder]
        E --> F["let lmStudioAvailable = FileManager.fileExists(...)"]
        F --> G[".disabled(!lmStudioAvailable)"]
        F --> H{lmStudioAvailable?}
        H -- true --> I["tooltip: Point Cotabby at LM Studio..."]
        H -- false --> J["tooltip: Install LM Studio first..."]
    end
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22settings-tooltips%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22settings-tooltips%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FMenuBarView.swift%3A93%0AThe%20tooltip%20on%20the%20per-app%20toggle%20reads%20%22Disable%20Cotabby%20just%20in%20this%20app%22%20regardless%20of%20the%20toggle's%20current%20state.%20When%20the%20toggle%20is%20already%20off%20%28Cotabby%20disabled%20for%20this%20app%29%20and%20the%20user%20hovers%2C%20the%20tooltip%20implies%20the%20action%20is%20to%20disable%20%E2%80%94%20but%20they'd%20actually%20be%20re-enabling%20it.%20A%20neutral%2C%20bidirectional%20description%20avoids%20this%20mismatch.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.help%28%22Override%20the%20global%20switch%20for%20this%20app%20only.%20Overrides%20Enable%20Globally.%22%29%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FMenuBarView.swift%3A93%0AThe%20tooltip%20on%20the%20per-app%20toggle%20reads%20%22Disable%20Cotabby%20just%20in%20this%20app%22%20regardless%20of%20the%20toggle's%20current%20state.%20When%20the%20toggle%20is%20already%20off%20%28Cotabby%20disabled%20for%20this%20app%29%20and%20the%20user%20hovers%2C%20the%20tooltip%20implies%20the%20action%20is%20to%20disable%20%E2%80%94%20but%20they'd%20actually%20be%20re-enabling%20it.%20A%20neutral%2C%20bidirectional%20description%20avoids%20this%20mismatch.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.help%28%22Override%20the%20global%20switch%20for%20this%20app%20only.%20Overrides%20Enable%20Globally.%22%29%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=313&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Mirror the new Settings tooltips on the ..."](https://github.com/fujacob/cotabby/commit/14f7b2144ef9fdcdd8425b7dce8bae250f5b702e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34121025)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->