### PR TITLE
Pin Settings sidebar visibility so the toolbar toggle stops teleporting

### DIFF
--- a/Cotabby/UI/Settings/SettingsContainerView.swift
+++ b/Cotabby/UI/Settings/SettingsContainerView.swift
@@ -30,20 +30,35 @@ struct SettingsContainerView: View {
     private var storedCategoryRawValue: String = SettingsCategory.general.rawValue
 
     @State private var selection: SettingsCategory = .general
+    // Pinning visibility to `.all` and binding it as constant tells NavigationSplitView the user
+    // is never allowed to collapse the sidebar. That removes the default toggle button from the
+    // title bar (which otherwise teleports between the sidebar header and the content header as
+    // the column collapses) and keeps the sidebar always present, which is what users expect from
+    // a Settings window.
+    @State private var columnVisibility: NavigationSplitViewVisibility = .all
 
     var body: some View {
-        NavigationSplitView {
+        NavigationSplitView(columnVisibility: $columnVisibility) {
             SettingsSidebarView(
                 selection: $selection,
                 attentionCategories: attentionCategories
             )
+            .toolbar(removing: .sidebarToggle)
         } detail: {
             detailPane
                 .id(selection)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .toolbar(removing: .sidebarToggle)
         }
         .navigationSplitViewStyle(.balanced)
         .frame(minWidth: 820, minHeight: 540)
+        .onChange(of: columnVisibility) { _, newValue in
+            // Snap back to `.all` if something tries to collapse the sidebar. Cheaper than wiring
+            // a custom binding and reads as the same intent: the sidebar is never optional here.
+            if newValue != .all {
+                columnVisibility = .all
+            }
+        }
         .onAppear {
             selection = SettingsCategory(rawValue: storedCategoryRawValue) ?? .general
             launchAtLoginService.refresh()


### PR DESCRIPTION
The default NavigationSplitView toolbar shows a collapse-sidebar toggle that hops between the sidebar header and the detail header as the column visibility changes. In a Settings window the user has no reason to collapse the sidebar, so the safer fix is to pin visibility to `.all` and explicitly remove the toggle from both toolbars.

- BUILD SUCCEEDED, swiftlint clean.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Pins the `NavigationSplitView` sidebar to always-visible in `SettingsContainerView` by holding `columnVisibility` at `.all`, removing the sidebar-toggle toolbar item from both columns, and adding an `onChange` guard that snaps visibility back if anything tries to collapse it.

- Removes the floating toolbar toggle that previously teleported between the sidebar and detail headers as column visibility changed — a clean, targeted fix for the reported UX regression.
- The `onChange` snap-back provides a defensive fallback, but the system `View › Hide Sidebar` menu command and its keyboard shortcut (`⌘⌃S`) are not suppressed, so users can still trigger a brief collapse animation before the snap-back fires.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is narrowly scoped to the Settings window and has no effect on data or navigation correctness.

The toolbar-removal and visibility-pinning approach is correct and well-commented. The one remaining gap is cosmetic: the macOS sidebar keyboard shortcut can still trigger a visible collapse-and-snap animation since the shortcut is not intercepted. This doesn't affect functionality, only polish.

No files require special attention; the single changed file is self-contained and the logic is straightforward.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/Settings/SettingsContainerView.swift | Adds columnVisibility state pinned to .all, removes sidebarToggle from both toolbar slots, and adds an onChange guard to snap back if anything tries to collapse the sidebar. Well-scoped fix; one minor concern around keyboard shortcut collapse still triggering a visible animation before the snap-back fires. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SettingsContainerView appears] --> B[columnVisibility = .all]
    B --> C[NavigationSplitView renders sidebar + detail]
    C --> D{Sidebar toggle toolbar button exists?}
    D -- Before PR --> E[Toggle shown in sidebar or detail header - jumps around]
    D -- After PR --> F[.toolbar removing .sidebarToggle applied to both columns]
    F --> G[Toggle removed from title bar]
    G --> H{Anything tries to collapse sidebar?}
    H -- No --> I[Sidebar stays visible ✓]
    H -- Yes e.g. ⌘⌃S keyboard shortcut --> J[columnVisibility changes]
    J --> K[onChange fires]
    K --> L[Snap back to .all]
    L --> I
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fsettings-sidebar-pin-visibility%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsettings-sidebar-pin-visibility%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FSettings%2FSettingsContainerView.swift%3A55-61%0A**%60onChange%60%20snap-back%20doesn't%20suppress%20the%20sidebar-collapse%20animation**%0A%0A%60.toolbar%28removing%3A%20.sidebarToggle%29%60%20removes%20the%20UI%20button%2C%20but%20the%20system%20%60View%20%E2%80%BA%20Hide%20Sidebar%60%20menu%20item%20and%20its%20default%20keyboard%20shortcut%20%28%60%E2%8C%98%E2%8C%83S%60%29%20remain%20active.%20When%20a%20user%20presses%20that%20shortcut%2C%20%60NavigationSplitView%60%20starts%20its%20collapse%20animation%20*before*%20%60onChange%60%20fires%20and%20resets%20%60columnVisibility%60%20to%20%60.all%60%2C%20producing%20a%20visible%20flash%2Fflicker.%20The%20toggle%20button%20fix%20is%20solid%3B%20consider%20also%20disabling%20the%20sidebar%20menu%20command%20%E2%80%94%20for%20example%20by%20overriding%20%60NSMenuItem%60%20for%20%60toggleSidebar%3A%60%20in%20the%20hosting%20window%2C%20or%20by%20intercepting%20it%20with%20a%20%60.commands%60%20modifier%20%E2%80%94%20to%20make%20the%20experience%20fully%20seamless.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FSettings%2FSettingsContainerView.swift%3A55-61%0A**%60onChange%60%20snap-back%20doesn't%20suppress%20the%20sidebar-collapse%20animation**%0A%0A%60.toolbar%28removing%3A%20.sidebarToggle%29%60%20removes%20the%20UI%20button%2C%20but%20the%20system%20%60View%20%E2%80%BA%20Hide%20Sidebar%60%20menu%20item%20and%20its%20default%20keyboard%20shortcut%20%28%60%E2%8C%98%E2%8C%83S%60%29%20remain%20active.%20When%20a%20user%20presses%20that%20shortcut%2C%20%60NavigationSplitView%60%20starts%20its%20collapse%20animation%20*before*%20%60onChange%60%20fires%20and%20resets%20%60columnVisibility%60%20to%20%60.all%60%2C%20producing%20a%20visible%20flash%2Fflicker.%20The%20toggle%20button%20fix%20is%20solid%3B%20consider%20also%20disabling%20the%20sidebar%20menu%20command%20%E2%80%94%20for%20example%20by%20overriding%20%60NSMenuItem%60%20for%20%60toggleSidebar%3A%60%20in%20the%20hosting%20window%2C%20or%20by%20intercepting%20it%20with%20a%20%60.commands%60%20modifier%20%E2%80%94%20to%20make%20the%20experience%20fully%20seamless.%0A%0A&repo=fujacob%2Fcotabby&pr=369&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Pin Settings sidebar visibility so the t..."](https://github.com/fujacob/cotabby/commit/b277af5991a680c1d8ba3790926db9313bc3a05a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34340355)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->