### PR TITLE
Widen Settings sidebar and label the orphan About section

### DIFF
--- a/Cotabby/UI/Settings/SettingsCategory.swift
+++ b/Cotabby/UI/Settings/SettingsCategory.swift
@@ -82,10 +82,15 @@ enum SettingsSidebarSection: CaseIterable {
 
     var title: String? {
         switch self {
-        case .top, .meta: return nil
+        case .top: return nil
         case .engineModel: return "Engine & Model"
         case .customize: return "Customize"
         case .system: return "System"
+        // SwiftUI's grouped sidebar still inserts inter-section spacing for header-less groups, so
+        // leaving `meta` headerless reads as an unexplained gap between Permissions and About.
+        // Naming the group avoids that visual hiccup without merging About into System (which would
+        // overload "System" with two unrelated concepts: permissions and app-info).
+        case .meta: return "Info"
         }
     }
 }

--- a/Cotabby/UI/Settings/SettingsContainerView.swift
+++ b/Cotabby/UI/Settings/SettingsContainerView.swift
@@ -56,7 +56,10 @@ struct SettingsContainerView: View {
         // longest label. The previous 1180pt floor came from an earlier sidebar experiment that
         // doubled column widths; with the sidebar tightened back down, that floor leaves the
         // detail pane oversized for the actual content.
-        .frame(minWidth: 780, minHeight: 560)
+        // Sidebar grew (min 260 / ideal 280) to fit the longest sub-row label without truncation.
+        // Bump the container floor in step so the detail pane keeps a comfortable working width
+        // (sidebar 260 + detail ~560 ≈ 820pt).
+        .frame(minWidth: 820, minHeight: 560)
         .onChange(of: columnVisibility) { _, newValue in
             // Snap back to `.all` if something tries to collapse the sidebar. Cheaper than wiring
             // a custom binding and reads as the same intent: the sidebar is never optional here.

--- a/Cotabby/UI/Settings/SettingsSidebarView.swift
+++ b/Cotabby/UI/Settings/SettingsSidebarView.swift
@@ -38,12 +38,14 @@ struct SettingsSidebarView: View {
         .safeAreaInset(edge: .top, spacing: 0) {
             Color.clear.frame(height: 12)
         }
-        // Previously bumped to 480/520/640, but with the window's overall `minWidth` the
-        // `.balanced` split style had to shrink the sidebar back below 240pt to keep the detail
-        // pane usable — which still truncated "Apple Intelligence" to "Apple Intell…". The
-        // tighter range here matches the longest user-facing label and lines up with the
-        // matching `minWidth` reduction on the container so the detail pane keeps its own room.
-        .navigationSplitViewColumnWidth(min: 220, ideal: 240, max: 280)
+        // 220/240/280 still truncated "Apple Intelligence" because that row is a sub-row with a
+        // 16pt leading indent (see `row(for:)` below), so its usable label space is sidebar width
+        // minus the indent, the icon, the row inset, and the attention-dot gutter. Bumping the
+        // floor to 260 gives the longest sub-row label real room even when `.balanced` clamps the
+        // sidebar to its minimum, and pushing the ideal up to 280 means most users see the label
+        // unclipped at the default window size. The matching container `minWidth` bump keeps the
+        // detail pane sized comfortably alongside the wider sidebar.
+        .navigationSplitViewColumnWidth(min: 260, ideal: 280, max: 320)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary

Two visual issues in the Settings sidebar:

1. **"Apple Intelligence" truncated** — the row is a sub-row with a 16pt leading indent, eating into the 220–240pt sidebar width. Bump column range to 260/280/320 and lift container `minWidth` from 780 → 820 so the detail pane keeps its working width.
2. **Awkward gap between Permissions and About** — the `meta` section had `title: nil` but SwiftUI still applied inter-section spacing, reading as an unexplained gap. Give the section the title "Info" so the gap reads as a deliberate group boundary.

## Validation

```
swiftlint lint --quiet                                  # exit 0
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby \
  -destination 'platform=macOS' build                   # ** BUILD SUCCEEDED **
```

Diff is three files of pure layout-knob changes; no behavior touched.

## Risk / rollout notes

- Window's `minWidth` bumps from 780 → 820. Users with the window already sized larger are unaffected; the minimum just shifts up by 40pt.
- No data migration needed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes two visual regressions in the Settings sidebar: "Apple Intelligence" was truncating because the sub-row's 16pt indent consumed usable label space within the old 220–240pt column range, and the `meta` section's missing header title produced an unexplained gap between Permissions and About.

- **Sidebar width** (`SettingsSidebarView.swift`): column range widened to 260/280/320 so the longest sub-row label has real room at the minimum window size.
- **Container floor** (`SettingsContainerView.swift`): `minWidth` bumped from 780 → 820 to keep the detail pane at a comfortable ~560pt alongside the wider sidebar.
- **Section header** (`SettingsCategory.swift`): `meta` section given the title `"Info"` so SwiftUI renders an explicit group boundary instead of silent inter-section spacing.

<h3>Confidence Score: 4/5</h3>

Safe to merge — all three changed files contain only layout constant and string-literal changes with no behavioral side effects.

The window's minWidth nudges up by 40pt and a section header string changes from absent to Info; neither touches logic, data, or user state. The only finding is a stale (240) reference in a comment that should now read (280) to match the updated ideal column width.

The stale comment in SettingsContainerView.swift is the only line worth a second look.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/UI/Settings/SettingsCategory.swift | Gives the `meta` section the title "Info" so the gap between Permissions and About reads as a deliberate section boundary rather than stray spacing. |
| Cotabby/UI/Settings/SettingsContainerView.swift | Bumps `minWidth` from 780 → 820 to match the wider sidebar; contains one stale comment that still references the old ideal width of 240 instead of the new 280. |
| Cotabby/UI/Settings/SettingsSidebarView.swift | Widens sidebar column range from 220/240/280 → 260/280/320 to prevent "Apple Intelligence" sub-row from truncating at minimum window size. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cotabby/UI/Settings/SettingsContainerView.swift`, line 54 ([link](https://github.com/fujacob/cotabby/blob/9012d1385ee42b5349cc0c7f156c176f223f7ee9/Cotabby/UI/Settings/SettingsContainerView.swift#L54)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> This comment was written when the sidebar ideal was 240pt and was not updated alongside the column-width change. It now misrepresents the actual ideal width of 280pt, which is what the arithmetic in the next comment block uses.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fsettings-sidebar-width-and-about-section%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsettings-sidebar-width-and-about-section%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FSettings%2FSettingsContainerView.swift%0ALine%3A%2054%0A%0AComment%3A%0AThis%20comment%20was%20written%20when%20the%20sidebar%20ideal%20was%20240pt%20and%20was%20not%20updated%20alongside%20the%20column-width%20change.%20It%20now%20misrepresents%20the%20actual%20ideal%20width%20of%20280pt%2C%20which%20is%20what%20the%20arithmetic%20in%20the%20next%20comment%20block%20uses.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Sized%20so%20the%20sidebar's%20%60ideal%60%20width%20%28280%29%20plus%20a%20detail%20pane%20that%20comfortably%20holds%20the%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FSettings%2FSettingsContainerView.swift%0ALine%3A%2054%0A%0AComment%3A%0AThis%20comment%20was%20written%20when%20the%20sidebar%20ideal%20was%20240pt%20and%20was%20not%20updated%20alongside%20the%20column-width%20change.%20It%20now%20misrepresents%20the%20actual%20ideal%20width%20of%20280pt%2C%20which%20is%20what%20the%20arithmetic%20in%20the%20next%20comment%20block%20uses.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Sized%20so%20the%20sidebar's%20%60ideal%60%20width%20%28280%29%20plus%20a%20detail%20pane%20that%20comfortably%20holds%20the%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=377&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fsettings-sidebar-width-and-about-section%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsettings-sidebar-width-and-about-section%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FSettings%2FSettingsContainerView.swift%3A54%0AThis%20comment%20was%20written%20when%20the%20sidebar%20ideal%20was%20240pt%20and%20was%20not%20updated%20alongside%20the%20column-width%20change.%20It%20now%20misrepresents%20the%20actual%20ideal%20width%20of%20280pt%2C%20which%20is%20what%20the%20arithmetic%20in%20the%20next%20comment%20block%20uses.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Sized%20so%20the%20sidebar's%20%60ideal%60%20width%20%28280%29%20plus%20a%20detail%20pane%20that%20comfortably%20holds%20the%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FSettings%2FSettingsContainerView.swift%3A54%0AThis%20comment%20was%20written%20when%20the%20sidebar%20ideal%20was%20240pt%20and%20was%20not%20updated%20alongside%20the%20column-width%20change.%20It%20now%20misrepresents%20the%20actual%20ideal%20width%20of%20280pt%2C%20which%20is%20what%20the%20arithmetic%20in%20the%20next%20comment%20block%20uses.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Sized%20so%20the%20sidebar's%20%60ideal%60%20width%20%28280%29%20plus%20a%20detail%20pane%20that%20comfortably%20holds%20the%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=377&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Widen Settings sidebar and label the orp..."](https://github.com/fujacob/cotabby/commit/9012d1385ee42b5349cc0c7f156c176f223f7ee9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34345044)</sub>

<!-- /greptile_comment -->