### PR TITLE
Revert #383: restore host-AX-publish ceiling to 400ms

### DIFF
--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
@@ -174,12 +174,10 @@ extension SuggestionCoordinator {
     }
 
     /// Maximum wall time we'll wait for the host app to publish post-keystroke AX before giving
-    /// up and generating against whatever's there. Dropped from 400ms to 60ms now that the
-    /// accept tap fail-open in #382 guarantees the user's keystroke reaches the host regardless
-    /// of AX timing. The publish-wait is purely a quality knob for the rescheduled suggestion;
-    /// it no longer masks an input-swallow bug, so we'd rather keep predictions snappy than
-    /// trade them off for AX accuracy that the model only marginally benefits from.
-    private static let hostPublishWaitCeilingMs = 60
+    /// up and generating against whatever's there. Chosen empirically: long enough to cover
+    /// Chrome's slower contenteditable publish on a busy page, short enough that the user can
+    /// always type ahead without the rescheduled suggestion feeling stuck.
+    private static let hostPublishWaitCeilingMs = 400
 
     /// Interval between AX polls while waiting for the host publish. Same order of magnitude as
     /// the focus poll itself (default 80ms) but tighter so we catch the publish promptly without


### PR DESCRIPTION
60ms was too tight in practice — rolled back to the 400ms ceiling. The fail-open accept tap in #382 remains as the swallow fix.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Reverts the `hostPublishWaitCeilingMs` constant from 60ms (introduced in #383) back to 400ms, and replaces the doc comment with an empirical rationale. The #382 fail-open accept-tap fix is unaffected.

- Restores the AX-publish poll ceiling to 400ms so Chrome's slower `contenteditable` publish on a busy page is reliably captured before generation fires.
- Updates the doc comment to drop the now-stale #382/60ms justification and describe the value as empirically chosen for responsiveness vs. AX accuracy.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-constant revert with no logic changes.

The only change is restoring a timeout constant from 60ms to 400ms and refreshing the accompanying doc comment. The polling logic (pollForHostPublish) is untouched; the fail-open accept tap from #382 is untouched. No new code paths are introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift | Reverts hostPublishWaitCeilingMs from 60ms back to 400ms and updates the doc comment to reflect the empirical rationale; no logic changes. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CGEvent as CGEvent Tap
    participant SuggC as SuggestionCoordinator
    participant FocusM as FocusModel (AX)
    participant Predict as Prediction Pipeline

    CGEvent->>SuggC: keystroke captured
    SuggC->>SuggC: schedulePredictionAfterHostPublishDelay()
    SuggC->>FocusM: refreshNow() (snapshot baseline)

    loop Poll every 30ms, up to ~370ms (ceiling 400ms)
        SuggC->>FocusM: refreshNow()
        alt AX state changed (text / element / selection)
            SuggC->>Predict: schedulePrediction()
        else "Ceiling reached (nextElapsed >= 400ms)"
            SuggC->>Predict: schedulePrediction() [fallback]
        else Still waiting
            SuggC->>SuggC: asyncAfter(30ms) → pollForHostPublish
        end
    end
```

<sub>Reviews (1): Last reviewed commit: ["Revert &quot;Drop host-AX-publish ceiling to ..."](https://github.com/fujacob/cotabby/commit/1b5dd6c1f971bd1745669d9f7481d6faeb727a09) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34398623)</sub>

<!-- /greptile_comment -->