### PR TITLE
Add Engine & Model parent and Apple Intelligence / Open Source sub-panes

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		58AC3193D846FDE88513377D /* BundledRuntimeLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18D990E515E1AE4F312F4E95 /* BundledRuntimeLocatorTests.swift */; };
 		5A441797D71A880A7482077D /* TextDirectionDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC24FD54860CE6737E65EF65 /* TextDirectionDetectorTests.swift */; };
 		5BE53CE921664582F593B7B0 /* FieldEdgeIconIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBD5FCB8CC56AA6138382B2C /* FieldEdgeIconIndicatorView.swift */; };
+		5DF31F465A3A1233260BD3A4 /* EngineAndModelPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC9ECD5408B0F5708149B5C0 /* EngineAndModelPaneView.swift */; };
 		5E10EFC426217CB7218A5847 /* CotabbyTestFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF1E065C7FFB697FCEB2FA5C /* CotabbyTestFixtures.swift */; };
 		5E92E3C1EB41D482FC06BC52 /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA0117B322C625F6D4BBEAB /* MenuBarView.swift */; };
 		5F019E5A0679FFB52F129798 /* InputModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F34AE24BB7C99D66E1F3904 /* InputModels.swift */; };
@@ -103,6 +104,7 @@
 		7E99F5676A1D1DF7EA7D7702 /* SuggestionCoordinator+Prediction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ED1EA9282E0AC7592E60889 /* SuggestionCoordinator+Prediction.swift */; };
 		7FC103944F4EF39DB965F469 /* InMemoryLogging in Frameworks */ = {isa = PBXBuildFile; productRef = 88921938DC814625ED57D605 /* InMemoryLogging */; };
 		82D4ADEAF05337ABDE4C586C /* RuntimeBootstrapModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60629DFE309C1A4BD8A7FB3B /* RuntimeBootstrapModel.swift */; };
+		8557DF86F088D19D2DAC70BC /* AppleIntelligencePaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5916CF13B85EFCE6A049296 /* AppleIntelligencePaneView.swift */; };
 		8865B95FE84198D70390DF80 /* ClipboardContentDistillerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFD89799BB82AF7A92559AEB /* ClipboardContentDistillerTests.swift */; };
 		88BCD795A14E1C9308F7BB31 /* SuggestionAvailabilityEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05B0439348261163B37C508 /* SuggestionAvailabilityEvaluatorTests.swift */; };
 		8B2DFC860803C0A7C4D34A36 /* ContextBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54EF3C7F5D9D6F3FA50FD51C /* ContextBuffer.swift */; };
@@ -158,6 +160,7 @@
 		DE236C9285635C686D66A2F6 /* TerminalAppDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E37A7E835D3BDE6265843C /* TerminalAppDetectorTests.swift */; };
 		E17CAA453B1F534D284F0D89 /* PermissionHostApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6ACCB12E4DB32D2F2BEA567 /* PermissionHostApp.swift */; };
 		E313639E71AE1374D2B9A956 /* SuggestionWorkController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B2D97BAA3618A7D0357AC44 /* SuggestionWorkController.swift */; };
+		E442A19096A4B5BDA944BDEA /* OpenSourcePaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E7064AC8B6EFEA971F4CA2 /* OpenSourcePaneView.swift */; };
 		E6EE3C13FA31F261CD734C69 /* DownloadOutcomeClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DE1975F3B5F4A70478DBF41 /* DownloadOutcomeClassifier.swift */; };
 		E912D4617AE1376061DF1F00 /* LanguageSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4793D4EA5D36D7E5CC216C27 /* LanguageSupportTests.swift */; };
 		E994FE418A961FB234D9057A /* DownloadFileRescuerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F46767D9D1F0D44E239CA8 /* DownloadFileRescuerTests.swift */; };
@@ -247,6 +250,7 @@
 		5F34AE24BB7C99D66E1F3904 /* InputModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputModels.swift; sourceTree = "<group>"; };
 		60629DFE309C1A4BD8A7FB3B /* RuntimeBootstrapModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimeBootstrapModel.swift; sourceTree = "<group>"; };
 		656F58E56FE9BC087B6F1D33 /* PermissionReminderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionReminderView.swift; sourceTree = "<group>"; };
+		65E7064AC8B6EFEA971F4CA2 /* OpenSourcePaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSourcePaneView.swift; sourceTree = "<group>"; };
 		67586807ACE8EB13C9014535 /* TickMarkSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TickMarkSlider.swift; sourceTree = "<group>"; };
 		6B2D97BAA3618A7D0357AC44 /* SuggestionWorkController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionWorkController.swift; sourceTree = "<group>"; };
 		6C4565D64DF64A2AA0DB1532 /* WelcomeProfileStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeProfileStepView.swift; sourceTree = "<group>"; };
@@ -327,6 +331,7 @@
 		D49F3B597374208594861B9B /* FoundationModelDriftEvalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoundationModelDriftEvalTests.swift; sourceTree = "<group>"; };
 		D4F6D5F94B238F7B4BE7C247 /* FocusCapabilityResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusCapabilityResolverTests.swift; sourceTree = "<group>"; };
 		D504BEB224E0C176F5FCFF6E /* CompletionRenderModePolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionRenderModePolicyTests.swift; sourceTree = "<group>"; };
+		D5916CF13B85EFCE6A049296 /* AppleIntelligencePaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleIntelligencePaneView.swift; sourceTree = "<group>"; };
 		D5D6C2318E405AA717D1C256 /* WelcomePermissionStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomePermissionStepView.swift; sourceTree = "<group>"; };
 		D84D4528EEC9EFEB8AE8E318 /* ActivationIndicatorController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivationIndicatorController.swift; sourceTree = "<group>"; };
 		DB0CE9AB1286367BA2E82392 /* SettingsContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsContainerView.swift; sourceTree = "<group>"; };
@@ -347,6 +352,7 @@
 		FB317C82CE2CBC69056BA4B8 /* TagChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagChip.swift; sourceTree = "<group>"; };
 		FC24FD54860CE6737E65EF65 /* TextDirectionDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextDirectionDetectorTests.swift; sourceTree = "<group>"; };
 		FC83D14A7557BC0196E59007 /* MirrorOverlayLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MirrorOverlayLayoutTests.swift; sourceTree = "<group>"; };
+		FC9ECD5408B0F5708149B5C0 /* EngineAndModelPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EngineAndModelPaneView.swift; sourceTree = "<group>"; };
 		FE7BF162A12703249726F20A /* FoundationModelPromptRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoundationModelPromptRenderer.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -426,7 +432,10 @@
 			children = (
 				A3FA53BBC3D81503C1D17477 /* AboutPaneView.swift */,
 				2B7A28471B8526C2693FFF65 /* AcknowledgementsView.swift */,
+				D5916CF13B85EFCE6A049296 /* AppleIntelligencePaneView.swift */,
+				FC9ECD5408B0F5708149B5C0 /* EngineAndModelPaneView.swift */,
 				07480CE96ED0EBD94817C6B1 /* GeneralPaneView.swift */,
+				65E7064AC8B6EFEA971F4CA2 /* OpenSourcePaneView.swift */,
 				7113D3373525113CA69E7597 /* PermissionsPaneView.swift */,
 				93028F328388432E72C58D09 /* PlaceholderPaneView.swift */,
 			);
@@ -813,6 +822,7 @@
 				26E0331E9E2F92FAE531BDEE /* ActivationIndicatorController.swift in Sources */,
 				0A3443AEE6540F11E5E6BF8F /* AppDelegate.swift in Sources */,
 				C4C6734678797669055988E0 /* AppUpdateManager.swift in Sources */,
+				8557DF86F088D19D2DAC70BC /* AppleIntelligencePaneView.swift in Sources */,
 				66C23A7C2FCDE0266FF425F8 /* ApplicationBundleMetadata.swift in Sources */,
 				3CBBC3BFAC0DC8952EE24EF7 /* BundledRuntimeLocator.swift in Sources */,
 				76FD91607794883F8E121450 /* CaretGeometrySelector.swift in Sources */,
@@ -831,6 +841,7 @@
 				47364583344BEA8FDC7178D8 /* DownloadFileRescuer.swift in Sources */,
 				E6EE3C13FA31F261CD734C69 /* DownloadOutcomeClassifier.swift in Sources */,
 				7D6BB9AF72F7076A4E5EE96F /* DownloadableModelCatalogView.swift in Sources */,
+				5DF31F465A3A1233260BD3A4 /* EngineAndModelPaneView.swift in Sources */,
 				5BE53CE921664582F593B7B0 /* FieldEdgeIconIndicatorView.swift in Sources */,
 				6E49ADEB31D04DC77A47DEB0 /* FileLogHandler.swift in Sources */,
 				CC98B842D10574C5206BEFA7 /* FocusCapabilityResolver.swift in Sources */,
@@ -872,6 +883,7 @@
 				31515DDD173535C4AC777853 /* MirrorOverlayLayout.swift in Sources */,
 				2F227738D7834B1A7A81D1D6 /* ModelDownloadManager.swift in Sources */,
 				317883210D1D1D5CD654E562 /* ModelFileValidator.swift in Sources */,
+				E442A19096A4B5BDA944BDEA /* OpenSourcePaneView.swift in Sources */,
 				0DDC0CFF5558A8F4355836B2 /* OverlayController.swift in Sources */,
 				0187EAA1D37B92DD5B264016 /* PermissionDragSourceView.swift in Sources */,
 				4B54ACE1255873955414CD06 /* PermissionGuidanceController.swift in Sources */,

--- a/Cotabby/UI/Settings/Panes/AppleIntelligencePaneView.swift
+++ b/Cotabby/UI/Settings/Panes/AppleIntelligencePaneView.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+/// File overview:
+/// "Apple Intelligence" sub-pane. Shows availability detail for the on-device Foundation Models
+/// path and offers a one-tap affordance to switch to this engine when the user is currently on the
+/// Open Source engine. The engine picker itself lives in the parent overview pane, not here.
+struct AppleIntelligencePaneView: View {
+    @ObservedObject var suggestionSettings: SuggestionSettingsModel
+    @ObservedObject var foundationModelAvailabilityService: FoundationModelAvailabilityService
+
+    var body: some View {
+        SettingsPaneScaffold(callout: callout) {
+            Section("Apple Intelligence") {
+                if !isSelectedEngine {
+                    LabeledContent {
+                        Button("Switch to Apple Intelligence") {
+                            suggestionSettings.selectEngine(.appleIntelligence)
+                        }
+                        .controlSize(.regular)
+                    } label: {
+                        Text("Currently using the Open Source engine. Switch to use Apple Intelligence instead.")
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+
+                LabeledContent("Availability") {
+                    Text(foundationModelAvailabilityService.userVisibleMessage)
+                        .foregroundStyle(foundationModelAvailabilityService.isAvailable ? .green : .orange)
+                        .multilineTextAlignment(.trailing)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+        .onAppear { foundationModelAvailabilityService.refresh() }
+    }
+
+    private var isSelectedEngine: Bool {
+        suggestionSettings.selectedEngine == .appleIntelligence
+    }
+
+    /// Only surface a callout when the user is on this engine *and* it is currently unavailable.
+    /// If they are on the other engine the pane is informational and no warning is warranted.
+    private var callout: SettingsPaneCallout? {
+        guard isSelectedEngine, !foundationModelAvailabilityService.isAvailable else {
+            return nil
+        }
+        return SettingsPaneCallout(
+            tone: .warning,
+            message: foundationModelAvailabilityService.userVisibleMessage
+        )
+    }
+}

--- a/Cotabby/UI/Settings/Panes/EngineAndModelPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/EngineAndModelPaneView.swift
@@ -27,7 +27,7 @@ struct EngineAndModelPaneView: View {
                 case .appleIntelligence:
                     LabeledContent("Availability") {
                         Text(foundationModelAvailabilityService.userVisibleMessage)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(foundationModelAvailabilityService.isAvailable ? .green : .orange)
                     }
                 case .llamaOpenSource:
                     LabeledContent("Runtime") {
@@ -50,6 +50,7 @@ struct EngineAndModelPaneView: View {
                 .padding(.vertical, 4)
             }
         }
+        .onAppear { foundationModelAvailabilityService.refresh() }
     }
 
     private var selectedEngineBinding: Binding<SuggestionEngineKind> {

--- a/Cotabby/UI/Settings/Panes/EngineAndModelPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/EngineAndModelPaneView.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+/// File overview:
+/// Parent overview pane for the "Engine & Model" group. Owns the engine picker (the only place
+/// the user can switch engines), shows the high-level status of the current choice, and points
+/// to the two sub-rows in the sidebar for engine-specific options.
+///
+/// Why the picker lives only here:
+/// Having a picker in both sub-panes would mean the same control writes the same setting from two
+/// places. Keeping it on the parent overview makes the engine choice a single source of truth and
+/// keeps each sub-pane focused on the engine it represents.
+struct EngineAndModelPaneView: View {
+    @ObservedObject var suggestionSettings: SuggestionSettingsModel
+    @ObservedObject var foundationModelAvailabilityService: FoundationModelAvailabilityService
+    @ObservedObject var runtimeModel: RuntimeBootstrapModel
+
+    var body: some View {
+        SettingsPaneScaffold {
+            Section("Engine") {
+                Picker("Engine", selection: selectedEngineBinding) {
+                    ForEach(SuggestionEngineKind.allCases) { engine in
+                        Text(engine.displayLabel).tag(engine)
+                    }
+                }
+
+                switch suggestionSettings.selectedEngine {
+                case .appleIntelligence:
+                    LabeledContent("Availability") {
+                        Text(foundationModelAvailabilityService.userVisibleMessage)
+                            .foregroundStyle(.secondary)
+                    }
+                case .llamaOpenSource:
+                    LabeledContent("Runtime") {
+                        Text(runtimeModel.state.summary)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+
+            Section {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Engine-specific options live under the sub-rows in the sidebar:")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                    Label("Apple Intelligence — on-device availability and status.", systemImage: "apple.logo")
+                        .font(.callout)
+                    Label("Open Source — pick or download a local GGUF model.", systemImage: "shippingbox.fill")
+                        .font(.callout)
+                }
+                .padding(.vertical, 4)
+            }
+        }
+    }
+
+    private var selectedEngineBinding: Binding<SuggestionEngineKind> {
+        Binding(
+            get: { suggestionSettings.selectedEngine },
+            set: { suggestionSettings.selectEngine($0) }
+        )
+    }
+}

--- a/Cotabby/UI/Settings/Panes/OpenSourcePaneView.swift
+++ b/Cotabby/UI/Settings/Panes/OpenSourcePaneView.swift
@@ -25,6 +25,7 @@ struct OpenSourcePaneView: View {
                         Button("Switch to Open Source") {
                             suggestionSettings.selectEngine(.llamaOpenSource)
                         }
+                        .controlSize(.regular)
                     } label: {
                         Text("Currently using Apple Intelligence. Switch to use the local llama runtime.")
                             .foregroundStyle(.secondary)
@@ -87,10 +88,6 @@ struct OpenSourcePaneView: View {
                                 refreshModels()
                             }
                             .disabled(!lmStudioAvailable)
-                                lmStudioAvailable
-                                    ? "Point Cotabby at LM Studio's models folder (~/.lmstudio/models) so you don't keep two copies."
-                                    : "Install LM Studio with at least one model first. Cotabby couldn't find ~/.lmstudio/models."
-                            )
 
                             Button("Reset Path") {
                                 BundledRuntimeLocator.setCustomModelDirectory(nil)

--- a/Cotabby/UI/Settings/Panes/OpenSourcePaneView.swift
+++ b/Cotabby/UI/Settings/Panes/OpenSourcePaneView.swift
@@ -1,0 +1,222 @@
+import SwiftUI
+
+/// File overview:
+/// "Open Source" sub-pane. Hosts everything the local llama runtime needs: selected model picker,
+/// downloadable catalog, Hugging Face browser, models folder controls, and the installed-models
+/// list with per-model delete. Lifted from the legacy `SettingsView.localModelControls` so
+/// behavior is preserved verbatim; only the wrapping scaffold is new.
+///
+/// The engine picker itself lives on the parent overview pane; this pane offers a one-tap switch
+/// affordance when the current engine is Apple Intelligence so users can land here and still flip
+/// without bouncing back up the sidebar.
+struct OpenSourcePaneView: View {
+    @ObservedObject var suggestionSettings: SuggestionSettingsModel
+    @ObservedObject var runtimeModel: RuntimeBootstrapModel
+    @ObservedObject var modelDownloadManager: ModelDownloadManager
+    @ObservedObject var huggingFaceSearchService: HuggingFaceSearchService
+
+    @State private var pendingDeletionModel: RuntimeModelOption?
+
+    var body: some View {
+        SettingsPaneScaffold(callout: callout) {
+            Section("Open Source") {
+                if !isSelectedEngine {
+                    LabeledContent {
+                        Button("Switch to Open Source") {
+                            suggestionSettings.selectEngine(.llamaOpenSource)
+                        }
+                    } label: {
+                        Text("Currently using Apple Intelligence. Switch to use the local llama runtime.")
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+
+                LabeledContent("Runtime") {
+                    Text(runtimeModel.state.summary)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.trailing)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+            Section("Models") {
+                Text(localModelsDescription)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                if runtimeModel.availableModels.isEmpty {
+                    Text("No local GGUF models found. Download one below or add your own model file.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    Picker("Selected Model", selection: selectedModelBinding) {
+                        ForEach(runtimeModel.availableModels) { model in
+                            Text(model.displayName).tag(model.filename)
+                        }
+                    }
+                }
+
+                DownloadableModelCatalogView(
+                    modelDownloadManager: modelDownloadManager,
+                    onRefreshModels: refreshModels
+                )
+
+                HuggingFaceModelBrowserView(
+                    searchService: huggingFaceSearchService,
+                    modelDownloadManager: modelDownloadManager,
+                    onRefreshModels: refreshModels
+                )
+            }
+
+            Section("Folder") {
+                LabeledContent("Path") {
+                    VStack(alignment: .trailing, spacing: 8) {
+                        Text(modelDownloadManager.modelsDirectoryPath)
+                            .font(.callout.monospaced())
+                            .textSelection(.enabled)
+                            .multilineTextAlignment(.trailing)
+
+                        HStack(spacing: 8) {
+                            let lmStudioURL = FileManager.default.homeDirectoryForCurrentUser
+                                .appendingPathComponent(".lmstudio/models")
+                            let lmStudioAvailable = FileManager.default.fileExists(atPath: lmStudioURL.path)
+                            let isUsingCustomPath = BundledRuntimeLocator.customModelDirectoryURL() != nil
+                            Button("Use LM Studio") {
+                                BundledRuntimeLocator.setCustomModelDirectory(lmStudioURL)
+                                modelDownloadManager.refreshSearchDirectories()
+                                refreshModels()
+                            }
+                            .disabled(!lmStudioAvailable)
+                                lmStudioAvailable
+                                    ? "Point Cotabby at LM Studio's models folder (~/.lmstudio/models) so you don't keep two copies."
+                                    : "Install LM Studio with at least one model first. Cotabby couldn't find ~/.lmstudio/models."
+                            )
+
+                            Button("Reset Path") {
+                                BundledRuntimeLocator.setCustomModelDirectory(nil)
+                                modelDownloadManager.refreshSearchDirectories()
+                                refreshModels()
+                            }
+                            .disabled(!isUsingCustomPath)
+
+                            Button("Open Folder") {
+                                modelDownloadManager.openModelsDirectory()
+                            }
+
+                            Button("Refresh") {
+                                refreshModels()
+                            }
+                        }
+                    }
+                }
+            }
+
+            if !runtimeModel.availableModels.isEmpty {
+                Section("Installed") {
+                    ForEach(runtimeModel.availableModels) { model in
+                        installedModelRow(model)
+                    }
+                }
+            }
+        }
+        .alert(
+            "Delete Model?",
+            isPresented: pendingDeletionAlertBinding,
+            presenting: pendingDeletionModel
+        ) { model in
+            Button("Delete") { deleteModel(model) }
+            Button("Cancel", role: .cancel) {}
+        } message: { model in
+            Text("Remove \(model.displayName) from Cotabby's local models folder?")
+        }
+    }
+
+    private var isSelectedEngine: Bool {
+        suggestionSettings.selectedEngine == .llamaOpenSource
+    }
+
+    /// Surface the runtime failure as a callout when the user is on this engine and the runtime
+    /// crashed during preparation. Other failure modes (no models found) are conveyed by the
+    /// inline empty-state text above.
+    private var callout: SettingsPaneCallout? {
+        guard isSelectedEngine,
+              case .failed(let detail) = runtimeModel.state else {
+            return nil
+        }
+        return SettingsPaneCallout(tone: .warning, message: detail)
+    }
+
+    private var localModelsDescription: String {
+        switch suggestionSettings.selectedEngine {
+        case .llamaOpenSource:
+            return "Download a model or add your own below. Models are stored locally on your Mac."
+        case .appleIntelligence:
+            return "These models are used when Engine is set to Open Source."
+        }
+    }
+
+    @ViewBuilder
+    private func installedModelRow(_ model: RuntimeModelOption) -> some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(model.displayName)
+
+                if model.displayName != model.actualModelName {
+                    Text(model.actualModelName)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Spacer(minLength: 0)
+
+            if model.filename == runtimeModel.selectedModelFilename {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.tint)
+            } else if modelDownloadManager.canDeleteModel(filename: model.filename) {
+                Button {
+                    pendingDeletionModel = model
+                } label: {
+                    Image(systemName: "trash")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.borderless)
+            }
+        }
+    }
+
+    private var selectedModelBinding: Binding<String> {
+        Binding(
+            get: {
+                runtimeModel.selectedModelFilename
+                    ?? runtimeModel.availableModels.first?.filename
+                    ?? ""
+            },
+            set: { filename in
+                Task { await runtimeModel.selectModel(filename) }
+            }
+        )
+    }
+
+    private var pendingDeletionAlertBinding: Binding<Bool> {
+        Binding(
+            get: { pendingDeletionModel != nil },
+            set: { isPresented in
+                if !isPresented {
+                    pendingDeletionModel = nil
+                }
+            }
+        )
+    }
+
+    private func deleteModel(_ model: RuntimeModelOption) {
+        modelDownloadManager.deleteModel(filename: model.filename)
+        runtimeModel.refreshAvailableModels()
+        pendingDeletionModel = nil
+    }
+
+    private func refreshModels() {
+        modelDownloadManager.refreshModelStates()
+        runtimeModel.refreshAvailableModels()
+    }
+}

--- a/Cotabby/UI/Settings/SettingsContainerView.swift
+++ b/Cotabby/UI/Settings/SettingsContainerView.swift
@@ -63,16 +63,29 @@ struct SettingsContainerView: View {
                 suggestionSettings: suggestionSettings,
                 onShowWelcome: onShowWelcome
             )
+        case .engineAndModel:
+            EngineAndModelPaneView(
+                suggestionSettings: suggestionSettings,
+                foundationModelAvailabilityService: foundationModelAvailabilityService,
+                runtimeModel: runtimeModel
+            )
+        case .appleIntelligence:
+            AppleIntelligencePaneView(
+                suggestionSettings: suggestionSettings,
+                foundationModelAvailabilityService: foundationModelAvailabilityService
+            )
+        case .openSource:
+            OpenSourcePaneView(
+                suggestionSettings: suggestionSettings,
+                runtimeModel: runtimeModel,
+                modelDownloadManager: modelDownloadManager,
+                huggingFaceSearchService: huggingFaceSearchService
+            )
         case .permissions:
             PermissionsPaneView(permissionManager: permissionManager)
         case .about:
             AboutPaneView(appUpdateManager: appUpdateManager)
-        case .engineAndModel,
-             .appleIntelligence,
-             .openSource,
-             .writing,
-             .shortcuts,
-             .apps:
+        case .writing, .shortcuts, .apps:
             PlaceholderPaneView(category: selection)
         }
     }


### PR DESCRIPTION
Re-opened after base branch deletion. Rebased onto current main (includes tooltip removal #362), cotabbyHelp calls stripped. Build/lint clean locally.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements three new settings panes — `EngineAndModelPaneView` (parent overview with the engine picker), `AppleIntelligencePaneView` (on-device availability + one-tap switch), and `OpenSourcePaneView` (local llama model management lifted verbatim from the legacy view) — and wires them into `SettingsContainerView`, replacing the previous `PlaceholderPaneView` fallback.

- `EngineAndModelPaneView` owns the sole engine picker and shows a live status summary for whichever engine is selected; sub-panes are linked via sidebar rows.
- `AppleIntelligencePaneView` shows the `FoundationModelAvailabilityService` state with a warning callout when the selected engine is unavailable.
- `OpenSourcePaneView` lifts the full model-management UI (download catalog, Hugging Face browser, folder controls, installed-model list with delete confirmation) from the legacy settings view with no behavioral changes.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all new panes are additive UI-only changes with no new business logic or data mutations beyond what already existed in the legacy settings view.

The three new panes are straightforward view decompositions that wire correctly into the container. The only noteworthy gap is that EngineAndModelPaneView omits the .fixedSize and .multilineTextAlignment modifiers present in the sibling AppleIntelligencePaneView, which can cause unavailability messages to be truncated in the parent overview. Everything else — engine switching, model deletion flow, callout logic — is consistent and correct.

EngineAndModelPaneView.swift — the availability Text display could truncate on narrow windows; OpenSourcePaneView.swift — inline filesystem calls inside body are inherited from legacy code but worth cleaning up.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/Settings/Panes/EngineAndModelPaneView.swift | New parent overview pane for engine/model settings with engine picker and high-level status; availability Text is missing multiline/fixedSize modifiers that its sibling sub-pane applies. |
| Cotabby/UI/Settings/Panes/AppleIntelligencePaneView.swift | New Apple Intelligence sub-pane showing availability callout and one-tap engine switch; logic and modifiers are consistent with the rest of the settings UI. |
| Cotabby/UI/Settings/Panes/OpenSourcePaneView.swift | New Open Source sub-pane lifting model management controls verbatim from the legacy view; inline FileManager.fileExists call inside body is a minor main-thread I/O concern. |
| Cotabby/UI/Settings/SettingsContainerView.swift | Wires the three new pane views into the switch and removes them from the PlaceholderPaneView fallback; straightforward routing change with no logic issues. |
| Cotabby.xcodeproj/project.pbxproj | Adds build file and file reference entries for the three new Swift source files; project structure changes look correct. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    SCV[SettingsContainerView] -->|selection == .engineAndModel| EMP[EngineAndModelPaneView]
    SCV -->|selection == .appleIntelligence| AIP[AppleIntelligencePaneView]
    SCV -->|selection == .openSource| OSP[OpenSourcePaneView]

    EMP -->|reads/writes| SS[SuggestionSettingsModel\n.selectedEngine]
    EMP -->|reads| FMAS[FoundationModelAvailabilityService\n.userVisibleMessage / .isAvailable]
    EMP -->|reads| RBM[RuntimeBootstrapModel\n.state.summary]
    EMP -->|.onAppear| FMAS

    AIP -->|reads| SS
    AIP -->|selectEngine .appleIntelligence| SS
    AIP -->|reads| FMAS
    AIP -->|.onAppear| FMAS

    OSP -->|reads| SS
    OSP -->|selectEngine .llamaOpenSource| SS
    OSP -->|reads/calls| RBM
    OSP -->|reads/calls| MDM[ModelDownloadManager]
    OSP -->|reads/calls| HFS[HuggingFaceSearchService]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fsettings-redesign-engine-model%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fsettings-redesign-engine-model%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FSettings%2FPanes%2FEngineAndModelPaneView.swift%3A29-32%0A**Missing%20text%20modifiers%20on%20availability%20label**%0A%0AThe%20sibling%20%60AppleIntelligencePaneView%60%20applies%20%60.multilineTextAlignment%28.trailing%29.fixedSize%28horizontal%3A%20false%2C%20vertical%3A%20true%29%60%20to%20the%20same%20%60userVisibleMessage%60%20text.%20Without%20those%20modifiers%20here%2C%20long%20unavailability%20strings%20%28e.g.%20%22Apple%20Intelligence%20requires%20macOS%2026%20or%20later.%20Use%20Open%20Source%20on%20this%20Mac.%22%29%20can%20be%20truncated%20or%20misaligned%20in%20the%20parent%20overview%20pane%20%E2%80%94%20the%20first%20thing%20a%20user%20sees%20when%20switching%20engines.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FUI%2FSettings%2FPanes%2FOpenSourcePaneView.swift%3A80-85%0ACalling%20%60FileManager.default.fileExists%28atPath%3A%29%60%20and%20%60BundledRuntimeLocator.customModelDirectoryURL%28%29%60%20directly%20inside%20the%20view%20body%20means%20a%20synchronous%20filesystem%20syscall%20runs%20on%20the%20main%20thread%20on%20every%20SwiftUI%20re-render.%20Extracting%20these%20into%20computed%20properties%20%28or%20%60%40State%60%20populated%20in%20%60.onAppear%60%2Fbutton%20actions%29%20avoids%20the%20repeated%20I%2FO%20and%20makes%20the%20intent%20clearer.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FSettings%2FPanes%2FEngineAndModelPaneView.swift%3A29-32%0A**Missing%20text%20modifiers%20on%20availability%20label**%0A%0AThe%20sibling%20%60AppleIntelligencePaneView%60%20applies%20%60.multilineTextAlignment%28.trailing%29.fixedSize%28horizontal%3A%20false%2C%20vertical%3A%20true%29%60%20to%20the%20same%20%60userVisibleMessage%60%20text.%20Without%20those%20modifiers%20here%2C%20long%20unavailability%20strings%20%28e.g.%20%22Apple%20Intelligence%20requires%20macOS%2026%20or%20later.%20Use%20Open%20Source%20on%20this%20Mac.%22%29%20can%20be%20truncated%20or%20misaligned%20in%20the%20parent%20overview%20pane%20%E2%80%94%20the%20first%20thing%20a%20user%20sees%20when%20switching%20engines.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FUI%2FSettings%2FPanes%2FOpenSourcePaneView.swift%3A80-85%0ACalling%20%60FileManager.default.fileExists%28atPath%3A%29%60%20and%20%60BundledRuntimeLocator.customModelDirectoryURL%28%29%60%20directly%20inside%20the%20view%20body%20means%20a%20synchronous%20filesystem%20syscall%20runs%20on%20the%20main%20thread%20on%20every%20SwiftUI%20re-render.%20Extracting%20these%20into%20computed%20properties%20%28or%20%60%40State%60%20populated%20in%20%60.onAppear%60%2Fbutton%20actions%29%20avoids%20the%20repeated%20I%2FO%20and%20makes%20the%20intent%20clearer.%0A%0A&repo=fujacob%2Fcotabby&pr=365&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Address Greptile feedback: align engine ..."](https://github.com/fujacob/cotabby/commit/2b6692f10d05a84bfa48bd1516b3c9814fbf7452) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34339665)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->