### PR TITLE
Hide the custom indicator icon picker from Settings

### DIFF
--- a/Cotabby/UI/SettingsView.swift
+++ b/Cotabby/UI/SettingsView.swift
@@ -27,9 +27,6 @@ struct SettingsView: View {
     @State private var pendingDeletionModel: RuntimeModelOption?
     @State private var isRecordingKeybind = false
     @State private var isRecordingFullAcceptKeybind = false
-    @State private var isIndicatorIconImporterPresented = false
-    @State private var didIndicatorIconImportFail = false
-
     var body: some View {
         Form {
             // Header keeps the app identity and the (important, frequently-checked) update
@@ -71,17 +68,6 @@ struct SettingsView: View {
             Button("Cancel", role: .cancel) {}
         } message: { model in
             Text("Remove \(model.displayName) from Cotabby's local models folder?")
-        }
-        .fileImporter(
-            isPresented: $isIndicatorIconImporterPresented,
-            allowedContentTypes: [.image]
-        ) { result in
-            handleIndicatorIconSelection(result)
-        }
-        .alert("Couldn't Use That Image", isPresented: $didIndicatorIconImportFail) {
-            Button("OK", role: .cancel) {}
-        } message: {
-            Text("Cotabby couldn't read that file as an image. Try a PNG or JPEG.")
         }
     }
 
@@ -162,24 +148,6 @@ struct SettingsView: View {
             Toggle("Show Indicator", isOn: showIndicatorBinding)
                 .help("Show a small icon next to the cursor when Cotabby is active in a field.")
 
-            LabeledContent("Indicator Icon") {
-                HStack(spacing: 8) {
-                    FieldEdgeIconIndicatorView(customImage: suggestionSettings.customIndicatorImage)
-
-                    Button("Choose Image…") {
-                        isIndicatorIconImporterPresented = true
-                    }
-
-                    if suggestionSettings.customIndicatorImage != nil {
-                        Button("Reset") {
-                            suggestionSettings.clearCustomIndicatorImage()
-                        }
-                        .help("Go back to the default indicator icon.")
-                    }
-                }
-            }
-            .help("Custom image used in place of the default indicator. PNG or JPEG.")
-
             Toggle("Show Accept Hint", isOn: showAcceptanceHintBinding)
                 .help("Show a small label near the ghost text reminding you which key accepts it.")
 
@@ -232,19 +200,6 @@ struct SettingsView: View {
                     onShowWelcome()
                 }
             }
-        }
-    }
-
-    /// Applies a picked image as the indicator icon, flagging an alert when the file can't be used.
-    private func handleIndicatorIconSelection(_ result: Result<URL, Error>) {
-        switch result {
-        case let .success(url):
-            if !suggestionSettings.setCustomIndicatorImage(from: url) {
-                didIndicatorIconImportFail = true
-            }
-
-        case .failure:
-            didIndicatorIconImportFail = true
         }
     }
 


### PR DESCRIPTION
## Summary

Removes the Settings UI for changing the field-edge indicator icon (the Choose Image / Reset row and its file importer / failure alert). The underlying storage and rendering path is untouched, so any custom image a user previously chose is still loaded and used at runtime.

## Validation

- swiftlint lint --quiet → exit 0
- xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build → ** BUILD SUCCEEDED **

## Linked issues

None.

## Risk / rollout notes

UI-only deletion. The model APIs (setCustomIndicatorImage, clearCustomIndicatorImage, customIndicatorImage) remain in place and are still consumed by AppDelegate, so this is a hide rather than a removal. If we want to fully retire the feature later, a follow-up can clean up the model and its UserDefaults key.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the Indicator Icon picker UI from `SettingsView` — specifically the "Choose Image…" / "Reset" row, its `fileImporter` sheet, and the import-failure alert — while leaving the underlying model APIs and `AppDelegate` rendering path fully intact.

- Removes three `@State` variables (`isIndicatorIconImporterPresented`, `didIndicatorIconImportFail`) and the private `handleIndicatorIconSelection` helper that drove the file-importer flow.
- Removes the `LabeledContent("Indicator Icon")` row from the General section and the associated `.fileImporter` / `.alert` view modifiers from the form.
- The `UniformTypeIdentifiers` import is still required because `presentDisabledAppPicker()` uses `panel.allowedContentTypes = [.application]`.

<h3>Confidence Score: 5/5</h3>

This is a straightforward UI-only deletion with no logic changes; the model layer and AppDelegate rendering path are untouched, so users who previously chose a custom icon will continue to see it at runtime.

Every piece removed in this PR (two @State vars, the fileImporter modifier, the failure alert, the LabeledContent row, and the handleIndicatorIconSelection helper) is self-contained and has no callers or dependents remaining in the file. The UniformTypeIdentifiers import is still exercised by presentDisabledAppPicker. Nothing was accidentally left dangling.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/SettingsView.swift | Clean removal of the indicator icon picker UI (state vars, fileImporter modifier, failure alert, LabeledContent row, and handler method). No dead code left behind; the UniformTypeIdentifiers import remains valid for the app-picker panel. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User opens Settings] --> B[General Section]
    B --> C[Show Indicator Toggle]
    C --> D["(Indicator Icon row — REMOVED)"]
    C --> E[Show Accept Hint Toggle]

    subgraph Removed["Removed in this PR"]
        D
        F[Choose Image… Button]
        G[Reset Button]
        H[fileImporter sheet]
        I[Couldn't Use That Image alert]
        J[handleIndicatorIconSelection]
        D --> F
        D --> G
        F --> H
        H --> J
        J --> I
    end

    subgraph Retained["Retained — model layer untouched"]
        K[SuggestionSettingsModel.setCustomIndicatorImage]
        L[SuggestionSettingsModel.clearCustomIndicatorImage]
        M[SuggestionSettingsModel.customIndicatorImage]
        N[AppDelegate — renders custom indicator at runtime]
        K & L & M --> N
    end

    style Removed fill:#fdd,stroke:#f00
    style Retained fill:#dfd,stroke:#0a0
```

<sub>Reviews (1): Last reviewed commit: ["Hide the custom indicator icon picker fr..."](https://github.com/fujacob/cotabby/commit/363ba22e584ffcab88243b53e3f3b359b4dbdea5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34325773)</sub>

<!-- /greptile_comment -->