### PR TITLE
Cap derived-quality ghost font size separately from exact

### DIFF
--- a/Cotabby/Services/UI/OverlayController.swift
+++ b/Cotabby/Services/UI/OverlayController.swift
@@ -13,6 +13,11 @@ final class OverlayController: SuggestionOverlayControlling {
     private enum Layout {
         static let minimumGhostFontSize: CGFloat = 14
         static let maximumGhostFontSize: CGFloat = 24
+        /// Derived caret rects come from line-box geometry rather than measured text bounds, so the
+        /// reported height often inflates against the host's real font size (Slack, several web
+        /// editors). Keep the ceiling well below the exact cap so a wrong derived reading cannot
+        /// render oversized ghost text — the observed failure mode is too-large, not too-small.
+        static let maximumDerivedGhostFontSize: CGFloat = 17
         static let maximumEstimatedGhostFontSize: CGFloat = 16
         static let fontToLineHeightRatio: CGFloat = 0.78
     }
@@ -240,11 +245,13 @@ final class OverlayController: SuggestionOverlayControlling {
         panel.orderFrontRegardless()
     }
 
-    /// Exact and derived caret rects usually reflect the real text line height, so they may scale
-    /// up in larger editors. Estimated rects are much less trustworthy because some apps only
-    /// expose the full field frame; the extra ceiling prevents one bad estimate from rendering
-    /// comically oversized ghost text. `caretHeight` is already floored to the per-session minimum
-    /// by `ghostFontStabilizer`, so this only applies the static floor and quality ceilings.
+    /// Caps the proposed font size by how much we trust the caret geometry:
+    ///   - `.exact`: measured text bounds, trusted up to the full ceiling so larger editors scale.
+    ///   - `.derived`: line-box geometry that commonly inflates against the real font, tightly
+    ///     capped to avoid the "insanely big derived" failure mode observed in Slack-like hosts.
+    ///   - `.estimated`: full-field-frame fallback, even less trustworthy, tightest ceiling.
+    /// `caretHeight` is already floored to the per-session minimum by `ghostFontStabilizer`, so this
+    /// only applies the static floor and the per-quality ceiling.
     private func resolvedGhostFontSize(
         forCaretHeight caretHeight: CGFloat,
         caretQuality: CaretGeometryQuality
@@ -253,9 +260,15 @@ final class OverlayController: SuggestionOverlayControlling {
             Layout.minimumGhostFontSize,
             caretHeight * Layout.fontToLineHeightRatio
         )
-        let qualityCap = caretQuality == .estimated
-            ? Layout.maximumEstimatedGhostFontSize
-            : Layout.maximumGhostFontSize
+        let qualityCap: CGFloat
+        switch caretQuality {
+        case .exact:
+            qualityCap = Layout.maximumGhostFontSize
+        case .derived:
+            qualityCap = Layout.maximumDerivedGhostFontSize
+        case .estimated:
+            qualityCap = Layout.maximumEstimatedGhostFontSize
+        }
 
         return min(proposedSize, qualityCap)
     }


### PR DESCRIPTION
## Summary

Split the ghost-text font-size ceiling in `OverlayController.resolvedGhostFontSize` so `.derived` caret quality no longer shares the `.exact` cap. Today `.exact` and `.derived` both clamp at 24pt; in hosts that emit `.derived` geometry from line-box bounds (Slack, several web editors) the reported caret height inflates against the host's real font size, and ghost text renders comically oversized. The observed failure mode is too-large, not too-small.

New tiers:

| Quality      | Cap (pt) | Rationale                                                            |
| ------------ | -------- | -------------------------------------------------------------------- |
| `.exact`     | 24       | Measured text bounds, trusted to scale up in larger editors.         |
| `.derived`   | 17       | Line-box geometry; more reliable than estimated but still not measured. |
| `.estimated` | 16       | Full-field-frame fallback, least trustworthy. Unchanged.             |

`GhostFontSizeStabilizer` still does per-focus-session downward smoothing on top of these caps, so a momentarily-better reading inside one session still narrows the ceiling.

## Validation

```
swiftlint lint --quiet Cotabby/Services/UI/OverlayController.swift
# exit 0

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **
```

Local full-test execution hits the documented Team ID code-signing mismatch on this machine; CI runs the test target against the merge ref.

## Linked issues

None filed; reported in-conversation.

## Risk / rollout notes

- Behavior change is bounded: in apps that today render correct ghost text at the upper end of the 17-24pt range with `.derived` quality, ghost text will now cap at 17pt and look slightly small. The current state is worse for affected hosts ("comically oversized") than for unaffected hosts (slightly small), so the asymmetry favors the cap.
- `.exact` paths (most native AppKit fields, Gmail/Outlook text-marker path) are unchanged.
- Pure value math; no new files, no project.yml changes, XcodeGen check stays green.
- If a future host turns out to need a higher derived ceiling, the constant is a one-line bump in `Layout`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR splits the ghost-text font-size ceiling in `resolvedGhostFontSize` so `.derived` caret quality gets its own cap (17 pt) instead of sharing the `.exact` cap (24 pt), fixing oversized ghost text in hosts like Slack that inflate caret height from line-box geometry.

- **New constant `maximumDerivedGhostFontSize = 17`** is added to `Layout`; the old binary ternary (`.estimated` vs everything else) is replaced with an exhaustive `switch` over all three `CaretGeometryQuality` cases.
- **`.exact` (24 pt) and `.estimated` (16 pt) caps are unchanged**; only `.derived` is tightened, isolating the regression risk to hosts that already report inflated derived geometry.
- The switch is exhaustive — Swift's compiler enforces coverage, so any future addition of a quality case will require a matching arm here.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is pure value math on three named constants, the switch is exhaustive and compiler-enforced, and the only affected path is `.derived` quality which is currently producing the worse "comically oversized" outcome.

The change is a tightly scoped constant split with an exhaustive switch. Adding `CaretGeometryQuality` cases in the future would produce a compile error rather than silently falling through to the wrong cap. The `.exact` and `.estimated` paths are byte-for-byte identical to before, and `.derived` tightening only affects hosts already exhibiting the oversized-text failure mode.

No files require special attention. The single changed file is self-contained value math with no side effects outside the font-size calculation.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Services/UI/OverlayController.swift | Adds `maximumDerivedGhostFontSize = 17` and expands the binary ternary into an exhaustive switch over all three `CaretGeometryQuality` cases, giving `.derived` its own cap between `.exact` (24) and `.estimated` (16). |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["resolvedGhostFontSize(caretHeight:caretQuality:)"] --> B["proposedSize = max(minFont, caretHeight × 0.78)"]
    B --> C{caretQuality}
    C -- ".exact" --> D["qualityCap = 24 pt\n(maximumGhostFontSize)"]
    C -- ".derived" --> E["qualityCap = 17 pt\n(maximumDerivedGhostFontSize)\n★ NEW"]
    C -- ".estimated" --> F["qualityCap = 16 pt\n(maximumEstimatedGhostFontSize)"]
    D --> G["return min(proposedSize, qualityCap)"]
    E --> G
    F --> G
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Ftighten-derived-ghost-font-cap%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Ftighten-derived-ghost-font-cap%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FServices%2FUI%2FOverlayController.swift%3A14-21%0ANow%20that%20all%20three%20caps%20are%20per-quality%20constants%2C%20%60maximumGhostFontSize%60%20is%20the%20odd%20one%20out%20%E2%80%94%20it's%20the%20only%20name%20that%20doesn't%20signal%20which%20quality%20tier%20it%20governs.%20Renaming%20it%20to%20match%20the%20pattern%20of%20its%20siblings%20makes%20the%20%60Layout%60%20enum%20self-documenting%20and%20avoids%20any%20future%20confusion%20about%20whether%20the%20generic%20name%20applies%20to%20all%20qualities.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20static%20let%20minimumGhostFontSize%3A%20CGFloat%20%3D%2014%0A%20%20%20%20%20%20%20%20%2F%2F%2F%20Measured%20text%20bounds%20from%20the%20accessibility%20API%3B%20trusted%20to%20scale%20up%20in%20larger%20editors.%0A%20%20%20%20%20%20%20%20static%20let%20maximumExactGhostFontSize%3A%20CGFloat%20%3D%2024%0A%20%20%20%20%20%20%20%20%2F%2F%2F%20Derived%20caret%20rects%20come%20from%20line-box%20geometry%20rather%20than%20measured%20text%20bounds%2C%20so%20the%0A%20%20%20%20%20%20%20%20%2F%2F%2F%20reported%20height%20often%20inflates%20against%20the%20host's%20real%20font%20size%20%28Slack%2C%20several%20web%0A%20%20%20%20%20%20%20%20%2F%2F%2F%20editors%29.%20Keep%20the%20ceiling%20well%20below%20the%20exact%20cap%20so%20a%20wrong%20derived%20reading%20cannot%0A%20%20%20%20%20%20%20%20%2F%2F%2F%20render%20oversized%20ghost%20text%20%E2%80%94%20the%20observed%20failure%20mode%20is%20too-large%2C%20not%20too-small.%0A%20%20%20%20%20%20%20%20static%20let%20maximumDerivedGhostFontSize%3A%20CGFloat%20%3D%2017%0A%20%20%20%20%20%20%20%20static%20let%20maximumEstimatedGhostFontSize%3A%20CGFloat%20%3D%2016%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FServices%2FUI%2FOverlayController.swift%3A14-21%0ANow%20that%20all%20three%20caps%20are%20per-quality%20constants%2C%20%60maximumGhostFontSize%60%20is%20the%20odd%20one%20out%20%E2%80%94%20it's%20the%20only%20name%20that%20doesn't%20signal%20which%20quality%20tier%20it%20governs.%20Renaming%20it%20to%20match%20the%20pattern%20of%20its%20siblings%20makes%20the%20%60Layout%60%20enum%20self-documenting%20and%20avoids%20any%20future%20confusion%20about%20whether%20the%20generic%20name%20applies%20to%20all%20qualities.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20static%20let%20minimumGhostFontSize%3A%20CGFloat%20%3D%2014%0A%20%20%20%20%20%20%20%20%2F%2F%2F%20Measured%20text%20bounds%20from%20the%20accessibility%20API%3B%20trusted%20to%20scale%20up%20in%20larger%20editors.%0A%20%20%20%20%20%20%20%20static%20let%20maximumExactGhostFontSize%3A%20CGFloat%20%3D%2024%0A%20%20%20%20%20%20%20%20%2F%2F%2F%20Derived%20caret%20rects%20come%20from%20line-box%20geometry%20rather%20than%20measured%20text%20bounds%2C%20so%20the%0A%20%20%20%20%20%20%20%20%2F%2F%2F%20reported%20height%20often%20inflates%20against%20the%20host's%20real%20font%20size%20%28Slack%2C%20several%20web%0A%20%20%20%20%20%20%20%20%2F%2F%2F%20editors%29.%20Keep%20the%20ceiling%20well%20below%20the%20exact%20cap%20so%20a%20wrong%20derived%20reading%20cannot%0A%20%20%20%20%20%20%20%20%2F%2F%2F%20render%20oversized%20ghost%20text%20%E2%80%94%20the%20observed%20failure%20mode%20is%20too-large%2C%20not%20too-small.%0A%20%20%20%20%20%20%20%20static%20let%20maximumDerivedGhostFontSize%3A%20CGFloat%20%3D%2017%0A%20%20%20%20%20%20%20%20static%20let%20maximumEstimatedGhostFontSize%3A%20CGFloat%20%3D%2016%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=386&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Cap derived-quality ghost font size sepa..."](https://github.com/fujacob/cotabby/commit/169b177271eec004803fa9054b301ffeb631285f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34432555)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->