### PR TITLE
Send FM trailing context, length hint, per-app tone, bigger prefix budget

### DIFF
--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
@@ -79,7 +79,8 @@ extension SuggestionCoordinator {
         // per-line filter can't disagree about what "shares tokens with the prefix" means.
         let truncatedPrefix = SuggestionRequestFactory.truncatedPromptPrefix(
             from: rawContext.precedingText,
-            configuration: configuration
+            configuration: configuration,
+            engine: settingsSnapshot.selectedEngine
         )
         let clipboardContext = clipboardRelevanceFilter.filter(
             clipboard: rawClipboard,

--- a/Cotabby/Models/SuggestionModels.swift
+++ b/Cotabby/Models/SuggestionModels.swift
@@ -80,6 +80,11 @@ struct SuggestionConfiguration: Equatable, Sendable {
     let randomSeed: UInt32?
     let maxPrefixWords: Int
     let maxPrefixCharacters: Int
+    /// Foundation Models has a noticeably larger shared context than the local llama path, so the
+    /// FM-selected request gets a separate (larger) prefix budget. Setting this above the llama
+    /// caps avoids crowding instructions while keeping the local-continuation focus.
+    let maxPrefixWordsFoundationModel: Int
+    let maxPrefixCharactersFoundationModel: Int
     let maxSuffixCharacters: Int
     /// Shipped first-launch default for the user's saved profile.
     /// `SuggestionSettingsModel` persists the user's real preference; configuration only provides
@@ -104,9 +109,15 @@ struct SuggestionConfiguration: Equatable, Sendable {
         repetitionPenalty: 1.05,
         randomSeed: nil,
         maxPrefixWords: 50,
-        // Prompt windows should stay small. Sending an entire editor buffer hurts latency with
-        // little quality gain because Cotabby is only completing the immediate local continuation.
+        // Prompt windows should stay small for the local llama path. Sending an entire editor
+        // buffer hurts latency with little quality gain because Cotabby is only completing the
+        // immediate local continuation.
         maxPrefixCharacters: 1000,
+        // Apple's on-device model has a 4096-token shared context. Even with instructions plus
+        // visual/clipboard context, there is room to send ~3x the llama window before crowding
+        // the prompt, and the extra surrounding sentences materially help mid-thought completions.
+        maxPrefixWordsFoundationModel: 150,
+        maxPrefixCharactersFoundationModel: 2500,
         maxSuffixCharacters: 192,
         // Seed the profile settings with lightweight defaults on first launch.
         defaultUserName: "Jacob",

--- a/Cotabby/Support/FoundationModelPromptRenderer.swift
+++ b/Cotabby/Support/FoundationModelPromptRenderer.swift
@@ -126,9 +126,11 @@ enum FoundationModelPromptRenderer {
         ])
 
         // Trailing context lets the model produce a continuation that bridges into what is already
-        // present after the caret instead of overwriting it. We send the suffix verbatim, capped
-        // to `maxSuffixCharacters` (the same cap used elsewhere) by the upstream context capture.
-        let trailing = request.context.trailingText
+        // present after the caret instead of overwriting it. The upstream focus snapshot does NOT
+        // bound this string (it returns the full document tail from the caret), so we apply
+        // `maxSuffixCharacters` here to keep a caret-at-top in a long document from pushing the
+        // entire body through Apple's 4096-token shared context window.
+        let trailing = String(request.context.trailingText.prefix(request.maxSuffixCharacters))
         if !trailing.isEmpty {
             sections.append(contentsOf: [
                 "",
@@ -170,16 +172,17 @@ enum FoundationModelPromptRenderer {
         return nil
     }
 
+    // Cursor ships under opaque ToDesktop hashes (com.todesktop.<id>) that change between builds,
+    // so prefix-matching is unreliable; omitted intentionally.
+    // Terminal emulators (iTerm2, Apple Terminal, Hyper) are also omitted: a shell prompt, log
+    // pager, or `git commit` buffer is mostly prose, not code, so the no-hint default is safer
+    // than a guessed code hint.
     private static let codeEditorBundlePrefixes: [String] = [
         "com.apple.dt.xcode",
         "com.microsoft.vscode",
-        "com.todesktop.230313mzl4w4u92",  // Cursor (stable id used at the time of writing)
         "com.jetbrains.",
         "com.sublimetext.",
-        "com.panic.nova",
-        "co.zeit.hyper",
-        "com.googlecode.iterm2",
-        "com.apple.terminal"
+        "com.panic.nova"
     ]
 
     private static let emailBundlePrefixes: [String] = [

--- a/Cotabby/Support/FoundationModelPromptRenderer.swift
+++ b/Cotabby/Support/FoundationModelPromptRenderer.swift
@@ -100,6 +100,12 @@ enum FoundationModelPromptRenderer {
             "User is on \(request.context.applicationName)."
         ]
 
+        // Per-app tone hint lives in the per-request prompt, not the session instructions, so it
+        // can vary as the user switches apps without invalidating the cached instruction prefix.
+        if let toneHint = appToneHint(forBundleIdentifier: request.context.bundleIdentifier) {
+            sections.append(toneHint)
+        }
+
         if let summary = request.visualContextSummary,
            !summary.isEmpty {
             sections.append("Screen content:")
@@ -116,13 +122,92 @@ enum FoundationModelPromptRenderer {
         sections.append(contentsOf: [
             "",
             "Text before the caret:",
-            prefixText,
+            prefixText
+        ])
+
+        // Trailing context lets the model produce a continuation that bridges into what is already
+        // present after the caret instead of overwriting it. We send the suffix verbatim, capped
+        // to `maxSuffixCharacters` (the same cap used elsewhere) by the upstream context capture.
+        let trailing = request.context.trailingText
+        if !trailing.isEmpty {
+            sections.append(contentsOf: [
+                "",
+                "Text after the caret:",
+                trailing
+            ])
+        }
+
+        // Length cue is reintroduced on the FM prompt channel (not instructions). Apple's model
+        // responds reliably to plain-language length hints, and the explicit cue keeps shorter
+        // completions from getting hard-truncated mid-word by `maximumResponseTokens` alone.
+        sections.append(contentsOf: [
             "",
-            "Write only the next continuation fragment."
+            "Write only the next continuation fragment.",
+            request.completionLengthInstruction
         ])
 
         return sections.joined(separator: "\n")
     }
+
+    /// Maps the focused app's bundle identifier to a one-line tone cue or nil if no rule matches.
+    /// The set is intentionally small: each entry has to earn its tokens, so we cover the
+    /// surfaces real users complain about (code editors, email/chat clients, browsers) and let
+    /// everything else fall back to the generic instructions.
+    private static func appToneHint(forBundleIdentifier identifier: String) -> String? {
+        let lower = identifier.lowercased()
+        if codeEditorBundlePrefixes.contains(where: { lower.hasPrefix($0) }) {
+            return "The user is writing code, so the continuation should be code rather than prose."
+        }
+        if emailBundlePrefixes.contains(where: { lower.hasPrefix($0) }) {
+            return "The user is writing an email, so keep the same register and finish the current thought."
+        }
+        if chatBundlePrefixes.contains(where: { lower.hasPrefix($0) }) {
+            return "The user is in a chat app, so keep the continuation short and informal."
+        }
+        if browserBundlePrefixes.contains(where: { lower.hasPrefix($0) }) {
+            return "The user is typing inside a browser, so keep the continuation concise."
+        }
+        return nil
+    }
+
+    private static let codeEditorBundlePrefixes: [String] = [
+        "com.apple.dt.xcode",
+        "com.microsoft.vscode",
+        "com.todesktop.230313mzl4w4u92",  // Cursor (stable id used at the time of writing)
+        "com.jetbrains.",
+        "com.sublimetext.",
+        "com.panic.nova",
+        "co.zeit.hyper",
+        "com.googlecode.iterm2",
+        "com.apple.terminal"
+    ]
+
+    private static let emailBundlePrefixes: [String] = [
+        "com.apple.mail",
+        "com.readdle.smartemail",
+        "com.airmailapp.airmail",
+        "com.microsoft.outlook"
+    ]
+
+    private static let chatBundlePrefixes: [String] = [
+        "com.tinyspeck.slackmacgap",
+        "com.microsoft.teams",
+        "com.hnc.discord",
+        "com.apple.mobilesms",
+        "ru.keepcoder.telegram",
+        "net.whatsapp.whatsapp"
+    ]
+
+    private static let browserBundlePrefixes: [String] = [
+        "com.apple.safari",
+        "com.apple.safaritechnologypreview",
+        "com.google.chrome",
+        "com.google.chrome.canary",
+        "org.mozilla.firefox",
+        "company.thebrowser.browser",  // Arc
+        "com.brave.browser",
+        "com.microsoft.edgemac"
+    ]
 
     /// Diagnostics need to show both payloads Apple receives: the high-priority instructions and
     /// the shorter request prompt. Keeping this renderer-owned prevents the menu/debug preview from

--- a/Cotabby/Support/SuggestionRequestFactory.swift
+++ b/Cotabby/Support/SuggestionRequestFactory.swift
@@ -38,7 +38,8 @@ enum SuggestionRequestFactory {
     ) -> SuggestionRequestBuildResult {
         let prefixText = truncatedPromptPrefix(
             from: context.precedingText,
-            configuration: configuration
+            configuration: configuration,
+            engine: settings.selectedEngine
         )
         let completionLengthInstruction = settings.selectedWordCountPreset.promptInstruction
         let userName = activeUserName(settings: settings)
@@ -101,15 +102,29 @@ enum SuggestionRequestFactory {
     ///
     /// Exposed (non-private) so the coordinator can compute the same bounded window before
     /// calling the relevance filter, ensuring the filter and the downstream distiller evaluate
-    /// token overlap against an identical prefix.
+    /// token overlap against an identical prefix. The `engine` parameter selects between the
+    /// llama-sized window (small, low latency) and the FM-sized window (larger, fits Apple's
+    /// shared context). Default arg keeps existing call sites and external usages source-compatible.
     static func truncatedPromptPrefix(
         from precedingText: String,
-        configuration: SuggestionConfiguration
+        configuration: SuggestionConfiguration,
+        engine: SuggestionEngineKind = .llamaOpenSource
     ) -> String {
-        let characterWindow = String(precedingText.suffix(configuration.maxPrefixCharacters))
+        let maxCharacters: Int
+        let maxWords: Int
+        switch engine {
+        case .appleIntelligence:
+            maxCharacters = configuration.maxPrefixCharactersFoundationModel
+            maxWords = configuration.maxPrefixWordsFoundationModel
+        case .llamaOpenSource:
+            maxCharacters = configuration.maxPrefixCharacters
+            maxWords = configuration.maxPrefixWords
+        }
+
+        let characterWindow = String(precedingText.suffix(maxCharacters))
         let trailingWords = characterWindow
             .split(whereSeparator: { $0.isWhitespace })
-            .suffix(configuration.maxPrefixWords)
+            .suffix(maxWords)
             .map(String.init)
             .joined(separator: " ")
 

--- a/CotabbyTests/PromptPolicyTests.swift
+++ b/CotabbyTests/PromptPolicyTests.swift
@@ -88,6 +88,99 @@ final class FoundationModelPromptRendererTests: XCTestCase {
         XCTAssertTrue(prompt.contains("  Hello from the field  "))
     }
 
+    /// Trailing context lets the model bridge into what is already after the caret instead of
+    /// overwriting it. The section appears only when there is suffix content to share.
+    func test_prompt_includesTrailingTextSectionWhenSuffixPresent() {
+        let request = CotabbyTestFixtures.suggestionRequest(
+            prefixText: "I'm flying to ",
+            precedingText: "I'm flying to ",
+            trailingText: " on Friday."
+        )
+
+        let prompt = FoundationModelPromptRenderer.prompt(for: request)
+
+        XCTAssertTrue(prompt.contains("Text after the caret:"))
+        XCTAssertTrue(prompt.contains(" on Friday."))
+    }
+
+    func test_prompt_omitsTrailingTextSectionWhenSuffixEmpty() {
+        let request = CotabbyTestFixtures.suggestionRequest(
+            prefixText: "Continue this",
+            precedingText: "Continue this"
+        )
+
+        let prompt = FoundationModelPromptRenderer.prompt(for: request)
+
+        XCTAssertFalse(prompt.contains("Text after the caret:"))
+    }
+
+    /// The natural-language length hint goes on the prompt channel (per-request), not the
+    /// instructions channel (which is cached on the FM session). That keeps the cached prefix
+    /// stable while still giving the model the cue it needs to stop at a clean word boundary.
+    func test_prompt_includesNaturalLanguageLengthHint() {
+        let request = CotabbyTestFixtures.suggestionRequest(
+            prefixText: "Continue this",
+            precedingText: "Continue this",
+            completionLengthInstruction: "Return only the next 7 to 12 words."
+        )
+
+        let prompt = FoundationModelPromptRenderer.prompt(for: request)
+
+        XCTAssertTrue(prompt.contains("Return only the next 7 to 12 words."))
+    }
+
+    /// Per-app tone hints live in the prompt rather than instructions so switching apps does not
+    /// invalidate the cached instruction prefix. Use a known code-editor bundle ID and verify the
+    /// matching cue appears; unknown bundle IDs fall through to no hint at all.
+    func test_prompt_includesCodeEditorToneHintForKnownBundleIdentifier() {
+        let context = CotabbyTestFixtures.focusedInputContext(
+            applicationName: "Xcode",
+            bundleIdentifier: "com.apple.dt.Xcode",
+            precedingText: "let total = items.reduce(0, "
+        )
+        let request = SuggestionRequest(
+            context: context,
+            prefixText: "let total = items.reduce(0, ",
+            prompt: "PROMPT",
+            generation: 1,
+            maxPredictionTokens: 16,
+            temperature: 0.1,
+            topK: 20,
+            topP: 0.7,
+            minP: 0.08,
+            repetitionPenalty: 1.05,
+            randomSeed: 42,
+            maxSuffixCharacters: 192,
+            completionLengthInstruction: "Return only the next 7 to 12 words.",
+            userName: nil,
+            customRules: [],
+            languageInstruction: nil,
+            clipboardContext: nil,
+            visualContextSummary: nil,
+            isMultiLineEnabled: false
+        )
+
+        let prompt = FoundationModelPromptRenderer.prompt(for: request)
+
+        XCTAssertTrue(prompt.contains("writing code"))
+    }
+
+    func test_prompt_omitsToneHintForUnknownBundleIdentifier() {
+        let request = CotabbyTestFixtures.suggestionRequest(
+            prefixText: "Continue this",
+            precedingText: "Continue this"
+        )
+
+        let prompt = FoundationModelPromptRenderer.prompt(for: request)
+
+        // The default fixture uses bundleIdentifier "com.example.TestApp", which is not in any of
+        // the tone-hint prefix sets, so the prompt must not carry a category cue.
+        XCTAssertFalse(prompt.contains("writing code"))
+        XCTAssertFalse(prompt.contains("writing an email"))
+        XCTAssertFalse(prompt.contains("chat app"))
+        XCTAssertFalse(prompt.contains("inside a browser"))
+    }
+
     func test_prompt_includesVisualContextWhenProvided() {
         let request = CotabbyTestFixtures.suggestionRequest(
             prefixText: "Continue this",
@@ -136,10 +229,13 @@ final class FoundationModelPromptRendererTests: XCTestCase {
         let preview = FoundationModelPromptRenderer.promptPreview(for: request)
 
         XCTAssertTrue(preview.contains("Instructions:\n"))
-        // Length cue removed from the prompt; it should not surface in the diagnostics preview either.
-        XCTAssertFalse(preview.contains("UNIQUE_LENGTH_POLICY"))
         XCTAssertTrue(preview.contains("Prompt:\n"))
         XCTAssertTrue(preview.contains("UNIQUE_APPLE_SCREEN_CONTEXT"))
+        // The length cue lives on the prompt channel now (PR 5), so it must surface in diagnostics.
+        XCTAssertTrue(preview.contains("UNIQUE_LENGTH_POLICY"))
+        // It still must not bleed into the cached instructions channel.
+        let instructions = FoundationModelPromptRenderer.sessionInstructions(for: request)
+        XCTAssertFalse(instructions.contains("UNIQUE_LENGTH_POLICY"))
     }
 }
 

--- a/CotabbyTests/PromptPolicyTests.swift
+++ b/CotabbyTests/PromptPolicyTests.swift
@@ -165,6 +165,49 @@ final class FoundationModelPromptRendererTests: XCTestCase {
         XCTAssertTrue(prompt.contains("writing code"))
     }
 
+    /// Terminal emulators host prose contexts (commit messages, log pagers, shell prompts) more
+    /// often than not, so they must not pick up the code-editor tone hint. Cursor is also
+    /// excluded because its ToDesktop bundle hash is unstable across releases.
+    func test_prompt_omitsCodeEditorToneHintForTerminalAndOpaqueCursorBundles() {
+        let bundles = [
+            "com.apple.Terminal",
+            "com.googlecode.iterm2",
+            "co.zeit.hyper",
+            "com.todesktop.230313mzl4w4u92"
+        ]
+        for bundle in bundles {
+            let context = CotabbyTestFixtures.focusedInputContext(
+                applicationName: "Test",
+                bundleIdentifier: bundle,
+                precedingText: "anything"
+            )
+            let request = SuggestionRequest(
+                context: context,
+                prefixText: "anything",
+                prompt: "PROMPT",
+                generation: 1,
+                maxPredictionTokens: 16,
+                temperature: 0.1,
+                topK: 20,
+                topP: 0.7,
+                minP: 0.08,
+                repetitionPenalty: 1.05,
+                randomSeed: 42,
+                maxSuffixCharacters: 192,
+                completionLengthInstruction: "Return only the next 7 to 12 words.",
+                userName: nil,
+                customRules: [],
+                languageInstruction: nil,
+                clipboardContext: nil,
+                visualContextSummary: nil,
+                isMultiLineEnabled: false
+            )
+
+            let prompt = FoundationModelPromptRenderer.prompt(for: request)
+            XCTAssertFalse(prompt.contains("writing code"), "bundle \(bundle) should not get the code-editor hint")
+        }
+    }
+
     func test_prompt_omitsToneHintForUnknownBundleIdentifier() {
         let request = CotabbyTestFixtures.suggestionRequest(
             prefixText: "Continue this",

--- a/CotabbyTests/SuggestionRequestFactoryTests.swift
+++ b/CotabbyTests/SuggestionRequestFactoryTests.swift
@@ -73,6 +73,8 @@ final class SuggestionRequestFactoryTests: XCTestCase {
             randomSeed: 42,
             maxPrefixWords: 3,
             maxPrefixCharacters: 32,
+            maxPrefixWordsFoundationModel: 9,
+            maxPrefixCharactersFoundationModel: 96,
             maxSuffixCharacters: 192,
             defaultUserName: nil,
             defaultWordCountPreset: .sevenToTwelve,
@@ -90,6 +92,50 @@ final class SuggestionRequestFactoryTests: XCTestCase {
         XCTAssertFalse(result.promptPreview.contains("alpha beta"))
     }
 
+    /// The Foundation Models path has a separate, larger prefix budget because Apple's shared
+    /// context window can take more local sentences without crowding instructions. This pins the
+    /// engine-aware truncation so a future change cannot quietly collapse the two budgets back
+    /// into one and shrink FM-side context with it.
+    func test_buildRequest_appliesFoundationModelPrefixBudgetWhenAppleEngineSelected() {
+        let precedingText = "alpha beta gamma delta epsilon zeta eta theta"
+        let context = CotabbyTestFixtures.focusedInputContext(precedingText: precedingText)
+        let configuration = SuggestionConfiguration(
+            maxPredictionTokens: 8,
+            debounceMilliseconds: 0,
+            temperature: 0.1,
+            topK: 20,
+            topP: 0.7,
+            minP: 0.08,
+            repetitionPenalty: 1.05,
+            randomSeed: 42,
+            maxPrefixWords: 3,
+            maxPrefixCharacters: 32,
+            maxPrefixWordsFoundationModel: 6,
+            maxPrefixCharactersFoundationModel: 96,
+            maxSuffixCharacters: 192,
+            defaultUserName: nil,
+            defaultWordCountPreset: .sevenToTwelve,
+            focusPollIntervalMilliseconds: 50
+        )
+
+        let llamaResult = SuggestionRequestFactory.buildRequest(
+            context: context,
+            settings: CotabbyTestFixtures.settingsSnapshot(selectedEngine: .llamaOpenSource),
+            configuration: configuration
+        )
+        let foundationModelResult = SuggestionRequestFactory.buildRequest(
+            context: context,
+            settings: CotabbyTestFixtures.settingsSnapshot(selectedEngine: .appleIntelligence),
+            configuration: configuration
+        )
+
+        XCTAssertEqual(llamaResult.request.prefixText, "zeta eta theta")
+        XCTAssertEqual(
+            foundationModelResult.request.prefixText,
+            "gamma delta epsilon zeta eta theta"
+        )
+    }
+
     func test_buildRequest_usesWordCountPresetForInstructionAndTokenBudget() {
         let context = CotabbyTestFixtures.focusedInputContext(precedingText: "Hello world")
         let configuration = SuggestionConfiguration(
@@ -103,6 +149,8 @@ final class SuggestionRequestFactoryTests: XCTestCase {
             randomSeed: 42,
             maxPrefixWords: 50,
             maxPrefixCharacters: 1000,
+            maxPrefixWordsFoundationModel: 150,
+            maxPrefixCharactersFoundationModel: 2500,
             maxSuffixCharacters: 192,
             defaultUserName: nil,
             defaultWordCountPreset: .sevenToTwelve,


### PR DESCRIPTION
## Summary

Four prompt-side improvements bundled because they all live in the FM prompt channel and were all measurable against the eval suite from the parent stack:

- **Trailing context.** The suffix (text after the caret) was captured but never sent to FM. Mid-line insertions now get a `Text after the caret:` section so the model can bridge into existing text rather than overwrite it.
- **Length hint.** The user's word-count preset (`Return only the next 7 to 12 words.`) is reintroduced on the prompt channel — not instructions, so it does not bust the cached session prefix from PR 2. Apple's model lands cleaner stopping points with a natural-language cue than with `maximumResponseTokens` alone.
- **Per-app tone hint.** A small bundle-ID dictionary maps focused-app categories (code editor, email, chat, browser) to one-line tone cues injected into the prompt. Unknown bundles fall through to no hint.
- **Bigger FM-side prefix budget.** `SuggestionConfiguration` gains FM-only prefix caps (2500 chars / 150 words) so Apple's larger context can take more surrounding sentences without crowding instructions. Llama keeps its existing tighter window.

Stacked on `refactor/fm-positive-frame`. Use the eval suite from the head of the stack to compare mid-word truncation, mid-line bridging, and category drift.

## Validation

`xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build CODE_SIGNING_ALLOWED=NO`
→ `** BUILD SUCCEEDED **`

`xcodebuild test ... -only-testing:CotabbyTests/FoundationModelPromptRendererTests -only-testing:CotabbyTests/SuggestionRequestFactoryTests -only-testing:CotabbyTests/SuggestionEngineRouterTests`
→ `Executed 33 tests, with 0 failures (0 unexpected)`

`swiftlint lint --quiet` → no violations.

Manual: focus a real text field in Mail / Slack / Xcode / Safari and verify the diagnostics panel shows the matching per-app tone hint and (where applicable) the trailing-text section.

## Linked issues

Refs the FM-quality investigation.

## Risk / rollout notes

- `SuggestionConfiguration` gained two new memberwise fields (`maxPrefixWordsFoundationModel`, `maxPrefixCharactersFoundationModel`). Production uses `.standard`, which is updated; the two explicit-constructor test sites were updated alongside.
- `SuggestionRequestFactory.truncatedPromptPrefix` now takes an optional `engine:` parameter (defaulting to `.llamaOpenSource`) so external callers stay source-compatible. The internal call from `buildRequest` and the coordinator's clipboard-filter call both pass the active engine explicitly.
- The per-app tone-hint dictionary is intentionally small. Adding bundle IDs is a one-line change in `FoundationModelPromptRenderer`; the absence of a hint is the safe default.
- Diagnostic preview now surfaces the length cue (it lives on the prompt channel), so the `test_promptPreview` assertion was flipped — and a new assertion ensures the cue still does NOT appear in instructions (so the session-cache key remains stable across word-count preset changes... wait, those *should* invalidate; correction: word-count preset only changes the prompt, not instructions, so cache stays warm).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enriches the Foundation Models prompt channel with four coordinated improvements: trailing-context injection (bounded by `maxSuffixCharacters`), a natural-language length hint on the per-request prompt, per-app tone cues keyed by bundle-ID prefix, and a separate, larger prefix budget (2500 chars / 150 words) for the FM path.

- Trailing text is now capped at `maxSuffixCharacters` before being sent, closing the previously identified gap where a caret at the top of a long document would flood the 4096-token context window.
- `SuggestionConfiguration` gains two new FM-specific prefix cap fields; all existing explicit constructors in tests were updated alongside, and `truncatedPromptPrefix` selects the right budget via an engine switch with a backward-compatible default.
- The bundle-ID tone-hint dictionary deliberately excludes terminal emulators and Cursor (whose ToDesktop hash is unstable), with tests covering both known-match and exclusion cases; one entry (`com.apple.mobilesms`) references an iOS-only bundle ID that will not match macOS Messages.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all prompt-channel changes are additive and the most significant correctness fix (trailing-text overflow) is properly addressed.

The trailing-text cap is correctly applied before injection, the engine-aware prefix budget switch is clean with a backward-compatible default, and the tone-hint dictionary's safe-default-on-no-match design means unknown or mismatched bundle IDs degrade gracefully. The one dead entry (com.apple.mobilesms) silently misses macOS Messages but causes no harm. Tests cover the new code paths thoroughly.

FoundationModelPromptRenderer.swift — the chatBundlePrefixes list contains one iOS-only entry that will not fire on macOS.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/FoundationModelPromptRenderer.swift | Adds trailing-context injection (bounded by maxSuffixCharacters), length hint on the prompt channel, and per-app tone hints via bundle-prefix dictionaries; one iOS-only bundle ID (com.apple.mobilesms) will never match on macOS. |
| Cotabby/Models/SuggestionModels.swift | Adds maxPrefixWordsFoundationModel and maxPrefixCharactersFoundationModel fields to SuggestionConfiguration; standard defaults set to 150 words / 2500 chars for the FM path. |
| Cotabby/Support/SuggestionRequestFactory.swift | truncatedPromptPrefix gains an engine parameter (defaulting to .llamaOpenSource for source-compatibility) and selects the appropriate character/word budget via a switch; logic is clean and both call sites updated correctly. |
| Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift | One-line change: passes the active engine to truncatedPromptPrefix so the clipboard relevance filter evaluates against the same bounded window the downstream request uses. |
| CotabbyTests/PromptPolicyTests.swift | Adds focused tests for trailing-text section, length hint placement, code-editor tone hint, terminal/Cursor exclusions, and unknown-bundle fallthrough; test_promptPreview assertion correctly flipped to verify length cue on prompt channel and absence from instructions. |
| CotabbyTests/SuggestionRequestFactoryTests.swift | Updates two existing SuggestionConfiguration constructors with the new FM prefix fields and adds a new test pinning that llama and FM paths receive distinct prefix budgets. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Coord as SuggestionCoordinator
    participant Factory as SuggestionRequestFactory
    participant FM as FoundationModelPromptRenderer
    participant Apple as Apple FM API

    Coord->>Factory: truncatedPromptPrefix(engine: .appleIntelligence)
    Note over Factory: Selects maxPrefixCharactersFoundationModel=2500<br/>maxPrefixWordsFoundationModel=150
    Factory-->>Coord: bounded prefixText

    Coord->>Factory: buildRequest(context, settings, configuration)
    Factory->>Factory: truncatedPromptPrefix(engine: appleIntelligence)
    Factory-->>Coord: SuggestionRequestBuildResult

    Coord->>FM: promptPreview(for: request)
    FM->>FM: sessionInstructions(for: request)
    Note over FM: Role + output contract + examples<br/>(no length hint, no tone hint)
    FM->>FM: prompt(for: request)
    Note over FM: appToneHint(bundleIdentifier)<br/>+ Text before caret (prefixText)<br/>+ Text after caret (trailingText, capped at maxSuffixCharacters)<br/>+ Write only the next continuation fragment.<br/>+ completionLengthInstruction
    FM-->>Coord: instructions + prompt

    Coord->>Apple: generate(instructions, prompt)
    Apple-->>Coord: completion text
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Ffm-richer-context%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Ffm-richer-context%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FSupport%2FFoundationModelPromptRenderer.swift%3A199%0A**iOS%20bundle%20ID%20will%20never%20match%20on%20macOS**%0A%0A%60%22com.apple.mobilesms%22%60%20is%20the%20iOS%20Messages%20bundle%20identifier%20%28%60MobileSMS.app%60%29%2C%20not%20the%20macOS%20Messages%20app.%20On%20macOS%2C%20Messages%20carries%20the%20bundle%20ID%20%60com.apple.iChat%60.%20Since%20Cotabby%20is%20a%20macOS%20accessibility%20extension%2C%20%60rawContext.bundleIdentifier%60%20for%20a%20Messages%20text%20field%20will%20be%20%60%22com.apple.iChat%22%60%2C%20which%20does%20not%20begin%20with%20%60%22com.apple.mobilesms%22%60%20%E2%80%94%20so%20macOS%20Messages%20users%20silently%20fall%20through%20to%20the%20no-hint%20default%20and%20the%20chat%20tone%20cue%20is%20never%20applied%20despite%20the%20explicit%20intent%20to%20cover%20chat%20surfaces.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FSupport%2FFoundationModelPromptRenderer.swift%3A199%0A**iOS%20bundle%20ID%20will%20never%20match%20on%20macOS**%0A%0A%60%22com.apple.mobilesms%22%60%20is%20the%20iOS%20Messages%20bundle%20identifier%20%28%60MobileSMS.app%60%29%2C%20not%20the%20macOS%20Messages%20app.%20On%20macOS%2C%20Messages%20carries%20the%20bundle%20ID%20%60com.apple.iChat%60.%20Since%20Cotabby%20is%20a%20macOS%20accessibility%20extension%2C%20%60rawContext.bundleIdentifier%60%20for%20a%20Messages%20text%20field%20will%20be%20%60%22com.apple.iChat%22%60%2C%20which%20does%20not%20begin%20with%20%60%22com.apple.mobilesms%22%60%20%E2%80%94%20so%20macOS%20Messages%20users%20silently%20fall%20through%20to%20the%20no-hint%20default%20and%20the%20chat%20tone%20cue%20is%20never%20applied%20despite%20the%20explicit%20intent%20to%20cover%20chat%20surfaces.%0A%0A&repo=fujacob%2Fcotabby&pr=344&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (4): Last reviewed commit: ["Address Greptile review on #344"](https://github.com/fujacob/cotabby/commit/2238567804fa99d2e0937159b39593acef9d6ddc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34326915)</sub>

<!-- /greptile_comment -->