### PR TITLE
Stream Foundation Models responses for cancellable decode

### DIFF
--- a/Cotabby/Services/Runtime/FoundationModelSuggestionEngine.swift
+++ b/Cotabby/Services/Runtime/FoundationModelSuggestionEngine.swift
@@ -73,14 +73,27 @@ final class FoundationModelSuggestionEngine {
                 options: generationOptions(for: request)
             )
             // Apple's stream yields cumulative `Snapshot` values whose `.content` carries the
-            // text generated so far. Capturing each snapshot (and re-checking cancellation around
-            // it) is what lets us bail out mid-decode without waiting for the full completion.
+            // text generated so far. Capture each snapshot first and check cancellation after, so a
+            // late cancel between the final snapshot and its assignment doesn't discard fully
+            // decoded text — cancellation always throws, but keeping the best-available text saved
+            // before honoring the signal makes the intent obvious.
             var rawSuggestion = ""
+            var didReceiveSnapshot = false
             for try await partial in stream {
-                try Task.checkCancellation()
                 rawSuggestion = partial.content
+                didReceiveSnapshot = true
+                try Task.checkCancellation()
             }
             try Task.checkCancellation()
+            // Apple's documented contract is at least one snapshot on a successful stream, so a
+            // zero-snapshot path is treated as a generation failure rather than a silent empty
+            // suggestion — the latter would let the overlay clear without surfacing that the model
+            // produced literally nothing.
+            guard didReceiveSnapshot else {
+                throw SuggestionClientError.generationFailed(
+                    "Apple Intelligence finished streaming without producing any content."
+                )
+            }
             let normalizedSuggestion = SuggestionTextNormalizer.normalize(
                 rawSuggestion,
                 for: request,

--- a/Cotabby/Services/Runtime/FoundationModelSuggestionEngine.swift
+++ b/Cotabby/Services/Runtime/FoundationModelSuggestionEngine.swift
@@ -22,6 +22,15 @@ import FoundationModels
 /// request is likely within a second." The coordinator calls it from the focus path; the engine
 /// builds (or reuses) the session and calls Apple's `LanguageModelSession.prewarm()` so weight
 /// loading and instruction tokenization happen before the first user-visible respond call.
+///
+/// Generation itself goes through `session.streamResponse` rather than `session.respond`. Apple's
+/// stream yields cumulative partials, so the loop captures the latest snapshot and exits with it
+/// as the final raw text. The win is responsiveness to cancellation: `Task.checkCancellation()`
+/// inside the loop lets the coordinator interrupt mid-decode when the user types past the
+/// in-flight suggestion, where `respond` would otherwise have to run to completion. The external
+/// `SuggestionResult` shape is unchanged, so the rest of the pipeline (overlay, presenter,
+/// active-session reconciliation) stays as-is — pushing partials all the way to the overlay is a
+/// separate, larger change scoped to a follow-up.
 #if canImport(FoundationModels)
 @available(macOS 26.0, *)
 @MainActor
@@ -59,13 +68,19 @@ final class FoundationModelSuggestionEngine {
             }
 
             let session = ensureSession(for: request, model: model)
-            let response = try await session.respond(
+            let stream = session.streamResponse(
                 to: prompt,
                 options: generationOptions(for: request)
             )
+            // Apple's stream yields cumulative `Snapshot` values whose `.content` carries the
+            // text generated so far. Capturing each snapshot (and re-checking cancellation around
+            // it) is what lets us bail out mid-decode without waiting for the full completion.
+            var rawSuggestion = ""
+            for try await partial in stream {
+                try Task.checkCancellation()
+                rawSuggestion = partial.content
+            }
             try Task.checkCancellation()
-
-            let rawSuggestion = response.content
             let normalizedSuggestion = SuggestionTextNormalizer.normalize(
                 rawSuggestion,
                 for: request,


### PR DESCRIPTION
## Summary

Swaps the FM engine's `session.respond` call for `session.streamResponse` and iterates the cumulative snapshots. The external `SuggestionResult` shape is unchanged — we still return after the final snapshot — but the inner loop now checks `Task.checkCancellation()` between snapshots, so a coordinator cancel (typing past the in-flight suggestion, switching apps) can abort mid-decode instead of waiting for the model to finish.

Stacked on `perf/fm-session-reuse-prewarm`. No prompt-policy change, no UI plumbing change yet — pushing partials all the way to the overlay is the natural follow-up and intentionally out of scope here.

## Validation

`xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build CODE_SIGNING_ALLOWED=NO`
→ `** BUILD SUCCEEDED **`

`xcodebuild test ... -only-testing:CotabbyTests/FoundationModelPromptRendererTests -only-testing:CotabbyTests/SuggestionEngineRouterTests CODE_SIGNING_ALLOWED=NO`
→ `Executed 9 tests, with 0 failures (0 unexpected)`

`swiftlint lint --quiet` → no violations.

Manual: type fast in a real app with Apple Intelligence selected and watch the suggestion debug panel. Latency on completed requests should be unchanged; CPU/latency on requests that get cancelled mid-flight (fast typer, browser AX flicker) should drop because the decode loop stops sooner.

## Linked issues

Refs the FM-quality investigation.

## Risk / rollout notes

- Behavior change is scoped to the FM critical path; llama is untouched.
- We rely on Apple's documented cumulative-snapshot streaming semantics: each yielded `Snapshot.content` is the entire response so far, so the final iteration carries the full text. If a future Apple update flips to delta semantics this code would degrade to producing only the last delta — easy to spot in the eval suite from the parent stack PR.
- `Task.checkCancellation()` is called both *inside* the loop (every snapshot) and once *after* the loop, so a late cancellation between the last snapshot and result construction also throws.
- No protocol change; `SuggestionGenerating`'s signature is unchanged.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR swaps `session.respond` for `session.streamResponse` in `FoundationModelSuggestionEngine`, iterating cumulative snapshots so `Task.checkCancellation()` can abort mid-decode instead of waiting for the full response. The external `SuggestionResult` shape is unchanged.

- The streaming loop saves `rawSuggestion = partial.content` before calling `try Task.checkCancellation()`, preserving the best available text even on a late cancel (addresses previous review feedback on ordering).
- A `guard didReceiveSnapshot` after the loop converts a zero-snapshot stream completion into an explicit `generationFailed` error rather than silently returning an empty suggestion (addresses previous review feedback on zero-iteration paths).

<h3>Confidence Score: 5/5</h3>

Safe to merge — the streaming loop is logically correct, both previously flagged concerns have been addressed, and the change is fully scoped to the FM generation path.

The snapshot-before-checkCancellation ordering is correct, the zero-snapshot guard is in place, all existing error cases (CancellationError, GenerationError, SuggestionClientError) continue to be caught and re-mapped appropriately, and the external SuggestionResult contract is unchanged.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Services/Runtime/FoundationModelSuggestionEngine.swift | Replaces `session.respond` with `session.streamResponse` + cumulative-snapshot iteration loop; adds `didReceiveSnapshot` guard and preserves all error-mapping and cancellation handling. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Coordinator
    participant Engine as FoundationModelSuggestionEngine
    participant Session as LanguageModelSession
    participant FM as Apple FM Framework

    Coordinator->>Engine: generateSuggestion(request)
    Engine->>Session: ensureSession(request, model)
    Session-->>Engine: session (cached or new)
    Engine->>FM: session.streamResponse(prompt, options)
    FM-->>Engine: "AsyncSequence<Snapshot>"

    loop for each cumulative snapshot
        FM->>Engine: partial.content (cumulative text so far)
        Engine->>Engine: "rawSuggestion = partial.content"
        Engine->>Engine: "didReceiveSnapshot = true"
        Engine->>Engine: Task.checkCancellation()
        alt Task cancelled
            Engine-->>Coordinator: throw SuggestionClientError.cancelled
        end
    end

    Engine->>Engine: Task.checkCancellation() (post-loop)
    Engine->>Engine: guard didReceiveSnapshot
    alt Zero snapshots received
        Engine-->>Coordinator: throw SuggestionClientError.generationFailed
    end
    Engine->>Engine: SuggestionTextNormalizer.normalize(rawSuggestion)
    Engine-->>Coordinator: SuggestionResult(text, rawText, latency)
```

<sub>Reviews (2): Last reviewed commit: ["Address Greptile: save snapshot before c..."](https://github.com/fujacob/cotabby/commit/0f3c8114f7d166df5a4ed7240ea47ebf3358c067) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34325792)</sub>

<!-- /greptile_comment -->