### PR TITLE
Inset Settings sidebar top and widen the column

### DIFF
--- a/Cotabby/UI/Settings/SettingsSidebarView.swift
+++ b/Cotabby/UI/Settings/SettingsSidebarView.swift
@@ -16,6 +16,14 @@ struct SettingsSidebarView: View {
 
     var body: some View {
         List(selection: $selection) {
+            // First row would otherwise sit flush against the window title bar. A clear-color
+            // sentinel that is excluded from selection gives the sidebar the same top breathing
+            // room as the detail pane without fighting `.listStyle(.sidebar)`.
+            Color.clear
+                .frame(height: 8)
+                .listRowBackground(Color.clear)
+                .selectionDisabled()
+
             ForEach(SettingsSidebarSection.allCases, id: \.self) { section in
                 let rows = SettingsCategory.allCases.filter { $0.section == section }
                 if !rows.isEmpty {
@@ -30,7 +38,8 @@ struct SettingsSidebarView: View {
             }
         }
         .listStyle(.sidebar)
-        .navigationSplitViewColumnWidth(min: 200, ideal: 220, max: 260)
+        // Wider min/ideal so labels like "Apple Intelligence" do not truncate to "Apple I...".
+        .navigationSplitViewColumnWidth(min: 240, ideal: 260, max: 320)
     }
 
     @ViewBuilder


### PR DESCRIPTION
First sidebar row was flush against the title bar; the column was also too narrow so labels like 'Apple Intelligence' truncated to 'Apple I...'. Inserts a clear-color spacer at the top of the List and bumps the column width to min 240 / ideal 260 / max 320.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two visual issues in the Settings sidebar: the first row was flush against the window title bar, and the column was too narrow for longer labels like "Apple Intelligence".

- A `Color.clear` spacer row (8 pt) is inserted at the top of the `List` with `.selectionDisabled()` to add top breathing room without conflicting with `.listStyle(.sidebar)`.
- The `navigationSplitViewColumnWidth` is bumped from `min: 200 / ideal: 220 / max: 260` to `min: 240 / ideal: 260 / max: 320` to prevent label truncation.

<h3>Confidence Score: 4/5</h3>

Safe to merge; changes are cosmetic layout tweaks with a single minor accessibility gap in the spacer row.

Both changes are narrow and purposeful. The wider column width is straightforward. The Color.clear spacer row works correctly for sighted users, but it is not marked .accessibilityHidden(true), so VoiceOver will encounter an unnamed, empty list element when navigating the sidebar.

Cotabby/UI/Settings/SettingsSidebarView.swift — the spacer row needs .accessibilityHidden(true) before the accessibility story is complete.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/Settings/SettingsSidebarView.swift | Adds an 8 pt clear spacer row at the top of the sidebar List to prevent the first row sitting flush against the title bar, and widens the column width (min 240 / ideal 260 / max 320). The spacer row is selection-disabled but not accessibility-hidden, leaving it reachable by VoiceOver. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SettingsSidebarView body] --> B[List with selection binding]
    B --> C[Color.clear spacer row]
    B --> D[ForEach SettingsSidebarSection.allCases]
    D --> E{section has rows?}
    E -- yes --> F{section has title?}
    F -- yes --> G[Section with header]
    F -- no --> H[Section no header]
    G --> I[ForEach rows]
    H --> I
    B --> J[.listStyle .sidebar]
    J --> K[navigationSplitViewColumnWidth min 240 ideal 260 max 320]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fsettings-sidebar-width%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsettings-sidebar-width%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FSettings%2FSettingsSidebarView.swift%3A22-25%0AAdding%20%60.accessibilityHidden%28true%29%60%20prevents%20VoiceOver%20from%20landing%20on%20this%20invisible%20placeholder%20row%20when%20the%20user%20navigates%20the%20sidebar.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20Color.clear%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.frame%28height%3A%208%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.listRowBackground%28Color.clear%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.selectionDisabled%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.accessibilityHidden%28true%29%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FSettings%2FSettingsSidebarView.swift%3A22-25%0AAdding%20%60.accessibilityHidden%28true%29%60%20prevents%20VoiceOver%20from%20landing%20on%20this%20invisible%20placeholder%20row%20when%20the%20user%20navigates%20the%20sidebar.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20Color.clear%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.frame%28height%3A%208%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.listRowBackground%28Color.clear%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.selectionDisabled%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.accessibilityHidden%28true%29%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=373&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Inset sidebar top + widen so labels stop..."](https://github.com/fujacob/cotabby/commit/9c57c0b70163acf7b4a6db72b8909cd4f08cd62a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34341430)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->