### PR TITLE
Defer keystroke-time focus refresh off the input event tap

### DIFF
--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
@@ -132,9 +132,10 @@ extension SuggestionCoordinator {
         }
 
         if event.shouldSchedulePrediction {
-            // Capture AX state immediately at keystroke time so the debounce window
-            // works with the freshest possible snapshot, not whenever the poll timer last fired.
-            focusModel.refreshNow()
+            // Refresh the AX snapshot off the synchronous tap path (see
+            // `scheduleNonBlockingFocusRefresh`) so the resolve cost never delays this keystroke.
+            // The fresh snapshot lands before the post-debounce generation re-reads it.
+            scheduleNonBlockingFocusRefresh()
             schedulePrediction()
         }
 
@@ -148,6 +149,34 @@ extension SuggestionCoordinator {
             generation: latestGenerationNumber,
             message: "Ignored Cotabby's own synthetic key event."
         )
+    }
+
+    /// Refreshes the focus snapshot without blocking keystroke delivery.
+    ///
+    /// `InputMonitor` runs the event-tap callback (and therefore `handleInputEvent`) synchronously
+    /// *before* macOS hands the keystroke to the focused app, so a synchronous `refreshNow()` here
+    /// adds the full Accessibility-resolve latency to every character typed. That resolve grows with
+    /// the field's text and AX subtree (candidate discovery, deep-geometry walks, full-value reads),
+    /// which is why typing into large or Chromium-based fields lagged badly while editing existing
+    /// text. Deferring the refresh to the next main-actor turn keeps the keystroke instant; the
+    /// snapshot still refreshes promptly, before the user's next event (e.g. a Tab acceptance) and
+    /// well before the post-debounce `generateFromCurrentFocus`, which re-reads it anyway.
+    ///
+    /// Coalesced via `isFocusRefreshScheduled`: continuous typing collapses to at most one pending
+    /// refresh, which reads the latest live AX state when it runs and so already reflects every
+    /// keystroke queued before it. The 80ms poll remains the backstop for freshness.
+    func scheduleNonBlockingFocusRefresh() {
+        guard !isFocusRefreshScheduled else {
+            return
+        }
+        isFocusRefreshScheduled = true
+        DispatchQueue.main.async { [weak self] in
+            guard let self else {
+                return
+            }
+            self.isFocusRefreshScheduled = false
+            self.focusModel.refreshNow()
+        }
     }
 
     /// While a suggestion tail is active, normal typing is interpreted relative to that tail first.
@@ -165,7 +194,7 @@ extension SuggestionCoordinator {
                 clearDiagnostics: false
             )
             if event.shouldSchedulePrediction {
-                focusModel.refreshNow()
+                scheduleNonBlockingFocusRefresh()
                 schedulePrediction()
             }
             return false
@@ -176,7 +205,7 @@ extension SuggestionCoordinator {
                 clearDiagnostics: false
             )
             if event.shouldSchedulePrediction {
-                focusModel.refreshNow()
+                scheduleNonBlockingFocusRefresh()
                 schedulePrediction()
             }
             return false

--- a/Cotabby/App/Coordinators/SuggestionCoordinator.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator.swift
@@ -61,6 +61,9 @@ final class SuggestionCoordinator: ObservableObject {
     // barrier task that the next generation must cross before it can ask the runtime for output.
     var cacheResetSequence: UInt64 = 0
     var pendingCacheReset: (sequence: UInt64, task: Task<Void, Never>)?
+    // Coalesces off-tap focus refreshes so fast typing can't queue a backlog of full AX resolves on
+    // the main actor. See `scheduleNonBlockingFocusRefresh`.
+    var isFocusRefreshScheduled = false
 
     init(
         permissionManager: any SuggestionPermissionProviding,


### PR DESCRIPTION
## Summary

Typing lagged in large or Chromium-based text fields because Cotabby ran a full Accessibility snapshot resolve synchronously inside the CGEvent tap, before macOS delivered each keystroke. The `InputMonitor` tap calls `handleInputEvent` synchronously and every text mutation called `focusModel.refreshNow()` inline, so the resolve latency was added to each character. That cost grows with the field's text and AX subtree (per-candidate value reads, candidate-discovery and deep-geometry walks), which is why it showed up most when editing inside existing text. This defers the per-keystroke refresh off the tap so it never blocks keystroke delivery, while keeping the snapshot fresh for acceptance and generation.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build-for-testing
# ** TEST BUILD SUCCEEDED **

swiftlint lint --quiet Cotabby/App/Coordinators/SuggestionCoordinator.swift Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
# exit 0 (only a pre-existing line-length warning on an untouched log line; no new violations)
```

This is a timing/threading change with no pure-logic delta, so existing state-transition tests are unaffected and no test asserts the previous synchronous-refresh behavior. Runtime "feel" still wants a manual check by typing into a heavy field (e.g. a long Gmail draft) to confirm the lag is gone.

## Linked issues

None.

## Risk / rollout notes

- Behavior change on the input critical path: the per-keystroke focus refresh now runs on the next main-actor turn (`scheduleNonBlockingFocusRefresh`) instead of synchronously inside the tap. I deferred it rather than deleting it specifically so the snapshot stays fresh for Tab-acceptance reconciliation, since `acceptSuggestion` reads `focusModel.snapshot` without its own refresh. Freshness is backstopped by the existing 80ms poll and the post-debounce refresh in `generateFromCurrentFocus`, which re-reads the snapshot anyway.
- Coalesced via a single `isFocusRefreshScheduled` flag so continuous typing collapses to at most one pending resolve rather than a backlog.
- Does not change the cost of the AX resolve itself (still run by the 80ms poll and post-debounce). A follow-up to cut that cost (cache candidate discovery in `editableDescendantCandidates`, avoid the double-resolve when the field signature changes per keystroke) is possible if this does not fully clear the lag in the heaviest fields.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes keystroke input lag in large or Chromium-based text fields by deferring the per-keystroke Accessibility snapshot resolve off the synchronous CGEvent tap path. Previously, `focusModel.refreshNow()` ran inline inside the tap callback before macOS delivered each character, adding full AX-resolve latency to every keystroke.

- Introduces `scheduleNonBlockingFocusRefresh()`, which dispatches the AX resolve to the next main-run-loop turn via `DispatchQueue.main.async`, replacing three direct `refreshNow()` call sites in `SuggestionCoordinator+Input.swift`.
- Adds an `isFocusRefreshScheduled` coalescing flag on `SuggestionCoordinator` so continuous rapid typing collapses to at most one pending AX resolve rather than queuing a backlog.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the deferred refresh reliably runs on the next main-loop iteration before any human Tab press, and the 80ms poll backstops freshness for acceptance.

The change is narrowly scoped to timing: the AX resolve still happens on the main actor, all state mutations remain single-threaded, and the coalescing flag is accessed only from @MainActor-isolated code. The two observations — DispatchQueue.main.async vs Task { @MainActor in … } for strict-concurrency hygiene, and the isFocusRefreshScheduled flag not being cleared in stop() — are both edge-case quality notes rather than present defects.

The stop() method in SuggestionCoordinator+Lifecycle.swift is worth a second look: it doesn't reset isFocusRefreshScheduled, so a rapid stop-then-restart cycle could leave the first post-restart keystroke's refresh silently coalesced away until the stale queued block drains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift | Replaces three synchronous focusModel.refreshNow() calls with scheduleNonBlockingFocusRefresh(), and adds the new method that defers the AX resolve via DispatchQueue.main.async with a coalescing flag. |
| Cotabby/App/Coordinators/SuggestionCoordinator.swift | Adds the isFocusRefreshScheduled: Bool coalescing flag; single-line addition with no other behavioral changes. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant macOS
    participant InputMonitor as InputMonitor (tap)
    participant Coordinator as SuggestionCoordinator
    participant MainQueue as Main Queue (async)
    participant FocusModel as FocusModel

    macOS->>InputMonitor: CGEvent tap fires (synchronous)
    InputMonitor->>Coordinator: handleInputEvent(event)
    alt event is acceptance (Tab)
        Coordinator->>Coordinator: acceptCurrentSuggestion()
        Coordinator->>FocusModel: reads snapshot (no refresh)
    else event.shouldSchedulePrediction (text mutation)
        Note over Coordinator: OLD: focusModel.refreshNow() inline — blocks keystroke delivery
        Coordinator->>Coordinator: scheduleNonBlockingFocusRefresh()
        alt "isFocusRefreshScheduled == false"
            Coordinator->>Coordinator: "isFocusRefreshScheduled = true"
            Coordinator->>MainQueue: DispatchQueue.main.async
        else "isFocusRefreshScheduled == true (coalesced)"
            Coordinator-->>Coordinator: guard return (skip duplicate)
        end
        Coordinator->>Coordinator: schedulePrediction()
    end
    Coordinator-->>InputMonitor: return
    InputMonitor-->>macOS: return (keystroke delivered instantly)
    macOS->>macOS: Delivers keystroke to focused app
    MainQueue->>Coordinator: async block fires (next run-loop turn)
    Coordinator->>Coordinator: "isFocusRefreshScheduled = false"
    Coordinator->>FocusModel: refreshNow() (AX resolve off tap path)
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22perf%2Finput-lag-investigation%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22perf%2Finput-lag-investigation%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BInput.swift%3A173-179%0AThe%20flag%20is%20reset%20to%20%60false%60%20before%20%60refreshNow%28%29%60%20is%20called%2C%20which%20is%20the%20right%20order%20for%20allowing%20re-coalescing.%20However%2C%20in%20Swift%206%20strict-concurrency%20mode%20%60DispatchQueue.main.async%60%20closures%20are%20not%20automatically%20%60%40MainActor%60-isolated%2C%20so%20the%20compiler%20may%20warn%20about%20accessing%20%60self.isFocusRefreshScheduled%60%20and%20%60self.focusModel%60%20from%20a%20non-isolated%20context.%20The%20existing%20%60schedulePostInsertionRefresh%60%20uses%20the%20same%20pattern%2C%20so%20this%20is%20consistent%20with%20the%20codebase%2C%20but%20annotating%20the%20closure%20or%20switching%20to%20%60Task%20%7B%20%40MainActor%20%5Bweak%20self%5D%20in%20%E2%80%A6%20%7D%60%20would%20silence%20any%20strict-concurrency%20diagnostics%20if%20the%20project%20ever%20enables%20them.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20Task%20%7B%20%40MainActor%20%5Bweak%20self%5D%20in%0A%20%20%20%20%20%20%20%20%20%20%20%20guard%20let%20self%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20self.isFocusRefreshScheduled%20%3D%20false%0A%20%20%20%20%20%20%20%20%20%20%20%20self.focusModel.refreshNow%28%29%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BInput.swift%3A173-179%0AThe%20flag%20is%20reset%20to%20%60false%60%20before%20%60refreshNow%28%29%60%20is%20called%2C%20which%20is%20the%20right%20order%20for%20allowing%20re-coalescing.%20However%2C%20in%20Swift%206%20strict-concurrency%20mode%20%60DispatchQueue.main.async%60%20closures%20are%20not%20automatically%20%60%40MainActor%60-isolated%2C%20so%20the%20compiler%20may%20warn%20about%20accessing%20%60self.isFocusRefreshScheduled%60%20and%20%60self.focusModel%60%20from%20a%20non-isolated%20context.%20The%20existing%20%60schedulePostInsertionRefresh%60%20uses%20the%20same%20pattern%2C%20so%20this%20is%20consistent%20with%20the%20codebase%2C%20but%20annotating%20the%20closure%20or%20switching%20to%20%60Task%20%7B%20%40MainActor%20%5Bweak%20self%5D%20in%20%E2%80%A6%20%7D%60%20would%20silence%20any%20strict-concurrency%20diagnostics%20if%20the%20project%20ever%20enables%20them.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20Task%20%7B%20%40MainActor%20%5Bweak%20self%5D%20in%0A%20%20%20%20%20%20%20%20%20%20%20%20guard%20let%20self%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20self.isFocusRefreshScheduled%20%3D%20false%0A%20%20%20%20%20%20%20%20%20%20%20%20self.focusModel.refreshNow%28%29%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=320&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Defer keystroke-time focus refresh off t..."](https://github.com/fujacob/cotabby/commit/644de882e2a76f287fcbffbc139038bd1966e015) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34126620)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->