### PR TITLE
Retire SmolLM-360M and rename tabby-pico → tabby-nano-2

### DIFF
--- a/Cotabby/Models/LlamaRuntimeModels.swift
+++ b/Cotabby/Models/LlamaRuntimeModels.swift
@@ -91,10 +91,8 @@ enum RuntimeModelCatalog {
             return "tabby-balanced-1"
         case "gemma-4-E4B-it-Q4_K_M.gguf":
             return "tabby-max-1"
-        case "SmolLM-360M-Instruct.Q8_0.gguf":
-            return "tabby-nano-1"
         case "SmolLM2-135M-Instruct-q8_0.gguf":
-            return "tabby-pico-1"
+            return "tabby-nano-2"
         default:
             return filename
         }
@@ -118,17 +116,6 @@ enum RuntimeModelCatalog {
             approximateSizeInGigabytes: 0.1,
             expectedSizeBytes: 144_811_552,
             sha256: "bc64cce8e1c11e4ed870633b557e04af718249c817c4cf8a6784116144ec3e28"
-        ),
-        DownloadableRuntimeModel(
-            filename: "SmolLM-360M-Instruct.Q8_0.gguf",
-            displayName: displayName(for: "SmolLM-360M-Instruct.Q8_0.gguf"),
-            downloadURL: URL(
-                string:
-                    "https://huggingface.co/QuantFactory/SmolLM-360M-Instruct-GGUF/resolve/main/SmolLM-360M-Instruct.Q8_0.gguf?download=true"
-            )!,
-            approximateSizeInGigabytes: 0.4,
-            expectedSizeBytes: 386_404_800,
-            sha256: "24ca4b7c7a5eb3673af7eb313fb2c68ab778f1d2a10c545ef23193faef706ca0"
         ),
         DownloadableRuntimeModel(
             filename: "Qwen3-0.6B-Q4_K_M.gguf",
@@ -182,7 +169,6 @@ struct LlamaRuntimeConfiguration: Equatable, Sendable {
             "gemma-4-E4B-it-Q4_K_M.gguf",
             "gemma-4-E2B-it-Q4_K_M.gguf",
             "Qwen3-0.6B-Q4_K_M.gguf",
-            "SmolLM-360M-Instruct.Q8_0.gguf",
             "SmolLM2-135M-Instruct-q8_0.gguf"
         ],
         contextWindowTokens: 2048,

--- a/README.md
+++ b/README.md
@@ -82,12 +82,11 @@ Everything runs on-device. No hosted API, no cloud round-trip.
 
 **Apple Intelligence**: uses Apple's on-device `FoundationModels` runtime on macOS 26 or later, no download required.
 
-**Open Source**: runs local GGUF models in-process through llama.cpp via `llama.swift`. Cotabby ships with five built-in downloadable models:
+**Open Source**: runs local GGUF models in-process through llama.cpp via `llama.swift`. Cotabby ships with four built-in downloadable models:
 
 | Model              | File                              | Size    | Source                                                                                                  |
 | ------------------ | --------------------------------- | ------- | ------------------------------------------------------------------------------------------------------- |
-| `tabby-pico-1`     | `SmolLM2-135M-Instruct-q8_0.gguf` | ~0.1 GB | [Mungert/SmolLM2-135M-Instruct-GGUF](https://huggingface.co/Mungert/SmolLM2-135M-Instruct-GGUF)         |
-| `tabby-nano-1`     | `SmolLM-360M-Instruct.Q8_0.gguf`  | ~0.4 GB | [QuantFactory/SmolLM-360M-Instruct-GGUF](https://huggingface.co/QuantFactory/SmolLM-360M-Instruct-GGUF) |
+| `tabby-nano-2`     | `SmolLM2-135M-Instruct-q8_0.gguf` | ~0.1 GB | [Mungert/SmolLM2-135M-Instruct-GGUF](https://huggingface.co/Mungert/SmolLM2-135M-Instruct-GGUF)         |
 | `tabby-fast-1`     | `Qwen3-0.6B-Q4_K_M.gguf`          | ~0.4 GB | [unsloth/Qwen3-0.6B-GGUF](https://huggingface.co/unsloth/Qwen3-0.6B-GGUF)                               |
 | `tabby-balanced-1` | `gemma-4-E2B-it-Q4_K_M.gguf`      | ~3.1 GB | [unsloth/gemma-4-E2B-it-GGUF](https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF)                       |
 | `tabby-max-1`      | `gemma-4-E4B-it-Q4_K_M.gguf`      | ~5.0 GB | [unsloth/gemma-4-E4B-it-GGUF](https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF)                       |


### PR DESCRIPTION
## Summary

Drop `SmolLM-360M-Instruct.Q8_0.gguf` from the curated catalog and rename the remaining small SmolLM2 entry from `tabby-pico-1` to `tabby-nano-2`. The 360M is no longer offered as a downloadable model, no longer in the bootstrap priority list, and no longer mapped to a product label; the 135M (`SmolLM2-135M-Instruct-q8_0.gguf`) becomes the smallest curated option.

## Validation

```
swiftlint lint --quiet Cotabby/Models/LlamaRuntimeModels.swift
# exit 0

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **
```

Local full-test execution still hits the documented Team ID code-signing mismatch on this machine. CI tests run cleanly against the merge ref.

## Linked issues

None.

## Risk / rollout notes

- **Existing users on the 135M** keep working without action: settings persist the GGUF filename (`actualModelName: String { filename }`), not the display name, so the rename is purely a label change in the menu.
- **Existing users on the 360M** also keep working: the locator picks any GGUF that exists on disk, and `RuntimeModelCatalog.displayName(for:)` falls back to the raw filename for entries it does not recognize, so a previously-downloaded 360M shows up as `SmolLM-360M-Instruct.Q8_0.gguf` and remains selectable.
- **New users** no longer see the 360M offered for download. The bootstrap priority list moves the 135M up one slot when none of the larger models are present.
- No structural `project.yml` edit; only file contents changed, so the XcodeGen check should remain green.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes `SmolLM-360M-Instruct.Q8_0.gguf` from the curated catalog and renames the 135M SmolLM2 entry's display alias from `tabby-pico-1` to `tabby-nano-2`. All three catalog touch-points (`displayName`, `downloadableModels`, `preferredModelNames`) are updated consistently, the README count is corrected from five to four, and no stale references remain anywhere in the codebase.

- `LlamaRuntimeModels.swift`: removes the 360M `DownloadableRuntimeModel`, drops it from the bootstrap priority list, and updates the `displayName` switch — the 135M entry is now the smallest curated option under the `tabby-nano-2` label.
- `README.md`: removes the 360M table row and reflects the `tabby-nano-2` rename, keeping documentation in sync with the catalog.

<h3>Confidence Score: 5/5</h3>

Safe to merge — catalog changes are minimal, consistent across all three touch-points, and backward-compatible for existing users who have either model on disk.

All three locations that reference the retired 360M model are cleaned up together. The 135M rename is a display-label-only change since settings persist the raw filename. No stale string references remain in tests, source, or docs.

No files require special attention. The only follow-up worth considering is adding a test assertion for the new tabby-nano-2 mapping in ModelAndPresentationValueTests.swift.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Models/LlamaRuntimeModels.swift | Removes the SmolLM-360M catalog entry from displayName, downloadableModels, and preferredModelNames; renames the 135M alias from tabby-pico-1 to tabby-nano-2. All three touch-points are consistent and no stale references remain. |
| README.md | Updates model count from five to four, removes the SmolLM-360M row, and renames tabby-pico-1 to tabby-nano-2 — matches the Swift catalog changes exactly. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User selects model] --> B{RuntimeModelCatalog.displayName}
    B -->|SmolLM2-135M-Instruct-q8_0.gguf| C[tabby-nano-2 ✅]
    B -->|Qwen3-0.6B-Q4_K_M.gguf| D[tabby-fast-1]
    B -->|gemma-4-E2B-it-Q4_K_M.gguf| E[tabby-balanced-1]
    B -->|gemma-4-E4B-it-Q4_K_M.gguf| F[tabby-max-1]
    B -->|SmolLM-360M-Instruct.Q8_0.gguf removed| G[raw filename fallback]
    B -->|unknown GGUF| G

    H[Bootstrap preferredModelNames] --> I[gemma-4-E4B]
    I --> J[gemma-4-E2B]
    J --> K[Qwen3-0.6B]
    K --> L[SmolLM2-135M ✅ smallest curated]
```

<sub>Reviews (1): Last reviewed commit: ["Retire SmolLM-360M from the catalog and ..."](https://github.com/fujacob/cotabby/commit/006e0621e38dd1bd3a5f3cb36e3cb6083160c3d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34335523)</sub>

<!-- /greptile_comment -->