### PR TITLE
Scaffold redesigned Settings: sidebar container behind feature flag

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -35,8 +35,10 @@
 		25D4FC8D191A50F63E6391F9 /* ModelAndPresentationValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03766F6253FF17639230C0F6 /* ModelAndPresentationValueTests.swift */; };
 		25F91CEF38400FD1ADB6B1AF /* CompletionRenderModePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D504BEB224E0C176F5FCFF6E /* CompletionRenderModePolicyTests.swift */; };
 		26E0331E9E2F92FAE531BDEE /* ActivationIndicatorController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84D4528EEC9EFEB8AE8E318 /* ActivationIndicatorController.swift */; };
+		27D4F5CACADE171F142178B4 /* SettingsSidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BADB38D0160B47637572FC5E /* SettingsSidebarView.swift */; };
 		2C6159231472A849F15BD0AE /* ScreenFrameReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5484C8A04B9C00CF79D589EB /* ScreenFrameReader.swift */; };
 		2DF5A3826AAB99C279EBB8DE /* InputMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B81DD30EB657368AACE9625A /* InputMonitor.swift */; };
+		2E3DEB7E89D0146274596F2E /* SettingsContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB0CE9AB1286367BA2E82392 /* SettingsContainerView.swift */; };
 		2EE05B312C990104BE934772 /* GhostFontSizeStabilizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335BF59EE80F3A0143B79740 /* GhostFontSizeStabilizerTests.swift */; };
 		2F227738D7834B1A7A81D1D6 /* ModelDownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51020F8CD58338BD643FBF63 /* ModelDownloadManager.swift */; };
 		2FC40D4BFDD05C2401D7A5E9 /* SuggestionInserter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3D1125B962CBE0269EEDDB /* SuggestionInserter.swift */; };
@@ -59,6 +61,7 @@
 		4AC255BE2D0CCC67B8882C7A /* WelcomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21CB3008986BE7FD2A4D9132 /* WelcomeCoordinator.swift */; };
 		4B4DDB569CAD806F765224DE /* CustomRulesEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F7F7355967725162DF2D1B /* CustomRulesEditor.swift */; };
 		4B54ACE1255873955414CD06 /* PermissionGuidanceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F2C764D29C8D50D0C854FF8 /* PermissionGuidanceController.swift */; };
+		4B93D26BACEEA932E92B1A19 /* SettingsPaneScaffold.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19BE12C28A4AB8A4A58C2FF7 /* SettingsPaneScaffold.swift */; };
 		4C6D8ED0A7B45D2EADF06DA5 /* SuggestionOverlayStabilityGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB25ABC4FFB0E63477CDCB0 /* SuggestionOverlayStabilityGateTests.swift */; };
 		4CAFD8F3444FEDC9ACAFF529 /* LlamaRuntimeModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A804F4DB6FD9BC8C27B2B65F /* LlamaRuntimeModels.swift */; };
 		4F369F5284DDCEABF082E59B /* SuggestionAvailabilityEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3609CC88A5280B3AA40414DF /* SuggestionAvailabilityEvaluator.swift */; };
@@ -100,6 +103,7 @@
 		88BCD795A14E1C9308F7BB31 /* SuggestionAvailabilityEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05B0439348261163B37C508 /* SuggestionAvailabilityEvaluatorTests.swift */; };
 		8B2DFC860803C0A7C4D34A36 /* ContextBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54EF3C7F5D9D6F3FA50FD51C /* ContextBuffer.swift */; };
 		8DA36F1521B6A59D8C20AC59 /* Logging in Frameworks */ = {isa = PBXBuildFile; productRef = 5A60D1467BBFECB3DFEB39C2 /* Logging */; };
+		907A0BF56C3BB0CBAF2649AB /* SettingsCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D0AEFF86F8210CBE7CFCBAD /* SettingsCategory.swift */; };
 		909EBE545CE644C6C57F1B5D /* SuggestionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F961F5DF2A392F6F5F94F8A /* SuggestionCoordinator.swift */; };
 		90CD3F7238E223DEBA2B4D92 /* TagChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB317C82CE2CBC69056BA4B8 /* TagChip.swift */; };
 		90DC9508F27F712EB61EEB06 /* PermissionReminderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 656F58E56FE9BC087B6F1D33 /* PermissionReminderView.swift */; };
@@ -131,6 +135,7 @@
 		B93AB7E845086F6FBB068369 /* SuggestionRequestFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE94342B888A5A2CCF66BC93 /* SuggestionRequestFactoryTests.swift */; };
 		BB6325CA50F97B18B9725918 /* SuggestionTextNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B424E2AC97C99D335B0D5751 /* SuggestionTextNormalizer.swift */; };
 		BBE22CE4EF43247F8775B25D /* FocusPollBackoff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09FADF683BE7B3558377FA76 /* FocusPollBackoff.swift */; };
+		BBE74B21ED1543DEACF18A1A /* PlaceholderPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93028F328388432E72C58D09 /* PlaceholderPaneView.swift */; };
 		BFCA7FAFDAEBF586AB615567 /* ClipboardRelevanceFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90B0D133AB77A2503FB08827 /* ClipboardRelevanceFilterTests.swift */; };
 		C2C958D6E5F5FE1CCC414BCE /* SuggestionSubsystemContracts.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB16474A67CE1D210B944C9 /* SuggestionSubsystemContracts.swift */; };
 		C4C6734678797669055988E0 /* AppUpdateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD9573F3504CAE6891DF9B7D /* AppUpdateManager.swift */; };
@@ -191,6 +196,7 @@
 		110CB0B53016644EF7840301 /* HuggingFaceAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceAPIClient.swift; sourceTree = "<group>"; };
 		12DD19BCE610808F1E38702D /* PermissionOverlayTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOverlayTrackerTests.swift; sourceTree = "<group>"; };
 		18D990E515E1AE4F312F4E95 /* BundledRuntimeLocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledRuntimeLocatorTests.swift; sourceTree = "<group>"; };
+		19BE12C28A4AB8A4A58C2FF7 /* SettingsPaneScaffold.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPaneScaffold.swift; sourceTree = "<group>"; };
 		19DB9558F4D3AFB108D71649 /* SuggestionStateHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionStateHelperTests.swift; sourceTree = "<group>"; };
 		1CE61E74928C221B8BB261C6 /* SuggestionTextColorCodec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionTextColorCodec.swift; sourceTree = "<group>"; };
 		1D00A031C0D9CF2A7A2330D9 /* PermissionDragSourceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionDragSourceView.swift; sourceTree = "<group>"; };
@@ -230,6 +236,7 @@
 		5AD3F4F9FBE82007E4E15F58 /* GhostSuggestionLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostSuggestionLayoutTests.swift; sourceTree = "<group>"; };
 		5C4E5869D103865486AAAEEC /* ModelFileValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelFileValidator.swift; sourceTree = "<group>"; };
 		5C9FDF029F7828CAF3FE8850 /* FocusTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusTracker.swift; sourceTree = "<group>"; };
+		5D0AEFF86F8210CBE7CFCBAD /* SettingsCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsCategory.swift; sourceTree = "<group>"; };
 		5F2C764D29C8D50D0C854FF8 /* PermissionGuidanceController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionGuidanceController.swift; sourceTree = "<group>"; };
 		5F34AE24BB7C99D66E1F3904 /* InputModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputModels.swift; sourceTree = "<group>"; };
 		60629DFE309C1A4BD8A7FB3B /* RuntimeBootstrapModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimeBootstrapModel.swift; sourceTree = "<group>"; };
@@ -256,6 +263,7 @@
 		8F961F5DF2A392F6F5F94F8A /* SuggestionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionCoordinator.swift; sourceTree = "<group>"; };
 		90B0D133AB77A2503FB08827 /* ClipboardRelevanceFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardRelevanceFilterTests.swift; sourceTree = "<group>"; };
 		92C6EB9FDA48ADF425A116A9 /* PermissionOverlayWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOverlayWindowController.swift; sourceTree = "<group>"; };
+		93028F328388432E72C58D09 /* PlaceholderPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceholderPaneView.swift; sourceTree = "<group>"; };
 		944065A858D9BC936CB12B23 /* LlamaRuntimeCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LlamaRuntimeCore.swift; sourceTree = "<group>"; };
 		9458F0820B3161FE9CF1DDAF /* GhostFontSizeStabilizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostFontSizeStabilizer.swift; sourceTree = "<group>"; };
 		96495E4147D828C0B1B22765 /* ClipboardContentDistiller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardContentDistiller.swift; sourceTree = "<group>"; };
@@ -288,6 +296,7 @@
 		B6D42CD456B4B3C988B148A6 /* FocusTrackingModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusTrackingModel.swift; sourceTree = "<group>"; };
 		B81DD30EB657368AACE9625A /* InputMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputMonitor.swift; sourceTree = "<group>"; };
 		BA705EDFE1C41294F0E381F1 /* FocusSnapshotResolverSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusSnapshotResolverSelectionTests.swift; sourceTree = "<group>"; };
+		BADB38D0160B47637572FC5E /* SettingsSidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSidebarView.swift; sourceTree = "<group>"; };
 		BB5C2AE9A7E55495D26AD074 /* DownloadableModelCatalogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadableModelCatalogView.swift; sourceTree = "<group>"; };
 		BC4F887528AE74AC0DD30314 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		BD42C7E2852F59BEF7972663 /* MenuBarStatusLabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarStatusLabelView.swift; sourceTree = "<group>"; };
@@ -312,6 +321,7 @@
 		D504BEB224E0C176F5FCFF6E /* CompletionRenderModePolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionRenderModePolicyTests.swift; sourceTree = "<group>"; };
 		D5D6C2318E405AA717D1C256 /* WelcomePermissionStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomePermissionStepView.swift; sourceTree = "<group>"; };
 		D84D4528EEC9EFEB8AE8E318 /* ActivationIndicatorController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivationIndicatorController.swift; sourceTree = "<group>"; };
+		DB0CE9AB1286367BA2E82392 /* SettingsContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsContainerView.swift; sourceTree = "<group>"; };
 		DDE858CB1E687E3CEB8FDD5B /* SuggestionRequestFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionRequestFactory.swift; sourceTree = "<group>"; };
 		DEB16474A67CE1D210B944C9 /* SuggestionSubsystemContracts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionSubsystemContracts.swift; sourceTree = "<group>"; };
 		E1D2782B6C7BE3F56BCB22DE /* LlamaVisualContextSummarizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LlamaVisualContextSummarizer.swift; sourceTree = "<group>"; };
@@ -403,6 +413,14 @@
 			path = Visual;
 			sourceTree = "<group>";
 		};
+		2EE526D7C9284AF6687A556B /* Panes */ = {
+			isa = PBXGroup;
+			children = (
+				93028F328388432E72C58D09 /* PlaceholderPaneView.swift */,
+			);
+			path = Panes;
+			sourceTree = "<group>";
+		};
 		3725B1A195A06A4F014B75B1 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -449,6 +467,14 @@
 				5C9FDF029F7828CAF3FE8850 /* FocusTracker.swift */,
 			);
 			path = Focus;
+			sourceTree = "<group>";
+		};
+		6E1171BBC9CB74DB623C5E8B /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				19BE12C28A4AB8A4A58C2FF7 /* SettingsPaneScaffold.swift */,
+			);
+			path = Components;
 			sourceTree = "<group>";
 		};
 		717EB52365B64107A6FB1126 /* Coordinators */ = {
@@ -543,6 +569,7 @@
 		B0EBE873B895FB333A0BC26F /* UI */ = {
 			isa = PBXGroup;
 			children = (
+				DCBC24D605EC0CBA1DD6097D /* Settings */,
 				82F7F7355967725162DF2D1B /* CustomRulesEditor.swift */,
 				BB5C2AE9A7E55495D26AD074 /* DownloadableModelCatalogView.swift */,
 				CBD5FCB8CC56AA6138382B2C /* FieldEdgeIconIndicatorView.swift */,
@@ -564,6 +591,18 @@
 				264CA64B2AB1611F82E5B760 /* WelcomeView.swift */,
 			);
 			path = UI;
+			sourceTree = "<group>";
+		};
+		DCBC24D605EC0CBA1DD6097D /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				6E1171BBC9CB74DB623C5E8B /* Components */,
+				2EE526D7C9284AF6687A556B /* Panes */,
+				5D0AEFF86F8210CBE7CFCBAD /* SettingsCategory.swift */,
+				DB0CE9AB1286367BA2E82392 /* SettingsContainerView.swift */,
+				BADB38D0160B47637572FC5E /* SettingsSidebarView.swift */,
+			);
+			path = Settings;
 			sourceTree = "<group>";
 		};
 		DFE8419B341AF83B4D276BC0 = {
@@ -827,12 +866,17 @@
 				6106B16C0DBA94EBF838D93E /* PermissionOverlayTracker.swift in Sources */,
 				61EC9D635D416115E7C96E0F /* PermissionOverlayWindowController.swift in Sources */,
 				90DC9508F27F712EB61EEB06 /* PermissionReminderView.swift in Sources */,
+				BBE74B21ED1543DEACF18A1A /* PlaceholderPaneView.swift in Sources */,
 				98E2E14A069384C1088CDB44 /* PromptContextSanitizer.swift in Sources */,
 				82D4ADEAF05337ABDE4C586C /* RuntimeBootstrapModel.swift in Sources */,
 				2C6159231472A849F15BD0AE /* ScreenFrameReader.swift in Sources */,
 				0C06CAD62975E87B2C852191 /* ScreenTextExtractor.swift in Sources */,
 				DD7FA343F1C21C4569F6D181 /* ScreenshotContextGenerator.swift in Sources */,
+				907A0BF56C3BB0CBAF2649AB /* SettingsCategory.swift in Sources */,
+				2E3DEB7E89D0146274596F2E /* SettingsContainerView.swift in Sources */,
 				644EEF959D07D54CC779BBF6 /* SettingsCoordinator.swift in Sources */,
+				4B93D26BACEEA932E92B1A19 /* SettingsPaneScaffold.swift in Sources */,
+				27D4F5CACADE171F142178B4 /* SettingsSidebarView.swift in Sources */,
 				A440C596EFD9CD1E44F2579B /* SettingsView.swift in Sources */,
 				4F369F5284DDCEABF082E59B /* SuggestionAvailabilityEvaluator.swift in Sources */,
 				A0657CE0488F69F0BD559CBC /* SuggestionCoordinator+Acceptance.swift in Sources */,

--- a/Cotabby/App/Coordinators/SettingsCoordinator.swift
+++ b/Cotabby/App/Coordinators/SettingsCoordinator.swift
@@ -45,6 +45,16 @@ final class SettingsCoordinator: NSObject, NSWindowDelegate {
         self.onShowWelcome = onShowWelcome
     }
 
+    /// UserDefaults key that toggles between the legacy single-form Settings and the redesigned
+    /// sidebar Settings. Default is `false` (legacy) until the redesign is feature-complete; flip
+    /// to `true` to dogfood. The key is intentionally kept narrow so a regression can be reverted
+    /// with a single `defaults write` without redeploying the app.
+    static let redesignEnabledDefaultsKey = "cotabbySettingsRedesignEnabled"
+
+    private var isRedesignEnabled: Bool {
+        UserDefaults.standard.bool(forKey: Self.redesignEnabledDefaultsKey)
+    }
+
     /// Shows the settings window, reusing the existing instance if it is already open.
     /// Reusing one window avoids subtle state duplication and matches standard macOS settings
     /// behavior where there is a single shared preferences surface for the app.
@@ -55,22 +65,55 @@ final class SettingsCoordinator: NSObject, NSWindowDelegate {
             return
         }
 
-        let hostingController = NSHostingController(
-            rootView: SettingsView(
-                appUpdateManager: appUpdateManager,
-                launchAtLoginService: launchAtLoginService,
-                permissionManager: permissionManager,
-                suggestionSettings: suggestionSettings,
-                foundationModelAvailabilityService: foundationModelAvailabilityService,
-                runtimeModel: runtimeModel,
-                modelDownloadManager: modelDownloadManager,
-                huggingFaceSearchService: huggingFaceSearchService,
-                onShowWelcome: onShowWelcome
+        let hostingController: NSHostingController<AnyView>
+        let initialFrame: CGRect
+        let minSize: NSSize
+        let autosaveName: String
+
+        if isRedesignEnabled {
+            hostingController = NSHostingController(
+                rootView: AnyView(
+                    SettingsContainerView(
+                        appUpdateManager: appUpdateManager,
+                        launchAtLoginService: launchAtLoginService,
+                        permissionManager: permissionManager,
+                        suggestionSettings: suggestionSettings,
+                        foundationModelAvailabilityService: foundationModelAvailabilityService,
+                        runtimeModel: runtimeModel,
+                        modelDownloadManager: modelDownloadManager,
+                        huggingFaceSearchService: huggingFaceSearchService,
+                        onShowWelcome: onShowWelcome
+                    )
+                )
             )
-        )
+            initialFrame = CGRect(x: 0, y: 0, width: 960, height: 680)
+            minSize = NSSize(width: 820, height: 540)
+            // Separate autosave name so the redesigned layout starts from its own default frame
+            // for users who already had a smaller saved frame from the legacy window.
+            autosaveName = "CotabbySettingsWindowV2"
+        } else {
+            hostingController = NSHostingController(
+                rootView: AnyView(
+                    SettingsView(
+                        appUpdateManager: appUpdateManager,
+                        launchAtLoginService: launchAtLoginService,
+                        permissionManager: permissionManager,
+                        suggestionSettings: suggestionSettings,
+                        foundationModelAvailabilityService: foundationModelAvailabilityService,
+                        runtimeModel: runtimeModel,
+                        modelDownloadManager: modelDownloadManager,
+                        huggingFaceSearchService: huggingFaceSearchService,
+                        onShowWelcome: onShowWelcome
+                    )
+                )
+            )
+            initialFrame = CGRect(x: 0, y: 0, width: 700, height: 620)
+            minSize = NSSize(width: 640, height: 520)
+            autosaveName = "CotabbySettingsWindow"
+        }
 
         let window = NSWindow(
-            contentRect: CGRect(x: 0, y: 0, width: 700, height: 620),
+            contentRect: initialFrame,
             styleMask: [.titled, .closable, .miniaturizable, .resizable],
             backing: .buffered,
             defer: false
@@ -80,8 +123,8 @@ final class SettingsCoordinator: NSObject, NSWindowDelegate {
         window.isReleasedWhenClosed = false
         window.level = .normal
         window.collectionBehavior = [.moveToActiveSpace, .fullScreenAuxiliary]
-        window.minSize = NSSize(width: 640, height: 520)
-        window.setFrameAutosaveName("CotabbySettingsWindow")
+        window.minSize = minSize
+        window.setFrameAutosaveName(autosaveName)
         window.delegate = self
         window.contentViewController = hostingController
 

--- a/Cotabby/UI/Settings/Components/SettingsPaneScaffold.swift
+++ b/Cotabby/UI/Settings/Components/SettingsPaneScaffold.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+
+/// File overview:
+/// Shared chrome for every settings detail pane. Pulls the form styling, scroll wrapping, and
+/// optional top-of-pane callout into one place so individual panes stay focused on their rows
+/// rather than repeating layout boilerplate.
+///
+/// Why a callout slot:
+/// The legacy settings window puts a single attention banner at the top of the form. The redesign
+/// surfaces attention per pane: when a pane is in a degraded state (missing permission, runtime
+/// unavailable) we render an inline callout above the form so the actionable surface lives next to
+/// the controls that fix it.
+struct SettingsPaneScaffold<Content: View>: View {
+    let callout: SettingsPaneCallout?
+    @ViewBuilder let content: () -> Content
+
+    init(
+        callout: SettingsPaneCallout? = nil,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
+        self.callout = callout
+        self.content = content
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                if let callout {
+                    SettingsCalloutView(callout: callout)
+                        .padding(.horizontal, 20)
+                        .padding(.top, 16)
+                }
+                Form {
+                    content()
+                }
+                .formStyle(.grouped)
+            }
+        }
+    }
+}
+
+struct SettingsPaneCallout: Equatable {
+    enum Tone {
+        case warning
+        case info
+    }
+
+    let tone: Tone
+    let message: String
+}
+
+private struct SettingsCalloutView: View {
+    let callout: SettingsPaneCallout
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: iconName)
+                .foregroundStyle(tint)
+                .imageScale(.medium)
+
+            Text(callout.message)
+                .font(.callout)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(tint.opacity(0.12))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(tint.opacity(0.4), lineWidth: 1)
+        )
+    }
+
+    private var iconName: String {
+        switch callout.tone {
+        case .warning: return "exclamationmark.triangle.fill"
+        case .info: return "info.circle.fill"
+        }
+    }
+
+    private var tint: Color {
+        switch callout.tone {
+        case .warning: return .orange
+        case .info: return .accentColor
+        }
+    }
+}

--- a/Cotabby/UI/Settings/Panes/PlaceholderPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/PlaceholderPaneView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+/// File overview:
+/// Stand-in detail pane used while the redesigned panes are being built out across the multi-PR
+/// stack. Each subsequent PR replaces one of these with a real pane. Keeping a placeholder shape
+/// in the scaffold PR means the container renders correctly even when only the framework is wired.
+struct PlaceholderPaneView: View {
+    let category: SettingsCategory
+
+    var body: some View {
+        SettingsPaneScaffold {
+            Section {
+                VStack(alignment: .leading, spacing: 10) {
+                    Label(category.label, systemImage: category.systemImage)
+                        .font(.system(size: 16, weight: .semibold, design: .rounded))
+
+                    Text("This pane is being moved into the new Settings layout in an upcoming change.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(.vertical, 6)
+            }
+        }
+    }
+}

--- a/Cotabby/UI/Settings/SettingsCategory.swift
+++ b/Cotabby/UI/Settings/SettingsCategory.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+/// File overview:
+/// The catalog of sidebar rows in the redesigned Settings window.
+///
+/// Each case is one selectable row. `section` drives the visual grouping in the sidebar (rows in
+/// the same section render under the same header). `engineAndModel` is intentionally also a row
+/// the user can land on: when neither sub-row is selected we show a parent overview pane that owns
+/// the engine picker, so the user has a single place to switch engines. The two sub-cases
+/// (`appleIntelligence`, `openSource`) host the engine-specific content.
+enum SettingsCategory: String, CaseIterable, Hashable, Identifiable {
+    case general
+    case engineAndModel
+    case appleIntelligence
+    case openSource
+    case writing
+    case shortcuts
+    case apps
+    case permissions
+    case about
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .general: return "General"
+        case .engineAndModel: return "Engine & Model"
+        case .appleIntelligence: return "Apple Intelligence"
+        case .openSource: return "Open Source"
+        case .writing: return "Writing"
+        case .shortcuts: return "Shortcuts"
+        case .apps: return "Apps"
+        case .permissions: return "Permissions"
+        case .about: return "About"
+        }
+    }
+
+    /// SF Symbol displayed at the left of each sidebar row.
+    var systemImage: String {
+        switch self {
+        case .general: return "gearshape.fill"
+        case .engineAndModel: return "cpu.fill"
+        case .appleIntelligence: return "apple.logo"
+        case .openSource: return "shippingbox.fill"
+        case .writing: return "square.and.pencil"
+        case .shortcuts: return "keyboard.fill"
+        case .apps: return "app.badge.fill"
+        case .permissions: return "lock.shield.fill"
+        case .about: return "info.circle.fill"
+        }
+    }
+
+    var section: SettingsSidebarSection {
+        switch self {
+        case .general: return .top
+        case .engineAndModel, .appleIntelligence, .openSource: return .engineModel
+        case .writing, .shortcuts, .apps: return .customize
+        case .permissions: return .system
+        case .about: return .meta
+        }
+    }
+
+    /// Rows that nest visually beneath their parent in the sidebar render with extra indentation.
+    /// Today only the two engine sub-rows count; everything else sits at the top level.
+    var isSubRow: Bool {
+        switch self {
+        case .appleIntelligence, .openSource: return true
+        default: return false
+        }
+    }
+}
+
+/// Visual groups used to render section headers in the sidebar. Cases without a `title` render
+/// without a header so the sidebar stays compact; cases with one show a small uppercase label
+/// above the rows in that group.
+enum SettingsSidebarSection: CaseIterable {
+    case top
+    case engineModel
+    case customize
+    case system
+    case meta
+
+    var title: String? {
+        switch self {
+        case .top, .meta: return nil
+        case .engineModel: return "Engine & Model"
+        case .customize: return "Customize"
+        case .system: return "System"
+        }
+    }
+}

--- a/Cotabby/UI/Settings/SettingsContainerView.swift
+++ b/Cotabby/UI/Settings/SettingsContainerView.swift
@@ -1,0 +1,80 @@
+import AppKit
+import SwiftUI
+
+/// File overview:
+/// Root of the redesigned Settings window. A `NavigationSplitView` with a sidebar of categorized
+/// rows on the left and a switching detail pane on the right. The detail body is built from
+/// `SettingsCategory`, so adding a new pane is a matter of adding an enum case and a `case` in the
+/// switch below.
+///
+/// Selection is persisted via `@AppStorage` so reopening Settings lands on the last-used pane.
+/// `.id(selection)` on the detail body is the documented workaround for the macOS 14 split-view
+/// selection bug where the first sidebar pick doesn't always re-render the detail column.
+///
+/// The view takes the same observable graph as the legacy `SettingsView` so the coordinator can
+/// swap hosting controllers behind a feature flag without rewiring dependencies.
+struct SettingsContainerView: View {
+    let appUpdateManager: AppUpdateManager
+
+    @ObservedObject var launchAtLoginService: LaunchAtLoginService
+    @ObservedObject var permissionManager: PermissionManager
+    @ObservedObject var suggestionSettings: SuggestionSettingsModel
+    @ObservedObject var foundationModelAvailabilityService: FoundationModelAvailabilityService
+    @ObservedObject var runtimeModel: RuntimeBootstrapModel
+    @ObservedObject var modelDownloadManager: ModelDownloadManager
+    @ObservedObject var huggingFaceSearchService: HuggingFaceSearchService
+
+    let onShowWelcome: () -> Void
+
+    @AppStorage("cotabbySettingsSelectedCategoryV2")
+    private var storedCategoryRawValue: String = SettingsCategory.general.rawValue
+
+    @State private var selection: SettingsCategory = .general
+
+    var body: some View {
+        NavigationSplitView {
+            SettingsSidebarView(selection: $selection)
+        } detail: {
+            detailPane
+                .id(selection)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .navigationSplitViewStyle(.balanced)
+        .frame(minWidth: 820, minHeight: 540)
+        .onAppear {
+            selection = SettingsCategory(rawValue: storedCategoryRawValue) ?? .general
+            launchAtLoginService.refresh()
+            permissionManager.refresh()
+        }
+        .onChange(of: selection) { _, newValue in
+            storedCategoryRawValue = newValue.rawValue
+            syncWindowTitle(for: newValue)
+        }
+    }
+
+    @ViewBuilder
+    private var detailPane: some View {
+        switch selection {
+        case .general,
+             .engineAndModel,
+             .appleIntelligence,
+             .openSource,
+             .writing,
+             .shortcuts,
+             .apps,
+             .permissions,
+             .about:
+            PlaceholderPaneView(category: selection)
+        }
+    }
+
+    /// Mirrors the chosen pane into the hosting `NSWindow.title` so the title bar reflects the
+    /// current selection. macOS settings windows traditionally use an inline title for the active
+    /// pane; this preserves that convention without rendering a duplicate large title inside the
+    /// content.
+    private func syncWindowTitle(for category: SettingsCategory) {
+        DispatchQueue.main.async {
+            NSApp.keyWindow?.title = "Settings — \(category.label)"
+        }
+    }
+}

--- a/Cotabby/UI/Settings/SettingsContainerView.swift
+++ b/Cotabby/UI/Settings/SettingsContainerView.swift
@@ -45,6 +45,9 @@ struct SettingsContainerView: View {
             selection = SettingsCategory(rawValue: storedCategoryRawValue) ?? .general
             launchAtLoginService.refresh()
             permissionManager.refresh()
+            // Set the title unconditionally on open: when the restored selection equals the
+            // initial @State value, `.onChange` does not fire and the title would stay blank.
+            syncWindowTitle(for: selection)
         }
         .onChange(of: selection) { _, newValue in
             storedCategoryRawValue = newValue.rawValue
@@ -73,8 +76,11 @@ struct SettingsContainerView: View {
     /// pane; this preserves that convention without rendering a duplicate large title inside the
     /// content.
     private func syncWindowTitle(for category: SettingsCategory) {
+        // Capture the key window now: between the tap and the async block running, a popover or
+        // alert could become key and we would retitle the wrong window.
+        let window = NSApp.keyWindow
         DispatchQueue.main.async {
-            NSApp.keyWindow?.title = "Settings — \(category.label)"
+            window?.title = "Settings — \(category.label)"
         }
     }
 }

--- a/Cotabby/UI/Settings/SettingsSidebarView.swift
+++ b/Cotabby/UI/Settings/SettingsSidebarView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+/// File overview:
+/// Renders the sidebar list of the redesigned Settings window. Sections drive visual grouping;
+/// `selection` is the binding the container view uses to decide which detail pane to show.
+///
+/// Why this lives in its own file:
+/// the sidebar's row ordering, section headers, and indentation rules are sidebar concerns. Keeping
+/// them out of the container view leaves the container as a small `NavigationSplitView` shell that
+/// is easy to skim.
+struct SettingsSidebarView: View {
+    @Binding var selection: SettingsCategory
+
+    var body: some View {
+        List(selection: $selection) {
+            ForEach(SettingsSidebarSection.allCases, id: \.self) { section in
+                let rows = SettingsCategory.allCases.filter { $0.section == section }
+                if !rows.isEmpty {
+                    if let title = section.title {
+                        Section(title) {
+                            ForEach(rows) { row(for: $0) }
+                        }
+                    } else {
+                        Section { ForEach(rows) { row(for: $0) } }
+                    }
+                }
+            }
+        }
+        .listStyle(.sidebar)
+        .navigationSplitViewColumnWidth(min: 200, ideal: 220, max: 260)
+    }
+
+    @ViewBuilder
+    private func row(for category: SettingsCategory) -> some View {
+        Label(category.label, systemImage: category.systemImage)
+            .padding(.leading, category.isSubRow ? 16 : 0)
+            .tag(category)
+    }
+}


### PR DESCRIPTION
## Summary

First PR in the Settings sidebar-redesign stack. Adds the new container view, sidebar list, pane scaffold, placeholder panes, and a feature flag in `SettingsCoordinator`. Default routes to the legacy `SettingsView`; flipping `defaults write com.jacobfu.tabby cotabbySettingsRedesignEnabled -bool YES` (or the `cotabbySettingsRedesignEnabled` key) routes to the new container. Subsequent PRs replace placeholders with real panes; the final PR in the stack flips the flag default.

## Validation

`xcodegen generate` + `xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build CODE_SIGNING_ALLOWED=NO`
→ `** BUILD SUCCEEDED **`

`swiftlint lint --quiet` → no violations.

Manual: with the flag flipped, open Settings and confirm the sidebar renders with eight rows under the planned sections, selection persists across reopens, and the title bar updates to "Settings — <pane>". With the flag off, behavior is unchanged.

## Linked issues

(none filed)

## Risk / rollout notes

- Default routing unchanged. Every existing user sees the legacy single-form layout until later PRs land and the final PR flips the flag.
- New window autosave name `CotabbySettingsWindowV2` is intentional so the redesigned layout starts from its own default frame rather than inheriting a smaller saved frame from the legacy window.
- `.id(selection)` is applied preemptively on the detail pane to work around the documented macOS 14 NavigationSplitView selection bug where the first sidebar tap doesn't always trigger a detail re-render.
- The `SettingsCategory` enum includes both `engineAndModel` (parent overview pane) and `appleIntelligence` / `openSource` (sub-rows). The parent pane will own the engine picker when PR 3 lands so the user has a single place to switch engines.
- `xcodegen generate` was rerun and the resulting `Cotabby.xcodeproj/project.pbxproj` is committed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR scaffolds the redesigned Settings window behind a `UserDefaults` feature flag in `SettingsCoordinator`. The legacy `SettingsView` remains the default; flipping `cotabbySettingsRedesignEnabled` routes to the new `SettingsContainerView`, a `NavigationSplitView` shell with a categorized sidebar and placeholder detail panes that subsequent PRs will fill in.

- **SettingsCoordinator**: adds `isRedesignEnabled` branch that selects the right hosting controller, initial frame, min size, and autosave name (`CotabbySettingsWindowV2`) per variant, leaving existing window-reuse and delegate teardown logic untouched.
- **SettingsContainerView / SettingsSidebarView**: `NavigationSplitView` with `@AppStorage`-persisted selection, `syncWindowTitle` called unconditionally in `onAppear` and on every selection change, and `.id(selection)` as the documented macOS 14 split-view workaround.
- **SettingsCategory / SettingsSidebarSection / SettingsPaneScaffold / PlaceholderPaneView**: new enum catalog, section grouping, shared pane chrome with optional callout banner, and a temporary placeholder rendered for every category until real panes land.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The redesign is fully gated behind a feature flag that defaults to off, so all existing users continue on the legacy settings path until a future PR flips the default.

All changes are additive and behind a UserDefaults flag that is off by default. The legacy window path is unchanged. The new container view, sidebar, pane scaffold, and placeholder panes are all scaffolding that only activates for developers who opt in via defaults write. No existing behavior is affected.

SettingsContainerView.swift — the @AppStorage/@State two-variable sync pattern is worth simplifying before real panes land, but it has no user-visible impact while all panes are placeholders.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/App/Coordinators/SettingsCoordinator.swift | Adds feature-flag branch (isRedesignEnabled) to route between legacy SettingsView and new SettingsContainerView, with matching frame/minSize/autosave name per variant. Clean refactor; existing window-reuse logic and delegate teardown unchanged. |
| Cotabby/UI/Settings/SettingsContainerView.swift | New root view for redesigned Settings; uses NavigationSplitView + AppStorage-persisted selection. A redundant @State/@AppStorage two-variable pattern is used where a single @AppStorage on SettingsCategory directly would suffice, causing the detail pane to render once with .general before onAppear corrects it to the stored category. |
| Cotabby/UI/Settings/SettingsSidebarView.swift | Renders the sidebar List grouped by SettingsSidebarSection. Uses SettingsSidebarSection.allCases ordering and .tag() for selection, with visual-only leading padding for sub-rows. Straightforward and correct. |
| Cotabby/UI/Settings/SettingsCategory.swift | Defines the SettingsCategory and SettingsSidebarSection enums that drive sidebar structure. All cases covered, section mapping matches PR description, isSubRow correctly targets only engine sub-rows. |
| Cotabby/UI/Settings/Components/SettingsPaneScaffold.swift | Reusable chrome for detail panes: scrollable Form with optional inline callout banner. Well-structured with clear tone/styling split; no issues. |
| Cotabby/UI/Settings/Panes/PlaceholderPaneView.swift | Temporary stand-in pane rendered for all SettingsCategory cases; intentional scaffold until subsequent PRs replace each placeholder. No issues. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant SettingsCoordinator
    participant NSWindow
    participant SettingsContainerView
    participant SettingsSidebarView
    participant AppStorage

    User->>SettingsCoordinator: showSettings()
    SettingsCoordinator->>SettingsCoordinator: isRedesignEnabled?
    alt redesign flag ON
        SettingsCoordinator->>NSWindow: create(frame: 960x680, autosave: V2)
        SettingsCoordinator->>SettingsContainerView: NSHostingController
    else redesign flag OFF
        SettingsCoordinator->>NSWindow: create(frame: 700x620, autosave: legacy)
        SettingsCoordinator->>NSWindow: SettingsView (legacy)
    end
    NSWindow->>User: makeKeyAndOrderFront

    User->>SettingsContainerView: onAppear
    AppStorage-->>SettingsContainerView: storedCategoryRawValue
    SettingsContainerView->>SettingsContainerView: "selection = stored ?? .general"
    SettingsContainerView->>NSWindow: syncWindowTitle(selection)

    User->>SettingsSidebarView: tap row
    SettingsSidebarView->>SettingsContainerView: $selection binding updated
    SettingsContainerView->>AppStorage: persist rawValue
    SettingsContainerView->>NSWindow: syncWindowTitle(newValue)
    SettingsContainerView->>SettingsContainerView: detailPane re-renders (.id workaround)
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fsettings-redesign-scaffold%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fsettings-redesign-scaffold%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FSettings%2FSettingsContainerView.swift%3A29-32%0A%60SettingsCategory%60%20is%20a%20%60String%60-backed%20%60RawRepresentable%60%20enum%2C%20so%20%60%40AppStorage%60%20can%20store%20it%20directly.%20The%20current%20two-variable%20design%20%28%60storedCategoryRawValue%60%20%2B%20%60selection%60%29%20causes%20the%20view%20to%20render%20once%20with%20the%20%60%40State%60%20default%20%28%60.general%60%29%20before%20%60onAppear%60%20corrects%20it%20to%20the%20stored%20category.%20If%20the%20user%20last%20closed%20on%20e.g.%20%60.about%60%2C%20the%20detail%20pane%20briefly%20shows%20the%20General%20placeholder%20on%20every%20open%20before%20switching.%20Using%20%60%40AppStorage%60%20directly%20on%20%60selection%60%20eliminates%20the%20sync%20dance%2C%20the%20redundant%20%60onChange%60%20write-back%2C%20and%20the%20first-frame%20flash.%0A%0A%60%60%60suggestion%0A%20%20%20%20%40AppStorage%28%22cotabbySettingsSelectedCategoryV2%22%29%0A%20%20%20%20private%20var%20selection%3A%20SettingsCategory%20%3D%20.general%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FUI%2FSettings%2FSettingsContainerView.swift%3A44-55%0AIf%20the%20%60%40AppStorage%60%20simplification%20above%20is%20applied%2C%20the%20%60onAppear%60%20block%20can%20drop%20the%20sync%20assignment%20and%20the%20redundant%20%60onChange%60%20write-back%2C%20keeping%20only%20the%20refresh%20calls%20and%20the%20unconditional%20title%20sync.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20.onAppear%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20launchAtLoginService.refresh%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20permissionManager.refresh%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Set%20the%20title%20unconditionally%20on%20open%3A%20when%20the%20restored%20selection%20equals%20the%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20initial%20%40AppStorage%20value%2C%20%60.onChange%60%20does%20not%20fire%20and%20the%20title%20would%20stay%20blank.%0A%20%20%20%20%20%20%20%20%20%20%20%20syncWindowTitle%28for%3A%20selection%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20.onChange%28of%3A%20selection%29%20%7B%20_%2C%20newValue%20in%0A%20%20%20%20%20%20%20%20%20%20%20%20syncWindowTitle%28for%3A%20newValue%29%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FSettings%2FSettingsContainerView.swift%3A29-32%0A%60SettingsCategory%60%20is%20a%20%60String%60-backed%20%60RawRepresentable%60%20enum%2C%20so%20%60%40AppStorage%60%20can%20store%20it%20directly.%20The%20current%20two-variable%20design%20%28%60storedCategoryRawValue%60%20%2B%20%60selection%60%29%20causes%20the%20view%20to%20render%20once%20with%20the%20%60%40State%60%20default%20%28%60.general%60%29%20before%20%60onAppear%60%20corrects%20it%20to%20the%20stored%20category.%20If%20the%20user%20last%20closed%20on%20e.g.%20%60.about%60%2C%20the%20detail%20pane%20briefly%20shows%20the%20General%20placeholder%20on%20every%20open%20before%20switching.%20Using%20%60%40AppStorage%60%20directly%20on%20%60selection%60%20eliminates%20the%20sync%20dance%2C%20the%20redundant%20%60onChange%60%20write-back%2C%20and%20the%20first-frame%20flash.%0A%0A%60%60%60suggestion%0A%20%20%20%20%40AppStorage%28%22cotabbySettingsSelectedCategoryV2%22%29%0A%20%20%20%20private%20var%20selection%3A%20SettingsCategory%20%3D%20.general%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FUI%2FSettings%2FSettingsContainerView.swift%3A44-55%0AIf%20the%20%60%40AppStorage%60%20simplification%20above%20is%20applied%2C%20the%20%60onAppear%60%20block%20can%20drop%20the%20sync%20assignment%20and%20the%20redundant%20%60onChange%60%20write-back%2C%20keeping%20only%20the%20refresh%20calls%20and%20the%20unconditional%20title%20sync.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20.onAppear%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20launchAtLoginService.refresh%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20permissionManager.refresh%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Set%20the%20title%20unconditionally%20on%20open%3A%20when%20the%20restored%20selection%20equals%20the%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20initial%20%40AppStorage%20value%2C%20%60.onChange%60%20does%20not%20fire%20and%20the%20title%20would%20stay%20blank.%0A%20%20%20%20%20%20%20%20%20%20%20%20syncWindowTitle%28for%3A%20selection%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20.onChange%28of%3A%20selection%29%20%7B%20_%2C%20newValue%20in%0A%20%20%20%20%20%20%20%20%20%20%20%20syncWindowTitle%28for%3A%20newValue%29%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=356&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Address Greptile feedback: initial title..."](https://github.com/fujacob/cotabby/commit/fb8c68b37a873720c00650578761754126d15cca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34335948)</sub>

<!-- /greptile_comment -->