### PR TITLE
Replay swallowed Tab when coordinator bails on acceptance

### DIFF
--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
@@ -10,25 +10,32 @@ extension SuggestionCoordinator {
     // MARK: - Acceptance and Session Reconciliation
 
     /// Accepts the next word of the current suggestion.
-    func acceptCurrentSuggestion() -> Bool {
-        acceptSuggestion(fullText: false, keyName: "Tab")
+    func acceptCurrentSuggestion(originalEvent: CapturedInputEvent? = nil) -> Bool {
+        acceptSuggestion(fullText: false, keyName: "Tab", originalEvent: originalEvent)
     }
 
     /// Accepts the entire remaining suggestion at once.
-    func acceptEntireSuggestion() -> Bool {
-        acceptSuggestion(fullText: true, keyName: "full-accept")
+    func acceptEntireSuggestion(originalEvent: CapturedInputEvent? = nil) -> Bool {
+        acceptSuggestion(fullText: true, keyName: "full-accept", originalEvent: originalEvent)
     }
 
     /// Shared acceptance path used by both word-by-word and full acceptance.
-    private func acceptSuggestion(fullText: Bool, keyName: String) -> Bool {
+    private func acceptSuggestion(
+        fullText: Bool,
+        keyName: String,
+        originalEvent: CapturedInputEvent?
+    ) -> Bool {
         let snapshot = focusModel.snapshot
 
         guard permissionManager.inputMonitoringGranted else {
-            return passTabThrough(reason: "Input Monitoring permission is required before Cotabby can accept suggestions.")
+            return passTabThrough(
+                reason: "Input Monitoring permission is required before Cotabby can accept suggestions.",
+                replay: originalEvent
+            )
         }
 
         guard case .supported = snapshot.capability, let rawContext = snapshot.context else {
-            return passTabThrough(reason: snapshot.capability.summary)
+            return passTabThrough(reason: snapshot.capability.summary, replay: originalEvent)
         }
 
         // Gate on the live session, not on `state`. A background refresh (notably the visual-context
@@ -40,7 +47,10 @@ extension SuggestionCoordinator {
         // trying to take. `validateSessionForAcceptance` still rejects the accept if the session no
         // longer reconciles with the live AX state.
         guard interactionState.activeSession != nil else {
-            return passTabThrough(reason: "Key passed through because no valid suggestion was ready.")
+            return passTabThrough(
+                reason: "Key passed through because no valid suggestion was ready.",
+                replay: originalEvent
+            )
         }
 
         let preparation = fullText
@@ -61,7 +71,7 @@ extension SuggestionCoordinator {
             acceptedChunk = preparedAcceptedChunk
 
         case let .invalid(reason):
-            return passTabThrough(reason: reason)
+            return passTabThrough(reason: reason, replay: originalEvent)
         }
 
         // Reconcile the word boundary against the *live* preceding text instead of trusting the
@@ -147,13 +157,23 @@ extension SuggestionCoordinator {
         }
     }
 
-    /// Returns control of `Tab` to the host app and clears stale suggestion UI.
-    func passTabThrough(reason: String) -> Bool {
+    /// Returns control of the accept key to the host app and clears stale suggestion UI.
+    ///
+    /// When `replay` is supplied (the original captured event from `handleInputEvent`), this
+    /// re-posts that key to the focused app *after* hiding the overlay — `hideOverlay` flips the
+    /// overlay state to `.hidden`, which tears down the active accept tap, so the replay reaches
+    /// the focused app without the tap re-consuming it. This is the only thing standing between
+    /// the user and a silently-swallowed Tab when the coordinator bails on acceptance after the
+    /// accept tap already consumed the keystroke (notably Gmail / browser AX races).
+    func passTabThrough(reason: String, replay: CapturedInputEvent? = nil) -> Bool {
         let generation = latestGenerationNumber
         cancelPredictionWork()
         clearSuggestion(clearDiagnostics: true)
         hideOverlay(reason: reason)
         state = .idle
+        if let replay {
+            inputMonitor.replayConsumedAcceptKey(keyCode: replay.keyCode, flags: replay.flags)
+        }
         logStage(
             "tab-passed-through",
             workID: currentWorkID,

--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
@@ -141,11 +141,11 @@ extension SuggestionCoordinator {
         }
 
         if event.kind == .acceptance {
-            return acceptCurrentSuggestion()
+            return acceptCurrentSuggestion(originalEvent: event)
         }
 
         if event.kind == .fullAcceptance {
-            return acceptEntireSuggestion()
+            return acceptEntireSuggestion(originalEvent: event)
         }
 
         if let activeSession = interactionState.activeSession {

--- a/Cotabby/Models/SuggestionSubsystemContracts.swift
+++ b/Cotabby/Models/SuggestionSubsystemContracts.swift
@@ -39,6 +39,12 @@ protocol SuggestionInputMonitoring: AnyObject {
     /// a suggestion overlay is visible and off otherwise, so Cotabby only sits in the synchronous
     /// keystroke path during the brief windows it actually needs to consume the accept key.
     func setAcceptInterceptionActive(_ active: Bool)
+
+    /// Re-posts an accept key that the active tap already swallowed, used when the coordinator
+    /// decides at the last moment not to insert a suggestion (stale AX, invalidated session).
+    /// Without this, browsers like Gmail experience the keystroke as silently dropped — see the
+    /// "missed Tab" symptom investigated alongside #337.
+    func replayConsumedAcceptKey(keyCode: CGKeyCode, flags: CGEventFlags)
 }
 
 @MainActor

--- a/Cotabby/Services/Input/InputMonitor.swift
+++ b/Cotabby/Services/Input/InputMonitor.swift
@@ -100,6 +100,26 @@ final class InputMonitor {
         }
     }
 
+    /// Re-posts an accept key that was already swallowed by the active tap. The coordinator
+    /// only calls this from the bail paths in `acceptSuggestion` — by which point the overlay
+    /// has been hidden (so `destroyAcceptTap` already ran via the overlay state change) and the
+    /// synthetic event we post will reach the focused application unmodified. Suppression is
+    /// armed beforehand so our own observer tap recognizes the replay as Cotabby's own work
+    /// instead of treating it as a fresh user keystroke.
+    func replayConsumedAcceptKey(keyCode: CGKeyCode, flags: CGEventFlags) {
+        guard let keyDown = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: true),
+              let keyUp = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: false) else {
+            CotabbyLogger.app.warning("Failed to synthesize replay for consumed accept key \(keyCode)")
+            return
+        }
+        keyDown.flags = flags
+        keyUp.flags = flags
+        suppressionController.registerSyntheticInsertion(expectedKeyDownCount: 1)
+        keyDown.post(tap: .cghidEventTap)
+        keyUp.post(tap: .cghidEventTap)
+        CotabbyLogger.app.debug("Replayed consumed accept key \(keyCode) to the focused app")
+    }
+
     private func installObserverTapIfNeeded() {
         guard observerTap == nil else {
             return


### PR DESCRIPTION
## Summary

Investigation in this conversation traced the "sometimes pressing Tab in Gmail doesn't accept and misses the capture" symptom to a contract violation in our acceptance path.

After #337 the active accept tap installs whenever the suggestion overlay is visible and unconditionally consumes Tab as long as it's there. But the coordinator's *decision* to actually accept runs later in `acceptSuggestion` (`SuggestionCoordinator+Acceptance.swift:22`) and can still bail along several paths:

1. AX capability flipped to unsupported between show and Tab.
2. `interactionState.activeSession == nil` (background refresh nuked the session while overlay was still up).
3. `prepareAcceptance` returns `.invalid` because the live preceding text no longer reconciles with the session's snapshot.

(3) is the Gmail one. Gmail compose is `contentEditable` rendered in Chrome/Safari/Arc; browser AX preceding-text reads occasionally lag selection state by a frame, so the reconciliation check returns `.invalid` more often there. When that happens the coordinator calls `passTabThrough(reason:)` — which, despite the name, only hides the overlay and clears state. Tab was already gone, swallowed by the tap. From Gmail's perspective the keystroke never arrived; from the user's perspective Cotabby ate their Tab.

This PR makes `passTabThrough` honest: thread the original `CapturedInputEvent` from `handleInputEvent` down through `acceptCurrentSuggestion`/`acceptEntireSuggestion` into `passTabThrough`, and after `hideOverlay` tears down the accept tap, re-post the captured key to the focused app via the new `InputMonitor.replayConsumedAcceptKey(keyCode:flags:)`. Suppression is armed beforehand so our observer tap recognizes the replay as Cotabby's own work instead of treating it as fresh input.

## Validation

- `swiftlint lint --quiet` → exit 0
- `xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build` → ** BUILD SUCCEEDED **
- `xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build-for-testing` → ** TEST BUILD SUCCEEDED **

Manual verification needed:
- Gmail compose: type, wait for a suggestion, press Tab → if Cotabby reconciles → suggestion inserts. If Cotabby bails → focus moves (Gmail's native Tab behavior), instead of nothing happening.
- Native AppKit text field (TextEdit / Notes): regression check, Tab still inserts the suggestion when there is one.
- After accept, no double-Tab side effects: the suppression token is consumed exactly once per replay.

## Linked issues

Refs #337 (which introduced the consume-before-confirm tap split).

## Risk / rollout notes

- The replay posts at `.cghidEventTap`, identical to how `SuggestionInserter` injects accepted suggestion text. Same suppression mechanism, so no new loop risk.
- The `originalEvent` parameter has a default value of `nil` everywhere it was added, so any existing internal caller that doesn't have an event (none today, but defensively) still compiles.
- If `replayConsumedAcceptKey` fails to construct a synthetic event (extremely unlikely) we log a warning and silently drop — same user-visible behavior as today, no regression.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a real usability bug where pressing Tab in Gmail (and similar browser-hosted `contentEditable` fields) would silently swallow the keystroke when Cotabby's AX reconciliation check rejected the accept. The fix threads the original `CapturedInputEvent` through the bail paths in `acceptSuggestion` and re-posts it via a new `replayConsumedAcceptKey` method after the accept tap is torn down.

- `InputMonitor.replayConsumedAcceptKey` synthesizes a new keyDown+keyUp pair at `.cghidEventTap` (matching the existing `SuggestionInserter` pattern) and arms `InputSuppressionController` beforehand so the observer tap treats the replay as Cotabby's own synthetic work rather than fresh user input.
- `passTabThrough` now accepts an optional `replay: CapturedInputEvent?` parameter, and each bail branch in `acceptSuggestion` forwards `originalEvent` into it; the default value of `nil` keeps all existing callers source-compatible.
- `SuggestionCoordinator+Input.swift` unconditionally passes `originalEvent: event` regardless of whether the overlay was visible — and therefore whether the accept tap was installed. When no suggestion is showing the accept tap is not active, the original Tab already reaches the focused app, and `replayConsumedAcceptKey` posts a second Tab, producing a double-keystroke on every Tab press in a text field with no suggestion active.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is: the fix correctly handles the Gmail bail case but introduces a double-Tab regression on every Tab press in any text field where no suggestion is currently showing.

The replay mechanism in `InputMonitor` and the `passTabThrough` changes are well-structured, but `SuggestionCoordinator+Input.swift` passes `originalEvent: event` unconditionally — including when the overlay is hidden and the accept tap was never installed. In that case the original Tab keyDown travels through to the focused app normally, and `replayConsumedAcceptKey` then posts a second Tab. The suppression token is consumed by the replayed keyDown at the observer tap (not the original), so the focused app sees both events. This would manifest as every Tab press in an enabled text field producing two Tab events whenever Cotabby has no active suggestion, which covers the vast majority of Tab presses throughout the day.

Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift — the two lines that pass `originalEvent: event` need to be gated on `overlayState.isVisible`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift | Passes `originalEvent` unconditionally to the acceptance path regardless of overlay visibility, causing `replayConsumedAcceptKey` to fire — and double-Tab — on every Tab press when no suggestion is active. |
| Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift | Threads `originalEvent` through all bail paths in `acceptSuggestion` into `passTabThrough`; the replay call is correctly placed after `hideOverlay` (which synchronously tears down the accept tap via the `onStateChange` chain), so the replayed Tab won't be re-consumed. |
| Cotabby/Services/Input/InputMonitor.swift | New `replayConsumedAcceptKey` arms suppression for exactly one keyDown before posting the synthesized keyDown+keyUp pair at `.cghidEventTap`, consistent with how `SuggestionInserter` handles accepted text. |
| Cotabby/Models/SuggestionSubsystemContracts.swift | Adds `replayConsumedAcceptKey` to the `SuggestionInputMonitoring` protocol with a clear doc comment; no issues. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant HID as HID Event Stream
    participant OT as Observer Tap (head, listen-only)
    participant AT as Accept Tap (tail, active)
    participant Coord as SuggestionCoordinator
    participant IM as InputMonitor
    participant SC as SuppressionController
    participant App as Focused App (e.g. Gmail)

    Note over User,App: Happy path — overlay visible, reconciliation succeeds
    User->>HID: Tab keyDown
    HID->>OT: keyDown
    OT->>Coord: handleInputEvent(.acceptance, event)
    Coord->>Coord: acceptSuggestion → prepareAcceptance → .ready
    Coord->>App: insert suggestion text (via SuggestionInserter)
    HID->>AT: keyDown
    AT-->>HID: nil (consumed)

    Note over User,App: Bail path (this PR) — overlay visible, reconciliation returns .invalid
    User->>HID: Tab keyDown
    HID->>OT: keyDown
    OT->>Coord: handleInputEvent(.acceptance, event)
    Coord->>Coord: acceptSuggestion → passTabThrough(replay: event)
    Coord->>Coord: hideOverlay → destroyAcceptTap (synchronous)
    Coord->>IM: replayConsumedAcceptKey(keyCode, flags)
    IM->>SC: registerSyntheticInsertion(expectedKeyDownCount: 1)
    IM->>HID: post keyDown (replay)
    IM->>HID: post keyUp (replay)
    HID->>AT: keyDown (original — accept tap fires despite invalidation)
    AT-->>HID: nil (consumed)
    HID->>OT: keyDown (replay)
    OT->>SC: consumeIfNeeded() → true
    OT-->>HID: passthrough (listen-only)
    HID->>App: replay keyDown
    HID->>App: replay keyUp

    Note over User,App: Bug (no overlay) — accept tap not installed, originalEvent passed unconditionally
    User->>HID: Tab keyDown (no suggestion visible)
    HID->>OT: keyDown
    OT->>Coord: handleInputEvent(.acceptance, event)
    Coord->>Coord: "activeSession==nil → passTabThrough(replay: event)"
    Coord->>IM: replayConsumedAcceptKey (accept tap was never installed!)
    IM->>HID: post keyDown (replay)
    HID->>App: original keyDown
    HID->>App: original keyUp
    HID->>App: replay keyDown (double-Tab)
    HID->>App: replay keyUp
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Freplay-consumed-tab-on-bail%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Freplay-consumed-tab-on-bail%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BInput.swift%3A141-149%0A**Double-keystroke%20regression%20when%20no%20suggestion%20is%20visible**%0A%0A%60originalEvent%60%20is%20forwarded%20unconditionally%20to%20%60acceptCurrentSuggestion%60%2F%60acceptEntireSuggestion%60.%20When%20the%20overlay%20is%20hidden%20the%20accept%20tap%20is%20not%20installed%2C%20so%20the%20original%20Tab%20reaches%20the%20focused%20app%20normally.%20But%20if%20%60interactionState.activeSession%20%3D%3D%20nil%60%20%28the%20typical%20state%20when%20nothing%20is%20suggested%29%2C%20%60acceptSuggestion%60%20falls%20through%20to%20%60passTabThrough%28replay%3A%20originalEvent%29%60%2C%20which%20calls%20%60replayConsumedAcceptKey%60%20and%20posts%20a%20second%20Tab%20to%20the%20HID%20stream.%20The%20focused%20app%20then%20receives%20the%20original%20Tab%20keyDown%20plus%20the%20replayed%20one%20%E2%80%94%20a%20silent%20double-Tab%20on%20every%20Tab%20press%20without%20an%20active%20suggestion.%0A%0AThe%20replay%20should%20only%20be%20dispatched%20when%20the%20accept%20tap%20was%20actually%20armed%2C%20i.e.%2C%20when%20the%20overlay%20was%20visible%20at%20the%20moment%20the%20keystroke%20arrived.%20Gating%20on%20%60overlayState.isVisible%60%20before%20passing%20%60originalEvent%60%20closes%20the%20gap%3A%20if%20the%20overlay%20is%20already%20hidden%20the%20accept%20tap%20never%20consumed%20the%20event%2C%20so%20there%20is%20nothing%20to%20replay.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20if%20event.kind%20%3D%3D%20.acceptance%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20acceptCurrentSuggestion%28originalEvent%3A%20overlayState.isVisible%20%3F%20event%20%3A%20nil%29%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20if%20event.kind%20%3D%3D%20.fullAcceptance%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20acceptEntireSuggestion%28originalEvent%3A%20overlayState.isVisible%20%3F%20event%20%3A%20nil%29%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BInput.swift%3A141-149%0A**Double-keystroke%20regression%20when%20no%20suggestion%20is%20visible**%0A%0A%60originalEvent%60%20is%20forwarded%20unconditionally%20to%20%60acceptCurrentSuggestion%60%2F%60acceptEntireSuggestion%60.%20When%20the%20overlay%20is%20hidden%20the%20accept%20tap%20is%20not%20installed%2C%20so%20the%20original%20Tab%20reaches%20the%20focused%20app%20normally.%20But%20if%20%60interactionState.activeSession%20%3D%3D%20nil%60%20%28the%20typical%20state%20when%20nothing%20is%20suggested%29%2C%20%60acceptSuggestion%60%20falls%20through%20to%20%60passTabThrough%28replay%3A%20originalEvent%29%60%2C%20which%20calls%20%60replayConsumedAcceptKey%60%20and%20posts%20a%20second%20Tab%20to%20the%20HID%20stream.%20The%20focused%20app%20then%20receives%20the%20original%20Tab%20keyDown%20plus%20the%20replayed%20one%20%E2%80%94%20a%20silent%20double-Tab%20on%20every%20Tab%20press%20without%20an%20active%20suggestion.%0A%0AThe%20replay%20should%20only%20be%20dispatched%20when%20the%20accept%20tap%20was%20actually%20armed%2C%20i.e.%2C%20when%20the%20overlay%20was%20visible%20at%20the%20moment%20the%20keystroke%20arrived.%20Gating%20on%20%60overlayState.isVisible%60%20before%20passing%20%60originalEvent%60%20closes%20the%20gap%3A%20if%20the%20overlay%20is%20already%20hidden%20the%20accept%20tap%20never%20consumed%20the%20event%2C%20so%20there%20is%20nothing%20to%20replay.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20if%20event.kind%20%3D%3D%20.acceptance%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20acceptCurrentSuggestion%28originalEvent%3A%20overlayState.isVisible%20%3F%20event%20%3A%20nil%29%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20if%20event.kind%20%3D%3D%20.fullAcceptance%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20acceptEntireSuggestion%28originalEvent%3A%20overlayState.isVisible%20%3F%20event%20%3A%20nil%29%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=363&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Replay swallowed Tab when coordinator ba..."](https://github.com/fujacob/cotabby/commit/1d64c77fca139c2b85a981f454abc9e5b04f4025) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34339208)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->