### PR TITLE
Update Support section copy and CTA

### DIFF
--- a/Cotabby/UI/SettingsView.swift
+++ b/Cotabby/UI/SettingsView.swift
@@ -559,14 +559,14 @@ struct SettingsView: View {
         Section("Support") {
             LabeledContent {
                 Link(destination: URL(string: "https://ko-fi.com/cotabby")!) {
-                    Text("Buy Us a Coffee")
+                    Label("Support", systemImage: "heart.fill")
                 }
                 .buttonStyle(.borderedProminent)
                 .tint(.blue)
             } label: {
                 Text(
-                    "Cotabby is free and open source, maintained by two university students. "
-                    + "If it's useful to you, consider supporting development."
+                    "Cotabby is free and open source, maintained by two university students in our free time. "
+                    + "If it's useful to you, please consider supporting development."
                 )
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)


### PR DESCRIPTION
## Summary

Tweaks the Settings → Support copy to acknowledge that Cotabby is built in our free time and to ask more directly for support. Replaces the "Buy Us a Coffee" button with a heart-iconed "Support" label so the call to action reads as broader than coffee.

## Validation

- `xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build` — `** BUILD SUCCEEDED **` (verified against the same edit before isolating to this branch).
- `swiftlint lint --quiet Cotabby/UI/SettingsView.swift` — exit 0.
- Manual: screenshot reviewers can spot-check by opening Settings; the new copy lives in the existing Support section, no layout change.

## Risk / rollout notes

Copy-only + one SF Symbol swap (`heart.fill`, available on all supported macOS versions). No behavior change, no schema or settings migration.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the Settings → Support section with revised copy and a refreshed call-to-action button. The change is purely cosmetic — no behavior, layout, or data model is affected.

- The description text gains \"in our free time\" and an added \"please\" to make the ask feel more personal.
- The `Text(\"Buy Us a Coffee\")` button label is replaced with `Label(\"Support\", systemImage: \"heart.fill\")`, keeping the same ko-fi destination URL and `.borderedProminent` styling.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is limited to two lines of UI copy and a SwiftUI label swap with no behavior or layout impact.

The diff touches only the supportSection view builder: one string literal gets two words added and one word inserted, and a plain Text CTA is replaced with a Label using the heart.fill SF Symbol (available since macOS 10.15). The ko-fi URL, button style, tint, and all other properties are unchanged. There is no logic, no data flow, and no new dependencies introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/SettingsView.swift | Copy-only update to the Support section: adds "in our free time" to the description and replaces the "Buy Us a Coffee" text button with a Label using heart.fill. No logic or layout changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Settings View] --> B[supportSection]
    B --> C[Section: Support]
    C --> D[LabeledContent]
    D --> E[Label: description text]
    D --> F[Link: ko-fi.com/cotabby]
    F --> G[Label: Support + heart.fill icon]
    G --> H[.borderedProminent .tint .blue]
```

<sub>Reviews (1): Last reviewed commit: ["Update Support section copy and CTA"](https://github.com/fujacob/cotabby/commit/d94062f337f03e24089521db4018f15a4cefce25) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34332317)</sub>

<!-- /greptile_comment -->