### PR TITLE
Allow modifier keys in accept shortcuts (⇧Tab, ⌥Tab, …)

### DIFF
--- a/Cotabby/App/Core/CotabbyAppEnvironment.swift
+++ b/Cotabby/App/Core/CotabbyAppEnvironment.swift
@@ -49,7 +49,9 @@ final class CotabbyAppEnvironment {
             suppressionController: suppressionController
         )
         inputMonitor.acceptanceKeyCodeProvider = { suggestionSettings.acceptanceKeyCode }
+        inputMonitor.acceptanceKeyModifiersProvider = { suggestionSettings.acceptanceKeyModifiers }
         inputMonitor.fullAcceptanceKeyCodeProvider = { suggestionSettings.fullAcceptanceKeyCode }
+        inputMonitor.fullAcceptanceKeyModifiersProvider = { suggestionSettings.fullAcceptanceKeyModifiers }
         let focusModel = FocusTrackingModel(
             permissionProvider: { permissionManager.accessibilityGranted },
             ignoredBundleIdentifier: Bundle.main.bundleIdentifier,

--- a/Cotabby/Models/InputModels.swift
+++ b/Cotabby/Models/InputModels.swift
@@ -1,4 +1,5 @@
 import ApplicationServices
+import CoreGraphics
 import Foundation
 
 /// File overview:
@@ -6,6 +7,36 @@ import Foundation
 /// `InputMonitor` translates raw global keyboard events into these values so the suggestion
 /// pipeline can reason about intent such as "text changed" or "caret moved" instead of
 /// platform-specific key codes.
+
+/// Normalized representation of the four modifier keys a Cotabby shortcut can require.
+///
+/// We don't reuse `CGEventFlags` directly because it carries unrelated bits — caps lock,
+/// numeric pad, secondary fn, device-specific flags — that we don't want to participate in
+/// shortcut equality. Reducing to a 4-bit mask gives unambiguous storage and comparison.
+struct ShortcutModifierMask: OptionSet, Hashable {
+    let rawValue: UInt32
+
+    init(rawValue: UInt32) {
+        self.rawValue = rawValue
+    }
+
+    static let command = ShortcutModifierMask(rawValue: 1 << 0)
+    static let shift = ShortcutModifierMask(rawValue: 1 << 1)
+    static let option = ShortcutModifierMask(rawValue: 1 << 2)
+    static let control = ShortcutModifierMask(rawValue: 1 << 3)
+
+    /// Reduces a raw `CGEventFlags` to just the four modifier bits we honor. Anything else
+    /// in `flags` (caps lock, fn, numeric pad markers) is intentionally discarded.
+    init(eventFlags: CGEventFlags) {
+        var mask: ShortcutModifierMask = []
+        if eventFlags.contains(.maskCommand) { mask.insert(.command) }
+        if eventFlags.contains(.maskShift) { mask.insert(.shift) }
+        if eventFlags.contains(.maskAlternate) { mask.insert(.option) }
+        if eventFlags.contains(.maskControl) { mask.insert(.control) }
+        self = mask
+    }
+}
+
 struct CapturedInputEvent: Equatable {
     /// This enum is intentionally smaller than the raw CGEvent universe.
     /// A reduced vocabulary keeps the suggestion state machine easier to reason about and test.

--- a/Cotabby/Models/SuggestionSettingsModel.swift
+++ b/Cotabby/Models/SuggestionSettingsModel.swift
@@ -36,8 +36,10 @@ final class SuggestionSettingsModel: ObservableObject {
     @Published private(set) var isMultiLineEnabled: Bool
     @Published private(set) var autoAcceptTrailingPunctuation: Bool
     @Published private(set) var acceptanceKeyCode: CGKeyCode
+    @Published private(set) var acceptanceKeyModifiers: ShortcutModifierMask
     @Published private(set) var acceptanceKeyLabel: String
     @Published private(set) var fullAcceptanceKeyCode: CGKeyCode
+    @Published private(set) var fullAcceptanceKeyModifiers: ShortcutModifierMask
     @Published private(set) var fullAcceptanceKeyLabel: String
     private let userDefaults: UserDefaults
 
@@ -63,8 +65,10 @@ final class SuggestionSettingsModel: ObservableObject {
     private static let multiLineEnabledDefaultsKey = "cotabbyMultiLineEnabled"
     private static let autoAcceptTrailingPunctuationDefaultsKey = "cotabbyAutoAcceptTrailingPunctuation"
     private static let acceptanceKeyCodeDefaultsKey = "cotabbyAcceptanceKeyCode"
+    private static let acceptanceKeyModifiersDefaultsKey = "cotabbyAcceptanceKeyModifiers"
     private static let acceptanceKeyLabelDefaultsKey = "cotabbyAcceptanceKeyLabel"
     private static let fullAcceptanceKeyCodeDefaultsKey = "cotabbyFullAcceptanceKeyCode"
+    private static let fullAcceptanceKeyModifiersDefaultsKey = "cotabbyFullAcceptanceKeyModifiers"
     private static let fullAcceptanceKeyLabelDefaultsKey = "cotabbyFullAcceptanceKeyLabel"
 
     static let defaultAcceptanceKeyCode: CGKeyCode = 48
@@ -175,12 +179,20 @@ final class SuggestionSettingsModel: ObservableObject {
             userDefaults.object(forKey: Self.acceptanceKeyCodeDefaultsKey) as? Int
                 ?? Int(Self.defaultAcceptanceKeyCode)
         )
+        // Absence means a pre-modifier-support install: default to no modifiers so the user's
+        // existing bare-key binding keeps working exactly as it did before this feature.
+        let resolvedAcceptanceKeyModifiers = ShortcutModifierMask(
+            rawValue: UInt32(userDefaults.object(forKey: Self.acceptanceKeyModifiersDefaultsKey) as? Int ?? 0)
+        )
         let resolvedAcceptanceKeyLabel = userDefaults.string(forKey: Self.acceptanceKeyLabelDefaultsKey)
             ?? Self.defaultAcceptanceKeyLabel
 
         let resolvedFullAcceptanceKeyCode = CGKeyCode(
             userDefaults.object(forKey: Self.fullAcceptanceKeyCodeDefaultsKey) as? Int
                 ?? Int(Self.defaultFullAcceptanceKeyCode)
+        )
+        let resolvedFullAcceptanceKeyModifiers = ShortcutModifierMask(
+            rawValue: UInt32(userDefaults.object(forKey: Self.fullAcceptanceKeyModifiersDefaultsKey) as? Int ?? 0)
         )
         let resolvedFullAcceptanceKeyLabel = userDefaults.string(forKey: Self.fullAcceptanceKeyLabelDefaultsKey)
             ?? Self.defaultFullAcceptanceKeyLabel
@@ -204,8 +216,10 @@ final class SuggestionSettingsModel: ObservableObject {
         isMultiLineEnabled = resolvedMultiLineEnabled
         autoAcceptTrailingPunctuation = resolvedAutoAcceptTrailingPunctuation
         acceptanceKeyCode = resolvedAcceptanceKeyCode
+        acceptanceKeyModifiers = resolvedAcceptanceKeyModifiers
         acceptanceKeyLabel = resolvedAcceptanceKeyLabel
         fullAcceptanceKeyCode = resolvedFullAcceptanceKeyCode
+        fullAcceptanceKeyModifiers = resolvedFullAcceptanceKeyModifiers
         fullAcceptanceKeyLabel = resolvedFullAcceptanceKeyLabel
 
         userDefaults.set(resolvedGloballyEnabled, forKey: Self.isGloballyEnabledDefaultsKey)
@@ -226,8 +240,13 @@ final class SuggestionSettingsModel: ObservableObject {
         userDefaults.set(resolvedMultiLineEnabled, forKey: Self.multiLineEnabledDefaultsKey)
         userDefaults.set(resolvedAutoAcceptTrailingPunctuation, forKey: Self.autoAcceptTrailingPunctuationDefaultsKey)
         userDefaults.set(Int(resolvedAcceptanceKeyCode), forKey: Self.acceptanceKeyCodeDefaultsKey)
+        userDefaults.set(Int(resolvedAcceptanceKeyModifiers.rawValue), forKey: Self.acceptanceKeyModifiersDefaultsKey)
         userDefaults.set(resolvedAcceptanceKeyLabel, forKey: Self.acceptanceKeyLabelDefaultsKey)
         userDefaults.set(Int(resolvedFullAcceptanceKeyCode), forKey: Self.fullAcceptanceKeyCodeDefaultsKey)
+        userDefaults.set(
+            Int(resolvedFullAcceptanceKeyModifiers.rawValue),
+            forKey: Self.fullAcceptanceKeyModifiersDefaultsKey
+        )
         userDefaults.set(resolvedFullAcceptanceKeyLabel, forKey: Self.fullAcceptanceKeyLabelDefaultsKey)
     }
 
@@ -562,44 +581,62 @@ final class SuggestionSettingsModel: ObservableObject {
         setLanguages(LanguageCatalog.defaultLanguages)
     }
 
-    func setAcceptanceKey(keyCode: CGKeyCode, label: String) {
-        guard acceptanceKeyCode != keyCode || acceptanceKeyLabel != label else {
+    func setAcceptanceKey(keyCode: CGKeyCode, modifiers: ShortcutModifierMask, label: String) {
+        let normalizedModifiers = keyCode == Self.disabledKeyCode ? [] : modifiers
+        guard acceptanceKeyCode != keyCode
+            || acceptanceKeyModifiers != normalizedModifiers
+            || acceptanceKeyLabel != label
+        else {
             return
         }
 
-        // Clear the other keybind if it would conflict.
-        if keyCode != Self.disabledKeyCode, keyCode == fullAcceptanceKeyCode {
+        // Two bindings on the same `(keyCode, modifiers)` would both fire on the same press,
+        // so clear the other side to keep classification unambiguous. We only treat it as a
+        // conflict when both the key and the modifier set match — `Tab` and `⇧Tab` are now
+        // distinct bindings and may coexist.
+        if keyCode != Self.disabledKeyCode,
+           keyCode == fullAcceptanceKeyCode,
+           normalizedModifiers == fullAcceptanceKeyModifiers {
             clearFullAcceptanceKey()
         }
 
         acceptanceKeyCode = keyCode
+        acceptanceKeyModifiers = normalizedModifiers
         acceptanceKeyLabel = label
         userDefaults.set(Int(keyCode), forKey: Self.acceptanceKeyCodeDefaultsKey)
+        userDefaults.set(Int(normalizedModifiers.rawValue), forKey: Self.acceptanceKeyModifiersDefaultsKey)
         userDefaults.set(label, forKey: Self.acceptanceKeyLabelDefaultsKey)
     }
 
     func clearAcceptanceKey() {
-        setAcceptanceKey(keyCode: Self.disabledKeyCode, label: Self.disabledKeyLabel)
+        setAcceptanceKey(keyCode: Self.disabledKeyCode, modifiers: [], label: Self.disabledKeyLabel)
     }
 
-    func setFullAcceptanceKey(keyCode: CGKeyCode, label: String) {
-        guard fullAcceptanceKeyCode != keyCode || fullAcceptanceKeyLabel != label else {
+    func setFullAcceptanceKey(keyCode: CGKeyCode, modifiers: ShortcutModifierMask, label: String) {
+        let normalizedModifiers = keyCode == Self.disabledKeyCode ? [] : modifiers
+        guard fullAcceptanceKeyCode != keyCode
+            || fullAcceptanceKeyModifiers != normalizedModifiers
+            || fullAcceptanceKeyLabel != label
+        else {
             return
         }
 
-        // Clear the other keybind if it would conflict.
-        if keyCode != Self.disabledKeyCode, keyCode == acceptanceKeyCode {
+        if keyCode != Self.disabledKeyCode,
+           keyCode == acceptanceKeyCode,
+           normalizedModifiers == acceptanceKeyModifiers {
             clearAcceptanceKey()
         }
 
         fullAcceptanceKeyCode = keyCode
+        fullAcceptanceKeyModifiers = normalizedModifiers
         fullAcceptanceKeyLabel = label
         userDefaults.set(Int(keyCode), forKey: Self.fullAcceptanceKeyCodeDefaultsKey)
+        userDefaults.set(Int(normalizedModifiers.rawValue), forKey: Self.fullAcceptanceKeyModifiersDefaultsKey)
         userDefaults.set(label, forKey: Self.fullAcceptanceKeyLabelDefaultsKey)
     }
 
     func clearFullAcceptanceKey() {
-        setFullAcceptanceKey(keyCode: Self.disabledKeyCode, label: Self.disabledKeyLabel)
+        setFullAcceptanceKey(keyCode: Self.disabledKeyCode, modifiers: [], label: Self.disabledKeyLabel)
     }
 
     private func persistSelectedEngine(_ engine: SuggestionEngineKind) {

--- a/Cotabby/Services/Input/InputMonitor.swift
+++ b/Cotabby/Services/Input/InputMonitor.swift
@@ -28,8 +28,14 @@ final class InputMonitor {
     /// Combine delivery lag between settings changes and the event classifier.
     var acceptanceKeyCodeProvider: @MainActor () -> CGKeyCode = { 48 }
 
+    /// Modifier mask required alongside the word-accept key code. Empty means the bare key.
+    var acceptanceKeyModifiersProvider: @MainActor () -> ShortcutModifierMask = { [] }
+
     /// Reads the current full-accept key code from the model at event time.
     var fullAcceptanceKeyCodeProvider: @MainActor () -> CGKeyCode = { CGKeyCode(UInt16.max) }
+
+    /// Modifier mask required alongside the full-accept key code. Empty means the bare key.
+    var fullAcceptanceKeyModifiersProvider: @MainActor () -> ShortcutModifierMask = { [] }
 
     /// When false, the observer passes keystrokes through without classifying or notifying the
     /// coordinator. This eliminates per-keystroke overhead in apps where Cotabby will never act
@@ -261,13 +267,16 @@ final class InputMonitor {
             }
 
             let keyCode = CGKeyCode(event.getIntegerValueField(.keyboardEventKeycode))
-            let flags = event.flags
-            let noModifiers = flags.isDisjoint(with: [.maskCommand, .maskControl, .maskAlternate, .maskShift])
-            guard noModifiers else {
-                return Unmanaged.passUnretained(event)
-            }
+            // Normalize to just the four bits we honor — caps lock, fn, numeric pad, and device
+            // flags must not influence shortcut equality.
+            let eventModifiers = ShortcutModifierMask(eventFlags: event.flags)
 
-            if keyCode == fullAcceptanceKeyCodeProvider() || keyCode == acceptanceKeyCodeProvider() {
+            let fullAcceptMatches = keyCode == fullAcceptanceKeyCodeProvider()
+                && eventModifiers == fullAcceptanceKeyModifiersProvider()
+            let acceptMatches = keyCode == acceptanceKeyCodeProvider()
+                && eventModifiers == acceptanceKeyModifiersProvider()
+
+            if fullAcceptMatches || acceptMatches {
                 return nil
             }
             return Unmanaged.passUnretained(event)
@@ -283,19 +292,27 @@ final class InputMonitor {
         let flags = event.flags
         let characters = event.unicodeString
 
-        let noModifiers = flags.isDisjoint(with: [.maskCommand, .maskControl, .maskAlternate, .maskShift])
+        // Normalize to just the four bits we care about — `CGEventFlags` also carries caps lock,
+        // numeric pad, secondary fn, and device flags that must not influence shortcut equality.
+        let eventModifiers = ShortcutModifierMask(eventFlags: flags)
 
-        // Read key codes from the model at event time so changes are always current.
+        // Read shortcut state from the model at event time so changes are always current.
         let fullAcceptKey = fullAcceptanceKeyCodeProvider()
+        let fullAcceptModifiers = fullAcceptanceKeyModifiersProvider()
         let acceptKey = acceptanceKeyCodeProvider()
+        let acceptModifiers = acceptanceKeyModifiersProvider()
 
         // Full-suggestion acceptance takes priority so pressing the full-accept key
         // doesn't silently fall through to word-accept when both are assigned.
-        if keyCode == fullAcceptKey, noModifiers {
+        // The acceptance checks run before the Command-key branch below so a binding like
+        // `⌘Tab` is classified as acceptance instead of being eaten by the shortcutMutation
+        // path. The bound modifier set must match the masked event modifiers exactly, so
+        // `Tab` and `⇧Tab` are distinct bindings and neither one triggers the other.
+        if keyCode == fullAcceptKey, eventModifiers == fullAcceptModifiers {
             return CapturedInputEvent(kind: .fullAcceptance, keyCode: keyCode, characters: characters, flags: flags)
         }
 
-        if keyCode == acceptKey, noModifiers {
+        if keyCode == acceptKey, eventModifiers == acceptModifiers {
             return CapturedInputEvent(kind: .acceptance, keyCode: keyCode, characters: characters, flags: flags)
         }
 

--- a/Cotabby/Support/KeyCodeLabels.swift
+++ b/Cotabby/Support/KeyCodeLabels.swift
@@ -20,13 +20,47 @@ enum KeyCodeLabels {
         101: "F9", 109: "F10", 103: "F11", 111: "F12"
     ]
 
+    /// Best-effort labels for keys that exist on ISO/JIS layouts but produce no useful
+    /// glyph via `charactersIgnoringModifiers` (dead keys, layout-specific physical keys).
+    /// Used only when the fallback string is empty, so US-ANSI users never see these.
+    private static let physicalKeyDescriptions: [CGKeyCode: String] = [
+        10: "Key above Tab",
+        50: "Key above Tab",
+        93: "Key beside Right Shift"
+    ]
+
     static func label(for keyCode: CGKeyCode, fallback: String?) -> String {
         if let special = specialKeys[keyCode] {
             return special
         }
-        if let chars = fallback, !chars.isEmpty {
+        if let chars = fallback?.trimmingCharacters(in: .whitespacesAndNewlines), !chars.isEmpty {
             return chars.uppercased()
         }
+        if let physical = physicalKeyDescriptions[keyCode] {
+            return physical
+        }
         return "Key \(keyCode)"
+    }
+
+    /// Builds the full shortcut label users see in the settings keycap and the ghost-text
+    /// hint pill: `"⌥ Tab"`, `"⇧ ⌘ Space"`, or just `"Tab"` when no modifiers are bound.
+    /// Glyph ordering matches macOS convention (Control, Option, Shift, Command).
+    static func label(
+        for keyCode: CGKeyCode,
+        modifiers: ShortcutModifierMask,
+        fallback: String?
+    ) -> String {
+        let keyLabel = label(for: keyCode, fallback: fallback)
+        let glyphs = modifierGlyphs(modifiers)
+        return glyphs.isEmpty ? keyLabel : "\(glyphs) \(keyLabel)"
+    }
+
+    static func modifierGlyphs(_ modifiers: ShortcutModifierMask) -> String {
+        var result = ""
+        if modifiers.contains(.control) { result.append("⌃") }
+        if modifiers.contains(.option) { result.append("⌥") }
+        if modifiers.contains(.shift) { result.append("⇧") }
+        if modifiers.contains(.command) { result.append("⌘") }
+        return result
     }
 }

--- a/Cotabby/UI/KeyRecorderView.swift
+++ b/Cotabby/UI/KeyRecorderView.swift
@@ -1,48 +1,84 @@
 import ApplicationServices
 import SwiftUI
 
-/// A small inline view that captures the next keypress and reports its key code and label.
-/// Installs an `NSEvent` local monitor on appear and removes it on disappear or capture,
-/// so no leaked monitors accumulate.
+/// A small inline view that captures the next keypress and reports its key code, modifier mask,
+/// and a display label. Installs `NSEvent` local monitors on appear and removes them on disappear
+/// or capture, so no leaked monitors accumulate.
+///
+/// The recorder supports modifier combinations (e.g. `⇧Tab`, `⌥`+key-above-Tab). A live preview
+/// of pressed modifiers is shown via `.flagsChanged` so the user sees they're holding `⌘⇧` before
+/// they commit to a key.
 struct KeyRecorderView: View {
-    let onKeyRecorded: (CGKeyCode, String) -> Void
+    let onKeyRecorded: (CGKeyCode, ShortcutModifierMask, String) -> Void
     var onCancelled: (() -> Void)?
 
     @State private var monitor: Any?
+    @State private var liveModifiers: ShortcutModifierMask = []
 
     var body: some View {
-        Text("Press a key…")
+        Text(promptText)
             .foregroundStyle(.secondary)
             .onAppear { installMonitor() }
             .onDisappear { removeMonitor() }
     }
 
+    private var promptText: String {
+        let glyphs = KeyCodeLabels.modifierGlyphs(liveModifiers)
+        return glyphs.isEmpty ? "Press a key…" : "\(glyphs) + key…"
+    }
+
     private func installMonitor() {
         removeMonitor()
-        monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [self] event in
-            let keyCode = event.keyCode
+        liveModifiers = []
+        monitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown, .flagsChanged]) { [self] event in
+            handle(event: event)
+        }
+    }
 
-            // Escape cancels recording rather than binding, so it stays the universal "get me out"
-            // affordance. This is the recorder's only keyboard cancel, not a pipeline restriction.
-            if keyCode == 53 {
-                removeMonitor()
-                onCancelled?()
-                return nil
-            }
-
-            // Any other key is fair game. The pipeline is key-agnostic: `InputMonitor.classify`
-            // matches the bound accept key before its behavioral branches, and acceptance only
-            // consumes the key while a suggestion is visible (otherwise it passes through and does
-            // its normal job). So even Return/Delete are safe to bind — they only intercept in the
-            // moment a suggestion is showing.
-            let label = KeyCodeLabels.label(
-                for: CGKeyCode(keyCode),
-                fallback: event.charactersIgnoringModifiers
-            )
-            removeMonitor()
-            onKeyRecorded(CGKeyCode(keyCode), label)
+    private func handle(event: NSEvent) -> NSEvent? {
+        if event.type == .flagsChanged {
+            liveModifiers = ShortcutModifierMask(nsEventFlags: event.modifierFlags)
             return nil
         }
+
+        guard event.type == .keyDown else { return event }
+
+        let keyCode = CGKeyCode(event.keyCode)
+        let modifiers = ShortcutModifierMask(nsEventFlags: event.modifierFlags)
+
+        // Plain Escape stays the universal "get me out" affordance. With any modifier held,
+        // Escape becomes a bindable shortcut (e.g. `⌘Escape`) instead of cancelling — so users
+        // who want it can still reach it.
+        if keyCode == 53, modifiers.isEmpty {
+            removeMonitor()
+            onCancelled?()
+            return nil
+        }
+
+        // Any other key is fair game. The pipeline is key-agnostic: `InputMonitor.classify`
+        // matches the bound shortcut before its behavioral branches, and acceptance only
+        // consumes the key while a suggestion is visible (otherwise it passes through and does
+        // its normal job). So even Return/Delete or `⌘V` are safe to bind — they only intercept
+        // in the moment a suggestion is showing.
+        let label = KeyCodeLabels.label(
+            for: keyCode,
+            modifiers: modifiers,
+            // Use `characters` ahead of `charactersIgnoringModifiers` so we still get a readable
+            // glyph for keys whose first level is a dead key (e.g. `^` on German QWERTZ). When
+            // both are empty, `KeyCodeLabels` falls back to a physical-position description.
+            fallback: bestCharacterFallback(for: event)
+        )
+        removeMonitor()
+        onKeyRecorded(keyCode, modifiers, label)
+        return nil
+    }
+
+    private func bestCharacterFallback(for event: NSEvent) -> String? {
+        if let ignoring = event.charactersIgnoringModifiers,
+           !ignoring.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return ignoring
+        }
+        return event.characters
     }
 
     private func removeMonitor() {
@@ -50,5 +86,18 @@ struct KeyRecorderView: View {
             NSEvent.removeMonitor(monitor)
         }
         monitor = nil
+    }
+}
+
+extension ShortcutModifierMask {
+    /// Bridges `NSEvent.ModifierFlags` (used by the recorder's local monitor) into the same
+    /// 4-bit shape we store. Mirrors `init(eventFlags:)` but for the AppKit flavour of flags.
+    init(nsEventFlags: NSEvent.ModifierFlags) {
+        var mask: ShortcutModifierMask = []
+        if nsEventFlags.contains(.command) { mask.insert(.command) }
+        if nsEventFlags.contains(.shift) { mask.insert(.shift) }
+        if nsEventFlags.contains(.option) { mask.insert(.option) }
+        if nsEventFlags.contains(.control) { mask.insert(.control) }
+        self = mask
     }
 }

--- a/Cotabby/UI/SettingsView.swift
+++ b/Cotabby/UI/SettingsView.swift
@@ -332,8 +332,12 @@ struct SettingsView: View {
 
                     if isRecordingKeybind {
                         KeyRecorderView(
-                            onKeyRecorded: { keyCode, label in
-                                suggestionSettings.setAcceptanceKey(keyCode: keyCode, label: label)
+                            onKeyRecorded: { keyCode, modifiers, label in
+                                suggestionSettings.setAcceptanceKey(
+                                    keyCode: keyCode,
+                                    modifiers: modifiers,
+                                    label: label
+                                )
                                 isRecordingKeybind = false
                             },
                             onCancelled: {
@@ -344,13 +348,15 @@ struct SettingsView: View {
                         Button("Change") {
                             isRecordingKeybind = true
                         }
-                        .help("Record a new key. Press any key to bind it; Escape to cancel.")
+                        .help("Record a new shortcut. Hold any modifiers and press a key to bind it; Escape to cancel.")
                     }
 
-                    if suggestionSettings.acceptanceKeyCode != SuggestionSettingsModel.defaultAcceptanceKeyCode {
+                    if suggestionSettings.acceptanceKeyCode != SuggestionSettingsModel.defaultAcceptanceKeyCode
+                        || !suggestionSettings.acceptanceKeyModifiers.isEmpty {
                         Button("Reset") {
                             suggestionSettings.setAcceptanceKey(
                                 keyCode: SuggestionSettingsModel.defaultAcceptanceKeyCode,
+                                modifiers: [],
                                 label: SuggestionSettingsModel.defaultAcceptanceKeyLabel
                             )
                             isRecordingKeybind = false
@@ -381,8 +387,12 @@ struct SettingsView: View {
 
                     if isRecordingFullAcceptKeybind {
                         KeyRecorderView(
-                            onKeyRecorded: { keyCode, label in
-                                suggestionSettings.setFullAcceptanceKey(keyCode: keyCode, label: label)
+                            onKeyRecorded: { keyCode, modifiers, label in
+                                suggestionSettings.setFullAcceptanceKey(
+                                    keyCode: keyCode,
+                                    modifiers: modifiers,
+                                    label: label
+                                )
                                 isRecordingFullAcceptKeybind = false
                             },
                             onCancelled: {
@@ -393,13 +403,15 @@ struct SettingsView: View {
                         Button("Change") {
                             isRecordingFullAcceptKeybind = true
                         }
-                        .help("Record a new key. Press any key to bind it; Escape to cancel.")
+                        .help("Record a new shortcut. Hold any modifiers and press a key to bind it; Escape to cancel.")
                     }
 
-                    if suggestionSettings.fullAcceptanceKeyCode != SuggestionSettingsModel.defaultFullAcceptanceKeyCode {
+                    if suggestionSettings.fullAcceptanceKeyCode != SuggestionSettingsModel.defaultFullAcceptanceKeyCode
+                        || !suggestionSettings.fullAcceptanceKeyModifiers.isEmpty {
                         Button("Reset") {
                             suggestionSettings.setFullAcceptanceKey(
                                 keyCode: SuggestionSettingsModel.defaultFullAcceptanceKeyCode,
+                                modifiers: [],
                                 label: SuggestionSettingsModel.defaultFullAcceptanceKeyLabel
                             )
                             isRecordingFullAcceptKeybind = false

--- a/Cotabby/UI/WelcomeView.swift
+++ b/Cotabby/UI/WelcomeView.swift
@@ -303,12 +303,20 @@ extension WelcomeView {
                     title: "Accept Word",
                     keyLabel: suggestionSettings.acceptanceKeyLabel,
                     isRecording: $isRecordingOnboardingKeybind,
-                    onKeyRecorded: { keyCode, label in
-                        suggestionSettings.setAcceptanceKey(keyCode: keyCode, label: label)
+                    onKeyRecorded: { keyCode, modifiers, label in
+                        suggestionSettings.setAcceptanceKey(
+                            keyCode: keyCode,
+                            modifiers: modifiers,
+                            label: label
+                        )
                     },
-                    onReset: suggestionSettings.acceptanceKeyCode != SuggestionSettingsModel.defaultAcceptanceKeyCode ? {
+                    onReset: (
+                        suggestionSettings.acceptanceKeyCode != SuggestionSettingsModel.defaultAcceptanceKeyCode
+                            || !suggestionSettings.acceptanceKeyModifiers.isEmpty
+                    ) ? {
                         suggestionSettings.setAcceptanceKey(
                             keyCode: SuggestionSettingsModel.defaultAcceptanceKeyCode,
+                            modifiers: [],
                             label: SuggestionSettingsModel.defaultAcceptanceKeyLabel
                         )
                     } : nil
@@ -318,12 +326,20 @@ extension WelcomeView {
                     title: "Accept Entire Suggestion",
                     keyLabel: suggestionSettings.fullAcceptanceKeyLabel,
                     isRecording: $isRecordingOnboardingFullAcceptKeybind,
-                    onKeyRecorded: { keyCode, label in
-                        suggestionSettings.setFullAcceptanceKey(keyCode: keyCode, label: label)
+                    onKeyRecorded: { keyCode, modifiers, label in
+                        suggestionSettings.setFullAcceptanceKey(
+                            keyCode: keyCode,
+                            modifiers: modifiers,
+                            label: label
+                        )
                     },
-                    onReset: suggestionSettings.fullAcceptanceKeyCode != SuggestionSettingsModel.defaultFullAcceptanceKeyCode ? {
+                    onReset: (
+                        suggestionSettings.fullAcceptanceKeyCode != SuggestionSettingsModel.defaultFullAcceptanceKeyCode
+                            || !suggestionSettings.fullAcceptanceKeyModifiers.isEmpty
+                    ) ? {
                         suggestionSettings.setFullAcceptanceKey(
                             keyCode: SuggestionSettingsModel.defaultFullAcceptanceKeyCode,
+                            modifiers: [],
                             label: SuggestionSettingsModel.defaultFullAcceptanceKeyLabel
                         )
                     } : nil
@@ -344,7 +360,7 @@ extension WelcomeView {
         title: String,
         keyLabel: String,
         isRecording: Binding<Bool>,
-        onKeyRecorded: @escaping (CGKeyCode, String) -> Void,
+        onKeyRecorded: @escaping (CGKeyCode, ShortcutModifierMask, String) -> Void,
         onReset: (() -> Void)? = nil
     ) -> some View {
         VStack(spacing: 6) {
@@ -364,8 +380,8 @@ extension WelcomeView {
 
                 if isRecording.wrappedValue {
                     KeyRecorderView(
-                        onKeyRecorded: { keyCode, label in
-                            onKeyRecorded(keyCode, label)
+                        onKeyRecorded: { keyCode, modifiers, label in
+                            onKeyRecorded(keyCode, modifiers, label)
                             isRecording.wrappedValue = false
                         },
                         onCancelled: {

--- a/CotabbyTests/SuggestionAvailabilityEvaluatorTests.swift
+++ b/CotabbyTests/SuggestionAvailabilityEvaluatorTests.swift
@@ -597,7 +597,7 @@ final class SuggestionSettingsModelDisabledAppsTests: XCTestCase {
         runOnMainActor {
             let model = makeModel()
 
-            model.setAcceptanceKey(keyCode: 49, label: "Space")
+            model.setAcceptanceKey(keyCode: 49, modifiers: [], label: "Space")
             XCTAssertEqual(model.acceptanceHintLabel, "Space", "Hint should follow the rebound word-accept key")
 
             // Clearing word-accept should fall back to the still-bound full-accept key.


### PR DESCRIPTION
## Summary

Adds modifier-key support to the word-accept and full-accept shortcuts, so users can bind combinations like ⇧Tab, ⌥Tab, or ⌃Space instead of only bare keys. Also fixes the related non-English-keyboard symptom in #326 where dead keys above Tab rendered as `"Key 10"` in the recorder.

## Validation

```
swiftlint lint --quiet
# exit 0, no new warnings (three pre-existing warnings in FocusTracker.swift and
# SuggestionCoordinator+Input.swift unchanged on main)

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby \
  -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby \
  -destination 'platform=macOS' build-for-testing
# ** TEST BUILD SUCCEEDED **
```

Local `test` execution hits the documented Team ID / signing mismatch (CLAUDE.md flags this as an environment issue, not a code failure); `build-for-testing` is the fallback as described there. Did not run the app end-to-end in a browser since this is a global keyboard-tap change; the build outputs sign and link cleanly.

## Linked issues

Fixes #326

## Risk / rollout notes

- **UserDefaults migration is invisible.** Two new keys (`cotabbyAcceptanceKeyModifiers`, `cotabbyFullAcceptanceKeyModifiers`) default to `0` when absent, so existing installs keep their bare-Tab / bare-backtick bindings without prompting. No reset needed.
- **Conflict-clearing semantics changed.** Word-accept and full-accept now compare the full `(keyCode, modifiers)` tuple, so `Tab` and `⇧Tab` can coexist (the old code would have cleared one when the other was assigned to the same key code). Worth a mental note for reviewers.
- **Aggressive bindings can shadow user shortcuts.** Binding `⌘V` to accept will intercept paste while a suggestion is showing. The recorder's docstring already acknowledges this for bare keys; modifiers don't change the shape, only the surface. macOS-reserved combos (⌘Tab, ⌘Space) are still bindable but won't fire in practice — no warning added for this v1.
- **No new tests beyond fixing one stale call site.** `SuggestionAvailabilityEvaluatorTests` had a `setAcceptanceKey(keyCode:label:)` call that needed `modifiers:` added. Worth a follow-up to add round-trip storage tests for `ShortcutModifierMask` and glyph-composition tests for `KeyCodeLabels.label(for:modifiers:fallback:)`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends Cotabby's word-accept and full-accept shortcuts to support modifier-key combinations (⇧Tab, ⌥Tab, ⌃Space, etc.) and fixes the non-English keyboard label issue (#326) where dead keys above Tab displayed as `\"Key 10\"`.

- Introduces `ShortcutModifierMask` (a 4-bit `OptionSet`) to normalize `CGEventFlags` / `NSEvent.ModifierFlags`, and threads it through settings storage, the `InputMonitor` event tap, the `KeyRecorderView` (with a live modifier preview via `.flagsChanged`), and both UI flows (Settings + Welcome).
- Conflict-clearing semantics change from key-code-only to a full `(keyCode, modifiers)` tuple, so `Tab` and `⇧Tab` can coexist as distinct bindings; migration is invisible since the new `cotabbyAcceptanceKeyModifiers` / `cotabbyFullAcceptanceKeyModifiers` UserDefaults keys default to `0`.
- `KeyCodeLabels` gains `physicalKeyDescriptions` for ISO/JIS dead-key positions and a new `label(for:modifiers:fallback:)` overload that composes modifier glyphs in macOS convention order (⌃⌥⇧⌘).

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core shortcut-matching and persistence logic is well-structured with no functional defects.

The KeyRecorderView returns nil for flagsChanged events while recording, which silently drops those events from the rest of the app's responder chain. The mismatched comment in bestCharacterFallback also slightly increases maintenance risk for the dead-key handling path. Neither issue blocks correctness today, but they are worth cleaning up before the recorder sees wider use.

Cotabby/UI/KeyRecorderView.swift — the flagsChanged consumption and comment mismatch both live here.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Models/InputModels.swift | Adds ShortcutModifierMask OptionSet that normalises CGEventFlags to the four modifier bits used for shortcut matching; clean design with no issues. |
| Cotabby/Models/SuggestionSettingsModel.swift | Adds acceptanceKeyModifiers / fullAcceptanceKeyModifiers with UserDefaults persistence (default 0 for migration safety); conflict-clearing updated to full (keyCode, modifiers) tuple comparison; no issues. |
| Cotabby/Services/Input/InputMonitor.swift | Replaces noModifiers guard with exact ShortcutModifierMask comparison in both the CGEvent tap and the classify path; acceptance checks correctly precede the Command-key branch. |
| Cotabby/Support/KeyCodeLabels.swift | Adds modifierGlyphs, a new label(for:modifiers:fallback:) overload, and physicalKeyDescriptions for ISO dead keys; modifier ordering matches macOS convention; no issues. |
| Cotabby/UI/KeyRecorderView.swift | Adds .flagsChanged monitoring for live modifier preview; flagsChanged events are consumed (return nil) which suppresses them from the rest of the app while recording; comment in handle also inverts the priority order described for bestCharacterFallback. |
| Cotabby/UI/SettingsView.swift | Threads modifiers through KeyRecorderView callbacks and updates Reset button visibility to also check modifier non-emptiness; straightforward and correct. |
| Cotabby/UI/WelcomeView.swift | Mirrors SettingsView changes for the onboarding flow; no issues. |
| Cotabby/App/Core/CotabbyAppEnvironment.swift | Wires acceptanceKeyModifiersProvider and fullAcceptanceKeyModifiersProvider onto InputMonitor; minimal and correct. |
| CotabbyTests/SuggestionAvailabilityEvaluatorTests.swift | Updates one stale setAcceptanceKey call site to include the new modifiers: parameter; no issues. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant KRV as KeyRecorderView
    participant SSM as SuggestionSettingsModel
    participant UD as UserDefaults
    participant IM as InputMonitor (CGEvent tap)

    U->>KRV: Hold modifier key
    KRV->>KRV: flagsChanged → liveModifiers updated

    U->>KRV: Press key (e.g. Tab)
    KRV->>KRV: build ShortcutModifierMask from NSEvent.modifierFlags
    KRV->>KRV: bestCharacterFallback → label via KeyCodeLabels
    KRV->>SSM: setAcceptanceKey(keyCode, modifiers, label)
    SSM->>SSM: normalise modifiers ([] if disabledKeyCode)
    SSM->>SSM: "conflict-clear if (keyCode, modifiers) == fullAccept binding"
    SSM->>UD: persist keyCode + modifiers.rawValue + label

    note over IM: At keypress time
    IM->>SSM: acceptanceKeyCodeProvider()
    IM->>SSM: acceptanceKeyModifiersProvider()
    IM->>IM: ShortcutModifierMask(eventFlags:) from CGEvent.flags
    alt exact (keyCode, modifiers) match
        IM-->>U: return nil (consume event)
    else no match
        IM-->>U: passUnretained (event passes through)
    end
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fmulti-key-shortcuts%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fmulti-key-shortcuts%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FKeyRecorderView.swift%3A63-70%0AThe%20inline%20comment%20says%20%22Use%20%60characters%60%20ahead%20of%20%60charactersIgnoringModifiers%60%22%2C%20but%20the%20implementation%20checks%20%60charactersIgnoringModifiers%60%20first%20and%20only%20falls%20back%20to%20%60characters%60.%20The%20code%20logic%20is%20correct%20for%20the%20dead-key%20use%20case%20%28you%20want%20the%20unmodified%20character%20when%20available%29%2C%20but%20the%20comment%20contradicts%20it%20and%20could%20mislead%20the%20next%20person%20maintaining%20this%20function.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20label%20%3D%20KeyCodeLabels.label%28%0A%20%20%20%20%20%20%20%20%20%20%20%20for%3A%20keyCode%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20modifiers%3A%20modifiers%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Prefer%20%60charactersIgnoringModifiers%60%20for%20a%20stable%20key%20label%3B%20fall%20back%20to%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20%60characters%60%20for%20keys%20whose%20unmodified%20level%20is%20a%20dead%20key%20%28e.g.%20%60%5E%60%20on%20German%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20QWERTZ%29.%20When%20both%20are%20empty%2C%20%60KeyCodeLabels%60%20falls%20back%20to%20a%20physical-position%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20description.%0A%20%20%20%20%20%20%20%20%20%20%20%20fallback%3A%20bestCharacterFallback%28for%3A%20event%29%0A%20%20%20%20%20%20%20%20%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FUI%2FKeyRecorderView.swift%3A39-42%0A**%60flagsChanged%60%20events%20consumed%20while%20recording**%0A%0AThe%20handler%20returns%20%60nil%60%20for%20every%20%60flagsChanged%60%20event%2C%20which%20drops%20those%20events%20from%20the%20local%20responder%20chain%20for%20the%20entire%20Cotabby%20app%20while%20recording%20is%20active.%20SwiftUI's%20own%20environment%20modifier%20tracking%20%28%60%5C.eventModifiers%60%29%20relies%20on%20%60flagsChanged%60%20to%20stay%20current%2C%20so%20any%20view%20in%20the%20app%20that%20conditionally%20adjusts%20its%20appearance%20on%20modifier%20state%20won't%20update%20until%20the%20recorder%20disappears%20and%20the%20monitor%20is%20removed.%20The%20fix%20is%20straightforward%3A%20pass%20the%20%60flagsChanged%60%20event%20through%20after%20reading%20the%20modifiers%20from%20it.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FKeyRecorderView.swift%3A63-70%0AThe%20inline%20comment%20says%20%22Use%20%60characters%60%20ahead%20of%20%60charactersIgnoringModifiers%60%22%2C%20but%20the%20implementation%20checks%20%60charactersIgnoringModifiers%60%20first%20and%20only%20falls%20back%20to%20%60characters%60.%20The%20code%20logic%20is%20correct%20for%20the%20dead-key%20use%20case%20%28you%20want%20the%20unmodified%20character%20when%20available%29%2C%20but%20the%20comment%20contradicts%20it%20and%20could%20mislead%20the%20next%20person%20maintaining%20this%20function.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20label%20%3D%20KeyCodeLabels.label%28%0A%20%20%20%20%20%20%20%20%20%20%20%20for%3A%20keyCode%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20modifiers%3A%20modifiers%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Prefer%20%60charactersIgnoringModifiers%60%20for%20a%20stable%20key%20label%3B%20fall%20back%20to%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20%60characters%60%20for%20keys%20whose%20unmodified%20level%20is%20a%20dead%20key%20%28e.g.%20%60%5E%60%20on%20German%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20QWERTZ%29.%20When%20both%20are%20empty%2C%20%60KeyCodeLabels%60%20falls%20back%20to%20a%20physical-position%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20description.%0A%20%20%20%20%20%20%20%20%20%20%20%20fallback%3A%20bestCharacterFallback%28for%3A%20event%29%0A%20%20%20%20%20%20%20%20%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FUI%2FKeyRecorderView.swift%3A39-42%0A**%60flagsChanged%60%20events%20consumed%20while%20recording**%0A%0AThe%20handler%20returns%20%60nil%60%20for%20every%20%60flagsChanged%60%20event%2C%20which%20drops%20those%20events%20from%20the%20local%20responder%20chain%20for%20the%20entire%20Cotabby%20app%20while%20recording%20is%20active.%20SwiftUI's%20own%20environment%20modifier%20tracking%20%28%60%5C.eventModifiers%60%29%20relies%20on%20%60flagsChanged%60%20to%20stay%20current%2C%20so%20any%20view%20in%20the%20app%20that%20conditionally%20adjusts%20its%20appearance%20on%20modifier%20state%20won't%20update%20until%20the%20recorder%20disappears%20and%20the%20monitor%20is%20removed.%20The%20fix%20is%20straightforward%3A%20pass%20the%20%60flagsChanged%60%20event%20through%20after%20reading%20the%20modifiers%20from%20it.%0A%0A&repo=fujacob%2Fcotabby&pr=341&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Allow modifier keys in accept shortcuts ..."](https://github.com/fujacob/cotabby/commit/acd4937f19b1343e2202e72d48d0ea39631f9271) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34326100)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->