### PR TITLE
Bring tooltips back on macOS 26 beta + show accept key as a keycap

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -147,6 +147,7 @@
 		DE236C9285635C686D66A2F6 /* TerminalAppDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E37A7E835D3BDE6265843C /* TerminalAppDetectorTests.swift */; };
 		E17CAA453B1F534D284F0D89 /* PermissionHostApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6ACCB12E4DB32D2F2BEA567 /* PermissionHostApp.swift */; };
 		E313639E71AE1374D2B9A956 /* SuggestionWorkController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B2D97BAA3618A7D0357AC44 /* SuggestionWorkController.swift */; };
+		E4118809465DA2449E21A8BE /* TooltipSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB73667A6FF0EA590D54DDF9 /* TooltipSupport.swift */; };
 		E6EE3C13FA31F261CD734C69 /* DownloadOutcomeClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DE1975F3B5F4A70478DBF41 /* DownloadOutcomeClassifier.swift */; };
 		E912D4617AE1376061DF1F00 /* LanguageSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4793D4EA5D36D7E5CC216C27 /* LanguageSupportTests.swift */; };
 		E994FE418A961FB234D9057A /* DownloadFileRescuerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F46767D9D1F0D44E239CA8 /* DownloadFileRescuerTests.swift */; };
@@ -308,6 +309,7 @@
 		D504BEB224E0C176F5FCFF6E /* CompletionRenderModePolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionRenderModePolicyTests.swift; sourceTree = "<group>"; };
 		D5D6C2318E405AA717D1C256 /* WelcomePermissionStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomePermissionStepView.swift; sourceTree = "<group>"; };
 		D84D4528EEC9EFEB8AE8E318 /* ActivationIndicatorController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivationIndicatorController.swift; sourceTree = "<group>"; };
+		DB73667A6FF0EA590D54DDF9 /* TooltipSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TooltipSupport.swift; sourceTree = "<group>"; };
 		DDE858CB1E687E3CEB8FDD5B /* SuggestionRequestFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionRequestFactory.swift; sourceTree = "<group>"; };
 		DEB16474A67CE1D210B944C9 /* SuggestionSubsystemContracts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionSubsystemContracts.swift; sourceTree = "<group>"; };
 		E1D2782B6C7BE3F56BCB22DE /* LlamaVisualContextSummarizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LlamaVisualContextSummarizer.swift; sourceTree = "<group>"; };
@@ -554,6 +556,7 @@
 				FB317C82CE2CBC69056BA4B8 /* TagChip.swift */,
 				58C0F017699EE44C81C095CA /* TagsInputView.swift */,
 				67586807ACE8EB13C9014535 /* TickMarkSlider.swift */,
+				DB73667A6FF0EA590D54DDF9 /* TooltipSupport.swift */,
 				D5D6C2318E405AA717D1C256 /* WelcomePermissionStepView.swift */,
 				6C4565D64DF64A2AA0DB1532 /* WelcomeProfileStepView.swift */,
 				264CA64B2AB1611F82E5B760 /* WelcomeView.swift */,
@@ -854,6 +857,7 @@
 				AB9C9C001F97F9D14F8B192A /* TerminalAppDetector.swift in Sources */,
 				96782E57CA26A16409368B69 /* TextDirectionDetector.swift in Sources */,
 				6014B31E2570EFFE45557E33 /* TickMarkSlider.swift in Sources */,
+				E4118809465DA2449E21A8BE /* TooltipSupport.swift in Sources */,
 				E9E4CC657771DF9F4C56183C /* VisualContextCoordinator.swift in Sources */,
 				4190F8A76196B16ED94D0A55 /* VisualContextModels.swift in Sources */,
 				19CB55B62977376E9AE8D428 /* VisualContextStartCoalescer.swift in Sources */,

--- a/Cotabby/UI/CustomRulesEditor.swift
+++ b/Cotabby/UI/CustomRulesEditor.swift
@@ -30,7 +30,7 @@ struct CustomRulesEditor: View {
             HStack {
                 Text("Rules")
                     .font(.system(size: 13, weight: .medium))
-                    .help("Short style instructions added to every prompt, like \"no em dashes\" "
+                    .cotabbyHelp("Short style instructions added to every prompt, like \"no em dashes\" "
                         + "or \"prefer short sentences\". Stored only on your Mac.")
                 Spacer()
                 if canClear {
@@ -40,7 +40,7 @@ struct CustomRulesEditor: View {
                     .buttonStyle(.plain)
                     .font(.system(size: 12))
                     .foregroundStyle(.secondary)
-                    .help("Remove all custom rules.")
+                    .cotabbyHelp("Remove all custom rules.")
                 }
             }
 

--- a/Cotabby/UI/LanguageTagsEditor.swift
+++ b/Cotabby/UI/LanguageTagsEditor.swift
@@ -29,7 +29,7 @@ struct LanguageTagsEditor: View {
             HStack {
                 Text("Languages")
                     .font(.system(size: 13, weight: .medium))
-                    .help("Languages you write in. Cotabby matches what you're currently typing; "
+                    .cotabbyHelp("Languages you write in. Cotabby matches what you're currently typing; "
                         + "these help when a field is empty or too short to tell. "
                         + "Leave empty to always follow the surrounding text.")
                 Spacer()
@@ -40,7 +40,7 @@ struct LanguageTagsEditor: View {
                     .buttonStyle(.plain)
                     .font(.system(size: 12))
                     .foregroundStyle(.secondary)
-                    .help("Remove all language tags.")
+                    .cotabbyHelp("Remove all language tags.")
                 }
             }
 

--- a/Cotabby/UI/MenuBarView.swift
+++ b/Cotabby/UI/MenuBarView.swift
@@ -73,7 +73,7 @@ struct MenuBarView: View {
             Toggle("Fast Mode", isOn: fastModeEnabledBinding)
                 .toggleStyle(.switch)
                 .controlSize(.small)
-                .help("Skip on-screen OCR context for faster, lower-overhead suggestions. Predictions still run.")
+                .cotabbyHelp("Skip on-screen OCR context for faster, lower-overhead suggestions. Predictions still run.")
 
             Divider()
 
@@ -83,14 +83,14 @@ struct MenuBarView: View {
                 Toggle("Enable Globally", isOn: globallyEnabledBinding)
                     .toggleStyle(.switch)
                     .controlSize(.small)
-                    .help("Master switch. Turn off to silence Cotabby in every app.")
+                    .cotabbyHelp("Master switch. Turn off to silence Cotabby in every app.")
 
                 if let application = focusModel.latestExternalApplication,
                    !TerminalAppDetector.isTerminal(bundleIdentifier: application.bundleIdentifier) {
                     Toggle("Enable in \(application.applicationName)", isOn: appEnabledBinding(for: application))
                         .toggleStyle(.switch)
                         .controlSize(.small)
-                        .help("Disable Cotabby just in this app. Overrides Enable Globally.")
+                        .cotabbyHelp("Disable Cotabby just in this app. Overrides Enable Globally.")
                 }
             }
 
@@ -101,12 +101,12 @@ struct MenuBarView: View {
                 Toggle("Include Clipboard Context", isOn: clipboardContextEnabledBinding)
                     .toggleStyle(.switch)
                     .controlSize(.small)
-                    .help("Include your latest clipboard contents in the prompt so completions can reference what you copied.")
+                    .cotabbyHelp("Include your latest clipboard contents in the prompt so completions can reference what you copied.")
 
                 Toggle("Allow Multi-line Suggestions", isOn: multiLineEnabledBinding)
                     .toggleStyle(.switch)
                     .controlSize(.small)
-                    .help("Let suggestions span more than one line. Off keeps them to a single line.")
+                    .cotabbyHelp("Let suggestions span more than one line. Off keeps them to a single line.")
             }
 
             Divider()
@@ -124,7 +124,7 @@ struct MenuBarView: View {
                     }
                     .labelsHidden()
                     .pickerStyle(.menu)
-                    .help("Apple Intelligence runs on-device through macOS. Llama runs a local GGUF model you pick below.")
+                    .cotabbyHelp("Apple Intelligence runs on-device through macOS. Llama runs a local GGUF model you pick below.")
                 }
 
                 if suggestionSettings.selectedEngine == .appleIntelligence,
@@ -147,7 +147,7 @@ struct MenuBarView: View {
                     }
                     .labelsHidden()
                     .pickerStyle(.menu)
-                    .help("How long completions tend to be. Shorter is faster and less likely to overreach.")
+                    .cotabbyHelp("How long completions tend to be. Shorter is faster and less likely to overreach.")
                 }
             }
         }
@@ -187,7 +187,7 @@ struct MenuBarView: View {
                 }
                 .buttonStyle(.borderless)
                 .controlSize(.small)
-                .help("Open Models Folder")
+                .cotabbyHelp("Open Models Folder")
 
                 Button {
                     modelDownloadManager.refreshModelStates()
@@ -197,7 +197,7 @@ struct MenuBarView: View {
                 }
                 .buttonStyle(.borderless)
                 .controlSize(.small)
-                .help("Refresh Available Models")
+                .cotabbyHelp("Refresh Available Models")
             }
         }
     }

--- a/Cotabby/UI/SettingsView.swift
+++ b/Cotabby/UI/SettingsView.swift
@@ -143,25 +143,38 @@ struct SettingsView: View {
     private var generalSection: some View {
         Section("General") {
             Toggle("Enable Globally", isOn: globallyEnabledBinding)
-                .help("Master switch. Turn off to silence Cotabby in every app.")
+                .cotabbyHelp("Master switch. Turn off to silence Cotabby in every app.")
 
             Toggle("Show Indicator", isOn: showIndicatorBinding)
-                .help("Show a small icon next to the cursor when Cotabby is active in a field.")
+                .cotabbyHelp("Show a small icon next to the cursor when Cotabby is active in a field.")
 
-            Toggle("Show Accept Hint", isOn: showAcceptanceHintBinding)
-                .help("Show a small label near the ghost text reminding you which key accepts it.")
+            Toggle(isOn: showAcceptanceHintBinding) {
+                HStack(spacing: 4) {
+                    Text("Show")
+                    Text(suggestionSettings.acceptanceKeyLabel)
+                        .font(.system(.body, design: .rounded).weight(.semibold))
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 1)
+                        .background(
+                            RoundedRectangle(cornerRadius: 4, style: .continuous)
+                                .fill(.quaternary)
+                        )
+                    Text("Key Hint")
+                }
+            }
+            .cotabbyHelp("Show a small label near the ghost text reminding you which key accepts it.")
 
             Toggle("Allow Multi-line Suggestions", isOn: multiLineEnabledBinding)
-                .help("Let suggestions span more than one line. Off keeps them to a single line.")
+                .cotabbyHelp("Let suggestions span more than one line. Off keeps them to a single line.")
 
             Toggle("Accept Punctuation With Word", isOn: autoAcceptTrailingPunctuationBinding)
-                .help("With this on, accepting a word also takes punctuation attached to it, like the \"?\" in \"you?\".")
+                .cotabbyHelp("With this on, accepting a word also takes punctuation attached to it, like the \"?\" in \"you?\".")
 
             Toggle("Include Clipboard Context", isOn: clipboardContextEnabledBinding)
-                .help("Include your latest clipboard contents in the prompt so completions can reference what you copied.")
+                .cotabbyHelp("Include your latest clipboard contents in the prompt so completions can reference what you copied.")
 
             Toggle("Fast Mode", isOn: fastModeEnabledBinding)
-                .help("Skip on-screen OCR context for faster, lower-overhead suggestions. Predictions still run.")
+                .cotabbyHelp("Skip on-screen OCR context for faster, lower-overhead suggestions. Predictions still run.")
 
             LabeledContent("Ghost Text Color") {
                 HStack(spacing: 8) {
@@ -170,7 +183,7 @@ struct SettingsView: View {
                     }
                 }
             }
-            .help("Color of the ghost text shown before you accept it.")
+            .cotabbyHelp("Color of the ghost text shown before you accept it.")
 
             LabeledContent("Ghost Text Opacity") {
                 HStack(spacing: 10) {
@@ -189,7 +202,7 @@ struct SettingsView: View {
                         .frame(width: 42, alignment: .trailing)
                 }
             }
-            .help("How visible the ghost text is. Lower values are subtler but harder to read.")
+            .cotabbyHelp("How visible the ghost text is. Lower values are subtler but harder to read.")
 
             // Open at Login is hidden until the quarantine/SMAppService issue is resolved.
             // The toggle reports .notFound for quarantined apps and apps outside /Applications,
@@ -214,7 +227,7 @@ struct SettingsView: View {
                         .tag(engine)
                 }
             }
-            .help("Apple Intelligence runs on-device through macOS. Llama runs a local GGUF model you pick below.")
+            .cotabbyHelp("Apple Intelligence runs on-device through macOS. Llama runs a local GGUF model you pick below.")
 
             switch suggestionSettings.selectedEngine {
             case .appleIntelligence:
@@ -245,7 +258,7 @@ struct SettingsView: View {
                         .tag(preset)
                 }
             }
-            .help("How long completions tend to be. Shorter is faster and less likely to overreach.")
+            .cotabbyHelp("How long completions tend to be. Shorter is faster and less likely to overreach.")
 
             VStack(alignment: .leading, spacing: 24) {
                 Text("This information is passed to the AI to help personalize your completions.")
@@ -261,7 +274,7 @@ struct SettingsView: View {
                         set: { suggestionSettings.setUserName($0) }
                     ))
                     .textFieldStyle(.roundedBorder)
-                    .help("How Cotabby refers to you when it matters, like signing off an email.")
+                    .cotabbyHelp("How Cotabby refers to you when it matters, like signing off an email.")
                 }
 
                 LanguageTagsEditor(suggestionSettings: suggestionSettings)
@@ -303,7 +316,7 @@ struct SettingsView: View {
                         Button("Change") {
                             isRecordingKeybind = true
                         }
-                        .help("Record a new shortcut. Hold any modifiers and press a key to bind it; Escape to cancel.")
+                        .cotabbyHelp("Record a new shortcut. Hold any modifiers and press a key to bind it; Escape to cancel.")
                     }
 
                     if suggestionSettings.acceptanceKeyCode != SuggestionSettingsModel.defaultAcceptanceKeyCode
@@ -316,7 +329,7 @@ struct SettingsView: View {
                             )
                             isRecordingKeybind = false
                         }
-                        .help("Restore the default key.")
+                        .cotabbyHelp("Restore the default key.")
                     }
 
                     if suggestionSettings.acceptanceKeyCode != SuggestionSettingsModel.disabledKeyCode {
@@ -324,11 +337,11 @@ struct SettingsView: View {
                             suggestionSettings.clearAcceptanceKey()
                             isRecordingKeybind = false
                         }
-                        .help("Unbind this shortcut. No key will accept word-by-word.")
+                        .cotabbyHelp("Unbind this shortcut. No key will accept word-by-word.")
                     }
                 }
             }
-            .help("Key that accepts the next word of the suggestion.")
+            .cotabbyHelp("Key that accepts the next word of the suggestion.")
 
             LabeledContent("Accept Entire Suggestion") {
                 HStack(spacing: 8) {
@@ -358,7 +371,7 @@ struct SettingsView: View {
                         Button("Change") {
                             isRecordingFullAcceptKeybind = true
                         }
-                        .help("Record a new shortcut. Hold any modifiers and press a key to bind it; Escape to cancel.")
+                        .cotabbyHelp("Record a new shortcut. Hold any modifiers and press a key to bind it; Escape to cancel.")
                     }
 
                     if suggestionSettings.fullAcceptanceKeyCode != SuggestionSettingsModel.defaultFullAcceptanceKeyCode
@@ -371,7 +384,7 @@ struct SettingsView: View {
                             )
                             isRecordingFullAcceptKeybind = false
                         }
-                        .help("Restore the default key.")
+                        .cotabbyHelp("Restore the default key.")
                     }
 
                     if suggestionSettings.fullAcceptanceKeyCode != SuggestionSettingsModel.disabledKeyCode {
@@ -379,11 +392,11 @@ struct SettingsView: View {
                             suggestionSettings.clearFullAcceptanceKey()
                             isRecordingFullAcceptKeybind = false
                         }
-                        .help("Unbind this shortcut. No key will accept the whole suggestion at once.")
+                        .cotabbyHelp("Unbind this shortcut. No key will accept the whole suggestion at once.")
                     }
                 }
             }
-            .help("Key that accepts the whole suggestion at once.")
+            .cotabbyHelp("Key that accepts the whole suggestion at once.")
         }
     }
 
@@ -396,7 +409,7 @@ struct SettingsView: View {
                 in: 10...500,
                 step: 10
             )
-            .help("How long Cotabby waits after you stop typing before generating. Higher saves CPU; lower feels snappier.")
+            .cotabbyHelp("How long Cotabby waits after you stop typing before generating. Higher saves CPU; lower feels snappier.")
 
             // Focus poll interval is intentionally hidden from the UI. The default (50 ms)
             // is tuned for the best balance of responsiveness and CPU usage. Exposing it
@@ -420,7 +433,7 @@ struct SettingsView: View {
             Button("Add App…") {
                 presentDisabledAppPicker()
             }
-            .help("Pick an app to disable Cotabby in.")
+            .cotabbyHelp("Pick an app to disable Cotabby in.")
         }
     }
 
@@ -470,7 +483,7 @@ struct SettingsView: View {
                             .tag(model.filename)
                     }
                 }
-                .help("Which GGUF file Cotabby loads. Larger models are smarter but slower and use more memory.")
+                .cotabbyHelp("Which GGUF file Cotabby loads. Larger models are smarter but slower and use more memory.")
             }
 
             DownloadableModelCatalogView(
@@ -502,7 +515,7 @@ struct SettingsView: View {
                             refreshModels()
                         }
                         .disabled(!lmStudioAvailable)
-                        .help(
+                        .cotabbyHelp(
                             lmStudioAvailable
                                 ? "Point Cotabby at LM Studio's models folder (~/.lmstudio/models) so you don't keep two copies."
                                 : "Install LM Studio with at least one model first. Cotabby couldn't find ~/.lmstudio/models."
@@ -514,7 +527,7 @@ struct SettingsView: View {
                             refreshModels()
                         }
                         .disabled(!isUsingCustomPath)
-                        .help("Go back to Cotabby's default models folder.")
+                        .cotabbyHelp("Go back to Cotabby's default models folder.")
 
                         Button("Open Folder") {
                             modelDownloadManager.openModelsDirectory()
@@ -523,11 +536,11 @@ struct SettingsView: View {
                         Button("Refresh") {
                             refreshModels()
                         }
-                        .help("Re-scan the folder for newly added or removed model files.")
+                        .cotabbyHelp("Re-scan the folder for newly added or removed model files.")
                     }
                 }
             }
-            .help("Where Cotabby looks for GGUF model files.")
+            .cotabbyHelp("Where Cotabby looks for GGUF model files.")
 
             if !runtimeModel.availableModels.isEmpty {
                 Text("Installed")
@@ -600,7 +613,7 @@ struct SettingsView: View {
                         .foregroundStyle(.secondary)
                 }
                 .buttonStyle(.borderless)
-                .help("Delete \(model.displayName)")
+                .cotabbyHelp("Delete \(model.displayName)")
             }
         }
     }
@@ -633,7 +646,7 @@ struct SettingsView: View {
                     .foregroundStyle(.secondary)
             }
             .buttonStyle(.borderless)
-            .help("Remove \(rule.displayName) from disabled apps")
+            .cotabbyHelp("Remove \(rule.displayName) from disabled apps")
         }
     }
 
@@ -669,7 +682,7 @@ struct SettingsView: View {
                     action()
                 }
                 .controlSize(.small)
-                .help("Open System Settings to Privacy & Security so you can grant this permission.")
+                .cotabbyHelp("Open System Settings to Privacy & Security so you can grant this permission.")
             }
         }
     }
@@ -824,7 +837,7 @@ struct SettingsView: View {
                 )
         }
         .buttonStyle(.plain)
-        .help(preset.name)
+        .cotabbyHelp(preset.name)
     }
 
     private func swatchFill(for preset: GhostTextColorPreset) -> Color {

--- a/Cotabby/UI/TooltipSupport.swift
+++ b/Cotabby/UI/TooltipSupport.swift
@@ -1,0 +1,53 @@
+import AppKit
+import SwiftUI
+
+/// File overview:
+/// AppKit-backed tooltip support for the Settings window and the menu-bar panel.
+///
+/// SwiftUI's `.help(_:)` modifier silently stopped rendering tooltips on the macOS 26 beta in
+/// menu-bar (LSUIElement) apps. Issue #313 wired up dozens of `.help(...)` calls that the user
+/// can no longer see. Until SwiftUI's bridge is fixed we paint our own tooltip via an
+/// `NSViewRepresentable` overlay that sets `NSView.toolTip` directly — AppKit's tooltip subsystem
+/// still works fine in this environment. We also keep calling `.help(_:)` so accessibility help
+/// stays wired up and the SwiftUI path "just starts working" again on a future macOS update.
+
+extension View {
+    /// Drop-in replacement for `.help(_:)` that also installs an AppKit tooltip overlay, so the
+    /// tip is actually visible on macOS 26 beta where SwiftUI's tooltip bridge is broken.
+    func cotabbyHelp(_ text: String) -> some View {
+        modifier(CotabbyTooltipModifier(text: text))
+    }
+}
+
+private struct CotabbyTooltipModifier: ViewModifier {
+    let text: String
+
+    func body(content: Content) -> some View {
+        content
+            .help(text)
+            .overlay(TooltipOverlayView(text: text))
+    }
+}
+
+/// Transparent NSView whose only job is to advertise a tooltip to AppKit's `NSToolTipManager`.
+/// `hitTest` returns `nil` so the overlay never intercepts clicks meant for the underlying
+/// SwiftUI control; tracking-area-based tooltip delivery is independent of hit testing.
+private struct TooltipOverlayView: NSViewRepresentable {
+    let text: String
+
+    func makeNSView(context: Context) -> NSView {
+        let view = ClickThroughTooltipView()
+        view.toolTip = text
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        nsView.toolTip = text
+    }
+}
+
+private final class ClickThroughTooltipView: NSView {
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        nil
+    }
+}


### PR DESCRIPTION
## Summary

Two fixes to the Settings + menu-bar surface, both reported in one ticket:

1. The tooltip PR (#313) sprinkled 40+ \`.help(_:)\` modifiers across Settings, the menu-bar panel, and the rule/language editors — but on macOS 26 beta SwiftUI's tooltip bridge silently stopped firing for LSUIElement (menu-bar) apps, so none of those tooltips were ever visible. AppKit's own tooltip subsystem still works fine, so this PR adds a thin \`.cotabbyHelp(_:)\` modifier that calls \`.help(_:)\` (for accessibility) and overlays a click-through \`NSViewRepresentable\` that sets \`NSView.toolTip\` directly. All 44 \`.help(\` call sites were updated. When SwiftUI's bridge is fixed in a later macOS update, the underlying \`.help(_:)\` will already be wired up and the overlay becomes a harmless no-op.

2. The 'Show Accept Hint' toggle's label was vague — it didn't say what the hint shows. Replaced with a live label that renders the user's actual accept key as an inline keycap pill: 'Show [Tab] Key Hint' (or '[⌥Tab]', '[\`]', etc., depending on what the user bound). Picks up rebinds automatically because it reads \`suggestionSettings.acceptanceKeyLabel\` directly.

## Validation

- \`swiftlint lint --quiet\` → exit 0
- \`xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build\` → ** BUILD SUCCEEDED **
- \`xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build-for-testing\` → ** TEST BUILD SUCCEEDED **
- \`xcodegen generate\` regenerated the project to pick up the new \`TooltipSupport.swift\`.

UI verification recommended: open Settings on macOS 26 beta and hover any control with a tooltip — pill should appear after ~1.5 s. Repeat in the menu-bar panel. Rebind the accept key from Settings and confirm the new key glyph appears in the 'Show ... Key Hint' label without restarting.

## Linked issues

Refs #313.

## Risk / rollout notes

- The click-through \`NSView\` overlay returns \`nil\` from \`hitTest\`, so it must not intercept clicks meant for the wrapped control. Worth a quick smoke on the toggles, the engine picker, and the keybind recorder to confirm interaction still feels normal.
- If we ever drop macOS 26 beta support and SwiftUI tooltips return, \`.cotabbyHelp(_:)\` can be reduced back to just \`.help(_:)\` with a one-line edit in \`TooltipSupport.swift\`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two issues on macOS 26 beta: it restores tooltips in the Settings window and menu-bar panel (where SwiftUI's tooltip bridge silently stopped working for LSUIElement apps) by introducing a thin `cotabbyHelp(_:)` modifier that layers an AppKit `NSView.toolTip` overlay over every existing `.help()` call, and it replaces the static "Show Accept Hint" toggle label with a live keycap pill that displays the user's currently bound acceptance key.

- **`TooltipSupport.swift`** (new): Defines `CotabbyTooltipModifier`, which chains `.help()` for accessibility and overlays a `ClickThroughTooltipView` (`hitTest → nil`) whose `toolTip` property drives AppKit's `NSToolTipManager` directly. All 44 existing call sites are updated to `.cotabbyHelp()`.
- **`SettingsView.swift`**: The "Show Accept Hint" toggle label is rebuilt as an `HStack` with an inline rounded-rectangle keycap pill reading `suggestionSettings.acceptanceKeyLabel`; rebinds are reflected immediately without restart.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the AppKit overlay is click-through by design and the tooltip workaround is well-scoped to the UI layer.

The `ClickThroughTooltipView` + `toolTip` approach is sound — AppKit tooltip tracking is independent of hit testing, so `hitTest → nil` correctly lets clicks pass through while still triggering tooltip popovers. The only non-trivial concerns are both non-blocking: when the acceptance key is cleared, the keycap pill reads "None" (producing "Show [None] Key Hint"), and once a future macOS ships with a fixed SwiftUI tooltip bridge, both `.help()` and the AppKit tracking area will be active simultaneously, risking duplicate tooltips until the workaround is removed.

Cotabby/UI/TooltipSupport.swift warrants a second look for the dual-tooltip scenario on future macOS; Cotabby/UI/SettingsView.swift's keycap pill is worth smoke-testing with the key unbound.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/TooltipSupport.swift | New file introducing `cotabbyHelp(_:)` — a thin AppKit-backed tooltip workaround for macOS 26 beta. Implementation is clean; minor concern that both SwiftUI and AppKit tooltip systems will fire simultaneously on a future OS where the bridge is fixed. |
| Cotabby/UI/SettingsView.swift | All `.help()` calls replaced with `.cotabbyHelp()`; "Show Accept Hint" toggle updated to show a live keycap pill. When the acceptance key is cleared, the pill displays "None", producing a slightly odd "Show [None] Key Hint" label. |
| Cotabby/UI/MenuBarView.swift | Mechanical `.help()` → `.cotabbyHelp()` replacements throughout; no logic changes. |
| Cotabby/UI/CustomRulesEditor.swift | Two `.help()` → `.cotabbyHelp()` replacements; no other changes. |
| Cotabby/UI/LanguageTagsEditor.swift | Two `.help()` → `.cotabbyHelp()` replacements; no other changes. |
| Cotabby.xcodeproj/project.pbxproj | Adds `TooltipSupport.swift` to the Xcode project sources; standard xcodegen output. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant SW as SwiftUI View
    participant CM as CotabbyTooltipModifier
    participant OV as TooltipOverlayView (NSViewRepresentable)
    participant AK as ClickThroughTooltipView (NSView)
    participant AM as AppKit NSToolTipManager
    participant ACC as Accessibility (.help)

    SW->>CM: .cotabbyHelp("text")
    CM->>ACC: .help("text") — wires up VoiceOver
    CM->>OV: .overlay(TooltipOverlayView)
    OV->>AK: "makeNSView → toolTip = "text""
    AK->>AM: registers tooltip tracking area
    Note over AK: hitTest → nil (click-through)
    AM-->>SW: tooltip popover on hover (AppKit path)

    Note over SW,ACC: On future macOS where SwiftUI bridge is fixed,<br/>both .help() and AppKit tracking area are active
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fvisible-tooltips-and-keycap-label%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fvisible-tooltips-and-keycap-label%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FSettingsView.swift%3A151-165%0A**Keycap%20pill%20shows%20%22None%22%20when%20acceptance%20key%20is%20disabled**%0A%0AWhen%20the%20user%20clears%20the%20word-by-word%20acceptance%20key%2C%20%60acceptanceKeyLabel%60%20becomes%20%60%22None%22%60%20%28the%20%60disabledKeyLabel%60%20constant%29%2C%20so%20the%20toggle%20label%20renders%20as%20%22Show%20%5BNone%5D%20Key%20Hint%22.%20This%20is%20accurate%20but%20may%20read%20oddly%20%E2%80%94%20a%20user%20who%20has%20unbound%20the%20key%20sees%20a%20hint%20referring%20to%20a%20non-existent%20binding.%20Consider%20falling%20back%20to%20a%20plain%20%22Show%20Key%20Hint%22%20label%20%28no%20pill%29%20when%20%60acceptanceKeyCode%20%3D%3D%20SuggestionSettingsModel.disabledKeyCode%60.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FUI%2FTooltipSupport.swift%3A25-29%0A**Duplicate%20tooltip%20risk%20on%20future%20macOS%20where%20SwiftUI's%20bridge%20is%20repaired**%0A%0ABoth%20%60.help%28text%29%60%20and%20the%20%60NSView.toolTip%60%20tracking%20area%20will%20be%20active%20simultaneously.%20On%20a%20macOS%20version%20that%20fixes%20the%20bridge%2C%20two%20separate%20tooltip%20managers%20may%20each%20fire%20for%20the%20same%20hover%2C%20producing%20a%20double%20tooltip.%20The%20PR%20notes%20this%20will%20%22become%20a%20harmless%20no-op%22%2C%20but%20that%20assumes%20only%20one%20system%20fires%20%E2%80%94%20which%20isn't%20guaranteed.%20Adding%20a%20version%20gate%20%28e.g.%2C%20%60if%20%23unavailable%28macOS%20X.Y%29%60%29%20around%20the%20overlay%20would%20prevent%20the%20double-fire%20once%20a%20fixed%20OS%20ships%20and%20makes%20the%20intended%20cleanup%20path%20explicit.%0A%0A%60%60%60suggestion%0A%20%20%20%20func%20body%28content%3A%20Content%29%20-%3E%20some%20View%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20On%20macOS%2026%20beta%20SwiftUI's%20tooltip%20bridge%20is%20broken%20for%20LSUIElement%20apps%20%28issue%20%23313%29.%0A%20%20%20%20%20%20%20%20%2F%2F%20Overlay%20an%20AppKit%20NSView%20so%20the%20tooltip%20is%20still%20shown%20via%20AppKit's%20own%20subsystem.%0A%20%20%20%20%20%20%20%20%2F%2F%20When%20SwiftUI's%20bridge%20is%20fixed%2C%20gate%20the%20overlay%20out%20with%20%60if%20%23unavailable%28macOS%20X.Y%29%60%0A%20%20%20%20%20%20%20%20%2F%2F%20to%20avoid%20both%20systems%20firing%20simultaneously.%0A%20%20%20%20%20%20%20%20content%0A%20%20%20%20%20%20%20%20%20%20%20%20.help%28text%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.overlay%28TooltipOverlayView%28text%3A%20text%29%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FSettingsView.swift%3A151-165%0A**Keycap%20pill%20shows%20%22None%22%20when%20acceptance%20key%20is%20disabled**%0A%0AWhen%20the%20user%20clears%20the%20word-by-word%20acceptance%20key%2C%20%60acceptanceKeyLabel%60%20becomes%20%60%22None%22%60%20%28the%20%60disabledKeyLabel%60%20constant%29%2C%20so%20the%20toggle%20label%20renders%20as%20%22Show%20%5BNone%5D%20Key%20Hint%22.%20This%20is%20accurate%20but%20may%20read%20oddly%20%E2%80%94%20a%20user%20who%20has%20unbound%20the%20key%20sees%20a%20hint%20referring%20to%20a%20non-existent%20binding.%20Consider%20falling%20back%20to%20a%20plain%20%22Show%20Key%20Hint%22%20label%20%28no%20pill%29%20when%20%60acceptanceKeyCode%20%3D%3D%20SuggestionSettingsModel.disabledKeyCode%60.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FUI%2FTooltipSupport.swift%3A25-29%0A**Duplicate%20tooltip%20risk%20on%20future%20macOS%20where%20SwiftUI's%20bridge%20is%20repaired**%0A%0ABoth%20%60.help%28text%29%60%20and%20the%20%60NSView.toolTip%60%20tracking%20area%20will%20be%20active%20simultaneously.%20On%20a%20macOS%20version%20that%20fixes%20the%20bridge%2C%20two%20separate%20tooltip%20managers%20may%20each%20fire%20for%20the%20same%20hover%2C%20producing%20a%20double%20tooltip.%20The%20PR%20notes%20this%20will%20%22become%20a%20harmless%20no-op%22%2C%20but%20that%20assumes%20only%20one%20system%20fires%20%E2%80%94%20which%20isn't%20guaranteed.%20Adding%20a%20version%20gate%20%28e.g.%2C%20%60if%20%23unavailable%28macOS%20X.Y%29%60%29%20around%20the%20overlay%20would%20prevent%20the%20double-fire%20once%20a%20fixed%20OS%20ships%20and%20makes%20the%20intended%20cleanup%20path%20explicit.%0A%0A%60%60%60suggestion%0A%20%20%20%20func%20body%28content%3A%20Content%29%20-%3E%20some%20View%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20On%20macOS%2026%20beta%20SwiftUI's%20tooltip%20bridge%20is%20broken%20for%20LSUIElement%20apps%20%28issue%20%23313%29.%0A%20%20%20%20%20%20%20%20%2F%2F%20Overlay%20an%20AppKit%20NSView%20so%20the%20tooltip%20is%20still%20shown%20via%20AppKit's%20own%20subsystem.%0A%20%20%20%20%20%20%20%20%2F%2F%20When%20SwiftUI's%20bridge%20is%20fixed%2C%20gate%20the%20overlay%20out%20with%20%60if%20%23unavailable%28macOS%20X.Y%29%60%0A%20%20%20%20%20%20%20%20%2F%2F%20to%20avoid%20both%20systems%20firing%20simultaneously.%0A%20%20%20%20%20%20%20%20content%0A%20%20%20%20%20%20%20%20%20%20%20%20.help%28text%29%0A%20%20%20%20%20%20%20%20%20%20%20%20.overlay%28TooltipOverlayView%28text%3A%20text%29%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=350&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Bring tooltips back on macOS 26 beta + s..."](https://github.com/fujacob/cotabby/commit/3a5186e7e0b36ead3b8170c40891b7c8b2fcc230) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34330396)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->