### PR TITLE
Anchor user-forced popup card to the caret line, not the field rect

### DIFF
--- a/Cotabby/Support/MirrorOverlayLayout.swift
+++ b/Cotabby/Support/MirrorOverlayLayout.swift
@@ -91,7 +91,7 @@ struct MirrorOverlayLayout: Equatable {
         let cardWidth = contentWidth + (Metrics.horizontalPadding * 2)
         let cardHeight = ceil(Metrics.fontSize * 1.6) + (Metrics.verticalPadding * 2)
 
-        let anchorTopY = computeAnchorTopY(geometry: geometry)
+        let anchorTopY = computeAnchorTopY(geometry: geometry, reason: reason)
         let anchorCenterX = computeAnchorCenterX(geometry: geometry)
 
         var originX = anchorCenterX - (cardWidth / 2)
@@ -133,15 +133,43 @@ struct MirrorOverlayLayout: Equatable {
     }
 
     /// The Y coordinate the card sits *under*. In AppKit's bottom-up coordinate system this is the
-    /// bottom edge of the anchor (field or caret rect) minus the gap.
-    private static func computeAnchorTopY(geometry: SuggestionOverlayGeometry) -> CGFloat {
-        if let inputFrame = geometry.inputFrameRect?.standardized, !inputFrame.isEmpty {
-            return inputFrame.minY - Metrics.anchorGap
+    /// bottom edge of the anchor minus the gap.
+    ///
+    /// The anchor choice depends on *why* mirror mode is active:
+    ///
+    /// - `.caretGeometryEstimated` means the host did not expose any of the trusted caret paths, so
+    ///   the caret rect itself is unreliable. We anchor to the input field rect when available
+    ///   because the field rect stays stable even when the caret estimate drifts.
+    /// - `.userPreference` and `.perAppOverride` mean the user pinned popup mode despite the caret
+    ///   geometry being trustworthy (`.exact` or `.derived`). Anchoring to the field rect in this
+    ///   case wastes the precise caret signal and lands the card far below where the eye is. We
+    ///   anchor to the caret rect instead, with the input field as a safety net only for the
+    ///   degenerate case where the caret rect is empty.
+    private static func computeAnchorTopY(
+        geometry: SuggestionOverlayGeometry,
+        reason: CompletionRenderMode.MirrorReason
+    ) -> CGFloat {
+        switch reason {
+        case .caretGeometryEstimated:
+            if let inputFrame = geometry.inputFrameRect?.standardized, !inputFrame.isEmpty {
+                return inputFrame.minY - Metrics.anchorGap
+            }
+            // Caret-rect fallback uses the larger offset because in `.estimated` we treat the caret
+            // height as unreliable; the extra slack keeps the card from overlapping the typed line.
+            return geometry.caretRect.minY - Metrics.caretFallbackVerticalOffset
+
+        case .userPreference, .perAppOverride:
+            // Caret geometry is trustworthy in these cases. Sit just under the caret line so the
+            // popup tracks the cursor like the inline ghost does, instead of floating below the
+            // entire field.
+            if !geometry.caretRect.isEmpty {
+                return geometry.caretRect.minY - Metrics.anchorGap
+            }
+            if let inputFrame = geometry.inputFrameRect?.standardized, !inputFrame.isEmpty {
+                return inputFrame.minY - Metrics.anchorGap
+            }
+            return geometry.caretRect.minY - Metrics.caretFallbackVerticalOffset
         }
-        // No field rect — fall back to the caret rect with an explicit vertical offset so the card
-        // doesn't overlap the caret line. The card lands slightly lower than ideal but at least
-        // doesn't sit directly on top of typed text.
-        return geometry.caretRect.minY - Metrics.caretFallbackVerticalOffset
     }
 
     /// Horizontal center the card aligns to. Prefer the caret's X because the user's eye is already

--- a/CotabbyTests/MirrorOverlayLayoutTests.swift
+++ b/CotabbyTests/MirrorOverlayLayoutTests.swift
@@ -59,6 +59,86 @@ final class MirrorOverlayLayoutTests: XCTestCase {
         )
     }
 
+    // MARK: - Caret-anchored path (user-forced / per-app-forced popup)
+
+    func test_make_userPreferenceAnchorsToCaretLine_notInputField() {
+        // The field's bottom edge (minY in AppKit coordinates) is at y=400. The caret line sits at
+        // y=500, far above the field's bottom edge. Pre-fix behavior anchored to the field minY
+        // even with .userPreference reason, dropping the popup ~100pt below where the eye is. The
+        // fix uses caret.minY for user/perApp reasons so the popup tracks the cursor.
+        let geometry = CotabbyTestFixtures.overlayGeometry(
+            caretRect: CGRect(x: 720, y: 500, width: 2, height: 18),
+            inputFrameRect: CGRect(x: 400, y: 400, width: 640, height: 200)
+        )
+
+        let userPreferenceLayout = MirrorOverlayLayout.make(
+            suggestion: "hello",
+            geometry: geometry,
+            visibleFrame: screen,
+            showsAcceptanceHint: true,
+            reason: .userPreference
+        )
+
+        // Card must sit close to the caret line (within one card-height worth of slack), not at the
+        // field's bottom edge.
+        XCTAssertLessThan(
+            userPreferenceLayout.panelFrame.maxY,
+            geometry.caretRect.minY,
+            "User-forced popup should sit below the caret line"
+        )
+        XCTAssertGreaterThan(
+            userPreferenceLayout.panelFrame.maxY,
+            geometry.inputFrameRect!.minY + 40,
+            "User-forced popup should NOT drop down to the field's bottom edge"
+        )
+    }
+
+    func test_make_perAppOverrideAnchorsToCaretLine() {
+        let geometry = CotabbyTestFixtures.overlayGeometry(
+            caretRect: CGRect(x: 720, y: 500, width: 2, height: 18),
+            inputFrameRect: CGRect(x: 400, y: 400, width: 640, height: 200)
+        )
+
+        let layout = MirrorOverlayLayout.make(
+            suggestion: "hello",
+            geometry: geometry,
+            visibleFrame: screen,
+            showsAcceptanceHint: true,
+            reason: .perAppOverride
+        )
+
+        XCTAssertLessThan(
+            layout.panelFrame.maxY,
+            geometry.caretRect.minY,
+            "Per-app forced popup should also sit below the caret line, not the field"
+        )
+    }
+
+    func test_make_estimatedReasonStillAnchorsToInputField() {
+        // Same geometry as the user-preference test above, but with .caretGeometryEstimated. The
+        // caret rect is exactly the kind of value that can't be trusted in this case, so the layout
+        // must keep the field-rect anchor it had before the fix.
+        let geometry = CotabbyTestFixtures.overlayGeometry(
+            caretRect: CGRect(x: 720, y: 500, width: 2, height: 18),
+            inputFrameRect: CGRect(x: 400, y: 400, width: 640, height: 200)
+        )
+
+        let layout = MirrorOverlayLayout.make(
+            suggestion: "hello",
+            geometry: geometry,
+            visibleFrame: screen,
+            showsAcceptanceHint: true,
+            reason: .caretGeometryEstimated
+        )
+
+        // Card sits below the FIELD edge, well below the caret line.
+        XCTAssertLessThan(
+            layout.panelFrame.maxY,
+            geometry.inputFrameRect!.minY,
+            "Estimated-reason popup should still anchor below the input field rect"
+        )
+    }
+
     // MARK: - Fallback when input frame missing
 
     func test_make_fallsBackToCaretRectWhenInputFrameMissing() {


### PR DESCRIPTION
## Summary

Follow-up to #351. When the user pinned popup mode (or a per-app override forced it), the card was still anchored to the input field's bottom edge — the strategy that exists specifically to dodge unreliable caret geometry. With `.exact` or `.derived` caret quality that anchor wastes the precise signal and drops the popup far below where the eye is. This PR branches the anchor choice on the mirror reason: keep the field-rect anchor for `caretGeometryEstimated`, switch to a caret-rect anchor for `userPreference` and `perAppOverride` so the popup tracks the cursor like inline ghost text does.

## Validation

```
swiftlint lint --quiet                             # exit 0
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby \
  -destination 'platform=macOS' build              # ** BUILD SUCCEEDED **
xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby \
  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO
# Test Suite 'All tests' passed   (full suite, 0 failures)
# MirrorOverlayLayoutTests: 12 / 12 passed
```

Three new tests cover the fix:
- `test_make_userPreferenceAnchorsToCaretLine_notInputField` — the bug case: card lands near the caret, not at the field's bottom edge.
- `test_make_perAppOverrideAnchorsToCaretLine` — same behavior for per-app override.
- `test_make_estimatedReasonStillAnchorsToInputField` — regression guard that the original `.estimated` path is unchanged.

## Risk / rollout notes

- Behavior unchanged for the `.caretGeometryEstimated` reason (the auto-mirror path users see by default). The fix only touches placement when popup mode is user-pinned or per-app forced, both of which require an explicit user action to reach today.
- Caret-anchored fallback still routes through the field rect when the caret rect is empty, so degenerate geometry doesn't put the card off-screen.

## Linked issues

Refs #351.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes popup-card placement for user-pinned and per-app-forced mirror mode. Previously all mirror reasons anchored to the input field's bottom edge; now `.userPreference` and `.perAppOverride` anchor to the caret rect (with the field rect as a fallback), while `.caretGeometryEstimated` keeps the original field-first ordering.

- `MirrorOverlayLayout.computeAnchorTopY` is refactored from a flat function into a `switch` over `CompletionRenderMode.MirrorReason`, routing each case to the appropriate anchor strategy.
- Three new tests in `MirrorOverlayLayoutTests` verify the caret-anchored path, the per-app path, and a regression guard for the estimated path.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the fix is narrowly scoped, only activates through an explicit user action, and all three expected behaviours are covered by the new tests.

The struct-level doc comment now directly contradicts the new caret-anchored behaviour for `.userPreference`/`.perAppOverride`, which will mislead future readers. The degenerate triple-fallback for those same branches produces a negative Y that relies entirely on the screen clamp to stay on-screen — a small logic gap compared to the `.caretGeometryEstimated` path. Both are quality concerns rather than functional breakage for end users today.

The struct-level docstring in `MirrorOverlayLayout.swift` needs to be updated to reflect the new anchor strategy for `.userPreference` and `.perAppOverride`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/Support/MirrorOverlayLayout.swift | Core layout logic refactored; struct-level doc comment now contradicts the new caret-anchored paths for `.userPreference`/`.perAppOverride`. |
| CotabbyTests/MirrorOverlayLayoutTests.swift | Three new tests added; degenerate case (empty caret + nil inputFrame) for the new `.userPreference`/`.perAppOverride` paths is untested. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[computeAnchorTopY] --> B{reason}

    B -- .caretGeometryEstimated --> C{inputFrameRect\navailable & non-empty?}
    C -- yes --> D[inputFrame.minY − anchorGap]
    C -- no --> E[caretRect.minY − caretFallbackVerticalOffset]

    B -- .userPreference\n.perAppOverride --> F{caretRect\nnon-empty?}
    F -- yes --> G[caretRect.minY − anchorGap]
    F -- no --> H{inputFrameRect\navailable & non-empty?}
    H -- yes --> I[inputFrame.minY − anchorGap]
    H -- no --> J[caretRect.minY − caretFallbackVerticalOffset\n⚠️ caretRect is empty here — minY = 0\nclamped to screen minY]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `Cotabby/Support/MirrorOverlayLayout.swift`, line 7-10 ([link](https://github.com/fujacob/cotabby/blob/93a67fcc405bf003ca6d4c63d8b3fcb87ef88645/Cotabby/Support/MirrorOverlayLayout.swift#L7-L10)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The struct-level doc comment now contradicts the new behaviour introduced by this PR. It says "this helper does not anchor to the caret rect for positioning", but the `.userPreference` and `.perAppOverride` branches added here do exactly that. A reader skimming the type-level docs will get the wrong mental model for those paths.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fpopup-mode-caret-anchor%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpopup-mode-caret-anchor%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FSupport%2FMirrorOverlayLayout.swift%0ALine%3A%207-10%0A%0AComment%3A%0AThe%20struct-level%20doc%20comment%20now%20contradicts%20the%20new%20behaviour%20introduced%20by%20this%20PR.%20It%20says%20%22this%20helper%20does%20not%20anchor%20to%20the%20caret%20rect%20for%20positioning%22%2C%20but%20the%20%60.userPreference%60%20and%20%60.perAppOverride%60%20branches%20added%20here%20do%20exactly%20that.%20A%20reader%20skimming%20the%20type-level%20docs%20will%20get%20the%20wrong%20mental%20model%20for%20those%20paths.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20Mirror%20mode%20covers%20three%20reasons.%20For%20%60.caretGeometryEstimated%60%20the%20caret%20rect%20is%20unreliable%2C%0A%2F%2F%2F%20so%20layout%20anchors%20to%20the%20input%20field's%20frame%20and%20falls%20back%20to%20the%20caret%20rect%20only%20when%20the%0A%2F%2F%2F%20field%20frame%20is%20missing%20%E2%80%94%20the%20opposite%20of%20the%20inline%20ghost%20layout.%20For%20%60.userPreference%60%20and%0A%2F%2F%2F%20%60.perAppOverride%60%20the%20caret%20geometry%20is%20trustworthy%2C%20so%20layout%20anchors%20to%20the%20caret%20rect%20first%0A%2F%2F%2F%20and%20uses%20the%20input%20field%20only%20as%20a%20safety%20net%20when%20the%20caret%20rect%20is%20empty.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FSupport%2FMirrorOverlayLayout.swift%0ALine%3A%207-10%0A%0AComment%3A%0AThe%20struct-level%20doc%20comment%20now%20contradicts%20the%20new%20behaviour%20introduced%20by%20this%20PR.%20It%20says%20%22this%20helper%20does%20not%20anchor%20to%20the%20caret%20rect%20for%20positioning%22%2C%20but%20the%20%60.userPreference%60%20and%20%60.perAppOverride%60%20branches%20added%20here%20do%20exactly%20that.%20A%20reader%20skimming%20the%20type-level%20docs%20will%20get%20the%20wrong%20mental%20model%20for%20those%20paths.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20Mirror%20mode%20covers%20three%20reasons.%20For%20%60.caretGeometryEstimated%60%20the%20caret%20rect%20is%20unreliable%2C%0A%2F%2F%2F%20so%20layout%20anchors%20to%20the%20input%20field's%20frame%20and%20falls%20back%20to%20the%20caret%20rect%20only%20when%20the%0A%2F%2F%2F%20field%20frame%20is%20missing%20%E2%80%94%20the%20opposite%20of%20the%20inline%20ghost%20layout.%20For%20%60.userPreference%60%20and%0A%2F%2F%2F%20%60.perAppOverride%60%20the%20caret%20geometry%20is%20trustworthy%2C%20so%20layout%20anchors%20to%20the%20caret%20rect%20first%0A%2F%2F%2F%20and%20uses%20the%20input%20field%20only%20as%20a%20safety%20net%20when%20the%20caret%20rect%20is%20empty.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=368&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>


2. `CotabbyTests/MirrorOverlayLayoutTests.swift`, line 145-157 ([link](https://github.com/fujacob/cotabby/blob/93a67fcc405bf003ca6d4c63d8b3fcb87ef88645/CotabbyTests/MirrorOverlayLayoutTests.swift#L145-L157)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Missing degenerate-geometry test for new branches**

   `test_make_fallsBackToCaretRectWhenInputFrameMissing` only exercises `.caretGeometryEstimated`. There is no test for what happens when both `caretRect` is empty and `inputFrameRect` is nil under `.userPreference` or `.perAppOverride`. The triple-fallback path in `computeAnchorTopY` now has different code for those reasons but no corresponding test to guard it against future regression.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fpopup-mode-caret-anchor%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpopup-mode-caret-anchor%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20CotabbyTests%2FMirrorOverlayLayoutTests.swift%0ALine%3A%20145-157%0A%0AComment%3A%0A**Missing%20degenerate-geometry%20test%20for%20new%20branches**%0A%0A%60test_make_fallsBackToCaretRectWhenInputFrameMissing%60%20only%20exercises%20%60.caretGeometryEstimated%60.%20There%20is%20no%20test%20for%20what%20happens%20when%20both%20%60caretRect%60%20is%20empty%20and%20%60inputFrameRect%60%20is%20nil%20under%20%60.userPreference%60%20or%20%60.perAppOverride%60.%20The%20triple-fallback%20path%20in%20%60computeAnchorTopY%60%20now%20has%20different%20code%20for%20those%20reasons%20but%20no%20corresponding%20test%20to%20guard%20it%20against%20future%20regression.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20CotabbyTests%2FMirrorOverlayLayoutTests.swift%0ALine%3A%20145-157%0A%0AComment%3A%0A**Missing%20degenerate-geometry%20test%20for%20new%20branches**%0A%0A%60test_make_fallsBackToCaretRectWhenInputFrameMissing%60%20only%20exercises%20%60.caretGeometryEstimated%60.%20There%20is%20no%20test%20for%20what%20happens%20when%20both%20%60caretRect%60%20is%20empty%20and%20%60inputFrameRect%60%20is%20nil%20under%20%60.userPreference%60%20or%20%60.perAppOverride%60.%20The%20triple-fallback%20path%20in%20%60computeAnchorTopY%60%20now%20has%20different%20code%20for%20those%20reasons%20but%20no%20corresponding%20test%20to%20guard%20it%20against%20future%20regression.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=368&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fpopup-mode-caret-anchor%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpopup-mode-caret-anchor%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0ACotabby%2FSupport%2FMirrorOverlayLayout.swift%3A7-10%0AThe%20struct-level%20doc%20comment%20now%20contradicts%20the%20new%20behaviour%20introduced%20by%20this%20PR.%20It%20says%20%22this%20helper%20does%20not%20anchor%20to%20the%20caret%20rect%20for%20positioning%22%2C%20but%20the%20%60.userPreference%60%20and%20%60.perAppOverride%60%20branches%20added%20here%20do%20exactly%20that.%20A%20reader%20skimming%20the%20type-level%20docs%20will%20get%20the%20wrong%20mental%20model%20for%20those%20paths.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20Mirror%20mode%20covers%20three%20reasons.%20For%20%60.caretGeometryEstimated%60%20the%20caret%20rect%20is%20unreliable%2C%0A%2F%2F%2F%20so%20layout%20anchors%20to%20the%20input%20field's%20frame%20and%20falls%20back%20to%20the%20caret%20rect%20only%20when%20the%0A%2F%2F%2F%20field%20frame%20is%20missing%20%E2%80%94%20the%20opposite%20of%20the%20inline%20ghost%20layout.%20For%20%60.userPreference%60%20and%0A%2F%2F%2F%20%60.perAppOverride%60%20the%20caret%20geometry%20is%20trustworthy%2C%20so%20layout%20anchors%20to%20the%20caret%20rect%20first%0A%2F%2F%2F%20and%20uses%20the%20input%20field%20only%20as%20a%20safety%20net%20when%20the%20caret%20rect%20is%20empty.%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0ACotabby%2FSupport%2FMirrorOverlayLayout.swift%3A161-171%0AWhen%20both%20%60caretRect%60%20is%20empty%20and%20%60inputFrameRect%60%20is%20nil%2Fempty%2C%20this%20final%20fallback%20applies%20%60caretFallbackVerticalOffset%60%20to%20an%20already-empty%20caret%20rect%20whose%20%60minY%60%20is%20%600%60%2C%20producing%20%60-22%60.%20The%20screen-edge%20clamping%20rescues%20the%20card%2C%20but%20the%20intent%20%E2%80%94%20a%20%22fallback%20vertical%20offset%22%20%E2%80%94%20is%20meaningless%20here%20since%20there%20is%20no%20real%20caret%20position%20to%20offset%20from.%20Using%20%60Metrics.anchorGap%60%20instead%20makes%20the%20intent%20explicit%20and%20avoids%20relying%20on%20the%20clamp%20to%20fix%20a%20large%20negative%20offset.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20case%20.userPreference%2C%20.perAppOverride%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Caret%20geometry%20is%20trustworthy%20in%20these%20cases.%20Sit%20just%20under%20the%20caret%20line%20so%20the%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20popup%20tracks%20the%20cursor%20like%20the%20inline%20ghost%20does%2C%20instead%20of%20floating%20below%20the%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20entire%20field.%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20!geometry.caretRect.isEmpty%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%20geometry.caretRect.minY%20-%20Metrics.anchorGap%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20let%20inputFrame%20%3D%20geometry.inputFrameRect%3F.standardized%2C%20!inputFrame.isEmpty%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%20inputFrame.minY%20-%20Metrics.anchorGap%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Both%20rects%20are%20degenerate%3B%20the%20card%20will%20be%20clamped%20to%20the%20screen%20edge%20by%20the%20caller.%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20Metrics.anchorGap%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0ACotabbyTests%2FMirrorOverlayLayoutTests.swift%3A145-157%0A**Missing%20degenerate-geometry%20test%20for%20new%20branches**%0A%0A%60test_make_fallsBackToCaretRectWhenInputFrameMissing%60%20only%20exercises%20%60.caretGeometryEstimated%60.%20There%20is%20no%20test%20for%20what%20happens%20when%20both%20%60caretRect%60%20is%20empty%20and%20%60inputFrameRect%60%20is%20nil%20under%20%60.userPreference%60%20or%20%60.perAppOverride%60.%20The%20triple-fallback%20path%20in%20%60computeAnchorTopY%60%20now%20has%20different%20code%20for%20those%20reasons%20but%20no%20corresponding%20test%20to%20guard%20it%20against%20future%20regression.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0ACotabby%2FSupport%2FMirrorOverlayLayout.swift%3A7-10%0AThe%20struct-level%20doc%20comment%20now%20contradicts%20the%20new%20behaviour%20introduced%20by%20this%20PR.%20It%20says%20%22this%20helper%20does%20not%20anchor%20to%20the%20caret%20rect%20for%20positioning%22%2C%20but%20the%20%60.userPreference%60%20and%20%60.perAppOverride%60%20branches%20added%20here%20do%20exactly%20that.%20A%20reader%20skimming%20the%20type-level%20docs%20will%20get%20the%20wrong%20mental%20model%20for%20those%20paths.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20Mirror%20mode%20covers%20three%20reasons.%20For%20%60.caretGeometryEstimated%60%20the%20caret%20rect%20is%20unreliable%2C%0A%2F%2F%2F%20so%20layout%20anchors%20to%20the%20input%20field's%20frame%20and%20falls%20back%20to%20the%20caret%20rect%20only%20when%20the%0A%2F%2F%2F%20field%20frame%20is%20missing%20%E2%80%94%20the%20opposite%20of%20the%20inline%20ghost%20layout.%20For%20%60.userPreference%60%20and%0A%2F%2F%2F%20%60.perAppOverride%60%20the%20caret%20geometry%20is%20trustworthy%2C%20so%20layout%20anchors%20to%20the%20caret%20rect%20first%0A%2F%2F%2F%20and%20uses%20the%20input%20field%20only%20as%20a%20safety%20net%20when%20the%20caret%20rect%20is%20empty.%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0ACotabby%2FSupport%2FMirrorOverlayLayout.swift%3A161-171%0AWhen%20both%20%60caretRect%60%20is%20empty%20and%20%60inputFrameRect%60%20is%20nil%2Fempty%2C%20this%20final%20fallback%20applies%20%60caretFallbackVerticalOffset%60%20to%20an%20already-empty%20caret%20rect%20whose%20%60minY%60%20is%20%600%60%2C%20producing%20%60-22%60.%20The%20screen-edge%20clamping%20rescues%20the%20card%2C%20but%20the%20intent%20%E2%80%94%20a%20%22fallback%20vertical%20offset%22%20%E2%80%94%20is%20meaningless%20here%20since%20there%20is%20no%20real%20caret%20position%20to%20offset%20from.%20Using%20%60Metrics.anchorGap%60%20instead%20makes%20the%20intent%20explicit%20and%20avoids%20relying%20on%20the%20clamp%20to%20fix%20a%20large%20negative%20offset.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20case%20.userPreference%2C%20.perAppOverride%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Caret%20geometry%20is%20trustworthy%20in%20these%20cases.%20Sit%20just%20under%20the%20caret%20line%20so%20the%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20popup%20tracks%20the%20cursor%20like%20the%20inline%20ghost%20does%2C%20instead%20of%20floating%20below%20the%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20entire%20field.%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20!geometry.caretRect.isEmpty%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%20geometry.caretRect.minY%20-%20Metrics.anchorGap%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20let%20inputFrame%20%3D%20geometry.inputFrameRect%3F.standardized%2C%20!inputFrame.isEmpty%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%20inputFrame.minY%20-%20Metrics.anchorGap%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Both%20rects%20are%20degenerate%3B%20the%20card%20will%20be%20clamped%20to%20the%20screen%20edge%20by%20the%20caller.%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20Metrics.anchorGap%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0ACotabbyTests%2FMirrorOverlayLayoutTests.swift%3A145-157%0A**Missing%20degenerate-geometry%20test%20for%20new%20branches**%0A%0A%60test_make_fallsBackToCaretRectWhenInputFrameMissing%60%20only%20exercises%20%60.caretGeometryEstimated%60.%20There%20is%20no%20test%20for%20what%20happens%20when%20both%20%60caretRect%60%20is%20empty%20and%20%60inputFrameRect%60%20is%20nil%20under%20%60.userPreference%60%20or%20%60.perAppOverride%60.%20The%20triple-fallback%20path%20in%20%60computeAnchorTopY%60%20now%20has%20different%20code%20for%20those%20reasons%20but%20no%20corresponding%20test%20to%20guard%20it%20against%20future%20regression.%0A%0A&repo=fujacob%2Fcotabby&pr=368&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Anchor user-forced popup card to the car..."](https://github.com/fujacob/cotabby/commit/93a67fcc405bf003ca6d4c63d8b3fcb87ef88645) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34340323)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->