### PR TITLE
Add General / Permissions / About panes to redesigned Settings

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -35,8 +35,10 @@
 		25D4FC8D191A50F63E6391F9 /* ModelAndPresentationValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03766F6253FF17639230C0F6 /* ModelAndPresentationValueTests.swift */; };
 		25F91CEF38400FD1ADB6B1AF /* CompletionRenderModePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D504BEB224E0C176F5FCFF6E /* CompletionRenderModePolicyTests.swift */; };
 		26E0331E9E2F92FAE531BDEE /* ActivationIndicatorController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84D4528EEC9EFEB8AE8E318 /* ActivationIndicatorController.swift */; };
+		27D4F5CACADE171F142178B4 /* SettingsSidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BADB38D0160B47637572FC5E /* SettingsSidebarView.swift */; };
 		2C6159231472A849F15BD0AE /* ScreenFrameReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5484C8A04B9C00CF79D589EB /* ScreenFrameReader.swift */; };
 		2DF5A3826AAB99C279EBB8DE /* InputMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B81DD30EB657368AACE9625A /* InputMonitor.swift */; };
+		2E3DEB7E89D0146274596F2E /* SettingsContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB0CE9AB1286367BA2E82392 /* SettingsContainerView.swift */; };
 		2EE05B312C990104BE934772 /* GhostFontSizeStabilizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335BF59EE80F3A0143B79740 /* GhostFontSizeStabilizerTests.swift */; };
 		2F227738D7834B1A7A81D1D6 /* ModelDownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51020F8CD58338BD643FBF63 /* ModelDownloadManager.swift */; };
 		2FC40D4BFDD05C2401D7A5E9 /* SuggestionInserter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3D1125B962CBE0269EEDDB /* SuggestionInserter.swift */; };
@@ -59,6 +61,7 @@
 		4AC255BE2D0CCC67B8882C7A /* WelcomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21CB3008986BE7FD2A4D9132 /* WelcomeCoordinator.swift */; };
 		4B4DDB569CAD806F765224DE /* CustomRulesEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F7F7355967725162DF2D1B /* CustomRulesEditor.swift */; };
 		4B54ACE1255873955414CD06 /* PermissionGuidanceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F2C764D29C8D50D0C854FF8 /* PermissionGuidanceController.swift */; };
+		4B93D26BACEEA932E92B1A19 /* SettingsPaneScaffold.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19BE12C28A4AB8A4A58C2FF7 /* SettingsPaneScaffold.swift */; };
 		4C6D8ED0A7B45D2EADF06DA5 /* SuggestionOverlayStabilityGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB25ABC4FFB0E63477CDCB0 /* SuggestionOverlayStabilityGateTests.swift */; };
 		4CAFD8F3444FEDC9ACAFF529 /* LlamaRuntimeModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A804F4DB6FD9BC8C27B2B65F /* LlamaRuntimeModels.swift */; };
 		4F369F5284DDCEABF082E59B /* SuggestionAvailabilityEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3609CC88A5280B3AA40414DF /* SuggestionAvailabilityEvaluator.swift */; };
@@ -100,6 +103,7 @@
 		88BCD795A14E1C9308F7BB31 /* SuggestionAvailabilityEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05B0439348261163B37C508 /* SuggestionAvailabilityEvaluatorTests.swift */; };
 		8B2DFC860803C0A7C4D34A36 /* ContextBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54EF3C7F5D9D6F3FA50FD51C /* ContextBuffer.swift */; };
 		8DA36F1521B6A59D8C20AC59 /* Logging in Frameworks */ = {isa = PBXBuildFile; productRef = 5A60D1467BBFECB3DFEB39C2 /* Logging */; };
+		907A0BF56C3BB0CBAF2649AB /* SettingsCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D0AEFF86F8210CBE7CFCBAD /* SettingsCategory.swift */; };
 		909EBE545CE644C6C57F1B5D /* SuggestionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F961F5DF2A392F6F5F94F8A /* SuggestionCoordinator.swift */; };
 		90CD3F7238E223DEBA2B4D92 /* TagChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB317C82CE2CBC69056BA4B8 /* TagChip.swift */; };
 		90DC9508F27F712EB61EEB06 /* PermissionReminderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 656F58E56FE9BC087B6F1D33 /* PermissionReminderView.swift */; };
@@ -131,6 +135,7 @@
 		B93AB7E845086F6FBB068369 /* SuggestionRequestFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE94342B888A5A2CCF66BC93 /* SuggestionRequestFactoryTests.swift */; };
 		BB6325CA50F97B18B9725918 /* SuggestionTextNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B424E2AC97C99D335B0D5751 /* SuggestionTextNormalizer.swift */; };
 		BBE22CE4EF43247F8775B25D /* FocusPollBackoff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09FADF683BE7B3558377FA76 /* FocusPollBackoff.swift */; };
+		BBE74B21ED1543DEACF18A1A /* PlaceholderPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93028F328388432E72C58D09 /* PlaceholderPaneView.swift */; };
 		BFCA7FAFDAEBF586AB615567 /* ClipboardRelevanceFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90B0D133AB77A2503FB08827 /* ClipboardRelevanceFilterTests.swift */; };
 		C2C958D6E5F5FE1CCC414BCE /* SuggestionSubsystemContracts.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB16474A67CE1D210B944C9 /* SuggestionSubsystemContracts.swift */; };
 		C4C6734678797669055988E0 /* AppUpdateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD9573F3504CAE6891DF9B7D /* AppUpdateManager.swift */; };
@@ -192,6 +197,7 @@
 		110CB0B53016644EF7840301 /* HuggingFaceAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceAPIClient.swift; sourceTree = "<group>"; };
 		12DD19BCE610808F1E38702D /* PermissionOverlayTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOverlayTrackerTests.swift; sourceTree = "<group>"; };
 		18D990E515E1AE4F312F4E95 /* BundledRuntimeLocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledRuntimeLocatorTests.swift; sourceTree = "<group>"; };
+		19BE12C28A4AB8A4A58C2FF7 /* SettingsPaneScaffold.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPaneScaffold.swift; sourceTree = "<group>"; };
 		19DB9558F4D3AFB108D71649 /* SuggestionStateHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionStateHelperTests.swift; sourceTree = "<group>"; };
 		1CE61E74928C221B8BB261C6 /* SuggestionTextColorCodec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionTextColorCodec.swift; sourceTree = "<group>"; };
 		1D00A031C0D9CF2A7A2330D9 /* PermissionDragSourceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionDragSourceView.swift; sourceTree = "<group>"; };
@@ -231,6 +237,7 @@
 		5AD3F4F9FBE82007E4E15F58 /* GhostSuggestionLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostSuggestionLayoutTests.swift; sourceTree = "<group>"; };
 		5C4E5869D103865486AAAEEC /* ModelFileValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelFileValidator.swift; sourceTree = "<group>"; };
 		5C9FDF029F7828CAF3FE8850 /* FocusTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusTracker.swift; sourceTree = "<group>"; };
+		5D0AEFF86F8210CBE7CFCBAD /* SettingsCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsCategory.swift; sourceTree = "<group>"; };
 		5F2C764D29C8D50D0C854FF8 /* PermissionGuidanceController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionGuidanceController.swift; sourceTree = "<group>"; };
 		5F34AE24BB7C99D66E1F3904 /* InputModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputModels.swift; sourceTree = "<group>"; };
 		60629DFE309C1A4BD8A7FB3B /* RuntimeBootstrapModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimeBootstrapModel.swift; sourceTree = "<group>"; };
@@ -257,6 +264,7 @@
 		8F961F5DF2A392F6F5F94F8A /* SuggestionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionCoordinator.swift; sourceTree = "<group>"; };
 		90B0D133AB77A2503FB08827 /* ClipboardRelevanceFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardRelevanceFilterTests.swift; sourceTree = "<group>"; };
 		92C6EB9FDA48ADF425A116A9 /* PermissionOverlayWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOverlayWindowController.swift; sourceTree = "<group>"; };
+		93028F328388432E72C58D09 /* PlaceholderPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceholderPaneView.swift; sourceTree = "<group>"; };
 		944065A858D9BC936CB12B23 /* LlamaRuntimeCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LlamaRuntimeCore.swift; sourceTree = "<group>"; };
 		9458F0820B3161FE9CF1DDAF /* GhostFontSizeStabilizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostFontSizeStabilizer.swift; sourceTree = "<group>"; };
 		96495E4147D828C0B1B22765 /* ClipboardContentDistiller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardContentDistiller.swift; sourceTree = "<group>"; };
@@ -289,6 +297,7 @@
 		B6D42CD456B4B3C988B148A6 /* FocusTrackingModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusTrackingModel.swift; sourceTree = "<group>"; };
 		B81DD30EB657368AACE9625A /* InputMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputMonitor.swift; sourceTree = "<group>"; };
 		BA705EDFE1C41294F0E381F1 /* FocusSnapshotResolverSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusSnapshotResolverSelectionTests.swift; sourceTree = "<group>"; };
+		BADB38D0160B47637572FC5E /* SettingsSidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSidebarView.swift; sourceTree = "<group>"; };
 		BB5C2AE9A7E55495D26AD074 /* DownloadableModelCatalogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadableModelCatalogView.swift; sourceTree = "<group>"; };
 		BC4F887528AE74AC0DD30314 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		BD42C7E2852F59BEF7972663 /* MenuBarStatusLabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarStatusLabelView.swift; sourceTree = "<group>"; };
@@ -313,6 +322,7 @@
 		D504BEB224E0C176F5FCFF6E /* CompletionRenderModePolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionRenderModePolicyTests.swift; sourceTree = "<group>"; };
 		D5D6C2318E405AA717D1C256 /* WelcomePermissionStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomePermissionStepView.swift; sourceTree = "<group>"; };
 		D84D4528EEC9EFEB8AE8E318 /* ActivationIndicatorController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivationIndicatorController.swift; sourceTree = "<group>"; };
+		DB0CE9AB1286367BA2E82392 /* SettingsContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsContainerView.swift; sourceTree = "<group>"; };
 		DB73667A6FF0EA590D54DDF9 /* TooltipSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TooltipSupport.swift; sourceTree = "<group>"; };
 		DDE858CB1E687E3CEB8FDD5B /* SuggestionRequestFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionRequestFactory.swift; sourceTree = "<group>"; };
 		DEB16474A67CE1D210B944C9 /* SuggestionSubsystemContracts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionSubsystemContracts.swift; sourceTree = "<group>"; };
@@ -405,6 +415,14 @@
 			path = Visual;
 			sourceTree = "<group>";
 		};
+		2EE526D7C9284AF6687A556B /* Panes */ = {
+			isa = PBXGroup;
+			children = (
+				93028F328388432E72C58D09 /* PlaceholderPaneView.swift */,
+			);
+			path = Panes;
+			sourceTree = "<group>";
+		};
 		3725B1A195A06A4F014B75B1 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -451,6 +469,14 @@
 				5C9FDF029F7828CAF3FE8850 /* FocusTracker.swift */,
 			);
 			path = Focus;
+			sourceTree = "<group>";
+		};
+		6E1171BBC9CB74DB623C5E8B /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				19BE12C28A4AB8A4A58C2FF7 /* SettingsPaneScaffold.swift */,
+			);
+			path = Components;
 			sourceTree = "<group>";
 		};
 		717EB52365B64107A6FB1126 /* Coordinators */ = {
@@ -545,6 +571,7 @@
 		B0EBE873B895FB333A0BC26F /* UI */ = {
 			isa = PBXGroup;
 			children = (
+				DCBC24D605EC0CBA1DD6097D /* Settings */,
 				82F7F7355967725162DF2D1B /* CustomRulesEditor.swift */,
 				BB5C2AE9A7E55495D26AD074 /* DownloadableModelCatalogView.swift */,
 				CBD5FCB8CC56AA6138382B2C /* FieldEdgeIconIndicatorView.swift */,
@@ -567,6 +594,18 @@
 				264CA64B2AB1611F82E5B760 /* WelcomeView.swift */,
 			);
 			path = UI;
+			sourceTree = "<group>";
+		};
+		DCBC24D605EC0CBA1DD6097D /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				6E1171BBC9CB74DB623C5E8B /* Components */,
+				2EE526D7C9284AF6687A556B /* Panes */,
+				5D0AEFF86F8210CBE7CFCBAD /* SettingsCategory.swift */,
+				DB0CE9AB1286367BA2E82392 /* SettingsContainerView.swift */,
+				BADB38D0160B47637572FC5E /* SettingsSidebarView.swift */,
+			);
+			path = Settings;
 			sourceTree = "<group>";
 		};
 		DFE8419B341AF83B4D276BC0 = {
@@ -830,12 +869,17 @@
 				6106B16C0DBA94EBF838D93E /* PermissionOverlayTracker.swift in Sources */,
 				61EC9D635D416115E7C96E0F /* PermissionOverlayWindowController.swift in Sources */,
 				90DC9508F27F712EB61EEB06 /* PermissionReminderView.swift in Sources */,
+				BBE74B21ED1543DEACF18A1A /* PlaceholderPaneView.swift in Sources */,
 				98E2E14A069384C1088CDB44 /* PromptContextSanitizer.swift in Sources */,
 				82D4ADEAF05337ABDE4C586C /* RuntimeBootstrapModel.swift in Sources */,
 				2C6159231472A849F15BD0AE /* ScreenFrameReader.swift in Sources */,
 				0C06CAD62975E87B2C852191 /* ScreenTextExtractor.swift in Sources */,
 				DD7FA343F1C21C4569F6D181 /* ScreenshotContextGenerator.swift in Sources */,
+				907A0BF56C3BB0CBAF2649AB /* SettingsCategory.swift in Sources */,
+				2E3DEB7E89D0146274596F2E /* SettingsContainerView.swift in Sources */,
 				644EEF959D07D54CC779BBF6 /* SettingsCoordinator.swift in Sources */,
+				4B93D26BACEEA932E92B1A19 /* SettingsPaneScaffold.swift in Sources */,
+				27D4F5CACADE171F142178B4 /* SettingsSidebarView.swift in Sources */,
 				A440C596EFD9CD1E44F2579B /* SettingsView.swift in Sources */,
 				4F369F5284DDCEABF082E59B /* SuggestionAvailabilityEvaluator.swift in Sources */,
 				A0657CE0488F69F0BD559CBC /* SuggestionCoordinator+Acceptance.swift in Sources */,

--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		0431AE1DBEE36C90C7F39C19 /* CustomRulesCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43E587E421AF544A8300CE4 /* CustomRulesCatalog.swift */; };
 		0A2DDD946654076675AC0FC6 /* LanguageCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4BB93056F291FD24EFAD22 /* LanguageCatalog.swift */; };
 		0A3443AEE6540F11E5E6BF8F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E8E86A14090BC7BD13BA76 /* AppDelegate.swift */; };
+		0A658BF137DBD0898E40B87F /* AcknowledgementsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7A28471B8526C2693FFF65 /* AcknowledgementsView.swift */; };
 		0AF568AB234033BA2DE4CAA7 /* SuggestionModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 386C98FFCF76EC1C8C7E82BB /* SuggestionModels.swift */; };
 		0C06CAD62975E87B2C852191 /* ScreenTextExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59E299BE2E9D42A33D5D2F5D /* ScreenTextExtractor.swift */; };
 		0C98ECB5BCEBA72C693AC1C9 /* SuggestionTextNormalizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B55A4362AB7F0528C661C4C /* SuggestionTextNormalizerTests.swift */; };
@@ -49,11 +50,13 @@
 		32A2915FAE21CD9CE818A9D9 /* SuggestionSettingsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86460C747AA883FDE756BDBA /* SuggestionSettingsModel.swift */; };
 		344B9BF352C97CFA830853D6 /* WelcomePermissionStepView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D6C2318E405AA717D1C256 /* WelcomePermissionStepView.swift */; };
 		36312821AEE03E3E62845958 /* FoundationModelPromptRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE7BF162A12703249726F20A /* FoundationModelPromptRenderer.swift */; };
+		39571AB31481959CD5C223AE /* PermissionsPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7113D3373525113CA69E7597 /* PermissionsPaneView.swift */; };
 		3985F0F2B3178DBB945B1064 /* CompletionRenderModePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53CF416511099C6818110F01 /* CompletionRenderModePolicy.swift */; };
 		3B3E08D1204E85F3776D8853 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = BAADA69C6172DD7F4A642E93 /* Sparkle */; };
 		3C23336EE6F6559857DE92EE /* SuggestionDebugLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003594B09C83EF2DF35577D5 /* SuggestionDebugLogger.swift */; };
 		3CBBC3BFAC0DC8952EE24EF7 /* BundledRuntimeLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA33F5FFAC5B99384E15CE3E /* BundledRuntimeLocator.swift */; };
 		3CF1A4E39F24917DF0470A7D /* PromptPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4696A84D17890B154533A08F /* PromptPolicyTests.swift */; };
+		4134ADBE464D00BB748BD9AE /* GeneralPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07480CE96ED0EBD94817C6B1 /* GeneralPaneView.swift */; };
 		4190F8A76196B16ED94D0A55 /* VisualContextModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE97A8169438D593C6C23412 /* VisualContextModels.swift */; };
 		42D40F37086294D0E58200C5 /* GhostFontSizeStabilizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9458F0820B3161FE9CF1DDAF /* GhostFontSizeStabilizer.swift */; };
 		46F341472191BC451B6BF6B5 /* SuggestionRequestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDE858CB1E687E3CEB8FDD5B /* SuggestionRequestFactory.swift */; };
@@ -92,6 +95,7 @@
 		6E49ADEB31D04DC77A47DEB0 /* FileLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8C2569A8217EE9BD3B197F /* FileLogHandler.swift */; };
 		744B06C2488156B178675615 /* PermissionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85BF316556FDA64CB8AD07B6 /* PermissionManager.swift */; };
 		76FD91607794883F8E121450 /* CaretGeometrySelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3C84377F352140759B448C9 /* CaretGeometrySelector.swift */; };
+		78FAE5DB691A1B71042B9D20 /* AboutPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3FA53BBC3D81503C1D17477 /* AboutPaneView.swift */; };
 		7B6A63F5DCC2C163CDFD2A5C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BC4F887528AE74AC0DD30314 /* Assets.xcassets */; };
 		7C94725B4837DEC9ECF1BC54 /* CompletionRenderMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A03E565A11581FD2150B142 /* CompletionRenderMode.swift */; };
 		7D6BB9AF72F7076A4E5EE96F /* DownloadableModelCatalogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5C2AE9A7E55495D26AD074 /* DownloadableModelCatalogView.swift */; };
@@ -188,6 +192,7 @@
 		043E8AA850F930222DD112C0 /* GhostSuggestionLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostSuggestionLayout.swift; sourceTree = "<group>"; };
 		04E25414C307A20B6F9F20EC /* FocusSnapshotResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusSnapshotResolver.swift; sourceTree = "<group>"; };
 		050D929E13BE52E6282B64D2 /* VisualContextStartCoalescerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualContextStartCoalescerTests.swift; sourceTree = "<group>"; };
+		07480CE96ED0EBD94817C6B1 /* GeneralPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralPaneView.swift; sourceTree = "<group>"; };
 		09FADF683BE7B3558377FA76 /* FocusPollBackoff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusPollBackoff.swift; sourceTree = "<group>"; };
 		0A3D1125B962CBE0269EEDDB /* SuggestionInserter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionInserter.swift; sourceTree = "<group>"; };
 		0C383AE85B971A9605787358 /* FocusModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusModels.swift; sourceTree = "<group>"; };
@@ -209,6 +214,7 @@
 		262BE2F1E97389FE8D7A5FB9 /* Cotabby.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Cotabby.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		264CA64B2AB1611F82E5B760 /* WelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
 		273B4DC844F79B4BE2C8910F /* FocusPollBackoffTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusPollBackoffTests.swift; sourceTree = "<group>"; };
+		2B7A28471B8526C2693FFF65 /* AcknowledgementsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcknowledgementsView.swift; sourceTree = "<group>"; };
 		2D1F9CEBAB0F330F8E7B61D8 /* InputSuppressionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputSuppressionController.swift; sourceTree = "<group>"; };
 		2F01FAC4F57EB08471521196 /* VisualContextStartCoalescer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualContextStartCoalescer.swift; sourceTree = "<group>"; };
 		3009812A35A1CDEF16295AB7 /* LlamaPromptRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LlamaPromptRendererTests.swift; sourceTree = "<group>"; };
@@ -247,6 +253,7 @@
 		6C4565D64DF64A2AA0DB1532 /* WelcomeProfileStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeProfileStepView.swift; sourceTree = "<group>"; };
 		70367FCC1E0F08EE3B8EB26F /* FocusCapabilityResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusCapabilityResolver.swift; sourceTree = "<group>"; };
 		711293EA57808B9428C7B908 /* CotabbyAppEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CotabbyAppEnvironment.swift; sourceTree = "<group>"; };
+		7113D3373525113CA69E7597 /* PermissionsPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsPaneView.swift; sourceTree = "<group>"; };
 		72B13136DF7318F3E96DF0D3 /* SuggestionCoordinator+Acceptance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SuggestionCoordinator+Acceptance.swift"; sourceTree = "<group>"; };
 		74BD1D4DB27D5D96D1E06096 /* DisplayCoordinateConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayCoordinateConverter.swift; sourceTree = "<group>"; };
 		77B0121E7BB173F8A2B0B108 /* WindowScreenshotService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowScreenshotService.swift; sourceTree = "<group>"; };
@@ -278,6 +285,7 @@
 		9D82FFC568527700EC17C07D /* PermissionModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionModels.swift; sourceTree = "<group>"; };
 		A168A7B6A7AD11559B60C56B /* ApplicationBundleMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationBundleMetadataTests.swift; sourceTree = "<group>"; };
 		A3E8E86A14090BC7BD13BA76 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		A3FA53BBC3D81503C1D17477 /* AboutPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutPaneView.swift; sourceTree = "<group>"; };
 		A520809E71697E3BB9A8139C /* HuggingFaceModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceModels.swift; sourceTree = "<group>"; };
 		A52D0B550E00EF173A5D157E /* LlamaRuntimeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LlamaRuntimeManager.swift; sourceTree = "<group>"; };
 		A804F4DB6FD9BC8C27B2B65F /* LlamaRuntimeModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LlamaRuntimeModels.swift; sourceTree = "<group>"; };
@@ -418,6 +426,10 @@
 		2EE526D7C9284AF6687A556B /* Panes */ = {
 			isa = PBXGroup;
 			children = (
+				A3FA53BBC3D81503C1D17477 /* AboutPaneView.swift */,
+				2B7A28471B8526C2693FFF65 /* AcknowledgementsView.swift */,
+				07480CE96ED0EBD94817C6B1 /* GeneralPaneView.swift */,
+				7113D3373525113CA69E7597 /* PermissionsPaneView.swift */,
 				93028F328388432E72C58D09 /* PlaceholderPaneView.swift */,
 			);
 			path = Panes;
@@ -799,6 +811,8 @@
 			files = (
 				30F3F2B6D13CD583136CD787 /* AXHelper.swift in Sources */,
 				D9C51DEDF01033E276A479CE /* AXTextGeometryResolver.swift in Sources */,
+				78FAE5DB691A1B71042B9D20 /* AboutPaneView.swift in Sources */,
+				0A658BF137DBD0898E40B87F /* AcknowledgementsView.swift in Sources */,
 				26E0331E9E2F92FAE531BDEE /* ActivationIndicatorController.swift in Sources */,
 				0A3443AEE6540F11E5E6BF8F /* AppDelegate.swift in Sources */,
 				C4C6734678797669055988E0 /* AppUpdateManager.swift in Sources */,
@@ -832,6 +846,7 @@
 				D0D4C0E28F5CD99669A49414 /* FoundationModelAvailabilityService.swift in Sources */,
 				36312821AEE03E3E62845958 /* FoundationModelPromptRenderer.swift in Sources */,
 				6DD1E22151571E1A22FF22F4 /* FoundationModelSuggestionEngine.swift in Sources */,
+				4134ADBE464D00BB748BD9AE /* GeneralPaneView.swift in Sources */,
 				42D40F37086294D0E58200C5 /* GhostFontSizeStabilizer.swift in Sources */,
 				ED9C51B0D7056F0753AADF2D /* GhostSuggestionLayout.swift in Sources */,
 				F4EEE6291095B0BF2D3FBA21 /* GhostTextColorPreset.swift in Sources */,
@@ -869,6 +884,7 @@
 				6106B16C0DBA94EBF838D93E /* PermissionOverlayTracker.swift in Sources */,
 				61EC9D635D416115E7C96E0F /* PermissionOverlayWindowController.swift in Sources */,
 				90DC9508F27F712EB61EEB06 /* PermissionReminderView.swift in Sources */,
+				39571AB31481959CD5C223AE /* PermissionsPaneView.swift in Sources */,
 				BBE74B21ED1543DEACF18A1A /* PlaceholderPaneView.swift in Sources */,
 				98E2E14A069384C1088CDB44 /* PromptContextSanitizer.swift in Sources */,
 				82D4ADEAF05337ABDE4C586C /* RuntimeBootstrapModel.swift in Sources */,

--- a/Cotabby/App/Coordinators/SettingsCoordinator.swift
+++ b/Cotabby/App/Coordinators/SettingsCoordinator.swift
@@ -45,6 +45,16 @@ final class SettingsCoordinator: NSObject, NSWindowDelegate {
         self.onShowWelcome = onShowWelcome
     }
 
+    /// UserDefaults key that toggles between the legacy single-form Settings and the redesigned
+    /// sidebar Settings. Default is `false` (legacy) until the redesign is feature-complete; flip
+    /// to `true` to dogfood. The key is intentionally kept narrow so a regression can be reverted
+    /// with a single `defaults write` without redeploying the app.
+    static let redesignEnabledDefaultsKey = "cotabbySettingsRedesignEnabled"
+
+    private var isRedesignEnabled: Bool {
+        UserDefaults.standard.bool(forKey: Self.redesignEnabledDefaultsKey)
+    }
+
     /// Shows the settings window, reusing the existing instance if it is already open.
     /// Reusing one window avoids subtle state duplication and matches standard macOS settings
     /// behavior where there is a single shared preferences surface for the app.
@@ -55,22 +65,55 @@ final class SettingsCoordinator: NSObject, NSWindowDelegate {
             return
         }
 
-        let hostingController = NSHostingController(
-            rootView: SettingsView(
-                appUpdateManager: appUpdateManager,
-                launchAtLoginService: launchAtLoginService,
-                permissionManager: permissionManager,
-                suggestionSettings: suggestionSettings,
-                foundationModelAvailabilityService: foundationModelAvailabilityService,
-                runtimeModel: runtimeModel,
-                modelDownloadManager: modelDownloadManager,
-                huggingFaceSearchService: huggingFaceSearchService,
-                onShowWelcome: onShowWelcome
+        let hostingController: NSHostingController<AnyView>
+        let initialFrame: CGRect
+        let minSize: NSSize
+        let autosaveName: String
+
+        if isRedesignEnabled {
+            hostingController = NSHostingController(
+                rootView: AnyView(
+                    SettingsContainerView(
+                        appUpdateManager: appUpdateManager,
+                        launchAtLoginService: launchAtLoginService,
+                        permissionManager: permissionManager,
+                        suggestionSettings: suggestionSettings,
+                        foundationModelAvailabilityService: foundationModelAvailabilityService,
+                        runtimeModel: runtimeModel,
+                        modelDownloadManager: modelDownloadManager,
+                        huggingFaceSearchService: huggingFaceSearchService,
+                        onShowWelcome: onShowWelcome
+                    )
+                )
             )
-        )
+            initialFrame = CGRect(x: 0, y: 0, width: 960, height: 680)
+            minSize = NSSize(width: 820, height: 540)
+            // Separate autosave name so the redesigned layout starts from its own default frame
+            // for users who already had a smaller saved frame from the legacy window.
+            autosaveName = "CotabbySettingsWindowV2"
+        } else {
+            hostingController = NSHostingController(
+                rootView: AnyView(
+                    SettingsView(
+                        appUpdateManager: appUpdateManager,
+                        launchAtLoginService: launchAtLoginService,
+                        permissionManager: permissionManager,
+                        suggestionSettings: suggestionSettings,
+                        foundationModelAvailabilityService: foundationModelAvailabilityService,
+                        runtimeModel: runtimeModel,
+                        modelDownloadManager: modelDownloadManager,
+                        huggingFaceSearchService: huggingFaceSearchService,
+                        onShowWelcome: onShowWelcome
+                    )
+                )
+            )
+            initialFrame = CGRect(x: 0, y: 0, width: 700, height: 620)
+            minSize = NSSize(width: 640, height: 520)
+            autosaveName = "CotabbySettingsWindow"
+        }
 
         let window = NSWindow(
-            contentRect: CGRect(x: 0, y: 0, width: 700, height: 620),
+            contentRect: initialFrame,
             styleMask: [.titled, .closable, .miniaturizable, .resizable],
             backing: .buffered,
             defer: false
@@ -80,8 +123,8 @@ final class SettingsCoordinator: NSObject, NSWindowDelegate {
         window.isReleasedWhenClosed = false
         window.level = .normal
         window.collectionBehavior = [.moveToActiveSpace, .fullScreenAuxiliary]
-        window.minSize = NSSize(width: 640, height: 520)
-        window.setFrameAutosaveName("CotabbySettingsWindow")
+        window.minSize = minSize
+        window.setFrameAutosaveName(autosaveName)
         window.delegate = self
         window.contentViewController = hostingController
 

--- a/Cotabby/UI/Settings/Components/SettingsPaneScaffold.swift
+++ b/Cotabby/UI/Settings/Components/SettingsPaneScaffold.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+
+/// File overview:
+/// Shared chrome for every settings detail pane. Pulls the form styling, scroll wrapping, and
+/// optional top-of-pane callout into one place so individual panes stay focused on their rows
+/// rather than repeating layout boilerplate.
+///
+/// Why a callout slot:
+/// The legacy settings window puts a single attention banner at the top of the form. The redesign
+/// surfaces attention per pane: when a pane is in a degraded state (missing permission, runtime
+/// unavailable) we render an inline callout above the form so the actionable surface lives next to
+/// the controls that fix it.
+struct SettingsPaneScaffold<Content: View>: View {
+    let callout: SettingsPaneCallout?
+    @ViewBuilder let content: () -> Content
+
+    init(
+        callout: SettingsPaneCallout? = nil,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
+        self.callout = callout
+        self.content = content
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                if let callout {
+                    SettingsCalloutView(callout: callout)
+                        .padding(.horizontal, 20)
+                        .padding(.top, 16)
+                }
+                Form {
+                    content()
+                }
+                .formStyle(.grouped)
+            }
+        }
+    }
+}
+
+struct SettingsPaneCallout: Equatable {
+    enum Tone {
+        case warning
+        case info
+    }
+
+    let tone: Tone
+    let message: String
+}
+
+private struct SettingsCalloutView: View {
+    let callout: SettingsPaneCallout
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: iconName)
+                .foregroundStyle(tint)
+                .imageScale(.medium)
+
+            Text(callout.message)
+                .font(.callout)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(tint.opacity(0.12))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(tint.opacity(0.4), lineWidth: 1)
+        )
+    }
+
+    private var iconName: String {
+        switch callout.tone {
+        case .warning: return "exclamationmark.triangle.fill"
+        case .info: return "info.circle.fill"
+        }
+    }
+
+    private var tint: Color {
+        switch callout.tone {
+        case .warning: return .orange
+        case .info: return .accentColor
+        }
+    }
+}

--- a/Cotabby/UI/Settings/Panes/AboutPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/AboutPaneView.swift
@@ -1,0 +1,120 @@
+import AppKit
+import SwiftUI
+
+/// File overview:
+/// "About" detail pane of the redesigned Settings window. Consolidates what used to live across
+/// three legacy sections (header, support CTA, uninstall) plus a new Acknowledgements modal that
+/// lists the third-party packages Cotabby ships with.
+struct AboutPaneView: View {
+    let appUpdateManager: AppUpdateManager
+
+    @State private var isShowingAcknowledgements = false
+
+    var body: some View {
+        SettingsPaneScaffold {
+            Section { aboutHeader }
+            Section("Support") { supportRow }
+            Section("Links") { linksRow }
+            Section("Uninstall") { uninstallText }
+        }
+        .sheet(isPresented: $isShowingAcknowledgements) {
+            AcknowledgementsView { isShowingAcknowledgements = false }
+        }
+    }
+
+    @ViewBuilder
+    private var aboutHeader: some View {
+        HStack(spacing: 12) {
+            Image("CotabbyLogo")
+                .resizable()
+                .scaledToFit()
+                .frame(width: 40, height: 40)
+                .clipShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Cotabby")
+                    .font(.system(size: 16, weight: .semibold, design: .rounded))
+
+                Text("Local macOS AI Autocomplete")
+                    .font(.system(size: 12, design: .rounded))
+                    .foregroundStyle(.secondary)
+
+                Text(appVersionText)
+                    .font(.system(size: 11, design: .rounded))
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: 12)
+
+            Button("Check for Updates") {
+                appUpdateManager.checkForUpdates()
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    @ViewBuilder
+    private var supportRow: some View {
+        LabeledContent {
+            Link(destination: URL(string: "https://ko-fi.com/cotabby")!) {
+                Label("Support", systemImage: "heart.fill")
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.blue)
+        } label: {
+            Text(
+                "Cotabby is free and open source, maintained by two university students in our free time. "
+                + "If it's useful to you, please consider supporting development."
+            )
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    @ViewBuilder
+    private var linksRow: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Link(destination: URL(string: "https://github.com/FuJacob/cotabby")!) {
+                Label("GitHub Repository", systemImage: "chevron.left.forwardslash.chevron.right")
+            }
+            Link(destination: URL(string: "https://github.com/FuJacob/Cotabby/wiki")!) {
+                Label("Wiki & Contributor Guide", systemImage: "book")
+            }
+            Button {
+                isShowingAcknowledgements = true
+            } label: {
+                Label("Acknowledgements", systemImage: "doc.text")
+            }
+            .buttonStyle(.link)
+        }
+    }
+
+    @ViewBuilder
+    private var uninstallText: some View {
+        Text(
+            "Drag Cotabby.app from Applications to the Trash. "
+            + "To remove leftover data, also delete ~/Library/Application Support/Cotabby. "
+            + "Privacy permissions can only be revoked in System Settings → Privacy & Security."
+        )
+        .font(.caption)
+        .foregroundStyle(.secondary)
+    }
+
+    /// The app bundle is the canonical source for human-facing version text.
+    private var appVersionText: String {
+        let shortVersion =
+            Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+        let buildNumber = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String
+
+        switch (shortVersion, buildNumber) {
+        case (let shortVersion?, let buildNumber?) where shortVersion != buildNumber:
+            return "Version \(shortVersion) (\(buildNumber))"
+        case (let shortVersion?, _):
+            return "Version \(shortVersion)"
+        case (_, let buildNumber?):
+            return "Build \(buildNumber)"
+        default:
+            return "Unknown version"
+        }
+    }
+}

--- a/Cotabby/UI/Settings/Panes/AboutPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/AboutPaneView.swift
@@ -56,11 +56,13 @@ struct AboutPaneView: View {
     @ViewBuilder
     private var supportRow: some View {
         LabeledContent {
-            Link(destination: URL(string: "https://ko-fi.com/cotabby")!) {
-                Label("Support", systemImage: "heart.fill")
+            if let supportURL = URL(string: "https://ko-fi.com/cotabby") {
+                Link(destination: supportURL) {
+                    Label("Support", systemImage: "heart.fill")
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.blue)
             }
-            .buttonStyle(.borderedProminent)
-            .tint(.blue)
         } label: {
             Text(
                 "Cotabby is free and open source, maintained by two university students in our free time. "
@@ -74,11 +76,15 @@ struct AboutPaneView: View {
     @ViewBuilder
     private var linksRow: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Link(destination: URL(string: "https://github.com/FuJacob/cotabby")!) {
-                Label("GitHub Repository", systemImage: "chevron.left.forwardslash.chevron.right")
+            if let repoURL = URL(string: "https://github.com/FuJacob/Cotabby") {
+                Link(destination: repoURL) {
+                    Label("GitHub Repository", systemImage: "chevron.left.forwardslash.chevron.right")
+                }
             }
-            Link(destination: URL(string: "https://github.com/FuJacob/Cotabby/wiki")!) {
-                Label("Wiki & Contributor Guide", systemImage: "book")
+            if let wikiURL = URL(string: "https://github.com/FuJacob/Cotabby/wiki") {
+                Link(destination: wikiURL) {
+                    Label("Wiki & Contributor Guide", systemImage: "book")
+                }
             }
             Button {
                 isShowingAcknowledgements = true

--- a/Cotabby/UI/Settings/Panes/AcknowledgementsView.swift
+++ b/Cotabby/UI/Settings/Panes/AcknowledgementsView.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+
+/// File overview:
+/// Modal sheet listing the third-party packages Cotabby ships with. Lightweight by design: each
+/// row names the project, summarizes what it does for Cotabby, and links to its repo. The intent
+/// is attribution, not a full license dump; the GitHub repo carries the verbatim license texts.
+struct AcknowledgementsView: View {
+    let onClose: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            Divider()
+            ScrollView {
+                VStack(alignment: .leading, spacing: 14) {
+                    ForEach(Self.entries) { entry in
+                        AcknowledgementRow(entry: entry)
+                    }
+                    Text(
+                        "Each project ships under its own license; see the linked repository for the "
+                        + "verbatim text."
+                    )
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                }
+                .padding(20)
+            }
+        }
+        .frame(width: 520, height: 460)
+    }
+
+    @ViewBuilder
+    private var header: some View {
+        HStack {
+            Text("Acknowledgements")
+                .font(.system(size: 15, weight: .semibold))
+            Spacer(minLength: 0)
+            Button("Done", action: onClose)
+                .keyboardShortcut(.defaultAction)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+    }
+
+    private static let entries: [AcknowledgementEntry] = [
+        AcknowledgementEntry(
+            name: "llama.cpp",
+            summary: "On-device inference engine for GGUF models on the Open Source path.",
+            url: "https://github.com/ggml-org/llama.cpp"
+        ),
+        AcknowledgementEntry(
+            name: "Sparkle",
+            summary: "Update framework used by the Check for Updates button.",
+            url: "https://github.com/sparkle-project/Sparkle"
+        ),
+        AcknowledgementEntry(
+            name: "swift-log",
+            summary: "Logging façade Cotabby uses across runtime, focus, and suggestion subsystems.",
+            url: "https://github.com/apple/swift-log"
+        ),
+        AcknowledgementEntry(
+            name: "CotabbyInference",
+            summary: "Swift wrapper around llama.cpp that exposes the inference API Cotabby links against.",
+            url: "https://github.com/FuJacob/cotabbyinference"
+        )
+    ]
+}
+
+private struct AcknowledgementEntry: Identifiable {
+    let name: String
+    let summary: String
+    let url: String
+
+    var id: String { name }
+}
+
+private struct AcknowledgementRow: View {
+    let entry: AcknowledgementEntry
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 6) {
+                Text(entry.name)
+                    .font(.system(size: 13, weight: .semibold))
+                if let url = URL(string: entry.url) {
+                    Link(destination: url) {
+                        Image(systemName: "arrow.up.right.square")
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+                }
+            }
+            Text(entry.summary)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}

--- a/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
@@ -1,0 +1,212 @@
+import SwiftUI
+
+/// File overview:
+/// "General" detail pane of the redesigned Settings window. Owns the everyday on/off toggles, the
+/// ghost-text appearance controls, and the onboarding re-entry. Lifted intact from the legacy
+/// `SettingsView.generalSection` so behavior, bindings, and tooltip copy stay identical; only the
+/// scaffolding around the form is new.
+struct GeneralPaneView: View {
+    @ObservedObject var suggestionSettings: SuggestionSettingsModel
+    let onShowWelcome: () -> Void
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        SettingsPaneScaffold {
+            Section("General") {
+                Toggle("Enable Globally", isOn: globallyEnabledBinding)
+                    .cotabbyHelp("Master switch. Turn off to silence Cotabby in every app.")
+
+                Toggle("Show Indicator", isOn: showIndicatorBinding)
+                    .cotabbyHelp("Show a small icon next to the cursor when Cotabby is active in a field.")
+
+                Toggle(isOn: showAcceptanceHintBinding) {
+                    HStack(spacing: 4) {
+                        Text("Show")
+                        Text(suggestionSettings.acceptanceKeyLabel)
+                            .font(.system(.body, design: .rounded).weight(.semibold))
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 1)
+                            .background(
+                                RoundedRectangle(cornerRadius: 4, style: .continuous)
+                                    .fill(.quaternary)
+                            )
+                        Text("Key Hint")
+                    }
+                }
+                .cotabbyHelp("Show a small label near the ghost text reminding you which key accepts it.")
+
+                Picker("Suggestion Display", selection: mirrorPreferenceBinding) {
+                    ForEach(MirrorPreference.allCases) { preference in
+                        Text(preference.displayLabel).tag(preference)
+                    }
+                }
+                .pickerStyle(.menu)
+                .help(
+                    "Auto uses inline ghost text when the focused field exposes a reliable cursor " +
+                    "position, and switches to a popup card when it doesn't (some Electron and web " +
+                    "editors). Choose Inline or Popup to pin one style for every app."
+                )
+
+                Toggle("Allow Multi-line Suggestions", isOn: multiLineEnabledBinding)
+                    .cotabbyHelp("Let suggestions span more than one line. Off keeps them to a single line.")
+
+                Toggle("Accept Punctuation With Word", isOn: autoAcceptTrailingPunctuationBinding)
+                    .cotabbyHelp("With this on, accepting a word also takes punctuation attached to it, like the \"?\" in \"you?\".")
+
+                Toggle("Include Clipboard Context", isOn: clipboardContextEnabledBinding)
+                    .cotabbyHelp("Include your latest clipboard contents in the prompt so completions can reference what you copied.")
+
+                Toggle("Fast Mode", isOn: fastModeEnabledBinding)
+                    .cotabbyHelp("Skip on-screen OCR context for faster, lower-overhead suggestions. Predictions still run.")
+
+                LabeledContent("Ghost Text Color") {
+                    HStack(spacing: 8) {
+                        ForEach(GhostTextColorPreset.all) { preset in
+                            ghostColorSwatch(for: preset)
+                        }
+                    }
+                }
+                .cotabbyHelp("Color of the ghost text shown before you accept it.")
+
+                LabeledContent("Ghost Text Opacity") {
+                    HStack(spacing: 10) {
+                        TickMarkSlider(
+                            value: ghostTextOpacityBinding,
+                            range: SuggestionSettingsModel.minimumGhostTextOpacity
+                                ... SuggestionSettingsModel.maximumGhostTextOpacity,
+                            step: SuggestionSettingsModel.ghostTextOpacityStep
+                        )
+                        .frame(width: 180)
+
+                        Text(ghostTextOpacityLabel)
+                            .font(.callout)
+                            .monospacedDigit()
+                            .foregroundStyle(.secondary)
+                            .frame(width: 42, alignment: .trailing)
+                    }
+                }
+                .cotabbyHelp("How visible the ghost text is. Lower values are subtler but harder to read.")
+
+                LabeledContent("Onboarding") {
+                    Button("Open Welcome Guide") {
+                        onShowWelcome()
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Bindings
+
+    private var globallyEnabledBinding: Binding<Bool> {
+        Binding(
+            get: { suggestionSettings.isGloballyEnabled },
+            set: { suggestionSettings.setGloballyEnabled($0) }
+        )
+    }
+
+    private var showIndicatorBinding: Binding<Bool> {
+        Binding(
+            get: { suggestionSettings.showIndicator },
+            set: { suggestionSettings.setShowIndicator($0) }
+        )
+    }
+
+    private var showAcceptanceHintBinding: Binding<Bool> {
+        Binding(
+            get: { suggestionSettings.showAcceptanceHint },
+            set: { suggestionSettings.setShowAcceptanceHint($0) }
+        )
+    }
+
+    private var mirrorPreferenceBinding: Binding<MirrorPreference> {
+        Binding(
+            get: { suggestionSettings.mirrorPreference },
+            set: { suggestionSettings.setMirrorPreference($0) }
+        )
+    }
+
+    private var multiLineEnabledBinding: Binding<Bool> {
+        Binding(
+            get: { suggestionSettings.isMultiLineEnabled },
+            set: { suggestionSettings.setMultiLineEnabled($0) }
+        )
+    }
+
+    private var autoAcceptTrailingPunctuationBinding: Binding<Bool> {
+        Binding(
+            get: { suggestionSettings.autoAcceptTrailingPunctuation },
+            set: { suggestionSettings.setAutoAcceptTrailingPunctuation($0) }
+        )
+    }
+
+    private var clipboardContextEnabledBinding: Binding<Bool> {
+        Binding(
+            get: { suggestionSettings.isClipboardContextEnabled },
+            set: { suggestionSettings.setClipboardContextEnabled($0) }
+        )
+    }
+
+    private var fastModeEnabledBinding: Binding<Bool> {
+        Binding(
+            get: { suggestionSettings.isFastModeEnabled },
+            set: { suggestionSettings.setFastModeEnabled($0) }
+        )
+    }
+
+    private var ghostTextOpacityBinding: Binding<Double> {
+        Binding(
+            get: { suggestionSettings.ghostTextOpacity },
+            set: { suggestionSettings.setGhostTextOpacity($0) }
+        )
+    }
+
+    // MARK: - Ghost color swatch helpers
+
+    /// Mirrors the overlay's automatic fallback (`GhostSuggestionView.ghostColor`) so the Automatic
+    /// swatch previews the same gray the user will actually see.
+    private var automaticGhostTextColor: Color {
+        colorScheme == .dark
+            ? Color(red: 0.65, green: 0.65, blue: 0.65)
+            : Color(red: 0.45, green: 0.45, blue: 0.45)
+    }
+
+    private var ghostTextOpacityLabel: String {
+        "\(Int((suggestionSettings.ghostTextOpacity * 100).rounded()))%"
+    }
+
+    @ViewBuilder
+    private func ghostColorSwatch(for preset: GhostTextColorPreset) -> some View {
+        let isSelected = GhostTextColorPreset.matching(
+            hex: suggestionSettings.customSuggestionTextColorHex
+        ) == preset
+
+        Button {
+            suggestionSettings.setCustomSuggestionTextColorHex(preset.hex)
+        } label: {
+            Circle()
+                .fill(swatchFill(for: preset))
+                .frame(width: 18, height: 18)
+                .overlay(
+                    Circle()
+                        .strokeBorder(
+                            Color.primary.opacity(isSelected ? 0.9 : 0.18),
+                            lineWidth: isSelected ? 2 : 1
+                        )
+                )
+        }
+        .buttonStyle(.plain)
+        .cotabbyHelp(preset.name)
+    }
+
+    private func swatchFill(for preset: GhostTextColorPreset) -> Color {
+        guard let hex = preset.hex,
+              let color = SuggestionTextColorCodec.color(fromHex: hex)
+        else {
+            return automaticGhostTextColor
+        }
+
+        return color
+    }
+}

--- a/Cotabby/UI/Settings/Panes/PermissionsPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/PermissionsPaneView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 /// shortcut into the relevant System Settings pane when one of them is missing.
 struct PermissionsPaneView: View {
     @ObservedObject var permissionManager: PermissionManager
+    @Environment(\.scenePhase) private var scenePhase
 
     var body: some View {
         SettingsPaneScaffold(callout: callout) {
@@ -34,6 +35,13 @@ struct PermissionsPaneView: View {
             }
         }
         .onAppear { permissionManager.refresh() }
+        // Re-check on scene activation: .onAppear does not fire when returning from
+        // System Settings, so permission status would otherwise stay stale.
+        .onChange(of: scenePhase) { _, newPhase in
+            if newPhase == .active {
+                permissionManager.refresh()
+            }
+        }
     }
 
     /// Top-of-pane callout when any required permission is still missing. The full picture stays

--- a/Cotabby/UI/Settings/Panes/PermissionsPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/PermissionsPaneView.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+/// File overview:
+/// "Permissions" detail pane of the redesigned Settings window. Renders status rows for the three
+/// permissions Cotabby requires (Accessibility, Input Monitoring, Screen Recording) and offers a
+/// shortcut into the relevant System Settings pane when one of them is missing.
+struct PermissionsPaneView: View {
+    @ObservedObject var permissionManager: PermissionManager
+
+    var body: some View {
+        SettingsPaneScaffold(callout: callout) {
+            Section("Permissions") {
+                Text("Cotabby needs Accessibility, Input Monitoring, and Screen Recording for autocomplete.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                permissionRow(
+                    title: "Accessibility",
+                    granted: permissionManager.accessibilityGranted,
+                    action: permissionManager.openAccessibilitySettings
+                )
+
+                permissionRow(
+                    title: "Input Monitoring",
+                    granted: permissionManager.inputMonitoringGranted,
+                    action: permissionManager.openInputMonitoringSettings
+                )
+
+                permissionRow(
+                    title: "Screen Recording",
+                    granted: permissionManager.screenRecordingGranted,
+                    action: permissionManager.openScreenRecordingSettings
+                )
+            }
+        }
+        .onAppear { permissionManager.refresh() }
+    }
+
+    /// Top-of-pane callout when any required permission is still missing. The full picture stays
+    /// in the rows below; this just surfaces the broken state without making the user read each row
+    /// in turn.
+    private var callout: SettingsPaneCallout? {
+        guard !permissionManager.requiredPermissionsGranted else {
+            return nil
+        }
+        return SettingsPaneCallout(
+            tone: .warning,
+            message: "Cotabby needs more access to run. Grant the permissions below to enable autocomplete."
+        )
+    }
+
+    @ViewBuilder
+    private func permissionRow(
+        title: String,
+        granted: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        HStack(spacing: 10) {
+            Text(title)
+            Spacer(minLength: 0)
+            Text(granted ? "Granted" : "Needs Access")
+                .font(.caption.weight(.medium))
+                .foregroundStyle(granted ? .green : .orange)
+
+            if !granted {
+                Button("Open Settings") {
+                    action()
+                }
+                .controlSize(.small)
+                .cotabbyHelp("Open System Settings to Privacy & Security so you can grant this permission.")
+            }
+        }
+    }
+}

--- a/Cotabby/UI/Settings/Panes/PlaceholderPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/PlaceholderPaneView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+/// File overview:
+/// Stand-in detail pane used while the redesigned panes are being built out across the multi-PR
+/// stack. Each subsequent PR replaces one of these with a real pane. Keeping a placeholder shape
+/// in the scaffold PR means the container renders correctly even when only the framework is wired.
+struct PlaceholderPaneView: View {
+    let category: SettingsCategory
+
+    var body: some View {
+        SettingsPaneScaffold {
+            Section {
+                VStack(alignment: .leading, spacing: 10) {
+                    Label(category.label, systemImage: category.systemImage)
+                        .font(.system(size: 16, weight: .semibold, design: .rounded))
+
+                    Text("This pane is being moved into the new Settings layout in an upcoming change.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(.vertical, 6)
+            }
+        }
+    }
+}

--- a/Cotabby/UI/Settings/SettingsCategory.swift
+++ b/Cotabby/UI/Settings/SettingsCategory.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+/// File overview:
+/// The catalog of sidebar rows in the redesigned Settings window.
+///
+/// Each case is one selectable row. `section` drives the visual grouping in the sidebar (rows in
+/// the same section render under the same header). `engineAndModel` is intentionally also a row
+/// the user can land on: when neither sub-row is selected we show a parent overview pane that owns
+/// the engine picker, so the user has a single place to switch engines. The two sub-cases
+/// (`appleIntelligence`, `openSource`) host the engine-specific content.
+enum SettingsCategory: String, CaseIterable, Hashable, Identifiable {
+    case general
+    case engineAndModel
+    case appleIntelligence
+    case openSource
+    case writing
+    case shortcuts
+    case apps
+    case permissions
+    case about
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .general: return "General"
+        case .engineAndModel: return "Engine & Model"
+        case .appleIntelligence: return "Apple Intelligence"
+        case .openSource: return "Open Source"
+        case .writing: return "Writing"
+        case .shortcuts: return "Shortcuts"
+        case .apps: return "Apps"
+        case .permissions: return "Permissions"
+        case .about: return "About"
+        }
+    }
+
+    /// SF Symbol displayed at the left of each sidebar row.
+    var systemImage: String {
+        switch self {
+        case .general: return "gearshape.fill"
+        case .engineAndModel: return "cpu.fill"
+        case .appleIntelligence: return "apple.logo"
+        case .openSource: return "shippingbox.fill"
+        case .writing: return "square.and.pencil"
+        case .shortcuts: return "keyboard.fill"
+        case .apps: return "app.badge.fill"
+        case .permissions: return "lock.shield.fill"
+        case .about: return "info.circle.fill"
+        }
+    }
+
+    var section: SettingsSidebarSection {
+        switch self {
+        case .general: return .top
+        case .engineAndModel, .appleIntelligence, .openSource: return .engineModel
+        case .writing, .shortcuts, .apps: return .customize
+        case .permissions: return .system
+        case .about: return .meta
+        }
+    }
+
+    /// Rows that nest visually beneath their parent in the sidebar render with extra indentation.
+    /// Today only the two engine sub-rows count; everything else sits at the top level.
+    var isSubRow: Bool {
+        switch self {
+        case .appleIntelligence, .openSource: return true
+        default: return false
+        }
+    }
+}
+
+/// Visual groups used to render section headers in the sidebar. Cases without a `title` render
+/// without a header so the sidebar stays compact; cases with one show a small uppercase label
+/// above the rows in that group.
+enum SettingsSidebarSection: CaseIterable {
+    case top
+    case engineModel
+    case customize
+    case system
+    case meta
+
+    var title: String? {
+        switch self {
+        case .top, .meta: return nil
+        case .engineModel: return "Engine & Model"
+        case .customize: return "Customize"
+        case .system: return "System"
+        }
+    }
+}

--- a/Cotabby/UI/Settings/SettingsContainerView.swift
+++ b/Cotabby/UI/Settings/SettingsContainerView.swift
@@ -1,0 +1,80 @@
+import AppKit
+import SwiftUI
+
+/// File overview:
+/// Root of the redesigned Settings window. A `NavigationSplitView` with a sidebar of categorized
+/// rows on the left and a switching detail pane on the right. The detail body is built from
+/// `SettingsCategory`, so adding a new pane is a matter of adding an enum case and a `case` in the
+/// switch below.
+///
+/// Selection is persisted via `@AppStorage` so reopening Settings lands on the last-used pane.
+/// `.id(selection)` on the detail body is the documented workaround for the macOS 14 split-view
+/// selection bug where the first sidebar pick doesn't always re-render the detail column.
+///
+/// The view takes the same observable graph as the legacy `SettingsView` so the coordinator can
+/// swap hosting controllers behind a feature flag without rewiring dependencies.
+struct SettingsContainerView: View {
+    let appUpdateManager: AppUpdateManager
+
+    @ObservedObject var launchAtLoginService: LaunchAtLoginService
+    @ObservedObject var permissionManager: PermissionManager
+    @ObservedObject var suggestionSettings: SuggestionSettingsModel
+    @ObservedObject var foundationModelAvailabilityService: FoundationModelAvailabilityService
+    @ObservedObject var runtimeModel: RuntimeBootstrapModel
+    @ObservedObject var modelDownloadManager: ModelDownloadManager
+    @ObservedObject var huggingFaceSearchService: HuggingFaceSearchService
+
+    let onShowWelcome: () -> Void
+
+    @AppStorage("cotabbySettingsSelectedCategoryV2")
+    private var storedCategoryRawValue: String = SettingsCategory.general.rawValue
+
+    @State private var selection: SettingsCategory = .general
+
+    var body: some View {
+        NavigationSplitView {
+            SettingsSidebarView(selection: $selection)
+        } detail: {
+            detailPane
+                .id(selection)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .navigationSplitViewStyle(.balanced)
+        .frame(minWidth: 820, minHeight: 540)
+        .onAppear {
+            selection = SettingsCategory(rawValue: storedCategoryRawValue) ?? .general
+            launchAtLoginService.refresh()
+            permissionManager.refresh()
+        }
+        .onChange(of: selection) { _, newValue in
+            storedCategoryRawValue = newValue.rawValue
+            syncWindowTitle(for: newValue)
+        }
+    }
+
+    @ViewBuilder
+    private var detailPane: some View {
+        switch selection {
+        case .general,
+             .engineAndModel,
+             .appleIntelligence,
+             .openSource,
+             .writing,
+             .shortcuts,
+             .apps,
+             .permissions,
+             .about:
+            PlaceholderPaneView(category: selection)
+        }
+    }
+
+    /// Mirrors the chosen pane into the hosting `NSWindow.title` so the title bar reflects the
+    /// current selection. macOS settings windows traditionally use an inline title for the active
+    /// pane; this preserves that convention without rendering a duplicate large title inside the
+    /// content.
+    private func syncWindowTitle(for category: SettingsCategory) {
+        DispatchQueue.main.async {
+            NSApp.keyWindow?.title = "Settings — \(category.label)"
+        }
+    }
+}

--- a/Cotabby/UI/Settings/SettingsContainerView.swift
+++ b/Cotabby/UI/Settings/SettingsContainerView.swift
@@ -55,15 +55,21 @@ struct SettingsContainerView: View {
     @ViewBuilder
     private var detailPane: some View {
         switch selection {
-        case .general,
-             .engineAndModel,
+        case .general:
+            GeneralPaneView(
+                suggestionSettings: suggestionSettings,
+                onShowWelcome: onShowWelcome
+            )
+        case .permissions:
+            PermissionsPaneView(permissionManager: permissionManager)
+        case .about:
+            AboutPaneView(appUpdateManager: appUpdateManager)
+        case .engineAndModel,
              .appleIntelligence,
              .openSource,
              .writing,
              .shortcuts,
-             .apps,
-             .permissions,
-             .about:
+             .apps:
             PlaceholderPaneView(category: selection)
         }
     }

--- a/Cotabby/UI/Settings/SettingsSidebarView.swift
+++ b/Cotabby/UI/Settings/SettingsSidebarView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+/// File overview:
+/// Renders the sidebar list of the redesigned Settings window. Sections drive visual grouping;
+/// `selection` is the binding the container view uses to decide which detail pane to show.
+///
+/// Why this lives in its own file:
+/// the sidebar's row ordering, section headers, and indentation rules are sidebar concerns. Keeping
+/// them out of the container view leaves the container as a small `NavigationSplitView` shell that
+/// is easy to skim.
+struct SettingsSidebarView: View {
+    @Binding var selection: SettingsCategory
+
+    var body: some View {
+        List(selection: $selection) {
+            ForEach(SettingsSidebarSection.allCases, id: \.self) { section in
+                let rows = SettingsCategory.allCases.filter { $0.section == section }
+                if !rows.isEmpty {
+                    if let title = section.title {
+                        Section(title) {
+                            ForEach(rows) { row(for: $0) }
+                        }
+                    } else {
+                        Section { ForEach(rows) { row(for: $0) } }
+                    }
+                }
+            }
+        }
+        .listStyle(.sidebar)
+        .navigationSplitViewColumnWidth(min: 200, ideal: 220, max: 260)
+    }
+
+    @ViewBuilder
+    private func row(for category: SettingsCategory) -> some View {
+        Label(category.label, systemImage: category.systemImage)
+            .padding(.leading, category.isSubRow ? 16 : 0)
+            .tag(category)
+    }
+}


### PR DESCRIPTION
## Summary

Second PR in the Settings sidebar-redesign stack. Replaces three of the placeholder panes with real implementations: General, Permissions, About. About also introduces an Acknowledgements sheet listing the third-party packages Cotabby ships with (llama.cpp, Sparkle, swift-log, CotabbyInference).

The legacy `SettingsView` is untouched; the feature flag from PR 1 still defaults to off, so end users see no change. With the flag flipped, these three panes are now functional.

Stacked on `feat/settings-redesign-scaffold`.

## Validation

`xcodegen generate` + `xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build CODE_SIGNING_ALLOWED=NO`
→ `** BUILD SUCCEEDED **`

`swiftlint lint --quiet` → no violations.

Manual: with the redesign flag on, walk through each pane. General should exercise every toggle plus the ghost-color swatches and opacity slider; Permissions should reflect grant state and offer the Open Settings shortcuts; About should show the version, Check for Updates, the Support link, the GitHub / Wiki / Acknowledgements links, and the uninstall text.

## Linked issues

(none filed)

## Risk / rollout notes

- Behavior of every individual control is intentionally identical to the legacy `SettingsView` sections; bindings and tooltip copy were lifted verbatim. Visual change is the scaffolding around them (per-pane `Form`, optional callout slot) rather than the controls themselves.
- Permissions pane shows a top-of-pane callout when any required permission is missing. This is a small preview of the per-pane attention pattern that PR 5 generalizes for the rest of the panes.
- About pane consolidates what used to live across three legacy sections (header, support CTA, uninstall) and adds Acknowledgements. No persisted setting or model property is changed; this is purely visual reorganization.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds three fully-implemented Settings panes (General, Permissions, About) to the redesigned sidebar-based Settings window, replacing their placeholder counterparts. The feature-flag-off default means end users see no change; behavior for each control is intentionally identical to the legacy `SettingsView` sections.

- **GeneralPaneView** re-homes all toggle, picker, ghost-color swatch, and opacity slider controls with manual `Binding` wrappers that delegate to `SuggestionSettingsModel`'s existing setter API.
- **PermissionsPaneView** renders live permission status rows and addresses the stale-status-on-return bug from the previous review by combining `.onAppear` with `.onChange(of: scenePhase)`.
- **AboutPaneView** consolidates the header, support CTA, and uninstall text; a new `AcknowledgementsView` sheet lists the four third-party packages shipped with the app.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are behind the existing feature flag, no persisted settings or model properties are altered, and the two issues flagged in the previous review have both been addressed.

The three pane implementations are purely additive UI, the bindings delegate to the same setter API already exercised by the legacy view, and the URL construction is now consistently guarded with if let throughout. No behavioral regression is possible while the feature flag remains off.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/Settings/Panes/GeneralPaneView.swift | All toggles, pickers, swatches, and the opacity slider wired correctly via delegating Binding wrappers; colorScheme used for accurate automatic-swatch preview. No issues. |
| Cotabby/UI/Settings/Panes/PermissionsPaneView.swift | scenePhase refresh fix from previous review is implemented; callout is computed and correctly re-evaluated on ObservedObject changes. No issues. |
| Cotabby/UI/Settings/Panes/AboutPaneView.swift | All URL(string:) usages correctly guarded with if let (force-unwrap issues from previous review resolved). appVersionText handles all four Bundle key combinations cleanly. No issues. |
| Cotabby/UI/Settings/Panes/AcknowledgementsView.swift | Fixed-size modal sheet with four static entries; URL links also guarded with if let. No issues. |
| Cotabby/UI/Settings/SettingsContainerView.swift | detailPane switch updated to route .general, .permissions, and .about to their new views; remaining cases fall through to PlaceholderPaneView as expected. No issues. |
| Cotabby.xcodeproj/project.pbxproj | Four new Swift source files correctly registered with matching PBXBuildFile, PBXFileReference, and PBXGroup entries. No issues. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    SCV["SettingsContainerView\n(NavigationSplitView)"]
    SCV -->|".general"| GPV["GeneralPaneView\n(SuggestionSettingsModel)"]
    SCV -->|".permissions"| PPV["PermissionsPaneView\n(PermissionManager)"]
    SCV -->|".about"| APV["AboutPaneView\n(AppUpdateManager)"]
    SCV -->|"other cases"| PLV["PlaceholderPaneView"]

    GPV --> SPS1["SettingsPaneScaffold\n(no callout)"]
    PPV --> SPS2["SettingsPaneScaffold\n(callout when perms missing)"]
    APV --> SPS3["SettingsPaneScaffold\n(no callout)"]

    APV -->|"sheet"| AKV["AcknowledgementsView\n(modal sheet)"]

    PPV -->|"onAppear + onChange(scenePhase)"| PM["PermissionManager.refresh()"]
```

<sub>Reviews (2): Last reviewed commit: ["Address Greptile feedback: scene-active ..."](https://github.com/fujacob/cotabby/commit/d9faf7597c286adbc3c835ce7a1799a8f93d6c6e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34336290)</sub>

<!-- /greptile_comment -->