### PR TITLE
Tighten Settings sidebar width and restore its top inset

### DIFF
--- a/Cotabby/UI/Settings/SettingsContainerView.swift
+++ b/Cotabby/UI/Settings/SettingsContainerView.swift
@@ -51,7 +51,12 @@ struct SettingsContainerView: View {
                 .toolbar(removing: .sidebarToggle)
         }
         .navigationSplitViewStyle(.balanced)
-        .frame(minWidth: 1180, minHeight: 720)
+        // Sized so the sidebar's `ideal` width (240) plus a detail pane that comfortably holds the
+        // grouped Form (~500pt) fits without forcing `.balanced` to squeeze the sidebar below the
+        // longest label. The previous 1180pt floor came from an earlier sidebar experiment that
+        // doubled column widths; with the sidebar tightened back down, that floor leaves the
+        // detail pane oversized for the actual content.
+        .frame(minWidth: 780, minHeight: 560)
         .onChange(of: columnVisibility) { _, newValue in
             // Snap back to `.all` if something tries to collapse the sidebar. Cheaper than wiring
             // a custom binding and reads as the same intent: the sidebar is never optional here.

--- a/Cotabby/UI/Settings/SettingsSidebarView.swift
+++ b/Cotabby/UI/Settings/SettingsSidebarView.swift
@@ -30,12 +30,20 @@ struct SettingsSidebarView: View {
             }
         }
         .listStyle(.sidebar)
-        // Doubled column width so every label fits without truncation and the sidebar reads as a
-        // real navigation column. The earlier clear-color top spacer is gone: it was pushing the
-        // first row well below where the detail pane's first card starts, breaking visual
-        // alignment between sidebar and content. The grouped form's own top inset on the detail
-        // side handles breathing room; the sidebar lines up with it naturally.
-        .navigationSplitViewColumnWidth(min: 480, ideal: 520, max: 640)
+        // Restores the breathing room the previous clear-color top spacer used to provide. Without
+        // it, the first sidebar row snaps to the toolbar baseline while the detail pane's grouped
+        // `Form` keeps its own ~20pt top inset, so the two columns visually disagree about where
+        // content begins. Insetting from the safe area keeps the inset out of scroll content so it
+        // never overlaps a row mid-scroll.
+        .safeAreaInset(edge: .top, spacing: 0) {
+            Color.clear.frame(height: 12)
+        }
+        // Previously bumped to 480/520/640, but with the window's overall `minWidth` the
+        // `.balanced` split style had to shrink the sidebar back below 240pt to keep the detail
+        // pane usable — which still truncated "Apple Intelligence" to "Apple Intell…". The
+        // tighter range here matches the longest user-facing label and lines up with the
+        // matching `minWidth` reduction on the container so the detail pane keeps its own room.
+        .navigationSplitViewColumnWidth(min: 220, ideal: 240, max: 280)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary

The Settings window had three pieces pulling against each other after the recent redesign work, producing the symptoms in the bug report (sidebar cut at the top, "Apple Intelligence" truncated, detail pane oversized). This PR tightens the sidebar column range back down to fit the longest label, reintroduces a small top inset so the first sidebar row aligns with the detail pane's first card, and drops the window's `minWidth` so the detail pane is sized to its actual content.

## Validation

User requested skipping local CI on this one. Diff is two files, three pure layout-knob changes; no behavior or logic touched.

## Risk / rollout notes

- Window minimum drops from 1180pt to 780pt. Users with the window already sized larger keep their size; the minimum just lets them shrink it now.
- Sidebar column range goes from 480/520/640 to 220/240/280. `.balanced` split style now has room to honor the ideal.
- Top inset is added via `.safeAreaInset(edge: .top)` so it stays outside the scroll content and never overlaps a row when scrolling.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Three layout constants are adjusted to fix a regression where the Settings sidebar showed truncated labels and misaligned top insets: `minWidth` drops from 1180 pt to 780 pt, sidebar column range narrows from 480/520/640 to 220/240/280, and a 12 pt `safeAreaInset` is added to align the first sidebar row with the detail pane's top inset.

- **`SettingsContainerView.swift`**: `minWidth` reduced to 780 pt and `minHeight` reduced from 720 pt to 560 pt; the prior 1180 pt floor was a leftover from a wider sidebar experiment.
- **`SettingsSidebarView.swift`**: Column width range tightened to 220/240/280 to match the longest label (\"Apple Intelligence\"), and a 12 pt `Color.clear` safe-area inset is added at the top so the first sidebar row visually aligns with the detail pane's grouped `Form` inset.

<h3>Confidence Score: 4/5</h3>

Safe to merge — all changes are pure layout constants with no behavioral impact.

Both files only touch frame dimensions and a safeAreaInset modifier. The safeAreaInset API is available since macOS 13 and the project targets macOS 14, so there is no availability concern. The one thing worth keeping an eye on is the minHeight drop from 720 to 560 pt — it is not called out in the PR rollout notes and could bite future pane expansions if they add taller content.

No files require special attention; the minHeight reduction in SettingsContainerView.swift is worth documenting for future reference.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/Settings/SettingsContainerView.swift | minWidth reduced from 1180 to 780, minHeight from 720 to 560; purely layout, no logic changes |
| Cotabby/UI/Settings/SettingsSidebarView.swift | Sidebar column width tightened to 220/240/280 and 12 pt safeAreaInset added at top; both changes are layout-only and appropriate for macOS 14 |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SettingsContainerView\nminWidth: 780pt, minHeight: 560pt] --> B[NavigationSplitView\n.balanced]
    B --> C[SettingsSidebarView\ncol: 220 / 240 / 280 pt]
    B --> D[Detail Pane\n~500 pt available]
    C --> E[.safeAreaInset top 12pt\nColor.clear overlay]
    C --> F[List rows\nFirst row aligned with detail Form]
    D --> G[GeneralPane / EnginePaneView\n/ AppleIntelligencePaneView / ...]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fsettings-panel-widths-and-sidebar-inset%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsettings-panel-widths-and-sidebar-inset%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FSettings%2FSettingsContainerView.swift%3A59%0A**Undocumented%20minHeight%20reduction**%0A%0A%60minHeight%60%20drops%20from%20720%20pt%20to%20560%20pt%20alongside%20the%20%60minWidth%60%20change%2C%20but%20this%20isn't%20called%20out%20in%20the%20PR%20description's%20rollout%20notes.%20At%20560%20pt%20the%20window%20is%20fairly%20compact%20%E2%80%94%20if%20any%20detail%20pane%20adds%20taller%20content%20in%20a%20follow-up%20%28e.g.%20a%20form%20with%20more%20rows%29%2C%20users%20who%20have%20the%20window%20pinned%20to%20minimum%20height%20would%20see%20truncation%20without%20a%20scroll%20view%20guarding%20the%20pane.%20Worth%20noting%20explicitly%20in%20the%20rollout%20notes%20and%20keeping%20in%20mind%20for%20future%20pane%20expansions.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FSettings%2FSettingsContainerView.swift%3A59%0A**Undocumented%20minHeight%20reduction**%0A%0A%60minHeight%60%20drops%20from%20720%20pt%20to%20560%20pt%20alongside%20the%20%60minWidth%60%20change%2C%20but%20this%20isn't%20called%20out%20in%20the%20PR%20description's%20rollout%20notes.%20At%20560%20pt%20the%20window%20is%20fairly%20compact%20%E2%80%94%20if%20any%20detail%20pane%20adds%20taller%20content%20in%20a%20follow-up%20%28e.g.%20a%20form%20with%20more%20rows%29%2C%20users%20who%20have%20the%20window%20pinned%20to%20minimum%20height%20would%20see%20truncation%20without%20a%20scroll%20view%20guarding%20the%20pane.%20Worth%20noting%20explicitly%20in%20the%20rollout%20notes%20and%20keeping%20in%20mind%20for%20future%20pane%20expansions.%0A%0A&repo=fujacob%2Fcotabby&pr=375&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Tighten Settings sidebar width and resto..."](https://github.com/fujacob/cotabby/commit/2bf5281f97204dc0fd9957af0f2767b18b0f4d59) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34342745)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->