### PR TITLE
Cancel llama autocomplete generation when the wrapping Task is cancelled

### DIFF
--- a/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
+++ b/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
@@ -150,6 +150,12 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
         var generatedText = ""
 
         for _ in 0 ..< options.maxPredictionTokens {
+            // Cooperative cancellation: when the wrapping Task is cancelled (caller hit a new
+            // keystroke, focus changed, Compose started), bail before the next sampleNext call so
+            // we release `autocompleteLock` instead of running the full prediction budget and
+            // making the next autocomplete wait behind us.
+            if Task.isCancelled { break }
+
             let result = engine.sampleNext(sequenceID)
 
             if result.was_cancelled || result.is_eos {

--- a/Cotabby/Services/Runtime/LlamaRuntimeManager.swift
+++ b/Cotabby/Services/Runtime/LlamaRuntimeManager.swift
@@ -109,7 +109,16 @@ final class LlamaRuntimeManager: ObservableObject {
                 )
             }
             return try await withTaskCancellationHandler {
-                try await task.value
+                // `core.generate` cooperates with cancellation by returning the partial buffer it
+                // accumulated instead of throwing, which is the right behavior for the inference
+                // layer (the KV-cache trim and lock release still need to run on the way out).
+                // The manager surfaces the cancellation as a thrown `CancellationError` so the
+                // `catch` below stays reachable and so callers see the same vocabulary as a
+                // throwing path. The outer task is the one that was cancelled (that is why
+                // `onCancel` ran), so `Task.checkCancellation()` throws here.
+                let partial = try await task.value
+                try Task.checkCancellation()
+                return partial
             } onCancel: {
                 task.cancel()
             }
@@ -149,7 +158,12 @@ final class LlamaRuntimeManager: ObservableObject {
                 )
             }
             return try await withTaskCancellationHandler {
-                try await task.value
+                // Same pattern as `generate`: the detached task returns partial text on cancel,
+                // so surface the cancel here via `Task.checkCancellation()` to keep the catch
+                // below reachable and the runtime vocabulary consistent across both paths.
+                let partial = try await task.value
+                try Task.checkCancellation()
+                return partial
             } onCancel: {
                 task.cancel()
             }

--- a/Cotabby/Services/Runtime/LlamaRuntimeManager.swift
+++ b/Cotabby/Services/Runtime/LlamaRuntimeManager.swift
@@ -97,13 +97,22 @@ final class LlamaRuntimeManager: ObservableObject {
 
         let core = self.core
         do {
-            return try await Task.detached {
+            // `Task.detached` does not inherit the caller's cancellation, so an outer cancel
+            // would otherwise leave `core.generate` running to its full prediction budget while
+            // holding `autocompleteLock`. The handler forwards the cancel signal, and the loop
+            // inside `core.generate` polls `Task.isCancelled` between sampleNext calls.
+            let task = Task.detached {
                 try core.generate(
                     prompt: prompt,
                     cachedPrefixBytes: cachedPrefixBytes,
                     options: options
                 )
-            }.value
+            }
+            return try await withTaskCancellationHandler {
+                try await task.value
+            } onCancel: {
+                task.cancel()
+            }
         } catch is CancellationError {
             CotabbyLogger.runtime.debug("Generation cancelled")
             throw LlamaRuntimeError.cancelled
@@ -133,12 +142,17 @@ final class LlamaRuntimeManager: ObservableObject {
             temperature: temperature
         )
         do {
-            return try await Task.detached {
+            let task = Task.detached {
                 try core.summarize(
                     prompt: prompt,
                     options: options
                 )
-            }.value
+            }
+            return try await withTaskCancellationHandler {
+                try await task.value
+            } onCancel: {
+                task.cancel()
+            }
         } catch is CancellationError {
             throw LlamaRuntimeError.cancelled
         } catch let error as LlamaRuntimeError {


### PR DESCRIPTION
## Summary

Outer `Task.cancel()` was not reaching `core.generate`'s sampling loop, so stale autocomplete generations ran to the full prediction budget while holding `autocompleteLock`. This propagates cancellation through `Task.detached` and adds a per-iteration cancel poll, freeing the lock so the next autocomplete (the one the user actually wants) can start ~100-400 ms sooner on Metal.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build-for-testing
# ** TEST BUILD SUCCEEDED **

swiftlint lint --quiet Cotabby/Services/Runtime/LlamaRuntimeCore.swift Cotabby/Services/Runtime/LlamaRuntimeManager.swift
# exit 0
```

Local `xcodebuild test` failed with a Team ID signing mismatch (`mapping process and mapped file (non-platform) have different Team IDs`) — known local-signing issue per `.claude/CLAUDE.md`. Will rely on CI to run the test suite.

## Linked issues

None.

## Risk / rollout notes

- `core.generate` now returns whatever partial text it has accumulated when the wrapping Task is cancelled, matching the existing behavior of `core.summarize`. Callers (`LlamaSuggestionEngine.generateSuggestion`) already follow the runtime call with `try Task.checkCancellation()`, so the partial text is dropped before it can reach the UI.
- `engine.cancelSequence` is deliberately not called for the persistent autocomplete sequence. The native cancellation flag is one-way: tripping it would force destroying and rebuilding the sequence on every cancellation and lose KV cache reuse. Per-iteration `Task.isCancelled` polling between `sampleNext` calls gives us ~10-15 ms cancellation granularity, which is fast enough.
- A stacked branch `batched-decode-refactor` exists for follow-up work on true batched decode in CotabbyInference. That refactor needs a Phase 0 spike (measure actual Metal throughput for `n_seq_max>1` batched vs separate contexts on the GGUF models we ship) before any code lands.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes stale autocomplete generations that previously ran to their full prediction budget while holding `autocompleteLock`, blocking the next (user-intended) autocomplete. Cancellation is now propagated end-to-end: the manager wraps both `generate` and `summarize` in `withTaskCancellationHandler` to forward outer-task cancellation to the detached inference task, and `LlamaRuntimeCore.generate()` gains a `Task.isCancelled` poll at the top of each sampling iteration (matching the pre-existing poll in `summarize`).

- **`LlamaRuntimeManager`** — replaces the bare `Task.detached {...}.value` pattern with `withTaskCancellationHandler` + an `onCancel` block that calls `task.cancel()`, then calls `Task.checkCancellation()` after `task.value` resolves to surface the cancel as `CancellationError` for the existing `catch` path.
- **`LlamaRuntimeCore.generate()`** — adds `if Task.isCancelled { break }` before each `sampleNext` call; on early exit the existing `defer` blocks still trim the KV cache and release `autocompleteLock`, so state remains consistent for the next request.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The cancellation path correctly releases `autocompleteLock` via the existing `defer` blocks, and the `withTaskCancellationHandler` pattern is the idiomatic Swift approach for forwarding cancellation to detached tasks.

Both changed files have well-contained, complementary edits. `LlamaRuntimeCore.generate()` gains a cooperative poll that mirrors the pre-existing one in `summarize()`, and the manager's `withTaskCancellationHandler` wrapper correctly connects outer-task cancellation to the detached task's flag. The `defer`-based lock and KV-trim cleanup runs on all exit paths including the new early-break, so no resource leaks or state corruption are introduced. The `try Task.checkCancellation()` call after `task.value` makes the existing `catch is CancellationError` block reachable again and ensures callers receive the expected `LlamaRuntimeError.cancelled` vocabulary.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Services/Runtime/LlamaRuntimeCore.swift | Adds `Task.isCancelled` poll at the top of the generation sampling loop, enabling cooperative cancellation that releases `autocompleteLock` early instead of running the full prediction budget. |
| Cotabby/Services/Runtime/LlamaRuntimeManager.swift | Refactors both `generate()` and `summarize()` to use `withTaskCancellationHandler` so outer-task cancellation is forwarded to the detached inference task; `Task.checkCancellation()` after `task.value` correctly surfaces the cancelled state as `CancellationError` for the existing catch path. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant OT as Outer Task (caller)
    participant MGR as LlamaRuntimeManager
    participant DT as Task.detached
    participant CORE as LlamaRuntimeCore

    OT->>MGR: generate(prompt, options)
    MGR->>DT: "Task.detached { core.generate(...) }"
    MGR->>MGR: "withTaskCancellationHandler { await task.value }"

    alt Normal path
        CORE-->>DT: sampleNext loop completes
        DT-->>MGR: task.value → full String
        MGR->>MGR: Task.checkCancellation() (no-op)
        MGR-->>OT: return full result
    else Cancellation path
        OT-xMGR: Task.cancel() (new keystroke / focus change)
        Note over MGR: onCancel fires → task.cancel()
        DT->>CORE: propagates cancel flag
        CORE->>CORE: "if Task.isCancelled { break }"
        Note over CORE: defer: trimKV, autocompleteLock.unlock()
        CORE-->>DT: return partial String
        DT-->>MGR: task.value → partial String
        MGR->>MGR: Task.checkCancellation() throws CancellationError
        MGR-->>OT: throw LlamaRuntimeError.cancelled
    end
```

<sub>Reviews (2): Last reviewed commit: ["Surface cancellation as CancellationErro..."](https://github.com/fujacob/cotabby/commit/9afae9e3bc17cfb3e56f360b3057d6cfa280c638) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34328137)</sub>

<!-- /greptile_comment -->