### PR TITLE
Run focus AX read off the synchronous keyboard event tap

### DIFF
--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
@@ -132,13 +132,29 @@ extension SuggestionCoordinator {
         }
 
         if event.shouldSchedulePrediction {
-            // Capture AX state immediately at keystroke time so the debounce window
-            // works with the freshest possible snapshot, not whenever the poll timer last fired.
-            focusModel.refreshNow()
-            schedulePrediction()
+            scheduleDeferredFocusRefreshAndPrediction()
         }
 
         return false
+    }
+
+    /// Refreshes the AX focus snapshot and schedules a prediction *off* the synchronous
+    /// event-tap callback.
+    ///
+    /// `FocusTracker.refreshNow()` performs a blocking Accessibility tree walk, and the keyboard
+    /// monitor is an active session event tap that the system routes the live input stream through
+    /// and waits on. Doing the AX read inline stalls every keystroke behind it, and against an
+    /// unresponsive app it can exceed the tap deadline, at which point macOS disables the tap and
+    /// drops the in-flight events queued behind it. Lost key-ups strand held keys (movement keys in
+    /// games keep firing) and desync modifier shortcuts. Hopping to the next main-actor turn lets
+    /// the keystroke flow through untouched; the debounced generation re-reads focus anyway
+    /// (`generateFromCurrentFocus`), so nothing downstream depends on this running inline.
+    func scheduleDeferredFocusRefreshAndPrediction() {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            self.focusModel.refreshNow()
+            self.schedulePrediction()
+        }
     }
 
     func handleSuppressedSyntheticInput() {
@@ -165,8 +181,7 @@ extension SuggestionCoordinator {
                 clearDiagnostics: false
             )
             if event.shouldSchedulePrediction {
-                focusModel.refreshNow()
-                schedulePrediction()
+                scheduleDeferredFocusRefreshAndPrediction()
             }
             return false
 
@@ -176,8 +191,7 @@ extension SuggestionCoordinator {
                 clearDiagnostics: false
             )
             if event.shouldSchedulePrediction {
-                focusModel.refreshNow()
-                schedulePrediction()
+                scheduleDeferredFocusRefreshAndPrediction()
             }
             return false
 


### PR DESCRIPTION
## Summary

On keystrokes that schedule a prediction, the suggestion coordinator called `FocusTracker.refreshNow()` directly inside the keyboard event-tap callback. That callback runs synchronously inside an active `.cgSessionEventTap` that the system routes the live input stream through and blocks on, and `refreshNow()` performs a blocking Accessibility tree walk. Against an unresponsive frontmost app that walk can exceed the tap deadline, so macOS disables the tap and drops the events queued behind it. Dropped key-ups leave keys logically held (continuous movement keys keep firing) and desync modifier shortcuts. This moves the AX refresh and prediction scheduling onto the next main-actor turn so the keystroke flows through the tap untouched.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

swiftlint lint --quiet Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
# only a pre-existing line-length warning on an unrelated trace log line (line 28)
```

The deferred read is safe because the debounced generation path (`generateFromCurrentFocus`) already re-reads focus before generating, so nothing downstream depends on the inline snapshot. The acceptance path already deferred its AX refresh via `asyncAfter`, so it was unaffected.

## Linked issues

<!-- none -->

## Risk / rollout notes

- Behavior change is timing-only: the focus snapshot used to seed the debounce gate is now read one main-actor turn later instead of inline. The debounce window (hundreds of ms) and the re-read inside generation absorb this.
- No schema, settings, or project file changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a macOS input-stream reliability issue by moving the blocking Accessibility tree walk (`FocusTracker.refreshNow()`) off the synchronous CGEvent tap callback and onto the next main-actor turn via `Task { @MainActor }`. Previously, a slow or unresponsive frontmost app could cause the AX read to exceed the tap deadline, causing macOS to disable the tap entirely and drop key-up events.

- Introduces `scheduleDeferredFocusRefreshAndPrediction()`, which wraps the `refreshNow()` + `schedulePrediction()` sequence in a `[weak self]` main-actor task, replacing three inline call sites across the active-session and default input-event paths.
- The change is safe because `generateFromCurrentFocus` already performs its own `refreshNow()` re-read after the debounce window expires, so no downstream path depends on the inline snapshot being current.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the timing change is well-contained and the generation path already re-reads focus independently.

The core fix is correct: deferring the blocking AX walk off the event tap prevents tap disablement under slow apps, and the weak self task is safe against coordinator deallocation. The only finding is that the new helper method is inadvertently exposed at module scope instead of being private, which is a minor inconsistency with the existing convention in this file. Nothing in the changed logic affects correctness.

No files require special attention beyond the access-control nit on the new helper method in SuggestionCoordinator+Input.swift.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift | Moves AX focus refresh and prediction scheduling off the synchronous event-tap callback into a deferred `Task { @MainActor }`. Logic is sound; the new helper method should be `private` to match the existing convention for internal-only helpers in this file. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant ET as CGEvent Tap (sync)
    participant SC as SuggestionCoordinator
    participant MA as Main Actor Queue
    participant FM as FocusModel
    participant WC as WorkController

    Note over ET,SC: Before this PR
    ET->>SC: handleInputEvent(event)
    SC->>FM: refreshNow() [blocks tap]
    FM-->>SC: snapshot updated
    SC->>WC: schedulePrediction()
    SC-->>ET: return false

    Note over ET,SC: After this PR
    ET->>SC: handleInputEvent(event)
    SC->>MA: "Task @MainActor enqueued"
    SC-->>ET: return false (tap unblocked)
    MA->>FM: refreshNow() [next turn]
    FM-->>MA: snapshot updated
    MA->>WC: schedulePrediction()
    WC->>WC: replaceDebouncedWork(delay: debounceMs)
    Note over WC: generateFromCurrentFocus re-reads focus after debounce
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fevent-tap-blocking-ax-on-keystroke%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fevent-tap-blocking-ax-on-keystroke%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BInput.swift%3A152-158%0A**Method%20should%20be%20private**%0A%0A%60scheduleDeferredFocusRefreshAndPrediction%60%20is%20only%20called%20from%20within%20this%20file%2C%20yet%20it%20sits%20in%20the%20non-%60private%60%20extension%20and%20is%20therefore%20visible%20at%20module%20scope.%20All%20three%20call%20sites%20are%20in%20the%20same%20file%2C%20and%20the%20existing%20internal-only%20formatting%20helpers%20%28%60focusDiagnostics%60%2C%20%60formatRect%60%29%20already%20live%20in%20the%20%60private%20extension%60%20block%20below.%20Moving%20this%20method%20there%20%28or%20adding%20an%20explicit%20%60private%60%20modifier%29%20keeps%20the%20public%20surface%20of%20%60SuggestionCoordinator%60%20consistent%20with%20the%20existing%20convention%20and%20avoids%20accidental%20callers%20in%20other%20coordinator%20files.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BInput.swift%3A152-158%0A**Method%20should%20be%20private**%0A%0A%60scheduleDeferredFocusRefreshAndPrediction%60%20is%20only%20called%20from%20within%20this%20file%2C%20yet%20it%20sits%20in%20the%20non-%60private%60%20extension%20and%20is%20therefore%20visible%20at%20module%20scope.%20All%20three%20call%20sites%20are%20in%20the%20same%20file%2C%20and%20the%20existing%20internal-only%20formatting%20helpers%20%28%60focusDiagnostics%60%2C%20%60formatRect%60%29%20already%20live%20in%20the%20%60private%20extension%60%20block%20below.%20Moving%20this%20method%20there%20%28or%20adding%20an%20explicit%20%60private%60%20modifier%29%20keeps%20the%20public%20surface%20of%20%60SuggestionCoordinator%60%20consistent%20with%20the%20existing%20convention%20and%20avoids%20accidental%20callers%20in%20other%20coordinator%20files.%0A%0A&repo=fujacob%2Fcotabby&pr=315&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Run focus AX read off the synchronous ke..."](https://github.com/fujacob/cotabby/commit/34c2f8d56c867e6315bbf8c126b98527cda2fe14) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34124126)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->