### PR TITLE
Give every Settings pane a consistent top inset

### DIFF
--- a/Cotabby/UI/Settings/Components/SettingsPaneScaffold.swift
+++ b/Cotabby/UI/Settings/Components/SettingsPaneScaffold.swift
@@ -34,6 +34,11 @@ struct SettingsPaneScaffold<Content: View>: View {
                     content()
                 }
                 .formStyle(.grouped)
+                // `.formStyle(.grouped)` only pads BEFORE a `Section` that has a header. Panes
+                // whose first section is header-less (General, About, Apps) would otherwise butt
+                // flush against the title bar. A fixed top inset gives every pane the same
+                // breathing room regardless of whether the first section carries a header.
+                .padding(.top, 12)
             }
         }
     }


### PR DESCRIPTION
Panes whose first Section has no header sat flush against the title bar. Adds a 12pt top padding to the Form inside `SettingsPaneScaffold` so every pane has the same breathing room.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a layout bug where Settings panes whose first `Section` had no header would render flush against the title bar by adding a uniform `.padding(.top, 12)` to the `Form` inside `SettingsPaneScaffold`.

- The fix is applied unconditionally, so panes whose first section *does* carry a header now receive the system's built-in inset *plus* 12 pt — worth a visual check across all panes to confirm headed panes don't feel over-spaced.
- When a `callout` banner is visible, the `VStack` has `spacing: 0` and the callout carries no explicit bottom padding, leaving only 12 pt between the banner's edge and the form — this may look tighter below the callout than above it.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is a single-line layout tweak with a clear, well-commented rationale.

The fix correctly addresses the flush-against-title-bar issue for header-less panes, but applying the inset unconditionally means headed panes gain extra top space they didn't have before. This is a cosmetic side-effect rather than a functional regression, but it warrants a visual pass across all settings panes before shipping.

SettingsPaneScaffold.swift — specifically the callout-plus-form layout path and any pane that uses a first section with a header.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/UI/Settings/Components/SettingsPaneScaffold.swift | Adds `.padding(.top, 12)` to the Form inside SettingsPaneScaffold to fix flush-against-title-bar layout on header-less panes; the fix is unconditional so headed panes also gain extra top space, and the gap between a visible callout and the form is narrow (only the 12 pt inset, no explicit callout-to-form spacing). |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SettingsPaneScaffold] --> B{callout present?}
    B -- Yes --> C[SettingsCalloutView\n.padding top:16, horizontal:20]
    B -- No --> D[skip callout]
    C --> E[VStack spacing:0]
    D --> E
    E --> F[Form with content\n.formStyle .grouped\n.padding top:12]
    F --> G{First Section has header?}
    G -- Yes --> H[system inset + 12 pt top gap]
    G -- No --> I[12 pt top gap only\nFIX: was 0]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cotabby/UI/Settings/Components/SettingsPaneScaffold.swift`, line 28-41 ([link](https://github.com/fujacob/cotabby/blob/6ac336f78c8ea44f54bb2ca5dffe0e45a239d28f/Cotabby/UI/Settings/Components/SettingsPaneScaffold.swift#L28-L41)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Tight gap between callout and form when callout is present**

   When a callout is rendered, `SettingsCalloutView` receives `.padding(.top, 16)` but no bottom padding. The `VStack` has `spacing: 0`, so the only gap between the callout's content edge and the form's first row is the 12 pt top inset added here. Depending on the internal `.padding(12)` of `SettingsCalloutView`, this may produce a noticeably tighter visual gap below the callout compared to the space above it.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fsettings-pane-top-padding%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsettings-pane-top-padding%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FSettings%2FComponents%2FSettingsPaneScaffold.swift%0ALine%3A%2028-41%0A%0AComment%3A%0A**Tight%20gap%20between%20callout%20and%20form%20when%20callout%20is%20present**%0A%0AWhen%20a%20callout%20is%20rendered%2C%20%60SettingsCalloutView%60%20receives%20%60.padding%28.top%2C%2016%29%60%20but%20no%20bottom%20padding.%20The%20%60VStack%60%20has%20%60spacing%3A%200%60%2C%20so%20the%20only%20gap%20between%20the%20callout's%20content%20edge%20and%20the%20form's%20first%20row%20is%20the%2012%20pt%20top%20inset%20added%20here.%20Depending%20on%20the%20internal%20%60.padding%2812%29%60%20of%20%60SettingsCalloutView%60%2C%20this%20may%20produce%20a%20noticeably%20tighter%20visual%20gap%20below%20the%20callout%20compared%20to%20the%20space%20above%20it.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FSettings%2FComponents%2FSettingsPaneScaffold.swift%0ALine%3A%2028-41%0A%0AComment%3A%0A**Tight%20gap%20between%20callout%20and%20form%20when%20callout%20is%20present**%0A%0AWhen%20a%20callout%20is%20rendered%2C%20%60SettingsCalloutView%60%20receives%20%60.padding%28.top%2C%2016%29%60%20but%20no%20bottom%20padding.%20The%20%60VStack%60%20has%20%60spacing%3A%200%60%2C%20so%20the%20only%20gap%20between%20the%20callout's%20content%20edge%20and%20the%20form's%20first%20row%20is%20the%2012%20pt%20top%20inset%20added%20here.%20Depending%20on%20the%20internal%20%60.padding%2812%29%60%20of%20%60SettingsCalloutView%60%2C%20this%20may%20produce%20a%20noticeably%20tighter%20visual%20gap%20below%20the%20callout%20compared%20to%20the%20space%20above%20it.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=371&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fsettings-pane-top-padding%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsettings-pane-top-padding%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FSettings%2FComponents%2FSettingsPaneScaffold.swift%3A41%0A**Extra%20top%20inset%20on%20panes%20whose%20first%20section%20already%20has%20a%20header**%0A%0A%60.formStyle%28.grouped%29%60%20on%20macOS%20inserts%20its%20own%20top%20gap%20before%20a%20section%20header.%20Applying%20an%20unconditional%20%60.padding%28.top%2C%2012%29%60%20on%20top%20of%20that%20means%20header-bearing%20panes%20%28e.g.%20any%20pane%20whose%20first%20%60Section%60%20has%20a%20non-empty%20title%29%20now%20receive%20the%20original%20system%20inset%20*plus*%2012%20pt%2C%20while%20header-less%20panes%20receive%20only%2012%20pt.%20The%20goal%20of%20uniform%20breathing%20room%20is%20achieved%20for%20the%20broken%20case%2C%20but%20headed%20panes%20will%20now%20sit%20lower%20than%20before%20%E2%80%94%20which%20may%20be%20the%20intended%20trade-off%2C%20but%20it's%20worth%20verifying%20visually%20across%20all%20panes.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FUI%2FSettings%2FComponents%2FSettingsPaneScaffold.swift%3A28-41%0A**Tight%20gap%20between%20callout%20and%20form%20when%20callout%20is%20present**%0A%0AWhen%20a%20callout%20is%20rendered%2C%20%60SettingsCalloutView%60%20receives%20%60.padding%28.top%2C%2016%29%60%20but%20no%20bottom%20padding.%20The%20%60VStack%60%20has%20%60spacing%3A%200%60%2C%20so%20the%20only%20gap%20between%20the%20callout's%20content%20edge%20and%20the%20form's%20first%20row%20is%20the%2012%20pt%20top%20inset%20added%20here.%20Depending%20on%20the%20internal%20%60.padding%2812%29%60%20of%20%60SettingsCalloutView%60%2C%20this%20may%20produce%20a%20noticeably%20tighter%20visual%20gap%20below%20the%20callout%20compared%20to%20the%20space%20above%20it.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FSettings%2FComponents%2FSettingsPaneScaffold.swift%3A41%0A**Extra%20top%20inset%20on%20panes%20whose%20first%20section%20already%20has%20a%20header**%0A%0A%60.formStyle%28.grouped%29%60%20on%20macOS%20inserts%20its%20own%20top%20gap%20before%20a%20section%20header.%20Applying%20an%20unconditional%20%60.padding%28.top%2C%2012%29%60%20on%20top%20of%20that%20means%20header-bearing%20panes%20%28e.g.%20any%20pane%20whose%20first%20%60Section%60%20has%20a%20non-empty%20title%29%20now%20receive%20the%20original%20system%20inset%20*plus*%2012%20pt%2C%20while%20header-less%20panes%20receive%20only%2012%20pt.%20The%20goal%20of%20uniform%20breathing%20room%20is%20achieved%20for%20the%20broken%20case%2C%20but%20headed%20panes%20will%20now%20sit%20lower%20than%20before%20%E2%80%94%20which%20may%20be%20the%20intended%20trade-off%2C%20but%20it's%20worth%20verifying%20visually%20across%20all%20panes.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FUI%2FSettings%2FComponents%2FSettingsPaneScaffold.swift%3A28-41%0A**Tight%20gap%20between%20callout%20and%20form%20when%20callout%20is%20present**%0A%0AWhen%20a%20callout%20is%20rendered%2C%20%60SettingsCalloutView%60%20receives%20%60.padding%28.top%2C%2016%29%60%20but%20no%20bottom%20padding.%20The%20%60VStack%60%20has%20%60spacing%3A%200%60%2C%20so%20the%20only%20gap%20between%20the%20callout's%20content%20edge%20and%20the%20form's%20first%20row%20is%20the%2012%20pt%20top%20inset%20added%20here.%20Depending%20on%20the%20internal%20%60.padding%2812%29%60%20of%20%60SettingsCalloutView%60%2C%20this%20may%20produce%20a%20noticeably%20tighter%20visual%20gap%20below%20the%20callout%20compared%20to%20the%20space%20above%20it.%0A%0A&repo=fujacob%2Fcotabby&pr=371&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Give every Settings pane a consistent to..."](https://github.com/fujacob/cotabby/commit/6ac336f78c8ea44f54bb2ca5dffe0e45a239d28f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34341111)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->