### PR TITLE
Expand FM eval suite: per-category scoring and latency

### DIFF
--- a/CotabbyTests/FoundationModelDriftEvalTests.swift
+++ b/CotabbyTests/FoundationModelDriftEvalTests.swift
@@ -267,8 +267,20 @@ final class FoundationModelDriftEvalTests: XCTestCase {
 
         let latenciesMs = outcomes.map { Int(($0.latency * 1000).rounded()) }.sorted()
         if !latenciesMs.isEmpty {
-            let p50 = latenciesMs[latenciesMs.count / 2]
-            let p95Index = min(latenciesMs.count - 1, Int(Double(latenciesMs.count) * 0.95))
+            // Median: for an even-length sample average the two middle values, otherwise pick the
+            // single middle. Reporting the upper-middle as "p50" would mask a small regression
+            // sitting right at the median.
+            let p50: Int
+            if latenciesMs.count.isMultiple(of: 2) {
+                let mid = latenciesMs.count / 2
+                p50 = (latenciesMs[mid - 1] + latenciesMs[mid]) / 2
+            } else {
+                p50 = latenciesMs[latenciesMs.count / 2]
+            }
+            // Nearest-rank: ceil(0.95 * n) gives the 1-indexed rank, so subtract 1 for the array
+            // index. Plain truncation overshoots for small per-category buckets.
+            let rank = Int((Double(latenciesMs.count) * 0.95).rounded(.up))
+            let p95Index = min(latenciesMs.count - 1, max(0, rank - 1))
             let p95 = latenciesMs[p95Index]
             lines.append("--- latency (ms) ---")
             lines.append("p50=\(p50), p95=\(p95), max=\(latenciesMs.last ?? 0)")
@@ -309,14 +321,14 @@ final class FoundationModelDriftEvalTests: XCTestCase {
     }
 
     /// Heuristic for "the token budget cut the model off mid-word". Empty strings are exempt
-    /// (counted under `empty`). A clean stop is final whitespace, sentence-ending punctuation,
-    /// or a closing bracket / paren that finishes a code fragment.
+    /// (counted under `empty`). A clean stop is sentence-ending punctuation or a closing bracket
+    /// / paren that finishes a code fragment. Trimming above strips any trailing whitespace, so a
+    /// whitespace check here would be dead code.
     private static func endsMidWord(_ text: String) -> Bool {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let last = trimmed.last else {
             return false
         }
-        if last.isWhitespace { return false }
         if last.isPunctuation { return false }
         if "})]>".contains(last) { return false }
         return true

--- a/CotabbyTests/FoundationModelDriftEvalTests.swift
+++ b/CotabbyTests/FoundationModelDriftEvalTests.swift
@@ -3,18 +3,29 @@ import XCTest
 
 #if canImport(FoundationModels)
 
-/// Live Apple Intelligence drift eval — deliberately NOT a CI test.
+/// Live Apple Intelligence drift and quality eval — deliberately NOT a CI test.
 ///
-/// Apple's system model is chat-tuned and used to break character on plain prefixes: greeting the
-/// user ("Jacob, how are you"), tacking on pleasantries ("Hope it's going well"), or replying like
-/// an assistant. This harness runs real on-device generations against the prefixes that historically
-/// drifted and reports how many still do, so prompt changes can be measured instead of guessed at.
+/// Apple's system model is chat-tuned. Historically it broke character on plain prefixes: greeting
+/// the user ("Jacob, how are you"), tacking on pleasantries ("Hope it's going well"), or replying
+/// like an assistant. The chat-drift bucket below preserves those failing cases; the other buckets
+/// (email, slack, code, code-comment, prose, mid-line insertion) widen coverage to the writing
+/// surfaces real users complain about so prompt and engine changes can be measured per category
+/// instead of averaged into one number.
 ///
-/// It is gated behind the `RUN_FM_EVAL` compilation condition because it (a) needs the on-device
-/// model, which CI runners do not have, and (b) is non-deterministic, so it is a local tuning tool
-/// rather than a hard gate. xcodebuild does not forward shell env vars to the macOS test host, so a
-/// compile flag (which *is* passable on the command line) is the reliable switch. CI never sets it
-/// — and `tests.yml` also `-skip-testing`s this class — so it is a no-op there.
+/// Per-case scoring captures four signals:
+///   - DRIFT     — output reads as an assistant reply (a "drift tell" phrase or unprompted greeting)
+///   - EMPTY     — normalization stripped the output to nothing (a hard miss in production)
+///   - NOISE     — chat-template residue leaked through (regression check for routing/normalization)
+///   - MIDWORD   — token budget cut the output mid-word (clean-stop heuristic)
+///
+/// Plus per-case latency, so latency-focused changes (session reuse, prewarm, streaming) can be
+/// measured with the same harness as quality-focused changes.
+///
+/// Gated behind the `RUN_FM_EVAL` compilation condition because it (a) needs the on-device model,
+/// which CI runners do not have, and (b) is non-deterministic, so it is a local tuning tool rather
+/// than a hard gate. xcodebuild does not forward shell env vars to the macOS test host, so a compile
+/// flag (which *is* passable on the command line) is the reliable switch. CI never sets it — and
+/// `tests.yml` also `-skip-testing`s this class — so it is a no-op there.
 ///
 /// Run locally with:
 ///   xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
@@ -24,23 +35,127 @@ import XCTest
 @MainActor
 final class FoundationModelDriftEvalTests: XCTestCase {
 #if RUN_FM_EVAL
-    /// Prefixes that previously pulled the model into assistant/chat replies. Each ends mid-thought,
-    /// where the correct behavior is to keep typing, not to greet or reply.
-    private static let cases: [String] = [
-        "Hey Jacob, ",
-        "Hi Sarah,\n\n",
-        "Thanks for ",
-        "I wanted to reach out about ",
-        "Good morning team, ",
-        "Let me know if ",
-        "lol yeah ",
-        "The quarterly numbers are ",
-        "Please review the ",
-        "Hello! "
+    /// One scored scenario. Categories let per-category thresholds catch regressions that
+    /// whole-set averages would smooth over.
+    private struct EvalCase {
+        enum Category: String, CaseIterable {
+            case chatDrift     // chat-prone prefixes the chat-tuned model historically replied to
+            case email         // mid-sentence business email writing
+            case slack         // short informal team chat
+            case code          // code-editor continuations (should produce code)
+            case codeComment   // English inside source files
+            case prose         // generic factual writing
+            case midLine       // insertion with non-empty trailing text
+        }
+
+        let category: Category
+        let prefix: String
+        let trailing: String  // empty unless category == .midLine
+    }
+
+    /// Per-case scoring outcome, kept as a flat struct so the report renderer can iterate without
+    /// re-running anything.
+    private struct CaseOutcome {
+        let scenario: EvalCase
+        let drifted: Bool
+        let empty: Bool
+        let noise: Bool
+        let midWord: Bool
+        let normalized: String
+        let raw: String
+        let latency: TimeInterval
+    }
+
+    /// Historical chat-drift triggers: salutations, partial greetings, mid-thought stoppers that
+    /// the chat-tuned model used to "reply" to instead of continuing.
+    private static let chatDriftCases: [EvalCase] = [
+        EvalCase(category: .chatDrift, prefix: "Hey Jacob, ", trailing: ""),
+        EvalCase(category: .chatDrift, prefix: "Hi Sarah,\n\n", trailing: ""),
+        EvalCase(category: .chatDrift, prefix: "Thanks for ", trailing: ""),
+        EvalCase(category: .chatDrift, prefix: "I wanted to reach out about ", trailing: ""),
+        EvalCase(category: .chatDrift, prefix: "Good morning team, ", trailing: ""),
+        EvalCase(category: .chatDrift, prefix: "Let me know if ", trailing: ""),
+        EvalCase(category: .chatDrift, prefix: "lol yeah ", trailing: ""),
+        EvalCase(category: .chatDrift, prefix: "The quarterly numbers are ", trailing: ""),
+        EvalCase(category: .chatDrift, prefix: "Please review the ", trailing: ""),
+        EvalCase(category: .chatDrift, prefix: "Hello! ", trailing: ""),
+        EvalCase(category: .chatDrift, prefix: "Dear hiring manager, ", trailing: ""),
+        EvalCase(category: .chatDrift, prefix: "Cheers,\n", trailing: "")
     ]
 
-    /// Phrases that mark a continuation as out-of-character: assistant replies, greetings, or the
-    /// pleasantries the user flagged. Matched case-insensitively anywhere in the output.
+    /// Mid-sentence email writing — the continuation should match tone and finish the thought,
+    /// not start a reply.
+    private static let emailCases: [EvalCase] = [
+        EvalCase(category: .email, prefix: "Following up on our call yesterday, I wanted to ", trailing: ""),
+        EvalCase(category: .email, prefix: "Per our discussion, the next step is to ", trailing: ""),
+        EvalCase(category: .email, prefix: "Apologies for the delay, I was waiting on ", trailing: ""),
+        EvalCase(category: .email, prefix: "Could you take a look at the attached and ", trailing: ""),
+        EvalCase(category: .email, prefix: "I've reviewed the proposal and overall it ", trailing: ""),
+        EvalCase(category: .email, prefix: "We're targeting end-of-quarter for the rollout, so ", trailing: ""),
+        EvalCase(category: .email, prefix: "Looping in Priya from legal so she can ", trailing: ""),
+        EvalCase(category: .email, prefix: "Happy to set up a call this week to ", trailing: "")
+    ]
+
+    /// Informal team chat — short, conversational, lowercase. The model should match the register.
+    private static let slackCases: [EvalCase] = [
+        EvalCase(category: .slack, prefix: "anyone seen the ", trailing: ""),
+        EvalCase(category: .slack, prefix: "merging the fix now, can someone ", trailing: ""),
+        EvalCase(category: .slack, prefix: "lunch at 1? thinking we ", trailing: ""),
+        EvalCase(category: .slack, prefix: "wfh today, ping me on ", trailing: ""),
+        EvalCase(category: .slack, prefix: "looks like CI is red again, probably ", trailing: ""),
+        EvalCase(category: .slack, prefix: "btw the new design ", trailing: "")
+    ]
+
+    /// Code-editor prefixes — the model should output code, not prose. These are chosen so any
+    /// plausible continuation is a well-formed code fragment.
+    private static let codeCases: [EvalCase] = [
+        EvalCase(category: .code, prefix: "def total(items):\n    return sum(", trailing: ""),
+        EvalCase(category: .code, prefix: "let total = items.reduce(0, { $0 + ", trailing: ""),
+        EvalCase(category: .code, prefix: "const sorted = items.sort((a, b) => a.priority - ", trailing: ""),
+        EvalCase(category: .code, prefix: "if let value = dictionary[\"", trailing: ""),
+        EvalCase(category: .code, prefix: "guard !text.isEmpty else { return ", trailing: ""),
+        EvalCase(category: .code, prefix: "func fibonacci(_ n: Int) -> Int {\n    if n < 2 { return ", trailing: ""),
+        EvalCase(category: .code, prefix: "try { await fetch(`/api/users/${", trailing: ""),
+        EvalCase(category: .code, prefix: "SELECT name, email FROM users WHERE created_at > ", trailing: "")
+    ]
+
+    /// English inside source files — should still be writing about code, not breaking into chat.
+    private static let codeCommentCases: [EvalCase] = [
+        EvalCase(category: .codeComment, prefix: "// TODO: handle the case where the response is ", trailing: ""),
+        EvalCase(category: .codeComment, prefix: "/// Returns the smallest positive integer that ", trailing: ""),
+        EvalCase(category: .codeComment, prefix: "// This is a workaround for the bug in ", trailing: ""),
+        EvalCase(category: .codeComment, prefix: "# This function expects a list of ", trailing: "")
+    ]
+
+    /// Generic factual prose — should stay factual, not break into chat or refusal.
+    private static let proseCases: [EvalCase] = [
+        EvalCase(category: .prose, prefix: "The Swift compiler enforces optionals because ", trailing: ""),
+        EvalCase(category: .prose, prefix: "Apple's on-device language model runs ", trailing: ""),
+        EvalCase(category: .prose, prefix: "Photosynthesis converts sunlight into ", trailing: ""),
+        EvalCase(category: .prose, prefix: "Inflation is when the general price level ", trailing: ""),
+        EvalCase(category: .prose, prefix: "In macOS, an accessibility element is ", trailing: ""),
+        EvalCase(category: .prose, prefix: "The largest moon of Saturn is ", trailing: "")
+    ]
+
+    /// Mid-line insertion — non-empty trailing text. Today FM never sees the trailing context, so
+    /// many of these will produce a continuation that does not bridge cleanly. PR 5 adds trailing
+    /// context to the request; rerunning this bucket against PR 5 is the way to measure that gain.
+    private static let midLineCases: [EvalCase] = [
+        EvalCase(category: .midLine, prefix: "I'm flying to ", trailing: " on Friday."),
+        EvalCase(category: .midLine, prefix: "The deadline is ", trailing: ", which gives us about a week."),
+        EvalCase(category: .midLine, prefix: "Could you bring the ", trailing: " when you come by?"),
+        EvalCase(category: .midLine, prefix: "Let's name the project ", trailing: ", that's catchy enough."),
+        EvalCase(category: .midLine, prefix: "The CEO will be in ", trailing: " for the offsite next month."),
+        EvalCase(category: .midLine, prefix: "for value in ", trailing: " {\n    process(value)\n}"),
+        EvalCase(category: .midLine, prefix: "func parse(_ input: ", trailing: ") -> Result<Value, Error> {"),
+        EvalCase(category: .midLine, prefix: "SELECT * FROM ", trailing: " WHERE id = ?")
+    ]
+
+    private static let allCases: [EvalCase] = chatDriftCases + emailCases + slackCases
+        + codeCases + codeCommentCases + proseCases + midLineCases
+
+    /// Phrases that mark a continuation as out-of-character. Matched case-insensitively anywhere
+    /// in the output, so a continuation that mentions one inside a longer thought still flags.
     private static let driftTells: [String] = [
         "how are you", "how's it going", "hows it going", "hope you", "hope it", "hope this",
         "as an ai", "i'm here to", "i am here to", "let me know if you", "feel free to",
@@ -50,7 +165,14 @@ final class FoundationModelDriftEvalTests: XCTestCase {
         "cannot help with", "unable to assist", "i cannot help", "i can't help"
     ]
 
-    func test_reportAssistantDriftRate() async throws {
+    /// Chat-template or decoder residue. None should appear on the FM-only path, but having them in
+    /// the rubric catches future routing regressions where the llama backend's output reaches the
+    /// FM normalizer.
+    private static let noiseMarkers: [String] = [
+        "<|im_start|>", "<|im_end|>", "<think>", "</think>", "[INST]", "[/INST]"
+    ]
+
+    func test_reportEvalSuite() async throws {
         let availability = FoundationModelAvailabilityService()
         availability.refresh()
         try XCTSkipUnless(
@@ -60,41 +182,120 @@ final class FoundationModelDriftEvalTests: XCTestCase {
 
         let engine = FoundationModelSuggestionEngine(availabilityService: availability)
 
-        var driftCount = 0
-        var report = "\n=== FM drift eval ===\n"
-        for (index, prefix) in Self.cases.enumerated() {
+        var outcomes: [CaseOutcome] = []
+        outcomes.reserveCapacity(Self.allCases.count)
+
+        for scenario in Self.allCases {
             let request = CotabbyTestFixtures.suggestionRequest(
-                prefixText: prefix,
+                prefixText: scenario.prefix,
+                trailingText: scenario.trailing,
                 maxPredictionTokens: 32
             )
+            let start = Date()
             let result = try await engine.generateSuggestion(for: request)
-            let drifted = Self.isDrift(prefix: prefix, output: result.text)
-            if drifted { driftCount += 1 }
-            report += "[\(index + 1)] \(drifted ? "DRIFT" : "ok   ") prefix=\(prefix.debugDescription)\n"
-            report += "        norm=\(result.text.debugDescription)\n"
-            report += "        raw =\(result.rawText.debugDescription)\n"
+            let elapsed = Date().timeIntervalSince(start)
+
+            let normalized = result.text
+            outcomes.append(
+                CaseOutcome(
+                    scenario: scenario,
+                    drifted: Self.isDrift(prefix: scenario.prefix, output: normalized),
+                    empty: normalized.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                    noise: Self.containsNoise(normalized) || Self.containsNoise(result.rawText),
+                    midWord: Self.endsMidWord(normalized),
+                    normalized: normalized,
+                    raw: result.rawText,
+                    latency: elapsed
+                )
+            )
         }
-        report += "drift: \(driftCount)/\(Self.cases.count)\n"
+
+        let report = Self.renderReport(outcomes: outcomes)
         print(report)
 
+        // Overall drift threshold stays permissive — we run this to track *trend*, not to gate CI.
+        // 20% of cases (rounded down, floor of 3) gives the eval headroom for stochastic samples.
+        let driftCount = outcomes.filter(\.drifted).count
+        let driftCeiling = max(outcomes.count / 5, 3)
         XCTAssertLessThanOrEqual(
             driftCount,
-            2,
-            "Too many out-of-character continuations.\(report)"
+            driftCeiling,
+            "Too many out-of-character continuations.\n\(report)"
+        )
+        XCTAssertEqual(
+            outcomes.filter(\.noise).count,
+            0,
+            "Chat-template residue leaked through.\n\(report)"
+        )
+        XCTAssertEqual(
+            outcomes.filter(\.empty).count,
+            0,
+            "Some prompts returned empty after normalization.\n\(report)"
         )
     }
 
-    /// A continuation drifts if it contains an assistant tell, or opens with a greeting word that the
-    /// prefix had not already started (so finishing "Hi Sa…" → "rah" is fine, but a bare "Hi there"
-    /// after a mid-sentence prefix is drift).
+    private static func renderReport(outcomes: [CaseOutcome]) -> String {
+        var lines = ["\n=== FM eval suite ==="]
+        for (index, outcome) in outcomes.enumerated() {
+            let tags = [
+                outcome.drifted ? "DRIFT" : nil,
+                outcome.empty ? "EMPTY" : nil,
+                outcome.noise ? "NOISE" : nil,
+                outcome.midWord ? "MIDWORD" : nil
+            ].compactMap { $0 }
+            let status = tags.isEmpty ? "ok" : tags.joined(separator: "+")
+            let ms = Int((outcome.latency * 1000).rounded())
+            lines.append("[\(index + 1)] \(outcome.scenario.category.rawValue) \(status) \(ms)ms")
+            lines.append("    prefix=\(outcome.scenario.prefix.debugDescription)")
+            if !outcome.scenario.trailing.isEmpty {
+                lines.append("    trail =\(outcome.scenario.trailing.debugDescription)")
+            }
+            lines.append("    norm  =\(outcome.normalized.debugDescription)")
+            lines.append("    raw   =\(outcome.raw.debugDescription)")
+        }
+
+        let categories = Set(outcomes.map(\.scenario.category)).sorted { $0.rawValue < $1.rawValue }
+        lines.append("--- per-category ---")
+        for category in categories {
+            let bucket = outcomes.filter { $0.scenario.category == category }
+            let drift = bucket.filter(\.drifted).count
+            let midWord = bucket.filter(\.midWord).count
+            lines.append(
+                "\(category.rawValue): drift \(drift)/\(bucket.count), midword \(midWord)/\(bucket.count)"
+            )
+        }
+
+        let latenciesMs = outcomes.map { Int(($0.latency * 1000).rounded()) }.sorted()
+        if !latenciesMs.isEmpty {
+            let p50 = latenciesMs[latenciesMs.count / 2]
+            let p95Index = min(latenciesMs.count - 1, Int(Double(latenciesMs.count) * 0.95))
+            let p95 = latenciesMs[p95Index]
+            lines.append("--- latency (ms) ---")
+            lines.append("p50=\(p50), p95=\(p95), max=\(latenciesMs.last ?? 0)")
+        }
+
+        let driftTotal = outcomes.filter(\.drifted).count
+        let midWordTotal = outcomes.filter(\.midWord).count
+        let emptyTotal = outcomes.filter(\.empty).count
+        let noiseTotal = outcomes.filter(\.noise).count
+        lines.append(
+            "TOTAL: \(outcomes.count) cases, drift=\(driftTotal), "
+                + "midword=\(midWordTotal), empty=\(emptyTotal), noise=\(noiseTotal)"
+        )
+        return lines.joined(separator: "\n")
+    }
+
+    /// A continuation drifts if it contains an assistant tell, or opens with a greeting word that
+    /// the prefix had not already started (so finishing "Hi Sa…" → "rah" is fine, but a bare
+    /// "Hi there" after a mid-sentence prefix is drift).
     private static func isDrift(prefix: String, output: String) -> Bool {
         let lower = output.lowercased()
         if driftTells.contains(where: { lower.contains($0) }) {
             return true
         }
 
-        // Greeting openers only — "thanks" is omitted because continuing the user's own message with
-        // a thank-you ("Hey Jacob, " -> "thanks for the update") is correct, not assistant drift.
+        // Greeting openers only — "thanks" is omitted because continuing the user's own message
+        // with a thank-you ("Hey Jacob, " -> "thanks for the update") is correct, not drift.
         let openers = ["hi ", "hey ", "hello", "dear ", "good morning", "good afternoon"]
         let trimmed = lower.trimmingCharacters(in: .whitespacesAndNewlines)
         let prefixLower = prefix.lowercased()
@@ -102,8 +303,26 @@ final class FoundationModelDriftEvalTests: XCTestCase {
             trimmed.hasPrefix(opener) && !prefixLower.contains(opener)
         }
     }
+
+    private static func containsNoise(_ text: String) -> Bool {
+        noiseMarkers.contains { text.contains($0) }
+    }
+
+    /// Heuristic for "the token budget cut the model off mid-word". Empty strings are exempt
+    /// (counted under `empty`). A clean stop is final whitespace, sentence-ending punctuation,
+    /// or a closing bracket / paren that finishes a code fragment.
+    private static func endsMidWord(_ text: String) -> Bool {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let last = trimmed.last else {
+            return false
+        }
+        if last.isWhitespace { return false }
+        if last.isPunctuation { return false }
+        if "})]>".contains(last) { return false }
+        return true
+    }
 #else
-    func test_reportAssistantDriftRate() throws {
+    func test_reportEvalSuite() throws {
         throw XCTSkip(
             "Live FM eval is local-only. Run with "
                 + "SWIFT_ACTIVE_COMPILATION_CONDITIONS='$(inherited) RUN_FM_EVAL' (see file header)."


### PR DESCRIPTION
## Summary

Grows `FoundationModelDriftEvalTests` from 10 chat-drift prefixes to 52 cases across seven categories (chat-drift, email, slack, code, code-comment, prose, mid-line insertion) and adds per-case scoring for drift, emptiness, chat-template noise, and mid-word truncation, plus per-case and P50/P95 latency. This is the baseline harness for the upcoming FM stack (session reuse, prewarm, streaming, prompt rewrite, richer context) so each later change can be compared head-to-head instead of guessed at.

Pure test infrastructure — no production code changes. Stays gated behind `RUN_FM_EVAL` and is `-skip-testing`'d in CI exactly as before.

## Validation

`xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build-for-testing CODE_SIGNING_ALLOWED=NO`
→ `** TEST BUILD SUCCEEDED **`

`xcodebuild ... SWIFT_ACTIVE_COMPILATION_CONDITIONS='$(inherited) RUN_FM_EVAL'`
→ `** TEST BUILD SUCCEEDED **`

The eval itself runs on-device only. Once this lands, run locally with:

```
xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby \
  -destination 'platform=macOS' \
  -only-testing:CotabbyTests/FoundationModelDriftEvalTests \
  SWIFT_ACTIVE_COMPILATION_CONDITIONS='$(inherited) RUN_FM_EVAL' \
  CODE_SIGNING_ALLOWED=NO
```

The report prints per-case status, per-category drift / mid-word counts, and P50/P95/max latency.

## Linked issues

Refs the FM-quality investigation that motivates the upcoming stack of PRs.

## Risk / rollout notes

- Test-only change. The class is excluded from CI (`tests.yml` `-skip-testing:CotabbyTests/FoundationModelDriftEvalTests`) and gated behind `RUN_FM_EVAL`. CI behavior is unchanged.
- Renamed the single test method `test_reportAssistantDriftRate` → `test_reportEvalSuite` to reflect its widened scope. `-skip-testing` targets the class, so no CI config changes needed.
- Local runs now do ~52 on-device generations instead of 10 (~30s wall on an M-series Mac). Expected; this is a tuning harness, not a CI gate.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Grows the `FoundationModelDriftEvalTests` harness from 10 chat-drift prefixes to 52 cases across seven categories, adds per-case scoring (DRIFT, EMPTY, NOISE, MIDWORD), per-case latency, and a structured `renderReport` that prints per-category and aggregate stats.

- **New categories**: email, slack, code, codeComment, prose, and midLine cases join the original chat-drift bucket; each is scored independently so category-level regressions aren't hidden by whole-set averages.
- **Corrected statistical methods**: p50 now averages the two middle values for even-length arrays, and p95 uses ceiling nearest-rank (`Int((n * 0.95).rounded(.up)) - 1`) rather than plain truncation — both were flagged in a prior review and are correctly addressed here.
- **Assertions expanded**: hard-zero assertions added for NOISE and EMPTY; drift threshold scaled to 20% with a minimum floor of 3.

<h3>Confidence Score: 5/5</h3>

Pure test-infrastructure change, gated behind RUN_FM_EVAL and excluded from CI — no production code is touched and CI behaviour is unchanged.

All three statistical bugs called out in the prior review are correctly addressed. The only remaining issue is that endsMidWord produces systematic false positives for code and codeComment categories, which degrades the usefulness of the MIDWORD metric for those buckets but does not affect any assertion or production behaviour.

No files require special attention; the single changed file is self-contained test infrastructure.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CotabbyTests/FoundationModelDriftEvalTests.swift | Expands FM eval from 10 chat-drift cases to 52 across 7 categories, adds per-case scoring (drift/empty/noise/midword), latency tracking, and a structured report; the three previously flagged statistical issues (dead isWhitespace check, upper-median p50, truncating p95) are addressed in this version; minor remaining issue is that endsMidWord produces systematic false positives for code and codeComment categories. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[test_reportEvalSuite] --> B[Skip if model unavailable]
    B --> C[Iterate 52 EvalCases]
    C --> D[Build SuggestionRequest]
    D --> E[generateSuggestion + measure latency]
    E --> F[Score output]
    F --> G[drifted via isDrift]
    F --> H[empty via trim check]
    F --> I[noise via containsNoise]
    F --> J[midWord via endsMidWord]
    G & H & I & J --> K[Append CaseOutcome]
    K --> C
    C -->|done| L[renderReport]
    L --> M[Per-case lines]
    L --> N[Per-category summary]
    L --> O[p50 and p95 latency]
    L --> P[TOTAL summary line]
    M & N & O & P --> Q[print report]
    Q --> R[Assert drift count under threshold]
    Q --> S[Assert zero noise]
    Q --> T[Assert zero empty]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22eval%2Ffm-expand-driftset%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22eval%2Ffm-expand-driftset%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabbyTests%2FFoundationModelDriftEvalTests.swift%3A327-335%0A**%60endsMidWord%60%20inflates%20MIDWORD%20counts%20for%20code%20categories**%0A%0AThe%20heuristic%20flags%20any%20completion%20whose%20last%20character%20is%20not%20punctuation%20or%20a%20closing%20bracket.%20For%20code%2FcodeComment%20cases%20this%20fires%20constantly%20on%20valid%20completions%3A%20%60%22n%22%60%20%28a%20variable%29%2C%20%60%22nil%22%60%20%28a%20keyword%29%2C%20%60%2242%22%60%20%28a%20literal%29%2C%20%60%22true%22%60%2F%60%22false%22%60%20%E2%80%94%20all%20end%20in%20a%20letter%20or%20digit%2C%20so%20%60endsMidWord%60%20returns%20%60true%60%20even%20though%20the%20token%20is%20complete.%20Concretely%2C%20the%20fibonacci%20and%20guard%20cases%20will%20almost%20always%20show%20MIDWORD%20regardless%20of%20generation%20quality%2C%20making%20the%20per-category%20midword%20count%20a%20flat%20line%20rather%20than%20a%20regression%20signal%20for%20those%20buckets.%20Consider%20gating%20the%20check%20on%20category%20at%20the%20call%20site%20%28skip%20it%20for%20%60.code%60%20and%20%60.codeComment%60%29%20or%20adjusting%20%60endsMidWord%60%20to%20return%20%60false%60%20when%20%60last.isNumber%60%20so%20numeric%20literals%20don't%20misfire.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabbyTests%2FFoundationModelDriftEvalTests.swift%3A327-335%0A**%60endsMidWord%60%20inflates%20MIDWORD%20counts%20for%20code%20categories**%0A%0AThe%20heuristic%20flags%20any%20completion%20whose%20last%20character%20is%20not%20punctuation%20or%20a%20closing%20bracket.%20For%20code%2FcodeComment%20cases%20this%20fires%20constantly%20on%20valid%20completions%3A%20%60%22n%22%60%20%28a%20variable%29%2C%20%60%22nil%22%60%20%28a%20keyword%29%2C%20%60%2242%22%60%20%28a%20literal%29%2C%20%60%22true%22%60%2F%60%22false%22%60%20%E2%80%94%20all%20end%20in%20a%20letter%20or%20digit%2C%20so%20%60endsMidWord%60%20returns%20%60true%60%20even%20though%20the%20token%20is%20complete.%20Concretely%2C%20the%20fibonacci%20and%20guard%20cases%20will%20almost%20always%20show%20MIDWORD%20regardless%20of%20generation%20quality%2C%20making%20the%20per-category%20midword%20count%20a%20flat%20line%20rather%20than%20a%20regression%20signal%20for%20those%20buckets.%20Consider%20gating%20the%20check%20on%20category%20at%20the%20call%20site%20%28skip%20it%20for%20%60.code%60%20and%20%60.codeComment%60%29%20or%20adjusting%20%60endsMidWord%60%20to%20return%20%60false%60%20when%20%60last.isNumber%60%20so%20numeric%20literals%20don't%20misfire.%0A%0A&repo=fujacob%2Fcotabby&pr=335&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Address Greptile review on #335"](https://github.com/fujacob/cotabby/commit/75032c942be98f84f6ccfd72a32e8249fe8d25cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34324070)</sub>

<!-- /greptile_comment -->