### PR TITLE
Wait for host AX publish before rescheduling, not a fixed 150ms

### DIFF
--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
@@ -173,22 +173,77 @@ extension SuggestionCoordinator {
         return false
     }
 
-    /// Schedules a fresh prediction after a short delay so Chromium-based editors (Chrome, Edge,
-    /// Slack, Discord, Notion, every Electron app) have time to publish the new contenteditable
-    /// text to AX. Without the delay, `schedulePrediction()` fires synchronously from inside the
-    /// CGEvent tap — which runs *before* the host app processes the keystroke — so the AX read
-    /// inside generation still sees pre-keystroke text. The result feels like Cotabby swallowed
-    /// the key: the active suggestion vanishes, a new one appears that does not reflect the
-    /// character the user just typed, and the user concludes their keystroke was eaten.
-    /// 150ms is chosen empirically: long enough for Chromium's contenteditable AX to settle on a
-    /// busy page, short enough that the rescheduled suggestion still feels responsive after the
-    /// user has just diverged from the previous one. `schedulePrediction()` internally
-    /// `replaceDebouncedWork`s, so back-to-back keystrokes still collapse cleanly.
+    /// Maximum wall time we'll wait for the host app to publish post-keystroke AX before giving
+    /// up and generating against whatever's there. Chosen empirically: long enough to cover
+    /// Chrome's slower contenteditable publish on a busy page, short enough that the user can
+    /// always type ahead without the rescheduled suggestion feeling stuck.
+    private static let hostPublishWaitCeilingMs = 400
+
+    /// Interval between AX polls while waiting for the host publish. Same order of magnitude as
+    /// the focus poll itself (default 80ms) but tighter so we catch the publish promptly without
+    /// burning CPU on AX queries that are themselves 5–15ms each.
+    private static let hostPublishPollIntervalMs = 30
+
+    /// Schedules a fresh prediction once the host app has actually published the new
+    /// contenteditable text to AX. The previous fix waited a fixed 150ms — see PR #376 — but the
+    /// logs in #381 showed Chromium's publish lag can exceed that ceiling on a busy page, so the
+    /// rescheduled generation still read pre-keystroke text and produced a suggestion that looked
+    /// like Cotabby swallowed the character.
+    ///
+    /// We now snapshot the AX state at keystroke time (focused element identity, preceding text,
+    /// selection) and poll `focusModel` until the snapshot actually moves on. The poll is capped
+    /// at `hostPublishWaitCeilingMs` so a silent host can't hang the pipeline — once the cap is
+    /// reached we generate against whatever's there, matching the old fixed-delay behavior.
+    /// `schedulePrediction()` internally `replaceDebouncedWork`s, so back-to-back keystrokes
+    /// still collapse cleanly.
     private func schedulePredictionAfterHostPublishDelay() {
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(150)) { [weak self] in
-            guard let self else { return }
-            self.focusModel.refreshNow()
-            self.schedulePrediction()
+        let baseline = focusModel.snapshot.context
+        pollForHostPublish(
+            baselineText: baseline?.precedingText,
+            baselineElementID: baseline?.elementIdentifier,
+            baselineSelectionLocation: baseline?.selection.location,
+            elapsedMs: 0
+        )
+    }
+
+    /// Drives the snapshot-changed gate. Reads the live focus snapshot, fires `schedulePrediction`
+    /// as soon as any of the captured baseline fields move on, and otherwise tail-calls itself
+    /// after `hostPublishPollIntervalMs` until the ceiling is hit.
+    private func pollForHostPublish(
+        baselineText: String?,
+        baselineElementID: String?,
+        baselineSelectionLocation: Int?,
+        elapsedMs: Int
+    ) {
+        focusModel.refreshNow()
+        let currentContext = focusModel.snapshot.context
+
+        // No focus context at all means the user moved away from any editable field — let
+        // `schedulePrediction` and its downstream guards handle the disabled / unsupported state.
+        let textChanged = currentContext?.precedingText != baselineText
+        let elementChanged = currentContext?.elementIdentifier != baselineElementID
+        let selectionChanged = currentContext?.selection.location != baselineSelectionLocation
+        if textChanged || elementChanged || selectionChanged {
+            schedulePrediction()
+            return
+        }
+
+        // Ceiling: stop polling and generate anyway. Without this fallback a host that genuinely
+        // produces no AX change (rare but possible — e.g. dead-key composition) would never get
+        // its next prediction.
+        let nextElapsed = elapsedMs + Self.hostPublishPollIntervalMs
+        guard nextElapsed < Self.hostPublishWaitCeilingMs else {
+            schedulePrediction()
+            return
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(Self.hostPublishPollIntervalMs)) { [weak self] in
+            self?.pollForHostPublish(
+                baselineText: baselineText,
+                baselineElementID: baselineElementID,
+                baselineSelectionLocation: baselineSelectionLocation,
+                elapsedMs: nextElapsed
+            )
         }
     }
 


### PR DESCRIPTION
## Summary

Replaces the fixed 150ms post-divergence reschedule delay from PR #376 with a snapshot-changed gate: capture the focused element identity, preceding text, and selection at keystroke time, then poll `focusModel.snapshot` every 30ms until any of those actually move on. Fires `schedulePrediction()` as soon as the host has published, with a 400ms ceiling so a silent host never hangs the pipeline.

The logs in #381 showed `work=93` and `work=95` generating against the same `oij3` prefix because Chrome hadn't published the new keystroke by the time the deferred reschedule fired — the rescheduled suggestion then appears with stale context, which reads to the user as the character being swallowed. This patch waits for evidence the publish actually happened instead of guessing a fixed delay.

## Validation

```
swiftlint lint --quiet
# exit 0, no new warnings

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build-for-testing
# ** TEST BUILD SUCCEEDED **
```

Manual reproduction required: type rapidly in a Chrome contenteditable, confirm regenerated suggestions reflect the latest typed character instead of the prior state.

## Linked issues

Refs #381

## Risk / rollout notes

- **All three call sites** in `handleInputEvent` (no-session path, active-session `.textMutation`, active-session `.shortcutMutation`) share the helper, so the gate carries to every place the old fixed delay applied.
- **400ms ceiling** is the fallback when AX never moves. Without it a dead-key composition or a host that genuinely produces no change would hang the pipeline. Generation against pre-keystroke text in that edge case matches the pre-fix behavior, which is acceptable since the user can always type again.
- **AX refresh cost.** Each poll calls `focusModel.refreshNow()` which is 5–15ms based on logged resolve timings. With a 30ms cadence and 400ms ceiling that's up to ~13 polls, so worst-case ~200ms of AX work concentrated in the rare hung case — still well within the AX poll interval budget elsewhere in the pipeline.
- **Selection-change detection** uses `selection.location` only. Length changes during a multi-key paste won't trigger the gate by themselves, but the trailing text change will, so behavior is preserved.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the fixed 150ms post-keystroke reschedule delay with a polling gate that captures the AX state (preceding text, element identity, selection) at keystroke time and waits for any of those fields to change before calling `schedulePrediction()`, falling back to a 400ms ceiling if the host never publishes.

- The core logic — snapshot baseline, poll every 30ms via `asyncAfter`, fire on first detected change — is sound and directly addresses the `oij3` prefix stale-context regression from #381.
- The first `pollForHostPublish` call fires synchronously inside `handleInputEvent`, adding a 5–15ms synchronous AX read to every keystroke's event-handler path; since the CGEvent tap fires before Chrome processes the key this first read almost always finds no change and is wasted.
- Each `schedulePredictionAfterHostPublishDelay` call spawns an independent 400ms chain; with rapid typing multiple chains run concurrently, multiplying the AX refresh rate beyond the single-keystroke budget analysis in the PR description.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the targeted regression fix; the polling logic is correct and the ceiling prevents pipeline hangs, though the synchronous first AX read and potential for concurrent loops in rapid typing are worth a follow-up.

The change correctly solves the stated problem and all three call sites are covered. The main concerns are performance-shaped rather than correctness-shaped: a wasted synchronous AX read on every keystroke handler and unbounded concurrent poll loops during rapid typing bursts. Neither breaks prediction correctness, but the concurrent-loops case multiplies AX work beyond what the PR's budget analysis accounts for.

Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift — specifically the synchronous first poll in `schedulePredictionAfterHostPublishDelay` and the lack of a guard against concurrent polling chains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift | Replaces the fixed 150ms post-keystroke reschedule delay with a polling loop that gates on AX snapshot changes; logic is sound but the first poll fires synchronously (blocking the main actor with an AX read on every keystroke), and multiple overlapping loops accumulate for rapid typing bursts. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CGEventTap as CGEvent Tap
    participant HC as handleInputEvent (MainActor)
    participant SPHD as schedulePredictionAfterHostPublishDelay
    participant PFH as pollForHostPublish
    participant FM as focusModel.refreshNow()
    participant Chrome as Chrome AX

    CGEventTap->>HC: keystroke event
    HC->>SPHD: "(elapsedMs=0, synchronous)"
    SPHD->>SPHD: "baseline = focusModel.snapshot.context"
    SPHD->>PFH: "pollForHostPublish(baseline, elapsedMs=0)"
    PFH->>FM: refreshNow() [5-15ms, SYNCHRONOUS]
    FM-->>PFH: snapshot (still pre-keystroke)
    PFH->>PFH: "textChanged=false, schedule next poll (30ms)"

    Note over Chrome: Chrome processes keystroke, publishes AX update

    PFH->>FM: "refreshNow() [t=30ms]"
    FM-->>PFH: snapshot (post-keystroke)
    PFH->>PFH: "textChanged=true, schedulePrediction()"

    alt Ceiling path (host never publishes)
        loop "every 30ms until nextElapsed >= 400"
            PFH->>FM: refreshNow()
            FM-->>PFH: snapshot (unchanged)
        end
        PFH->>PFH: schedulePrediction() at ceiling (~390ms)
    end
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fchrome-ax-snapshot-gate%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fchrome-ax-snapshot-gate%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BInput.swift%3A212-218%0A**First%20poll%20fires%20synchronously%2C%20blocking%20the%20main%20actor**%0A%0A%60pollForHostPublish%60%20is%20called%20synchronously%20inside%20%60handleInputEvent%60%20%28both%20are%20%60%40MainActor%60%29%2C%20so%20%60focusModel.refreshNow%28%29%60%20%E2%80%94%20a%20full%20AX%20tree%20walk%20of%205%E2%80%9315ms%20%E2%80%94%20runs%20before%20the%20main%20run%20loop%20returns%20from%20keyboard%20event%20handling.%20Since%20the%20CGEvent%20tap%20fires%20*before*%20Chrome%20processes%20the%20keystroke%2C%20this%20first%20refresh%20will%20almost%20always%20see%20unchanged%20text%2C%20making%20the%20read%20wasted.%20The%20old%20%60asyncAfter%28150ms%29%60%20design%20never%20touched%20AX%20during%20event%20delivery.%20With%20rapid%20typing%20this%20also%20means%20one%20synchronous%20AX%20read%20is%20added%20to%20every%20single%20keystroke's%20event-handler%20cost.%0A%0AA%20simple%20fix%20is%20to%20skip%20the%20synchronous%20call%20entirely%20and%20start%20with%20a%2030ms%20%60asyncAfter%60%20%28same%20as%20every%20subsequent%20poll%29%2C%20since%20there%20is%20no%20information%20to%20be%20gained%20at%20t%3D0%20before%20Chrome%20has%20processed%20the%20key.%0A%0A%23%23%23%20Issue%202%20of%203%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BInput.swift%3A199-207%0A**Concurrent%20poll%20loops%20accumulate%20for%20rapid%20typing**%0A%0AEach%20call%20to%20%60schedulePredictionAfterHostPublishDelay%60%20%28invoked%20on%20every%20%60shouldSchedulePrediction%60%20keystroke%20across%20all%20three%20call%20sites%29%20spawns%20an%20independent%20400ms%20polling%20chain.%20Rapid%20typing%20%E2%80%94%20say%208%20keys%20in%20200ms%20%E2%80%94%20leaves%20up%20to%208%20simultaneous%20loops%20each%20calling%20%60focusModel.refreshNow%28%29%60%20every%2030ms.%20That%20is%20~8%C3%97%20the%20budgeted%20AX%20read%20rate%20during%20a%20burst%2C%20and%20%60refreshNow%28%29%60%20resets%20the%20tracker's%20idle%20backoff%20on%20every%20call%2C%20so%20the%20normal%20back-off%20never%20gets%20a%20chance%20to%20engage.%20The%20PR's%20%22up%20to%20~13%20polls%22%20budget%20analysis%20only%20covers%20the%20single-keystroke%20case.%0A%0AConsider%20tracking%20whether%20a%20poll%20loop%20is%20already%20in%20flight%20%28e.g.%2C%20a%20%60Bool%60%20flag%20set%20in%20%60schedulePredictionAfterHostPublishDelay%60%20and%20cleared%20when%20%60schedulePrediction%28%29%60%20fires%29%20and%20returning%20early%20when%20one%20is%20already%20running.%20The%20%60replaceDebouncedWork%60%20inside%20%60schedulePrediction%28%29%60%20already%20collapses%20generations%2C%20so%20only%20the%20most%20recent%20baseline%20matters%20anyway.%0A%0A%23%23%23%20Issue%203%20of%203%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BInput.swift%3A234-238%0A**%60elapsedMs%60%20tracks%20logical%20intervals%2C%20not%20wall%20time**%0A%0A%60elapsedMs%60%20increments%20by%2030ms%20per%20iteration%20regardless%20of%20how%20long%20each%20AX%20read%20takes.%20Since%20%60refreshNow%28%29%60%20resolves%20in%205%E2%80%9315ms%2C%20the%20real%20wall-clock%20duration%20of%20the%20ceiling%20path%20is%20up%20to%20%E2%89%88390ms%20%2B%20%2813%20polls%20%C3%97%2015ms%29%20%E2%89%88%20585ms%20%E2%80%94%20substantially%20more%20than%20the%20400ms%20stated%20in%20comments%20and%20the%20PR%20description.%20The%20discrepancy%20matters%20when%20callers%20reason%20about%20%22how%20long%20can%20a%20stale%20prediction%20be%20generated%22%20in%20the%20dead-key%20%2F%20non-publishing%20host%20path.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BInput.swift%3A212-218%0A**First%20poll%20fires%20synchronously%2C%20blocking%20the%20main%20actor**%0A%0A%60pollForHostPublish%60%20is%20called%20synchronously%20inside%20%60handleInputEvent%60%20%28both%20are%20%60%40MainActor%60%29%2C%20so%20%60focusModel.refreshNow%28%29%60%20%E2%80%94%20a%20full%20AX%20tree%20walk%20of%205%E2%80%9315ms%20%E2%80%94%20runs%20before%20the%20main%20run%20loop%20returns%20from%20keyboard%20event%20handling.%20Since%20the%20CGEvent%20tap%20fires%20*before*%20Chrome%20processes%20the%20keystroke%2C%20this%20first%20refresh%20will%20almost%20always%20see%20unchanged%20text%2C%20making%20the%20read%20wasted.%20The%20old%20%60asyncAfter%28150ms%29%60%20design%20never%20touched%20AX%20during%20event%20delivery.%20With%20rapid%20typing%20this%20also%20means%20one%20synchronous%20AX%20read%20is%20added%20to%20every%20single%20keystroke's%20event-handler%20cost.%0A%0AA%20simple%20fix%20is%20to%20skip%20the%20synchronous%20call%20entirely%20and%20start%20with%20a%2030ms%20%60asyncAfter%60%20%28same%20as%20every%20subsequent%20poll%29%2C%20since%20there%20is%20no%20information%20to%20be%20gained%20at%20t%3D0%20before%20Chrome%20has%20processed%20the%20key.%0A%0A%23%23%23%20Issue%202%20of%203%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BInput.swift%3A199-207%0A**Concurrent%20poll%20loops%20accumulate%20for%20rapid%20typing**%0A%0AEach%20call%20to%20%60schedulePredictionAfterHostPublishDelay%60%20%28invoked%20on%20every%20%60shouldSchedulePrediction%60%20keystroke%20across%20all%20three%20call%20sites%29%20spawns%20an%20independent%20400ms%20polling%20chain.%20Rapid%20typing%20%E2%80%94%20say%208%20keys%20in%20200ms%20%E2%80%94%20leaves%20up%20to%208%20simultaneous%20loops%20each%20calling%20%60focusModel.refreshNow%28%29%60%20every%2030ms.%20That%20is%20~8%C3%97%20the%20budgeted%20AX%20read%20rate%20during%20a%20burst%2C%20and%20%60refreshNow%28%29%60%20resets%20the%20tracker's%20idle%20backoff%20on%20every%20call%2C%20so%20the%20normal%20back-off%20never%20gets%20a%20chance%20to%20engage.%20The%20PR's%20%22up%20to%20~13%20polls%22%20budget%20analysis%20only%20covers%20the%20single-keystroke%20case.%0A%0AConsider%20tracking%20whether%20a%20poll%20loop%20is%20already%20in%20flight%20%28e.g.%2C%20a%20%60Bool%60%20flag%20set%20in%20%60schedulePredictionAfterHostPublishDelay%60%20and%20cleared%20when%20%60schedulePrediction%28%29%60%20fires%29%20and%20returning%20early%20when%20one%20is%20already%20running.%20The%20%60replaceDebouncedWork%60%20inside%20%60schedulePrediction%28%29%60%20already%20collapses%20generations%2C%20so%20only%20the%20most%20recent%20baseline%20matters%20anyway.%0A%0A%23%23%23%20Issue%203%20of%203%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BInput.swift%3A234-238%0A**%60elapsedMs%60%20tracks%20logical%20intervals%2C%20not%20wall%20time**%0A%0A%60elapsedMs%60%20increments%20by%2030ms%20per%20iteration%20regardless%20of%20how%20long%20each%20AX%20read%20takes.%20Since%20%60refreshNow%28%29%60%20resolves%20in%205%E2%80%9315ms%2C%20the%20real%20wall-clock%20duration%20of%20the%20ceiling%20path%20is%20up%20to%20%E2%89%88390ms%20%2B%20%2813%20polls%20%C3%97%2015ms%29%20%E2%89%88%20585ms%20%E2%80%94%20substantially%20more%20than%20the%20400ms%20stated%20in%20comments%20and%20the%20PR%20description.%20The%20discrepancy%20matters%20when%20callers%20reason%20about%20%22how%20long%20can%20a%20stale%20prediction%20be%20generated%22%20in%20the%20dead-key%20%2F%20non-publishing%20host%20path.%0A%0A&repo=fujacob%2Fcotabby&pr=379&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Wait for the host&#39;s AX publish before re..."](https://github.com/fujacob/cotabby/commit/76ed170629c812c8a168e0a4fd90c489e49f7fcb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34346277)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->