### PR TITLE
Stop CGEvent tap from gating keystrokes in unrelated apps (#328)

### DIFF
--- a/Cotabby/App/Coordinators/SuggestionCoordinator.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator.swift
@@ -136,7 +136,17 @@ final class SuggestionCoordinator: ObservableObject {
         }
 
         overlayController.onStateChange = { [weak self] state in
-            self?.overlayState = state
+            guard let self else { return }
+            self.overlayState = state
+            // Only sit in the synchronous keystroke critical path while a suggestion is actually
+            // visible. With the overlay hidden, Cotabby observes via a listen-only tap that does
+            // not gate event delivery to other apps (issue #328).
+            switch state {
+            case .visible:
+                self.inputMonitor.setAcceptInterceptionActive(true)
+            case .hidden:
+                self.inputMonitor.setAcceptInterceptionActive(false)
+            }
         }
 
         visualContextCoordinator.onStateChange = { [weak self] status, excerpt in

--- a/Cotabby/Models/SuggestionSubsystemContracts.swift
+++ b/Cotabby/Models/SuggestionSubsystemContracts.swift
@@ -34,6 +34,11 @@ protocol SuggestionFocusProviding: AnyObject {
 protocol SuggestionInputMonitoring: AnyObject {
     var onEvent: ((CapturedInputEvent) -> Bool)? { get set }
     var onSuppressedSyntheticInput: (() -> Void)? { get set }
+
+    /// Drives the lifecycle of the active accept-key tap. The coordinator turns this on while
+    /// a suggestion overlay is visible and off otherwise, so Cotabby only sits in the synchronous
+    /// keystroke path during the brief windows it actually needs to consume the accept key.
+    func setAcceptInterceptionActive(_ active: Bool)
 }
 
 @MainActor

--- a/Cotabby/Services/Input/InputMonitor.swift
+++ b/Cotabby/Services/Input/InputMonitor.swift
@@ -3,15 +3,22 @@ import Foundation
 import Logging
 
 /// File overview:
-/// Owns the global keyboard event tap used to detect typing, navigation, dismissal keys,
+/// Owns the global keyboard event taps used to detect typing, navigation, dismissal keys,
 /// and `Tab` acceptance. This is the boundary between raw CGEvents and Cotabby's smaller
 /// input-event vocabulary.
 ///
 /// `CapturedInputEvent` now lives in `Models/InputModels.swift` so the rest of the app can depend
 /// on the semantic event type without importing this event-tap implementation.
 
-/// Installs a session event tap.
-/// We still observe normal typing, but we can now consume `Tab` when Cotabby has a valid suggestion.
+/// Installs two taps:
+/// - A steady-state `.listenOnly` observer at the head of the chain. Listen-only taps do not gate
+///   event delivery on the callback's return, so a slow main actor cannot stall global keystrokes
+///   in unrelated apps (DaVinci Resolve's Spacebar play/pause is the canonical victim of an active
+///   tap here — see issue #328).
+/// - A narrow `.defaultTap` accept tap at the tail, installed only while a suggestion is visible.
+///   This is the only path that consumes events, and it only exists for the brief window a
+///   suggestion is on screen. When no overlay is showing, Cotabby is fully out of the keystroke
+///   critical path.
 @MainActor
 final class InputMonitor {
     var onEvent: ((CapturedInputEvent) -> Bool)?
@@ -24,16 +31,19 @@ final class InputMonitor {
     /// Reads the current full-accept key code from the model at event time.
     var fullAcceptanceKeyCodeProvider: @MainActor () -> CGKeyCode = { CGKeyCode(UInt16.max) }
 
-    /// When false, the tap passes keystrokes through without classifying or notifying the
-    /// coordinator. This eliminates per-keystroke overhead in apps where Tabby will never act
+    /// When false, the observer passes keystrokes through without classifying or notifying the
+    /// coordinator. This eliminates per-keystroke overhead in apps where Cotabby will never act
     /// (terminals, globally disabled, per-app disabled).
     var shouldProcessEventsProvider: @MainActor () -> Bool = { true }
 
     private let permissionProvider: @MainActor () -> Bool
     private let suppressionController: InputSuppressionController
 
-    private var eventTap: CFMachPort?
-    private var runLoopSource: CFRunLoopSource?
+    private var observerTap: CFMachPort?
+    private var observerRunLoopSource: CFRunLoopSource?
+
+    private var acceptTap: CFMachPort?
+    private var acceptRunLoopSource: CFRunLoopSource?
 
     init(
         permissionProvider: @escaping @MainActor () -> Bool,
@@ -43,30 +53,49 @@ final class InputMonitor {
         self.suppressionController = suppressionController
     }
 
-    /// Installs the event tap and begins listening for global keyboard activity.
+    /// Installs the observer tap and begins listening for global keyboard activity.
     func start() {
         CotabbyLogger.app.info("Input monitor starting")
         refresh()
     }
 
-    /// Removes the event tap and stops observing keyboard events.
+    /// Removes both taps and stops observing keyboard events.
     func stop() {
         CotabbyLogger.app.info("Input monitor stopping")
-        destroyTap()
+        destroyAcceptTap()
+        destroyObserverTap()
     }
 
-    /// Re-evaluates whether the tap should exist after a permission change.
+    /// Re-evaluates whether the observer tap should exist after a permission change.
+    /// The accept tap is also torn down if permission was revoked; it gets re-installed lazily
+    /// the next time the coordinator presents a suggestion.
     func refresh() {
         if permissionProvider() {
-            installTapIfNeeded()
+            installObserverTapIfNeeded()
         } else {
-            destroyTap()
+            destroyAcceptTap()
+            destroyObserverTap()
         }
     }
 
-    /// Creates and enables the CGEvent tap only when permissions allow observation.
-    private func installTapIfNeeded() {
-        guard eventTap == nil else {
+    /// Installs (when `active == true`) or removes (when `false`) the narrow active tap that
+    /// consumes the accept key so the focused application never sees it. The coordinator calls
+    /// this when a suggestion becomes visible or hidden, so Cotabby only blocks event delivery
+    /// during the brief window when there is actually something to accept.
+    func setAcceptInterceptionActive(_ active: Bool) {
+        guard permissionProvider() else {
+            destroyAcceptTap()
+            return
+        }
+        if active {
+            installAcceptTapIfNeeded()
+        } else {
+            destroyAcceptTap()
+        }
+    }
+
+    private func installObserverTapIfNeeded() {
+        guard observerTap == nil else {
             return
         }
 
@@ -77,29 +106,27 @@ final class InputMonitor {
             }
 
             let monitor = Unmanaged<InputMonitor>.fromOpaque(userInfo).takeUnretainedValue()
-            // The CGEvent tap callback is a C function pointer. `assumeIsolated` tells Swift that
-            // we are deliberately hopping back onto this `@MainActor` object before touching state.
             return MainActor.assumeIsolated {
-                monitor.handleTap(type: type, event: event)
+                monitor.handleObserverTap(type: type, event: event)
             }
         }
 
         guard let tap = CGEvent.tapCreate(
             tap: .cgSessionEventTap,
             place: .headInsertEventTap,
-            options: .defaultTap,
+            options: .listenOnly,
             eventsOfInterest: CGEventMask(mask),
             callback: callback,
             userInfo: Unmanaged.passUnretained(self).toOpaque()
         ) else {
-            CotabbyLogger.app.warning("Failed to create CGEvent tap — Input Monitoring permission may be missing")
+            CotabbyLogger.app.warning("Failed to create CGEvent observer tap — Input Monitoring permission may be missing")
             return
         }
-        CotabbyLogger.app.info("CGEvent tap installed")
+        CotabbyLogger.app.info("CGEvent observer tap installed (listen-only)")
 
-        eventTap = tap
+        observerTap = tap
         let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
-        runLoopSource = source
+        observerRunLoopSource = source
 
         if let source {
             CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
@@ -108,28 +135,88 @@ final class InputMonitor {
         CGEvent.tapEnable(tap: tap, enable: true)
     }
 
-    /// Tears down the event tap and run-loop source to avoid leaking global event observers.
-    private func destroyTap() {
-        if let source = runLoopSource {
-            CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
+    private func installAcceptTapIfNeeded() {
+        guard acceptTap == nil else {
+            return
         }
 
-        runLoopSource = nil
+        let mask = (1 << CGEventType.keyDown.rawValue)
+        let callback: CGEventTapCallBack = { _, type, event, userInfo in
+            guard let userInfo else {
+                return Unmanaged.passUnretained(event)
+            }
 
-        if let tap = eventTap {
-            CFMachPortInvalidate(tap)
+            let monitor = Unmanaged<InputMonitor>.fromOpaque(userInfo).takeUnretainedValue()
+            return MainActor.assumeIsolated {
+                monitor.handleAcceptTap(type: type, event: event)
+            }
         }
 
-        eventTap = nil
+        // Tail-append so this tap runs *after* the head-inserted observer. The observer is
+        // listen-only and never drops events, so the accept tap reliably sees the accept key
+        // even though it runs second; the order guarantees the observer's classification fires
+        // before this tap consumes the event.
+        guard let tap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .tailAppendEventTap,
+            options: .defaultTap,
+            eventsOfInterest: CGEventMask(mask),
+            callback: callback,
+            userInfo: Unmanaged.passUnretained(self).toOpaque()
+        ) else {
+            CotabbyLogger.app.warning("Failed to create CGEvent accept tap")
+            return
+        }
+        CotabbyLogger.app.info("CGEvent accept tap installed (active, accept-key only)")
+
+        acceptTap = tap
+        let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        acceptRunLoopSource = source
+
+        if let source {
+            CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+        }
+
+        CGEvent.tapEnable(tap: tap, enable: true)
     }
 
-    /// Routes each raw keyboard event through suppression, classification, and optional interception.
-    private func handleTap(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+    private func destroyObserverTap() {
+        if let source = observerRunLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
+        }
+        observerRunLoopSource = nil
+
+        if let tap = observerTap {
+            CFMachPortInvalidate(tap)
+        }
+        observerTap = nil
+    }
+
+    private func destroyAcceptTap() {
+        guard acceptTap != nil || acceptRunLoopSource != nil else {
+            return
+        }
+        if let source = acceptRunLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
+        }
+        acceptRunLoopSource = nil
+
+        if let tap = acceptTap {
+            CFMachPortInvalidate(tap)
+        }
+        acceptTap = nil
+        CotabbyLogger.app.info("CGEvent accept tap removed")
+    }
+
+    /// Listen-only observer: classifies the event and notifies the coordinator. The return value
+    /// of `onEvent` is ignored here because a listen-only tap cannot drop or modify events.
+    /// Consumption of the accept key is handled by the separate active accept tap.
+    private func handleObserverTap(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         switch type {
         case .tapDisabledByTimeout, .tapDisabledByUserInput:
-            CotabbyLogger.app.warning("CGEvent tap was disabled by system, re-enabling")
-            if let eventTap {
-                CGEvent.tapEnable(tap: eventTap, enable: true)
+            CotabbyLogger.app.warning("Observer tap was disabled by system, re-enabling")
+            if let observerTap {
+                CGEvent.tapEnable(tap: observerTap, enable: true)
             }
             return Unmanaged.passUnretained(event)
 
@@ -139,17 +226,51 @@ final class InputMonitor {
                 return Unmanaged.passUnretained(event)
             }
 
-            // Short-circuit before classification when Tabby won't act on events for the
-            // current app (terminals, globally disabled, per-app disabled). The tap callback
-            // runs synchronously before macOS delivers the keystroke, so any work here adds
-            // latency the user feels in the target app.
+            // Short-circuit before classification when Cotabby won't act on events for the
+            // current app. Even though this tap is listen-only, classification still does work
+            // on the main actor that we should skip when nothing will use the result.
             guard shouldProcessEventsProvider() else {
                 return Unmanaged.passUnretained(event)
             }
 
             let capturedEvent = classify(event: event)
-            let shouldIntercept = onEvent?(capturedEvent) ?? false
-            return shouldIntercept ? nil : Unmanaged.passUnretained(event)
+            _ = onEvent?(capturedEvent)
+            return Unmanaged.passUnretained(event)
+
+        default:
+            return Unmanaged.passUnretained(event)
+        }
+    }
+
+    /// Active accept tap: only consumes the configured accept keys, so the focused application
+    /// never sees them when a suggestion is on screen. All other keys pass through unchanged.
+    /// This tap intentionally does not invoke `onEvent` — the observer tap is the single source
+    /// of classification, and it has already fired for this keystroke by the time we run.
+    private func handleAcceptTap(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+        switch type {
+        case .tapDisabledByTimeout, .tapDisabledByUserInput:
+            CotabbyLogger.app.warning("Accept tap was disabled by system, re-enabling")
+            if let acceptTap {
+                CGEvent.tapEnable(tap: acceptTap, enable: true)
+            }
+            return Unmanaged.passUnretained(event)
+
+        case .keyDown:
+            guard shouldProcessEventsProvider() else {
+                return Unmanaged.passUnretained(event)
+            }
+
+            let keyCode = CGKeyCode(event.getIntegerValueField(.keyboardEventKeycode))
+            let flags = event.flags
+            let noModifiers = flags.isDisjoint(with: [.maskCommand, .maskControl, .maskAlternate, .maskShift])
+            guard noModifiers else {
+                return Unmanaged.passUnretained(event)
+            }
+
+            if keyCode == fullAcceptanceKeyCodeProvider() || keyCode == acceptanceKeyCodeProvider() {
+                return nil
+            }
+            return Unmanaged.passUnretained(event)
 
         default:
             return Unmanaged.passUnretained(event)


### PR DESCRIPTION
## Summary

Fixes #328 (Cotabby messing with DaVinci Resolve's Spacebar play/pause). The single active `.defaultTap` we installed at the head of the system event chain held every keyDown synchronously until our main-actor callback returned, so any contention on the main actor (AX polling, prediction work, SwiftUI updates) translated into observable keystroke delay in *every* app — even when Cotabby was disabled globally, because the tap callback still ran before the early-exit check.

Replaced with a two-tap design:

- **Observer tap**: steady-state `.listenOnly` at `.headInsertEventTap`. Sees every keyDown for classification, but the system does not wait on the callback's return, so a slow main actor cannot stall global keystrokes.
- **Accept tap**: narrow active `.defaultTap` at `.tailAppendEventTap`, installed only while a suggestion overlay is visible. Consumes the configured accept key(s) and nothing else. The coordinator turns it on/off via the existing `overlayController.onStateChange` hook.

In DaVinci Resolve (and any other app where no suggestion ever appears) the accept tap is never installed, so Cotabby is fully out of the synchronous keystroke critical path.

## Validation

- `swiftlint lint --quiet` — exit 0
- `xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build` — ** BUILD SUCCEEDED **
- `xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build-for-testing` — ** TEST BUILD SUCCEEDED **

Manual verification recommended: with Cotabby running, play/pause in DaVinci Resolve via Spacebar should now feel native. Tab acceptance in normal text fields should continue to work — verify in TextEdit / Notes / VS Code that the accept tap still swallows Tab when a suggestion is shown.

## Linked issues

Fixes #328

## Risk / rollout notes

- Touches the global keyboard input path, so worth a manual smoke on Tab acceptance across a few apps.
- The accept tap now runs at `.tailAppendEventTap` rather than `.headInsertEventTap`. The observer is listen-only and never drops events, so the accept tap reliably sees every keystroke regardless of order; this guarantees the observer's classification fires before the accept tap consumes.
- Follow-up worth filing: `FocusTracker` still polls AX every 80 ms regardless of `isGloballyEnabled`. That doesn't block keystrokes anymore, but it is still wasted main-actor work when Cotabby is disabled in the focused app.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the single always-active `CGEvent` tap with a two-tap design to fix keystroke latency in unrelated apps (DaVinci Resolve #328): a permanent listen-only observer at `headInsertEventTap` for classification, and a narrow active accept tap at `tailAppendEventTap` that is installed only while a suggestion overlay is visible.

- **Observer tap** (`listenOnly`, HEAD): always on, never blocks event delivery. Classifies every keyDown and calls `onEvent` for coordinator notification. The return value of `onEvent` is now discarded — the old synchronous veto path no longer exists.
- **Accept tap** (active, TAIL): installed/removed by `setAcceptInterceptionActive` in response to `overlayController.onStateChange`. Independently consumes the accept key based on key-code matching alone, without consulting the coordinator's decision.
- **Risk area**: when the coordinator falls through to `passTabThrough()` (state not ready, permission issue) while the accept tap is installed, it destroys the tap and returns `false` — but the accept tap may already be committed to the current event delivery chain and could still swallow the Tab key the coordinator intended to pass through.

<h3>Confidence Score: 3/5</h3>

The core latency fix is architecturally sound, but the two-tap design decouples event consumption from the coordinator's decision in a way that could silently swallow Tab keystrokes in edge cases.

The normal acceptance path (overlay visible → Tab pressed → suggestion ready) works correctly. The concern is the decoupled design: the accept tap consumes the key based on key-code alone, while the coordinator's onEvent return value (previously the exclusive veto gate) is now ignored. If acceptCurrentSuggestion() hits a guard and calls passTabThrough() while the accept tap is in the current event delivery chain, the coordinator's intent to let Tab through may not be honoured.

InputMonitor.swift — specifically handleAcceptTap and the interaction with destroyAcceptTap being called mid-chain from the observer callback.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Services/Input/InputMonitor.swift | Core change: replaces a single active defaultTap with a listen-only observer (HEAD) + narrow active accept tap (TAIL, lifecycle-managed). The accept tap independently consumes the key without consulting the coordinator's onEvent return value, breaking the old veto contract and creating a potential Tab-swallow on the passTabThrough path. |
| Cotabby/App/Coordinators/SuggestionCoordinator.swift | Wires up accept tap lifecycle to overlay visibility via onStateChange. The hook is correct, but the coordinator's Bool return from handleInputEvent is now silently discarded by the observer, meaning the coordinator can no longer veto accept-key interception. |
| Cotabby/Models/SuggestionSubsystemContracts.swift | Adds setAcceptInterceptionActive to the protocol; the existing onEvent: ((CapturedInputEvent) -> Bool)? return type is now unused dead weight that misleads future implementors. |

</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fnon-blocking-input-tap%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fnon-blocking-input-tap%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0ACotabby%2FServices%2FInput%2FInputMonitor.swift%3A258-273%0A**Accept%20tap%20consumes%20key%20independently%20of%20coordinator's%20veto**%0A%0AThe%20accept%20tap%20returns%20%60nil%60%20%28consumes%20the%20event%29%20based%20only%20on%20key-code%20matching%2C%20never%20consulting%20the%20coordinator.%20When%20%60acceptCurrentSuggestion%28%29%60%20falls%20through%20to%20%60passTabThrough%28%29%60%20%E2%80%94%20e.g.%2C%20the%20%60guard%20case%20.ready%20%3D%20state%60%20check%20fails%20because%20state%20was%20changed%20without%20the%20overlay%20hiding%20yet%20%E2%80%94%20%60passTabThrough%60%20calls%20%60hideOverlay%28%29%60%20%E2%86%92%20%60destroyAcceptTap%28%29%60%20and%20returns%20%60false%60.%20In%20the%20old%20design%20that%20%60false%60%20directly%20prevented%20consumption.%20Here%2C%20if%20the%20accept%20tap%20was%20already%20committed%20to%20the%20current%20event%20delivery%20chain%20before%20%60CFMachPortInvalidate%60%20ran%20%28CGEvent%20tap%20chain%20snapshots%20are%20typically%20taken%20at%20dispatch%20time%29%2C%20it%20will%20still%20fire%20and%20silently%20swallow%20the%20Tab%20key%20that%20the%20coordinator%20explicitly%20decided%20should%20reach%20the%20app.%20The%20coordination%20contract%20that%20the%20%60Bool%60%20return%20of%20%60onEvent%60%20expressed%20is%20now%20broken.%0A%0A%23%23%23%20Issue%202%20of%203%0ACotabby%2FModels%2FSuggestionSubsystemContracts.swift%3A35%0A**%60onEvent%60%20return%20value%20is%20now%20dead%20weight**%0A%0A%60handleObserverTap%60%20discards%20the%20return%20with%20%60_%20%3D%20onEvent%3F%28capturedEvent%29%60%2C%20and%20the%20accept%20tap%20independently%20decides%20whether%20to%20consume%20the%20event.%20The%20%60Bool%60%20return%20type%20implies%20callers%20can%20still%20control%20interception%20through%20this%20callback%2C%20but%20they%20no%20longer%20can.%20Changing%20to%20%60Void%60%20removes%20a%20source%20of%20confusion%20for%20future%20maintainers%20and%20makes%20the%20new%20architectural%20split%20explicit%20in%20the%20protocol%20contract.%0A%0A%60%60%60suggestion%0A%20%20%20%20var%20onEvent%3A%20%28%28CapturedInputEvent%29%20-%3E%20Void%29%3F%20%7B%20get%20set%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0ACotabby%2FServices%2FInput%2FInputMonitor.swift%3A183-209%0A**%60destroyObserverTap%60%20is%20asymmetric%20with%20%60destroyAcceptTap%60**%0A%0A%60destroyObserverTap%60%20does%20not%20log%20its%20removal%20%28no%20%60CotabbyLogger.app.info%28...%29%60%20call%29%2C%20while%20%60destroyAcceptTap%60%20does.%20This%20inconsistency%20makes%20it%20harder%20to%20diagnose%20tap%20lifecycle%20issues%20from%20logs%20when%20the%20observer%20tap%20is%20unexpectedly%20torn%20down%20%28e.g.%2C%20during%20permission%20revocation%29.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0ACotabby%2FServices%2FInput%2FInputMonitor.swift%3A258-273%0A**Accept%20tap%20consumes%20key%20independently%20of%20coordinator's%20veto**%0A%0AThe%20accept%20tap%20returns%20%60nil%60%20%28consumes%20the%20event%29%20based%20only%20on%20key-code%20matching%2C%20never%20consulting%20the%20coordinator.%20When%20%60acceptCurrentSuggestion%28%29%60%20falls%20through%20to%20%60passTabThrough%28%29%60%20%E2%80%94%20e.g.%2C%20the%20%60guard%20case%20.ready%20%3D%20state%60%20check%20fails%20because%20state%20was%20changed%20without%20the%20overlay%20hiding%20yet%20%E2%80%94%20%60passTabThrough%60%20calls%20%60hideOverlay%28%29%60%20%E2%86%92%20%60destroyAcceptTap%28%29%60%20and%20returns%20%60false%60.%20In%20the%20old%20design%20that%20%60false%60%20directly%20prevented%20consumption.%20Here%2C%20if%20the%20accept%20tap%20was%20already%20committed%20to%20the%20current%20event%20delivery%20chain%20before%20%60CFMachPortInvalidate%60%20ran%20%28CGEvent%20tap%20chain%20snapshots%20are%20typically%20taken%20at%20dispatch%20time%29%2C%20it%20will%20still%20fire%20and%20silently%20swallow%20the%20Tab%20key%20that%20the%20coordinator%20explicitly%20decided%20should%20reach%20the%20app.%20The%20coordination%20contract%20that%20the%20%60Bool%60%20return%20of%20%60onEvent%60%20expressed%20is%20now%20broken.%0A%0A%23%23%23%20Issue%202%20of%203%0ACotabby%2FModels%2FSuggestionSubsystemContracts.swift%3A35%0A**%60onEvent%60%20return%20value%20is%20now%20dead%20weight**%0A%0A%60handleObserverTap%60%20discards%20the%20return%20with%20%60_%20%3D%20onEvent%3F%28capturedEvent%29%60%2C%20and%20the%20accept%20tap%20independently%20decides%20whether%20to%20consume%20the%20event.%20The%20%60Bool%60%20return%20type%20implies%20callers%20can%20still%20control%20interception%20through%20this%20callback%2C%20but%20they%20no%20longer%20can.%20Changing%20to%20%60Void%60%20removes%20a%20source%20of%20confusion%20for%20future%20maintainers%20and%20makes%20the%20new%20architectural%20split%20explicit%20in%20the%20protocol%20contract.%0A%0A%60%60%60suggestion%0A%20%20%20%20var%20onEvent%3A%20%28%28CapturedInputEvent%29%20-%3E%20Void%29%3F%20%7B%20get%20set%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0ACotabby%2FServices%2FInput%2FInputMonitor.swift%3A183-209%0A**%60destroyObserverTap%60%20is%20asymmetric%20with%20%60destroyAcceptTap%60**%0A%0A%60destroyObserverTap%60%20does%20not%20log%20its%20removal%20%28no%20%60CotabbyLogger.app.info%28...%29%60%20call%29%2C%20while%20%60destroyAcceptTap%60%20does.%20This%20inconsistency%20makes%20it%20harder%20to%20diagnose%20tap%20lifecycle%20issues%20from%20logs%20when%20the%20observer%20tap%20is%20unexpectedly%20torn%20down%20%28e.g.%2C%20during%20permission%20revocation%29.%0A%0A&repo=fujacob%2Fcotabby&pr=337&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Split CGEvent tap into listen-only obser..."](https://github.com/fujacob/cotabby/commit/91383e07cb4105b71a82ee2c482afb4b42222464) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34324949)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->