### PR TITLE
Add mirror overlay fallback for unreliable caret geometry

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		0D8241CD31942A25EC4E0EE4 /* CotabbyDebugOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B2D34A6F3AC9DFD61350F7 /* CotabbyDebugOptions.swift */; };
 		0DDC0CFF5558A8F4355836B2 /* OverlayController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F308F6E274CC645E27CB651F /* OverlayController.swift */; };
 		1003373E13779882503C0E9D /* DisplayCoordinateConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74BD1D4DB27D5D96D1E06096 /* DisplayCoordinateConverter.swift */; };
+		14D77F0B8A195AC2FA8D24A9 /* MirrorOverlayLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC83D14A7557BC0196E59007 /* MirrorOverlayLayoutTests.swift */; };
 		156E6AB3D24134EEC29FDB93 /* FocusSnapshotResolverSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA705EDFE1C41294F0E381F1 /* FocusSnapshotResolverSelectionTests.swift */; };
 		157A55EB796BEB7819B90D5D /* ClipboardRelevanceFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A2AC525DC664DB540D4F19 /* ClipboardRelevanceFilter.swift */; };
 		15FA56CEF6FB5FF54C2FBA6F /* PermissionAndContextModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F42112F14026E6253BB865 /* PermissionAndContextModelTests.swift */; };
@@ -31,6 +32,7 @@
 		2402DC57AE2BCF6A686D30ED /* FocusModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C383AE85B971A9605787358 /* FocusModels.swift */; };
 		258EAFB0292290C88520E915 /* SystemSettingsWindowLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5976600F428C1265121D4C0C /* SystemSettingsWindowLocator.swift */; };
 		25D4FC8D191A50F63E6391F9 /* ModelAndPresentationValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03766F6253FF17639230C0F6 /* ModelAndPresentationValueTests.swift */; };
+		25F91CEF38400FD1ADB6B1AF /* CompletionRenderModePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D504BEB224E0C176F5FCFF6E /* CompletionRenderModePolicyTests.swift */; };
 		26E0331E9E2F92FAE531BDEE /* ActivationIndicatorController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84D4528EEC9EFEB8AE8E318 /* ActivationIndicatorController.swift */; };
 		2C6159231472A849F15BD0AE /* ScreenFrameReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5484C8A04B9C00CF79D589EB /* ScreenFrameReader.swift */; };
 		2DF5A3826AAB99C279EBB8DE /* InputMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B81DD30EB657368AACE9625A /* InputMonitor.swift */; };
@@ -38,11 +40,13 @@
 		2F227738D7834B1A7A81D1D6 /* ModelDownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51020F8CD58338BD643FBF63 /* ModelDownloadManager.swift */; };
 		2FC40D4BFDD05C2401D7A5E9 /* SuggestionInserter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3D1125B962CBE0269EEDDB /* SuggestionInserter.swift */; };
 		30F3F2B6D13CD583136CD787 /* AXHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC70775535A3428991025AB8 /* AXHelper.swift */; };
+		31515DDD173535C4AC777853 /* MirrorOverlayLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54150A507B03221F137D539B /* MirrorOverlayLayout.swift */; };
 		317883210D1D1D5CD654E562 /* ModelFileValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C4E5869D103865486AAAEEC /* ModelFileValidator.swift */; };
 		31DCCE980B6708401256D4D1 /* FoundationModelDriftEvalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D49F3B597374208594861B9B /* FoundationModelDriftEvalTests.swift */; };
 		32A2915FAE21CD9CE818A9D9 /* SuggestionSettingsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86460C747AA883FDE756BDBA /* SuggestionSettingsModel.swift */; };
 		344B9BF352C97CFA830853D6 /* WelcomePermissionStepView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D6C2318E405AA717D1C256 /* WelcomePermissionStepView.swift */; };
 		36312821AEE03E3E62845958 /* FoundationModelPromptRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE7BF162A12703249726F20A /* FoundationModelPromptRenderer.swift */; };
+		3985F0F2B3178DBB945B1064 /* CompletionRenderModePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53CF416511099C6818110F01 /* CompletionRenderModePolicy.swift */; };
 		3B3E08D1204E85F3776D8853 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = BAADA69C6172DD7F4A642E93 /* Sparkle */; };
 		3C23336EE6F6559857DE92EE /* SuggestionDebugLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003594B09C83EF2DF35577D5 /* SuggestionDebugLogger.swift */; };
 		3CBBC3BFAC0DC8952EE24EF7 /* BundledRuntimeLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA33F5FFAC5B99384E15CE3E /* BundledRuntimeLocator.swift */; };
@@ -84,6 +88,7 @@
 		744B06C2488156B178675615 /* PermissionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85BF316556FDA64CB8AD07B6 /* PermissionManager.swift */; };
 		76FD91607794883F8E121450 /* CaretGeometrySelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3C84377F352140759B448C9 /* CaretGeometrySelector.swift */; };
 		7B6A63F5DCC2C163CDFD2A5C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BC4F887528AE74AC0DD30314 /* Assets.xcassets */; };
+		7C94725B4837DEC9ECF1BC54 /* CompletionRenderMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A03E565A11581FD2150B142 /* CompletionRenderMode.swift */; };
 		7D6BB9AF72F7076A4E5EE96F /* DownloadableModelCatalogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5C2AE9A7E55495D26AD074 /* DownloadableModelCatalogView.swift */; };
 		7E9413CE7C999C4612348248 /* SuggestionSessionReconcilerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C8F07AC52C7A482F5FE34C5 /* SuggestionSessionReconcilerTests.swift */; };
 		7E99F5676A1D1DF7EA7D7702 /* SuggestionCoordinator+Prediction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ED1EA9282E0AC7592E60889 /* SuggestionCoordinator+Prediction.swift */; };
@@ -212,12 +217,15 @@
 		4696A84D17890B154533A08F /* PromptPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptPolicyTests.swift; sourceTree = "<group>"; };
 		4793D4EA5D36D7E5CC216C27 /* LanguageSupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageSupportTests.swift; sourceTree = "<group>"; };
 		51020F8CD58338BD643FBF63 /* ModelDownloadManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelDownloadManager.swift; sourceTree = "<group>"; };
+		53CF416511099C6818110F01 /* CompletionRenderModePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionRenderModePolicy.swift; sourceTree = "<group>"; };
+		54150A507B03221F137D539B /* MirrorOverlayLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MirrorOverlayLayout.swift; sourceTree = "<group>"; };
 		5484C8A04B9C00CF79D589EB /* ScreenFrameReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenFrameReader.swift; sourceTree = "<group>"; };
 		54EF3C7F5D9D6F3FA50FD51C /* ContextBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextBuffer.swift; sourceTree = "<group>"; };
 		5664E34B23FBDF69292FEF43 /* FoundationModelSuggestionEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoundationModelSuggestionEngine.swift; sourceTree = "<group>"; };
 		58C0F017699EE44C81C095CA /* TagsInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagsInputView.swift; sourceTree = "<group>"; };
 		5976600F428C1265121D4C0C /* SystemSettingsWindowLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemSettingsWindowLocator.swift; sourceTree = "<group>"; };
 		59E299BE2E9D42A33D5D2F5D /* ScreenTextExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenTextExtractor.swift; sourceTree = "<group>"; };
+		5A03E565A11581FD2150B142 /* CompletionRenderMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionRenderMode.swift; sourceTree = "<group>"; };
 		5A567677424A82D9EEF47495 /* KeyRecorderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyRecorderView.swift; sourceTree = "<group>"; };
 		5AD3F4F9FBE82007E4E15F58 /* GhostSuggestionLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostSuggestionLayoutTests.swift; sourceTree = "<group>"; };
 		5C4E5869D103865486AAAEEC /* ModelFileValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelFileValidator.swift; sourceTree = "<group>"; };
@@ -300,6 +308,7 @@
 		D3A2AC525DC664DB540D4F19 /* ClipboardRelevanceFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardRelevanceFilter.swift; sourceTree = "<group>"; };
 		D49F3B597374208594861B9B /* FoundationModelDriftEvalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoundationModelDriftEvalTests.swift; sourceTree = "<group>"; };
 		D4F6D5F94B238F7B4BE7C247 /* FocusCapabilityResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusCapabilityResolverTests.swift; sourceTree = "<group>"; };
+		D504BEB224E0C176F5FCFF6E /* CompletionRenderModePolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionRenderModePolicyTests.swift; sourceTree = "<group>"; };
 		D5D6C2318E405AA717D1C256 /* WelcomePermissionStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomePermissionStepView.swift; sourceTree = "<group>"; };
 		D84D4528EEC9EFEB8AE8E318 /* ActivationIndicatorController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivationIndicatorController.swift; sourceTree = "<group>"; };
 		DDE858CB1E687E3CEB8FDD5B /* SuggestionRequestFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionRequestFactory.swift; sourceTree = "<group>"; };
@@ -319,6 +328,7 @@
 		FA4B45B91D4DEAC979C3113E /* PromptContextSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptContextSanitizer.swift; sourceTree = "<group>"; };
 		FB317C82CE2CBC69056BA4B8 /* TagChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagChip.swift; sourceTree = "<group>"; };
 		FC24FD54860CE6737E65EF65 /* TextDirectionDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextDirectionDetectorTests.swift; sourceTree = "<group>"; };
+		FC83D14A7557BC0196E59007 /* MirrorOverlayLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MirrorOverlayLayoutTests.swift; sourceTree = "<group>"; };
 		FE7BF162A12703249726F20A /* FoundationModelPromptRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoundationModelPromptRenderer.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -468,6 +478,7 @@
 		8D43A99A396CBAE5922C2969 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				5A03E565A11581FD2150B142 /* CompletionRenderMode.swift */,
 				E43E587E421AF544A8300CE4 /* CustomRulesCatalog.swift */,
 				0C383AE85B971A9605787358 /* FocusModels.swift */,
 				B6D42CD456B4B3C988B148A6 /* FocusTrackingModel.swift */,
@@ -494,6 +505,7 @@
 				18D990E515E1AE4F312F4E95 /* BundledRuntimeLocatorTests.swift */,
 				EFD89799BB82AF7A92559AEB /* ClipboardContentDistillerTests.swift */,
 				90B0D133AB77A2503FB08827 /* ClipboardRelevanceFilterTests.swift */,
+				D504BEB224E0C176F5FCFF6E /* CompletionRenderModePolicyTests.swift */,
 				AF1E065C7FFB697FCEB2FA5C /* CotabbyTestFixtures.swift */,
 				AD752451330486FE270018B0 /* CustomRulesTests.swift */,
 				C1C5DE0F3FF63545000E2453 /* DisplayCoordinateConverterTests.swift */,
@@ -508,6 +520,7 @@
 				B097727248B5B32885D99036 /* IndicatorIconImageProcessorTests.swift */,
 				4793D4EA5D36D7E5CC216C27 /* LanguageSupportTests.swift */,
 				3009812A35A1CDEF16295AB7 /* LlamaPromptRendererTests.swift */,
+				FC83D14A7557BC0196E59007 /* MirrorOverlayLayoutTests.swift */,
 				03766F6253FF17639230C0F6 /* ModelAndPresentationValueTests.swift */,
 				A829F28F01FAE76CA7244BBC /* ModelFileValidatorTests.swift */,
 				E7F42112F14026E6253BB865 /* PermissionAndContextModelTests.swift */,
@@ -596,6 +609,7 @@
 				E3C84377F352140759B448C9 /* CaretGeometrySelector.swift */,
 				96495E4147D828C0B1B22765 /* ClipboardContentDistiller.swift */,
 				D3A2AC525DC664DB540D4F19 /* ClipboardRelevanceFilter.swift */,
+				53CF416511099C6818110F01 /* CompletionRenderModePolicy.swift */,
 				C7B2D34A6F3AC9DFD61350F7 /* CotabbyDebugOptions.swift */,
 				74BD1D4DB27D5D96D1E06096 /* DisplayCoordinateConverter.swift */,
 				CE8C2569A8217EE9BD3B197F /* FileLogHandler.swift */,
@@ -608,6 +622,7 @@
 				EBEDE359CFD99EF906FA50BC /* IndicatorIconImageProcessor.swift */,
 				EAAE6B395FAB604DF059280A /* KeyCodeLabels.swift */,
 				B5679E08C9A09065531C37B5 /* LlamaPromptRenderer.swift */,
+				54150A507B03221F137D539B /* MirrorOverlayLayout.swift */,
 				E6423D6CC8CC371D2DA899DE /* PermissionOverlayTracker.swift */,
 				FA4B45B91D4DEAC979C3113E /* PromptContextSanitizer.swift */,
 				3609CC88A5280B3AA40414DF /* SuggestionAvailabilityEvaluator.swift */,
@@ -751,6 +766,8 @@
 				6E01052209B73D7361C12CEF /* ClipboardContentDistiller.swift in Sources */,
 				D2CAA59F69BCBC07DDA2B0D8 /* ClipboardContextProvider.swift in Sources */,
 				157A55EB796BEB7819B90D5D /* ClipboardRelevanceFilter.swift in Sources */,
+				7C94725B4837DEC9ECF1BC54 /* CompletionRenderMode.swift in Sources */,
+				3985F0F2B3178DBB945B1064 /* CompletionRenderModePolicy.swift in Sources */,
 				8B2DFC860803C0A7C4D34A36 /* ContextBuffer.swift in Sources */,
 				AA2E09FF7E430D66ECA8ECD5 /* CotabbyApp.swift in Sources */,
 				FCC571EC239846F06007BFCA /* CotabbyAppEnvironment.swift in Sources */,
@@ -799,6 +816,7 @@
 				0333B3CE8F189DD1BEC4AD26 /* MenuBarSections.swift in Sources */,
 				AECC7289DA796B071B4FE3C0 /* MenuBarStatusLabelView.swift in Sources */,
 				5E92E3C1EB41D482FC06BC52 /* MenuBarView.swift in Sources */,
+				31515DDD173535C4AC777853 /* MirrorOverlayLayout.swift in Sources */,
 				2F227738D7834B1A7A81D1D6 /* ModelDownloadManager.swift in Sources */,
 				317883210D1D1D5CD654E562 /* ModelFileValidator.swift in Sources */,
 				0DDC0CFF5558A8F4355836B2 /* OverlayController.swift in Sources */,
@@ -864,6 +882,7 @@
 				58AC3193D846FDE88513377D /* BundledRuntimeLocatorTests.swift in Sources */,
 				8865B95FE84198D70390DF80 /* ClipboardContentDistillerTests.swift in Sources */,
 				BFCA7FAFDAEBF586AB615567 /* ClipboardRelevanceFilterTests.swift in Sources */,
+				25F91CEF38400FD1ADB6B1AF /* CompletionRenderModePolicyTests.swift in Sources */,
 				5E10EFC426217CB7218A5847 /* CotabbyTestFixtures.swift in Sources */,
 				91D1F16B8C5DA281D4B7F699 /* CustomRulesTests.swift in Sources */,
 				56611BA0087710277140E9E6 /* DisplayCoordinateConverterTests.swift in Sources */,
@@ -878,6 +897,7 @@
 				9B086C44BEE317231CE2AD45 /* IndicatorIconImageProcessorTests.swift in Sources */,
 				E912D4617AE1376061DF1F00 /* LanguageSupportTests.swift in Sources */,
 				190C571B3CDFE117F4D15484 /* LlamaPromptRendererTests.swift in Sources */,
+				14D77F0B8A195AC2FA8D24A9 /* MirrorOverlayLayoutTests.swift in Sources */,
 				25D4FC8D191A50F63E6391F9 /* ModelAndPresentationValueTests.swift in Sources */,
 				65478B0DABF5460C32D4C458 /* ModelFileValidatorTests.swift in Sources */,
 				15FA56CEF6FB5FF54C2FBA6F /* PermissionAndContextModelTests.swift in Sources */,

--- a/Cotabby/Models/CompletionRenderMode.swift
+++ b/Cotabby/Models/CompletionRenderMode.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// File overview:
+/// Names the visual strategy `OverlayController` uses to surface a suggestion. The split exists
+/// because some hosts expose unreliable caret geometry (Electron canvases, certain web editors).
+/// Drawing inline ghost text in those hosts produces a "marching" effect as the caret estimate
+/// drifts. Mirror mode sidesteps that by rendering the suggestion in a Cotabby-owned card anchored
+/// to the input field rectangle, which is much more stable than the caret rect in those apps.
+///
+/// The enum lives in `Models/` rather than `Support/` because both the policy (which picks the mode)
+/// and `OverlayState` (which records which mode the panel is currently in) need to spell out the
+/// same case names without depending on rendering code.
+enum CompletionRenderMode: Equatable, Sendable {
+    /// Ghost text drawn next to the live caret. The default for hosts with trustworthy AX geometry.
+    case inline
+
+    /// Suggestion drawn inside a Cotabby-owned card. Used when caret geometry is unreliable, or
+    /// when the user explicitly prefers the preview-card presentation. The reason is informational
+    /// only; the rendering pipeline does not branch on it.
+    case mirror(reason: MirrorReason)
+
+    /// Why mirror mode was chosen for this presentation. Surfaced in the focus debug overlay and
+    /// in `OverlayState.detail` so operators can confirm the policy is firing as expected.
+    enum MirrorReason: String, Equatable, Sendable {
+        /// Caret quality came back `.estimated`, meaning the host did not expose `AXBoundsForRange`
+        /// or any of the derived geometry paths. Inline rendering would land at a guessed X that
+        /// drifts as the user types.
+        case caretGeometryEstimated
+
+        /// User set their global preference to always use mirror mode. Phase 2 wiring.
+        case userPreference
+
+        /// Per-app override forced mirror mode for this host. Phase 2 wiring.
+        case perAppOverride
+    }
+
+    /// Short, debug-friendly label for diagnostics and logs.
+    var label: String {
+        switch self {
+        case .inline:
+            return "inline"
+        case .mirror(let reason):
+            return "mirror(\(reason.rawValue))"
+        }
+    }
+
+    var isMirror: Bool {
+        if case .mirror = self {
+            return true
+        }
+        return false
+    }
+}

--- a/Cotabby/Models/SuggestionModels.swift
+++ b/Cotabby/Models/SuggestionModels.swift
@@ -381,9 +381,13 @@ struct SuggestionOverlayGeometry: Equatable, Sendable {
 
 /// The overlay is intentionally modeled as data so diagnostics can reason about visibility
 /// without poking into AppKit window objects directly.
+///
+/// `visible` carries the active `CompletionRenderMode` so the focus debug overlay, tests, and
+/// presenter state-diffing can distinguish an inline ghost from a mirror card without inspecting
+/// `OverlayController` internals.
 enum OverlayState: Equatable {
     case hidden(reason: String)
-    case visible(text: String, geometry: SuggestionOverlayGeometry)
+    case visible(text: String, geometry: SuggestionOverlayGeometry, mode: CompletionRenderMode)
 
     var shortLabel: String {
         switch self {
@@ -398,10 +402,10 @@ enum OverlayState: Equatable {
         switch self {
         case let .hidden(reason):
             return reason
-        case let .visible(text, geometry):
+        case let .visible(text, geometry, mode):
             return "Showing \(text.count) characters near " +
                 "(\(Int(geometry.caretRect.minX)), \(Int(geometry.caretRect.minY))) " +
-                "using \(geometry.caretQuality.label) caret geometry."
+                "using \(geometry.caretQuality.label) caret geometry (\(mode.label))."
         }
     }
 
@@ -414,11 +418,18 @@ enum OverlayState: Equatable {
     }
 
     var visibleText: String? {
-        guard case let .visible(text, _) = self else {
+        guard case let .visible(text, _, _) = self else {
             return nil
         }
 
         return text
+    }
+
+    var visibleMode: CompletionRenderMode? {
+        guard case let .visible(_, _, mode) = self else {
+            return nil
+        }
+        return mode
     }
 }
 

--- a/Cotabby/Services/Suggestion/SuggestionOverlayPresenter.swift
+++ b/Cotabby/Services/Suggestion/SuggestionOverlayPresenter.swift
@@ -18,6 +18,11 @@ struct SuggestionOverlayPresenter {
     }
 
     /// Shows or repositions ghost text while preserving the previous overlay message when nothing changed.
+    ///
+    /// The state diff intentionally ignores the active `CompletionRenderMode` when deciding whether
+    /// to skip the AppKit call: the controller picks the mode internally each time and re-applying
+    /// the same text/geometry is cheap. The diagnostic messages below do distinguish a mode flip so
+    /// operators see when inline → mirror (or back) actually happened.
     func present(
         text: String,
         geometry: SuggestionOverlayGeometry,
@@ -28,33 +33,48 @@ struct SuggestionOverlayPresenter {
             return hide(reason: "Overlay hidden because the suggestion text was empty.")
         }
 
-        guard previousState != .visible(
-            text: displayText,
-            geometry: geometry
-        ) else {
+        // Compare against the previous visible content while ignoring `mode`, which the controller
+        // resolves from geometry each call. If the controller swaps modes for the same text+geometry
+        // it does the resulting state transition; we still need to invoke `showSuggestion` so the
+        // panel re-renders.
+        if case let .visible(previousText, previousGeometry, _) = previousState,
+           previousText == displayText,
+           previousGeometry == geometry {
             return nil
         }
 
         overlayController.showSuggestion(displayText, geometry: geometry)
 
         switch previousState {
-        case .visible(let previousText, let previousGeometry)
+        case .visible(let previousText, let previousGeometry, let previousMode)
+        where previousText == displayText
+            && previousGeometry.caretRect == geometry.caretRect
+            && previousMode.isMirror != currentModeIsMirror():
+            return "Switched overlay render mode for the latest geometry."
+
+        case .visible(let previousText, let previousGeometry, _)
         where previousText == displayText
             && previousGeometry.caretRect == geometry.caretRect
             && previousGeometry.caretQuality != geometry.caretQuality:
             return "Updated ghost text styling for the latest caret quality."
 
-        case .visible(let previousText, let previousGeometry)
+        case .visible(let previousText, let previousGeometry, _)
         where previousText == displayText && previousGeometry.caretRect != geometry.caretRect:
             return "Moved ghost text to the latest caret position."
 
-        case .visible(let previousText, _)
+        case .visible(let previousText, _, _)
         where previousText == displayText:
             return "Updated ghost text layout for the latest input bounds."
 
         default:
             return "Displayed ghost text near the caret."
         }
+    }
+
+    /// Reads the live overlay state after the controller updated it, so the mode-flip diagnostic
+    /// reflects whatever the controller actually picked this presentation.
+    private func currentModeIsMirror() -> Bool {
+        overlayController.state.visibleMode?.isMirror ?? false
     }
 
     func hide(reason: String) -> String {

--- a/Cotabby/Services/UI/OverlayController.swift
+++ b/Cotabby/Services/UI/OverlayController.swift
@@ -20,6 +20,12 @@ final class OverlayController: SuggestionOverlayControlling {
     var onStateChange: ((OverlayState) -> Void)?
 
     private let suggestionSettings: SuggestionSettingsModel
+    private let renderModePolicy: CompletionRenderModePolicy
+
+    /// Bundle identifier of the currently focused host app, supplied by the coordinator each time
+    /// a suggestion is presented. The policy uses this to look up per-app overrides. Nil in tests
+    /// or when the focus pipeline could not identify the host.
+    private var currentBundleIdentifier: String?
 
     private(set) var state: OverlayState = .hidden(reason: "Overlay idle.") {
         didSet {
@@ -30,15 +36,31 @@ final class OverlayController: SuggestionOverlayControlling {
     /// Reused across overlay updates to avoid allocating a new SwiftUI hosting view on every
     /// tab-per-word cycle. Only the rootView is swapped, which triggers a lightweight diff
     /// instead of a full view rebuild + layout pass.
-    private var hostingView: NSHostingView<GhostSuggestionView>?
+    ///
+    /// Inline and mirror modes keep separate hosting views because their root view types differ
+    /// (`GhostSuggestionView` vs `MirrorOverlayView`). Sharing one hosting view via `AnyView` would
+    /// defeat SwiftUI's type-aware diffing.
+    private var inlineHostingView: NSHostingView<GhostSuggestionView>?
+    private var mirrorHostingView: NSHostingView<MirrorOverlayView>?
 
     /// Per-focus-session floor for caret-derived font size. Caret height flickers between the real
     /// line height and the coarse field-height fallback from poll to poll; stabilizing keeps ghost
     /// text from ballooning when the fallback wins. See `GhostFontSizeStabilizer`.
     private var ghostFontStabilizer = GhostFontSizeStabilizer()
 
-    init(suggestionSettings: SuggestionSettingsModel) {
+    init(
+        suggestionSettings: SuggestionSettingsModel,
+        renderModePolicy: CompletionRenderModePolicy = CompletionRenderModePolicy()
+    ) {
         self.suggestionSettings = suggestionSettings
+        self.renderModePolicy = renderModePolicy
+    }
+
+    /// Coordinator hook that updates the bundle identifier used by per-app overrides. Phase 1
+    /// callers do not need this (policy is `.auto` with no overrides); Phase 2 will wire it through
+    /// the presenter so per-app settings take effect immediately when the focused app changes.
+    func setCurrentBundleIdentifier(_ bundleIdentifier: String?) {
+        currentBundleIdentifier = bundleIdentifier
     }
 
     private lazy var panel: OverlayPanel = {
@@ -64,13 +86,39 @@ final class OverlayController: SuggestionOverlayControlling {
         return panel
     }()
 
-    /// Sizes and positions the overlay next to the reported caret bounds for the current field.
+    /// Sizes and positions the overlay using the render mode the policy picks for this geometry.
+    /// Each mode is responsible for its own layout math and SwiftUI view; this entry point just
+    /// routes and records the resulting state.
     func showSuggestion(_ text: String, geometry: SuggestionOverlayGeometry) {
         guard !text.isEmpty else {
             hide(reason: "Overlay not shown because the suggestion was empty.")
             return
         }
 
+        let mode = renderModePolicy.mode(
+            for: geometry,
+            bundleIdentifier: currentBundleIdentifier
+        )
+
+        switch mode {
+        case .inline:
+            showInline(text: text, geometry: geometry)
+        case .mirror(let reason):
+            showMirror(text: text, geometry: geometry, reason: reason)
+        }
+
+        state = .visible(text: text, geometry: geometry, mode: mode)
+    }
+
+    /// Hides the floating panel and records why the overlay is no longer visible.
+    func hide(reason: String) {
+        panel.orderOut(nil)
+        state = .hidden(reason: reason)
+    }
+
+    /// Inline ghost text drawn next to the caret. This is the original rendering path; the body
+    /// stays unchanged from the pre-mirror behavior aside from being extracted into its own method.
+    private func showInline(text: String, geometry: SuggestionOverlayGeometry) {
         let stabilizedCaretHeight = ghostFontStabilizer.stabilizedCaretHeight(
             geometry.caretRect.height,
             focusSessionKey: geometry.focusChangeSequence
@@ -93,30 +141,32 @@ final class OverlayController: SuggestionOverlayControlling {
             fromHex: suggestionSettings.customSuggestionTextColorHex
         )
         let ghostOpacity = suggestionSettings.ghostTextOpacity
+
+        let rootView = GhostSuggestionView(
+            layout: layout,
+            fontSize: fontSize,
+            customColor: customGhostColor,
+            keycapLabel: acceptanceHintLabel,
+            opacity: ghostOpacity
+        )
+
         let contentView: NSHostingView<GhostSuggestionView>
-        if let existing = hostingView {
-            existing.rootView = GhostSuggestionView(
-                layout: layout,
-                fontSize: fontSize,
-                customColor: customGhostColor,
-                keycapLabel: acceptanceHintLabel,
-                opacity: ghostOpacity
-            )
+        if let existing = inlineHostingView {
+            existing.rootView = rootView
             contentView = existing
         } else {
-            let fresh = NSHostingView(
-                rootView: GhostSuggestionView(
-                    layout: layout,
-                    fontSize: fontSize,
-                    customColor: customGhostColor,
-                    keycapLabel: acceptanceHintLabel,
-                    opacity: ghostOpacity
-                )
-            )
-            hostingView = fresh
-            panel.contentView = fresh
+            let fresh = NSHostingView(rootView: rootView)
+            inlineHostingView = fresh
             contentView = fresh
         }
+
+        // Mirror mode and inline mode share the same panel but use different SwiftUI root view
+        // types. Switching modes mid-suggestion requires re-attaching the panel's contentView; an
+        // identity check skips the re-attach when we're already on the right view.
+        if panel.contentView !== contentView {
+            panel.contentView = contentView
+        }
+
         contentView.layoutSubtreeIfNeeded()
         let contentSize = contentView.fittingSize
 
@@ -124,13 +174,54 @@ final class OverlayController: SuggestionOverlayControlling {
 
         panel.setFrame(frame.integral, display: true)
         panel.orderFrontRegardless()
-        state = .visible(text: text, geometry: geometry)
     }
 
-    /// Hides the floating panel and records why the overlay is no longer visible.
-    func hide(reason: String) {
-        panel.orderOut(nil)
-        state = .hidden(reason: reason)
+    /// Mirror-mode rendering. Draws the suggestion inside a Cotabby-owned card anchored to the
+    /// input field rectangle (not the caret rect) so unreliable caret geometry does not propagate
+    /// into the card position. The card is otherwise visually similar to inline ghost text plus a
+    /// backdrop that makes it read as a UI element rather than free-floating text.
+    private func showMirror(
+        text: String,
+        geometry: SuggestionOverlayGeometry,
+        reason: CompletionRenderMode.MirrorReason
+    ) {
+        let acceptanceHintLabel = suggestionSettings.acceptanceHintLabel
+        let visibleFrame = targetScreenVisibleFrame(for: geometry.caretRect)
+        let layout = MirrorOverlayLayout.make(
+            suggestion: text,
+            geometry: geometry,
+            visibleFrame: visibleFrame,
+            showsAcceptanceHint: acceptanceHintLabel != nil,
+            reason: reason
+        )
+        let customGhostColor = SuggestionTextColorCodec.color(
+            fromHex: suggestionSettings.customSuggestionTextColorHex
+        )
+        let ghostOpacity = suggestionSettings.ghostTextOpacity
+
+        let rootView = MirrorOverlayView(
+            layout: layout,
+            customColor: customGhostColor,
+            keycapLabel: acceptanceHintLabel,
+            opacity: ghostOpacity
+        )
+
+        let contentView: NSHostingView<MirrorOverlayView>
+        if let existing = mirrorHostingView {
+            existing.rootView = rootView
+            contentView = existing
+        } else {
+            let fresh = NSHostingView(rootView: rootView)
+            mirrorHostingView = fresh
+            contentView = fresh
+        }
+
+        if panel.contentView !== contentView {
+            panel.contentView = contentView
+        }
+
+        panel.setFrame(layout.panelFrame, display: true)
+        panel.orderFrontRegardless()
     }
 
     /// Exact and derived caret rects usually reflect the real text line height, so they may scale
@@ -259,5 +350,72 @@ private struct GhostKeycap: View {
                     .stroke(borderColor, lineWidth: 1)
             )
             .fixedSize(horizontal: true, vertical: true)
+    }
+}
+
+/// Mirror-mode card. Renders the suggestion inside a Cotabby-owned backdrop anchored below the
+/// focused field. Unlike `GhostSuggestionView`, this view is single-line by design — the whole
+/// reason mirror mode exists is that the host's caret rect is unreliable, so multi-line wrapping
+/// would just compound the positioning uncertainty.
+///
+/// The backdrop and shadow are what make this read as a deliberate UI element instead of a stray
+/// floating text label. We do not try to disguise the card as the host editor; Cotypist's product
+/// language ("preview") is the right framing here.
+private struct MirrorOverlayView: View {
+    @Environment(\.colorScheme) var colorScheme
+    let layout: MirrorOverlayLayout
+    let customColor: Color?
+    let keycapLabel: String?
+    let opacity: Double
+
+    private var ghostColor: Color {
+        let baseColor = customColor
+            ?? (
+                colorScheme == .dark
+                    ? Color(red: 0.85, green: 0.85, blue: 0.85)
+                    : Color(red: 0.25, green: 0.25, blue: 0.25)
+            )
+        return baseColor.opacity(opacity)
+    }
+
+    private var backdropColor: Color {
+        colorScheme == .dark
+            ? Color(white: 0.16).opacity(0.96)
+            : Color(white: 0.98).opacity(0.96)
+    }
+
+    private var borderColor: Color {
+        colorScheme == .dark ? Color(white: 0.28) : Color(white: 0.82)
+    }
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
+            Text(layout.suggestionText)
+                .font(.system(size: layout.fontSize))
+                .foregroundStyle(ghostColor)
+                .lineLimit(1)
+                .truncationMode(.tail)
+
+            if let keycapLabel {
+                GhostKeycap(label: keycapLabel)
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(backdropColor)
+                .shadow(color: .black.opacity(0.12), radius: 6, x: 0, y: 2)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(borderColor, lineWidth: 0.5)
+        )
+        // The panel itself is sized by MirrorOverlayLayout to the card dimensions, so we don't
+        // need fixedSize here — the view fills the panel exactly.
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        // Right-to-left hosts get the SwiftUI environment flip so the keycap lands on the leading
+        // side of the suggestion text, mirroring how RTL languages read.
+        .environment(\.layoutDirection, layout.isRightToLeft ? .rightToLeft : .leftToRight)
     }
 }

--- a/Cotabby/Support/CompletionRenderModePolicy.swift
+++ b/Cotabby/Support/CompletionRenderModePolicy.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// User-facing preference for how Cotabby presents completions.
+///
+/// `auto` defers to caret-geometry quality: trustworthy geometry stays inline, weak geometry promotes
+/// to mirror mode. `alwaysInline` and `alwaysMirror` let power users pin a strategy when the
+/// auto rule misfires for their host mix.
+///
+/// Phase 1 hardcodes `.auto` everywhere; the global setting and per-app overrides land in Phase 2.
+enum MirrorPreference: String, Codable, CaseIterable, Equatable, Sendable {
+    case auto
+    case alwaysInline
+    case alwaysMirror
+
+    /// Human-readable label for Settings UI. Kept here so Settings code does not have to repeat the
+    /// mapping; the policy is the single source of truth for both the rule and the copy.
+    var displayLabel: String {
+        switch self {
+        case .auto:
+            return "Auto (recommended)"
+        case .alwaysInline:
+            return "Always inline"
+        case .alwaysMirror:
+            return "Always preview card"
+        }
+    }
+}
+
+/// Pure rule that translates "what kind of geometry do we have, and what does the user want?" into
+/// the concrete `CompletionRenderMode` the overlay should use right now.
+///
+/// Pulling the decision into its own value type keeps `OverlayController` focused on AppKit layout
+/// and makes the rule trivially unit-testable. Adding a new trigger (per-domain, telemetry-driven,
+/// etc.) means editing this one struct rather than threading conditionals through the controller.
+///
+/// `Sendable` because the policy is a pure value type built from `Sendable` members; explicit
+/// `nonisolated init` keeps the default-parameter expression `CompletionRenderModePolicy()` from
+/// being inferred as `@MainActor`-isolated when used as a default in main-actor classes.
+struct CompletionRenderModePolicy: Equatable, Sendable {
+    let userPreference: MirrorPreference
+
+    /// Per-app override map keyed by bundle identifier. Empty in Phase 1; populated by Settings in
+    /// Phase 2. A bundle in this map wins over `userPreference`.
+    let perAppOverrides: [String: MirrorPreference]
+
+    nonisolated init(
+        userPreference: MirrorPreference = .auto,
+        perAppOverrides: [String: MirrorPreference] = [:]
+    ) {
+        self.userPreference = userPreference
+        self.perAppOverrides = perAppOverrides
+    }
+
+    /// Decides which render mode to use for one presentation. `bundleIdentifier` may be nil when the
+    /// host app could not be identified; in that case only the global preference applies.
+    func mode(
+        for geometry: SuggestionOverlayGeometry,
+        bundleIdentifier: String?
+    ) -> CompletionRenderMode {
+        let effectivePreference: MirrorPreference
+        if let bundleIdentifier, let override = perAppOverrides[bundleIdentifier] {
+            effectivePreference = override
+        } else {
+            effectivePreference = userPreference
+        }
+
+        switch effectivePreference {
+        case .alwaysInline:
+            return .inline
+
+        case .alwaysMirror:
+            // The per-app branch is recorded separately because the user-set "always mirror" toggle
+            // and a per-app override carry different product semantics. Diagnostics can distinguish.
+            let reason: CompletionRenderMode.MirrorReason
+            if let bundleIdentifier,
+               perAppOverrides[bundleIdentifier] == .alwaysMirror {
+                reason = .perAppOverride
+            } else {
+                reason = .userPreference
+            }
+            return .mirror(reason: reason)
+
+        case .auto:
+            // Only `.estimated` geometry triggers auto-mirror. `.derived` already lands close enough
+            // to the real caret to render inline ghost text confidently; promoting it would over-fire
+            // the card for hosts that work fine today (Gmail, Outlook, Discord text-marker path).
+            return geometry.caretQuality == .estimated
+                ? .mirror(reason: .caretGeometryEstimated)
+                : .inline
+        }
+    }
+}

--- a/Cotabby/Support/MirrorOverlayLayout.swift
+++ b/Cotabby/Support/MirrorOverlayLayout.swift
@@ -82,10 +82,12 @@ struct MirrorOverlayLayout: Equatable {
         let measuredTextWidth = measuredWidth(of: normalizedSuggestion, fontSize: Metrics.fontSize)
         let keycapReservation = showsAcceptanceHint ? Metrics.keycapReservation : 0
 
-        let contentWidth = min(
-            Metrics.maxCardWidth,
-            max(Metrics.minCardWidth, measuredTextWidth + keycapReservation)
-        )
+        // Reserve the keycap on top of the text width, not inside the min/max clamp. Otherwise a
+        // short suggestion (measured width below `minCardWidth`) gets the same card as one with the
+        // hint disabled because the minimum floor absorbs the reservation.
+        let textBudget = max(0, Metrics.maxCardWidth - keycapReservation)
+        let textContentWidth = min(textBudget, max(Metrics.minCardWidth, measuredTextWidth))
+        let contentWidth = textContentWidth + keycapReservation
         let cardWidth = contentWidth + (Metrics.horizontalPadding * 2)
         let cardHeight = ceil(Metrics.fontSize * 1.6) + (Metrics.verticalPadding * 2)
 

--- a/Cotabby/Support/MirrorOverlayLayout.swift
+++ b/Cotabby/Support/MirrorOverlayLayout.swift
@@ -1,0 +1,172 @@
+import AppKit
+import CoreGraphics
+import Foundation
+
+/// Pure layout math for the mirror-overlay rendering mode.
+///
+/// Mirror mode is reached when the host's caret geometry is unreliable, so this helper does not
+/// anchor to the caret rect for positioning — it anchors to the input field's frame and falls back
+/// to the caret rect only when the field frame is missing. That ordering is the opposite of the
+/// inline ghost layout, which trusts the caret rect first.
+///
+/// Layout decisions live here as a pure value type so `OverlayController` can stay focused on
+/// AppKit window plumbing and the rules below stay easy to test without spinning up SwiftUI.
+struct MirrorOverlayLayout: Equatable {
+    /// Final panel frame in screen coordinates. The caller passes this directly to `NSPanel.setFrame`.
+    let panelFrame: CGRect
+
+    /// Fixed font size for the suggestion text. Mirror mode deliberately ignores the caret-derived
+    /// font sizing used by inline ghost text. The whole reason we are in mirror mode is that the
+    /// caret rect (and therefore its height) is untrustworthy, so deriving font size from it would
+    /// just propagate the same unreliable signal into the UI.
+    let fontSize: CGFloat
+
+    /// The suggestion to render. Whitespace collapsed for single-line display.
+    let suggestionText: String
+
+    /// Reading direction for the host text. The card lays out left-to-right even in RTL hosts so the
+    /// "[hint] [Tab]" pattern stays readable; the field is repeated as `isRightToLeft` for callers
+    /// that need to flip secondary chrome (Phase 3 prefix hint will use this).
+    let isRightToLeft: Bool
+
+    /// Which trigger surfaced this presentation. Plumbed through purely for diagnostics so the
+    /// debug overlay can show why mirror mode is up.
+    let reason: CompletionRenderMode.MirrorReason
+
+    private enum Metrics {
+        /// Fixed font size for the suggestion in the card. Sized for legibility at typical viewing
+        /// distance, not to match the host editor (mirror is explicitly a preview, not a forgery).
+        static let fontSize: CGFloat = 13
+
+        /// Vertical gap between the bottom of the input field (or caret rect) and the top of the
+        /// card. Large enough that the card does not look like it is part of the field.
+        static let anchorGap: CGFloat = 8
+
+        /// Internal padding inside the card around the text + keycap row.
+        static let horizontalPadding: CGFloat = 10
+        static let verticalPadding: CGFloat = 6
+
+        /// Estimated keycap pill width (matches GhostKeycap's roughly 28pt label + spacing). Used to
+        /// reserve room for the acceptance hint when computing card width.
+        static let keycapReservation: CGFloat = 36
+
+        /// Width budget caps. We do not want a card that spans the whole monitor for a long
+        /// completion; clamp to a comfortable reading width with horizontal scrolling-style ellipsis
+        /// handled by SwiftUI lineLimit.
+        static let maxCardWidth: CGFloat = 520
+        static let minCardWidth: CGFloat = 120
+
+        /// Distance the card must keep from screen edges so it never clips against the menu bar or
+        /// dock. The visibleFrame already excludes those, but a small inset still looks more
+        /// intentional than touching the edge.
+        static let screenMargin: CGFloat = 12
+
+        /// Vertical offset used when only the caret rect is available (no input frame). Spans about
+        /// one line height so the card sits just below the caret line rather than on top of it.
+        static let caretFallbackVerticalOffset: CGFloat = 22
+    }
+
+    /// Computes the layout for one presentation.
+    ///
+    /// `geometry.inputFrameRect` is the preferred anchor. When it is nil the card falls back to a
+    /// fixed offset below the caret rect — worse, but at least directionally correct. `visibleFrame`
+    /// is the target screen's visible region and is used to clamp the card on-screen.
+    static func make(
+        suggestion: String,
+        geometry: SuggestionOverlayGeometry,
+        visibleFrame: CGRect,
+        showsAcceptanceHint: Bool,
+        reason: CompletionRenderMode.MirrorReason
+    ) -> MirrorOverlayLayout {
+        let normalizedSuggestion = normalizedDisplayText(suggestion)
+        let measuredTextWidth = measuredWidth(of: normalizedSuggestion, fontSize: Metrics.fontSize)
+        let keycapReservation = showsAcceptanceHint ? Metrics.keycapReservation : 0
+
+        let contentWidth = min(
+            Metrics.maxCardWidth,
+            max(Metrics.minCardWidth, measuredTextWidth + keycapReservation)
+        )
+        let cardWidth = contentWidth + (Metrics.horizontalPadding * 2)
+        let cardHeight = ceil(Metrics.fontSize * 1.6) + (Metrics.verticalPadding * 2)
+
+        let anchorTopY = computeAnchorTopY(geometry: geometry)
+        let anchorCenterX = computeAnchorCenterX(geometry: geometry)
+
+        var originX = anchorCenterX - (cardWidth / 2)
+        // Card sits BELOW the field/caret. AppKit screen coordinates are bottom-up, so subtracting
+        // the card height from the anchor's bottom edge places the card just under the anchor line.
+        var originY = anchorTopY - cardHeight
+
+        // Clamp to the visible frame so the card never disappears off-screen for hosts near edges.
+        let minX = visibleFrame.minX + Metrics.screenMargin
+        let maxX = visibleFrame.maxX - Metrics.screenMargin - cardWidth
+        if maxX >= minX {
+            originX = min(max(originX, minX), maxX)
+        } else {
+            originX = minX
+        }
+
+        let minY = visibleFrame.minY + Metrics.screenMargin
+        let maxY = visibleFrame.maxY - Metrics.screenMargin - cardHeight
+        if maxY >= minY {
+            originY = min(max(originY, minY), maxY)
+        } else {
+            originY = minY
+        }
+
+        let panelFrame = CGRect(
+            x: originX,
+            y: originY,
+            width: cardWidth,
+            height: cardHeight
+        ).integral
+
+        return MirrorOverlayLayout(
+            panelFrame: panelFrame,
+            fontSize: Metrics.fontSize,
+            suggestionText: normalizedSuggestion,
+            isRightToLeft: geometry.isRightToLeft,
+            reason: reason
+        )
+    }
+
+    /// The Y coordinate the card sits *under*. In AppKit's bottom-up coordinate system this is the
+    /// bottom edge of the anchor (field or caret rect) minus the gap.
+    private static func computeAnchorTopY(geometry: SuggestionOverlayGeometry) -> CGFloat {
+        if let inputFrame = geometry.inputFrameRect?.standardized, !inputFrame.isEmpty {
+            return inputFrame.minY - Metrics.anchorGap
+        }
+        // No field rect — fall back to the caret rect with an explicit vertical offset so the card
+        // doesn't overlap the caret line. The card lands slightly lower than ideal but at least
+        // doesn't sit directly on top of typed text.
+        return geometry.caretRect.minY - Metrics.caretFallbackVerticalOffset
+    }
+
+    /// Horizontal center the card aligns to. Prefer the caret's X because the user's eye is already
+    /// near the caret; only fall back to the field center if the caret rect looks degenerate.
+    private static func computeAnchorCenterX(geometry: SuggestionOverlayGeometry) -> CGFloat {
+        if geometry.caretRect.width > 0 || geometry.caretRect.minX > 0 {
+            return geometry.caretRect.midX
+        }
+        if let inputFrame = geometry.inputFrameRect?.standardized, !inputFrame.isEmpty {
+            return inputFrame.midX
+        }
+        return geometry.caretRect.midX
+    }
+
+    /// Collapses internal whitespace and trims edges so the card never renders a multi-line block.
+    /// Mirror mode is single-line by design — the inline ghost is what handles multi-line wrapping.
+    private static func normalizedDisplayText(_ text: String) -> String {
+        let collapsed = text
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+        return collapsed
+    }
+
+    private static func measuredWidth(of text: String, fontSize: CGFloat) -> CGFloat {
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: fontSize)
+        ]
+        return (text as NSString).size(withAttributes: attributes).width
+    }
+}

--- a/Cotabby/Support/SuggestionSessionReconciler.swift
+++ b/Cotabby/Support/SuggestionSessionReconciler.swift
@@ -329,7 +329,7 @@ enum SuggestionSessionReconciler {
     /// The overlay may be hidden briefly while waiting for the host app to publish an updated
     /// caret position, so hidden does not automatically mean "reject Tab."
     static func overlayAllowsAcceptance(of text: String, overlayState: OverlayState) -> Bool {
-        guard case let .visible(visibleText, _) = overlayState else {
+        guard case let .visible(visibleText, _, _) = overlayState else {
             return true
         }
 

--- a/CotabbyTests/CompletionRenderModePolicyTests.swift
+++ b/CotabbyTests/CompletionRenderModePolicyTests.swift
@@ -1,0 +1,126 @@
+import CoreGraphics
+import XCTest
+@testable import Cotabby
+
+/// Locks in the auto/explicit-preference rules so a regression in the policy is loud rather than
+/// a silent UX change. The policy is pure, so these tests do not touch AppKit.
+final class CompletionRenderModePolicyTests: XCTestCase {
+
+    // MARK: - Auto preference (Phase 1 default)
+
+    func test_auto_returnsInlineForExactCaretGeometry() {
+        let policy = CompletionRenderModePolicy(userPreference: .auto)
+        let geometry = CotabbyTestFixtures.overlayGeometry(caretQuality: .exact)
+
+        XCTAssertEqual(
+            policy.mode(for: geometry, bundleIdentifier: "com.apple.TextEdit"),
+            .inline
+        )
+    }
+
+    func test_auto_returnsInlineForDerivedCaretGeometry() {
+        // `.derived` is intentionally NOT a mirror trigger. Cotypist-equivalent hosts (Gmail,
+        // Outlook, Discord via text marker) land on `.derived` today and render fine inline.
+        let policy = CompletionRenderModePolicy(userPreference: .auto)
+        let geometry = CotabbyTestFixtures.overlayGeometry(caretQuality: .derived)
+
+        XCTAssertEqual(
+            policy.mode(for: geometry, bundleIdentifier: "com.google.Chrome"),
+            .inline
+        )
+    }
+
+    func test_auto_returnsMirrorForEstimatedCaretGeometry() {
+        let policy = CompletionRenderModePolicy(userPreference: .auto)
+        let geometry = CotabbyTestFixtures.overlayGeometry(caretQuality: .estimated)
+
+        XCTAssertEqual(
+            policy.mode(for: geometry, bundleIdentifier: "com.microsoft.VSCode"),
+            .mirror(reason: .caretGeometryEstimated)
+        )
+    }
+
+    // MARK: - Always-inline preference
+
+    func test_alwaysInline_keepsInlineEvenForEstimatedGeometry() {
+        let policy = CompletionRenderModePolicy(userPreference: .alwaysInline)
+        let geometry = CotabbyTestFixtures.overlayGeometry(caretQuality: .estimated)
+
+        XCTAssertEqual(
+            policy.mode(for: geometry, bundleIdentifier: nil),
+            .inline
+        )
+    }
+
+    // MARK: - Always-mirror preference
+
+    func test_alwaysMirror_returnsMirrorWithUserPreferenceReason() {
+        let policy = CompletionRenderModePolicy(userPreference: .alwaysMirror)
+        let geometry = CotabbyTestFixtures.overlayGeometry(caretQuality: .exact)
+
+        XCTAssertEqual(
+            policy.mode(for: geometry, bundleIdentifier: nil),
+            .mirror(reason: .userPreference)
+        )
+    }
+
+    // MARK: - Per-app overrides
+
+    func test_perAppOverride_winsOverGlobalAutoPreference() {
+        // Auto would say inline for `.exact`, but the per-app override forces mirror.
+        let policy = CompletionRenderModePolicy(
+            userPreference: .auto,
+            perAppOverrides: ["com.example.QuirkyApp": .alwaysMirror]
+        )
+        let geometry = CotabbyTestFixtures.overlayGeometry(caretQuality: .exact)
+
+        XCTAssertEqual(
+            policy.mode(for: geometry, bundleIdentifier: "com.example.QuirkyApp"),
+            .mirror(reason: .perAppOverride)
+        )
+    }
+
+    func test_perAppOverride_doesNotAffectOtherApps() {
+        let policy = CompletionRenderModePolicy(
+            userPreference: .auto,
+            perAppOverrides: ["com.example.QuirkyApp": .alwaysMirror]
+        )
+        let geometry = CotabbyTestFixtures.overlayGeometry(caretQuality: .exact)
+
+        XCTAssertEqual(
+            policy.mode(for: geometry, bundleIdentifier: "com.apple.TextEdit"),
+            .inline
+        )
+    }
+
+    func test_perAppOverride_canForceInlineForKnownGoodApp() {
+        // The estimated-geometry trigger should be overridable — some apps fall into estimated but
+        // still render inline ghost text correctly, and users should be able to opt out of the
+        // promotion.
+        let policy = CompletionRenderModePolicy(
+            userPreference: .auto,
+            perAppOverrides: ["com.example.WeirdGeometry": .alwaysInline]
+        )
+        let geometry = CotabbyTestFixtures.overlayGeometry(caretQuality: .estimated)
+
+        XCTAssertEqual(
+            policy.mode(for: geometry, bundleIdentifier: "com.example.WeirdGeometry"),
+            .inline
+        )
+    }
+
+    // MARK: - Nil bundle identifier
+
+    func test_nilBundleIdentifier_fallsBackToUserPreference() {
+        let policy = CompletionRenderModePolicy(
+            userPreference: .alwaysMirror,
+            perAppOverrides: ["com.example.AnyApp": .alwaysInline]
+        )
+        let geometry = CotabbyTestFixtures.overlayGeometry(caretQuality: .exact)
+
+        XCTAssertEqual(
+            policy.mode(for: geometry, bundleIdentifier: nil),
+            .mirror(reason: .userPreference)
+        )
+    }
+}

--- a/CotabbyTests/MirrorOverlayLayoutTests.swift
+++ b/CotabbyTests/MirrorOverlayLayoutTests.swift
@@ -1,0 +1,198 @@
+import CoreGraphics
+import XCTest
+@testable import Cotabby
+
+/// Locks in the positioning, clamping, and fallback rules for the mirror-overlay card. The layout
+/// is pure value math (no AppKit windows), so these tests run fast and isolate regressions to a
+/// single helper.
+final class MirrorOverlayLayoutTests: XCTestCase {
+
+    private let screen = CGRect(x: 0, y: 0, width: 1440, height: 900)
+
+    // MARK: - Anchoring to the input field
+
+    func test_make_anchorsBelowInputFrameWhenAvailable() {
+        // Field sits in the middle of the screen with its bottom edge at y=400. The card should
+        // appear below it (lower y in AppKit's bottom-up coordinate system).
+        let geometry = CotabbyTestFixtures.overlayGeometry(
+            caretRect: CGRect(x: 720, y: 405, width: 2, height: 18),
+            inputFrameRect: CGRect(x: 400, y: 400, width: 640, height: 30)
+        )
+
+        let layout = MirrorOverlayLayout.make(
+            suggestion: "tomorrow afternoon",
+            geometry: geometry,
+            visibleFrame: screen,
+            showsAcceptanceHint: true,
+            reason: .caretGeometryEstimated
+        )
+
+        XCTAssertLessThan(
+            layout.panelFrame.maxY,
+            geometry.inputFrameRect!.minY,
+            "Card should sit below the input field"
+        )
+        XCTAssertEqual(layout.suggestionText, "tomorrow afternoon")
+        XCTAssertEqual(layout.reason, .caretGeometryEstimated)
+    }
+
+    func test_make_centersCardOnCaretX() {
+        let caretX: CGFloat = 720
+        let geometry = CotabbyTestFixtures.overlayGeometry(
+            caretRect: CGRect(x: caretX, y: 500, width: 2, height: 18),
+            inputFrameRect: CGRect(x: 400, y: 480, width: 640, height: 30)
+        )
+
+        let layout = MirrorOverlayLayout.make(
+            suggestion: "hello",
+            geometry: geometry,
+            visibleFrame: screen,
+            showsAcceptanceHint: false,
+            reason: .userPreference
+        )
+
+        // Card center should be within 1pt of caret center after .integral rounding.
+        XCTAssertLessThanOrEqual(
+            abs(layout.panelFrame.midX - (caretX + 1)),
+            1.5,
+            "Card center should align horizontally to caret X"
+        )
+    }
+
+    // MARK: - Fallback when input frame missing
+
+    func test_make_fallsBackToCaretRectWhenInputFrameMissing() {
+        let geometry = CotabbyTestFixtures.overlayGeometry(
+            caretRect: CGRect(x: 200, y: 600, width: 2, height: 18),
+            inputFrameRect: nil
+        )
+
+        let layout = MirrorOverlayLayout.make(
+            suggestion: "fallback",
+            geometry: geometry,
+            visibleFrame: screen,
+            showsAcceptanceHint: true,
+            reason: .caretGeometryEstimated
+        )
+
+        // The card should still land below the caret rect since no field rect is available. The
+        // fallback uses a fixed vertical offset, so the card's maxY is strictly less than the caret
+        // rect's minY (with some tolerance for the gap).
+        XCTAssertLessThan(layout.panelFrame.maxY, geometry.caretRect.minY)
+    }
+
+    // MARK: - Screen-edge clamping
+
+    func test_make_clampsCardToVisibleFrame_rightEdge() {
+        // Caret near the right edge — card would overflow without clamping.
+        let geometry = CotabbyTestFixtures.overlayGeometry(
+            caretRect: CGRect(x: screen.maxX - 5, y: 500, width: 2, height: 18),
+            inputFrameRect: CGRect(x: screen.maxX - 100, y: 480, width: 100, height: 30)
+        )
+
+        let layout = MirrorOverlayLayout.make(
+            suggestion: "this is a fairly long completion that would overflow",
+            geometry: geometry,
+            visibleFrame: screen,
+            showsAcceptanceHint: true,
+            reason: .caretGeometryEstimated
+        )
+
+        XCTAssertLessThanOrEqual(layout.panelFrame.maxX, screen.maxX)
+        XCTAssertGreaterThanOrEqual(layout.panelFrame.minX, screen.minX)
+    }
+
+    func test_make_clampsCardToVisibleFrame_leftEdge() {
+        let geometry = CotabbyTestFixtures.overlayGeometry(
+            caretRect: CGRect(x: screen.minX + 2, y: 500, width: 2, height: 18),
+            inputFrameRect: CGRect(x: screen.minX, y: 480, width: 80, height: 30)
+        )
+
+        let layout = MirrorOverlayLayout.make(
+            suggestion: "left edge test",
+            geometry: geometry,
+            visibleFrame: screen,
+            showsAcceptanceHint: true,
+            reason: .caretGeometryEstimated
+        )
+
+        XCTAssertGreaterThanOrEqual(layout.panelFrame.minX, screen.minX)
+    }
+
+    func test_make_clampsCardToVisibleFrame_bottomEdge() {
+        // Field near the bottom of the screen; card would otherwise be clipped below the visible
+        // region. With clamping it should be pushed up to fit on-screen.
+        let geometry = CotabbyTestFixtures.overlayGeometry(
+            caretRect: CGRect(x: 500, y: screen.minY + 12, width: 2, height: 18),
+            inputFrameRect: CGRect(x: 400, y: screen.minY + 5, width: 300, height: 30)
+        )
+
+        let layout = MirrorOverlayLayout.make(
+            suggestion: "near bottom edge",
+            geometry: geometry,
+            visibleFrame: screen,
+            showsAcceptanceHint: false,
+            reason: .userPreference
+        )
+
+        XCTAssertGreaterThanOrEqual(layout.panelFrame.minY, screen.minY)
+    }
+
+    // MARK: - Text normalization
+
+    func test_make_collapsesWhitespaceInSuggestion() {
+        let geometry = CotabbyTestFixtures.overlayGeometry()
+        let layout = MirrorOverlayLayout.make(
+            suggestion: "  hello\n\nworld   foo  ",
+            geometry: geometry,
+            visibleFrame: screen,
+            showsAcceptanceHint: false,
+            reason: .userPreference
+        )
+
+        // Mirror mode is single-line by design: explicit newlines and runs of whitespace collapse
+        // to single spaces.
+        XCTAssertEqual(layout.suggestionText, "hello world foo")
+    }
+
+    // MARK: - Direction passthrough
+
+    func test_make_preservesRightToLeftFlag() {
+        let geometry = CotabbyTestFixtures.overlayGeometry(isRightToLeft: true)
+        let layout = MirrorOverlayLayout.make(
+            suggestion: "اختبار",
+            geometry: geometry,
+            visibleFrame: screen,
+            showsAcceptanceHint: true,
+            reason: .userPreference
+        )
+
+        XCTAssertTrue(layout.isRightToLeft)
+    }
+
+    // MARK: - Acceptance-hint reservation
+
+    func test_make_widerCardWhenAcceptanceHintEnabled() {
+        let geometry = CotabbyTestFixtures.overlayGeometry()
+        let withHint = MirrorOverlayLayout.make(
+            suggestion: "abc",
+            geometry: geometry,
+            visibleFrame: screen,
+            showsAcceptanceHint: true,
+            reason: .userPreference
+        )
+        let withoutHint = MirrorOverlayLayout.make(
+            suggestion: "abc",
+            geometry: geometry,
+            visibleFrame: screen,
+            showsAcceptanceHint: false,
+            reason: .userPreference
+        )
+
+        XCTAssertGreaterThan(
+            withHint.panelFrame.width,
+            withoutHint.panelFrame.width,
+            "Reserving room for the keycap should widen the card"
+        )
+    }
+}

--- a/CotabbyTests/ModelAndPresentationValueTests.swift
+++ b/CotabbyTests/ModelAndPresentationValueTests.swift
@@ -66,15 +66,17 @@ final class SuggestionModelValueTests: XCTestCase {
             geometry: CotabbyTestFixtures.overlayGeometry(
                 caretRect: CGRect(x: 12.9, y: 40.1, width: 2, height: 18),
                 caretQuality: .derived
-            )
+            ),
+            mode: .inline
         )
 
         XCTAssertEqual(state.shortLabel, "Visible")
         XCTAssertEqual(
             state.detail,
-            "Showing 5 characters near (12, 40) using derived caret geometry."
+            "Showing 5 characters near (12, 40) using derived caret geometry (inline)."
         )
         XCTAssertEqual(state.visibleText, "hello")
+        XCTAssertEqual(state.visibleMode, .inline)
     }
 
     func test_ghostSuggestionLayoutWrapsOverflowToInputLeftEdge() {

--- a/CotabbyTests/SuggestionSessionReconcilerTests.swift
+++ b/CotabbyTests/SuggestionSessionReconcilerTests.swift
@@ -214,7 +214,8 @@ final class SuggestionSessionReconcilerTests: XCTestCase {
                 of: " world",
                 overlayState: .visible(
                     text: " world",
-                    geometry: CotabbyTestFixtures.overlayGeometry(caretRect: caretRect)
+                    geometry: CotabbyTestFixtures.overlayGeometry(caretRect: caretRect),
+                    mode: .inline
                 )
             )
         )
@@ -223,7 +224,8 @@ final class SuggestionSessionReconcilerTests: XCTestCase {
                 of: " world",
                 overlayState: .visible(
                     text: " there",
-                    geometry: CotabbyTestFixtures.overlayGeometry(caretRect: caretRect)
+                    geometry: CotabbyTestFixtures.overlayGeometry(caretRect: caretRect),
+                    mode: .inline
                 )
             )
         )

--- a/CotabbyTests/SuggestionStateHelperTests.swift
+++ b/CotabbyTests/SuggestionStateHelperTests.swift
@@ -125,7 +125,8 @@ final class SuggestionInteractionStateTests: XCTestCase {
                 from: snapshot,
                 overlayState: .visible(
                     text: " world again",
-                    geometry: CotabbyTestFixtures.overlayGeometry(caretRect: context.caretRect)
+                    geometry: CotabbyTestFixtures.overlayGeometry(caretRect: context.caretRect),
+                    mode: .inline
                 )
             )
 
@@ -149,7 +150,8 @@ final class SuggestionInteractionStateTests: XCTestCase {
                 from: CotabbyTestFixtures.focusedInputSnapshot(precedingText: "Hello"),
                 overlayState: .visible(
                     text: " different",
-                    geometry: CotabbyTestFixtures.overlayGeometry(caretRect: context.caretRect)
+                    geometry: CotabbyTestFixtures.overlayGeometry(caretRect: context.caretRect),
+                    mode: .inline
                 )
             )
 
@@ -427,7 +429,7 @@ final class SuggestionOverlayPresenterTests: XCTestCase {
             let caretRect = CGRect(x: 10, y: 20, width: 2, height: 18)
             let geometry = CotabbyTestFixtures.overlayGeometry(caretRect: caretRect)
             let overlayController = FakeOverlayController(
-                initialState: .visible(text: " world", geometry: geometry)
+                initialState: .visible(text: " world", geometry: geometry, mode: .inline)
             )
             let presenter = SuggestionOverlayPresenter(overlayController: overlayController)
 
@@ -454,7 +456,8 @@ final class SuggestionOverlayPresenterTests: XCTestCase {
                 geometry: CotabbyTestFixtures.overlayGeometry(caretRect: nextRect),
                 previousState: .visible(
                     text: " world",
-                    geometry: CotabbyTestFixtures.overlayGeometry(caretRect: previousRect)
+                    geometry: CotabbyTestFixtures.overlayGeometry(caretRect: previousRect),
+                    mode: .inline
                 )
             )
 
@@ -476,7 +479,8 @@ final class SuggestionOverlayPresenterTests: XCTestCase {
                 ),
                 previousState: .visible(
                     text: " world",
-                    geometry: CotabbyTestFixtures.overlayGeometry(caretRect: caretRect)
+                    geometry: CotabbyTestFixtures.overlayGeometry(caretRect: caretRect),
+                    mode: .inline
                 )
             )
 
@@ -555,7 +559,10 @@ private final class FakeOverlayController: SuggestionOverlayControlling {
         lastShownText = text
         lastShownCaretRect = geometry.caretRect
         lastShownGeometry = geometry
-        state = .visible(text: text, geometry: geometry)
+        // The fake does not run the production policy; it just records the call. Defaulting to
+        // inline keeps existing tests unchanged. Mirror-aware tests inject explicit state via
+        // `initialState:`.
+        state = .visible(text: text, geometry: geometry, mode: .inline)
         onStateChange?(state)
     }
 


### PR DESCRIPTION
## Summary

When `AXTextGeometryResolver` falls back to `.estimated` quality, the host didn't expose any of the trusted caret-position paths and inline ghost text drifts as the user types — the "marching ghost" failure mode in Electron canvases and some web editors. This PR routes those presentations through a new mirror render mode that draws the suggestion in a Cotabby-owned card anchored to the input field rect (much more stable than the caret rect in affected hosts). A pure `CompletionRenderModePolicy` picks the mode from geometry plus an optional user/per-app preference, defaulting to `.auto`, so hosts that report `.exact` or `.derived` stay on the byte-for-byte original inline path.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby \
  -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **  (no warnings)

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby \
  -destination 'platform=macOS' build-for-testing
# ** TEST BUILD SUCCEEDED **

swiftlint lint --quiet
# exit 0
```

16 new pure-value tests added: 8 for the render-mode policy (auto/explicit/per-app overrides, nil bundle id), 8 for the mirror layout (field anchor, caret fallback, screen-edge clamping on all sides, whitespace collapse, RTL passthrough, keycap reservation). All call sites for the updated `OverlayState.visible` signature were migrated.

Local `xcodebuild test` runs hit a Team ID code-signing mismatch on this machine, which is the known local-dev case CLAUDE.md calls out; the tests compile and need CI signing or Xcode UI to execute.

## Risk / rollout notes

- `OverlayState.visible` gains a new `mode` associated value. ~8 internal/test call sites updated; no public API change beyond the `SuggestionOverlayControlling` protocol's state type.
- Policy defaults to `.auto`; only `.estimated` caret quality triggers the new mode. Hosts that today resolve `.exact` or `.derived` (Gmail/Outlook text-marker path, most native AppKit fields, etc.) are unchanged.
- Inline rendering is byte-for-byte the original behavior, just extracted into `showInline`. The panel, focus invariants, input pipeline, and acceptance hotkey are all untouched.
- `xcodegen generate` was rerun; `project.pbxproj` diff is the auto-discovery of the 5 new source files.
- Settings UI for the global preference and per-app overrides is intentionally out of scope here. The policy already accepts both inputs; wiring them through `SuggestionSettingsModel` lands in a follow-up phase.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a mirror render mode for hosts where `AXTextGeometryResolver` returns `.estimated` caret quality, routing those presentations through a `MirrorOverlayView` card anchored to the input field rect instead of the drifting caret rect. A new `CompletionRenderModePolicy` pure-value struct picks the mode from geometry quality and optional user/per-app preferences, defaulting to `.auto` so the existing inline path is completely unchanged for hosts that report `.exact` or `.derived`.

- **`CompletionRenderMode` + `CompletionRenderModePolicy`** — new pure value types; policy is `.auto` in Phase 1 and already accepts Phase 2 per-app override maps.
- **`MirrorOverlayLayout`** — pure layout math anchoring the card below the input field rect; 8 new tests cover clamping, fallback, whitespace collapse, and RTL passthrough.
- **`OverlayController`** — splits `hostingView` into `inlineHostingView`/`mirrorHostingView` with an identity-checked `panel.contentView` swap for mode transitions; `OverlayState.visible` gains a `mode` associated value, migrating ~8 call sites.

<h3>Confidence Score: 4/5</h3>

Safe to merge for Phase 1 behaviour; one defect in the presenter deduplication guard will silently drop mode flips when Phase 2 per-app overrides are wired.

The deduplication guard in `SuggestionOverlayPresenter.present` returns nil without calling `showSuggestion` whenever text+geometry are unchanged — even when the render mode has changed. Its own inline comment says "we still need to invoke `showSuggestion` so the panel re-renders", and `setCurrentBundleIdentifier`'s docstring promises per-app overrides take effect immediately. In Phase 1 the mode is derived purely from geometry quality, so this gap has no observable impact today. But the defect is already present in the code shipped by this PR and will activate as soon as Phase 2 wires the bundle-identifier updates through the presenter.

Cotabby/Services/Suggestion/SuggestionOverlayPresenter.swift — the early-return deduplication guard at the top of `present`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Models/CompletionRenderMode.swift | New model file defining the CompletionRenderMode enum and MirrorReason; clean, well-documented value type with no issues. |
| Cotabby/Services/Suggestion/SuggestionOverlayPresenter.swift | Deduplication guard ignores mode in the wildcard match but the inline comment says showSuggestion must still be called on mode flips — a contradiction that will silently drop per-app override changes in Phase 2. |
| Cotabby/Services/UI/OverlayController.swift | Splits into showInline/showMirror; shared panel with identity-checked contentView swap is correct; screen selection for the mirror card still uses the unreliable caretRect (flagged separately). |
| Cotabby/Support/CompletionRenderModePolicy.swift | Pure rule struct mapping geometry + preferences to CompletionRenderMode; logic is correct, per-app override reasoning in the alwaysMirror branch works as intended. |
| Cotabby/Support/MirrorOverlayLayout.swift | Pure layout math for the mirror card; computeAnchorCenterX degenerate-caret guard has the x=0 edge case noted in a prior thread; clamping and fallback logic is otherwise sound. |
| Cotabby/Support/SuggestionSessionReconciler.swift | Single call-site migration to three-label OverlayState.visible destructuring; mechanical and correct. |
| CotabbyTests/CompletionRenderModePolicyTests.swift | Eight pure-value tests covering auto, alwaysInline, alwaysMirror, per-app overrides, and nil bundle ID paths; comprehensive coverage for the policy. |
| CotabbyTests/MirrorOverlayLayoutTests.swift | Eight layout tests covering field anchor, caret fallback, all four screen-edge clamp directions, whitespace collapse, RTL passthrough, and keycap reservation. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[present called with text + geometry] --> B{displayText empty?}
    B -- yes --> C[hide overlay]
    B -- no --> D{previousState.visible\nwith same text+geometry?}
    D -- yes --> E[return nil — no AppKit call\nMODE FLIP SILENTLY DROPPED]
    D -- no --> F[showSuggestion called]
    F --> G[renderModePolicy.mode\ngeometry + bundleIdentifier]
    G --> H{effectivePreference}
    H -- alwaysInline --> I[.inline]
    H -- alwaysMirror --> J[.mirror reason]
    H -- auto --> K{caretQuality == .estimated?}
    K -- yes --> L[.mirror caretGeometryEstimated]
    K -- no --> M[.inline]
    I & J & L & M --> N{switch mode}
    N -- .inline --> O[showInline GhostSuggestionView]
    N -- .mirror --> P[showMirror MirrorOverlayView]
    O & P --> Q[state = .visible text geometry mode]
    Q --> R[Diagnostic switch on previousState]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fmirror-overlay-fallback%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fmirror-overlay-fallback%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FServices%2FSuggestion%2FSuggestionOverlayPresenter.swift%3A288-292%0A**Early%20return%20prevents%20mode%20flip%20when%20text%2Bgeometry%20are%20unchanged**%0A%0AThe%20guard%20returns%20%60nil%60%20without%20ever%20calling%20%60showSuggestion%60%20when%20%60previousText%20%3D%3D%20displayText%20%26%26%20previousGeometry%20%3D%3D%20geometry%60%2C%20regardless%20of%20whether%20the%20render%20mode%20has%20changed.%20The%20comment%20placed%20immediately%20above%20this%20block%20says%20the%20opposite%3A%20*%22we%20still%20need%20to%20invoke%20%60showSuggestion%60%20so%20the%20panel%20re-renders%22*%20%E2%80%94%20a%20direct%20contradiction%20that%20signals%20the%20implementation%20doesn't%20match%20the%20intent.%0A%0AThe%20concrete%20failure%20path%20arrives%20with%20Phase%202%20wiring%3A%20%60setCurrentBundleIdentifier%60's%20own%20docstring%20promises%20that%20%22per-app%20settings%20take%20effect%20**immediately**%20when%20the%20focused%20app%20changes.%22%20If%20an%20app%20switch%20changes%20the%20effective%20per-app%20override%20%28e.g.%20from%20%60.auto%20%E2%86%92%20.alwaysMirror%60%29%20while%20the%20overlay%20is%20already%20showing%20the%20same%20text%20at%20an%20unchanged%20caret%20position%2C%20this%20guard%20fires%20and%20the%20inline%20card%20stays%20on%20screen%20instead%20of%20switching%20to%20a%20mirror%20card.%20The%20fix%20is%20to%20also%20check%20that%20the%20mode%20from%20the%20*previous*%20state%20matches%20what%20the%20controller%20would%20now%20pick%20%E2%80%94%20or%2C%20at%20minimum%2C%20only%20skip%20the%20call%20when%20the%20mode%20is%20guaranteed%20unchanged%20%28i.e.%2C%20derived%20purely%20from%20%60geometry.caretQuality%60%2C%20not%20from%20%60currentBundleIdentifier%60%29.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FServices%2FSuggestion%2FSuggestionOverlayPresenter.swift%3A288-292%0A**Early%20return%20prevents%20mode%20flip%20when%20text%2Bgeometry%20are%20unchanged**%0A%0AThe%20guard%20returns%20%60nil%60%20without%20ever%20calling%20%60showSuggestion%60%20when%20%60previousText%20%3D%3D%20displayText%20%26%26%20previousGeometry%20%3D%3D%20geometry%60%2C%20regardless%20of%20whether%20the%20render%20mode%20has%20changed.%20The%20comment%20placed%20immediately%20above%20this%20block%20says%20the%20opposite%3A%20*%22we%20still%20need%20to%20invoke%20%60showSuggestion%60%20so%20the%20panel%20re-renders%22*%20%E2%80%94%20a%20direct%20contradiction%20that%20signals%20the%20implementation%20doesn't%20match%20the%20intent.%0A%0AThe%20concrete%20failure%20path%20arrives%20with%20Phase%202%20wiring%3A%20%60setCurrentBundleIdentifier%60's%20own%20docstring%20promises%20that%20%22per-app%20settings%20take%20effect%20**immediately**%20when%20the%20focused%20app%20changes.%22%20If%20an%20app%20switch%20changes%20the%20effective%20per-app%20override%20%28e.g.%20from%20%60.auto%20%E2%86%92%20.alwaysMirror%60%29%20while%20the%20overlay%20is%20already%20showing%20the%20same%20text%20at%20an%20unchanged%20caret%20position%2C%20this%20guard%20fires%20and%20the%20inline%20card%20stays%20on%20screen%20instead%20of%20switching%20to%20a%20mirror%20card.%20The%20fix%20is%20to%20also%20check%20that%20the%20mode%20from%20the%20*previous*%20state%20matches%20what%20the%20controller%20would%20now%20pick%20%E2%80%94%20or%2C%20at%20minimum%2C%20only%20skip%20the%20call%20when%20the%20mode%20is%20guaranteed%20unchanged%20%28i.e.%2C%20derived%20purely%20from%20%60geometry.caretQuality%60%2C%20not%20from%20%60currentBundleIdentifier%60%29.%0A%0A&repo=fujacob%2Fcotabby&pr=347&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Reserve keycap width outside the min/max..."](https://github.com/fujacob/cotabby/commit/a3f4ac9310b227e12aba68fccc9de2405d5dffe5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34328274)</sub>

<!-- /greptile_comment -->