### PR TITLE
Fix CI: add missing CaretGeometrySelector type referenced by tests

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		6E01052209B73D7361C12CEF /* ClipboardContentDistiller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96495E4147D828C0B1B22765 /* ClipboardContentDistiller.swift */; };
 		6E49ADEB31D04DC77A47DEB0 /* FileLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8C2569A8217EE9BD3B197F /* FileLogHandler.swift */; };
 		744B06C2488156B178675615 /* PermissionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85BF316556FDA64CB8AD07B6 /* PermissionManager.swift */; };
+		76FD91607794883F8E121450 /* CaretGeometrySelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3C84377F352140759B448C9 /* CaretGeometrySelector.swift */; };
 		7B6A63F5DCC2C163CDFD2A5C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BC4F887528AE74AC0DD30314 /* Assets.xcassets */; };
 		7D6BB9AF72F7076A4E5EE96F /* DownloadableModelCatalogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5C2AE9A7E55495D26AD074 /* DownloadableModelCatalogView.swift */; };
 		7E9413CE7C999C4612348248 /* SuggestionSessionReconcilerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C8F07AC52C7A482F5FE34C5 /* SuggestionSessionReconcilerTests.swift */; };
@@ -305,6 +306,7 @@
 		DEB16474A67CE1D210B944C9 /* SuggestionSubsystemContracts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionSubsystemContracts.swift; sourceTree = "<group>"; };
 		E1D2782B6C7BE3F56BCB22DE /* LlamaVisualContextSummarizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LlamaVisualContextSummarizer.swift; sourceTree = "<group>"; };
 		E217A66717D78E1E49350EC8 /* DownloadOutcomeClassifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadOutcomeClassifierTests.swift; sourceTree = "<group>"; };
+		E3C84377F352140759B448C9 /* CaretGeometrySelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaretGeometrySelector.swift; sourceTree = "<group>"; };
 		E43E587E421AF544A8300CE4 /* CustomRulesCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomRulesCatalog.swift; sourceTree = "<group>"; };
 		E6423D6CC8CC371D2DA899DE /* PermissionOverlayTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOverlayTracker.swift; sourceTree = "<group>"; };
 		E7F42112F14026E6253BB865 /* PermissionAndContextModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionAndContextModelTests.swift; sourceTree = "<group>"; };
@@ -591,6 +593,7 @@
 				352AF5B2834FEE1F597394E4 /* ApplicationBundleMetadata.swift */,
 				AC70775535A3428991025AB8 /* AXHelper.swift */,
 				AA33F5FFAC5B99384E15CE3E /* BundledRuntimeLocator.swift */,
+				E3C84377F352140759B448C9 /* CaretGeometrySelector.swift */,
 				96495E4147D828C0B1B22765 /* ClipboardContentDistiller.swift */,
 				D3A2AC525DC664DB540D4F19 /* ClipboardRelevanceFilter.swift */,
 				C7B2D34A6F3AC9DFD61350F7 /* CotabbyDebugOptions.swift */,
@@ -744,6 +747,7 @@
 				C4C6734678797669055988E0 /* AppUpdateManager.swift in Sources */,
 				66C23A7C2FCDE0266FF425F8 /* ApplicationBundleMetadata.swift in Sources */,
 				3CBBC3BFAC0DC8952EE24EF7 /* BundledRuntimeLocator.swift in Sources */,
+				76FD91607794883F8E121450 /* CaretGeometrySelector.swift in Sources */,
 				6E01052209B73D7361C12CEF /* ClipboardContentDistiller.swift in Sources */,
 				D2CAA59F69BCBC07DDA2B0D8 /* ClipboardContextProvider.swift in Sources */,
 				157A55EB796BEB7819B90D5D /* ClipboardRelevanceFilter.swift in Sources */,

--- a/Cotabby/Services/Focus/FocusSnapshotResolver.swift
+++ b/Cotabby/Services/Focus/FocusSnapshotResolver.swift
@@ -119,26 +119,25 @@ struct FocusSnapshotResolver {
         }
 
         // The input target and the geometry source don't need to be the same element.
-        // Native AppKit apps give exact caret rects on the input target itself. Chrome's
-        // AXTextArea, by contrast, answers BoundsForRange(loc-1, 1) with a multi-line union
-        // rect — labeled `.derived` here but actually unusable. The leaf AXStaticText holding
-        // the active line carries its own zero-length selection range and
-        // AXSelectedTextMarkerRange, so the deep BFS in `resolveDeepGeometrySource` can
-        // synthesize a real `.exact` rect via Branch 1.5 (TextMarker) on that leaf.
-        //
-        // Precedence:
-        //   1. primary `.exact`   (single API call, perfect — no walk needed)
-        //   2. deep `.exact`      (beats primary `.derived` so we escape Chrome's union-rect trap)
-        //   3. primary `.derived`
-        //   4. deep `.derived`
-        //   5. primary `.estimated` / unknown fallback
-        // The walk is skipped entirely when primary is already `.exact`, and otherwise throttled to
-        // one BFS per `deepWalkThrottleInterval` while focus stays in the same field. Chromium
-        // editors keep the focused element at `.derived`, so without the throttle the ~200-node walk
-        // ran on every keystroke and pinned a CPU core. Within the window we reuse the previous deep
-        // result, which can trail the live caret by up to one throttle interval of fast typing.
+        // Native AppKit apps give exact caret rects on the input target itself. The deep BFS in
+        // `resolveDeepGeometrySource` can recover a real `.exact` rect from a leaf AXStaticText
+        // (via Branch 1.5 (TextMarker) on its zero-length selection range) when the focused input
+        // only exposes weak geometry. Selection precedence and the search decision live in the
+        // pure `CaretGeometrySelector`:
+        //   1. primary `.exact`    (single API call, perfect — no walk needed)
+        //   2. primary `.derived`  (trusted; the walk is skipped entirely for it)
+        //   3. deep (any)          (only reached when primary is `.estimated`/unknown)
+        //   4. primary (any, fallback)
+        // The walk is skipped whenever primary geometry is already trustworthy (`.exact`/`.derived`),
+        // and otherwise throttled to one BFS per `deepWalkThrottleInterval` while focus stays in the
+        // same field, so the ~200-node walk does not run on every keystroke and pin a CPU core.
+        // Within the window we reuse the previous deep result, which can trail the live caret by up
+        // to one throttle interval of fast typing.
         let deepResult: CaretGeometryResult?
-        if resolvedCandidate.caretQuality == .exact {
+        if !CaretGeometrySelector.shouldSearchDeep(
+            primaryRect: resolvedCandidate.caretRect,
+            primaryQuality: resolvedCandidate.caretQuality
+        ) {
             deepResult = nil
         } else {
             deepResult = deepWalkThrottle.result(
@@ -153,7 +152,7 @@ struct FocusSnapshotResolver {
             }
         }
 
-        guard let caret = Self.selectCaretGeometry(
+        guard let caret = CaretGeometrySelector.select(
             primaryRect: resolvedCandidate.caretRect,
             primaryQuality: resolvedCandidate.caretQuality,
             primaryObservedCharWidth: resolvedCandidate.observedCharWidth,
@@ -268,61 +267,6 @@ struct FocusSnapshotResolver {
         }
 
         return ordered
-    }
-
-    /// Chooses the caret geometry to ship from the primary candidate and the optional deep-tree
-    /// result, following a fixed precedence (see the call site). Pulled out of `resolveSnapshot`
-    /// so that method stays under the cyclomatic-complexity limit; returns `nil` when neither
-    /// source produced a rect, which the caller maps to an unsupported snapshot.
-    ///
-    /// Precedence: primary `.exact` → deep `.exact` (beats primary `.derived`, escaping Chrome's
-    /// union-rect trap) → primary `.derived` → deep (any) → primary (any, fallback).
-    private struct SelectedCaretGeometry {
-        let rect: CGRect
-        let source: String
-        let quality: CaretGeometryQuality
-        let observedCharWidth: CGFloat?
-    }
-
-    private static func selectCaretGeometry(
-        primaryRect: CGRect?,
-        primaryQuality: CaretGeometryQuality?,
-        primaryObservedCharWidth: CGFloat?,
-        deepResult: CaretGeometryResult?
-    ) -> SelectedCaretGeometry? {
-        if let primary = primaryRect, primaryQuality == .exact {
-            return SelectedCaretGeometry(
-                rect: primary, source: "exact primary", quality: .exact,
-                observedCharWidth: primaryObservedCharWidth
-            )
-        }
-        if let deep = deepResult, deep.quality == .exact {
-            return SelectedCaretGeometry(
-                rect: deep.rect, source: "exact deep", quality: .exact,
-                observedCharWidth: deep.observedCharWidth
-            )
-        }
-        if let primary = primaryRect, primaryQuality == .derived {
-            return SelectedCaretGeometry(
-                rect: primary, source: "derived primary", quality: .derived,
-                observedCharWidth: primaryObservedCharWidth
-            )
-        }
-        if let deep = deepResult {
-            return SelectedCaretGeometry(
-                rect: deep.rect, source: "\(deep.quality.label) deep", quality: deep.quality,
-                observedCharWidth: deep.observedCharWidth
-            )
-        }
-        if let primary = primaryRect {
-            return SelectedCaretGeometry(
-                rect: primary,
-                source: "\(primaryQuality?.label ?? "unknown") primary-fallback",
-                quality: primaryQuality ?? .estimated,
-                observedCharWidth: primaryObservedCharWidth
-            )
-        }
-        return nil
     }
 
     /// Runs deep geometry search from the resolved editable candidate first, then falls back to

--- a/Cotabby/Support/CaretGeometrySelector.swift
+++ b/Cotabby/Support/CaretGeometrySelector.swift
@@ -1,0 +1,89 @@
+import CoreGraphics
+import Foundation
+
+/// Pure caret-geometry trust policy used by `FocusSnapshotResolver`.
+///
+/// Two decisions live here, kept free of live Accessibility objects so they can be unit tested:
+///   1. `shouldSearchDeep` — whether the focused input's own caret geometry is too weak to trust,
+///      so the resolver should run the expensive deep AX-tree walk for a better source.
+///   2. `select` — given the primary candidate's geometry and an optional deep-walk result, which
+///      rect to actually ship, following a fixed precedence.
+///
+/// The regression these protect against is trusting a descendant rect over the focused input's own
+/// usable rect (or vice versa). Chrome's AXTextArea answers BoundsForRange with a multi-line union
+/// rect — labelled `.derived` but unusable for precise caret placement — while the leaf AXStaticText
+/// holding the active line carries a real `.exact` rect that the deep walk can recover.
+enum CaretGeometrySelector {
+    /// The caret geometry chosen to ship, plus a human-readable source label for diagnostics.
+    struct Selected: Equatable {
+        let rect: CGRect
+        let source: String
+        let quality: CaretGeometryQuality
+        let observedCharWidth: CGFloat?
+    }
+
+    /// Whether the primary (focused-input) caret geometry is too weak to trust, so the resolver
+    /// should run the deep AX-tree walk for a more precise source.
+    ///
+    /// `.exact` and `.derived` are trusted as-is; only `.estimated`, unknown quality, or a missing
+    /// rect justify the ~200-node walk. The walk pins a CPU core when run on every keystroke, so we
+    /// avoid it whenever the primary geometry is already good enough.
+    static func shouldSearchDeep(
+        primaryRect: CGRect?,
+        primaryQuality: CaretGeometryQuality?
+    ) -> Bool {
+        guard primaryRect != nil else {
+            return true
+        }
+        switch primaryQuality {
+        case .exact, .derived:
+            return false
+        default:
+            return true
+        }
+    }
+
+    /// Chooses the caret geometry to ship from the primary candidate and the optional deep-tree
+    /// result. Returns `nil` when neither source produced a rect, which the caller maps to an
+    /// unsupported snapshot.
+    ///
+    /// Precedence:
+    ///   1. primary `.exact`    (single API call, perfect — no walk needed)
+    ///   2. primary `.derived`  (trusted; `shouldSearchDeep` skips the walk entirely for it)
+    ///   3. deep (any)          (only reached when primary is `.estimated`/unknown)
+    ///   4. primary (any, fallback)
+    static func select(
+        primaryRect: CGRect?,
+        primaryQuality: CaretGeometryQuality?,
+        primaryObservedCharWidth: CGFloat?,
+        deepResult: CaretGeometryResult?
+    ) -> Selected? {
+        if let primary = primaryRect, primaryQuality == .exact {
+            return Selected(
+                rect: primary, source: "exact primary", quality: .exact,
+                observedCharWidth: primaryObservedCharWidth
+            )
+        }
+        if let primary = primaryRect, primaryQuality == .derived {
+            return Selected(
+                rect: primary, source: "derived primary", quality: .derived,
+                observedCharWidth: primaryObservedCharWidth
+            )
+        }
+        if let deep = deepResult {
+            return Selected(
+                rect: deep.rect, source: "\(deep.quality.label) deep", quality: deep.quality,
+                observedCharWidth: deep.observedCharWidth
+            )
+        }
+        if let primary = primaryRect {
+            return Selected(
+                rect: primary,
+                source: "\(primaryQuality?.label ?? "unknown") primary-fallback",
+                quality: primaryQuality ?? .estimated,
+                observedCharWidth: primaryObservedCharWidth
+            )
+        }
+        return nil
+    }
+}


### PR DESCRIPTION
## Summary

The `Tests` workflow on `main` was red because `FocusSnapshotResolverSelectionTests` (added in #321) referenced a `CaretGeometrySelector` type that was never committed — `cannot find 'CaretGeometrySelector' in scope`. This adds that type as a pure helper in `Support/` and wires `FocusSnapshotResolver` through it, removing the now-duplicated private `selectCaretGeometry`/`SelectedCaretGeometry`.

The extracted policy also reflects the behavior the tests encode: primary `.derived` caret geometry is now trusted over a deep `.exact` result and skips the deep AX-tree walk entirely (consistent with `shouldSearchDeep` returning `false` for `.derived`).

## Validation

```
swiftlint lint --quiet Cotabby/Support/CaretGeometrySelector.swift Cotabby/Services/Focus/FocusSnapshotResolver.swift
# exit 0

xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  -only-testing:CotabbyTests/FocusSnapshotResolverSelectionTests CODE_SIGNING_ALLOWED=NO
# ** TEST SUCCEEDED **  5 tests, 0 failures

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build CODE_SIGNING_ALLOWED=NO
# ** BUILD SUCCEEDED **
```

`xcodegen generate` re-run; the only project drift is the new `CaretGeometrySelector.swift` source reference.

## Linked issues

Refs #321

## Risk / rollout notes

- Behavior change: primary `.derived` caret geometry now wins over deep `.exact` and no longer triggers the deep AX walk. This trusts the focused input's own rect for `.derived`-quality geometry rather than escaping to a descendant leaf. Matches the trust policy asserted by the new tests.
- `Cotabby.xcodeproj/project.pbxproj` regenerated to register the new source file.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a broken CI build by adding the missing `CaretGeometrySelector` type that the tests added in #321 referenced but was never committed. As a side effect it refactors `FocusSnapshotResolver`'s private `selectCaretGeometry`/`SelectedCaretGeometry` pair into the new public `CaretGeometrySelector` enum, and changes the caret-geometry trust policy so that a primary `.derived` result is now trusted and the deep AX-tree walk is skipped for it.

- `CaretGeometrySelector.swift` (new): pure, testable enum containing `shouldSearchDeep` and `select`; `.derived` primary geometry is now treated as trustworthy, reversing the old precedence where deep `.exact` could override primary `.derived`.
- `FocusSnapshotResolver.swift`: removes the old private `SelectedCaretGeometry` struct and `selectCaretGeometry` helper, delegates both the search-deep decision and the geometry-selection precedence to `CaretGeometrySelector`.
- `project.pbxproj`: registers the new source file in the Xcode build system.

<h3>Confidence Score: 3/5</h3>

The refactor is structurally clean but ships an intentional trust-policy change whose correctness for real Chrome sessions is not validated by the new unit tests.

The new `CaretGeometrySelector` class doc explicitly states that Chrome's AXTextArea labels a multi-line union rect `.derived` and it is "unusable for precise caret placement," then says the deep walk can recover a real `.exact` from the leaf. Yet `shouldSearchDeep` now returns `false` for `.derived` and `select` ships the primary `.derived` over any deep `.exact`. If Chrome still exposes that union rect as `.derived`, caret placement in web editors breaks silently — no integration-level test covers this path and the unit tests use synthetic coordinates that cannot distinguish a precise caret rect from a broad union rect.

CaretGeometrySelector.swift — its own header describes the Chrome scenario that the implementation no longer handles; whether that is stale documentation or a latent regression needs confirmation against a real Chromium editor.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/CaretGeometrySelector.swift | New pure type extracting caret-geometry trust policy; class doc describes the Chrome `.derived`-is-unusable scenario but the implementation no longer guards against it — `shouldSearchDeep` returns false for `.derived` and `select` trusts it over a deep `.exact`. |
| Cotabby/Services/Focus/FocusSnapshotResolver.swift | Private `selectCaretGeometry`/`SelectedCaretGeometry` removed and delegated to `CaretGeometrySelector`; the call sites and surrounding throttle logic look correct, but inherit the behavior change in the selector. |
| Cotabby.xcodeproj/project.pbxproj | Registers `CaretGeometrySelector.swift` in both the file-reference and build-file sections; looks correct and complete. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[resolveSnapshot called] --> B[Build primary candidate\ncaretRect + caretQuality]
    B --> C{CaretGeometrySelector\n.shouldSearchDeep?}
    C -- primaryRect nil\nor quality .estimated/nil --> D[Run deepWalkThrottle\nresolveDeepGeometrySource BFS\nup to ~200 AX nodes]
    C -- quality .exact or .derived --> E[deepResult = nil\nskip BFS entirely]
    D --> F[CaretGeometrySelector.select]
    E --> F
    F --> G{primary .exact?}
    G -- yes --> H[Ship primary .exact]
    G -- no --> I{primary .derived?}
    I -- yes --> J[Ship primary .derived\ndeepResult ignored]
    I -- no --> K{deepResult present?}
    K -- yes --> L[Ship deep result\nany quality]
    K -- no --> M{primary rect present?}
    M -- yes --> N[Ship primary fallback\n.estimated quality]
    M -- no --> O[Return nil →\nunsupported snapshot]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fcaret-geometry-selector%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fcaret-geometry-selector%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FSupport%2FCaretGeometrySelector.swift%3A12-15%0A**Class%20doc%20contradicts%20the%20implementation%20it%20describes**%0A%0ALines%2013%E2%80%9315%20say%20Chrome's%20AXTextArea%20labels%20its%20multi-line%20union%20rect%20%60.derived%60%2C%20it%20is%20%22unusable%20for%20precise%20caret%20placement%2C%22%20and%20%22the%20deep%20walk%20can%20recover%22%20a%20real%20%60.exact%60%20rect%20from%20the%20leaf%20%60AXStaticText%60.%20But%20%60shouldSearchDeep%60%20now%20returns%20%60false%60%20for%20%60.derived%60%2C%20and%20%60select%60%20prefers%20primary%20%60.derived%60%20over%20a%20deep%20%60.exact%60%20%28see%20%60testPrimaryDerivedWinsOverDeepExact%60%29.%20The%20protection%20described%20in%20the%20header%20is%20exactly%20the%20behavior%20this%20PR%20removes.%20A%20Chrome%20user%20with%20a%20%60.derived%60%20primary%20union%20rect%20will%20get%20that%20unusable%20rect%20shipped%3B%20the%20deep%20walk%20that%20recovered%20the%20leaf's%20%60.exact%60%20no%20longer%20fires.%0A%0AEither%20the%20doc%20is%20stale%20%28Chrome's%20%60.derived%60%20geometry%20is%20now%20actually%20usable%29%20and%20the%20comment%20should%20be%20updated%20or%20removed%2C%20or%20the%20code%20regresses%20Chrome%20caret%20placement%20for%20editors%20that%20still%20expose%20a%20wide%20union%20rect%20under%20%60.derived%60.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FSupport%2FCaretGeometrySelector.swift%3A12-15%0A**Class%20doc%20contradicts%20the%20implementation%20it%20describes**%0A%0ALines%2013%E2%80%9315%20say%20Chrome's%20AXTextArea%20labels%20its%20multi-line%20union%20rect%20%60.derived%60%2C%20it%20is%20%22unusable%20for%20precise%20caret%20placement%2C%22%20and%20%22the%20deep%20walk%20can%20recover%22%20a%20real%20%60.exact%60%20rect%20from%20the%20leaf%20%60AXStaticText%60.%20But%20%60shouldSearchDeep%60%20now%20returns%20%60false%60%20for%20%60.derived%60%2C%20and%20%60select%60%20prefers%20primary%20%60.derived%60%20over%20a%20deep%20%60.exact%60%20%28see%20%60testPrimaryDerivedWinsOverDeepExact%60%29.%20The%20protection%20described%20in%20the%20header%20is%20exactly%20the%20behavior%20this%20PR%20removes.%20A%20Chrome%20user%20with%20a%20%60.derived%60%20primary%20union%20rect%20will%20get%20that%20unusable%20rect%20shipped%3B%20the%20deep%20walk%20that%20recovered%20the%20leaf's%20%60.exact%60%20no%20longer%20fires.%0A%0AEither%20the%20doc%20is%20stale%20%28Chrome's%20%60.derived%60%20geometry%20is%20now%20actually%20usable%29%20and%20the%20comment%20should%20be%20updated%20or%20removed%2C%20or%20the%20code%20regresses%20Chrome%20caret%20placement%20for%20editors%20that%20still%20expose%20a%20wide%20union%20rect%20under%20%60.derived%60.%0A%0A&repo=fujacob%2Fcotabby&pr=322&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Fix CI: add CaretGeometrySelector type r..."](https://github.com/fujacob/cotabby/commit/b9359f82f722f2ae434a8500698ee3e5f89864f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34138978)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->