### PR TITLE
Stop indeterminate ProgressView spinners from pinning CPU

### DIFF
--- a/Cotabby/UI/DownloadableModelCatalogView.swift
+++ b/Cotabby/UI/DownloadableModelCatalogView.swift
@@ -140,8 +140,13 @@ private struct DownloadableModelRow: View {
                         .foregroundStyle(.blue)
                         .frame(width: 40, alignment: .trailing)
                 } else {
-                    ProgressView()
-                        .controlSize(.small)
+                    // A static glyph, not an indeterminate `ProgressView`. Indeterminate spinners
+                    // animate continuously via a detached display-link/NSAnimation loop that can
+                    // keep running (and pegging CPU) even after this window closes, and onboarding
+                    // shows several of these at once. The "…" reads as "starting" without spinning.
+                    Image(systemName: "ellipsis")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.blue)
                         .frame(width: 40)
                 }
                 // Plain SF Symbol button keeps the row compact and matches
@@ -207,14 +212,11 @@ private struct DownloadableModelRow: View {
 
     @ViewBuilder
     private var downloadProgressBar: some View {
-        if let progress = state.progressFraction {
-            ProgressView(value: progress, total: 1)
-                .progressViewStyle(.linear)
-                .tint(.blue)
-        } else {
-            ProgressView()
-                .progressViewStyle(.linear)
-                .tint(.blue)
-        }
+        // Always a determinate bar: it sits at 0 while the progress fraction is still unknown and
+        // fills as bytes arrive. An indeterminate linear `ProgressView` animates a moving stripe
+        // forever, which keeps a CoreAnimation loop pinned even when the window is closed.
+        ProgressView(value: state.progressFraction ?? 0, total: 1)
+            .progressViewStyle(.linear)
+            .tint(.blue)
     }
 }

--- a/Cotabby/UI/HuggingFaceModelBrowserView.swift
+++ b/Cotabby/UI/HuggingFaceModelBrowserView.swift
@@ -44,13 +44,11 @@ struct HuggingFaceModelBrowserView: View {
             EmptyView()
 
         case .searching:
-            HStack(spacing: 6) {
-                ProgressView()
-                    .controlSize(.small)
-                Text("Searching…")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
+            // Plain label rather than an indeterminate spinner: the spinner animates continuously
+            // and can leak its animation loop after the window closes. The "…" already reads as busy.
+            Text("Searching…")
+                .font(.caption)
+                .foregroundStyle(.secondary)
 
         case .noResults:
             Text("No GGUF models found.")
@@ -85,12 +83,8 @@ struct HuggingFaceModelBrowserView: View {
                     searchService.loadMore()
                 } label: {
                     if searchService.isLoadingMore {
-                        HStack(spacing: 6) {
-                            ProgressView()
-                                .controlSize(.small)
-                            Text("Loading…")
-                                .font(.caption)
-                        }
+                        Text("Loading…")
+                            .font(.caption)
                     } else {
                         Text("Load More")
                             .font(.caption)
@@ -110,14 +104,11 @@ struct HuggingFaceModelBrowserView: View {
         if isRepoSelected(repoId) {
             switch searchService.detailState {
             case .loading:
-                HStack(spacing: 6) {
-                    ProgressView()
-                        .controlSize(.small)
-                    Text("Loading files…")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-                .padding(.leading, 16)
+                // Plain label rather than an indeterminate spinner; see `.searching` above.
+                Text("Loading files…")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(.leading, 16)
                 .padding(.top, 4)
 
             case .failed(let message):
@@ -235,12 +226,10 @@ private struct HFFileRow: View {
                 actionButton
             }
 
-            if state.isDownloading, let progress = state.progressFraction {
-                ProgressView(value: progress, total: 1)
-                    .progressViewStyle(.linear)
-                    .tint(.blue)
-            } else if state.isDownloading {
-                ProgressView()
+            if state.isDownloading {
+                // Determinate bar pinned at 0 until the fraction is known. An indeterminate linear
+                // `ProgressView` animates forever and leaks that animation loop past window close.
+                ProgressView(value: state.progressFraction ?? 0, total: 1)
                     .progressViewStyle(.linear)
                     .tint(.blue)
             }
@@ -274,8 +263,10 @@ private struct HFFileRow: View {
                             .foregroundStyle(.blue)
                             .frame(width: 40, alignment: .trailing)
                     } else {
-                        ProgressView()
-                            .controlSize(.small)
+                        // Static glyph instead of an indeterminate spinner; see DownloadableModelCatalogView.
+                        Image(systemName: "ellipsis")
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundStyle(.blue)
                             .frame(width: 40)
                     }
                     Button {


### PR DESCRIPTION
## Summary

Profiling a high-CPU/laggy session of the app showed the entire cost in ~5 concurrent AppKit animation loops (`-[NSAnimation _runBlocking]` driven by CADisplayLinks committing CoreAnimation transactions), with no Cotabby Swift code on-CPU. That is the fingerprint of indeterminate `ProgressView()` spinners. Every indeterminate spinner in the app lives in the model download and HuggingFace browser UI, and an indeterminate `ProgressView` animates continuously on a detached display-link loop that can keep running (and burning CPU) even after its window is closed. Onboarding makes this worse by rendering several at once while recommended models download. This replaces every indeterminate spinner in that surface with affordances that do not animate at rest.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

swiftlint lint --quiet Cotabby/UI/HuggingFaceModelBrowserView.swift Cotabby/UI/DownloadableModelCatalogView.swift
# exit 0
```

Confirmed `grep` finds no remaining indeterminate `ProgressView()` in the codebase; only the two determinate `ProgressView(value:)` bars remain (these animate only on value change and stop at rest).

Behavioral checks done by reading the diff: download bars now render a determinate bar pinned at 0 until a byte fraction is known then fill normally; the "starting" action state shows a static ellipsis glyph in the same 40pt slot; HuggingFace searching/loading/load-more keep their existing text labels.

## Linked issues

<!-- none -->

## Risk / rollout notes

- Pure UI change. No model, settings, or project file changes.
- Visual change: loading states that previously showed a spinning indicator now show a static label or a determinate bar at 0. The "working" intent is still communicated by the existing text ("Searching…", "Loading…") and the ellipsis glyph.
- A determinate bar still animates its fill transiently when progress updates during an active download, but stops at rest, so it cannot keep an animation loop alive when idle or after the window closes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces every indeterminate `ProgressView()` spinner in the model-download and HuggingFace browser UI with alternatives that do not keep CoreAnimation loops alive at rest, fixing a CPU-pinning issue identified via profiling.

- In both `DownloadableModelCatalogView` and `HFFileRow`, the action-button slot swaps the indeterminate spinner for a static `"ellipsis"` SF Symbol glyph, and the progress bar is collapsed to a single `ProgressView(value: fraction ?? 0, total: 1)` call that starts at 0 and fills as bytes arrive.
- In `HuggingFaceModelBrowserView`, the spinners accompanying "Searching…", "Loading files…", and "Loading…" are removed, leaving the text labels alone to communicate busy state.

<h3>Confidence Score: 4/5</h3>

Safe to merge — purely visual changes that remove continuous animation loops without altering any model, settings, or data logic.

The change is well-scoped and the root-cause reasoning is sound. The only thing worth a second look is HuggingFaceModelBrowserView.swift, where a leftover indentation inconsistency on .padding(.top, 4) survived the refactor. Everything else is clean.

HuggingFaceModelBrowserView.swift — minor indentation artefact on the loading-files label after HStack removal.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/DownloadableModelCatalogView.swift | Replaces indeterminate ProgressView spinners with a static ellipsis glyph (action-button slot) and a 0-pinned determinate bar (progress bar slot); logic and layout are otherwise unchanged. |
| Cotabby/UI/HuggingFaceModelBrowserView.swift | Removes spinners from searching/loading/load-more states and uses same static-ellipsis+0-bar pattern as DownloadableModelCatalogView; minor indentation inconsistency on the .padding(.top, 4) modifier after the HStack removal (line 112). |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Download triggered] --> B{progressFraction known?}
    B -- Yes --> C[ProgressView value=fraction/1 determinate fill]
    B -- No --> D[ProgressView value=0/1 pinned at 0%]
    D --> E{fraction arrives?}
    E -- Yes --> C
    C --> F[Download complete]
    F --> G[Bar stops animating]

    H[Action button slot] --> I{state}
    I -- downloading, no fraction --> J[static ellipsis glyph]
    I -- downloading, fraction known --> K[percentage text]
    I -- idle --> L[Get button]
    I -- downloaded --> M[checkmark]
    I -- failed --> N[Retry button]

    O[HuggingFace browser] --> P{searchState}
    P -- searching --> Q[Text: Searching no spinner]
    P -- loading files --> R[Text: Loading files no spinner]
    P -- load more in flight --> S[Text: Loading no spinner + disabled button]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Findeterminate-progressview-cpu%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Findeterminate-progressview-cpu%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FHuggingFaceModelBrowserView.swift%3A108-112%0AThe%20%60.padding%28.top%2C%204%29%60%20modifier%20is%20at%20the%20same%20indent%20level%20as%20%60Text%28...%29%60%20rather%20than%20aligned%20with%20the%20other%20modifiers%20%E2%80%94%20a%20formatting%20artefact%20from%20removing%20the%20outer%20%60HStack%60.%20Re-aligning%20it%20keeps%20the%20chain%20readable%20and%20avoids%20a%20potential%20SwiftLint%20indentation%20warning.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Text%28%22Loading%20files%E2%80%A6%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.font%28.caption%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.foregroundStyle%28.secondary%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.padding%28.leading%2C%2016%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.padding%28.top%2C%204%29%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FHuggingFaceModelBrowserView.swift%3A108-112%0AThe%20%60.padding%28.top%2C%204%29%60%20modifier%20is%20at%20the%20same%20indent%20level%20as%20%60Text%28...%29%60%20rather%20than%20aligned%20with%20the%20other%20modifiers%20%E2%80%94%20a%20formatting%20artefact%20from%20removing%20the%20outer%20%60HStack%60.%20Re-aligning%20it%20keeps%20the%20chain%20readable%20and%20avoids%20a%20potential%20SwiftLint%20indentation%20warning.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Text%28%22Loading%20files%E2%80%A6%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.font%28.caption%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.foregroundStyle%28.secondary%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.padding%28.leading%2C%2016%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.padding%28.top%2C%204%29%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=319&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Stop indeterminate ProgressView spinners..."](https://github.com/fujacob/cotabby/commit/d86225fc3bc296286b5dd46edc01d40cc0d1f92f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34126216)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->