### PR TITLE
Replace 'App:' prompt prefix with natural-language phrasing

### DIFF
--- a/Cotabby/Support/FoundationModelPromptRenderer.swift
+++ b/Cotabby/Support/FoundationModelPromptRenderer.swift
@@ -107,7 +107,7 @@ enum FoundationModelPromptRenderer {
 
         var sections = [
             "Screen context:",
-            "App: \(request.context.applicationName)"
+            "User is on \(request.context.applicationName)."
         ]
 
         if let summary = request.visualContextSummary,

--- a/Cotabby/Support/LlamaPromptRenderer.swift
+++ b/Cotabby/Support/LlamaPromptRenderer.swift
@@ -57,7 +57,7 @@ enum LlamaPromptRenderer {
 
         sections.append("")
         sections.append("Screen context:")
-        sections.append("App: \(applicationName)")
+        sections.append("User is on \(applicationName).")
         if let summary = visualContextSummary, !summary.isEmpty {
             sections.append("Screen content:")
             sections.append(summary)

--- a/CotabbyTests/LlamaPromptRendererTests.swift
+++ b/CotabbyTests/LlamaPromptRendererTests.swift
@@ -91,7 +91,7 @@ final class LlamaPromptRendererTests: XCTestCase {
             userName: nil
         )
 
-        XCTAssertTrue(prompt.contains("App: Slack"))
+        XCTAssertTrue(prompt.contains("User is on Slack."))
         XCTAssertTrue(prompt.contains("My prefix text here"))
     }
 

--- a/CotabbyTests/PromptPolicyTests.swift
+++ b/CotabbyTests/PromptPolicyTests.swift
@@ -48,7 +48,7 @@ final class FoundationModelPromptRendererTests: XCTestCase {
 
         let prompt = FoundationModelPromptRenderer.prompt(for: request)
 
-        XCTAssertTrue(prompt.contains("App: TestApp"))
+        XCTAssertTrue(prompt.contains("User is on TestApp."))
         XCTAssertTrue(prompt.contains("  Hello from the field  "))
     }
 


### PR DESCRIPTION
## Summary

The 'App: <name>' label in the screen-context block was leaking into model outputs, with completions occasionally emitting 'App: ...' as if it were continuation text. Rewriting it as 'User is on <name>.' keeps the signal but removes the label-style cue that encourages the bad pattern.

## Validation

- xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build → ** BUILD SUCCEEDED **
- swiftlint lint --quiet → exit 0
- Updated PromptPolicyTests and LlamaPromptRendererTests to match the new phrasing.

## Linked issues

None.

## Risk / rollout notes

Prompt-only change. Affects both the llama.cpp and Foundation Models renderers, so suggestion phrasing may shift slightly even for completions that previously behaved well.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the label-style `App: <name>` line in the screen-context block with the natural-language sentence `User is on <name>.` across both the llama.cpp and Foundation Models prompt renderers, addressing a model-output artifact where the old key-value phrasing occasionally leaked into completions.

- Both `LlamaPromptRenderer` and `FoundationModelPromptRenderer` receive the identical one-line wording change, keeping the two engines in sync.
- Tests in `LlamaPromptRendererTests` and `PromptPolicyTests` are updated to assert the new string, preserving full deterministic coverage of the prompt-rendering contract.

<h3>Confidence Score: 5/5</h3>

Prompt-only, two-line change with no logic modifications; safe to merge.

The change is purely textual — one string literal replaced consistently in both renderers and both test files. No control flow, data model, or API surface is touched, and the existing deterministic tests continue to cover the exact output contract.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/FoundationModelPromptRenderer.swift | Single-line prompt wording change: `App: <name>` → `User is on <name>.` in the screen-context block of the request prompt. |
| Cotabby/Support/LlamaPromptRenderer.swift | Identical single-line prompt wording change as the Foundation Models renderer, keeping both engines in sync. |
| CotabbyTests/LlamaPromptRendererTests.swift | Test assertion updated from `App: Slack` to `User is on Slack.` to match the new renderer output; no other test logic changed. |
| CotabbyTests/PromptPolicyTests.swift | Test assertion updated from `App: TestApp` to `User is on TestApp.` to match the new Foundation Models renderer output; no other test logic changed. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant SC as SuggestionCoordinator
    participant LPR as LlamaPromptRenderer
    participant FMPR as FoundationModelPromptRenderer
    participant M as Model (llama / Foundation)

    SC->>LPR: prompt(prefixText, applicationName, ...)
    LPR-->>SC: "Screen context:\nUser is on <name>.\n..."
    SC->>M: infer(prompt)

    SC->>FMPR: prompt(for: request)
    FMPR-->>SC: "Screen context:\nUser is on <name>.\n..."
    SC->>M: generate(instructions, prompt)
```

<sub>Reviews (1): Last reviewed commit: ["Replace &#39;App:&#39; prompt prefix with natura..."](https://github.com/fujacob/cotabby/commit/5c6e4ffd10ec6b670552b36ea37037c9cb8f4e45) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34322890)</sub>

<!-- /greptile_comment -->