### PR TITLE
Group Settings General into cards, surface Fast Mode + clarify context cost

### DIFF
--- a/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
@@ -1,10 +1,11 @@
 import SwiftUI
 
 /// File overview:
-/// "General" detail pane of the redesigned Settings window. Owns the everyday on/off toggles, the
-/// ghost-text appearance controls, and the onboarding re-entry. Lifted intact from the legacy
-/// `SettingsView.generalSection` so behavior, bindings, and tooltip copy stay identical; only the
-/// scaffolding around the form is new.
+/// "General" detail pane of the redesigned Settings window. Groups settings into four visually
+/// separated `Section`s (`.formStyle(.grouped)` renders each as its own rounded card, which is
+/// the macOS-native equivalent of a divider): top-level on/off toggles, behavior tuning, display
+/// surface, and appearance. The `Display` picker label here matches the same name used by the
+/// menu-bar quick control so users can connect the two.
 struct GeneralPaneView: View {
     @ObservedObject var suggestionSettings: SuggestionSettingsModel
     let onShowWelcome: () -> Void
@@ -13,8 +14,35 @@ struct GeneralPaneView: View {
 
     var body: some View {
         SettingsPaneScaffold {
-            Section("General") {
+            Section {
                 Toggle("Enable Globally", isOn: globallyEnabledBinding)
+
+                // Fast Mode is the most user-facing performance lever, so it gets prime real
+                // estate at the top. The "(no screen context)" suffix tells the user concretely
+                // what gets skipped so they can decide whether they care.
+                Toggle("Fast Mode (no screen context)", isOn: fastModeEnabledBinding)
+            }
+
+            Section("Behavior") {
+                Toggle("Include Clipboard Context", isOn: clipboardContextEnabledBinding)
+
+                Toggle("Allow Multi-line Suggestions", isOn: multiLineEnabledBinding)
+
+                Toggle("Accept Punctuation With Word", isOn: autoAcceptTrailingPunctuationBinding)
+            }
+
+            Section("Display") {
+                Picker("Suggestion Display", selection: mirrorPreferenceBinding) {
+                    ForEach(MirrorPreference.allCases) { preference in
+                        Text(preference.displayLabel).tag(preference)
+                    }
+                }
+                .pickerStyle(.menu)
+                .help(
+                    "Auto uses inline ghost text when the focused field exposes a reliable cursor " +
+                    "position, and switches to a popup card when it doesn't (some Electron and web " +
+                    "editors). Choose Inline or Popup to pin one style for every app."
+                )
 
                 Toggle("Show Indicator", isOn: showIndicatorBinding)
 
@@ -32,27 +60,9 @@ struct GeneralPaneView: View {
                         Text("Key Hint")
                     }
                 }
+            }
 
-                Picker("Suggestion Display", selection: mirrorPreferenceBinding) {
-                    ForEach(MirrorPreference.allCases) { preference in
-                        Text(preference.displayLabel).tag(preference)
-                    }
-                }
-                .pickerStyle(.menu)
-                .help(
-                    "Auto uses inline ghost text when the focused field exposes a reliable cursor " +
-                    "position, and switches to a popup card when it doesn't (some Electron and web " +
-                    "editors). Choose Inline or Popup to pin one style for every app."
-                )
-
-                Toggle("Allow Multi-line Suggestions", isOn: multiLineEnabledBinding)
-
-                Toggle("Accept Punctuation With Word", isOn: autoAcceptTrailingPunctuationBinding)
-
-                Toggle("Include Clipboard Context", isOn: clipboardContextEnabledBinding)
-
-                Toggle("Fast Mode", isOn: fastModeEnabledBinding)
-
+            Section("Appearance") {
                 LabeledContent("Ghost Text Color") {
                     HStack(spacing: 8) {
                         ForEach(GhostTextColorPreset.all) { preset in
@@ -78,7 +88,9 @@ struct GeneralPaneView: View {
                             .frame(width: 42, alignment: .trailing)
                     }
                 }
+            }
 
+            Section {
                 LabeledContent("Onboarding") {
                     Button("Open Welcome Guide") {
                         onShowWelcome()


### PR DESCRIPTION
Splits the General pane into four grouped Sections that render as separate cards under `.formStyle(.grouped)` (the macOS-native equivalent of dividers), moves Fast Mode to the top alongside Enable Globally with a `(no screen context)` suffix so the cost is visible, and keeps the picker label as "Suggestion Display".

Layout:
1. Top card: Enable Globally, Fast Mode (no screen context)
2. Behavior: Clipboard, Multi-line, Auto-accept punctuation
3. Display: Suggestion Display picker, Show Indicator, Show Key Hint
4. Appearance: Ghost text color, Ghost text opacity
5. Onboarding: Open Welcome Guide

Build + lint clean.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reorganises the General settings pane by splitting a single flat `Section` into five grouped `Section`s that render as native rounded cards under `.formStyle(.grouped)`. Fast Mode is promoted to the top card alongside "Enable Globally" and gains a `(no screen context)` suffix to make its cost visible.

- The top card now holds the two primary on/off levers; Behavior, Display, and Appearance sections follow, each containing the settings most logically related to that category.
- All bindings, model calls, and business logic are untouched — this is a pure layout and labelling change.
- The file-overview doc comment still says "four" sections, but the view body contains five; a one-word fix aligns them.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely a visual grouping change with no logic touched.

Every binding, model call, and behavioral path in the file is untouched. The only changes are how existing controls are wrapped in Section containers and the label text of the Fast Mode toggle. The sole noteworthy item is a doc comment that says four sections when there are five — harmless and easy to fix.

No files require special attention; the single changed file is a straightforward layout rearrangement.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/Settings/Panes/GeneralPaneView.swift | Pure UI restructure: splits one flat Section into five grouped Section cards, moves Fast Mode to the top with a clarifying label suffix, and reorders existing toggles/controls into logical groups. All bindings and logic are unchanged. One doc comment says "four" sections but the code has five. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[GeneralPaneView] --> B[SettingsPaneScaffold]
    B --> C["Section (unlabeled)\nEnable Globally\nFast Mode (no screen context)"]
    B --> D["Section: Behavior\nInclude Clipboard Context\nAllow Multi-line Suggestions\nAccept Punctuation With Word"]
    B --> E["Section: Display\nSuggestion Display picker\nShow Indicator\nShow Key Hint toggle"]
    B --> F["Section: Appearance\nGhost Text Color swatches\nGhost Text Opacity slider"]
    B --> G["Section (unlabeled)\nOnboarding → Open Welcome Guide"]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fsettings-general-tidy%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsettings-general-tidy%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FSettings%2FPanes%2FGeneralPaneView.swift%3A4-8%0A**Doc%20comment%20says%20%22four%22%20but%20five%20%60Section%60s%20are%20present**%0A%0AThe%20file-overview%20comment%20says%20the%20view%20groups%20settings%20into%20%22four%20visually%20separated%20%60Section%60s%22%2C%20but%20the%20body%20contains%20five%3A%20the%20unlabeled%20top%20card%2C%20%60Behavior%60%2C%20%60Display%60%2C%20%60Appearance%60%2C%20and%20the%20unlabeled%20%60Onboarding%60%20card%20at%20the%20bottom.%20The%20count%20mismatch%20could%20mislead%20a%20future%20reader%20counting%20sections%20when%20adding%20or%20reordering%20them.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20separated%20%60Section%60s%20%28%60.formStyle%28.grouped%29%60%20renders%20each%20as%20its%20own%20rounded%20card%2C%20which%20is%0A%2F%2F%2F%20the%20macOS-native%20equivalent%20of%20a%20divider%29%3A%20top-level%20on%2Foff%20toggles%2C%20behavior%20tuning%2C%20display%0A%2F%2F%2F%20surface%2C%20appearance%2C%20and%20onboarding.%20The%20%60Display%60%20picker%20label%20here%20matches%20the%20same%20name%20used%20by%20the%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FSettings%2FPanes%2FGeneralPaneView.swift%3A4-8%0A**Doc%20comment%20says%20%22four%22%20but%20five%20%60Section%60s%20are%20present**%0A%0AThe%20file-overview%20comment%20says%20the%20view%20groups%20settings%20into%20%22four%20visually%20separated%20%60Section%60s%22%2C%20but%20the%20body%20contains%20five%3A%20the%20unlabeled%20top%20card%2C%20%60Behavior%60%2C%20%60Display%60%2C%20%60Appearance%60%2C%20and%20the%20unlabeled%20%60Onboarding%60%20card%20at%20the%20bottom.%20The%20count%20mismatch%20could%20mislead%20a%20future%20reader%20counting%20sections%20when%20adding%20or%20reordering%20them.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20separated%20%60Section%60s%20%28%60.formStyle%28.grouped%29%60%20renders%20each%20as%20its%20own%20rounded%20card%2C%20which%20is%0A%2F%2F%2F%20the%20macOS-native%20equivalent%20of%20a%20divider%29%3A%20top-level%20on%2Foff%20toggles%2C%20behavior%20tuning%2C%20display%0A%2F%2F%2F%20surface%2C%20appearance%2C%20and%20onboarding.%20The%20%60Display%60%20picker%20label%20here%20matches%20the%20same%20name%20used%20by%20the%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=370&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Group Settings General into cards, surfa..."](https://github.com/fujacob/cotabby/commit/8ccbe2170a2b419bc266ac244c65b788316a6a1b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34340684)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->