### PR TITLE
Fix last tab issue

### DIFF
--- a/Cotabby/Services/Input/InputMonitor.swift
+++ b/Cotabby/Services/Input/InputMonitor.swift
@@ -56,6 +56,12 @@ final class InputMonitor {
 
     private var acceptTap: CFMachPort?
     private var acceptRunLoopSource: CFRunLoopSource?
+    // The listen-only observer runs before the tail accept tap. If accepting the final chunk hides
+    // the overlay during the observer callback, we must keep the tail tap alive long enough to
+    // swallow that same physical Tab; otherwise Chrome receives Tab after Cotabby inserts text.
+    private var pendingObserverAcceptedKeyEvent: PendingAcceptedKeyEvent?
+    private var isHandlingAcceptKeyObserverEvent = false
+    private var shouldRemoveAcceptTapAfterPendingEvent = false
 
     init(
         permissionProvider: @escaping @MainActor () -> Bool,
@@ -74,7 +80,7 @@ final class InputMonitor {
     /// Removes both taps and stops observing keyboard events.
     func stop() {
         CotabbyLogger.app.info("Input monitor stopping")
-        destroyAcceptTap()
+        destroyAcceptTap(deferDuringCurrentAcceptKeyEvent: false)
         destroyObserverTap()
     }
 
@@ -85,7 +91,7 @@ final class InputMonitor {
         if permissionProvider() {
             installObserverTapIfNeeded()
         } else {
-            destroyAcceptTap()
+            destroyAcceptTap(deferDuringCurrentAcceptKeyEvent: false)
             destroyObserverTap()
         }
     }
@@ -96,7 +102,7 @@ final class InputMonitor {
     /// during the brief window when there is actually something to accept.
     func setAcceptInterceptionActive(_ active: Bool) {
         guard permissionProvider() else {
-            destroyAcceptTap()
+            destroyAcceptTap(deferDuringCurrentAcceptKeyEvent: false)
             return
         }
         if active {
@@ -224,7 +230,17 @@ final class InputMonitor {
         observerTap = nil
     }
 
-    private func destroyAcceptTap() {
+    private func destroyAcceptTap(deferDuringCurrentAcceptKeyEvent: Bool = true) {
+        if deferDuringCurrentAcceptKeyEvent, isHandlingAcceptKeyObserverEvent {
+            shouldRemoveAcceptTapAfterPendingEvent = true
+            CotabbyLogger.app.trace("Deferring accept tap removal until current accept key finishes")
+            return
+        }
+
+        destroyAcceptTapImmediately()
+    }
+
+    private func destroyAcceptTapImmediately() {
         guard acceptTap != nil || acceptRunLoopSource != nil else {
             return
         }
@@ -237,6 +253,8 @@ final class InputMonitor {
             CFMachPortInvalidate(tap)
         }
         acceptTap = nil
+        pendingObserverAcceptedKeyEvent = nil
+        shouldRemoveAcceptTapAfterPendingEvent = false
         CotabbyLogger.app.info("CGEvent accept tap removed")
     }
 
@@ -266,7 +284,28 @@ final class InputMonitor {
             }
 
             let capturedEvent = classify(event: event)
-            _ = onEvent?(capturedEvent)
+            let isAcceptKeyEvent = capturedEvent.kind == .acceptance || capturedEvent.kind == .fullAcceptance
+
+            if isAcceptKeyEvent {
+                isHandlingAcceptKeyObserverEvent = true
+            }
+            defer {
+                if isAcceptKeyEvent {
+                    isHandlingAcceptKeyObserverEvent = false
+                    if shouldRemoveAcceptTapAfterPendingEvent, pendingObserverAcceptedKeyEvent == nil {
+                        destroyAcceptTapImmediately()
+                    }
+                }
+            }
+
+            let shouldConsume = onEvent?(capturedEvent) ?? false
+
+            if isAcceptKeyEvent, shouldConsume, acceptTap != nil {
+                pendingObserverAcceptedKeyEvent = PendingAcceptedKeyEvent(
+                    keyCode: capturedEvent.keyCode,
+                    modifiers: ShortcutModifierMask(eventFlags: capturedEvent.flags)
+                )
+            }
             return Unmanaged.passUnretained(event)
 
         default:
@@ -303,6 +342,18 @@ final class InputMonitor {
                 && eventModifiers == acceptanceKeyModifiersProvider()
 
             if fullAcceptMatches || acceptMatches {
+                if let pendingObserverAcceptedKeyEvent,
+                   pendingObserverAcceptedKeyEvent.matches(keyCode: keyCode, modifiers: eventModifiers) {
+                    self.pendingObserverAcceptedKeyEvent = nil
+                    CotabbyLogger.app.debug(
+                        "Accept tap consumed keyCode=\(keyCode) modifiers=\(eventModifiers.rawValue)"
+                    )
+                    if shouldRemoveAcceptTapAfterPendingEvent {
+                        destroyAcceptTapImmediately()
+                    }
+                    return nil
+                }
+
                 // Layer 1 — never consume a bare printable character. The recorder can store
                 // bindings like (keyCode: 0, modifiers: []) which is the 'a' key. Without this
                 // guard the bound character would silently disappear every time the user typed
@@ -407,6 +458,15 @@ final class InputMonitor {
 }
 
 extension InputMonitor: SuggestionInputMonitoring {}
+
+private struct PendingAcceptedKeyEvent {
+    let keyCode: CGKeyCode
+    let modifiers: ShortcutModifierMask
+
+    func matches(keyCode: CGKeyCode, modifiers: ShortcutModifierMask) -> Bool {
+        self.keyCode == keyCode && self.modifiers == modifiers
+    }
+}
 
 private extension CGEvent {
     var unicodeString: String {


### PR DESCRIPTION
## Summary

<!--
One or two sentences: what changed and why. Skip the play-by-play.
The diff already shows what; this section should explain why.
-->

## Validation

<!--
What you actually ran and what you actually saw, not what you intended to run.
Examples:

  xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby \
    -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO
  # ** TEST SUCCEEDED **  N tests, 0 failures

  swiftlint lint --config .swiftlint.yml --quiet
  # exit 0

For UI changes, attach a screenshot or short screen recording.
For changes that can't be verified end-to-end yet, say so explicitly.
-->

## Linked issues

<!--
Use `Fixes #N` to auto-close on merge, `Refs #N` to link without closing.
-->

## Risk / rollout notes

<!--
Anything reviewers should know that isn't visible from the diff:
- Schema, settings, or pbxproj migrations
- Behavior changes that touch existing user flows
- Performance characteristics worth flagging
- Follow-up issues filed (link them)

Skip this section entirely if there's nothing to flag.
-->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a race condition where Chrome (and similar apps) would receive a spurious Tab keystroke after Cotabby inserted text on the final suggestion chunk. The root cause is the ordering of the two event taps: the listen-only observer (head-insert) fires first and can trigger overlay dismissal — which previously destroyed the accept tap — before the active accept tap (tail-append) had a chance to swallow the same physical Tab.

- Three new instance-state fields (`pendingObserverAcceptedKeyEvent`, `isHandlingAcceptKeyObserverEvent`, `shouldRemoveAcceptTapAfterPendingEvent`) coordinate deferred teardown: `destroyAcceptTap()` now defaults to deferring removal when called from inside an observer accept-key callback, and the accept tap itself handles the deferred cleanup once it has consumed the pending key.
- All explicit `stop()`, `refresh()`, and permission-revoked call-sites pass `deferDuringCurrentAcceptKeyEvent: false` to preserve the previous immediate-teardown semantics for those paths.

<h3>Confidence Score: 4/5</h3>

The change is confined to a single file and the happy path is well-reasoned; the main residual risk is a stale pending-event record if the accept tap is system-disabled at a narrow moment between the observer and accept-tap callbacks.

The fix correctly threads three new state flags through the observer and accept tap callbacks on the MainActor, preserving all existing safeguards for every path except the new deferred-consume path where those guards are intentionally bypassed because the decision was already made by the observer. Two minor robustness gaps exist: the system-tap-disabled re-enable path does not clear the pending event record, and the two consumption log messages are identical, making post-hoc log analysis harder.

Cotabby/Services/Input/InputMonitor.swift — specifically the .tapDisabledByTimeout branch in handleAcceptTap and the duplicate debug log string near the new pending-event consumption site.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Services/Input/InputMonitor.swift | Adds deferred accept-tap teardown and a pending-event record to prevent the last Tab keystroke from leaking to the host app when the overlay is dismissed inside the observer callback. Three new instance-state fields coordinate the two-tap pipeline; logic is correct for the primary flow with two minor robustness gaps. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as User presses Tab
    participant OT as Observer Tap head listen-only
    participant Coord as Coordinator onEvent
    participant AT as Accept Tap tail active
    participant App as Host App

    User->>OT: keyDown Tab
    OT->>OT: classify as .acceptance
    OT->>OT: "isHandlingAcceptKeyObserverEvent = true"
    OT->>Coord: onEvent returns true
    Coord->>Coord: hide overlay
    Coord->>OT: setAcceptInterceptionActive false deferred
    OT->>OT: set pendingObserverAcceptedKeyEvent
    OT->>OT: defer clears flag skip immediate destroy
    OT-->>AT: event propagates in chain
    AT->>AT: key matches accept binding
    AT->>AT: pendingObserverAcceptedKeyEvent matches cleared
    AT->>AT: shouldRemoveAcceptTapAfterPendingEvent destroyAcceptTapImmediately
    AT-->>App: return nil event consumed
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22james%2Ffix-tabbing-on-last-suggestion%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22james%2Ffix-tabbing-on-last-suggestion%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FServices%2FInput%2FInputMonitor.swift%3A348-350%0A**Duplicate%20log%20message%20makes%20the%20two%20consumption%20paths%20indistinguishable**%0A%0AThe%20new%20deferred-pending-event%20path%20%28around%20line%20349%29%20emits%20the%20exact%20same%20%60.debug%60%20string%20as%20the%20original%20Layer-2%20consumption%20path%20%28~line%20384%29.%20When%20grepping%20logs%20to%20diagnose%20a%20timing%20issue%20it%20is%20impossible%20to%20tell%20which%20path%20fired.%20Adding%20a%20short%20qualifier%20like%20%60%22pending%22%60%20to%20the%20new%20path's%20message%20would%20make%20the%20two%20branches%20immediately%20distinguishable%20without%20any%20other%20changes.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FServices%2FInput%2FInputMonitor.swift%3A303-308%0A**%60pendingObserverAcceptedKeyEvent%60%20has%20no%20cleanup%20path%20when%20the%20accept%20tap%20is%20system-disabled%20mid-flight**%0A%0AIf%20the%20system%20disables%20the%20accept%20tap%20%28%60.tapDisabledByTimeout%60%29%20between%20the%20observer%20callback%20setting%20%60pendingObserverAcceptedKeyEvent%60%20and%20the%20tap's%20%60keyDown%60%20handler%20running%2C%20%60handleAcceptTap%60%20receives%20the%20disable%20notification%2C%20re-enables%20the%20tap%2C%20and%20returns%20%E2%80%94%20without%20clearing%20%60pendingObserverAcceptedKeyEvent%60.%20macOS%20should%20re-deliver%20the%20original%20%60keyDown%60%20after%20re-enable%20so%20the%20pending%20event%20is%20consumed%20in%20the%20next%20callback%2C%20but%20if%20the%20event%20is%20somehow%20dropped%20%28e.g.%20very%20short%20tap%20disable%20window%29%2C%20the%20accept%20tap%20stays%20alive%20indefinitely%20with%20a%20stale%20pending%20entry%20and%20%60shouldRemoveAcceptTapAfterPendingEvent%20%3D%20true%60.%20The%20tap%20will%20then%20consume%20and%20destroy%20itself%20on%20the%20*next*%20Tab%20press%20even%20after%20a%20new%20suggestion%20session%20starts%2C%20leaving%20the%20new%20session's%20accept%20tap%20unexpectedly%20gone.%20Clearing%20%60pendingObserverAcceptedKeyEvent%60%20%28and%20resetting%20%60shouldRemoveAcceptTapAfterPendingEvent%60%29%20in%20the%20%60.tapDisabledByTimeout%60%20%2F%20%60.tapDisabledByUserInput%60%20branch%20of%20%60handleAcceptTap%60%20would%20close%20this%20window.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FServices%2FInput%2FInputMonitor.swift%3A348-350%0A**Duplicate%20log%20message%20makes%20the%20two%20consumption%20paths%20indistinguishable**%0A%0AThe%20new%20deferred-pending-event%20path%20%28around%20line%20349%29%20emits%20the%20exact%20same%20%60.debug%60%20string%20as%20the%20original%20Layer-2%20consumption%20path%20%28~line%20384%29.%20When%20grepping%20logs%20to%20diagnose%20a%20timing%20issue%20it%20is%20impossible%20to%20tell%20which%20path%20fired.%20Adding%20a%20short%20qualifier%20like%20%60%22pending%22%60%20to%20the%20new%20path's%20message%20would%20make%20the%20two%20branches%20immediately%20distinguishable%20without%20any%20other%20changes.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FServices%2FInput%2FInputMonitor.swift%3A303-308%0A**%60pendingObserverAcceptedKeyEvent%60%20has%20no%20cleanup%20path%20when%20the%20accept%20tap%20is%20system-disabled%20mid-flight**%0A%0AIf%20the%20system%20disables%20the%20accept%20tap%20%28%60.tapDisabledByTimeout%60%29%20between%20the%20observer%20callback%20setting%20%60pendingObserverAcceptedKeyEvent%60%20and%20the%20tap's%20%60keyDown%60%20handler%20running%2C%20%60handleAcceptTap%60%20receives%20the%20disable%20notification%2C%20re-enables%20the%20tap%2C%20and%20returns%20%E2%80%94%20without%20clearing%20%60pendingObserverAcceptedKeyEvent%60.%20macOS%20should%20re-deliver%20the%20original%20%60keyDown%60%20after%20re-enable%20so%20the%20pending%20event%20is%20consumed%20in%20the%20next%20callback%2C%20but%20if%20the%20event%20is%20somehow%20dropped%20%28e.g.%20very%20short%20tap%20disable%20window%29%2C%20the%20accept%20tap%20stays%20alive%20indefinitely%20with%20a%20stale%20pending%20entry%20and%20%60shouldRemoveAcceptTapAfterPendingEvent%20%3D%20true%60.%20The%20tap%20will%20then%20consume%20and%20destroy%20itself%20on%20the%20*next*%20Tab%20press%20even%20after%20a%20new%20suggestion%20session%20starts%2C%20leaving%20the%20new%20session's%20accept%20tap%20unexpectedly%20gone.%20Clearing%20%60pendingObserverAcceptedKeyEvent%60%20%28and%20resetting%20%60shouldRemoveAcceptTapAfterPendingEvent%60%29%20in%20the%20%60.tapDisabledByTimeout%60%20%2F%20%60.tapDisabledByUserInput%60%20branch%20of%20%60handleAcceptTap%60%20would%20close%20this%20window.%0A%0A&repo=fujacob%2Fcotabby&pr=385&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Fix last tab issue"](https://github.com/fujacob/cotabby/commit/d3dfa5ed51330c40724a44e085fb5d329dea25b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34432382)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->