### PR TITLE
Roll our own hover tooltip popover so tooltips actually appear

### DIFF
--- a/Cotabby/UI/TooltipSupport.swift
+++ b/Cotabby/UI/TooltipSupport.swift
@@ -2,18 +2,28 @@ import AppKit
 import SwiftUI
 
 /// File overview:
-/// AppKit-backed tooltip support for the Settings window and the menu-bar panel.
+/// Custom hover-tooltip support for the Settings window and the menu-bar panel.
 ///
-/// SwiftUI's `.help(_:)` modifier silently stopped rendering tooltips on the macOS 26 beta in
-/// menu-bar (LSUIElement) apps. Issue #313 wired up dozens of `.help(...)` calls that the user
-/// can no longer see. Until SwiftUI's bridge is fixed we paint our own tooltip via an
-/// `NSViewRepresentable` overlay that sets `NSView.toolTip` directly — AppKit's tooltip subsystem
-/// still works fine in this environment. We also keep calling `.help(_:)` so accessibility help
-/// stays wired up and the SwiftUI path "just starts working" again on a future macOS update.
+/// SwiftUI's `.help(_:)` does not render visible tooltips for LSUIElement apps on the macOS 26
+/// beta, and an earlier AppKit attempt (#350) failed because the click-through overlay returned
+/// `nil` from `hitTest(_:)` — which makes `NSToolTipManager` skip the view entirely, so the
+/// `toolTip` property was set but never queried. This file replaces that with a hand-rolled
+/// tracking + floating-panel implementation that does not depend on `NSToolTipManager` at all:
+///
+///   - An overlay `NSView` reports `nil` from `hitTest(_:)` so clicks still reach the SwiftUI
+///     control underneath.
+///   - The same view installs an `NSTrackingArea` whose `mouseEntered:`/`mouseExited:` callbacks
+///     do *not* require hit testing — they fire purely on the mouse position vs the tracked
+///     rect, which is exactly the property the previous attempt mistakenly relied on.
+///   - On enter, after a short delay, we order in a borderless floating `NSPanel` next to the
+///     anchor. The panel ignores mouse events, so the chicken-and-egg (mouse enters panel →
+///     exits anchor → panel closes) cycle never happens.
+///   - `.help(_:)` is still applied alongside so VoiceOver accessibility-help text stays wired
+///     up; when SwiftUI's tooltip bridge is fixed, the overlay becomes a harmless redundancy.
 
 extension View {
-    /// Drop-in replacement for `.help(_:)` that also installs an AppKit tooltip overlay, so the
-    /// tip is actually visible on macOS 26 beta where SwiftUI's tooltip bridge is broken.
+    /// Drop-in replacement for `.help(_:)` that also shows a visible tooltip via a floating panel.
+    /// Use everywhere `.help(_:)` is used in Settings and the menu bar — see issue #350.
     func cotabbyHelp(_ text: String) -> some View {
         modifier(CotabbyTooltipModifier(text: text))
     }
@@ -25,29 +35,212 @@ private struct CotabbyTooltipModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .help(text)
-            .overlay(TooltipOverlayView(text: text))
+            .overlay(TooltipOverlay(text: text).accessibilityHidden(true))
     }
 }
 
-/// Transparent NSView whose only job is to advertise a tooltip to AppKit's `NSToolTipManager`.
-/// `hitTest` returns `nil` so the overlay never intercepts clicks meant for the underlying
-/// SwiftUI control; tracking-area-based tooltip delivery is independent of hit testing.
-private struct TooltipOverlayView: NSViewRepresentable {
+private struct TooltipOverlay: NSViewRepresentable {
     let text: String
 
     func makeNSView(context: Context) -> NSView {
-        let view = ClickThroughTooltipView()
-        view.toolTip = text
+        let view = TooltipTrackingView()
+        view.text = text
         return view
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {
-        nsView.toolTip = text
+        guard let view = nsView as? TooltipTrackingView else { return }
+        view.text = text
+    }
+
+    static func dismantleNSView(_ nsView: NSView, coordinator: ()) {
+        (nsView as? TooltipTrackingView)?.dismantle()
     }
 }
 
-private final class ClickThroughTooltipView: NSView {
-    override func hitTest(_ point: NSPoint) -> NSView? {
-        nil
+/// Tracking-only NSView. Hit testing is intentionally disabled so clicks pass through to the
+/// SwiftUI control beneath. Tracking-area entered/exited events fire independently of hit testing,
+/// which is what makes the click-through-and-still-hover trick work here.
+private final class TooltipTrackingView: NSView {
+    var text: String = "" {
+        didSet { refreshPanelContentIfShowing() }
+    }
+
+    private var trackingArea: NSTrackingArea?
+    private var showWorkItem: DispatchWorkItem?
+    private var panel: TooltipPanel?
+    private var hostingView: NSHostingView<TooltipBody>?
+
+    /// macOS shows the first tooltip after a longer delay and subsequent ones immediately while
+    /// the user keeps scrubbing across help-equipped controls. Matching that behavior keeps the
+    /// tooltips feeling native rather than chatty.
+    private static var lastDismissedAt: Date = .distantPast
+    private static let standardDelay: TimeInterval = 0.6
+    private static let scrubbingWindow: TimeInterval = 0.5
+
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+
+    override var isFlipped: Bool { true }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let trackingArea {
+            removeTrackingArea(trackingArea)
+        }
+        let area = NSTrackingArea(
+            rect: bounds,
+            options: [.mouseEnteredAndExited, .activeInActiveApp, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(area)
+        trackingArea = area
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        scheduleShow()
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        cancelShow()
+        hidePanelIfNeeded()
+    }
+
+    override func viewWillMove(toWindow newWindow: NSWindow?) {
+        super.viewWillMove(toWindow: newWindow)
+        if newWindow == nil {
+            cancelShow()
+            hidePanelIfNeeded()
+        }
+    }
+
+    func dismantle() {
+        cancelShow()
+        panel?.orderOut(nil)
+        panel = nil
+        hostingView = nil
+    }
+
+    private func scheduleShow() {
+        cancelShow()
+        guard !text.isEmpty else { return }
+        let delay = Date().timeIntervalSince(Self.lastDismissedAt) < Self.scrubbingWindow
+            ? 0
+            : Self.standardDelay
+        let item = DispatchWorkItem { [weak self] in
+            self?.showPanelNow()
+        }
+        showWorkItem = item
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: item)
+    }
+
+    private func cancelShow() {
+        showWorkItem?.cancel()
+        showWorkItem = nil
+    }
+
+    private func showPanelNow() {
+        guard !text.isEmpty,
+              let window,
+              window.isVisible,
+              window.isKeyWindow || NSApp.isActive
+        else { return }
+
+        let panel = ensurePanel()
+        hostingView?.rootView = TooltipBody(text: text)
+        hostingView?.layoutSubtreeIfNeeded()
+        let contentSize = hostingView?.fittingSize ?? CGSize(width: 200, height: 24)
+        panel.setContentSize(contentSize)
+
+        // Position the panel just below the anchor view. AppKit windows are y-up, but our view is
+        // flipped (y-down) — convert both edges through the window/screen to land the panel where
+        // a native tooltip would sit.
+        let belowAnchorInView = NSPoint(x: 0, y: bounds.maxY + 4)
+        let belowAnchorInWindow = convert(belowAnchorInView, to: nil)
+        let onScreen = window.convertPoint(toScreen: belowAnchorInWindow)
+        // Flipped → on-screen y was the top edge of where we want the panel; subtract its height.
+        let origin = NSPoint(x: onScreen.x, y: onScreen.y - contentSize.height)
+        panel.setFrameOrigin(clampedOnScreen(origin: origin, size: contentSize))
+        panel.orderFrontRegardless()
+    }
+
+    private func ensurePanel() -> TooltipPanel {
+        if let panel {
+            return panel
+        }
+        let host = NSHostingView(rootView: TooltipBody(text: text))
+        host.autoresizingMask = [.width, .height]
+
+        let panel = TooltipPanel(
+            contentRect: CGRect(x: 0, y: 0, width: 200, height: 28),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: true
+        )
+        panel.isFloatingPanel = true
+        panel.level = .floating
+        panel.backgroundColor = .clear
+        panel.isOpaque = false
+        panel.hasShadow = true
+        panel.ignoresMouseEvents = true
+        panel.animationBehavior = .none
+        panel.collectionBehavior = [.transient, .ignoresCycle, .fullScreenAuxiliary]
+        panel.hidesOnDeactivate = true
+        panel.contentView = host
+
+        self.panel = panel
+        self.hostingView = host
+        return panel
+    }
+
+    private func hidePanelIfNeeded() {
+        guard let panel, panel.isVisible else { return }
+        panel.orderOut(nil)
+        Self.lastDismissedAt = Date()
+    }
+
+    private func refreshPanelContentIfShowing() {
+        guard let hostingView, let panel, panel.isVisible else { return }
+        hostingView.rootView = TooltipBody(text: text)
+    }
+
+    /// Keep the tooltip inside the active screen so a control flush against the screen edge
+    /// doesn't push the panel into the abyss.
+    private func clampedOnScreen(origin: NSPoint, size: CGSize) -> NSPoint {
+        guard let screen = window?.screen ?? NSScreen.main else { return origin }
+        let visible = screen.visibleFrame
+        let clampedX = min(max(origin.x, visible.minX + 4), visible.maxX - size.width - 4)
+        let clampedY = min(max(origin.y, visible.minY + 4), visible.maxY - size.height - 4)
+        return NSPoint(x: clampedX, y: clampedY)
+    }
+}
+
+private final class TooltipPanel: NSPanel {
+    override var canBecomeKey: Bool { false }
+    override var canBecomeMain: Bool { false }
+}
+
+/// SwiftUI body of the tooltip. Sized with `fixedSize(vertical:)` so long help strings wrap up to
+/// `maxWidth` instead of forcing a single line, which keeps the layout close to what AppKit's
+/// native tooltips do.
+private struct TooltipBody: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 12))
+            .foregroundStyle(.primary)
+            .padding(.horizontal, 9)
+            .padding(.vertical, 5)
+            .frame(maxWidth: 280, alignment: .leading)
+            .fixedSize(horizontal: false, vertical: true)
+            .background(
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(.regularMaterial)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .strokeBorder(Color.primary.opacity(0.12), lineWidth: 0.5)
+            )
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #350 — that PR was supposed to bring tooltips back on the macOS 26 beta, but the workaround it shipped didn't actually do anything: the click-through overlay set `NSView.toolTip` and returned `nil` from `hitTest(_:)`, but `NSToolTipManager` only displays a tooltip for the view it hit-tests under the cursor. So the tooltip data was wired up correctly and then never queried, and every `.cotabbyHelp(...)` call was effectively a no-op.

This PR replaces the `NSToolTipManager` dependency entirely. The overlay still returns `nil` from `hitTest(_:)` so clicks reach the SwiftUI control beneath, but instead of asking AppKit to show a tooltip on hover, we install an `NSTrackingArea` on the same view (whose `mouseEntered:`/`mouseExited:` callbacks fire independent of hit testing) and order a borderless non-activating `NSPanel` into the floating layer ourselves. The panel sets `ignoresMouseEvents = true`, which avoids the chicken-and-egg cycle where the panel appearing under the mouse would have triggered `mouseExited` on the anchor and immediately closed itself.

Two niceties on top of the basic show/hide:

- Native scrubbing: longer first-show delay (~0.6s), then near-instant for follow-up tooltips while the user keeps moving across help-equipped controls within ~500ms.
- Panel position clamps to the active screen so a control flush against the screen edge doesn't push the tooltip into the abyss.

`.help(_:)` is still applied alongside so VoiceOver accessibility-help text stays wired up; the overlay becomes a harmless redundancy on a future macOS update that fixes SwiftUI's tooltip bridge.

## Validation

- `swiftlint lint --quiet` → exit 0
- `xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build` → ** BUILD SUCCEEDED **

UI verification needed on macOS 26 beta:
- Hover any Settings toggle for ~1s → tooltip appears below the control.
- Move directly to an adjacent help-equipped control → tooltip appears with no delay.
- Move off → tooltip disappears.
- Click the underlying toggle/button → still toggles (overlay is click-through).
- Hover a control flush against the right edge of the screen → tooltip stays within the visible frame.

## Linked issues

Fixes #350 (the prior attempt that did not work).

## Risk / rollout notes

- `NSPanel` floats above all windows including full-screen apps. The panel is closed on `mouseExited:` and on the parent SwiftUI view dismantle (\`dismantleNSView\`), so leaks are bounded to the lifetime of the host view.
- Long help strings wrap up to 280pt before clipping. None of our current tooltips are near that length, but if one ever is, the body uses \`.fixedSize(vertical:)\` so it grows vertically.
- The follow-up scrubbing delay uses a per-process timestamp; behaves correctly across windows but resets if you fully unhover for >500ms.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the non-functional `NSToolTipManager`-based overlay from #350 with a hand-rolled tracking-area + floating `NSPanel` approach that correctly fires `mouseEntered`/`mouseExited` independent of hit testing, making hover tooltips actually visible in LSUIElement apps on the macOS 26 beta.

- `TooltipTrackingView` installs an `NSTrackingArea` and schedules/cancels a work item to show a borderless `NSPanel` (`ignoresMouseEvents = true`) after a configurable delay, with scrubbing heuristics that match native macOS tooltip timing.
- Cleanup is handled in three layers — `mouseExited`, `viewWillMove(toWindow:nil)`, and `dismantleNSView` — so the panel should never leak beyond the lifetime of the host view.
- Screen-edge clamping keeps the panel within the visible frame, and `.help(_:)` is preserved alongside the overlay so VoiceOver accessibility remains wired up.

<h3>Confidence Score: 4/5</h3>

Safe to merge; panels are properly torn down on all exit paths and the new approach correctly bypasses the hit-test shortcoming that broke #350.

The core mechanism is sound and cleanup paths cover the expected lifecycle. Two minor edge cases exist: panel size isn't recalculated when tooltip text updates while the panel is visible, and dismantle() skips recording the dismissal timestamp, which can briefly corrupt the scrubbing heuristic after a view teardown.

Cotabby/UI/TooltipSupport.swift — specifically the refreshPanelContentIfShowing and dismantle methods.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/TooltipSupport.swift | Replaces NSToolTipManager approach with a hand-rolled NSTrackingArea + floating NSPanel implementation; well-structured cleanup paths, minor edge cases around panel resizing on text update and lastDismissedAt not being recorded in dismantle() |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Mouse enters tracking area\nmouseEntered] --> B{lastDismissedAt\n< 500ms ago?}
    B -- Yes --> C[delay = 0]
    B -- No --> D[delay = 0.6s]
    C --> E[DispatchWorkItem scheduled]
    D --> E
    E --> F{Mouse exited\nbefore delay?}
    F -- Yes --> G[cancelShow\nwork item cancelled]
    F -- No --> H{window visible &\nkey or app active?}
    H -- No --> I[return / no-op]
    H -- Yes --> J[ensurePanel\ncreate if needed]
    J --> K[Update hostingView content\nlayoutSubtreeIfNeeded\nfittingSize]
    K --> L[Compute position\nflipped → screen coords\nclampedOnScreen]
    L --> M[orderFrontRegardless\nPanel visible]
    M --> N[Mouse exits\nmouseExited]
    N --> O[cancelShow\nhidePanelIfNeeded]
    O --> P[lastDismissedAt = now]
    P --> B
    Q[dismantleNSView] --> R[dismantle\ncancelShow + orderOut\npanel = nil]
    S[viewWillMove toWindow=nil] --> T[cancelShow\nhidePanelIfNeeded]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Ftooltip-popover-panel%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Ftooltip-popover-panel%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FTooltipSupport.swift%3A202-205%0A%60refreshPanelContentIfShowing%60%20updates%20the%20tooltip%20body%20text%20but%20leaves%20the%20panel%20at%20its%20previously%20computed%20size.%20If%20the%20new%20text%20is%20longer%20or%20shorter%2C%20the%20%60NSPanel%60%20frame%20stays%20stale%2C%20causing%20text%20to%20clip%20or%20leaving%20a%20gap.%20The%20resize%20logic%20from%20%60showPanelNow%60%20%28layout%20pass%20%E2%86%92%20%60fittingSize%60%20%E2%86%92%20%60setContentSize%60%29%20should%20be%20applied%20here%20too.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20func%20refreshPanelContentIfShowing%28%29%20%7B%0A%20%20%20%20%20%20%20%20guard%20let%20hostingView%2C%20let%20panel%2C%20panel.isVisible%20else%20%7B%20return%20%7D%0A%20%20%20%20%20%20%20%20hostingView.rootView%20%3D%20TooltipBody%28text%3A%20text%29%0A%20%20%20%20%20%20%20%20hostingView.layoutSubtreeIfNeeded%28%29%0A%20%20%20%20%20%20%20%20let%20contentSize%20%3D%20hostingView.fittingSize%0A%20%20%20%20%20%20%20%20guard%20contentSize%20!%3D%20panel.frame.size%20else%20%7B%20return%20%7D%0A%20%20%20%20%20%20%20%20panel.setContentSize%28contentSize%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FUI%2FTooltipSupport.swift%3A117-122%0A%60dismantle%28%29%60%20orders%20the%20panel%20out%20but%20does%20not%20record%20the%20dismissal%20time%20in%20%60lastDismissedAt%60.%20If%20the%20tooltip%20is%20visible%20when%20the%20host%20view%20tears%20down%20%28e.g.%2C%20the%20settings%20sheet%20closes%29%2C%20the%20next%20hover%20within%20500%20ms%20will%20skip%20the%200.6%20s%20initial%20delay%20and%20appear%20instantly%2C%20as%20if%20the%20user%20had%20been%20scrubbing.%20Calling%20%60hidePanelIfNeeded%28%29%60%20instead%20of%20an%20open-coded%20%60orderOut%60%20would%20keep%20the%20timestamp%20consistent.%0A%0A%60%60%60suggestion%0A%20%20%20%20func%20dismantle%28%29%20%7B%0A%20%20%20%20%20%20%20%20cancelShow%28%29%0A%20%20%20%20%20%20%20%20hidePanelIfNeeded%28%29%0A%20%20%20%20%20%20%20%20panel%20%3D%20nil%0A%20%20%20%20%20%20%20%20hostingView%20%3D%20nil%0A%20%20%20%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FTooltipSupport.swift%3A202-205%0A%60refreshPanelContentIfShowing%60%20updates%20the%20tooltip%20body%20text%20but%20leaves%20the%20panel%20at%20its%20previously%20computed%20size.%20If%20the%20new%20text%20is%20longer%20or%20shorter%2C%20the%20%60NSPanel%60%20frame%20stays%20stale%2C%20causing%20text%20to%20clip%20or%20leaving%20a%20gap.%20The%20resize%20logic%20from%20%60showPanelNow%60%20%28layout%20pass%20%E2%86%92%20%60fittingSize%60%20%E2%86%92%20%60setContentSize%60%29%20should%20be%20applied%20here%20too.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20func%20refreshPanelContentIfShowing%28%29%20%7B%0A%20%20%20%20%20%20%20%20guard%20let%20hostingView%2C%20let%20panel%2C%20panel.isVisible%20else%20%7B%20return%20%7D%0A%20%20%20%20%20%20%20%20hostingView.rootView%20%3D%20TooltipBody%28text%3A%20text%29%0A%20%20%20%20%20%20%20%20hostingView.layoutSubtreeIfNeeded%28%29%0A%20%20%20%20%20%20%20%20let%20contentSize%20%3D%20hostingView.fittingSize%0A%20%20%20%20%20%20%20%20guard%20contentSize%20!%3D%20panel.frame.size%20else%20%7B%20return%20%7D%0A%20%20%20%20%20%20%20%20panel.setContentSize%28contentSize%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FUI%2FTooltipSupport.swift%3A117-122%0A%60dismantle%28%29%60%20orders%20the%20panel%20out%20but%20does%20not%20record%20the%20dismissal%20time%20in%20%60lastDismissedAt%60.%20If%20the%20tooltip%20is%20visible%20when%20the%20host%20view%20tears%20down%20%28e.g.%2C%20the%20settings%20sheet%20closes%29%2C%20the%20next%20hover%20within%20500%20ms%20will%20skip%20the%200.6%20s%20initial%20delay%20and%20appear%20instantly%2C%20as%20if%20the%20user%20had%20been%20scrubbing.%20Calling%20%60hidePanelIfNeeded%28%29%60%20instead%20of%20an%20open-coded%20%60orderOut%60%20would%20keep%20the%20timestamp%20consistent.%0A%0A%60%60%60suggestion%0A%20%20%20%20func%20dismantle%28%29%20%7B%0A%20%20%20%20%20%20%20%20cancelShow%28%29%0A%20%20%20%20%20%20%20%20hidePanelIfNeeded%28%29%0A%20%20%20%20%20%20%20%20panel%20%3D%20nil%0A%20%20%20%20%20%20%20%20hostingView%20%3D%20nil%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=354&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Roll our own hover tooltip popover for m..."](https://github.com/fujacob/cotabby/commit/31998a1d727cddd6a7d88486aa788ba49a3618cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34334971)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->