### PR TITLE
Larger Settings window, wider sidebar, align sidebar top with detail

### DIFF
--- a/Cotabby/App/Coordinators/SettingsCoordinator.swift
+++ b/Cotabby/App/Coordinators/SettingsCoordinator.swift
@@ -94,11 +94,11 @@ final class SettingsCoordinator: NSObject, NSWindowDelegate {
                     )
                 )
             )
-            initialFrame = CGRect(x: 0, y: 0, width: 960, height: 680)
-            minSize = NSSize(width: 820, height: 540)
-            // Separate autosave name so the redesigned layout starts from its own default frame
-            // for users who already had a smaller saved frame from the legacy window.
-            autosaveName = "CotabbySettingsWindowV2"
+            initialFrame = CGRect(x: 0, y: 0, width: 1320, height: 820)
+            minSize = NSSize(width: 1180, height: 720)
+            // Bumped autosave name again so existing dogfooders get the new larger default
+            // frame instead of inheriting the previous V2 size.
+            autosaveName = "CotabbySettingsWindowV3"
         } else {
             hostingController = NSHostingController(
                 rootView: AnyView(

--- a/Cotabby/UI/Settings/SettingsContainerView.swift
+++ b/Cotabby/UI/Settings/SettingsContainerView.swift
@@ -51,7 +51,7 @@ struct SettingsContainerView: View {
                 .toolbar(removing: .sidebarToggle)
         }
         .navigationSplitViewStyle(.balanced)
-        .frame(minWidth: 820, minHeight: 540)
+        .frame(minWidth: 1180, minHeight: 720)
         .onChange(of: columnVisibility) { _, newValue in
             // Snap back to `.all` if something tries to collapse the sidebar. Cheaper than wiring
             // a custom binding and reads as the same intent: the sidebar is never optional here.

--- a/Cotabby/UI/Settings/SettingsSidebarView.swift
+++ b/Cotabby/UI/Settings/SettingsSidebarView.swift
@@ -16,14 +16,6 @@ struct SettingsSidebarView: View {
 
     var body: some View {
         List(selection: $selection) {
-            // First row would otherwise sit flush against the window title bar. A clear-color
-            // sentinel that is excluded from selection gives the sidebar the same top breathing
-            // room as the detail pane without fighting `.listStyle(.sidebar)`.
-            Color.clear
-                .frame(height: 8)
-                .listRowBackground(Color.clear)
-                .selectionDisabled()
-
             ForEach(SettingsSidebarSection.allCases, id: \.self) { section in
                 let rows = SettingsCategory.allCases.filter { $0.section == section }
                 if !rows.isEmpty {
@@ -38,8 +30,12 @@ struct SettingsSidebarView: View {
             }
         }
         .listStyle(.sidebar)
-        // Wider min/ideal so labels like "Apple Intelligence" do not truncate to "Apple I...".
-        .navigationSplitViewColumnWidth(min: 240, ideal: 260, max: 320)
+        // Doubled column width so every label fits without truncation and the sidebar reads as a
+        // real navigation column. The earlier clear-color top spacer is gone: it was pushing the
+        // first row well below where the detail pane's first card starts, breaking visual
+        // alignment between sidebar and content. The grouped form's own top inset on the detail
+        // side handles breathing room; the sidebar lines up with it naturally.
+        .navigationSplitViewColumnWidth(min: 480, ideal: 520, max: 640)
     }
 
     @ViewBuilder


### PR DESCRIPTION
Default 1320x820 / min 1180x720 so content doesn't get cut. Sidebar column doubled to 480/520/640 so labels fit. Removed the clear-color top spacer that was pushing the General row well below the detail pane's first card. Autosave name bumped to V3 to give existing dogfooders the new default.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR widens the redesigned Settings window (default 1320×820, min 1180×720), doubles the sidebar column width so labels no longer truncate, removes a clear-color spacer that was misaligning the sidebar's first row with the detail pane, and bumps the autosave name to V3 so existing users receive the new default frame.

- **`SettingsCoordinator.swift`**: `initialFrame` and `minSize` both enlarged; `autosaveName` incremented to `"CotabbySettingsWindowV3"` to force a fresh default for users who already had a V2 saved frame.
- **`SettingsContainerView.swift`**: SwiftUI `.frame` constraint updated to `minWidth: 1180, minHeight: 720`, keeping it in sync with the coordinator's `NSWindow.minSize`.
- **`SettingsSidebarView.swift`**: `Color.clear` top spacer removed and `.navigationSplitViewColumnWidth` raised from `min: 240/ideal: 260/max: 320` to `min: 480/ideal: 520/max: 640`.

<h3>Confidence Score: 4/5</h3>

Safe to merge — changes are purely layout/sizing with no logic, data, or API surface touched.

All three files contain only numeric dimension constants and one removed spacer view. The autosave name bump correctly isolates dogfooders from their old frame. The two observations (sidebar floor being very wide, and the initial frame being close to the limits of a 13" MacBook display) are cosmetic and do not affect correctness or data.

SettingsSidebarView.swift — the 480 px minimum sidebar width is worth a second look against the full label inventory; SettingsCoordinator.swift — the 1320 px initial frame may feel large on entry-level MacBook displays.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/App/Coordinators/SettingsCoordinator.swift | Bumps initial frame to 1320×820, minimum size to 1180×720, and autosave name to V3 so existing users get the new defaults instead of the old V2 frame. |
| Cotabby/UI/Settings/SettingsContainerView.swift | Updates SwiftUI frame constraint to minWidth 1180 / minHeight 720, keeping it consistent with the coordinator's NSWindow minSize. |
| Cotabby/UI/Settings/SettingsSidebarView.swift | Removes the clear-color top spacer and triples the minimum sidebar column width (240→480), which could feel overly wide on the minimum-sized window. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[showSettings called] --> B{autosave\nV3 frame\nexists?}
    B -- yes --> C[Restore saved frame]
    B -- no --> D[Apply initialFrame\n1320 x 820]
    C --> E[NSWindow\nminSize: 1180 x 720]
    D --> E
    E --> F[window.center]
    F --> G[NavigationSplitView\nbalanced style]
    G --> H[Sidebar column\nmin:480 ideal:520 max:640]
    G --> I[Detail pane\nremaining width]
    H --> J[SwiftUI frame\nminWidth:1180 minHeight:720]
    I --> J
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fsettings-window-size%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsettings-window-size%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FSettings%2FSettingsSidebarView.swift%3A38%0A**Sidebar%20min%20width%20may%20be%20overly%20generous**%0A%0A480%20px%20is%20roughly%20double%20what%20the%20widest%20label%20%28%22Apple%20Intelligence%22%20at%20~160%20px%20in%20SF%20Pro%2013pt%29%20actually%20needs.%20At%20minimum%20window%20width%20%281180%20px%29%2C%20the%20sidebar%20already%20occupies%2040%20%25%20of%20the%20total%20surface%20area%2C%20leaving%20the%20detail%20pane%20only%20~700%20px.%20If%20more%20sidebar%20items%20are%20added%20or%20the%20window%20is%20pushed%20toward%20its%20minimum%2C%20this%20ratio%20will%20keep%20squeezing%20the%20content%20side.%20Consider%20whether%20something%20closer%20to%20280%E2%80%93320%20px%20min%20%28with%20a%20larger%20ideal%2Fmax%20if%20you%20want%20the%20default%20to%20be%20wider%29%20would%20give%20the%20labels%20room%20without%20anchoring%20such%20a%20large%20floor.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FApp%2FCoordinators%2FSettingsCoordinator.swift%3A97-98%0A**Initial%20frame%20may%20overflow%20smaller%20MacBook%20displays**%0A%0AThe%20new%20%60initialFrame%60%20of%201320%C3%97820%20is%20larger%20than%20the%20effective%20resolution%20of%20a%2013%22%20MacBook%20Air%20at%20default%20scaling%20%28~1440%C3%97900%20usable%2C%20but%20with%20menu%20bar%20and%20Dock%20that%20can%20leave%20as%20little%20as%20~1440%C3%97840%20of%20available%20space%29.%20AppKit%20will%20clamp%20the%20window%20when%20%60center%28%29%60%20is%20called%2C%20but%20a%20user%20on%20such%20a%20machine%20will%20see%20the%20window%20immediately%20span%20nearly%20their%20full%20screen%20on%20first%20open.%20The%20minimum%20size%20of%201180%C3%97720%20is%20the%20more%20important%20floor%20%E2%80%94%20consider%20whether%20the%20%60initialFrame%60%20default%20could%20be%20set%20closer%20to%20it%20%28e.g.%201180%E2%80%931200%20px%20wide%29%20so%20the%20first-launch%20experience%20is%20less%20jarring%20on%20small%20displays%20while%20still%20allowing%20users%20to%20expand%20freely.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FSettings%2FSettingsSidebarView.swift%3A38%0A**Sidebar%20min%20width%20may%20be%20overly%20generous**%0A%0A480%20px%20is%20roughly%20double%20what%20the%20widest%20label%20%28%22Apple%20Intelligence%22%20at%20~160%20px%20in%20SF%20Pro%2013pt%29%20actually%20needs.%20At%20minimum%20window%20width%20%281180%20px%29%2C%20the%20sidebar%20already%20occupies%2040%20%25%20of%20the%20total%20surface%20area%2C%20leaving%20the%20detail%20pane%20only%20~700%20px.%20If%20more%20sidebar%20items%20are%20added%20or%20the%20window%20is%20pushed%20toward%20its%20minimum%2C%20this%20ratio%20will%20keep%20squeezing%20the%20content%20side.%20Consider%20whether%20something%20closer%20to%20280%E2%80%93320%20px%20min%20%28with%20a%20larger%20ideal%2Fmax%20if%20you%20want%20the%20default%20to%20be%20wider%29%20would%20give%20the%20labels%20room%20without%20anchoring%20such%20a%20large%20floor.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FApp%2FCoordinators%2FSettingsCoordinator.swift%3A97-98%0A**Initial%20frame%20may%20overflow%20smaller%20MacBook%20displays**%0A%0AThe%20new%20%60initialFrame%60%20of%201320%C3%97820%20is%20larger%20than%20the%20effective%20resolution%20of%20a%2013%22%20MacBook%20Air%20at%20default%20scaling%20%28~1440%C3%97900%20usable%2C%20but%20with%20menu%20bar%20and%20Dock%20that%20can%20leave%20as%20little%20as%20~1440%C3%97840%20of%20available%20space%29.%20AppKit%20will%20clamp%20the%20window%20when%20%60center%28%29%60%20is%20called%2C%20but%20a%20user%20on%20such%20a%20machine%20will%20see%20the%20window%20immediately%20span%20nearly%20their%20full%20screen%20on%20first%20open.%20The%20minimum%20size%20of%201180%C3%97720%20is%20the%20more%20important%20floor%20%E2%80%94%20consider%20whether%20the%20%60initialFrame%60%20default%20could%20be%20set%20closer%20to%20it%20%28e.g.%201180%E2%80%931200%20px%20wide%29%20so%20the%20first-launch%20experience%20is%20less%20jarring%20on%20small%20displays%20while%20still%20allowing%20users%20to%20expand%20freely.%0A%0A&repo=fujacob%2Fcotabby&pr=374&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Larger Settings window, wider sidebar, a..."](https://github.com/fujacob/cotabby/commit/149a06ff6c1e98ce941bb1822d646a3c8b2a2059) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34341798)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->