### PR TITLE
Synthesize boundary space when accept would glue the suggestion onto the user's last word

### DIFF
--- a/Cotabby/Support/SuggestionSessionReconciler.swift
+++ b/Cotabby/Support/SuggestionSessionReconciler.swift
@@ -279,28 +279,54 @@ enum SuggestionSessionReconciler {
         return wordEnd
     }
 
-    /// Returns the text to actually type for an acceptance chunk, dropping its leading whitespace run
-    /// when the live text before the caret already ends in whitespace — so accepting never stacks a
-    /// second space onto a boundary the field already provides.
+    /// Returns the text to actually type for an acceptance chunk, reconciling the word boundary
+    /// against the live text before the caret. Two complementary rules run here:
     ///
-    /// This is the authoritative, accept-time counterpart to the generation-time space handling in
+    /// 1. If the live preceding text already ends in horizontal whitespace, drop the chunk's leading
+    ///    whitespace run so we never stack a second space onto a boundary the field already provides.
+    /// 2. If the live preceding text ends in a word character and the chunk starts in a word
+    ///    character, insert a single space between them so the suggestion doesn't glue onto the
+    ///    user's last word.
+    ///
+    /// Rule 1 is the accept-time counterpart to the generation-time space handling in
     /// `SuggestionTextNormalizer`. That normalizer decides whether to keep the model's leading space
     /// against a prefix *snapshot* taken when the request was built, which can be stale by the time
     /// the user accepts — most often because they typed the separating space themselves after the
-    /// ghost appeared, or because AX reported the prefix before that space landed. Reconciling here
-    /// against the live preceding text makes the boundary deterministic instead of relying on the
-    /// timing-sensitive session reconciler to consume the typed space first.
+    /// ghost appeared, or because AX reported the prefix before that space landed.
     ///
-    /// The session still advances by the full (untrimmed) chunk: the whitespace we skip typing is
-    /// exactly the whitespace already present in the field, so the consumed-suffix accounting the
-    /// reconciler does after insertion still lines up.
+    /// Rule 2 is the inverse: when the model emits a fresh word without its own leading space
+    /// (either because the small local model just omitted one, or because the normalizer stripped it
+    /// against a stale snapshot that thought the field ended in whitespace), there is no boundary in
+    /// the chunk and none in the field. We add the boundary explicitly here so accept never glues
+    /// "Hello"+"World" into "HelloWorld". The tradeoff is that we don't try to distinguish a fresh
+    /// new word from a partial-word completion — Cotabby's prompt is biased toward continuing at the
+    /// caret with multi-word output, so the "new word" interpretation matches what users see.
+    ///
+    /// Session accounting: rule 1 advances the session by the full (untrimmed) acceptedChunk; the
+    /// whitespace we skip typing is the field's own, so the consumed-suffix reconciliation lines up.
+    /// Rule 2 types one character the session does NOT account for — fullText has no leading space
+    /// to consume, so the post-insertion reconciler enters its tolerate path and the session stays
+    /// alive for follow-up word-by-word accepts. A user who then types a character that would have
+    /// typed-matched the next suggestion char will fall out of the tolerate window and the session
+    /// will be invalidated, which is acceptable: the next prediction picks up from the corrected
+    /// field state without any visible glue.
     static func insertionChunk(forAcceptedChunk chunk: String, precedingText: String) -> String {
-        guard let lastScalar = precedingText.unicodeScalars.last,
-              CharacterSet.whitespaces.contains(lastScalar) else {
+        if let lastScalar = precedingText.unicodeScalars.last,
+           CharacterSet.whitespaces.contains(lastScalar) {
+            // The drop predicate mirrors the guard's horizontal-whitespace definition so a chunk
+            // that legitimately starts with a newline (e.g. a full-accept spanning a line break) is
+            // not silently dropped when the field happens to end in a space or tab.
+            return String(chunk.drop(while: { $0.unicodeScalars.allSatisfy(CharacterSet.whitespaces.contains) }))
+        }
+
+        guard let firstChunkChar = chunk.first,
+              firstChunkChar.isAcceptanceWordCharacter,
+              let lastPrecedingChar = precedingText.last,
+              lastPrecedingChar.isAcceptanceWordCharacter else {
             return chunk
         }
 
-        return String(chunk.drop(while: { $0.isWhitespace }))
+        return " " + chunk
     }
 
     /// Counts word-like tokens so punctuation-only accepts do not inflate productivity metrics.

--- a/CotabbyTests/SuggestionSessionReconcilerTests.swift
+++ b/CotabbyTests/SuggestionSessionReconcilerTests.swift
@@ -189,6 +189,89 @@ final class SuggestionSessionReconcilerTests: XCTestCase {
         )
     }
 
+    func test_insertionChunk_addsBoundarySpaceWhenChunkAndFieldWouldGlue() {
+        // The reported "no space" regression: the chunk has no leading whitespace (model omitted it,
+        // or the normalizer stripped it against a stale prefix snapshot) and the field doesn't have
+        // a trailing one either, so we synthesize the word boundary at insert time.
+        XCTAssertEqual(
+            SuggestionSessionReconciler.insertionChunk(forAcceptedChunk: "World", precedingText: "Hello"),
+            " World"
+        )
+    }
+
+    func test_insertionChunk_addsBoundarySpaceForLowercaseNewWord() {
+        // Lowercase new words are the harder half of the model-omission case; the heuristic still
+        // fires because both boundary characters are word characters.
+        XCTAssertEqual(
+            SuggestionSessionReconciler.insertionChunk(forAcceptedChunk: "world", precedingText: "the"),
+            " world"
+        )
+    }
+
+    func test_insertionChunk_addsBoundarySpaceAcrossDigitWordBoundary() {
+        // A digit followed by a letter (or letter followed by digit) is still a word/word boundary
+        // that the user expects to read as two tokens.
+        XCTAssertEqual(
+            SuggestionSessionReconciler.insertionChunk(forAcceptedChunk: "abc", precedingText: "123"),
+            " abc"
+        )
+        XCTAssertEqual(
+            SuggestionSessionReconciler.insertionChunk(forAcceptedChunk: "1st", precedingText: "Hello"),
+            " 1st"
+        )
+    }
+
+    func test_insertionChunk_doesNotAddBoundarySpaceWhenChunkStartsWithPunctuation() {
+        // Punctuation-leading chunks ("." closes a sentence, "'s" is a possessive, "," is a list
+        // continuation) intentionally attach to the prior word without a separator.
+        XCTAssertEqual(
+            SuggestionSessionReconciler.insertionChunk(forAcceptedChunk: ".", precedingText: "Hello"),
+            "."
+        )
+        XCTAssertEqual(
+            SuggestionSessionReconciler.insertionChunk(forAcceptedChunk: "'s", precedingText: "John"),
+            "'s"
+        )
+        XCTAssertEqual(
+            SuggestionSessionReconciler.insertionChunk(forAcceptedChunk: ", more", precedingText: "first"),
+            ", more"
+        )
+    }
+
+    func test_insertionChunk_doesNotAddBoundarySpaceAfterPunctuation() {
+        // Opening punctuation in the prefix means the chunk should hug it, not be separated from it.
+        XCTAssertEqual(
+            SuggestionSessionReconciler.insertionChunk(forAcceptedChunk: "World", precedingText: "Hello ("),
+            "World"
+        )
+    }
+
+    func test_insertionChunk_doesNotAddBoundarySpaceAfterNewline() {
+        // A line break is a hard boundary on its own; we should not synthesize an indent space here.
+        XCTAssertEqual(
+            SuggestionSessionReconciler.insertionChunk(forAcceptedChunk: "World", precedingText: "line\n"),
+            "World"
+        )
+    }
+
+    func test_insertionChunk_doesNotAddBoundarySpaceWhenPrecedingTextIsEmpty() {
+        // At the very start of an empty field there is no last word to glue onto.
+        XCTAssertEqual(
+            SuggestionSessionReconciler.insertionChunk(forAcceptedChunk: "World", precedingText: ""),
+            "World"
+        )
+    }
+
+    func test_insertionChunk_dropsLeadingHorizontalWhitespaceButNotLeadingNewline() {
+        // The drop predicate must mirror the guard's horizontal-whitespace definition, so a chunk
+        // whose first character is a newline survives even when the field ends in a space — keeping
+        // the structural line break the suggestion was authored with.
+        XCTAssertEqual(
+            SuggestionSessionReconciler.insertionChunk(forAcceptedChunk: "\nnext", precedingText: "first "),
+            "\nnext"
+        )
+    }
+
     func test_acceptedWordCount_countsOnlyTokensWithAlphanumerics() {
         let count = SuggestionSessionReconciler.acceptedWordCount(
             in: "hello, !!! world 123 --"


### PR DESCRIPTION
## Summary

PR #303 added an accept-time word-boundary reconciler that drops a chunk's leading whitespace when the live preceding text already ends in whitespace, fixing double-space-on-accept. It only covered the strip half: when the chunk arrived without a leading space (model omitted one, or the normalizer stripped it against a stale prefix snapshot) and the field didn't end in whitespace either, accept rendered `"Hello"`+`"World"` as `"HelloWorld"` (issue #324). The strip branch's `drop(while:)` predicate also used `Character.isWhitespace` while the guard used `CharacterSet.whitespaces` — Greptile flagged this on the original PR — so a chunk that legitimately started with a newline could be silently dropped.

This adds the inverse rule and tightens the drop predicate in `SuggestionSessionReconciler.insertionChunk`:

- If the live preceding text ends in a word character and the chunk starts in a word character (no leading whitespace), prepend a single space so accept never glues the suggestion onto the user's last word.
- The strip branch's `drop(while:)` now mirrors the guard's horizontal-whitespace definition, so a chunk whose first character is a newline survives even when the field ends in a space or tab.

Session accounting: rule 1 still advances by the untrimmed `acceptedChunk` (the whitespace we skip typing is the field's own). Rule 2 types one character the session doesn't account for — `fullText` has no leading space to consume — so post-insertion reconciliation falls into the existing tolerate path and the session stays alive for follow-up word-by-word accepts. A user who then types a character that would have typed-matched the next suggestion char will fall out of tolerate and invalidate the session, which is acceptable: the next prediction picks up from the corrected field state without any visible glue.

## Validation

```bash
xcodebuild build -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS'
# ** BUILD SUCCEEDED **
xcodebuild build-for-testing -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS'
# ** TEST BUILD SUCCEEDED **
xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  -only-testing:CotabbyTests/SuggestionSessionReconcilerTests \
  -only-testing:CotabbyTests/SuggestionTextNormalizerTests \
  -only-testing:CotabbyTests/SuggestionInteractionStateTests \
  CODE_SIGNING_ALLOWED=NO
# ** TEST SUCCEEDED **  43 reconciler tests + normalizer + interaction state, 0 failures
swiftlint lint --quiet Cotabby/Support/SuggestionSessionReconciler.swift CotabbyTests/SuggestionSessionReconcilerTests.swift
# exit 0
```

Eight new unit tests cover the add-space path and the exclusions: basic `"Hello"`+`"World"` → `" World"`, lowercase new word (`"the"`+`"world"`), digit/word boundary (`"123"`+`"abc"`, `"Hello"`+`"1st"`), punctuation-leading chunks (`.`, `'s`, `, more`), opening punctuation in the prefix (`"Hello ("`), newline boundary in the prefix, empty preceding text, and the strip-but-not-newline case (`"first "`+`"\nnext"`). The original seven `insertionChunk` tests from PR #303 still pass unchanged. App-hosted `test` only runs with `CODE_SIGNING_ALLOWED=NO` here (local Team ID mismatch, per `CLAUDE.md`).

## Linked issues

Fixes #324

## Risk / rollout notes

- This is intentionally aggressive: rule 2 fires on any word-char/word-char boundary, which means a partial-word completion suggestion like `"wor"` + `"ld"` will insert as `"wor ld"` rather than `"world"`. Cotabby's prompt biases the model toward multi-word continuations rather than single-word completions, so the "new word" interpretation matches what users actually see; this tradeoff is documented in the helper's docstring.
- The added space rides the existing post-insertion tolerate window in `SuggestionSessionReconciler.reconcile`, so single-Tab accepts and Tab-then-Tab sequences behave normally. A user who types a character matching the next expected suggestion char immediately after a space-added Tab will fall out of tolerate and the session will be invalidated; a fresh prediction takes over without visible glue.
- The strip-predicate tightening means a chunk starting with `\n` after a space-or-tab field tail is now preserved instead of silently dropped (Greptile's review comment on #303).
- No changes to the session model, the coordinator, or generation-time normalization.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the inverse of the double-space bug addressed in #303: when neither the field nor the suggestion chunk carries a word boundary, acceptance was silently gluing adjacent words (`"Hello"+"World"` → `"HelloWorld"`). It also tightens the existing strip predicate so a chunk whose first character is a newline is no longer silently dropped when the field ends in a space or tab.

- **Rule 2 added to `insertionChunk`**: if `precedingText` ends in a word character (`isLetter || isNumber`) and `chunk` starts in a word character, a single space is prepended before insertion. The session advances by the original untrimmed chunk, relying on the existing tolerate window to absorb the extra injected character.
- **Strip-predicate tightened**: the `drop(while:)` closure now uses `allSatisfy(CharacterSet.whitespaces.contains)` instead of `Character.isWhitespace`, aligning it with the horizontal-only `CharacterSet.whitespaces` guard so newline-leading chunks survive Rule 1.
- **Eight new unit tests** cover the add-space path and all documented exclusions (punctuation-leading chunks, post-newline/post-parenthesis preceding text, empty field, and the strip-but-not-newline case).

<h3>Confidence Score: 4/5</h3>

Safe to merge; the fix is well-scoped to a single pure function with no effect on the session model, coordinator, or generation-time normalization.

The two rules in `insertionChunk` are mutually exclusive, logically correct, and covered by 15 targeted unit tests. The strip-predicate change is a clean correctness fix. The main unverified path is the reconciler's tolerate-loop behavior after Rule 2 fires (a follow-up Tab-then-Tab accept sequence), which is documented in prose but has no end-to-end test. The acknowledged partial-completion tradeoff also lacks a pinning test. Neither gap can produce incorrect output under normal use, but both are worth closing before the pattern is extended.

The tolerate-path integration in `SuggestionSessionReconciler.reconcile` deserves a second look alongside the new Rule 2 path — specifically the sentinel-clearing block at lines 96–101, which is bypassed whenever `reconcileConsumedSuggestionText` returns early.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/SuggestionSessionReconciler.swift | Refactors `insertionChunk` to add Rule 2 (synthesize a boundary space when both the field and chunk end/start with word characters), and fixes the Rule 1 strip predicate to use `CharacterSet.whitespaces` (`allSatisfy`) instead of `isWhitespace`, preserving newlines correctly. |
| CotabbyTests/SuggestionSessionReconcilerTests.swift | Adds 8 new unit tests covering Rule 2's add-space path and its exclusions (punctuation-leading chunks, post-newline preceding text, empty preceding text, and the strip-but-not-newline case); all 7 original `insertionChunk` tests pass unchanged. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["insertionChunk(chunk, precedingText)"] --> B{"precedingText last scalar\nin CharacterSet.whitespaces?"}
    B -- Yes --> C["drop(while: allSatisfy\nCharacterSet.whitespaces)"]
    C --> D["Return stripped chunk\n(newline-leading chunks preserved)"]
    B -- No --> E{"chunk.first\nisAcceptanceWordCharacter?"}
    E -- No --> F["Return chunk unchanged\n(punctuation-leading chunk hugs prior word)"]
    E -- Yes --> G{"precedingText.last\nisAcceptanceWordCharacter?"}
    G -- No --> F
    G -- Yes --> H["Return ' ' + chunk\n(Rule 2: synthesize boundary space)"]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Faccept-missing-space%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Faccept-missing-space%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabbyTests%2FSuggestionSessionReconcilerTests.swift%3A192-200%0A**Missing%20end-to-end%20tolerate-path%20test%20after%20Rule%202%20fires**%0A%0AThe%20docstring%20explains%20that%20Rule%202%20types%20one%20character%20the%20session%20doesn't%20account%20for%2C%20so%20the%20post-insertion%20reconciler%20enters%20a%20tolerate%20loop%20that%20persists%20until%20the%20session%20is%20explicitly%20invalidated.%20Because%20%60reconcileConsumedSuggestionText%60%20returns%20early%20%28tolerate%29%20before%20reaching%20the%20sentinel-clearing%20block%20at%20lines%2096%E2%80%93101%2C%20%60pendingInsertionConsumedCount%60%20is%20never%20set%20to%20%60nil%60%2C%20and%20%60isAwaitingInsertedTextSync%60%20stays%20%60true%60%20for%20every%20subsequent%20reconcile%20cycle.%20There%20is%20no%20test%20that%20exercises%20this%3A%20accept%20a%20chunk%20via%20Rule%202%2C%20then%20calls%20%60reconcile%60%20to%20confirm%20the%20session%20remains%20%60.valid%60%2C%20then%20accepts%20a%20second%20chunk%20and%20reconciles%20again.%20Without%20it%2C%20the%20%22session%20stays%20alive%20for%20follow-up%20word-by-word%20accepts%22%20guarantee%20is%20purely%20documented%2C%20not%20verified.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabbyTests%2FSuggestionSessionReconcilerTests.swift%3A192-200%0A**No%20test%20for%20the%20partial-word-completion%20false-positive**%0A%0AThe%20PR%20description%20explicitly%20calls%20out%20that%20%60%22wor%22%60%20%2B%20%60%22ld%22%60%20inserts%20as%20%60%22wor%20ld%22%60%20rather%20than%20%60%22world%22%60%20because%20Rule%202%20fires%20on%20any%20word-char%2Fword-char%20boundary.%20This%20tradeoff%20is%20documented%20in%20the%20docstring%2C%20but%20there%20is%20no%20test%20that%20confirms%20this%20exact%20scenario.%20Adding%20one%20%28expected%3A%20%60%22%20ld%22%60%29%20would%20lock%20in%20the%20decision%20and%20serve%20as%20a%20reminder%20that%20this%20case%20is%20intentional%20rather%20than%20an%20oversight%20if%20someone%20revisits%20the%20heuristic%20later.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabbyTests%2FSuggestionSessionReconcilerTests.swift%3A192-200%0A**Missing%20end-to-end%20tolerate-path%20test%20after%20Rule%202%20fires**%0A%0AThe%20docstring%20explains%20that%20Rule%202%20types%20one%20character%20the%20session%20doesn't%20account%20for%2C%20so%20the%20post-insertion%20reconciler%20enters%20a%20tolerate%20loop%20that%20persists%20until%20the%20session%20is%20explicitly%20invalidated.%20Because%20%60reconcileConsumedSuggestionText%60%20returns%20early%20%28tolerate%29%20before%20reaching%20the%20sentinel-clearing%20block%20at%20lines%2096%E2%80%93101%2C%20%60pendingInsertionConsumedCount%60%20is%20never%20set%20to%20%60nil%60%2C%20and%20%60isAwaitingInsertedTextSync%60%20stays%20%60true%60%20for%20every%20subsequent%20reconcile%20cycle.%20There%20is%20no%20test%20that%20exercises%20this%3A%20accept%20a%20chunk%20via%20Rule%202%2C%20then%20calls%20%60reconcile%60%20to%20confirm%20the%20session%20remains%20%60.valid%60%2C%20then%20accepts%20a%20second%20chunk%20and%20reconciles%20again.%20Without%20it%2C%20the%20%22session%20stays%20alive%20for%20follow-up%20word-by-word%20accepts%22%20guarantee%20is%20purely%20documented%2C%20not%20verified.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabbyTests%2FSuggestionSessionReconcilerTests.swift%3A192-200%0A**No%20test%20for%20the%20partial-word-completion%20false-positive**%0A%0AThe%20PR%20description%20explicitly%20calls%20out%20that%20%60%22wor%22%60%20%2B%20%60%22ld%22%60%20inserts%20as%20%60%22wor%20ld%22%60%20rather%20than%20%60%22world%22%60%20because%20Rule%202%20fires%20on%20any%20word-char%2Fword-char%20boundary.%20This%20tradeoff%20is%20documented%20in%20the%20docstring%2C%20but%20there%20is%20no%20test%20that%20confirms%20this%20exact%20scenario.%20Adding%20one%20%28expected%3A%20%60%22%20ld%22%60%29%20would%20lock%20in%20the%20decision%20and%20serve%20as%20a%20reminder%20that%20this%20case%20is%20intentional%20rather%20than%20an%20oversight%20if%20someone%20revisits%20the%20heuristic%20later.%0A%0A&repo=fujacob%2Fcotabby&pr=348&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Synthesize the boundary space when accep..."](https://github.com/fujacob/cotabby/commit/762dcfcc72b20b53cd844e4ee5def0b0a80246af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34329534)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->