### PR TITLE
Delay post-divergence prediction so Chromium AX can catch up

### DIFF
--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
@@ -171,6 +171,25 @@ extension SuggestionCoordinator {
         return false
     }
 
+    /// Schedules a fresh prediction after a short delay so Chromium-based editors (Chrome, Edge,
+    /// Slack, Discord, Notion, every Electron app) have time to publish the new contenteditable
+    /// text to AX. Without the delay, `schedulePrediction()` fires synchronously from inside the
+    /// CGEvent tap — which runs *before* the host app processes the keystroke — so the AX read
+    /// inside generation still sees pre-keystroke text. The result feels like Cotabby swallowed
+    /// the key: the active suggestion vanishes, a new one appears that does not reflect the
+    /// character the user just typed, and the user concludes their keystroke was eaten.
+    /// 150ms is chosen empirically: long enough for Chromium's contenteditable AX to settle on a
+    /// busy page, short enough that the rescheduled suggestion still feels responsive after the
+    /// user has just diverged from the previous one. `schedulePrediction()` internally
+    /// `replaceDebouncedWork`s, so back-to-back keystrokes still collapse cleanly.
+    private func schedulePredictionAfterHostPublishDelay() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(150)) { [weak self] in
+            guard let self else { return }
+            self.focusModel.refreshNow()
+            self.schedulePrediction()
+        }
+    }
+
     func handleSuppressedSyntheticInput() {
         logStage(
             "suppressed-synthetic-input",
@@ -195,8 +214,7 @@ extension SuggestionCoordinator {
                 clearDiagnostics: false
             )
             if event.shouldSchedulePrediction {
-                focusModel.refreshNow()
-                schedulePrediction()
+                schedulePredictionAfterHostPublishDelay()
             }
             return false
 
@@ -206,8 +224,7 @@ extension SuggestionCoordinator {
                 clearDiagnostics: false
             )
             if event.shouldSchedulePrediction {
-                focusModel.refreshNow()
-                schedulePrediction()
+                schedulePredictionAfterHostPublishDelay()
             }
             return false
 


### PR DESCRIPTION
User report: in Chrome / Electron inputs, pressing a non-accept key with a suggestion visible feels like Cotabby swallows the key and just regenerates a new suggestion that ignores what was typed.

Root cause: the active-session `.textMutation` and `.shortcutMutation` paths call `focusModel.refreshNow()` + `schedulePrediction()` synchronously from inside the CGEvent tap. The tap runs BEFORE the host app processes the keystroke. Chromium-based editors then take 100-200ms to publish the new contenteditable text to AX. So generation reads pre-keystroke AX, makes a suggestion against stale text, and visually erases the user's input.

Fix: defer the post-divergence reschedule by 150ms. The active suggestion still invalidates immediately (overlay clears) so the user has no stale ghost text in their way; only the regeneration is held back long enough for AX to settle. `schedulePrediction()` uses `replaceDebouncedWork` internally so back-to-back keystrokes still collapse cleanly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a 150ms deferred reschedule path (`schedulePredictionAfterHostPublishDelay`) for the active-session divergence cases (`.textMutation` and `.shortcutMutation`) so that Chromium-based editors have time to publish new contenteditable text to AX before prediction fires. The overlay is still cleared synchronously on divergence; only the regeneration is held back.

- The delay is applied only on the active-session path — the no-active-session path retains its immediate `refreshNow()` + `schedulePrediction()` call, consistent with its existing comment about capturing the freshest snapshot at keystroke time.
- `schedulePrediction()` internally uses `replaceDebouncedWork`, so back-to-back keystrokes will collapse into a single prediction pass even with multiple deferred closures queued.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the fix correctly targets the Chromium AX timing race and does not touch any prediction logic, acceptance flows, or non-active-session paths.

The change is small and well-scoped. The one thing worth a second look is that `schedulePredictionAfterHostPublishDelay` enqueues a new non-cancellable `asyncAfter` closure on every divergence, so rapid typing accumulates multiple closures that each call `focusModel.refreshNow()`. The redundant AX reads are harmless in practice because `replaceDebouncedWork` coalesces the actual prediction work, but replacing `asyncAfter` with a stored, cancellable `DispatchWorkItem` would make the pattern cleaner and avoid unnecessary overhead.

No files require special attention beyond the single helper method added in `SuggestionCoordinator+Input.swift`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift | Introduces `schedulePredictionAfterHostPublishDelay()` to defer AX refresh + prediction by 150ms on active-session divergence; the delay is correct and well-targeted, but the helper uses non-cancellable `asyncAfter` closures that accumulate with rapid keystrokes. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CGEventTap as CGEvent Tap
    participant Coordinator as SuggestionCoordinator
    participant MainQueue as DispatchQueue.main
    participant FocusModel as focusModel
    participant Engine as SuggestionEngine

    User->>CGEventTap: keypress (diverges from suggestion)
    CGEventTap->>Coordinator: handleInputEvent(_:with:)
    Coordinator->>Coordinator: invalidateActiveSuggestion() — overlay clears immediately
    Coordinator->>MainQueue: asyncAfter(+150ms)

    Note over CGEventTap,Engine: Host app processes keystroke and publishes new AX text (~100–200ms)

    MainQueue-->>Coordinator: fires after 150ms
    Coordinator->>FocusModel: refreshNow() — reads settled AX state
    Coordinator->>Coordinator: schedulePrediction() → replaceDebouncedWork(delay: debounceMs)

    Note over Coordinator,Engine: After debounce window...

    Coordinator->>FocusModel: refreshNow() — final AX read inside generateFromCurrentFocus
    Coordinator->>Engine: generate(request) — uses post-keystroke text
    Engine-->>Coordinator: suggestion
    Coordinator-->>User: overlay shows correct suggestion
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fchrome-textmutation-defer%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fchrome-textmutation-defer%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BInput.swift%3A185-191%0ANon-cancellable%20%60asyncAfter%60%20closures%20accumulate%20with%20rapid%20divergences.%20Every%20call%20to%20%60schedulePredictionAfterHostPublishDelay%28%29%60%20enqueues%20a%20new%2C%20non-cancellable%20closure.%20With%20N%20rapid%20divergences%2C%20N%20closures%20will%20fire%20in%20quick%20succession%20%E2%80%94%20each%20calling%20%60focusModel.refreshNow%28%29%60%20and%20%60schedulePrediction%28%29%60.%20While%20%60replaceDebouncedWork%60%20inside%20%60schedulePrediction%28%29%60%20collapses%20the%20prediction%20work%20correctly%2C%20the%20%60refreshNow%28%29%60%20calls%20are%20not%20coalesced%20and%20will%20each%20trigger%20an%20AX%20read.%20Storing%20a%20cancellable%20%60DispatchWorkItem%60%20and%20cancelling%20the%20previous%20one%20before%20enqueuing%20a%20new%20one%20avoids%20the%20redundant%20reads.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20var%20pendingHostPublishDelayItem%3A%20DispatchWorkItem%3F%0A%0A%20%20%20%20private%20func%20schedulePredictionAfterHostPublishDelay%28%29%20%7B%0A%20%20%20%20%20%20%20%20pendingHostPublishDelayItem%3F.cancel%28%29%0A%20%20%20%20%20%20%20%20let%20item%20%3D%20DispatchWorkItem%20%7B%20%5Bweak%20self%5D%20in%0A%20%20%20%20%20%20%20%20%20%20%20%20guard%20let%20self%20else%20%7B%20return%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20self.focusModel.refreshNow%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20self.schedulePrediction%28%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20pendingHostPublishDelayItem%20%3D%20item%0A%20%20%20%20%20%20%20%20DispatchQueue.main.asyncAfter%28deadline%3A%20.now%28%29%20%2B%20.milliseconds%28150%29%2C%20execute%3A%20item%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BInput.swift%3A185-191%0ANon-cancellable%20%60asyncAfter%60%20closures%20accumulate%20with%20rapid%20divergences.%20Every%20call%20to%20%60schedulePredictionAfterHostPublishDelay%28%29%60%20enqueues%20a%20new%2C%20non-cancellable%20closure.%20With%20N%20rapid%20divergences%2C%20N%20closures%20will%20fire%20in%20quick%20succession%20%E2%80%94%20each%20calling%20%60focusModel.refreshNow%28%29%60%20and%20%60schedulePrediction%28%29%60.%20While%20%60replaceDebouncedWork%60%20inside%20%60schedulePrediction%28%29%60%20collapses%20the%20prediction%20work%20correctly%2C%20the%20%60refreshNow%28%29%60%20calls%20are%20not%20coalesced%20and%20will%20each%20trigger%20an%20AX%20read.%20Storing%20a%20cancellable%20%60DispatchWorkItem%60%20and%20cancelling%20the%20previous%20one%20before%20enqueuing%20a%20new%20one%20avoids%20the%20redundant%20reads.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20var%20pendingHostPublishDelayItem%3A%20DispatchWorkItem%3F%0A%0A%20%20%20%20private%20func%20schedulePredictionAfterHostPublishDelay%28%29%20%7B%0A%20%20%20%20%20%20%20%20pendingHostPublishDelayItem%3F.cancel%28%29%0A%20%20%20%20%20%20%20%20let%20item%20%3D%20DispatchWorkItem%20%7B%20%5Bweak%20self%5D%20in%0A%20%20%20%20%20%20%20%20%20%20%20%20guard%20let%20self%20else%20%7B%20return%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20self.focusModel.refreshNow%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20self.schedulePrediction%28%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20pendingHostPublishDelayItem%20%3D%20item%0A%20%20%20%20%20%20%20%20DispatchQueue.main.asyncAfter%28deadline%3A%20.now%28%29%20%2B%20.milliseconds%28150%29%2C%20execute%3A%20item%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=376&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Delay post-divergence reschedule so Chro..."](https://github.com/fujacob/cotabby/commit/41c88524a05b33b26eeb10934aefd1eb81793470) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34343867)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->