### PR TITLE
Hold overlay position across post-accept AX reconciles

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		0C98ECB5BCEBA72C693AC1C9 /* SuggestionTextNormalizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B55A4362AB7F0528C661C4C /* SuggestionTextNormalizerTests.swift */; };
 		0D8241CD31942A25EC4E0EE4 /* CotabbyDebugOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B2D34A6F3AC9DFD61350F7 /* CotabbyDebugOptions.swift */; };
 		0DDC0CFF5558A8F4355836B2 /* OverlayController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F308F6E274CC645E27CB651F /* OverlayController.swift */; };
+		0F3267956257401F39386773 /* SuggestionOverlayStabilityGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2F95847D76893C8A5B504B4 /* SuggestionOverlayStabilityGate.swift */; };
 		1003373E13779882503C0E9D /* DisplayCoordinateConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74BD1D4DB27D5D96D1E06096 /* DisplayCoordinateConverter.swift */; };
 		14D77F0B8A195AC2FA8D24A9 /* MirrorOverlayLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC83D14A7557BC0196E59007 /* MirrorOverlayLayoutTests.swift */; };
 		156E6AB3D24134EEC29FDB93 /* FocusSnapshotResolverSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA705EDFE1C41294F0E381F1 /* FocusSnapshotResolverSelectionTests.swift */; };
@@ -58,6 +59,7 @@
 		4AC255BE2D0CCC67B8882C7A /* WelcomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21CB3008986BE7FD2A4D9132 /* WelcomeCoordinator.swift */; };
 		4B4DDB569CAD806F765224DE /* CustomRulesEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F7F7355967725162DF2D1B /* CustomRulesEditor.swift */; };
 		4B54ACE1255873955414CD06 /* PermissionGuidanceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F2C764D29C8D50D0C854FF8 /* PermissionGuidanceController.swift */; };
+		4C6D8ED0A7B45D2EADF06DA5 /* SuggestionOverlayStabilityGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB25ABC4FFB0E63477CDCB0 /* SuggestionOverlayStabilityGateTests.swift */; };
 		4CAFD8F3444FEDC9ACAFF529 /* LlamaRuntimeModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A804F4DB6FD9BC8C27B2B65F /* LlamaRuntimeModels.swift */; };
 		4F369F5284DDCEABF082E59B /* SuggestionAvailabilityEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3609CC88A5280B3AA40414DF /* SuggestionAvailabilityEvaluator.swift */; };
 		4F38CE1C2602CF4F41323032 /* PermissionOverlayTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12DD19BCE610808F1E38702D /* PermissionOverlayTrackerTests.swift */; };
@@ -279,6 +281,7 @@
 		AD9573F3504CAE6891DF9B7D /* AppUpdateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdateManager.swift; sourceTree = "<group>"; };
 		ADBE3E6CC585C1683787C877 /* SuggestionEngineModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionEngineModels.swift; sourceTree = "<group>"; };
 		AF1E065C7FFB697FCEB2FA5C /* CotabbyTestFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CotabbyTestFixtures.swift; sourceTree = "<group>"; };
+		B2F95847D76893C8A5B504B4 /* SuggestionOverlayStabilityGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionOverlayStabilityGate.swift; sourceTree = "<group>"; };
 		B424E2AC97C99D335B0D5751 /* SuggestionTextNormalizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionTextNormalizer.swift; sourceTree = "<group>"; };
 		B4B4A2E2DD6733658EC05BD8 /* DownloadFileRescuer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadFileRescuer.swift; sourceTree = "<group>"; };
 		B5679E08C9A09065531C37B5 /* LlamaPromptRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LlamaPromptRenderer.swift; sourceTree = "<group>"; };
@@ -300,6 +303,7 @@
 		CB58035EFFD65B767949BAE6 /* AXTextGeometryResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AXTextGeometryResolver.swift; sourceTree = "<group>"; };
 		CBD5FCB8CC56AA6138382B2C /* FieldEdgeIconIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FieldEdgeIconIndicatorView.swift; sourceTree = "<group>"; };
 		CC1EDFB535AAA2EE0D67828A /* CotabbyApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CotabbyApp.swift; sourceTree = "<group>"; };
+		CDB25ABC4FFB0E63477CDCB0 /* SuggestionOverlayStabilityGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionOverlayStabilityGateTests.swift; sourceTree = "<group>"; };
 		CE0AA0503128B0FC3951D700 /* SuggestionSessionReconciler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionSessionReconciler.swift; sourceTree = "<group>"; };
 		CE8C2569A8217EE9BD3B197F /* FileLogHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileLogHandler.swift; sourceTree = "<group>"; };
 		D2F46767D9D1F0D44E239CA8 /* DownloadFileRescuerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadFileRescuerTests.swift; sourceTree = "<group>"; };
@@ -525,6 +529,7 @@
 				0D80CC2CCAAFE3F23FB8C37A /* PromptContextSanitizerTests.swift */,
 				4696A84D17890B154533A08F /* PromptPolicyTests.swift */,
 				C05B0439348261163B37C508 /* SuggestionAvailabilityEvaluatorTests.swift */,
+				CDB25ABC4FFB0E63477CDCB0 /* SuggestionOverlayStabilityGateTests.swift */,
 				EE94342B888A5A2CCF66BC93 /* SuggestionRequestFactoryTests.swift */,
 				9C8F07AC52C7A482F5FE34C5 /* SuggestionSessionReconcilerTests.swift */,
 				19DB9558F4D3AFB108D71649 /* SuggestionStateHelperTests.swift */,
@@ -623,6 +628,7 @@
 				E6423D6CC8CC371D2DA899DE /* PermissionOverlayTracker.swift */,
 				FA4B45B91D4DEAC979C3113E /* PromptContextSanitizer.swift */,
 				3609CC88A5280B3AA40414DF /* SuggestionAvailabilityEvaluator.swift */,
+				B2F95847D76893C8A5B504B4 /* SuggestionOverlayStabilityGate.swift */,
 				DDE858CB1E687E3CEB8FDD5B /* SuggestionRequestFactory.swift */,
 				CE0AA0503128B0FC3951D700 /* SuggestionSessionReconciler.swift */,
 				1CE61E74928C221B8BB261C6 /* SuggestionTextColorCodec.swift */,
@@ -844,6 +850,7 @@
 				A982E243A4D8BC1BF7504B3E /* SuggestionInteractionState.swift in Sources */,
 				0AF568AB234033BA2DE4CAA7 /* SuggestionModels.swift in Sources */,
 				02DA43985CDAE6859014F14F /* SuggestionOverlayPresenter.swift in Sources */,
+				0F3267956257401F39386773 /* SuggestionOverlayStabilityGate.swift in Sources */,
 				46F341472191BC451B6BF6B5 /* SuggestionRequestFactory.swift in Sources */,
 				CA5B2D226FBAA5419E78F14F /* SuggestionSessionReconciler.swift in Sources */,
 				32A2915FAE21CD9CE818A9D9 /* SuggestionSettingsModel.swift in Sources */,
@@ -901,6 +908,7 @@
 				934885ACC2DEA20B27F10948 /* PromptContextSanitizerTests.swift in Sources */,
 				3CF1A4E39F24917DF0470A7D /* PromptPolicyTests.swift in Sources */,
 				88BCD795A14E1C9308F7BB31 /* SuggestionAvailabilityEvaluatorTests.swift in Sources */,
+				4C6D8ED0A7B45D2EADF06DA5 /* SuggestionOverlayStabilityGateTests.swift in Sources */,
 				B93AB7E845086F6FBB068369 /* SuggestionRequestFactoryTests.swift in Sources */,
 				7E9413CE7C999C4612348248 /* SuggestionSessionReconcilerTests.swift in Sources */,
 				CB65A79F164269991FABC32E /* SuggestionStateHelperTests.swift in Sources */,

--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
@@ -314,12 +314,28 @@ extension SuggestionCoordinator {
             }
 
             state = .ready(text: reconciledSession.remainingText, latency: reconciledSession.latency)
-            presentOverlay(
-                text: reconciledSession.remainingText,
-                at: liveContext.caretRect,
-                context: liveContext,
-                isRightToLeft: TextDirectionDetector.isRightToLeft(liveContext.precedingText)
-            )
+            // Reconciliation runs both for legitimate context changes (window drag, field switch,
+            // user typing through the tail) and for the +30ms post-insertion AX refresh that fires
+            // after every Tab accept. In the post-insertion case the underlying state has not
+            // meaningfully changed (the overlay already shows the right tail at the predicted
+            // caret), but AX commonly returns a slightly different `caretRect` / `observedCharWidth`
+            // than the predicted pair. Re-rendering against those drifted measurements is what
+            // causes the visible one-frame "shift left and down then snap back" on accept. Hold the
+            // existing geometry whenever the field, text, and on-screen field bounds have not
+            // materially moved; the gate below still re-anchors on legitimate context changes.
+            if SuggestionOverlayStabilityGate.shouldRePresent(
+                currentOverlay: overlayState,
+                newText: reconciledSession.remainingText,
+                newInputFrameRect: liveContext.inputFrameRect,
+                newFocusChangeSequence: liveContext.focusChangeSequence
+            ) {
+                presentOverlay(
+                    text: reconciledSession.remainingText,
+                    at: liveContext.caretRect,
+                    context: liveContext,
+                    isRightToLeft: TextDirectionDetector.isRightToLeft(liveContext.precedingText)
+                )
+            }
             if let advancement {
                 logStage(
                     advancement.stage,

--- a/Cotabby/Support/SuggestionOverlayStabilityGate.swift
+++ b/Cotabby/Support/SuggestionOverlayStabilityGate.swift
@@ -1,0 +1,58 @@
+import CoreGraphics
+import Foundation
+
+/// File overview:
+/// Pure decision for whether a reconcile tick should reposition the visible ghost-text overlay.
+///
+/// Why this file exists:
+/// `SuggestionCoordinator` reconciles the active suggestion many times: on every focus poll, on
+/// every settings publication, and on the +30ms post-insertion refresh that fires after each Tab
+/// accept. The post-insertion path is the one that visibly hurts: AX commonly returns a slightly
+/// drifted `caretRect` / `observedCharWidth` after a synthesized insertion, and re-rendering
+/// against those drifted measurements is what causes the visible one-frame "shift left and down
+/// then snap back" the user sees on accept. The gate below holds the existing geometry whenever
+/// the field, text, and on-screen field bounds have not materially moved; legitimate context
+/// changes (field switch, window drag, text change) still re-anchor. Keeping the rule outside the
+/// coordinator means it can be unit-tested in isolation from any AppKit state.
+enum SuggestionOverlayStabilityGate {
+    /// Slack absorbed when comparing `inputFrameRect` between renders. 1pt is enough to swallow
+    /// the sub-pixel noise that mixed Retina/non-Retina setups produce on consecutive AX reads
+    /// of the same field, while still catching whole-pixel movements from a real window drag.
+    private static let inputFrameTolerance: CGFloat = 1
+
+    /// Returns `true` when the coordinator should call `presentOverlay` for this reconcile tick.
+    /// Returns `false` to hold the existing overlay geometry exactly as it was last drawn.
+    ///
+    /// Re-anchor when:
+    ///   - The overlay is currently hidden (this is a fresh show).
+    ///   - The focus session changed (different field, or the same field after focus toggled).
+    ///   - The displayed text changed (user partially accepted, or typed-through advanced the tail).
+    ///   - The host editor's frame moved on screen (window drag, sheet appear, etc.).
+    static func shouldRePresent(
+        currentOverlay: OverlayState,
+        newText: String,
+        newInputFrameRect: CGRect?,
+        newFocusChangeSequence: UInt64
+    ) -> Bool {
+        guard case let .visible(currentText, currentGeometry) = currentOverlay else {
+            return true
+        }
+        if currentGeometry.focusChangeSequence != newFocusChangeSequence {
+            return true
+        }
+        if currentText != newText {
+            return true
+        }
+        switch (currentGeometry.inputFrameRect, newInputFrameRect) {
+        case (nil, nil):
+            return false
+        case (nil, _), (_, nil):
+            return true
+        case let (old?, new?):
+            return abs(old.origin.x - new.origin.x) > inputFrameTolerance
+                || abs(old.origin.y - new.origin.y) > inputFrameTolerance
+                || abs(old.size.width - new.size.width) > inputFrameTolerance
+                || abs(old.size.height - new.size.height) > inputFrameTolerance
+        }
+    }
+}

--- a/Cotabby/Support/SuggestionOverlayStabilityGate.swift
+++ b/Cotabby/Support/SuggestionOverlayStabilityGate.swift
@@ -34,7 +34,9 @@ enum SuggestionOverlayStabilityGate {
         newInputFrameRect: CGRect?,
         newFocusChangeSequence: UInt64
     ) -> Bool {
-        guard case let .visible(currentText, currentGeometry) = currentOverlay else {
+        // Render mode is the third associated value; it is not part of the stability decision, so
+        // we ignore it. A mode change still re-anchors because text or geometry will also differ.
+        guard case let .visible(currentText, currentGeometry, _) = currentOverlay else {
             return true
         }
         if currentGeometry.focusChangeSequence != newFocusChangeSequence {
@@ -43,6 +45,13 @@ enum SuggestionOverlayStabilityGate {
         if currentText != newText {
             return true
         }
+        // `observedCharWidth` is intentionally NOT compared here. Drift in that value also affects
+        // `GhostSuggestionLayout.singleLineFits` (and therefore the panel-origin branch), so during
+        // a sustained window drag where `inputFrameRect` also moves, the first re-anchor past the
+        // tolerance can render with a drifted char-width for one frame. Including char-width in the
+        // gate would re-introduce the post-accept jitter this file exists to suppress, so we accept
+        // the drag-time tradeoff. If a future host shows the wrong-layout frame in practice, the fix
+        // belongs in `GhostSuggestionLayout` (smoothing char-width) rather than this gate.
         switch (currentGeometry.inputFrameRect, newInputFrameRect) {
         case (nil, nil):
             return false

--- a/CotabbyTests/SuggestionOverlayStabilityGateTests.swift
+++ b/CotabbyTests/SuggestionOverlayStabilityGateTests.swift
@@ -45,7 +45,7 @@ final class SuggestionOverlayStabilityGateTests: XCTestCase {
     /// has drifted by a sub-pixel amount in the latest AX read. Holding the geometry is what
     /// prevents the post-accept jitter.
     func test_sameFieldSameTextStableFrame_holdsGeometry() {
-        let current: OverlayState = .visible(text: "draft and send", geometry: Self.geometry())
+        let current: OverlayState = .visible(text: "draft and send", geometry: Self.geometry(), mode: .inline)
 
         XCTAssertFalse(
             SuggestionOverlayStabilityGate.shouldRePresent(
@@ -60,7 +60,8 @@ final class SuggestionOverlayStabilityGateTests: XCTestCase {
     func test_focusSessionChanged_reAnchors() {
         let current: OverlayState = .visible(
             text: "draft and send",
-            geometry: Self.geometry(focusChangeSequence: 7)
+            geometry: Self.geometry(focusChangeSequence: 7),
+            mode: .inline
         )
 
         XCTAssertTrue(
@@ -74,7 +75,7 @@ final class SuggestionOverlayStabilityGateTests: XCTestCase {
     }
 
     func test_displayedTextChanged_reAnchors() {
-        let current: OverlayState = .visible(text: "draft and send", geometry: Self.geometry())
+        let current: OverlayState = .visible(text: "draft and send", geometry: Self.geometry(), mode: .inline)
 
         XCTAssertTrue(
             SuggestionOverlayStabilityGate.shouldRePresent(
@@ -90,7 +91,7 @@ final class SuggestionOverlayStabilityGateTests: XCTestCase {
     /// re-anchor or the overlay will lag behind the dragged window.
     func test_inputFrameMovedBeyondTolerance_reAnchors() {
         let movedFrame = Self.inputFrame.offsetBy(dx: 12, dy: 0)
-        let current: OverlayState = .visible(text: "draft and send", geometry: Self.geometry())
+        let current: OverlayState = .visible(text: "draft and send", geometry: Self.geometry(), mode: .inline)
 
         XCTAssertTrue(
             SuggestionOverlayStabilityGate.shouldRePresent(
@@ -106,7 +107,7 @@ final class SuggestionOverlayStabilityGateTests: XCTestCase {
     /// post-accept regression we are guarding against.
     func test_inputFrameSubPixelNoise_holdsGeometry() {
         let nudgedFrame = Self.inputFrame.offsetBy(dx: 0.4, dy: -0.3)
-        let current: OverlayState = .visible(text: "draft and send", geometry: Self.geometry())
+        let current: OverlayState = .visible(text: "draft and send", geometry: Self.geometry(), mode: .inline)
 
         XCTAssertFalse(
             SuggestionOverlayStabilityGate.shouldRePresent(
@@ -121,11 +122,13 @@ final class SuggestionOverlayStabilityGateTests: XCTestCase {
     func test_inputFrameAppearedOrDisappeared_reAnchors() {
         let visibleWithFrame: OverlayState = .visible(
             text: "draft and send",
-            geometry: Self.geometry(inputFrameRect: Self.inputFrame)
+            geometry: Self.geometry(inputFrameRect: Self.inputFrame),
+            mode: .inline
         )
         let visibleWithoutFrame: OverlayState = .visible(
             text: "draft and send",
-            geometry: Self.geometry(inputFrameRect: nil)
+            geometry: Self.geometry(inputFrameRect: nil),
+            mode: .inline
         )
 
         XCTAssertTrue(
@@ -146,10 +149,27 @@ final class SuggestionOverlayStabilityGateTests: XCTestCase {
         )
     }
 
+    /// Exactly at the 1pt boundary: drift of 1.0pt is absorbed (strict `>` comparison).
+    /// Pins the contract so a future change to `>=` would flip a documented branch and fail here.
+    func test_inputFrameAtExactTolerance_holdsGeometry() {
+        let exactFrame = Self.inputFrame.offsetBy(dx: 1.0, dy: 0)
+        let current: OverlayState = .visible(text: "draft and send", geometry: Self.geometry(), mode: .inline)
+
+        XCTAssertFalse(
+            SuggestionOverlayStabilityGate.shouldRePresent(
+                currentOverlay: current,
+                newText: "draft and send",
+                newInputFrameRect: exactFrame,
+                newFocusChangeSequence: 7
+            )
+        )
+    }
+
     func test_bothFramesNil_holdsGeometry() {
         let current: OverlayState = .visible(
             text: "draft and send",
-            geometry: Self.geometry(inputFrameRect: nil)
+            geometry: Self.geometry(inputFrameRect: nil),
+            mode: .inline
         )
 
         XCTAssertFalse(

--- a/CotabbyTests/SuggestionOverlayStabilityGateTests.swift
+++ b/CotabbyTests/SuggestionOverlayStabilityGateTests.swift
@@ -1,0 +1,164 @@
+import CoreGraphics
+import XCTest
+@testable import Cotabby
+
+/// Tests for the post-accept overlay-stability gate.
+///
+/// The bug this gate fixes: after every Tab accept, AX returns slightly drifted `caretRect` /
+/// `observedCharWidth` values for the same underlying field state. The +30ms post-insertion
+/// reconcile used to call `presentOverlay` with those drifted values, producing a visible
+/// one-frame "shift left and down then snap back". The gate stops the reconcile from
+/// re-rendering when the field, text, and on-screen field bounds have not materially moved,
+/// while still allowing legitimate context changes (window drag, field switch, text change)
+/// to re-anchor the overlay.
+final class SuggestionOverlayStabilityGateTests: XCTestCase {
+    private static let inputFrame = CGRect(x: 100, y: 200, width: 400, height: 32)
+    private static let caretRect = CGRect(x: 140, y: 210, width: 2, height: 18)
+
+    private static func geometry(
+        caretRect: CGRect = caretRect,
+        inputFrameRect: CGRect? = inputFrame,
+        focusChangeSequence: UInt64 = 7
+    ) -> SuggestionOverlayGeometry {
+        SuggestionOverlayGeometry(
+            caretRect: caretRect,
+            inputFrameRect: inputFrameRect,
+            caretQuality: .exact,
+            observedCharWidth: 8,
+            isRightToLeft: false,
+            focusChangeSequence: focusChangeSequence
+        )
+    }
+
+    func test_hiddenOverlay_alwaysReRenders() {
+        XCTAssertTrue(
+            SuggestionOverlayStabilityGate.shouldRePresent(
+                currentOverlay: .hidden(reason: "idle"),
+                newText: "draft",
+                newInputFrameRect: Self.inputFrame,
+                newFocusChangeSequence: 7
+            )
+        )
+    }
+
+    /// The exact scenario the gate exists for: text and field are identical, only the caret rect
+    /// has drifted by a sub-pixel amount in the latest AX read. Holding the geometry is what
+    /// prevents the post-accept jitter.
+    func test_sameFieldSameTextStableFrame_holdsGeometry() {
+        let current: OverlayState = .visible(text: "draft and send", geometry: Self.geometry())
+
+        XCTAssertFalse(
+            SuggestionOverlayStabilityGate.shouldRePresent(
+                currentOverlay: current,
+                newText: "draft and send",
+                newInputFrameRect: Self.inputFrame,
+                newFocusChangeSequence: 7
+            )
+        )
+    }
+
+    func test_focusSessionChanged_reAnchors() {
+        let current: OverlayState = .visible(
+            text: "draft and send",
+            geometry: Self.geometry(focusChangeSequence: 7)
+        )
+
+        XCTAssertTrue(
+            SuggestionOverlayStabilityGate.shouldRePresent(
+                currentOverlay: current,
+                newText: "draft and send",
+                newInputFrameRect: Self.inputFrame,
+                newFocusChangeSequence: 8
+            )
+        )
+    }
+
+    func test_displayedTextChanged_reAnchors() {
+        let current: OverlayState = .visible(text: "draft and send", geometry: Self.geometry())
+
+        XCTAssertTrue(
+            SuggestionOverlayStabilityGate.shouldRePresent(
+                currentOverlay: current,
+                newText: "and send notes tomorrow",
+                newInputFrameRect: Self.inputFrame,
+                newFocusChangeSequence: 7
+            )
+        )
+    }
+
+    /// Window-drag case: the field's screen frame moves by whole-pixel amounts. The gate must
+    /// re-anchor or the overlay will lag behind the dragged window.
+    func test_inputFrameMovedBeyondTolerance_reAnchors() {
+        let movedFrame = Self.inputFrame.offsetBy(dx: 12, dy: 0)
+        let current: OverlayState = .visible(text: "draft and send", geometry: Self.geometry())
+
+        XCTAssertTrue(
+            SuggestionOverlayStabilityGate.shouldRePresent(
+                currentOverlay: current,
+                newText: "draft and send",
+                newInputFrameRect: movedFrame,
+                newFocusChangeSequence: 7
+            )
+        )
+    }
+
+    /// Sub-pixel noise inside the 1pt tolerance must be swallowed — this is the actual
+    /// post-accept regression we are guarding against.
+    func test_inputFrameSubPixelNoise_holdsGeometry() {
+        let nudgedFrame = Self.inputFrame.offsetBy(dx: 0.4, dy: -0.3)
+        let current: OverlayState = .visible(text: "draft and send", geometry: Self.geometry())
+
+        XCTAssertFalse(
+            SuggestionOverlayStabilityGate.shouldRePresent(
+                currentOverlay: current,
+                newText: "draft and send",
+                newInputFrameRect: nudgedFrame,
+                newFocusChangeSequence: 7
+            )
+        )
+    }
+
+    func test_inputFrameAppearedOrDisappeared_reAnchors() {
+        let visibleWithFrame: OverlayState = .visible(
+            text: "draft and send",
+            geometry: Self.geometry(inputFrameRect: Self.inputFrame)
+        )
+        let visibleWithoutFrame: OverlayState = .visible(
+            text: "draft and send",
+            geometry: Self.geometry(inputFrameRect: nil)
+        )
+
+        XCTAssertTrue(
+            SuggestionOverlayStabilityGate.shouldRePresent(
+                currentOverlay: visibleWithFrame,
+                newText: "draft and send",
+                newInputFrameRect: nil,
+                newFocusChangeSequence: 7
+            )
+        )
+        XCTAssertTrue(
+            SuggestionOverlayStabilityGate.shouldRePresent(
+                currentOverlay: visibleWithoutFrame,
+                newText: "draft and send",
+                newInputFrameRect: Self.inputFrame,
+                newFocusChangeSequence: 7
+            )
+        )
+    }
+
+    func test_bothFramesNil_holdsGeometry() {
+        let current: OverlayState = .visible(
+            text: "draft and send",
+            geometry: Self.geometry(inputFrameRect: nil)
+        )
+
+        XCTAssertFalse(
+            SuggestionOverlayStabilityGate.shouldRePresent(
+                currentOverlay: current,
+                newText: "draft and send",
+                newInputFrameRect: nil,
+                newFocusChangeSequence: 7
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary

The ghost-text overlay visibly shifted slightly LEFT and DOWN for one frame on every Tab accept, then snapped back. The fix holds the existing overlay geometry across reconcile ticks whenever the field, displayed text, and on-screen field bounds have not materially changed; legitimate context changes (window drag, field switch, new text) still re-anchor.

## Cause

Tab acceptance produces two overlay renders in succession:
1. Immediate: `acceptSuggestion` calls `presentOverlay(at: predictedCaret, ...)` using a `predictedCaretRect` computed from the pre-accept caret plus the chunk width.
2. +30ms: `schedulePostInsertionRefresh` calls `focusModel.refreshNow()` and then `reconcileActiveSession(with: focusModel.snapshot)`, which in turn calls `presentOverlay(at: liveContext.caretRect, ...)` again.

In the second render, AX commonly returns slightly different values for the same underlying state:
- `caretRect` drifts by a sub-pixel to a few-pixel amount as the host's caret rendering settles.
- `observedCharWidth` is recomputed from the field's child text runs whose composition changed when the inserted chunk committed. Even a small change can flip `GhostSuggestionLayout.singleLineFits`, switching `panelOriginX` from `firstLineAnchor` (right of caret) to `usableFrame.minX` (field left edge) and adding a `-lineHeight` Y offset. That is the left-and-down shift the user sees.
- `caretQuality` can momentarily degrade from `.exact` to `.derived` or `.estimated` if AX is mid-rerender, which pushes the layout through a different fallback branch.

The reconcile call site at `SuggestionCoordinator+Prediction.swift:317` re-presented the overlay unconditionally, so any of these drifted values caused a one-frame jitter even though the underlying state had not meaningfully changed.

## Fix

New pure helper `SuggestionOverlayStabilityGate.shouldRePresent(...)` (`Cotabby/Support/`) decides whether a reconcile tick should reposition the overlay. It returns:

- `true` if the overlay is hidden (fresh show), the focus session changed, the displayed text changed, or the host editor's frame moved on screen beyond a 1pt tolerance.
- `false` otherwise (the post-accept jitter case): hold the geometry from the prior `presentOverlay` call exactly as it was last drawn.

The reconcile branch in `SuggestionCoordinator+Prediction.swift` now calls `presentOverlay` only when the gate returns `true`. The +30ms post-insertion path therefore no longer re-anchors against drifted AX measurements, while window drags and field switches still re-anchor.

The 1pt input-frame tolerance is the smallest amount that swallows sub-pixel AX noise on mixed Retina / non-Retina setups; whole-pixel window movement still trips the gate.

## Validation

`xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build CODE_SIGNING_ALLOWED=NO`
→ `** BUILD SUCCEEDED **`

`xcodebuild test ... -only-testing:CotabbyTests CODE_SIGNING_ALLOWED=NO`
→ `Executed 381 tests, with 1 test skipped and 0 failures (0 unexpected)` (the skipped test is the gated FM eval, unrelated)

`swiftlint lint --quiet` → no violations.

8 new unit tests in `SuggestionOverlayStabilityGateTests` cover: hidden→render, identical-state→hold, focus-session-changed→render, text-changed→render, frame-moved→render, sub-pixel-frame-noise→hold, frame-appeared/disappeared→render, both-frames-nil→hold.

Manual check expected after merge: focus a real text field, generate a suggestion, press Tab to accept one word, and watch the remaining ghost text. It should advance to the new caret position once and stay there without the post-Tab jitter.

## Linked issues

(none filed; reported in-conversation by the project owner)

## Risk / rollout notes

- The gate runs only inside the `case .valid` branch of `reconcileActiveSession`. All other overlay paths (`apply(result:)` on a fresh generation, the partial-accept `presentOverlay` in `+Acceptance.swift`, `advanceActiveSessionIfTypedCharactersMatch`) call `presentOverlay` directly and are unaffected.
- `project.yml` is the source of truth for the Xcode project. The two new files (`Cotabby/Support/SuggestionOverlayStabilityGate.swift`, `CotabbyTests/SuggestionOverlayStabilityGateTests.swift`) are picked up automatically by XcodeGen; `xcodegen generate` was rerun and the resulting `Cotabby.xcodeproj/project.pbxproj` is committed.
- If a future regression makes the prediction in `acceptSuggestion` significantly wrong, the gate would now keep the overlay at that wrong position until the user accepts another chunk or the field changes. The eval is the right place to catch that: the 1pt tolerance is intentionally tight enough that a real misprediction would also move `inputFrameRect` (the caret implementation in AppKit/AX typically tracks the field origin), but if a host app turned out to move the caret without moving the field bounds, we'd need to add a separate caret-delta threshold. Calling that out so the next reviewer of this area knows the tradeoff.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a one-frame ghost-text jitter visible after every Tab accept by introducing `SuggestionOverlayStabilityGate`, a pure helper that gates the reconcile path's `presentOverlay` call. The gate holds existing overlay geometry when the focus session, displayed text, and input-frame position are all stable within a 1pt tolerance; legitimate re-anchors (window drag, field switch, text change) still pass through.

- **New `SuggestionOverlayStabilityGate` enum** (`Cotabby/Support/`) with a single static method `shouldRePresent`; it compares `focusChangeSequence`, text, and all four rect dimensions against stored `OverlayState` geometry and returns early-out booleans for each re-anchor condition.
- **`SuggestionCoordinator+Prediction.swift` call site** (line 326) wraps the existing `presentOverlay` call in an `if shouldRePresent` guard, leaving all other overlay paths (fresh generation, partial accept in `+Acceptance.swift`, typed-through advance) unaffected.
- **8 unit tests** covering hidden→render, identical-state→hold, focus-changed, text-changed, frame-moved, sub-pixel noise, frame appeared/disappeared, both-nil, and the exact 1pt boundary contract.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the gate is narrowly scoped to the reconcile path and all other overlay call sites are unaffected.

The change is a pure, side-effect-free predicate inserted at one call site. It cannot suppress a legitimate re-anchor because every re-anchor condition (focus session change, text change, frame movement beyond 1pt) is explicitly covered, and the guard defaults to re-presenting when overlayState is hidden. The 1pt tolerance boundary is pinned by a dedicated test so the contract is explicit. No existing tests were modified, and the build and full test suite pass.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/SuggestionOverlayStabilityGate.swift | New pure helper; logic is correct — checks focusChangeSequence, text, and all four inputFrameRect dimensions with a documented 1pt tolerance. Intentional omissions (caretRect drift, observedCharWidth) are explained in inline comments. |
| Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift | The single-line gate wrapping presentOverlay is minimal and scoped to the .valid reconcile branch; all other overlay call sites remain unaffected. |
| CotabbyTests/SuggestionOverlayStabilityGateTests.swift | Eight tests cover all documented branches including the exact 1pt boundary contract; no gaps found relative to the gate's decision tree. |
| Cotabby.xcodeproj/project.pbxproj | Two new files registered with correct UUIDs in both the app Sources and test Sources build phases; no other modifications. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Coordinator as SuggestionCoordinator
    participant Gate as StabilityGate
    participant Overlay as OverlayPresenter
    participant AX as Accessibility API

    User->>Coordinator: Tab accept
    Coordinator->>AX: predictedCaretRect (pre-accept)
    Coordinator->>Overlay: presentOverlay(predictedCaret) — immediate
    Overlay-->>Coordinator: "overlayState = .visible(text, geometry)"

    Note over Coordinator: +30ms schedulePostInsertionRefresh
    Coordinator->>AX: refreshNow() → reconcileActiveSession
    AX-->>Coordinator: liveContext (drifted caretRect / charWidth)

    Coordinator->>Gate: shouldRePresent(overlayState, newText, newInputFrameRect, newFocusChangeSequence)
    alt "text changed OR frame moved >1pt OR focus session changed"
        Gate-->>Coordinator: true → re-anchor
        Coordinator->>Overlay: presentOverlay(liveContext.caretRect)
    else same text, stable frame, same session
        Gate-->>Coordinator: false → hold geometry
        Note over Overlay: Overlay stays at predicted position (no jitter)
    end
```

<sub>Reviews (3): Last reviewed commit: ["Address Greptile review on overlay stabi..."](https://github.com/fujacob/cotabby/commit/7b2e84a135cdbb5e676e58023ccec8edddb4b7d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34329744)</sub>

<!-- /greptile_comment -->