### PR TITLE
Fix accept keybind swallowing keystroke during background refresh

### DIFF
--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
@@ -31,7 +31,15 @@ extension SuggestionCoordinator {
             return passTabThrough(reason: snapshot.capability.summary)
         }
 
-        guard case .ready = state else {
+        // Gate on the live session, not on `state`. A background refresh (notably the visual-context
+        // path that calls `schedulePrediction` once OCR finishes) flips `state` to `.debouncing`
+        // while the previous suggestion is still buffered and its overlay is still on screen — and
+        // the accept tap is still installed because the overlay is visible. Gating on `.ready` here
+        // would `passTabThrough` for the keystroke the accept tap just consumed, swallowing the
+        // user's accept and letting the background regeneration replace the suggestion they were
+        // trying to take. `validateSessionForAcceptance` still rejects the accept if the session no
+        // longer reconciles with the live AX state.
+        guard interactionState.activeSession != nil else {
             return passTabThrough(reason: "Key passed through because no valid suggestion was ready.")
         }
 


### PR DESCRIPTION
## Summary

The accept keybind was gated on `state == .ready` in `SuggestionCoordinator+Acceptance.swift`, but the state machine transitions to `.debouncing` / `.generating` while a previously ready suggestion is still buffered and its overlay is still on screen. This happens most reliably when the visual-context coordinator finishes OCR and calls `schedulePredictionForCurrentFocusIfPossible`, which fires `schedulePrediction()` without first clearing the active session or hiding the overlay. Because the accept tap is installed for the duration of overlay visibility, the user's accept keystroke is consumed by the tap, `passTabThrough` runs (no insertion), and the in-flight background regeneration then replaces the suggestion the user was trying to take. End result matches the reported "swallowed accept + regeneration" symptom.

Gate on `interactionState.activeSession` instead. `validateSessionForAcceptance` still reconciles against the live AX snapshot and rejects the accept when the buffered session no longer matches the field.

## Validation

```
swiftlint lint --quiet Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
# exit 0, no warnings

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build-for-testing
# ** TEST BUILD SUCCEEDED **
```

`test-without-building` failed to load `CotabbyTests.xctest` with the local-signing Team ID mismatch (xctest bundle signed with the user dev cert but loaded into the host app process). CLAUDE.md calls this out explicitly as a local-environment failure, not a code regression, and instructs to proceed once `build-for-testing` succeeds.

## Linked issues

None filed for this specific symptom yet.

## Risk / rollout notes

Behavioral change is narrow: an accept keystroke that previously fell into `passTabThrough` solely because `state` was `.debouncing` / `.generating` (while `activeSession` was still set) will now flow into `prepareAcceptance` and attempt to insert. `validateSessionForAcceptance` still rejects on selected text, prefix/trailing-text divergence, process change, or session exhaustion, so a stale suggestion does not get inserted into a field the user has since edited. Every site that clears `activeSession` also hides the overlay, so the existing invariant "overlay visible iff `activeSession != nil`" still drives the accept tap's lifecycle.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a keystroke-swallowing bug where a Tab/accept keypress was silently dropped during a background suggestion refresh. The previous gate (`guard case .ready = state`) was too strict because `schedulePrediction()` transitions `state` to `.debouncing` without clearing `activeSession` or hiding the overlay, so the accept tap remained installed but the keystroke fell through to `passTabThrough` instead of `prepareAcceptance`.

- **Core change**: The guard in `acceptSuggestion` now checks `interactionState.activeSession != nil` instead of `state == .ready`, allowing acceptance when a previous suggestion is buffered and on screen even while a background regeneration is in flight.
- **Safety preserved**: `validateSessionForAcceptance` still reconciles against the live AX snapshot and rejects accepts on selected text, prefix/trailing-text divergence, process change, and exhausted sessions — so no stale suggestion can be incorrectly inserted.
- **Invariant confirmed**: Every code path that sets `activeSession = nil` also calls `hideOverlay`, and the accept tap is driven by overlay visibility; so `activeSession != nil ↔ overlay visible` continues to hold.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the narrowly scoped guard change is backed by robust session-reconciliation validation and the accept tap's existing lifecycle invariants.

The one-line change is correct: `activeSession != nil` accurately captures "a buffered suggestion is still available," while the old `state == .ready` was incorrectly rejecting accepts during background refreshes. `validateSessionForAcceptance` provides multiple independent rejection conditions (selected text, prefix divergence, process change, exhausted session) so no stale suggestion can slip through. All `activeSession = nil` sites also call `hideOverlay`, preserving the overlay-visibility invariant that gates the accept tap. The `@MainActor` isolation means there are no race conditions between the async generation task and the synchronous accept path.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift | Replaces the `state == .ready` guard with `activeSession != nil`; the one-line logic change is correct and well-protected by downstream `validateSessionForAcceptance` reconciliation. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant AcceptTap as Accept Tap (overlay visible)
    participant acceptSuggestion
    participant validate as validateSessionForAcceptance
    participant schedulePrediction

    Note over schedulePrediction: OCR finishes → schedulePrediction() called
    schedulePrediction->>schedulePrediction: "state = .debouncing (activeSession still set)"

    User->>AcceptTap: Tab keystroke
    AcceptTap->>acceptSuggestion: acceptSuggestion()

    Note over acceptSuggestion: OLD: guard case .ready = state → passTabThrough (swallowed)
    Note over acceptSuggestion: NEW: guard activeSession != nil → proceeds

    acceptSuggestion->>validate: prepareAcceptance(from: snapshot)
    validate->>validate: reconcile vs live AX snapshot
    alt reconciliation passes
        validate-->>acceptSuggestion: .ready(liveContext, session, chunk)
        acceptSuggestion->>acceptSuggestion: insert chunk, cancelPredictionWork()
        acceptSuggestion-->>User: suggestion accepted
    else reconciliation fails
        validate-->>acceptSuggestion: .invalid(reason)
        acceptSuggestion-->>User: passTabThrough (safe fallback)
    end
```

<sub>Reviews (1): Last reviewed commit: ["Gate accept on the live session instead ..."](https://github.com/fujacob/cotabby/commit/a9477b1272d0d414cb03b5db137ed75431a49742) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34328089)</sub>

<!-- /greptile_comment -->