### PR TITLE
Fail-open accept tap: never consume bare printables, never consume without verified session

### DIFF
--- a/Cotabby/App/Coordinators/SuggestionCoordinator.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator.swift
@@ -135,6 +135,21 @@ final class SuggestionCoordinator: ObservableObject {
             self?.handleSuppressedSyntheticInput()
         }
 
+        // Fail-open authorization for the active accept tap. The tap will only consume a
+        // keystroke when this predicate returns `true` at the moment the event arrives — i.e.,
+        // when the coordinator currently holds a ready, valid, visible suggestion session. Any
+        // lifecycle gap (tap left over after invalidate, stale settings race, etc.) collapses to
+        // "no" and the keystroke falls through to the host. Without this, the accept tap's
+        // matching predicate could swallow a keystroke based on stale state — exactly the
+        // "letter never reaches Chrome" report.
+        inputMonitor.shouldConsumeAcceptKeyProvider = { [weak self] in
+            guard let self else { return false }
+            guard case .ready = self.state else { return false }
+            guard self.interactionState.activeSession != nil else { return false }
+            guard self.overlayState.isVisible else { return false }
+            return true
+        }
+
         overlayController.onStateChange = { [weak self] state in
             guard let self else { return }
             self.overlayState = state

--- a/Cotabby/Models/SuggestionSubsystemContracts.swift
+++ b/Cotabby/Models/SuggestionSubsystemContracts.swift
@@ -35,6 +35,12 @@ protocol SuggestionInputMonitoring: AnyObject {
     var onEvent: ((CapturedInputEvent) -> Bool)? { get set }
     var onSuppressedSyntheticInput: (() -> Void)? { get set }
 
+    /// Fail-open authorization for the active accept tap. The tap only consumes a matching
+    /// keystroke when this closure returns `true` at event time. The coordinator wires it to a
+    /// live check (ready state + active session + visible overlay) so any lifecycle gap collapses
+    /// to "pass through" instead of swallowing the user's keystroke.
+    var shouldConsumeAcceptKeyProvider: @MainActor () -> Bool { get set }
+
     /// Drives the lifecycle of the active accept-key tap. The coordinator turns this on while
     /// a suggestion overlay is visible and off otherwise, so Cotabby only sits in the synchronous
     /// keystroke path during the brief windows it actually needs to consume the accept key.

--- a/Cotabby/Services/Input/InputMonitor.swift
+++ b/Cotabby/Services/Input/InputMonitor.swift
@@ -42,6 +42,12 @@ final class InputMonitor {
     /// (terminals, globally disabled, per-app disabled).
     var shouldProcessEventsProvider: @MainActor () -> Bool = { true }
 
+    /// Fail-open authorization for the active accept tap. The tap only consumes a keystroke
+    /// when this returns `true` at the moment the event arrives. Default returns `false` so
+    /// stale or misinstalled taps never eat input. The coordinator wires this to a real check
+    /// (ready state + live active session + visible overlay) at construction time.
+    var shouldConsumeAcceptKeyProvider: @MainActor () -> Bool = { false }
+
     private let permissionProvider: @MainActor () -> Bool
     private let suppressionController: InputSuppressionController
 
@@ -297,6 +303,35 @@ final class InputMonitor {
                 && eventModifiers == acceptanceKeyModifiersProvider()
 
             if fullAcceptMatches || acceptMatches {
+                // Layer 1 — never consume a bare printable character. The recorder can store
+                // bindings like (keyCode: 0, modifiers: []) which is the 'a' key. Without this
+                // guard the bound character would silently disappear every time the user typed
+                // it system-wide. Acceptance via a bare letter is incoherent anyway (the same
+                // press cannot both insert the user's character and accept).
+                let isBarePrintable = eventModifiers.isEmpty
+                    && !event.unicodeString.trimmingCharacters(in: .controlCharacters).isEmpty
+                if isBarePrintable {
+                    let message = "Accept tap refusing to consume bare printable keyCode=\(keyCode). "
+                        + "Rebind with a modifier in Settings > Shortcuts."
+                    CotabbyLogger.app.warning("\(message)")
+                    return Unmanaged.passUnretained(event)
+                }
+
+                // Layer 2 — fail-open. The accept tap is only allowed to swallow when the
+                // coordinator confirms IN-THE-MOMENT that a ready, valid, visible session exists.
+                // Any stale install, lifecycle gap, or settings race causes the predicate to
+                // return false, the key falls through to the host, and the user never loses
+                // input. This is the "if Cotabby is unsure, pass through" rule.
+                guard shouldConsumeAcceptKeyProvider() else {
+                    let message = "Accept tap declining to consume keyCode=\(keyCode): "
+                        + "coordinator reports no ready session"
+                    CotabbyLogger.app.debug("\(message)")
+                    return Unmanaged.passUnretained(event)
+                }
+
+                CotabbyLogger.app.debug(
+                    "Accept tap consumed keyCode=\(keyCode) modifiers=\(eventModifiers.rawValue)"
+                )
                 return nil
             }
             return Unmanaged.passUnretained(event)


### PR DESCRIPTION
## Root cause

User report: typing regular letters/numbers in Chrome with a Cotabby suggestion visible silently drops the character. Three subagent investigations converged on the same structural cause introduced by #337 (split-tap model):

The active accept tap (.defaultTap, tail) returns nil and swallows any keystroke whose (keyCode, modifiers) matches the user's bound accept binding. The matching is correct in isolation, but:

- KeyRecorderView accepts and stores any keycode the user presses, including bare alphanumerics. (keyCode: 0, modifiers: []) is a valid stored binding meaning 'a'. From that moment every bare 'a' in any app while a suggestion is visible is eaten.
- The default full-accept binding is bare backtick. Users type backticks regularly.
- The matching uses providers read at event time. There is no in-the-moment check that a real, ready, valid session exists when the tap consumes.

## Fix (two layers, both fail-open)

1. Bare-printable safeguard. In handleAcceptTap, if the binding match would fire for a keystroke that has no modifiers and produces a non-control printable, refuse to consume and warn in the log. Acceptance via a bare letter is incoherent (the same press cannot both insert the user's character and trigger acceptance).
2. Coordinator authorization. New shouldConsumeAcceptKeyProvider closure on InputMonitor. The coordinator wires it to a live check: state == .ready AND interactionState.activeSession != nil AND overlayState.isVisible. The tap only consumes when all three hold at event time. Any stale install, lifecycle gap, or settings race collapses to pass-through.

Plus debug logging on every consume decision so future swallow reports can be diagnosed from the runtime log.

## Why this prevents the symptom

- A corrupt bare-letter binding can no longer eat typing — Layer 1 catches it.
- A stale active tap surviving past a session invalidation can no longer eat typing — Layer 2 catches it.
- The legitimate acceptance path is unchanged: when state is .ready, the session is live, and the overlay is visible, the predicate returns true and the bound key is consumed as before.

## Test plan

1. Repro the swallow: bind bare 'a' in Shortcuts, type 'a' in Chrome with a suggestion visible. On main the character disappears. With this PR it reaches Chrome and a warning lands in the runtime log.
2. Backtick: leave default binding, type code containing backticks in Chrome with a suggestion visible. On main the backtick disappears. With this PR it reaches Chrome.
3. Stale-session race: prime a state where the overlay is briefly visible but state has flipped to .debouncing. The accept key now falls through instead of being consumed.
4. Regression: bind ⌃Tab, generate a suggestion, press ⌃Tab. Acceptance still fires and the keystroke does not reach the host.
5. Build + lint clean.

## Risk / rollout notes

- Fail-open by design. The worst case for the fix is that a legitimate accept key is occasionally passed through — the user sees their key reach the host instead of accepting the suggestion, which is the safe failure mode.
- shouldConsumeAcceptKeyProvider defaults to { false } on InputMonitor, so any test or future call site that constructs the monitor without wiring the coordinator will pass keys through rather than swallow.
- This does not address the duplicate-Tab bug Agent 3 flagged in passTabThrough's unconditional replay. That is a separate PR.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two fail-open guards to the active accept tap: Layer 1 refuses to consume keystrokes whose binding has no modifiers and produces a printable character, and Layer 2 delegates the consume decision to a new `shouldConsumeAcceptKeyProvider` closure wired in `SuggestionCoordinator` to a live three-condition predicate (state `.ready` + active session + visible overlay).

- **`InputMonitor.swift`**: `handleAcceptTap` gains the two guard layers and structured debug/warning logging for every consume decision.
- **`SuggestionSubsystemContracts.swift`**: `shouldConsumeAcceptKeyProvider: @MainActor () -> Bool` added to `SuggestionInputMonitoring`, defaulting to `{ false }` on `InputMonitor` so stale installs are automatically fail-open.
- **`SuggestionCoordinator.swift`**: The provider closure is wired at `init` time before any overlay callbacks, using `[weak self]` so deallocation also collapses to `false`.

<h3>Confidence Score: 3/5</h3>

The two-tap architecture means the observer tap always drives acceptance independently of what the accept tap subsequently decides — Layer 1 prevents consumption but cannot un-do the acceptance already triggered by the observer for the same event.

The Layer 2 wiring is correct and the fail-open default is safe. Layer 1's bare-printable guard creates an observable double-action for any user with a misconfigured bare-printable binding: the observer tap classifies the keypress as `.acceptance` and drives suggestion insertion before the accept tap even runs, so acceptance happens AND the character reaches Chrome. Additionally, in the normal acceptance success path the observer hides the overlay (updating `overlayState`) before the accept tap fires, so Layer 2 reads `overlayState.isVisible = false` — whether this causes the accept key to leak to the focused app depends on undocumented `CFMachPortInvalidate` in-flight semantics that should be validated empirically.

Cotabby/Services/Input/InputMonitor.swift — both the Layer 1 guard in handleAcceptTap and the Layer 2 overlayState timing need a second look before merge.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Services/Input/InputMonitor.swift | Adds two new guards in handleAcceptTap: Layer 1 rejects bare-printable bindings before consuming, and Layer 2 delegates the consume decision to a new shouldConsumeAcceptKeyProvider closure. The layered approach is sound, but because the observer tap (which fires first) always drives the full acceptance flow independently of what the accept tap ultimately does, a bare-printable binding still triggers suggestion acceptance AND passes the character to Chrome — a double-action regression. |
| Cotabby/Models/SuggestionSubsystemContracts.swift | Adds shouldConsumeAcceptKeyProvider to the SuggestionInputMonitoring protocol. The addition is minimal and correctly typed as @MainActor () -> Bool, consistent with the existing provider pattern in the protocol. |
| Cotabby/App/Coordinators/SuggestionCoordinator.swift | Wires shouldConsumeAcceptKeyProvider to a live three-condition predicate (state == .ready, activeSession != nil, overlayState.isVisible). The [weak self] capture, fail-open default (returns false when self is nil), and init-time placement before any overlay callbacks are all correct. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant macOS
    participant ObserverTap as Observer Tap (head, listen-only)
    participant Coordinator as SuggestionCoordinator
    participant AcceptTap as Accept Tap (tail, active)
    participant Chrome

    User->>macOS: keyDown (accept key)
    macOS->>ObserverTap: event delivered (1st)
    ObserverTap->>Coordinator: classify → onEvent(.acceptance)
    Coordinator->>Coordinator: acceptSuggestion()
    Note over Coordinator: Guards: session≠nil, state==.ready, overlay visible
    Coordinator->>Coordinator: insert suggestion text
    Coordinator->>Coordinator: hideOverlay → destroyAcceptTap()
    ObserverTap-->>macOS: passUnretained (always)

    macOS->>AcceptTap: event delivered (2nd)
    Note over AcceptTap: Layer 1: isBarePrintable?
    alt "isBarePrintable == true"
        AcceptTap-->>macOS: passUnretained (key NOT consumed)
        macOS->>Chrome: key delivered
    else "isBarePrintable == false"
        Note over AcceptTap: Layer 2: shouldConsumeAcceptKeyProvider()
        alt session ready + active + overlay visible
            AcceptTap-->>macOS: nil (key consumed)
        else any condition false
            AcceptTap-->>macOS: passUnretained (key NOT consumed)
            macOS->>Chrome: key delivered
        end
    end
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22audit%2Finput-swallow%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22audit%2Finput-swallow%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FServices%2FInput%2FInputMonitor.swift%3A311-318%0A**Double-action%20when%20a%20bare-printable%20binding%20matches%20an%20active%20session**%0A%0ALayer%201%20prevents%20the%20accept%20tap%20from%20*consuming*%20the%20key%2C%20but%20it%20cannot%20prevent%20the%20observer%20tap%20%28which%20fires%20first%2C%20at%20the%20head%29%20from%20having%20already%20classified%20the%20same%20keystroke%20as%20%60.acceptance%60%2F%60.fullAcceptance%60%20and%20driven%20the%20full%20acceptance%20flow%20through%20%60acceptSuggestion%60.%20When%20a%20session%20is%20active%2C%20%60acceptSuggestion%60%20inserts%20the%20suggestion%20text%20and%20calls%20%60hideOverlay%60%20%E2%80%94%20all%20before%20the%20accept%20tap%20even%20runs.%20Layer%201%20then%20passes%20the%20key%20through%20to%20Chrome.%0A%0AConcrete%20failure%3A%20user%20binds%20bare%20%60a%60%2C%20types%20%60a%60%20with%20a%20visible%20suggestion.%20The%20observer%20fires%2C%20%60acceptSuggestion%60%20succeeds%20and%20inserts%20the%20AI%20text.%20Then%20the%20accept%20tap%20fires%3A%20%60isBarePrintable%60%20is%20%60true%60%2C%20so%20%60a%60%20also%20reaches%20Chrome.%20The%20user%20sees%20the%20suggestion%20text%20*plus*%20a%20literal%20%60a%60%20appended.%0A%0AThe%20fix%20would%20be%20to%20also%20guard%20%60classify%28%29%60%20%28or%20%60handleObserverTap%60%29%20so%20that%20it%20does%20not%20emit%20%60.acceptance%60%2F%60.fullAcceptance%60%20when%20the%20binding%20is%20a%20bare%20printable%20%E2%80%94%20or%20to%20gate%20%60acceptCurrentSuggestion%60%2F%60acceptEntireSuggestion%60%20on%20%60shouldConsumeAcceptKeyProvider%28%29%60%20directly.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FServices%2FInput%2FInputMonitor.swift%3A325-330%0A**Layer%202%20reads%20%60overlayState%60%20that%20was%20updated%20by%20the%20observer%20callback%20for%20the%20same%20event**%0A%0AThe%20observer%20tap%20fires%20first%20%28head-inserted%29%2C%20potentially%20drives%20a%20successful%20acceptance%20that%20calls%20%60hideOverlay%28%29%60%20%E2%86%92%20%60setAcceptInterceptionActive%28false%29%60%20%E2%86%92%20%60destroyAcceptTap%28%29%60%2C%20and%20returns.%20%60overlayState%60%20is%20now%20%60.hidden%60.%20When%20the%20accept%20tap%20fires%20next%2C%20%60shouldConsumeAcceptKeyProvider%28%29%60%20reads%20%60self.overlayState.isVisible%20%3D%20false%60%20and%20returns%20%60false%60%2C%20passing%20the%20accept%20key%20through.%0A%0AWhether%20this%20actually%20regresses%20the%20happy%20path%20%28Tab%2F%E2%8C%83Tab%29%20depends%20on%20whether%20%60CFMachPortInvalidate%60%20prevents%20the%20accept%20tap%20from%20being%20invoked%20at%20all%20for%20the%20in-flight%20event.%20If%20the%20callback%20is%20not%20invoked%20after%20invalidation%2C%20this%20is%20benign%3B%20if%20it%20is%2C%20every%20successful%20acceptance%20would%20also%20deliver%20the%20accept%20key%20to%20the%20focused%20app.%20The%20PR's%20test%204%20claim%20%28%22keystroke%20does%20not%20reach%20the%20host%22%29%20should%20be%20validated%20against%20a%20case%20where%20the%20accept%20tap%20*is*%20still%20installed%20%28i.e.%2C%20where%20%60destroyAcceptTap%60%20is%20NOT%20called%20during%20the%20observer%20callback%29.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FServices%2FInput%2FInputMonitor.swift%3A311-318%0A**Double-action%20when%20a%20bare-printable%20binding%20matches%20an%20active%20session**%0A%0ALayer%201%20prevents%20the%20accept%20tap%20from%20*consuming*%20the%20key%2C%20but%20it%20cannot%20prevent%20the%20observer%20tap%20%28which%20fires%20first%2C%20at%20the%20head%29%20from%20having%20already%20classified%20the%20same%20keystroke%20as%20%60.acceptance%60%2F%60.fullAcceptance%60%20and%20driven%20the%20full%20acceptance%20flow%20through%20%60acceptSuggestion%60.%20When%20a%20session%20is%20active%2C%20%60acceptSuggestion%60%20inserts%20the%20suggestion%20text%20and%20calls%20%60hideOverlay%60%20%E2%80%94%20all%20before%20the%20accept%20tap%20even%20runs.%20Layer%201%20then%20passes%20the%20key%20through%20to%20Chrome.%0A%0AConcrete%20failure%3A%20user%20binds%20bare%20%60a%60%2C%20types%20%60a%60%20with%20a%20visible%20suggestion.%20The%20observer%20fires%2C%20%60acceptSuggestion%60%20succeeds%20and%20inserts%20the%20AI%20text.%20Then%20the%20accept%20tap%20fires%3A%20%60isBarePrintable%60%20is%20%60true%60%2C%20so%20%60a%60%20also%20reaches%20Chrome.%20The%20user%20sees%20the%20suggestion%20text%20*plus*%20a%20literal%20%60a%60%20appended.%0A%0AThe%20fix%20would%20be%20to%20also%20guard%20%60classify%28%29%60%20%28or%20%60handleObserverTap%60%29%20so%20that%20it%20does%20not%20emit%20%60.acceptance%60%2F%60.fullAcceptance%60%20when%20the%20binding%20is%20a%20bare%20printable%20%E2%80%94%20or%20to%20gate%20%60acceptCurrentSuggestion%60%2F%60acceptEntireSuggestion%60%20on%20%60shouldConsumeAcceptKeyProvider%28%29%60%20directly.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FServices%2FInput%2FInputMonitor.swift%3A325-330%0A**Layer%202%20reads%20%60overlayState%60%20that%20was%20updated%20by%20the%20observer%20callback%20for%20the%20same%20event**%0A%0AThe%20observer%20tap%20fires%20first%20%28head-inserted%29%2C%20potentially%20drives%20a%20successful%20acceptance%20that%20calls%20%60hideOverlay%28%29%60%20%E2%86%92%20%60setAcceptInterceptionActive%28false%29%60%20%E2%86%92%20%60destroyAcceptTap%28%29%60%2C%20and%20returns.%20%60overlayState%60%20is%20now%20%60.hidden%60.%20When%20the%20accept%20tap%20fires%20next%2C%20%60shouldConsumeAcceptKeyProvider%28%29%60%20reads%20%60self.overlayState.isVisible%20%3D%20false%60%20and%20returns%20%60false%60%2C%20passing%20the%20accept%20key%20through.%0A%0AWhether%20this%20actually%20regresses%20the%20happy%20path%20%28Tab%2F%E2%8C%83Tab%29%20depends%20on%20whether%20%60CFMachPortInvalidate%60%20prevents%20the%20accept%20tap%20from%20being%20invoked%20at%20all%20for%20the%20in-flight%20event.%20If%20the%20callback%20is%20not%20invoked%20after%20invalidation%2C%20this%20is%20benign%3B%20if%20it%20is%2C%20every%20successful%20acceptance%20would%20also%20deliver%20the%20accept%20key%20to%20the%20focused%20app.%20The%20PR's%20test%204%20claim%20%28%22keystroke%20does%20not%20reach%20the%20host%22%29%20should%20be%20validated%20against%20a%20case%20where%20the%20accept%20tap%20*is*%20still%20installed%20%28i.e.%2C%20where%20%60destroyAcceptTap%60%20is%20NOT%20called%20during%20the%20observer%20callback%29.%0A%0A&repo=fujacob%2Fcotabby&pr=382&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Fail-open accept tap: never consume bare..."](https://github.com/fujacob/cotabby/commit/c26e759a03205f5f687cbecc06db8f0d38b60581) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34395281)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->