### PR TITLE
Rename built-in models to the tabby-1-* family

### DIFF
--- a/Cotabby/Models/LlamaRuntimeModels.swift
+++ b/Cotabby/Models/LlamaRuntimeModels.swift
@@ -96,13 +96,13 @@ enum RuntimeModelCatalog {
     static func displayName(for filename: String) -> String {
         switch filename {
         case "Qwen3-0.6B-Q4_K_M.gguf":
-            return "tabby-fast-1"
+            return "tabby-1-mini"
         case "gemma-4-E2B-it-Q4_K_M.gguf":
-            return "tabby-balanced-1"
+            return "tabby-1-base"
         case "gemma-4-E4B-it-Q4_K_M.gguf":
-            return "tabby-max-1"
+            return "tabby-1-pro"
         case "SmolLM2-135M-Instruct-q8_0.gguf":
-            return "tabby-nano-2"
+            return "tabby-1-nano"
         default:
             return filename
         }

--- a/CotabbyTests/ModelAndPresentationValueTests.swift
+++ b/CotabbyTests/ModelAndPresentationValueTests.swift
@@ -145,11 +145,11 @@ final class RuntimeAndInputModelValueTests: XCTestCase {
     func test_runtimeModelCatalogMapsKnownNamesAndLeavesCustomNamesAlone() {
         XCTAssertEqual(
             RuntimeModelCatalog.displayName(for: "Qwen3-0.6B-Q4_K_M.gguf"),
-            "tabby-fast-1"
+            "tabby-1-mini"
         )
         XCTAssertEqual(
             RuntimeModelCatalog.displayName(for: "gemma-4-E2B-it-Q4_K_M.gguf"),
-            "tabby-balanced-1"
+            "tabby-1-base"
         )
         // Retired models fall back to their raw filename like any unknown local GGUF.
         XCTAssertEqual(

--- a/README.md
+++ b/README.md
@@ -84,12 +84,12 @@ Everything runs on-device. No hosted API, no cloud round-trip.
 
 **Open Source**: runs local GGUF models in-process through llama.cpp via `llama.swift`. Cotabby ships with four built-in downloadable models:
 
-| Model              | File                              | Size    | Source                                                                                                  |
-| ------------------ | --------------------------------- | ------- | ------------------------------------------------------------------------------------------------------- |
-| `tabby-nano-2`     | `SmolLM2-135M-Instruct-q8_0.gguf` | ~0.1 GB | [Mungert/SmolLM2-135M-Instruct-GGUF](https://huggingface.co/Mungert/SmolLM2-135M-Instruct-GGUF)         |
-| `tabby-fast-1`     | `Qwen3-0.6B-Q4_K_M.gguf`          | ~0.4 GB | [unsloth/Qwen3-0.6B-GGUF](https://huggingface.co/unsloth/Qwen3-0.6B-GGUF)                               |
-| `tabby-balanced-1` | `gemma-4-E2B-it-Q4_K_M.gguf`      | ~3.1 GB | [unsloth/gemma-4-E2B-it-GGUF](https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF)                       |
-| `tabby-max-1`      | `gemma-4-E4B-it-Q4_K_M.gguf`      | ~5.0 GB | [unsloth/gemma-4-E4B-it-GGUF](https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF)                       |
+| Model          | File                              | Size    | Source                                                                                                  |
+| -------------- | --------------------------------- | ------- | ------------------------------------------------------------------------------------------------------- |
+| `tabby-1-nano` | `SmolLM2-135M-Instruct-q8_0.gguf` | ~0.1 GB | [Mungert/SmolLM2-135M-Instruct-GGUF](https://huggingface.co/Mungert/SmolLM2-135M-Instruct-GGUF)         |
+| `tabby-1-mini` | `Qwen3-0.6B-Q4_K_M.gguf`          | ~0.4 GB | [unsloth/Qwen3-0.6B-GGUF](https://huggingface.co/unsloth/Qwen3-0.6B-GGUF)                               |
+| `tabby-1-base` | `gemma-4-E2B-it-Q4_K_M.gguf`      | ~3.1 GB | [unsloth/gemma-4-E2B-it-GGUF](https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF)                       |
+| `tabby-1-pro`  | `gemma-4-E4B-it-Q4_K_M.gguf`      | ~5.0 GB | [unsloth/gemma-4-E4B-it-GGUF](https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF)                       |
 
 ### Bring your own model
 


### PR DESCRIPTION
## Summary

Aligns the four built-in downloadable model presets under a single, version-prefixed naming scheme so future iterations land as a family rather than a one-off rename. Display labels only; the underlying GGUF filenames are untouched.

| Before             | After          |
| ------------------ | -------------- |
| `tabby-nano-2`     | `tabby-1-nano` |
| `tabby-fast-1`     | `tabby-1-mini` |
| `tabby-balanced-1` | `tabby-1-base` |
| `tabby-max-1`      | `tabby-1-pro`  |

## Validation

```
swiftlint lint --quiet                                # exit 0
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby \
  -destination 'platform=macOS' build                 # ** BUILD SUCCEEDED **
xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby \
  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO
# Test Suite 'All tests' passed (full suite, 0 failures)
```

Verified `grep -rn` for both old and new names: no stale references remain.

## Risk / rollout notes

- Pure rename of presentation strings. The `RuntimeModelCatalog.displayName(for:)` switch is keyed on the GGUF filename, which is unchanged, so already-downloaded models keep working and per-model settings keyed off filename keep resolving correctly.
- Existing users who already have a model installed will see the new label show up immediately on next launch.
- Three files touched: `Cotabby/Models/LlamaRuntimeModels.swift` (the catalog), `CotabbyTests/ModelAndPresentationValueTests.swift` (test expectations), and `README.md` (the user-facing table).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR renames the four built-in downloadable model presets from ad-hoc names (`tabby-nano-2`, `tabby-fast-1`, `tabby-balanced-1`, `tabby-max-1`) to a unified `tabby-1-*` family (`tabby-1-nano`, `tabby-1-mini`, `tabby-1-base`, `tabby-1-pro`). The change is purely presentational — GGUF filenames used as switch keys and settings identifiers are untouched.

- **`LlamaRuntimeModels.swift`**: All four `return` strings in `RuntimeModelCatalog.displayName(for:)` updated to the new naming scheme.
- **`ModelAndPresentationValueTests.swift`**: Test expectations refreshed for two of the four models; `tabby-1-pro` and `tabby-1-nano` assertions are absent.
- **`README.md`**: User-facing model table updated to show all four new names alongside their unchanged GGUF filenames and download sources.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the rename is purely presentational and the underlying GGUF filenames used as persistent identifiers are unchanged.

The catalog logic and README are correct and complete. The test suite only exercises two of the four renamed branches, so a future typo in the `tabby-1-pro` or `tabby-1-nano` return strings would go undetected until runtime.

CotabbyTests/ModelAndPresentationValueTests.swift — missing assertions for `tabby-1-pro` and `tabby-1-nano`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Models/LlamaRuntimeModels.swift | All four display name strings in `RuntimeModelCatalog.displayName(for:)` correctly renamed to the `tabby-1-*` family; GGUF filenames (the switch keys) are untouched. |
| CotabbyTests/ModelAndPresentationValueTests.swift | Test expectations updated for two of the four renamed models; `tabby-1-pro` and `tabby-1-nano` assertions are missing, leaving those branches untested. |
| README.md | Model table updated cleanly to reflect all four new `tabby-1-*` names; GGUF filenames, sizes, and HuggingFace source links are unchanged. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[GGUF filename\nswitch key] --> B{RuntimeModelCatalog\n.displayName}
    B -->|Qwen3-0.6B-Q4_K_M.gguf| C["tabby-1-mini ✓"]
    B -->|gemma-4-E2B-it-Q4_K_M.gguf| D["tabby-1-base ✓"]
    B -->|gemma-4-E4B-it-Q4_K_M.gguf| E["tabby-1-pro ✓"]
    B -->|SmolLM2-135M-Instruct-q8_0.gguf| F["tabby-1-nano ✓"]
    B -->|anything else| G[raw filename]

    C -->|tested| H([✅ test coverage])
    D -->|tested| H
    E -->|not tested| I([⚠️ no assertion])
    F -->|not tested| I
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22rename%2Fmodel-tabby-1-family%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22rename%2Fmodel-tabby-1-family%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabbyTests%2FModelAndPresentationValueTests.swift%3A146-154%0AThe%20test%20function%20only%20asserts%20the%20new%20display%20names%20for%20%60tabby-1-mini%60%20and%20%60tabby-1-base%60%2C%20leaving%20%60tabby-1-pro%60%20%28%60gemma-4-E4B-it-Q4_K_M.gguf%60%29%20and%20%60tabby-1-nano%60%20%28%60SmolLM2-135M-Instruct-q8_0.gguf%60%29%20uncovered.%20A%20typo%20in%20either%20of%20those%20two%20%60return%60%20strings%20would%20not%20be%20caught%20by%20this%20suite.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20XCTAssertEqual%28%0A%20%20%20%20%20%20%20%20%20%20%20%20RuntimeModelCatalog.displayName%28for%3A%20%22Qwen3-0.6B-Q4_K_M.gguf%22%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22tabby-1-mini%22%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20XCTAssertEqual%28%0A%20%20%20%20%20%20%20%20%20%20%20%20RuntimeModelCatalog.displayName%28for%3A%20%22gemma-4-E2B-it-Q4_K_M.gguf%22%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22tabby-1-base%22%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20XCTAssertEqual%28%0A%20%20%20%20%20%20%20%20%20%20%20%20RuntimeModelCatalog.displayName%28for%3A%20%22gemma-4-E4B-it-Q4_K_M.gguf%22%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22tabby-1-pro%22%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20XCTAssertEqual%28%0A%20%20%20%20%20%20%20%20%20%20%20%20RuntimeModelCatalog.displayName%28for%3A%20%22SmolLM2-135M-Instruct-q8_0.gguf%22%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22tabby-1-nano%22%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%2F%2F%20Retired%20models%20fall%20back%20to%20their%20raw%20filename%20like%20any%20unknown%20local%20GGUF.%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabbyTests%2FModelAndPresentationValueTests.swift%3A146-154%0AThe%20test%20function%20only%20asserts%20the%20new%20display%20names%20for%20%60tabby-1-mini%60%20and%20%60tabby-1-base%60%2C%20leaving%20%60tabby-1-pro%60%20%28%60gemma-4-E4B-it-Q4_K_M.gguf%60%29%20and%20%60tabby-1-nano%60%20%28%60SmolLM2-135M-Instruct-q8_0.gguf%60%29%20uncovered.%20A%20typo%20in%20either%20of%20those%20two%20%60return%60%20strings%20would%20not%20be%20caught%20by%20this%20suite.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20XCTAssertEqual%28%0A%20%20%20%20%20%20%20%20%20%20%20%20RuntimeModelCatalog.displayName%28for%3A%20%22Qwen3-0.6B-Q4_K_M.gguf%22%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22tabby-1-mini%22%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20XCTAssertEqual%28%0A%20%20%20%20%20%20%20%20%20%20%20%20RuntimeModelCatalog.displayName%28for%3A%20%22gemma-4-E2B-it-Q4_K_M.gguf%22%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22tabby-1-base%22%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20XCTAssertEqual%28%0A%20%20%20%20%20%20%20%20%20%20%20%20RuntimeModelCatalog.displayName%28for%3A%20%22gemma-4-E4B-it-Q4_K_M.gguf%22%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22tabby-1-pro%22%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20XCTAssertEqual%28%0A%20%20%20%20%20%20%20%20%20%20%20%20RuntimeModelCatalog.displayName%28for%3A%20%22SmolLM2-135M-Instruct-q8_0.gguf%22%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22tabby-1-nano%22%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%2F%2F%20Retired%20models%20fall%20back%20to%20their%20raw%20filename%20like%20any%20unknown%20local%20GGUF.%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=372&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Rename built-in models to the tabby-1-\* ..."](https://github.com/fujacob/cotabby/commit/f2510beee28976ab5dfd836b15fa12fbb2398cf2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34341349)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->