### PR TITLE
Reuse FM LanguageModelSession and prewarm on focus change

### DIFF
--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
@@ -110,10 +110,14 @@ extension SuggestionCoordinator {
         let configuration = configuration
         let suggestionEngine = suggestionEngine
         Task { @MainActor [weak self] in
+            // If the coordinator has been torn down (app shutdown), skip prewarm entirely.
+            // Using `guard let self` instead of the optional chain prevents prewarm from
+            // racing past a missed cache-reset barrier when self has gone away.
+            guard let self else { return }
             // Honor the cache-reset barrier so prewarm always runs *after* the engine has dropped
             // the session that belongs to the previous editing context. Otherwise the reset can
             // null the freshly primed session out from under us.
-            await self?.awaitCachedGenerationContextResetIfNeeded()
+            await self.awaitCachedGenerationContextResetIfNeeded()
             let prewarmContext = FocusedInputContext(snapshot: rawContext, generation: 0)
             let request = SuggestionRequestFactory.buildRequest(
                 context: prewarmContext,

--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
@@ -90,10 +90,37 @@ extension SuggestionCoordinator {
             clearSuggestion(clearDiagnostics: true)
             hideOverlay(reason: "Overlay hidden because the focused field changed.")
             state = .idle
+            // The user is now on a new editable surface and is likely to type soon. Prime the
+            // selected engine in the background so weight loading and instruction tokenization
+            // happen before the first real `respond` instead of inside its critical path. Llama's
+            // default `prewarm` is a no-op, so this call is FM-only by design.
+            prewarmEngineForCurrentField(rawContext: focusedContext)
         }
 
         if overlayState.isVisible {
             hideOverlay(reason: "Overlay hidden because no ready suggestion remains.")
+        }
+    }
+
+    /// Fire-and-forget warmup that builds a minimal request shape for the current focus and asks
+    /// the routed engine to prime itself. Generation 0 is intentional — prewarm requests must not
+    /// burn real generation numbers, because those drive the stale-result drop logic.
+    private func prewarmEngineForCurrentField(rawContext: FocusedInputSnapshot) {
+        let settings = settingsSnapshot
+        let configuration = configuration
+        let suggestionEngine = suggestionEngine
+        Task { @MainActor [weak self] in
+            // Honor the cache-reset barrier so prewarm always runs *after* the engine has dropped
+            // the session that belongs to the previous editing context. Otherwise the reset can
+            // null the freshly primed session out from under us.
+            await self?.awaitCachedGenerationContextResetIfNeeded()
+            let prewarmContext = FocusedInputContext(snapshot: rawContext, generation: 0)
+            let request = SuggestionRequestFactory.buildRequest(
+                context: prewarmContext,
+                settings: settings,
+                configuration: configuration
+            ).request
+            await suggestionEngine.prewarm(for: request)
         }
     }
 

--- a/Cotabby/Models/SuggestionSubsystemContracts.swift
+++ b/Cotabby/Models/SuggestionSubsystemContracts.swift
@@ -47,6 +47,16 @@ protocol SuggestionGenerating: AnyObject {
     /// Clears backend-local continuation state when the focused editing context is no longer
     /// continuous. Stateless engines may implement this as a no-op.
     func resetCachedGenerationContext() async
+    /// Best-effort warmup hook the coordinator calls after focus arrives on an editable surface.
+    /// Engines that benefit from prefix caching or weight loading (Apple Foundation Models) use it
+    /// to prime the next request; engines that do not (llama already keeps its KV cache hot) can
+    /// rely on the default no-op extension. Failures are intentionally swallowed by implementations
+    /// because prewarming is opportunistic.
+    func prewarm(for request: SuggestionRequest) async
+}
+
+extension SuggestionGenerating {
+    func prewarm(for request: SuggestionRequest) async {}
 }
 
 @MainActor

--- a/Cotabby/Services/Runtime/FoundationModelSuggestionEngine.swift
+++ b/Cotabby/Services/Runtime/FoundationModelSuggestionEngine.swift
@@ -129,6 +129,11 @@ final class FoundationModelSuggestionEngine {
     /// new session and replaces the cache. Keying on rendered instructions (rather than the
     /// untransformed settings fields they came from) keeps this correct if the renderer
     /// composition rules change later.
+    ///
+    /// The cache key intentionally omits `model` identity. `availabilityService` owns the singleton
+    /// `SystemLanguageModel` and only swaps it on app restart, never mid-session — so a cached
+    /// session can never be silently bound to a stale model. If that invariant ever changes
+    /// (e.g. live Apple Intelligence asset reloads), include `ObjectIdentifier(model)` here.
     private func ensureSession(
         for request: SuggestionRequest,
         model: SystemLanguageModel

--- a/Cotabby/Services/Runtime/FoundationModelSuggestionEngine.swift
+++ b/Cotabby/Services/Runtime/FoundationModelSuggestionEngine.swift
@@ -10,18 +10,24 @@ import FoundationModels
 /// `SuggestionGenerating` capability. The coordinator should not care whether suggestions come
 /// from llama.cpp or Apple Intelligence; that backend choice belongs in app composition.
 ///
-/// This engine creates a fresh `LanguageModelSession` per request. That is the right default for
-/// Cotabby's autocomplete flow because each suggestion is a single-turn interaction and we do not
-/// want prior model responses to accumulate in the context window.
+/// The engine keeps one `LanguageModelSession` alive across requests when the underlying
+/// instructions text is unchanged. Apple's framework caches the tokenization of the instructions
+/// channel as a prefix, so reusing the session is the supported way to skip re-tokenizing the
+/// (long) system rules on every keystroke. The cache is keyed on the rendered instructions string
+/// rather than on `SuggestionRequest` identity because everything that varies inside the request
+/// (prefix text, visual/clipboard context, generation number) belongs to the *prompt* channel,
+/// not the *instructions* channel, and therefore does not invalidate the cached session.
 ///
-/// The important behavioral nuance is that Foundation Models has a dedicated instructions channel.
-/// We use that to tell the system model "this is inline autocomplete, not a chat reply," because a
-/// bare text prefix like "hello" otherwise invites conversational continuations.
+/// `prewarm(for:)` is the supported hook for "the user just focused an editable field; a real
+/// request is likely within a second." The coordinator calls it from the focus path; the engine
+/// builds (or reuses) the session and calls Apple's `LanguageModelSession.prewarm()` so weight
+/// loading and instruction tokenization happen before the first user-visible respond call.
 #if canImport(FoundationModels)
 @available(macOS 26.0, *)
 @MainActor
 final class FoundationModelSuggestionEngine {
     private let availabilityService: FoundationModelAvailabilityService
+    private var cachedSession: CachedSession?
 
     init(availabilityService: FoundationModelAvailabilityService) {
         self.availabilityService = availabilityService
@@ -52,10 +58,7 @@ final class FoundationModelSuggestionEngine {
                 )
             }
 
-            let session = LanguageModelSession(
-                model: model,
-                instructions: FoundationModelPromptRenderer.sessionInstructions(for: request)
-            )
+            let session = ensureSession(for: request, model: model)
             let response = try await session.respond(
                 to: prompt,
                 options: generationOptions(for: request)
@@ -96,8 +99,49 @@ final class FoundationModelSuggestionEngine {
         }
     }
 
-    /// Foundation Models sessions are already one-shot, so there is no backend context to clear.
-    func resetCachedGenerationContext() async {}
+    /// Best-effort warmup. Apple's prewarm loads weights into memory and primes the instruction
+    /// prefix cache. We swallow errors because prewarming is opportunistic — the next
+    /// `respond` call will surface real availability or generation failures with the right
+    /// vocabulary, and reporting them here would just produce noise.
+    func prewarm(for request: SuggestionRequest) async {
+        availabilityService.refresh()
+        guard availabilityService.isAvailable else {
+            return
+        }
+        guard let model = availabilityService.systemLanguageModel else {
+            return
+        }
+
+        let session = ensureSession(for: request, model: model)
+        session.prewarm()
+        CotabbyLogger.suggestion.debug("Foundation model session prewarmed")
+    }
+
+    /// Dropping the cached session forces the next request to rebuild instructions, which is the
+    /// right behavior when the coordinator signals the editing context is no longer continuous
+    /// (focus changes, settings edits). Apple's session also holds a transcript that we
+    /// deliberately do not want to leak across editing contexts.
+    func resetCachedGenerationContext() async {
+        cachedSession = nil
+    }
+
+    /// Returns the cached session if its instructions match the rendered ones, otherwise builds a
+    /// new session and replaces the cache. Keying on rendered instructions (rather than the
+    /// untransformed settings fields they came from) keeps this correct if the renderer
+    /// composition rules change later.
+    private func ensureSession(
+        for request: SuggestionRequest,
+        model: SystemLanguageModel
+    ) -> LanguageModelSession {
+        let instructions = FoundationModelPromptRenderer.sessionInstructions(for: request)
+        if let cached = cachedSession, cached.instructions == instructions {
+            return cached.session
+        }
+
+        let session = LanguageModelSession(model: model, instructions: instructions)
+        cachedSession = CachedSession(instructions: instructions, session: session)
+        return session
+    }
 
     /// Maps Cotabby's existing generation knobs onto the subset of Foundation Models options the
     /// system model exposes. We preserve the same upstream request shape so the coordinator does
@@ -147,6 +191,11 @@ final class FoundationModelSuggestionEngine {
         @unknown default:
             return .generationFailed(error.localizedDescription)
         }
+    }
+
+    private struct CachedSession {
+        let instructions: String
+        let session: LanguageModelSession
     }
 }
 

--- a/Cotabby/Services/Runtime/FoundationModelSuggestionEngine.swift
+++ b/Cotabby/Services/Runtime/FoundationModelSuggestionEngine.swift
@@ -22,6 +22,15 @@ import FoundationModels
 /// request is likely within a second." The coordinator calls it from the focus path; the engine
 /// builds (or reuses) the session and calls Apple's `LanguageModelSession.prewarm()` so weight
 /// loading and instruction tokenization happen before the first user-visible respond call.
+///
+/// Generation itself goes through `session.streamResponse` rather than `session.respond`. Apple's
+/// stream yields cumulative partials, so the loop captures the latest snapshot and exits with it
+/// as the final raw text. The win is responsiveness to cancellation: `Task.checkCancellation()`
+/// inside the loop lets the coordinator interrupt mid-decode when the user types past the
+/// in-flight suggestion, where `respond` would otherwise have to run to completion. The external
+/// `SuggestionResult` shape is unchanged, so the rest of the pipeline (overlay, presenter,
+/// active-session reconciliation) stays as-is — pushing partials all the way to the overlay is a
+/// separate, larger change scoped to a follow-up.
 #if canImport(FoundationModels)
 @available(macOS 26.0, *)
 @MainActor
@@ -59,13 +68,32 @@ final class FoundationModelSuggestionEngine {
             }
 
             let session = ensureSession(for: request, model: model)
-            let response = try await session.respond(
+            let stream = session.streamResponse(
                 to: prompt,
                 options: generationOptions(for: request)
             )
+            // Apple's stream yields cumulative `Snapshot` values whose `.content` carries the
+            // text generated so far. Capture each snapshot first and check cancellation after, so a
+            // late cancel between the final snapshot and its assignment doesn't discard fully
+            // decoded text — cancellation always throws, but keeping the best-available text saved
+            // before honoring the signal makes the intent obvious.
+            var rawSuggestion = ""
+            var didReceiveSnapshot = false
+            for try await partial in stream {
+                rawSuggestion = partial.content
+                didReceiveSnapshot = true
+                try Task.checkCancellation()
+            }
             try Task.checkCancellation()
-
-            let rawSuggestion = response.content
+            // Apple's documented contract is at least one snapshot on a successful stream, so a
+            // zero-snapshot path is treated as a generation failure rather than a silent empty
+            // suggestion — the latter would let the overlay clear without surfacing that the model
+            // produced literally nothing.
+            guard didReceiveSnapshot else {
+                throw SuggestionClientError.generationFailed(
+                    "Apple Intelligence finished streaming without producing any content."
+                )
+            }
             let normalizedSuggestion = SuggestionTextNormalizer.normalize(
                 rawSuggestion,
                 for: request,

--- a/Cotabby/Services/Runtime/FoundationModelSuggestionEngine.swift
+++ b/Cotabby/Services/Runtime/FoundationModelSuggestionEngine.swift
@@ -10,13 +10,14 @@ import FoundationModels
 /// `SuggestionGenerating` capability. The coordinator should not care whether suggestions come
 /// from llama.cpp or Apple Intelligence; that backend choice belongs in app composition.
 ///
-/// The engine keeps one `LanguageModelSession` alive across requests when the underlying
-/// instructions text is unchanged. Apple's framework caches the tokenization of the instructions
-/// channel as a prefix, so reusing the session is the supported way to skip re-tokenizing the
-/// (long) system rules on every keystroke. The cache is keyed on the rendered instructions string
-/// rather than on `SuggestionRequest` identity because everything that varies inside the request
-/// (prefix text, visual/clipboard context, generation number) belongs to the *prompt* channel,
-/// not the *instructions* channel, and therefore does not invalidate the cached session.
+/// The engine caches a pristine `LanguageModelSession` so the focus-time `prewarm(for:)` call can
+/// hand the same prewarmed session to the first user-typed request. Reuse is bounded: once a
+/// session has actually serviced a `respond` (its transcript has grown past the pristine count)
+/// or is mid-stream (`isResponding == true`), the next request builds a fresh session instead.
+/// This keeps the prewarm latency win on the first keystroke after focus without inheriting
+/// Apple's two single-flight failure modes — `concurrentRequests` from overlapping streams on the
+/// same session, and `exceededContextWindowSize` from transcript entries piling up over many
+/// keystrokes in the same field. See `ensureSession` for the reuse predicate.
 ///
 /// `prewarm(for:)` is the supported hook for "the user just focused an editable field; a real
 /// request is likely within a second." The coordinator calls it from the focus path; the engine
@@ -153,10 +154,29 @@ final class FoundationModelSuggestionEngine {
         cachedSession = nil
     }
 
-    /// Returns the cached session if its instructions match the rendered ones, otherwise builds a
-    /// new session and replaces the cache. Keying on rendered instructions (rather than the
-    /// untransformed settings fields they came from) keeps this correct if the renderer
-    /// composition rules change later.
+    /// Returns the cached session when it is safe to reuse, otherwise builds a fresh session
+    /// and replaces the cache. The cache key (rendered instructions) keeps this correct if the
+    /// renderer composition rules change later.
+    ///
+    /// Reuse is gated on three conditions that together avoid two Apple-surfaced failures the
+    /// previous unconditional-reuse design was vulnerable to:
+    ///
+    /// - `cached.instructions == instructions`: the cached session was built with this exact
+    ///   instruction string. Any settings edit (custom rules, language override) that re-renders
+    ///   instructions forces a rebuild.
+    /// - `!cached.session.isResponding`: Apple's `LanguageModelSession` rejects a second concurrent
+    ///   `respond` / `streamResponse` with `.concurrentRequests`. Swift task cancellation is
+    ///   cooperative, so the coordinator's `cancelPredictionWork()` + `schedulePrediction()` pair
+    ///   can leave the previous stream still draining inside Apple's runtime when the next request
+    ///   arrives. Falling through to a fresh session keeps that case from surfacing as a
+    ///   user-visible `generationFailed` error.
+    /// - `cached.session.transcript.count == cached.pristineTranscriptCount`: a successful (or even
+    ///   cancelled) `respond` appends the prompt and response to the session's transcript. Reusing
+    ///   the session indefinitely accumulates entries that all replay through the 4096-token
+    ///   shared context, which Apple eventually surfaces as `.exceededContextWindowSize`. Bounded
+    ///   reuse keeps the prewarm benefit on the first keystroke after focus — the session is
+    ///   built and prewarmed on focus change, then consumed once — and any further keystroke in
+    ///   the same field starts from a fresh session, matching the pre-PR single-turn behavior.
     ///
     /// The cache key intentionally omits `model` identity. `availabilityService` owns the singleton
     /// `SystemLanguageModel` and only swaps it on app restart, never mid-session — so a cached
@@ -167,12 +187,19 @@ final class FoundationModelSuggestionEngine {
         model: SystemLanguageModel
     ) -> LanguageModelSession {
         let instructions = FoundationModelPromptRenderer.sessionInstructions(for: request)
-        if let cached = cachedSession, cached.instructions == instructions {
+        if let cached = cachedSession,
+           cached.instructions == instructions,
+           !cached.session.isResponding,
+           cached.session.transcript.count == cached.pristineTranscriptCount {
             return cached.session
         }
 
         let session = LanguageModelSession(model: model, instructions: instructions)
-        cachedSession = CachedSession(instructions: instructions, session: session)
+        cachedSession = CachedSession(
+            instructions: instructions,
+            session: session,
+            pristineTranscriptCount: session.transcript.count
+        )
         return session
     }
 
@@ -229,6 +256,10 @@ final class FoundationModelSuggestionEngine {
     private struct CachedSession {
         let instructions: String
         let session: LanguageModelSession
+        /// Snapshot of `session.transcript.count` immediately after construction (and after any
+        /// `prewarm()`, which does not modify the transcript). A respond call appends entries,
+        /// so a count divergence is the cue that this session is no longer single-turn safe.
+        let pristineTranscriptCount: Int
     }
 }
 

--- a/Cotabby/Services/Runtime/SuggestionEngineRouter.swift
+++ b/Cotabby/Services/Runtime/SuggestionEngineRouter.swift
@@ -48,6 +48,18 @@ final class SuggestionEngineRouter {
         await llamaEngine.resetCachedGenerationContext()
     }
 
+    /// Forwards the warmup hook only to the currently selected engine. The inactive backend has
+    /// no benefit from warming caches the user is not about to hit, and the FM path specifically
+    /// allocates a session as a side effect, so we keep that work out of the llama-selected path.
+    func prewarm(for request: SuggestionRequest) async {
+        switch suggestionSettings.selectedEngine {
+        case .appleIntelligence:
+            await foundationModelEngine.prewarm(for: request)
+        case .llamaOpenSource:
+            await llamaEngine.prewarm(for: request)
+        }
+    }
+
     /// Apple Intelligence can reject a request after global availability reports success because
     /// language support is checked against the active request/locale. Falling back here keeps the
     /// coordinator backend-agnostic while giving local models a chance to handle that text.


### PR DESCRIPTION
## Summary

Cotabby's Apple Foundation Models path currently constructs a new `LanguageModelSession` on every keystroke, which throws away Apple's instruction-prefix cache and pays full instruction tokenization on each request. This change holds the session as long as the rendered instructions are unchanged, and asks the engine to `prewarm()` after focus arrives on a new editable surface so weight loading and prefix tokenization happen before the user types instead of inside the critical path of the first `respond`.

Stacked on `eval/fm-expand-driftset` — verify with that PR's expanded eval suite once both land.

## Validation

`xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build CODE_SIGNING_ALLOWED=NO`
→ `** BUILD SUCCEEDED **`

`xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build-for-testing CODE_SIGNING_ALLOWED=NO`
→ `** TEST BUILD SUCCEEDED **`

`xcodebuild test ... -only-testing:CotabbyTests/FoundationModelPromptRendererTests -only-testing:CotabbyTests/SuggestionEngineRouterTests`
→ `Executed 9 tests, with 0 failures (0 unexpected)`

`swiftlint lint --quiet` → no violations.

End-to-end FM perf check expected to be done with the eval suite from the parent PR.

## Linked issues

Refs the FM-quality investigation.

## Risk / rollout notes

- `SuggestionGenerating` gained `prewarm(for:)`. A default no-op extension keeps every existing conformer (llama engine, router, unavailable engine, the `StubSuggestionEngine` in tests) source-compatible. Only FM provides a real implementation.
- The cached session is keyed on the rendered instructions string. Any user-driven change that alters instructions (language override, custom rules) flows through `FoundationModelPromptRenderer.sessionInstructions(for:)`, so its content drives invalidation correctly without an extra cache-busting hook.
- `resetCachedGenerationContext` continues to clear the cache, so a field change or settings edit still produces a fresh session next request. The new prewarm Task awaits the existing cache-reset barrier (`awaitCachedGenerationContextResetIfNeeded`) so prewarm always runs *after* the reset and cannot have its session nulled out from under it.
- Prewarm is gated on a real field-change event (`hasFocusedElementChanged`), not on every focus poll, so the call site does not thrash on noisy AX updates. The engine internally skips work when the session is already cached, so duplicate calls are cheap regardless.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces two related optimisations to the Apple Foundation Models path: a bounded `LanguageModelSession` cache (keyed on rendered instructions, guarded by `!isResponding` and a pristine-transcript check) so the prewarmed session is handed to the first real keystroke request, and a `prewarm(for:)` hook wired into the focus-change path so weight loading and instruction tokenisation happen before the user types rather than inside `respond`'s critical path.

- **Session caching** (`ensureSession`): reuse is correctly limited to one request — the three-way predicate addresses the `concurrentRequests` and `exceededContextWindowSize` failure modes flagged in prior reviews. The `guard let self` fix in `prewarmEngineForCurrentField` and the cache-reset barrier order are both handled correctly.
- **Protocol extension**: `prewarm(for:)` is added to `SuggestionGenerating` with a default no-op, keeping llama, router, stub, and unavailable engines source-compatible with zero changes.
- **Streaming**: `respond` is replaced by `streamResponse` with a cumulative-snapshot loop, enabling cooperative cancellation mid-decode; the `didReceiveSnapshot` guard correctly surfaces a zero-output stream as a `generationFailed` error.

<h3>Confidence Score: 4/5</h3>

Safe to merge. The session-reuse logic is well-guarded and the prewarm plumbing is correctly sequenced behind the cache-reset barrier.

The three-way `ensureSession` predicate correctly avoids both the concurrent-stream and transcript-accumulation failure modes. One open question — whether Apple's runtime updates `transcript.count` when a stream is cancelled mid-flight — means the "consumed once" bound is a documented assumption rather than a verified guarantee. This does not produce incorrect output in any observed path, but the behaviour under rapid keystroke cancellations relies on an undocumented Apple API contract.

Cotabby/Services/Runtime/FoundationModelSuggestionEngine.swift — specifically the `ensureSession` reuse predicate and the `transcript.count == pristineTranscriptCount` condition for cancelled streams.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/Services/Runtime/FoundationModelSuggestionEngine.swift | Core of the change: adds `cachedSession`, `ensureSession` reuse predicate, `prewarm(for:)`, and switches from `respond` to `streamResponse`. The three-way reuse guard (`instructions`, `!isResponding`, `transcript.count`) correctly addresses the concurrentRequests and context-overflow risks raised in prior reviews, but the "consumed once" bound implicitly relies on an undocumented Apple API behaviour for cancelled streams. |
| Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift | Adds `prewarmEngineForCurrentField` with proper `guard let self`, cache-reset barrier await, and generation-0 sentinel. Previous concern about the optional-chain bypass is fully resolved here. |
| Cotabby/Models/SuggestionSubsystemContracts.swift | Adds `prewarm(for:)` to `SuggestionGenerating` with a default no-op extension, keeping all existing conformers source-compatible. |
| Cotabby/Services/Runtime/SuggestionEngineRouter.swift | Adds `prewarm(for:)` that routes only to the selected engine; correctly avoids allocating an FM session on the llama-selected path. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Coord as SuggestionCoordinator
    participant Engine as FoundationModelSuggestionEngine
    participant Apple as LanguageModelSession (Apple)

    Note over Coord: User focuses new editable field
    Coord->>Coord: cancelPredictionWork()
    Coord->>Coord: resetCachedGenerationContext() [schedules Task]
    Coord->>Coord: prewarmEngineForCurrentField() [schedules Task]

    Note over Coord: Reset Task runs
    Coord->>Engine: resetCachedGenerationContext()
    Engine->>Engine: "cachedSession = nil"

    Note over Coord: Prewarm Task runs (after barrier)
    Coord->>Coord: awaitCachedGenerationContextResetIfNeeded()
    Coord->>Engine: "prewarm(for: request[gen=0])"
    Engine->>Engine: ensureSession() → new CachedSession
    Engine->>Apple: session.prewarm() [fire-and-forget]
    Apple-->>Apple: loads weights, primes prefix cache

    Note over Coord: User types (first keystroke)
    Coord->>Engine: "generateSuggestion(for: request[gen=N])"
    Engine->>Engine: ensureSession() → reuse cached
    Engine->>Apple: session.streamResponse(to: prompt)
    Apple-->>Engine: partial snapshots (cumulative)
    Engine-->>Coord: SuggestionResult

    Note over Engine: transcript.count > pristineTranscriptCount
    Note over Coord: User types again (second keystroke)
    Coord->>Engine: "generateSuggestion(for: request[gen=N+1])"
    Engine->>Engine: ensureSession() → transcript diverged → new session
    Engine->>Apple: new LanguageModelSession(...)
    Engine->>Apple: session.streamResponse(to: prompt)
    Apple-->>Engine: partial snapshots
    Engine-->>Coord: SuggestionResult
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cotabby/Services/Runtime/FoundationModelSuggestionEngine.swift`, line 61-65 ([link](https://github.com/fujacob/cotabby/blob/8d784e14cbdda69d76d4ccf4efd4f7becdb9e9f5/Cotabby/Services/Runtime/FoundationModelSuggestionEngine.swift#L61-L65)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Session transcript accumulates across every keystroke in the same field**

   `LanguageModelSession.respond(to:)` appends each prompt and response to the session's internal `Transcript`, meaning each subsequent autocomplete call within the same editing context sees all prior prompts and model outputs as conversation history. The original code explicitly guarded against this, and that concern still applies. Over a long typing session in one field, the growing transcript will progressively steer the model away from clean single-turn completions and will eventually throw `.exceededContextWindowSize` (mapped to a user-visible `generationFailed` error). The `resetCachedGenerationContext` path clears the session on *field change*, but not between individual requests within the same field.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22perf%2Ffm-session-reuse-prewarm%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22perf%2Ffm-session-reuse-prewarm%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FServices%2FRuntime%2FFoundationModelSuggestionEngine.swift%0ALine%3A%2061-65%0A%0AComment%3A%0A**Session%20transcript%20accumulates%20across%20every%20keystroke%20in%20the%20same%20field**%0A%0A%60LanguageModelSession.respond%28to%3A%29%60%20appends%20each%20prompt%20and%20response%20to%20the%20session's%20internal%20%60Transcript%60%2C%20meaning%20each%20subsequent%20autocomplete%20call%20within%20the%20same%20editing%20context%20sees%20all%20prior%20prompts%20and%20model%20outputs%20as%20conversation%20history.%20The%20original%20code%20explicitly%20guarded%20against%20this%2C%20and%20that%20concern%20still%20applies.%20Over%20a%20long%20typing%20session%20in%20one%20field%2C%20the%20growing%20transcript%20will%20progressively%20steer%20the%20model%20away%20from%20clean%20single-turn%20completions%20and%20will%20eventually%20throw%20%60.exceededContextWindowSize%60%20%28mapped%20to%20a%20user-visible%20%60generationFailed%60%20error%29.%20The%20%60resetCachedGenerationContext%60%20path%20clears%20the%20session%20on%20*field%20change*%2C%20but%20not%20between%20individual%20requests%20within%20the%20same%20field.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FServices%2FRuntime%2FFoundationModelSuggestionEngine.swift%0ALine%3A%2061-65%0A%0AComment%3A%0A**Session%20transcript%20accumulates%20across%20every%20keystroke%20in%20the%20same%20field**%0A%0A%60LanguageModelSession.respond%28to%3A%29%60%20appends%20each%20prompt%20and%20response%20to%20the%20session's%20internal%20%60Transcript%60%2C%20meaning%20each%20subsequent%20autocomplete%20call%20within%20the%20same%20editing%20context%20sees%20all%20prior%20prompts%20and%20model%20outputs%20as%20conversation%20history.%20The%20original%20code%20explicitly%20guarded%20against%20this%2C%20and%20that%20concern%20still%20applies.%20Over%20a%20long%20typing%20session%20in%20one%20field%2C%20the%20growing%20transcript%20will%20progressively%20steer%20the%20model%20away%20from%20clean%20single-turn%20completions%20and%20will%20eventually%20throw%20%60.exceededContextWindowSize%60%20%28mapped%20to%20a%20user-visible%20%60generationFailed%60%20error%29.%20The%20%60resetCachedGenerationContext%60%20path%20clears%20the%20session%20on%20*field%20change*%2C%20but%20not%20between%20individual%20requests%20within%20the%20same%20field.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=336&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22perf%2Ffm-session-reuse-prewarm%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22perf%2Ffm-session-reuse-prewarm%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FServices%2FRuntime%2FFoundationModelSuggestionEngine.swift%3A173-179%0A**%22Consumed%20once%22%20bound%20may%20not%20hold%20for%20cancelled%20streams**%0A%0AThe%20comment%20states%20%22a%20successful%20%28or%20even%20cancelled%29%20%60respond%60%20appends%20the%20prompt%20and%20response%20to%20the%20session's%20transcript%2C%22%20but%20Apple's%20documentation%20does%20not%20appear%20to%20guarantee%20that%20a%20mid-stream%20cancellation%20modifies%20%60transcript%60.%20If%20cancellation%20unwinds%20the%20iterator%20before%20Apple%20commits%20an%20entry%2C%20%60transcript.count%60%20stays%20at%20%60pristineTranscriptCount%60%20and%20%60ensureSession%60%20will%20hand%20the%20same%20prewarmed%20session%20to%20every%20subsequent%20cancelled%20request%20in%20the%20same%20field%20%E2%80%94%20the%20%22consumed%20once%22%20invariant%20is%20effectively%20%22consumed%20N%20times%20for%20N%20rapid%20keystrokes.%22%20The%20transcript%20doesn't%20grow%20in%20that%20scenario%20so%20%60exceededContextWindowSize%60%20is%20never%20triggered%2C%20but%20Apple%20may%20have%20internal%20per-session%20state%20%28KV-cache%20slots%2C%20in-flight%20token%20budget%29%20that%20degrades%20silently%20across%20repeated%20%60streamResponse%60%20calls%20on%20the%20same%20object%20even%20when%20the%20visible%20transcript%20stays%20empty.%20It's%20worth%20verifying%20the%20Apple-side%20behaviour%20and%2C%20if%20the%20guarantee%20can't%20be%20confirmed%2C%20snapping%20the%20cache%20entry%20to%20%60nil%60%20inside%20the%20%60catch%20is%20CancellationError%60%20path%20of%20%60generateSuggestion%60%20so%20a%20cancelled%20request%20definitively%20retires%20the%20session.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FServices%2FRuntime%2FFoundationModelSuggestionEngine.swift%3A173-179%0A**%22Consumed%20once%22%20bound%20may%20not%20hold%20for%20cancelled%20streams**%0A%0AThe%20comment%20states%20%22a%20successful%20%28or%20even%20cancelled%29%20%60respond%60%20appends%20the%20prompt%20and%20response%20to%20the%20session's%20transcript%2C%22%20but%20Apple's%20documentation%20does%20not%20appear%20to%20guarantee%20that%20a%20mid-stream%20cancellation%20modifies%20%60transcript%60.%20If%20cancellation%20unwinds%20the%20iterator%20before%20Apple%20commits%20an%20entry%2C%20%60transcript.count%60%20stays%20at%20%60pristineTranscriptCount%60%20and%20%60ensureSession%60%20will%20hand%20the%20same%20prewarmed%20session%20to%20every%20subsequent%20cancelled%20request%20in%20the%20same%20field%20%E2%80%94%20the%20%22consumed%20once%22%20invariant%20is%20effectively%20%22consumed%20N%20times%20for%20N%20rapid%20keystrokes.%22%20The%20transcript%20doesn't%20grow%20in%20that%20scenario%20so%20%60exceededContextWindowSize%60%20is%20never%20triggered%2C%20but%20Apple%20may%20have%20internal%20per-session%20state%20%28KV-cache%20slots%2C%20in-flight%20token%20budget%29%20that%20degrades%20silently%20across%20repeated%20%60streamResponse%60%20calls%20on%20the%20same%20object%20even%20when%20the%20visible%20transcript%20stays%20empty.%20It's%20worth%20verifying%20the%20Apple-side%20behaviour%20and%2C%20if%20the%20guarantee%20can't%20be%20confirmed%2C%20snapping%20the%20cache%20entry%20to%20%60nil%60%20inside%20the%20%60catch%20is%20CancellationError%60%20path%20of%20%60generateSuggestion%60%20so%20a%20cancelled%20request%20definitively%20retires%20the%20session.%0A%0A&repo=fujacob%2Fcotabby&pr=336&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (4): Last reviewed commit: ["Trigger CI after base change to main"](https://github.com/fujacob/cotabby/commit/e12c762ccf7c9f724b5e63b07160b1dfae01745d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34324897)</sub>

<!-- /greptile_comment -->