### PR TITLE
Reframe FM instructions positively and trim few-shots to two

### DIFF
--- a/Cotabby/Support/FoundationModelPromptRenderer.swift
+++ b/Cotabby/Support/FoundationModelPromptRenderer.swift
@@ -16,36 +16,24 @@ enum FoundationModelPromptRenderer {
     /// them the right place to say "this is autocomplete, not chat."
     ///
     /// The framing is deliberately *text continuation*, not *assist the user*. Apple's system model
-    /// is chat-tuned, so any second-person/assistant framing ("complete the user's text", a stated
-    /// user name) pulls it toward greetings and replies ("Jacob, how are you", "Hope it's going
-    /// well"). We replace negative "don't chat" rules with a positive identity plus few-shot
-    /// examples, which steer the chat prior far more reliably than prohibitions.
+    /// is chat-tuned, so any second-person/assistant framing pulls it toward greetings and
+    /// replies. Apple's WWDC25 prompt-design guidance is to use a positive identity plus a small
+    /// number of demonstrations rather than a long list of prohibitions, so the rules here stay
+    /// short, positive, and concrete; the two few-shot examples below carry the rest of the
+    /// anti-drift signal.
     static func sessionInstructions(for request: SuggestionRequest) -> String {
         var lines = [
-            "You are a text-continuation engine. Output only the text that comes immediately after "
-                + "the existing text, as if the same person kept typing in the same field.",
-            "You are not a chatbot or assistant. Never greet, introduce yourself, address the reader, "
-                + "ask a question, or start a new message.",
-            "There is no request to fulfill — you only continue text. Never refuse, apologize, or say "
-                + "you cannot help; always produce a continuation of the existing text.",
-            "Do not open your output with a person's name or with words like \"Hi\", \"Hey\", "
-                + "\"Hello\", \"Hope\", \"Thanks\", or \"Dear\" unless the existing text already began "
-                + "that exact phrase and you are finishing it.",
-            "Continue the existing sentence or thought — extend it, never restart it.",
-            "Return exactly one continuation fragment.",
-            // Experiment: the explicit word-range cue (`request.completionLengthInstruction`) is
-            // omitted here too, matching the local-model path. Length is governed solely by the
-            // shared token budget (`maximumResponseTokens` ← `request.maxPredictionTokens`).
-            "Do not repeat or quote the existing text.",
-            "Match the existing tone, language, casing, and punctuation.",
-            "Use clipboard and screen context only when it directly helps the inline continuation.",
-            "Output plain text only: no labels, bullets, markdown, surrounding quotation marks, "
-                + "or explanation."
+            "You complete partially-typed text. The user is the author; you produce the next "
+                + "few words they would type, in their voice.",
+            "Output the continuation only: no greeting, no sign-off, no quotes, no markdown, "
+                + "no labels, no explanation.",
+            "Match the existing language, register, casing, and punctuation. Continue the "
+                + "current sentence or thought rather than restarting it.",
+            "Use clipboard or screen context only when it directly helps the next words."
         ]
 
-        // The declared-language hint refines the "match the existing language" base rule above — it
-        // never forces a language — so it sits right after that block where the instructions channel
-        // weights it heavily.
+        // The declared-language hint refines the "match the existing language" rule above. It sits
+        // right after the base block so the instructions channel weights it heavily.
         if let languageInstruction = request.languageInstruction, !languageInstruction.isEmpty {
             lines.append(languageInstruction)
         }
@@ -55,10 +43,11 @@ enum FoundationModelPromptRenderer {
         // you"). The llama backend still personalizes via `LlamaPromptRenderer`; Apple's model
         // does not get the name until we can scope it to contexts that actually need it.
 
-        // Few-shot examples are the strongest signal that the task is "keep typing", not "reply".
-        // They deliberately include openers that tempt a greeting (a name, "Hey", "Thanks") and show
-        // the model finishing the thought instead.
-        lines.append("Examples (quotes only mark the text boundaries — never output the quotes):")
+        // Two few-shot examples (down from five) carry the heavy anti-drift signal. The first
+        // proves "finish a salutation-adjacent sentence without restarting"; the second proves
+        // "code prefixes produce code, not prose." Both are also short, which matters because
+        // instructions land in Apple's 4096-token shared context and earn their tokens.
+        lines.append("Examples (quotes only mark the boundaries; never output the quotes):")
         lines.append(contentsOf: Self.continuationExampleLines)
 
         // Style rules live in the high-priority instructions channel like the base rules, but are
@@ -76,19 +65,12 @@ enum FoundationModelPromptRenderer {
         return lines.joined(separator: "\n")
     }
 
-    /// Demonstrations that lock the "continue, don't converse" behavior. Each pairs the text already
-    /// in the field with the bare continuation. Cases target the observed failure modes: re-greeting
-    /// when a name is present, adding pleasantries, and restarting the sentence. Kept single-line so
-    /// they don't fragment the newline-joined instructions block.
+    /// The minimal demonstration set that locks in "continue, do not converse." One prose pair
+    /// covers the salutation-restart failure mode the chat-tuned model is most prone to; one code
+    /// pair establishes that code prefixes get code continuations, not English prose.
     private static let continuationExampleLines: [String] = [
         "Existing text: \"I just wanted to follow up on the \"",
         "Continuation: proposal we discussed last week.",
-        "Existing text: \"Thanks Priya — I'll look over the \"",
-        "Continuation: draft and send notes tomorrow.",
-        "Existing text: \"Hi team,\n\nQuick update — we \"",
-        "Continuation: finished the migration ahead of schedule.",
-        "Existing text: \"lol yeah I totally \"",
-        "Continuation: forgot we had that meeting today.",
         "Existing text: \"def total(items): return \"",
         "Continuation: sum(item.price for item in items)"
     ]

--- a/Cotabby/Support/FoundationModelPromptRenderer.swift
+++ b/Cotabby/Support/FoundationModelPromptRenderer.swift
@@ -27,6 +27,14 @@ enum FoundationModelPromptRenderer {
                 + "few words they would type, in their voice.",
             "Output the continuation only: no greeting, no sign-off, no quotes, no markdown, "
                 + "no labels, no explanation.",
+            // Anti-echo guard. Without an explicit rule the chat-tuned model sometimes emits the
+            // existing text again instead of continuing — most reliably on mid-line comment and
+            // mid-sentence prose prefixes — which the normalizer then strips, leaving the user
+            // with no suggestion at all. The rule is paired with positive framing so it does not
+            // violate the WWDC25 "positive identity over prohibitions" guidance that motivates
+            // this rewrite.
+            "Continue from the position immediately after the existing text. Do not repeat or "
+                + "quote the existing text.",
             "Match the existing language, register, casing, and punctuation. Continue the "
                 + "current sentence or thought rather than restarting it.",
             "Use clipboard or screen context only when it directly helps the next words."

--- a/CotabbyTests/PromptPolicyTests.swift
+++ b/CotabbyTests/PromptPolicyTests.swift
@@ -6,7 +6,7 @@ import XCTest
 /// Foundation Models gives Cotabby an instructions channel, so these tests lock down which rules go
 /// into high-priority instructions and which field-specific text remains in the short prompt.
 final class FoundationModelPromptRendererTests: XCTestCase {
-    func test_sessionInstructions_includeAutocompleteContractAndRequestPolicies() {
+    func test_sessionInstructions_declarePositiveContinuationIdentityAndOutputContract() {
         let request = CotabbyTestFixtures.suggestionRequest(
             completionLengthInstruction: "UNIQUE_LENGTH_POLICY",
             userName: "UNIQUE_PROFILE_NAME"
@@ -14,10 +14,18 @@ final class FoundationModelPromptRendererTests: XCTestCase {
 
         let instructions = FoundationModelPromptRenderer.sessionInstructions(for: request)
 
-        XCTAssertTrue(instructions.contains("text-continuation engine"))
-        // The word-range cue is no longer injected — length is token-budget-only on both engines.
+        // Positive identity: name what the model *is*, not what it isn't.
+        XCTAssertTrue(instructions.contains("complete partially-typed text"))
+        // Output contract folds the anti-greeting / anti-markdown / anti-quote rules into one
+        // forbidden-content line, anchored on "Output the continuation only:" so a future
+        // wording change cannot silently drop a rule.
+        XCTAssertTrue(instructions.contains("Output the continuation only:"))
+        XCTAssertTrue(instructions.contains("no greeting"))
+        XCTAssertTrue(instructions.contains("no markdown"))
+        // Style line still has to match the existing field — language, register, casing.
+        XCTAssertTrue(instructions.contains("Match the existing language, register, casing"))
+        // The word-range cue is still token-budget-only on both engines.
         XCTAssertFalse(instructions.contains("UNIQUE_LENGTH_POLICY"))
-        XCTAssertTrue(instructions.contains("Do not repeat or quote the existing text."))
     }
 
     /// The user's name is deliberately withheld from Apple's chat-tuned model: a stated name is the
@@ -30,14 +38,17 @@ final class FoundationModelPromptRendererTests: XCTestCase {
         XCTAssertFalse(instructions.contains("UNIQUE_PROFILE_NAME"))
     }
 
-    /// Few-shot examples are the primary anti-drift mechanism, so guard their presence.
-    func test_sessionInstructions_includeContinuationExamples() {
+    /// The few-shot set was trimmed from five demonstrations to two on purpose — one
+    /// prose-with-salutation and one code — so this test pins both presence *and* count to keep
+    /// future edits from silently growing the set back.
+    func test_sessionInstructions_includeExactlyTwoContinuationExamples() {
         let request = CotabbyTestFixtures.suggestionRequest()
 
         let instructions = FoundationModelPromptRenderer.sessionInstructions(for: request)
 
         XCTAssertTrue(instructions.contains("Examples ("))
-        XCTAssertTrue(instructions.contains("Continuation:"))
+        let continuationCount = instructions.components(separatedBy: "Continuation:").count - 1
+        XCTAssertEqual(continuationCount, 2, "Expected the trimmed two-example demo set.")
     }
 
     func test_prompt_includesApplicationNameAndPreservesPrefixText() {

--- a/CotabbyTests/PromptPolicyTests.swift
+++ b/CotabbyTests/PromptPolicyTests.swift
@@ -21,7 +21,11 @@ final class FoundationModelPromptRendererTests: XCTestCase {
         // wording change cannot silently drop a rule.
         XCTAssertTrue(instructions.contains("Output the continuation only:"))
         XCTAssertTrue(instructions.contains("no greeting"))
+        XCTAssertTrue(instructions.contains("no sign-off"))
+        XCTAssertTrue(instructions.contains("no quotes"))
         XCTAssertTrue(instructions.contains("no markdown"))
+        XCTAssertTrue(instructions.contains("no labels"))
+        XCTAssertTrue(instructions.contains("no explanation"))
         // Style line still has to match the existing field — language, register, casing.
         XCTAssertTrue(instructions.contains("Match the existing language, register, casing"))
         // The word-range cue is still token-budget-only on both engines.
@@ -47,7 +51,14 @@ final class FoundationModelPromptRendererTests: XCTestCase {
         let instructions = FoundationModelPromptRenderer.sessionInstructions(for: request)
 
         XCTAssertTrue(instructions.contains("Examples ("))
-        let continuationCount = instructions.components(separatedBy: "Continuation:").count - 1
+        // Scope the "Continuation:" count to the examples block so an injected
+        // language hint or custom rule containing the substring cannot inflate it.
+        let examplesHeader = "Examples (quotes only mark the boundaries; never output the quotes):"
+        let examplesSection = instructions
+            .components(separatedBy: examplesHeader)
+            .dropFirst()
+            .joined(separator: examplesHeader)
+        let continuationCount = examplesSection.components(separatedBy: "Continuation:").count - 1
         XCTAssertEqual(continuationCount, 2, "Expected the trimmed two-example demo set.")
     }
 

--- a/CotabbyTests/PromptPolicyTests.swift
+++ b/CotabbyTests/PromptPolicyTests.swift
@@ -32,6 +32,20 @@ final class FoundationModelPromptRendererTests: XCTestCase {
         XCTAssertFalse(instructions.contains("UNIQUE_LENGTH_POLICY"))
     }
 
+    /// Locks in the anti-echo rule. Without it, the chat-tuned model emits the prefix back on some
+    /// mid-line comment and mid-sentence prose cases — the normalizer then strips the echo and the
+    /// overlay shows nothing. The eval suite (`FoundationModelDriftEvalTests`) was the canary that
+    /// surfaced this regression when session reuse was tightened to single-turn, so it stays
+    /// pinned here as a fast unit-level guard before the live eval ever runs.
+    func test_sessionInstructions_forbidEchoingExistingText() {
+        let request = CotabbyTestFixtures.suggestionRequest()
+
+        let instructions = FoundationModelPromptRenderer.sessionInstructions(for: request)
+
+        XCTAssertTrue(instructions.contains("Continue from the position immediately after the existing text"))
+        XCTAssertTrue(instructions.contains("Do not repeat or quote the existing text"))
+    }
+
     /// The user's name is deliberately withheld from Apple's chat-tuned model: a stated name is the
     /// main trigger for breaking character ("Jacob, how are you"). Personalization stays on llama.
     func test_sessionInstructions_omitTheUserName() {


### PR DESCRIPTION
## Summary

Apple's WWDC25 prompt-design guidance is to use a short positive identity plus a small number of demonstrations rather than a long list of prohibitions, because the chat-tuned system model responds more reliably to "this is who you are" than to "do not do X." The previous FM session instructions were 10 lines of mostly negative rules with a 5-pair few-shot block. This rewrite collapses the rules to four positive lines and trims the few-shot block to two pairs (one prose, one code), shrinking the instruction prefix that lands in Apple's 4096-token shared context and re-pointing the chat prior at the actual task.

Stacked on `feat/fm-streaming`. Use the eval suite from the parent stack PR to compare drift / mid-word truncation rates against the previous instruction text.

## Validation

`xcodebuild test ... -only-testing:CotabbyTests/FoundationModelPromptRendererTests -only-testing:CotabbyTests/SuggestionEngineRouterTests CODE_SIGNING_ALLOWED=NO`
→ `Executed 9 tests, with 0 failures (0 unexpected)`

`swiftlint lint --quiet` → no violations.

Manual: pick prefixes that historically drifted ("Hey Jacob, ", "Thanks for ", "Hi Sarah,\n\n") and verify the suggestion continues the sentence in voice instead of greeting the user back.

## Linked issues

Refs the FM-quality investigation.

## Risk / rollout notes

- Pure prompt-policy change. No protocol, request shape, or engine wiring change.
- Three test assertions changed shape: the old ones pinned on phrases ("text-continuation engine", "Do not repeat or quote the existing text.") that no longer appear. The new ones lock in the positive identity ("complete partially-typed text"), the output contract anchor ("Output the continuation only:"), specific forbidden-content tokens ("no greeting", "no markdown"), and the style line.
- A new test (`test_sessionInstructions_includeExactlyTwoContinuationExamples`) pins the few-shot count to two so the trim cannot silently regrow.
- The instruction-prefix cache from PR 2 (`perf/fm-session-reuse-prewarm`) is keyed on the rendered instructions string. After this lands, the first request on each session rebuilds the cache once with the shorter instructions; subsequent requests reuse it. No special migration needed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the FM session instruction block with a shorter, positively-framed identity following Apple's WWDC25 prompt-design guidance, and trims the few-shot demonstration set from five pairs to two (one prose salutation, one code). No request shape, engine wiring, or output-normalizer logic changes.

- `FoundationModelPromptRenderer.swift`: the base rules array shrinks from 10 lines to 5 positive identity lines; `continuationExampleLines` shrinks from 10 strings (5 pairs) to 4 strings (2 pairs), keeping the prose-salutation and code cases that cover the two principal failure modes.
- `CotabbyTests/PromptPolicyTests.swift`: three tests are renamed and rewritten to match the new instruction text, and a new `test_sessionInstructions_includeExactlyTwoContinuationExamples` is added to pin the few-shot count so a silent regrowth would fail fast.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a pure prompt-text change with no logic, protocol, or wiring modifications.

Every changed line is a string constant or a test assertion that mirrors it. The instruction-prefix cache rebuild on first request after landing is acknowledged and requires no migration. The new tests are accurate, and the few-shot trim is deliberate and well-reasoned.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/FoundationModelPromptRenderer.swift | Rewrites FM session instructions from 10 negative prohibition lines + 5 few-shot pairs to 5 positive identity lines + 2 few-shot pairs; production logic is unchanged — the diff is purely string constants. |
| CotabbyTests/PromptPolicyTests.swift | Three test renames/rewrites plus a new count-pinning test; assertions are accurate for the new instruction text, and the coverage split across tests is appropriate. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SuggestionRequest] --> B[sessionInstructions]
    B --> C[5 positive identity lines]
    C --> C1["1. Positive identity: 'You complete partially-typed text'"]
    C --> C2["2. Output contract: no greeting/sign-off/quotes/markdown/labels/explanation"]
    C --> C3["3. Anti-echo guard: Continue from position after existing text"]
    C --> C4["4. Style match: language, register, casing, punctuation"]
    C --> C5["5. Context usage: clipboard/screen only when helpful"]
    B --> D{languageInstruction?}
    D -- yes --> E[Append language hint]
    D -- no --> F[Skip]
    E --> G["Examples header + 2 few-shot pairs"]
    F --> G
    G --> G1["Pair 1: prose salutation (anti-restart)"]
    G --> G2["Pair 2: code prefix → code continuation"]
    G --> H{customRules?}
    H -- yes --> I["'Your style preferences:' + rules + subordination line"]
    H -- no --> J[Skip]
    I --> K[lines.joined separator newline]
    J --> K
    K --> L[Instructions string → Apple FM channel]
```

<sub>Reviews (4): Last reviewed commit: ["Restore no-echo rule to prevent empty co..."](https://github.com/fujacob/cotabby/commit/3a129d0e40217b47ef82f900240ea74b2d7fa457) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34326179)</sub>

<!-- /greptile_comment -->