### PR TITLE
Drop host-AX-publish ceiling to 60ms now that swallow bug is fixed

### DIFF
--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
@@ -174,10 +174,12 @@ extension SuggestionCoordinator {
     }
 
     /// Maximum wall time we'll wait for the host app to publish post-keystroke AX before giving
-    /// up and generating against whatever's there. Chosen empirically: long enough to cover
-    /// Chrome's slower contenteditable publish on a busy page, short enough that the user can
-    /// always type ahead without the rescheduled suggestion feeling stuck.
-    private static let hostPublishWaitCeilingMs = 400
+    /// up and generating against whatever's there. Dropped from 400ms to 60ms now that the
+    /// accept tap fail-open in #382 guarantees the user's keystroke reaches the host regardless
+    /// of AX timing. The publish-wait is purely a quality knob for the rescheduled suggestion;
+    /// it no longer masks an input-swallow bug, so we'd rather keep predictions snappy than
+    /// trade them off for AX accuracy that the model only marginally benefits from.
+    private static let hostPublishWaitCeilingMs = 60
 
     /// Interval between AX polls while waiting for the host publish. Same order of magnitude as
     /// the focus poll itself (default 80ms) but tighter so we catch the publish promptly without


### PR DESCRIPTION
Now that #382 makes the accept tap fail-open, the long publish wait no longer masks an input-swallow bug. Dropping the ceiling from 400ms to 60ms keeps post-divergence predictions snappy.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Reduces the AX-publish wait ceiling in `pollForHostPublish` from 400ms to 60ms, relying on the fail-open accept tap added in #382 to ensure keystrokes are never swallowed regardless of AX timing. With `hostPublishPollIntervalMs = 30`, the new ceiling allows exactly one async retry (at ~30ms wall time) before the loop falls back to generating against whatever AX state is current.

- **Ceiling reduction:** `hostPublishWaitCeilingMs` drops 400 → 60ms; Chrome contenteditable fields on busy pages that publish AX after 30ms will now receive predictions against pre-keystroke text more often, which is explicitly accepted as a quality tradeoff for snappier predictions.
- **Poll-loop coupling:** The ceiling and poll interval are now tightly coupled (60ms ceiling / 30ms interval = exactly one retry); a future increase of the poll interval to ≥ 60ms would silently eliminate all async retries — worth documenting on the constant.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the one-line constant change is well-reasoned and the poll-loop fallback ensures predictions always fire even if AX never updates.

The change is minimal and intentional. The only gap is a now-stale comment on `hostPublishPollIntervalMs` that still cites "default 80ms" — a value that would exceed the new 60ms ceiling and eliminate all async retries if someone tried to match it. That is a documentation hazard, not a current defect.

The poll-interval comment at lines 184–187 in `SuggestionCoordinator+Input.swift` is the only part worth revisiting.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift | Drops `hostPublishWaitCeilingMs` from 400ms to 60ms; with the 30ms poll interval this yields exactly one async AX retry before giving up — the poll-interval comment still references "default 80ms" which now exceeds the ceiling and would eliminate all retries if used. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Keystroke received via CGEvent tap] --> B[schedulePredictionAfterHostPublishDelay]
    B --> C[Snapshot baseline: text, elementID, selectionLocation]
    C --> D[pollForHostPublish\nelapsedMs = 0]
    D --> E[focusModel.refreshNow\nsynchronous AX read]
    E --> F{AX snapshot\nchanged?}
    F -- Yes --> G[schedulePrediction]
    F -- No --> H["nextElapsed = elapsedMs + 30ms\n(hostPublishPollIntervalMs)"]
    H --> I{"nextElapsed < 60ms?\n(hostPublishWaitCeilingMs)"}
    I -- "Yes (0+30=30 < 60)" --> J[asyncAfter 30ms]
    J --> K[pollForHostPublish\nelapsedMs = 30]
    K --> L[focusModel.refreshNow]
    L --> M{AX snapshot\nchanged?}
    M -- Yes --> G
    M -- "No: 30+30=60 >= 60\n(ceiling hit)" --> G
    I -- "No (fires immediately if\npollInterval >= ceiling)" --> G
    style G fill:#4CAF50,color:#fff
    style I fill:#FF9800,color:#fff
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift`, line 184-187 ([link](https://github.com/fujacob/cotabby/blob/c9064d788e0313a58e7555451b18836a0207836b/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift#L184-L187)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `hostPublishPollIntervalMs` comment says it is the "same order of magnitude as the focus poll itself (default 80ms)" — but with the ceiling now at 60ms, any poll interval at or above 60ms would cause the ceiling guard (`nextElapsed < hostPublishWaitCeilingMs`) to fire immediately on the first tail-call, giving zero async retries. Even using the 80ms value mentioned in the comment would silently eliminate all polling. The comment should be updated to reflect the new ceiling so future maintainers know the two constants are tightly coupled.

   

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22chore%2Flower-ax-publish-delay%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2Flower-ax-publish-delay%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BInput.swift%0ALine%3A%20184-187%0A%0AComment%3A%0AThe%20%60hostPublishPollIntervalMs%60%20comment%20says%20it%20is%20the%20%22same%20order%20of%20magnitude%20as%20the%20focus%20poll%20itself%20%28default%2080ms%29%22%20%E2%80%94%20but%20with%20the%20ceiling%20now%20at%2060ms%2C%20any%20poll%20interval%20at%20or%20above%2060ms%20would%20cause%20the%20ceiling%20guard%20%28%60nextElapsed%20%3C%20hostPublishWaitCeilingMs%60%29%20to%20fire%20immediately%20on%20the%20first%20tail-call%2C%20giving%20zero%20async%20retries.%20Even%20using%20the%2080ms%20value%20mentioned%20in%20the%20comment%20would%20silently%20eliminate%20all%20polling.%20The%20comment%20should%20be%20updated%20to%20reflect%20the%20new%20ceiling%20so%20future%20maintainers%20know%20the%20two%20constants%20are%20tightly%20coupled.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Interval%20between%20AX%20polls%20while%20waiting%20for%20the%20host%20publish.%20Must%20remain%20strictly%20less%0A%20%20%20%20%2F%2F%2F%20than%20%60hostPublishWaitCeilingMs%60%20%28currently%2060ms%29%3B%20if%20it%20equals%20or%20exceeds%20the%20ceiling%20the%0A%20%20%20%20%2F%2F%2F%20guard%20fires%20on%20the%20first%20tail-call%20and%20zero%20async%20retries%20occur.%20Kept%20at%2030ms%20so%20we%20still%0A%20%20%20%20%2F%2F%2F%20get%20one%20retry%20window%20before%20the%20ceiling%20fires%20without%20burning%20CPU%20on%20back-to-back%0A%20%20%20%20%2F%2F%2F%20AX%20queries%20that%20are%20themselves%205%E2%80%9315ms%20each.%0A%20%20%20%20private%20static%20let%20hostPublishPollIntervalMs%20%3D%2030%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BInput.swift%0ALine%3A%20184-187%0A%0AComment%3A%0AThe%20%60hostPublishPollIntervalMs%60%20comment%20says%20it%20is%20the%20%22same%20order%20of%20magnitude%20as%20the%20focus%20poll%20itself%20%28default%2080ms%29%22%20%E2%80%94%20but%20with%20the%20ceiling%20now%20at%2060ms%2C%20any%20poll%20interval%20at%20or%20above%2060ms%20would%20cause%20the%20ceiling%20guard%20%28%60nextElapsed%20%3C%20hostPublishWaitCeilingMs%60%29%20to%20fire%20immediately%20on%20the%20first%20tail-call%2C%20giving%20zero%20async%20retries.%20Even%20using%20the%2080ms%20value%20mentioned%20in%20the%20comment%20would%20silently%20eliminate%20all%20polling.%20The%20comment%20should%20be%20updated%20to%20reflect%20the%20new%20ceiling%20so%20future%20maintainers%20know%20the%20two%20constants%20are%20tightly%20coupled.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Interval%20between%20AX%20polls%20while%20waiting%20for%20the%20host%20publish.%20Must%20remain%20strictly%20less%0A%20%20%20%20%2F%2F%2F%20than%20%60hostPublishWaitCeilingMs%60%20%28currently%2060ms%29%3B%20if%20it%20equals%20or%20exceeds%20the%20ceiling%20the%0A%20%20%20%20%2F%2F%2F%20guard%20fires%20on%20the%20first%20tail-call%20and%20zero%20async%20retries%20occur.%20Kept%20at%2030ms%20so%20we%20still%0A%20%20%20%20%2F%2F%2F%20get%20one%20retry%20window%20before%20the%20ceiling%20fires%20without%20burning%20CPU%20on%20back-to-back%0A%20%20%20%20%2F%2F%2F%20AX%20queries%20that%20are%20themselves%205%E2%80%9315ms%20each.%0A%20%20%20%20private%20static%20let%20hostPublishPollIntervalMs%20%3D%2030%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=383&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22chore%2Flower-ax-publish-delay%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2Flower-ax-publish-delay%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BInput.swift%3A184-187%0AThe%20%60hostPublishPollIntervalMs%60%20comment%20says%20it%20is%20the%20%22same%20order%20of%20magnitude%20as%20the%20focus%20poll%20itself%20%28default%2080ms%29%22%20%E2%80%94%20but%20with%20the%20ceiling%20now%20at%2060ms%2C%20any%20poll%20interval%20at%20or%20above%2060ms%20would%20cause%20the%20ceiling%20guard%20%28%60nextElapsed%20%3C%20hostPublishWaitCeilingMs%60%29%20to%20fire%20immediately%20on%20the%20first%20tail-call%2C%20giving%20zero%20async%20retries.%20Even%20using%20the%2080ms%20value%20mentioned%20in%20the%20comment%20would%20silently%20eliminate%20all%20polling.%20The%20comment%20should%20be%20updated%20to%20reflect%20the%20new%20ceiling%20so%20future%20maintainers%20know%20the%20two%20constants%20are%20tightly%20coupled.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Interval%20between%20AX%20polls%20while%20waiting%20for%20the%20host%20publish.%20Must%20remain%20strictly%20less%0A%20%20%20%20%2F%2F%2F%20than%20%60hostPublishWaitCeilingMs%60%20%28currently%2060ms%29%3B%20if%20it%20equals%20or%20exceeds%20the%20ceiling%20the%0A%20%20%20%20%2F%2F%2F%20guard%20fires%20on%20the%20first%20tail-call%20and%20zero%20async%20retries%20occur.%20Kept%20at%2030ms%20so%20we%20still%0A%20%20%20%20%2F%2F%2F%20get%20one%20retry%20window%20before%20the%20ceiling%20fires%20without%20burning%20CPU%20on%20back-to-back%0A%20%20%20%20%2F%2F%2F%20AX%20queries%20that%20are%20themselves%205%E2%80%9315ms%20each.%0A%20%20%20%20private%20static%20let%20hostPublishPollIntervalMs%20%3D%2030%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BInput.swift%3A184-187%0AThe%20%60hostPublishPollIntervalMs%60%20comment%20says%20it%20is%20the%20%22same%20order%20of%20magnitude%20as%20the%20focus%20poll%20itself%20%28default%2080ms%29%22%20%E2%80%94%20but%20with%20the%20ceiling%20now%20at%2060ms%2C%20any%20poll%20interval%20at%20or%20above%2060ms%20would%20cause%20the%20ceiling%20guard%20%28%60nextElapsed%20%3C%20hostPublishWaitCeilingMs%60%29%20to%20fire%20immediately%20on%20the%20first%20tail-call%2C%20giving%20zero%20async%20retries.%20Even%20using%20the%2080ms%20value%20mentioned%20in%20the%20comment%20would%20silently%20eliminate%20all%20polling.%20The%20comment%20should%20be%20updated%20to%20reflect%20the%20new%20ceiling%20so%20future%20maintainers%20know%20the%20two%20constants%20are%20tightly%20coupled.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Interval%20between%20AX%20polls%20while%20waiting%20for%20the%20host%20publish.%20Must%20remain%20strictly%20less%0A%20%20%20%20%2F%2F%2F%20than%20%60hostPublishWaitCeilingMs%60%20%28currently%2060ms%29%3B%20if%20it%20equals%20or%20exceeds%20the%20ceiling%20the%0A%20%20%20%20%2F%2F%2F%20guard%20fires%20on%20the%20first%20tail-call%20and%20zero%20async%20retries%20occur.%20Kept%20at%2030ms%20so%20we%20still%0A%20%20%20%20%2F%2F%2F%20get%20one%20retry%20window%20before%20the%20ceiling%20fires%20without%20burning%20CPU%20on%20back-to-back%0A%20%20%20%20%2F%2F%2F%20AX%20queries%20that%20are%20themselves%205%E2%80%9315ms%20each.%0A%20%20%20%20private%20static%20let%20hostPublishPollIntervalMs%20%3D%2030%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=383&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Drop host-AX-publish ceiling to 60ms now..."](https://github.com/fujacob/cotabby/commit/c9064d788e0313a58e7555451b18836a0207836b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34396548)</sub>

<!-- /greptile_comment -->