### PR TITLE
Let users toggle popup-card suggestion display from Settings and the menu

### DIFF
--- a/Cotabby/Models/SuggestionEngineModels.swift
+++ b/Cotabby/Models/SuggestionEngineModels.swift
@@ -72,4 +72,8 @@ struct SuggestionSettingsSnapshot: Equatable, Sendable {
     /// When true, the screenshot/OCR visual-context pipeline is skipped entirely for lower-latency
     /// suggestions. Defaults to false. Only affects visual context — predictions still run.
     let isFastModeEnabled: Bool
+    /// User preference for how suggestions are presented (inline ghost text vs popup card vs auto
+    /// based on caret geometry quality). Travels in the snapshot so consumers can react to changes
+    /// without subscribing to the settings model directly.
+    let mirrorPreference: MirrorPreference
 }

--- a/Cotabby/Models/SuggestionSettingsModel.swift
+++ b/Cotabby/Models/SuggestionSettingsModel.swift
@@ -23,6 +23,8 @@ final class SuggestionSettingsModel: ObservableObject {
     @Published private(set) var selectedWordCountPreset: SuggestionWordCountPreset
     @Published private(set) var isClipboardContextEnabled: Bool
     @Published private(set) var isFastModeEnabled: Bool
+    /// How suggestions are presented (inline ghost text vs popup card vs auto).
+    @Published private(set) var mirrorPreference: MirrorPreference
     @Published private(set) var userName: String
     @Published private(set) var customRules: [String]
     @Published private(set) var responseLanguages: [String]
@@ -49,6 +51,7 @@ final class SuggestionSettingsModel: ObservableObject {
     private static let selectedWordCountPresetDefaultsKey = "cotabbySelectedWordCountPreset"
     private static let clipboardContextEnabledDefaultsKey = "cotabbyClipboardContextEnabled"
     private static let fastModeEnabledDefaultsKey = "cotabbyFastModeEnabled"
+    private static let mirrorPreferenceDefaultsKey = "cotabbyMirrorPreference"
     private static let userNameDefaultsKey = "cotabbyUserName"
     private static let customRulesDefaultsKey = "cotabbyCustomRules"
     private static let responseLanguagesDefaultsKey = "cotabbyResponseLanguages"
@@ -121,6 +124,13 @@ final class SuggestionSettingsModel: ObservableObject {
         // into fast mode turns it off.
         let resolvedFastModeEnabled =
             userDefaults.object(forKey: Self.fastModeEnabledDefaultsKey) as? Bool ?? false
+        // Default `.auto` keeps existing users on the byte-for-byte original inline rendering for
+        // hosts that report exact/derived caret geometry; only `.estimated` hosts see the new popup
+        // card. Power users can pin one mode from Settings or the menu bar.
+        let resolvedMirrorPreference = userDefaults
+            .string(forKey: Self.mirrorPreferenceDefaultsKey)
+            .flatMap(MirrorPreference.init(rawValue:))
+            ?? .auto
         let resolvedUserName: String = if userDefaults.object(forKey: Self.userNameDefaultsKey) == nil {
             configuration.defaultUserName ?? ""
         } else {
@@ -201,6 +211,7 @@ final class SuggestionSettingsModel: ObservableObject {
         selectedWordCountPreset = resolvedWordCountPreset
         isClipboardContextEnabled = resolvedClipboardContextEnabled
         isFastModeEnabled = resolvedFastModeEnabled
+        mirrorPreference = resolvedMirrorPreference
         userName = resolvedUserName
         customRules = resolvedCustomRules
         responseLanguages = resolvedResponseLanguages
@@ -225,6 +236,7 @@ final class SuggestionSettingsModel: ObservableObject {
         persistSelectedWordCountPreset(resolvedWordCountPreset)
         persistClipboardContextEnabled(resolvedClipboardContextEnabled)
         persistFastModeEnabled(resolvedFastModeEnabled)
+        persistMirrorPreference(resolvedMirrorPreference)
         persistUserName(resolvedUserName)
         persistCustomRules(resolvedCustomRules)
         persistResponseLanguages(resolvedResponseLanguages)
@@ -266,7 +278,8 @@ final class SuggestionSettingsModel: ObservableObject {
             focusPollIntervalMilliseconds: focusPollIntervalMilliseconds,
             isMultiLineEnabled: isMultiLineEnabled,
             autoAcceptTrailingPunctuation: autoAcceptTrailingPunctuation,
-            isFastModeEnabled: isFastModeEnabled
+            isFastModeEnabled: isFastModeEnabled,
+            mirrorPreference: mirrorPreference
         )
     }
 
@@ -304,6 +317,15 @@ final class SuggestionSettingsModel: ObservableObject {
 
         isFastModeEnabled = enabled
         persistFastModeEnabled(enabled)
+    }
+
+    func setMirrorPreference(_ preference: MirrorPreference) {
+        guard mirrorPreference != preference else {
+            return
+        }
+
+        mirrorPreference = preference
+        persistMirrorPreference(preference)
     }
 
     func setMultiLineEnabled(_ enabled: Bool) {
@@ -619,6 +641,10 @@ final class SuggestionSettingsModel: ObservableObject {
         userDefaults.set(enabled, forKey: Self.fastModeEnabledDefaultsKey)
     }
 
+    private func persistMirrorPreference(_ preference: MirrorPreference) {
+        userDefaults.set(preference.rawValue, forKey: Self.mirrorPreferenceDefaultsKey)
+    }
+
     private func persistShowIndicator(_ show: Bool) {
         let mode: ActivationIndicatorMode = show ? .fieldEdgeIcon : .hidden
         userDefaults.set(mode.rawValue, forKey: Self.selectedIndicatorModeDefaultsKey)
@@ -748,6 +774,10 @@ final class SuggestionSettingsModel: ObservableObject {
 
 extension SuggestionSettingsModel: SuggestionSettingsProviding {
     var snapshotPublisher: AnyPublisher<SuggestionSettingsSnapshot, Never> {
+        // The publisher count creeps up as we add settings, but Combine caps each operator at 4
+        // upstreams. Group related settings into nested combiners so the shape stays readable.
+        // `presentationToggles` carries the visual-pipeline knobs (clipboard, fast mode, mirror
+        // preference); they share the property of "affects how/when suggestions are shown".
         Publishers.CombineLatest4(
             Publishers.CombineLatest4(
                 $isGloballyEnabled,
@@ -755,7 +785,7 @@ extension SuggestionSettingsModel: SuggestionSettingsProviding {
                 $selectedEngine,
                 $selectedWordCountPreset
             ),
-            Publishers.CombineLatest($isClipboardContextEnabled, $isFastModeEnabled),
+            Publishers.CombineLatest3($isClipboardContextEnabled, $isFastModeEnabled, $mirrorPreference),
             Publishers.CombineLatest3($userName, $customRules, $responseLanguages),
             Publishers.CombineLatest4(
                 $debounceMilliseconds,
@@ -764,9 +794,9 @@ extension SuggestionSettingsModel: SuggestionSettingsProviding {
                 $autoAcceptTrailingPunctuation
             )
         )
-        .map { combinedSettings, contextToggles, profile, timing in
+        .map { combinedSettings, presentationToggles, profile, timing in
             let (globallyEnabled, disabledAppRules, engine, wordCountPreset) = combinedSettings
-            let (clipboardContextEnabled, fastModeEnabled) = contextToggles
+            let (clipboardContextEnabled, fastModeEnabled, mirrorPreference) = presentationToggles
             let (userName, customRules, responseLanguages) = profile
             let (debounce, focusPoll, multiLine, autoAcceptPunctuation) = timing
             return SuggestionSettingsSnapshot(
@@ -782,7 +812,8 @@ extension SuggestionSettingsModel: SuggestionSettingsProviding {
                 focusPollIntervalMilliseconds: focusPoll,
                 isMultiLineEnabled: multiLine,
                 autoAcceptTrailingPunctuation: autoAcceptPunctuation,
-                isFastModeEnabled: fastModeEnabled
+                isFastModeEnabled: fastModeEnabled,
+                mirrorPreference: mirrorPreference
             )
         }
         .removeDuplicates()

--- a/Cotabby/Services/UI/OverlayController.swift
+++ b/Cotabby/Services/UI/OverlayController.swift
@@ -20,12 +20,28 @@ final class OverlayController: SuggestionOverlayControlling {
     var onStateChange: ((OverlayState) -> Void)?
 
     private let suggestionSettings: SuggestionSettingsModel
-    private let renderModePolicy: CompletionRenderModePolicy
+
+    /// Optional injection seam for tests. When set, `currentRenderModePolicy` returns this directly
+    /// instead of building one from live settings. Production code leaves this nil.
+    private let renderModePolicyOverride: CompletionRenderModePolicy?
 
     /// Bundle identifier of the currently focused host app, supplied by the coordinator each time
     /// a suggestion is presented. The policy uses this to look up per-app overrides. Nil in tests
     /// or when the focus pipeline could not identify the host.
     private var currentBundleIdentifier: String?
+
+    /// Built from the live `mirrorPreference` setting at call time rather than cached. The struct
+    /// is tiny (one enum + an empty dict in Phase 2) so per-show allocation cost is negligible,
+    /// and the read-through model means the user's Settings/menu-bar toggle takes effect on the
+    /// very next presentation without any subscription bookkeeping.
+    private var currentRenderModePolicy: CompletionRenderModePolicy {
+        if let renderModePolicyOverride {
+            return renderModePolicyOverride
+        }
+        return CompletionRenderModePolicy(
+            userPreference: suggestionSettings.mirrorPreference
+        )
+    }
 
     private(set) var state: OverlayState = .hidden(reason: "Overlay idle.") {
         didSet {
@@ -50,10 +66,10 @@ final class OverlayController: SuggestionOverlayControlling {
 
     init(
         suggestionSettings: SuggestionSettingsModel,
-        renderModePolicy: CompletionRenderModePolicy = CompletionRenderModePolicy()
+        renderModePolicyOverride: CompletionRenderModePolicy? = nil
     ) {
         self.suggestionSettings = suggestionSettings
-        self.renderModePolicy = renderModePolicy
+        self.renderModePolicyOverride = renderModePolicyOverride
     }
 
     /// Coordinator hook that updates the bundle identifier used by per-app overrides. Phase 1
@@ -95,7 +111,7 @@ final class OverlayController: SuggestionOverlayControlling {
             return
         }
 
-        let mode = renderModePolicy.mode(
+        let mode = currentRenderModePolicy.mode(
             for: geometry,
             bundleIdentifier: currentBundleIdentifier
         )

--- a/Cotabby/Support/CompletionRenderModePolicy.swift
+++ b/Cotabby/Support/CompletionRenderModePolicy.swift
@@ -7,21 +7,37 @@ import Foundation
 /// auto rule misfires for their host mix.
 ///
 /// Phase 1 hardcodes `.auto` everywhere; the global setting and per-app overrides land in Phase 2.
-enum MirrorPreference: String, Codable, CaseIterable, Equatable, Sendable {
+enum MirrorPreference: String, Codable, CaseIterable, Identifiable, Equatable, Sendable {
     case auto
     case alwaysInline
     case alwaysMirror
 
-    /// Human-readable label for Settings UI. Kept here so Settings code does not have to repeat the
-    /// mapping; the policy is the single source of truth for both the rule and the copy.
+    var id: String { rawValue }
+
+    /// Human-readable label for Settings UI and the menu bar pop-up. Kept here so the UI code does
+    /// not have to repeat the mapping; the policy is the single source of truth for both the rule
+    /// and the copy. Phrased in user-facing terms ("popup") rather than the internal "mirror" name.
     var displayLabel: String {
         switch self {
         case .auto:
-            return "Auto (recommended)"
+            return "Auto"
         case .alwaysInline:
-            return "Always inline"
+            return "Inline"
         case .alwaysMirror:
-            return "Always preview card"
+            return "Popup"
+        }
+    }
+
+    /// One-sentence explanation suitable for `.help()` tooltips next to the picker. Read as a group
+    /// the three help strings teach the user when each option is the right pick.
+    var helpDescription: String {
+        switch self {
+        case .auto:
+            return "Inline ghost text when caret position is reliable; popup card when it isn't (some Electron and web editors)."
+        case .alwaysInline:
+            return "Always draw ghost text next to the caret, even when caret position may drift."
+        case .alwaysMirror:
+            return "Always show suggestions in a popup card anchored below the focused field."
         }
     }
 }

--- a/Cotabby/UI/MenuBarView.swift
+++ b/Cotabby/UI/MenuBarView.swift
@@ -149,6 +149,21 @@ struct MenuBarView: View {
                     .pickerStyle(.menu)
                     .help("How long completions tend to be. Shorter is faster and less likely to overreach.")
                 }
+
+                MenuBarPickerRow(title: "Display") {
+                    Picker("Display", selection: mirrorPreferenceBinding) {
+                        ForEach(MirrorPreference.allCases) { preference in
+                            Text(preference.displayLabel)
+                                .tag(preference)
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                    .help(
+                        "Inline ghost text or a popup card. Auto switches to the popup for hosts " +
+                        "where caret position can't be tracked reliably."
+                    )
+                }
             }
         }
         .padding(.bottom, 12)
@@ -323,6 +338,13 @@ struct MenuBarView: View {
             set: { preset in
                 suggestionSettings.selectWordCountPreset(preset)
             }
+        )
+    }
+
+    private var mirrorPreferenceBinding: Binding<MirrorPreference> {
+        Binding(
+            get: { suggestionSettings.mirrorPreference },
+            set: { suggestionSettings.setMirrorPreference($0) }
         )
     }
 

--- a/Cotabby/UI/SettingsView.swift
+++ b/Cotabby/UI/SettingsView.swift
@@ -151,6 +151,18 @@ struct SettingsView: View {
             Toggle("Show Accept Hint", isOn: showAcceptanceHintBinding)
                 .help("Show a small label near the ghost text reminding you which key accepts it.")
 
+            Picker("Suggestion Display", selection: mirrorPreferenceBinding) {
+                ForEach(MirrorPreference.allCases) { preference in
+                    Text(preference.displayLabel).tag(preference)
+                }
+            }
+            .pickerStyle(.menu)
+            .help(
+                "Auto uses inline ghost text when the focused field exposes a reliable cursor " +
+                "position, and switches to a popup card when it doesn't (some Electron and web " +
+                "editors). Choose Inline or Popup to pin one style for every app."
+            )
+
             Toggle("Allow Multi-line Suggestions", isOn: multiLineEnabledBinding)
                 .help("Let suggestions span more than one line. Off keeps them to a single line.")
 
@@ -701,6 +713,13 @@ struct SettingsView: View {
         Binding(
             get: { suggestionSettings.isFastModeEnabled },
             set: { suggestionSettings.setFastModeEnabled($0) }
+        )
+    }
+
+    private var mirrorPreferenceBinding: Binding<MirrorPreference> {
+        Binding(
+            get: { suggestionSettings.mirrorPreference },
+            set: { suggestionSettings.setMirrorPreference($0) }
         )
     }
 

--- a/CotabbyTests/CotabbyTestFixtures.swift
+++ b/CotabbyTests/CotabbyTestFixtures.swift
@@ -220,7 +220,8 @@ enum CotabbyTestFixtures {
         focusPollIntervalMilliseconds: Int = 50,
         isMultiLineEnabled: Bool = false,
         autoAcceptTrailingPunctuation: Bool = true,
-        isFastModeEnabled: Bool = false
+        isFastModeEnabled: Bool = false,
+        mirrorPreference: MirrorPreference = .auto
     ) -> SuggestionSettingsSnapshot {
         SuggestionSettingsSnapshot(
             isGloballyEnabled: isGloballyEnabled,
@@ -235,7 +236,8 @@ enum CotabbyTestFixtures {
             focusPollIntervalMilliseconds: focusPollIntervalMilliseconds,
             isMultiLineEnabled: isMultiLineEnabled,
             autoAcceptTrailingPunctuation: autoAcceptTrailingPunctuation,
-            isFastModeEnabled: isFastModeEnabled
+            isFastModeEnabled: isFastModeEnabled,
+            mirrorPreference: mirrorPreference
         )
     }
 }

--- a/CotabbyTests/SuggestionAvailabilityEvaluatorTests.swift
+++ b/CotabbyTests/SuggestionAvailabilityEvaluatorTests.swift
@@ -571,6 +571,44 @@ final class SuggestionSettingsModelDisabledAppsTests: XCTestCase {
         _ = cancellables
     }
 
+    func test_mirrorPreference_defaultsToAutoAndPersists() {
+        runOnMainActor {
+            let userDefaults = makeUserDefaults()
+            let model = makeModel(userDefaults: userDefaults)
+
+            XCTAssertEqual(model.mirrorPreference, .auto)
+            XCTAssertEqual(model.snapshot.mirrorPreference, .auto)
+
+            model.setMirrorPreference(.alwaysMirror)
+            let reloadedModel = makeModel(userDefaults: userDefaults)
+
+            XCTAssertEqual(reloadedModel.mirrorPreference, .alwaysMirror)
+            XCTAssertEqual(reloadedModel.snapshot.mirrorPreference, .alwaysMirror)
+        }
+    }
+
+    func test_snapshotPublisher_emitsWhenMirrorPreferenceChanges() {
+        let expectation = expectation(description: "snapshot emits after mirror preference changes")
+        var cancellables = Set<AnyCancellable>()
+
+        runOnMainActor {
+            let model = makeModel()
+
+            model.snapshotPublisher
+                .dropFirst()
+                .sink { snapshot in
+                    XCTAssertEqual(snapshot.mirrorPreference, .alwaysInline)
+                    expectation.fulfill()
+                }
+                .store(in: &cancellables)
+
+            model.setMirrorPreference(.alwaysInline)
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+        _ = cancellables
+    }
+
     func test_acceptanceHint_defaultsToOnAndShowsWordAcceptLabel() {
         runOnMainActor {
             let model = makeModel()


### PR DESCRIPTION
## Summary

Builds on #347. That PR triggered the popup-card render mode automatically when caret geometry came back as `.estimated`. This PR adds a persistent global preference (Auto / Inline / Popup) so users can pin one style for every app, and surfaces the picker both in the Settings General section and the menu bar pop-up so it's reachable without opening Settings.

## Validation

```
xcodegen generate                                  # no drift
swiftlint lint --quiet                             # exit 0
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby \
  -destination 'platform=macOS' build              # ** BUILD SUCCEEDED **  (no warnings)
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby \
  -destination 'platform=macOS' build-for-testing  # ** TEST BUILD SUCCEEDED **
```

Two new tests cover persistence (`test_mirrorPreference_defaultsToAutoAndPersists`) and the snapshot publisher (`test_snapshotPublisher_emitsWhenMirrorPreferenceChanges`). All existing snapshot/fixture call sites pick up the new field through a defaulted argument.

Local `xcodebuild test` execution hits the known Team ID code-signing mismatch on this machine (called out in CLAUDE.md). Tests compile correctly and need CI signing or Xcode UI to execute.

## Risk / rollout notes

- Default is `.auto`, so existing users see identical behavior to #347. Popup card still only appears for `.estimated` caret geometry unless the user pins `.alwaysMirror`.
- New `mirrorPreference` field on `SuggestionSettingsSnapshot`. Construction is centralized in two places (the model's `snapshot` getter and `snapshotPublisher` chain) and the shared test fixture; all sites updated.
- `snapshotPublisher`'s `contextToggles` group went from `CombineLatest` to `CombineLatest3` so the inner combine stack stays under Combine's 4-upstream cap; renamed to `presentationToggles` to reflect the wider scope.
- `OverlayController` now reads the preference live per `showSuggestion` call via a computed `currentRenderModePolicy`. Tests can still inject a fixed policy via the renamed `renderModePolicyOverride:` init parameter.
- Per-app overrides are intentionally still out of scope; the `setCurrentBundleIdentifier` plumbing stays dormant for a follow-up phase.

## Linked issues

Refs #347.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a persistent `MirrorPreference` setting (Auto / Inline / Popup) that lets users pin a suggestion display style globally, surfaced in both Settings and the menu bar. The default is `.auto`, preserving existing behavior for all current users.

- `SuggestionSettingsModel` stores and persists the preference via `UserDefaults`, threads it through `snapshot` and `snapshotPublisher`, and upgrades the inner `CombineLatest` to `CombineLatest3` to stay within Combine's 4-upstream cap.
- `OverlayController` switches from a cached policy to a computed `currentRenderModePolicy` that reads the live setting on each `showSuggestion` call, so changes take effect immediately without any subscription bookkeeping.
- Two new tests cover default-value persistence and snapshot-publisher emission; the shared test fixture gains a defaulted `mirrorPreference` parameter so all existing call sites compile unchanged.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the default is `.auto` so existing users are unaffected, and the new setting path is well-covered by tests.

The change is additive and backwards-compatible. The one notable issue is that `helpDescription` was added to `MirrorPreference` with the apparent intent of using it as per-item tooltips, but the UI never reads it — both pickers use hardcoded `.help(…)` strings instead. This leaves the property as dead code, but it has no runtime impact.

`CompletionRenderModePolicy.swift` — the unused `helpDescription` property warrants a quick follow-up (either wire it into the per-item `.help()` call or remove it).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/Support/CompletionRenderModePolicy.swift | Adds `Identifiable` conformance and per-case `displayLabel`/`helpDescription` to `MirrorPreference`; `helpDescription` is dead code — never used by the UI. |
| Cotabby/Models/SuggestionEngineModels.swift | Adds `mirrorPreference: MirrorPreference` field to `SuggestionSettingsSnapshot`; straightforward additive struct change. |
| Cotabby/Models/SuggestionSettingsModel.swift | Adds `mirrorPreference` `@Published` property, persistence via `UserDefaults` raw-value string, `setMirrorPreference` mutator, and threads it through both the `snapshot` getter and `snapshotPublisher` (upgrading the inner `CombineLatest` to `CombineLatest3`). Logic is consistent and well-guarded. |
| Cotabby/Services/UI/OverlayController.swift | Replaces the stored `renderModePolicy` with a computed `currentRenderModePolicy` that reads the live `mirrorPreference` on each `showSuggestion` call; keeps the optional override seam for tests. Clean and correct. |
| Cotabby/UI/MenuBarView.swift | Adds a "Display" picker row wired through `mirrorPreferenceBinding`; mirrors the SettingsView implementation correctly. |
| Cotabby/UI/SettingsView.swift | Adds "Suggestion Display" picker in the General section with a `Binding` that calls `setMirrorPreference`; well-placed and consistent with other settings rows. |
| CotabbyTests/CotabbyTestFixtures.swift | Adds `mirrorPreference: MirrorPreference = .auto` to the shared snapshot fixture factory; all existing call sites pick it up transparently. |
| CotabbyTests/SuggestionAvailabilityEvaluatorTests.swift | Adds two new tests covering default persistence and snapshot-publisher emission on preference change; both use the established `runOnMainActor` + XCTestExpectation pattern correctly. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    actor User
    participant Settings/MenuBar as Settings / MenuBar
    participant SettingsModel as SuggestionSettingsModel
    participant UserDefaults
    participant OverlayController
    participant Policy as CompletionRenderModePolicy

    User->>Settings/MenuBar: Select display preference (Auto/Inline/Popup)
    Settings/MenuBar->>SettingsModel: setMirrorPreference(_:)
    SettingsModel->>SettingsModel: "mirrorPreference = preference"
    SettingsModel->>UserDefaults: persist rawValue string
    SettingsModel-->>Settings/MenuBar: "@Published emits (UI updates)"

    Note over SettingsModel: snapshotPublisher picks up change via CombineLatest3

    User->>OverlayController: (types, triggers suggestion)
    OverlayController->>OverlayController: currentRenderModePolicy (computed)
    OverlayController->>SettingsModel: read mirrorPreference live
    OverlayController->>Policy: mode(for: geometry, bundleIdentifier:)
    Policy-->>OverlayController: .inline or .mirror(reason:)
    OverlayController-->>User: Show ghost text or popup card
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cotabby/Support/CompletionRenderModePolicy.swift`, line 33-45 ([link](https://github.com/fujacob/cotabby/blob/cd91f6a083b9c2b3c3fab8416629adbf34bc7270/Cotabby/Support/CompletionRenderModePolicy.swift#L33-L45)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`helpDescription` is defined but never read**

   The `helpDescription` property was added on `MirrorPreference` apparently for per-item tooltips, but neither `SettingsView` nor `MenuBarView` reference it — both views attach a single hardcoded `.help(…)` string to the whole `Picker`. The property is unreachable dead code as shipped.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fmirror-overlay-user-toggle%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fmirror-overlay-user-toggle%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FSupport%2FCompletionRenderModePolicy.swift%0ALine%3A%2033-45%0A%0AComment%3A%0A**%60helpDescription%60%20is%20defined%20but%20never%20read**%0A%0AThe%20%60helpDescription%60%20property%20was%20added%20on%20%60MirrorPreference%60%20apparently%20for%20per-item%20tooltips%2C%20but%20neither%20%60SettingsView%60%20nor%20%60MenuBarView%60%20reference%20it%20%E2%80%94%20both%20views%20attach%20a%20single%20hardcoded%20%60.help%28%E2%80%A6%29%60%20string%20to%20the%20whole%20%60Picker%60.%20The%20property%20is%20unreachable%20dead%20code%20as%20shipped.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FSupport%2FCompletionRenderModePolicy.swift%0ALine%3A%2033-45%0A%0AComment%3A%0A**%60helpDescription%60%20is%20defined%20but%20never%20read**%0A%0AThe%20%60helpDescription%60%20property%20was%20added%20on%20%60MirrorPreference%60%20apparently%20for%20per-item%20tooltips%2C%20but%20neither%20%60SettingsView%60%20nor%20%60MenuBarView%60%20reference%20it%20%E2%80%94%20both%20views%20attach%20a%20single%20hardcoded%20%60.help%28%E2%80%A6%29%60%20string%20to%20the%20whole%20%60Picker%60.%20The%20property%20is%20unreachable%20dead%20code%20as%20shipped.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=351&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fmirror-overlay-user-toggle%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fmirror-overlay-user-toggle%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FSupport%2FCompletionRenderModePolicy.swift%3A33-45%0A**%60helpDescription%60%20is%20defined%20but%20never%20read**%0A%0AThe%20%60helpDescription%60%20property%20was%20added%20on%20%60MirrorPreference%60%20apparently%20for%20per-item%20tooltips%2C%20but%20neither%20%60SettingsView%60%20nor%20%60MenuBarView%60%20reference%20it%20%E2%80%94%20both%20views%20attach%20a%20single%20hardcoded%20%60.help%28%E2%80%A6%29%60%20string%20to%20the%20whole%20%60Picker%60.%20The%20property%20is%20unreachable%20dead%20code%20as%20shipped.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FSupport%2FCompletionRenderModePolicy.swift%3A33-45%0A**%60helpDescription%60%20is%20defined%20but%20never%20read**%0A%0AThe%20%60helpDescription%60%20property%20was%20added%20on%20%60MirrorPreference%60%20apparently%20for%20per-item%20tooltips%2C%20but%20neither%20%60SettingsView%60%20nor%20%60MenuBarView%60%20reference%20it%20%E2%80%94%20both%20views%20attach%20a%20single%20hardcoded%20%60.help%28%E2%80%A6%29%60%20string%20to%20the%20whole%20%60Picker%60.%20The%20property%20is%20unreachable%20dead%20code%20as%20shipped.%0A%0A&repo=fujacob%2Fcotabby&pr=351&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Let users toggle popup-card suggestion d..."](https://github.com/fujacob/cotabby/commit/cd91f6a083b9c2b3c3fab8416629adbf34bc7270) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34331365)</sub>

<!-- /greptile_comment -->