### PR TITLE
Fix final Tab acceptance routing

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		0D8241CD31942A25EC4E0EE4 /* CotabbyDebugOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B2D34A6F3AC9DFD61350F7 /* CotabbyDebugOptions.swift */; };
 		0DDC0CFF5558A8F4355836B2 /* OverlayController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F308F6E274CC645E27CB651F /* OverlayController.swift */; };
 		0F3267956257401F39386773 /* SuggestionOverlayStabilityGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2F95847D76893C8A5B504B4 /* SuggestionOverlayStabilityGate.swift */; };
+		11F3AF0F7E0A4B72A4A67C70 /* InputMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F3AF0E7E0A4B72A4A67C70 /* InputMonitorTests.swift */; };
 		1003373E13779882503C0E9D /* DisplayCoordinateConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74BD1D4DB27D5D96D1E06096 /* DisplayCoordinateConverter.swift */; };
 		12995E5DDB11E3395E6AF82F /* ShortcutsPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB630F9814388203DD1CA2EC /* ShortcutsPaneView.swift */; };
 		14D77F0B8A195AC2FA8D24A9 /* MirrorOverlayLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC83D14A7557BC0196E59007 /* MirrorOverlayLayoutTests.swift */; };
@@ -206,6 +207,7 @@
 		0E0F6AFF229D20B73CF14C6C /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		0F5E263AB69029D5E13D5EE8 /* FocusDebugOverlayController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusDebugOverlayController.swift; sourceTree = "<group>"; };
 		110CB0B53016644EF7840301 /* HuggingFaceAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceAPIClient.swift; sourceTree = "<group>"; };
+		11F3AF0E7E0A4B72A4A67C70 /* InputMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputMonitorTests.swift; sourceTree = "<group>"; };
 		12DD19BCE610808F1E38702D /* PermissionOverlayTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOverlayTrackerTests.swift; sourceTree = "<group>"; };
 		18D990E515E1AE4F312F4E95 /* BundledRuntimeLocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledRuntimeLocatorTests.swift; sourceTree = "<group>"; };
 		19BE12C28A4AB8A4A58C2FF7 /* SettingsPaneScaffold.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPaneScaffold.swift; sourceTree = "<group>"; };
@@ -574,6 +576,7 @@
 				D49F3B597374208594861B9B /* FoundationModelDriftEvalTests.swift */,
 				335BF59EE80F3A0143B79740 /* GhostFontSizeStabilizerTests.swift */,
 				5AD3F4F9FBE82007E4E15F58 /* GhostSuggestionLayoutTests.swift */,
+				11F3AF0E7E0A4B72A4A67C70 /* InputMonitorTests.swift */,
 				4793D4EA5D36D7E5CC216C27 /* LanguageSupportTests.swift */,
 				3009812A35A1CDEF16295AB7 /* LlamaPromptRendererTests.swift */,
 				FC83D14A7557BC0196E59007 /* MirrorOverlayLayoutTests.swift */,
@@ -981,6 +984,7 @@
 				31DCCE980B6708401256D4D1 /* FoundationModelDriftEvalTests.swift in Sources */,
 				2EE05B312C990104BE934772 /* GhostFontSizeStabilizerTests.swift in Sources */,
 				A0BB87E3665EF6C209034798 /* GhostSuggestionLayoutTests.swift in Sources */,
+				11F3AF0F7E0A4B72A4A67C70 /* InputMonitorTests.swift in Sources */,
 				E912D4617AE1376061DF1F00 /* LanguageSupportTests.swift in Sources */,
 				190C571B3CDFE117F4D15484 /* LlamaPromptRendererTests.swift in Sources */,
 				14D77F0B8A195AC2FA8D24A9 /* MirrorOverlayLayoutTests.swift in Sources */,

--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
@@ -10,46 +10,42 @@ extension SuggestionCoordinator {
     // MARK: - Acceptance and Session Reconciliation
 
     /// Accepts the next word of the current suggestion.
-    func acceptCurrentSuggestion(originalEvent: CapturedInputEvent? = nil) -> Bool {
-        acceptSuggestion(fullText: false, keyName: "Tab", originalEvent: originalEvent)
+    func acceptCurrentSuggestion() -> Bool {
+        acceptSuggestion(fullText: false, keyName: "Tab")
     }
 
     /// Accepts the entire remaining suggestion at once.
-    func acceptEntireSuggestion(originalEvent: CapturedInputEvent? = nil) -> Bool {
-        acceptSuggestion(fullText: true, keyName: "full-accept", originalEvent: originalEvent)
+    func acceptEntireSuggestion() -> Bool {
+        acceptSuggestion(fullText: true, keyName: "full-accept")
     }
 
     /// Shared acceptance path used by both word-by-word and full acceptance.
     private func acceptSuggestion(
         fullText: Bool,
-        keyName: String,
-        originalEvent: CapturedInputEvent?
+        keyName: String
     ) -> Bool {
         let snapshot = focusModel.snapshot
 
         guard permissionManager.inputMonitoringGranted else {
             return passTabThrough(
-                reason: "Input Monitoring permission is required before Cotabby can accept suggestions.",
-                replay: originalEvent
+                reason: "Input Monitoring permission is required before Cotabby can accept suggestions."
             )
         }
 
         guard case .supported = snapshot.capability, let rawContext = snapshot.context else {
-            return passTabThrough(reason: snapshot.capability.summary, replay: originalEvent)
+            return passTabThrough(reason: snapshot.capability.summary)
         }
 
         // Gate on the live session, not on `state`. A background refresh (notably the visual-context
         // path that calls `schedulePrediction` once OCR finishes) flips `state` to `.debouncing`
         // while the previous suggestion is still buffered and its overlay is still on screen — and
-        // the accept tap is still installed because the overlay is visible. Gating on `.ready` here
-        // would `passTabThrough` for the keystroke the accept tap just consumed, swallowing the
-        // user's accept and letting the background regeneration replace the suggestion they were
-        // trying to take. `validateSessionForAcceptance` still rejects the accept if the session no
-        // longer reconciles with the live AX state.
+        // the accept tap is still installed because the overlay is visible. Gating on `.ready`
+        // would let Tab fall through even though the user sees ghost text they can still accept.
+        // `validateSessionForAcceptance` still rejects the accept if the session no longer
+        // reconciles with the live AX state.
         guard interactionState.activeSession != nil else {
             return passTabThrough(
-                reason: "Key passed through because no valid suggestion was ready.",
-                replay: originalEvent
+                reason: "Key passed through because no valid suggestion was ready."
             )
         }
 
@@ -71,7 +67,7 @@ extension SuggestionCoordinator {
             acceptedChunk = preparedAcceptedChunk
 
         case let .invalid(reason):
-            return passTabThrough(reason: reason, replay: originalEvent)
+            return passTabThrough(reason: reason)
         }
 
         // Reconcile the word boundary against the *live* preceding text instead of trusting the
@@ -159,21 +155,15 @@ extension SuggestionCoordinator {
 
     /// Returns control of the accept key to the host app and clears stale suggestion UI.
     ///
-    /// When `replay` is supplied (the original captured event from `handleInputEvent`), this
-    /// re-posts that key to the focused app *after* hiding the overlay — `hideOverlay` flips the
-    /// overlay state to `.hidden`, which tears down the active accept tap, so the replay reaches
-    /// the focused app without the tap re-consuming it. This is the only thing standing between
-    /// the user and a silently-swallowed Tab when the coordinator bails on acceptance after the
-    /// accept tap already consumed the keystroke (notably Gmail / browser AX races).
-    func passTabThrough(reason: String, replay: CapturedInputEvent? = nil) -> Bool {
+    /// `InputMonitor` calls this from the consuming tap before returning a callback result. A `false`
+    /// return tells that tap to pass the original key event through naturally, so no synthetic replay
+    /// is needed.
+    func passTabThrough(reason: String) -> Bool {
         let generation = latestGenerationNumber
         cancelPredictionWork()
         clearSuggestion(clearDiagnostics: true)
         hideOverlay(reason: reason)
         state = .idle
-        if let replay {
-            inputMonitor.replayConsumedAcceptKey(keyCode: replay.keyCode, flags: replay.flags)
-        }
         logStage(
             "tab-passed-through",
             workID: currentWorkID,

--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
@@ -141,11 +141,11 @@ extension SuggestionCoordinator {
         }
 
         if event.kind == .acceptance {
-            return acceptCurrentSuggestion(originalEvent: event)
+            return acceptCurrentSuggestion()
         }
 
         if event.kind == .fullAcceptance {
-            return acceptEntireSuggestion(originalEvent: event)
+            return acceptEntireSuggestion()
         }
 
         if let activeSession = interactionState.activeSession {

--- a/Cotabby/App/Coordinators/SuggestionCoordinator.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator.swift
@@ -135,16 +135,13 @@ final class SuggestionCoordinator: ObservableObject {
             self?.handleSuppressedSyntheticInput()
         }
 
-        // Fail-open authorization for the active accept tap. The tap will only consume a
-        // keystroke when this predicate returns `true` at the moment the event arrives — i.e.,
-        // when the coordinator currently holds a ready, valid, visible suggestion session. Any
-        // lifecycle gap (tap left over after invalidate, stale settings race, etc.) collapses to
-        // "no" and the keystroke falls through to the host. Without this, the accept tap's
-        // matching predicate could swallow a keystroke based on stale state — exactly the
-        // "letter never reaches Chrome" report.
+        // Fail-open preflight for the active accept tap. The tap should only route a matching key
+        // into the coordinator while a visible overlay has a buffered session behind it. We
+        // deliberately do not require `.ready`: a background refresh can put `state` into
+        // `.debouncing` while the visible ghost text is still valid and accept-worthy. The
+        // acceptance path performs the expensive live AX/session validation before the tap consumes.
         inputMonitor.shouldConsumeAcceptKeyProvider = { [weak self] in
             guard let self else { return false }
-            guard case .ready = self.state else { return false }
             guard self.interactionState.activeSession != nil else { return false }
             guard self.overlayState.isVisible else { return false }
             return true

--- a/Cotabby/Models/SuggestionSubsystemContracts.swift
+++ b/Cotabby/Models/SuggestionSubsystemContracts.swift
@@ -35,10 +35,9 @@ protocol SuggestionInputMonitoring: AnyObject {
     var onEvent: ((CapturedInputEvent) -> Bool)? { get set }
     var onSuppressedSyntheticInput: (() -> Void)? { get set }
 
-    /// Fail-open authorization for the active accept tap. The tap only consumes a matching
-    /// keystroke when this closure returns `true` at event time. The coordinator wires it to a
-    /// live check (ready state + active session + visible overlay) so any lifecycle gap collapses
-    /// to "pass through" instead of swallowing the user's keystroke.
+    /// Fail-open preflight for the active accept tap. The tap only routes a matching key into the
+    /// coordinator when this closure returns `true` at event time. The coordinator still performs
+    /// full session validation before the tap consumes the original key.
     var shouldConsumeAcceptKeyProvider: @MainActor () -> Bool { get set }
 
     /// Drives the lifecycle of the active accept-key tap. The coordinator turns this on while
@@ -46,11 +45,6 @@ protocol SuggestionInputMonitoring: AnyObject {
     /// keystroke path during the brief windows it actually needs to consume the accept key.
     func setAcceptInterceptionActive(_ active: Bool)
 
-    /// Re-posts an accept key that the active tap already swallowed, used when the coordinator
-    /// decides at the last moment not to insert a suggestion (stale AX, invalidated session).
-    /// Without this, browsers like Gmail experience the keystroke as silently dropped — see the
-    /// "missed Tab" symptom investigated alongside #337.
-    func replayConsumedAcceptKey(keyCode: CGKeyCode, flags: CGEventFlags)
 }
 
 @MainActor

--- a/Cotabby/Services/Input/InputMonitor.swift
+++ b/Cotabby/Services/Input/InputMonitor.swift
@@ -14,11 +14,11 @@ import Logging
 /// - A steady-state `.listenOnly` observer at the head of the chain. Listen-only taps do not gate
 ///   event delivery on the callback's return, so a slow main actor cannot stall global keystrokes
 ///   in unrelated apps (DaVinci Resolve's Spacebar play/pause is the canonical victim of an active
-///   tap here — see issue #328).
+///   tap here — see issue #328). It handles ordinary typing, navigation, and dismissal events.
 /// - A narrow `.defaultTap` accept tap at the tail, installed only while a suggestion is visible.
-///   This is the only path that consumes events, and it only exists for the brief window a
-///   suggestion is on screen. When no overlay is showing, Cotabby is fully out of the keystroke
-///   critical path.
+///   This is the only path that consumes events, so it also owns acceptance side effects. Keeping
+///   insertion and consumption in the same callback prevents the coordinator from hiding the overlay
+///   before the tap has decided what to do with the original Tab.
 @MainActor
 final class InputMonitor {
     var onEvent: ((CapturedInputEvent) -> Bool)?
@@ -42,10 +42,9 @@ final class InputMonitor {
     /// (terminals, globally disabled, per-app disabled).
     var shouldProcessEventsProvider: @MainActor () -> Bool = { true }
 
-    /// Fail-open authorization for the active accept tap. The tap only consumes a keystroke
-    /// when this returns `true` at the moment the event arrives. Default returns `false` so
-    /// stale or misinstalled taps never eat input. The coordinator wires this to a real check
-    /// (ready state + live active session + visible overlay) at construction time.
+    /// Fail-open authorization for routing a matching accept key into the active accept tap.
+    /// The tap still consumes only when the coordinator successfully accepts the event; this
+    /// preflight keeps stale or misinstalled taps from even attempting acceptance.
     var shouldConsumeAcceptKeyProvider: @MainActor () -> Bool = { false }
 
     private let permissionProvider: @MainActor () -> Bool
@@ -90,10 +89,9 @@ final class InputMonitor {
         }
     }
 
-    /// Installs (when `active == true`) or removes (when `false`) the narrow active tap that
-    /// consumes the accept key so the focused application never sees it. The coordinator calls
-    /// this when a suggestion becomes visible or hidden, so Cotabby only blocks event delivery
-    /// during the brief window when there is actually something to accept.
+    /// Installs (when `active == true`) or removes (when `false`) the narrow active tap that can
+    /// consume the accept key. The coordinator calls this when a suggestion becomes visible or
+    /// hidden, so Cotabby only enters the synchronous event path while there is something to accept.
     func setAcceptInterceptionActive(_ active: Bool) {
         guard permissionProvider() else {
             destroyAcceptTap()
@@ -104,26 +102,6 @@ final class InputMonitor {
         } else {
             destroyAcceptTap()
         }
-    }
-
-    /// Re-posts an accept key that was already swallowed by the active tap. The coordinator
-    /// only calls this from the bail paths in `acceptSuggestion` — by which point the overlay
-    /// has been hidden (so `destroyAcceptTap` already ran via the overlay state change) and the
-    /// synthetic event we post will reach the focused application unmodified. Suppression is
-    /// armed beforehand so our own observer tap recognizes the replay as Cotabby's own work
-    /// instead of treating it as a fresh user keystroke.
-    func replayConsumedAcceptKey(keyCode: CGKeyCode, flags: CGEventFlags) {
-        guard let keyDown = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: true),
-              let keyUp = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: false) else {
-            CotabbyLogger.app.warning("Failed to synthesize replay for consumed accept key \(keyCode)")
-            return
-        }
-        keyDown.flags = flags
-        keyUp.flags = flags
-        suppressionController.registerSyntheticInsertion(expectedKeyDownCount: 1)
-        keyDown.post(tap: .cghidEventTap)
-        keyUp.post(tap: .cghidEventTap)
-        CotabbyLogger.app.debug("Replayed consumed accept key \(keyCode) to the focused app")
     }
 
     private func installObserverTapIfNeeded() {
@@ -185,9 +163,8 @@ final class InputMonitor {
         }
 
         // Tail-append so this tap runs *after* the head-inserted observer. The observer is
-        // listen-only and never drops events, so the accept tap reliably sees the accept key
-        // even though it runs second; the order guarantees the observer's classification fires
-        // before this tap consumes the event.
+        // listen-only and intentionally ignores acceptance keys, so the default tap remains the
+        // single place where accept insertion and original-key consumption are decided.
         guard let tap = CGEvent.tapCreate(
             tap: .cgSessionEventTap,
             place: .tailAppendEventTap,
@@ -243,7 +220,9 @@ final class InputMonitor {
     /// Listen-only observer: classifies the event and notifies the coordinator. The return value
     /// of `onEvent` is ignored here because a listen-only tap cannot drop or modify events.
     /// Consumption of the accept key is handled by the separate active accept tap.
-    private func handleObserverTap(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+    /// Handles the listen-only tap callback. Internal so tests can lock down which tap owns
+    /// acceptance without installing real global event taps.
+    func handleObserverTap(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         switch type {
         case .tapDisabledByTimeout, .tapDisabledByUserInput:
             CotabbyLogger.app.warning("Observer tap was disabled by system, re-enabling")
@@ -266,6 +245,13 @@ final class InputMonitor {
             }
 
             let capturedEvent = classify(event: event)
+            guard !capturedEvent.kind.isAcceptance else {
+                // Acceptance is handled by the active default tap, because only that callback can
+                // make insertion and "consume the original key" one atomic decision. If the active
+                // tap is absent, the Tab naturally belongs to the focused app.
+                return Unmanaged.passUnretained(event)
+            }
+
             _ = onEvent?(capturedEvent)
             return Unmanaged.passUnretained(event)
 
@@ -275,10 +261,12 @@ final class InputMonitor {
     }
 
     /// Active accept tap: only consumes the configured accept keys, so the focused application
-    /// never sees them when a suggestion is on screen. All other keys pass through unchanged.
-    /// This tap intentionally does not invoke `onEvent` — the observer tap is the single source
-    /// of classification, and it has already fired for this keystroke by the time we run.
-    private func handleAcceptTap(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+    /// never sees them when a suggestion is accepted. All other keys pass through unchanged.
+    /// This tap owns acceptance because it can return `nil` for the exact key event that triggered
+    /// insertion. The listen-only observer cannot do that safely.
+    /// Handles the consuming tap callback. Internal so tests can verify that successful acceptance
+    /// returns `nil` for the original key while declined acceptance passes that key through.
+    func handleAcceptTap(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         switch type {
         case .tapDisabledByTimeout, .tapDisabledByUserInput:
             CotabbyLogger.app.warning("Accept tap was disabled by system, re-enabling")
@@ -317,15 +305,27 @@ final class InputMonitor {
                     return Unmanaged.passUnretained(event)
                 }
 
-                // Layer 2 — fail-open. The accept tap is only allowed to swallow when the
-                // coordinator confirms IN-THE-MOMENT that a ready, valid, visible session exists.
-                // Any stale install, lifecycle gap, or settings race causes the predicate to
-                // return false, the key falls through to the host, and the user never loses
-                // input. This is the "if Cotabby is unsure, pass through" rule.
+                // Layer 2 — fail-open preflight. A stale accept tap should never ask the
+                // coordinator to insert text. The coordinator still performs full AX/session
+                // validation below before this callback consumes the original key.
                 guard shouldConsumeAcceptKeyProvider() else {
                     let message = "Accept tap declining to consume keyCode=\(keyCode): "
-                        + "coordinator reports no ready session"
+                        + "coordinator reports no visible active session"
                     CotabbyLogger.app.debug("\(message)")
+                    return Unmanaged.passUnretained(event)
+                }
+
+                let kind: CapturedInputEvent.Kind = fullAcceptMatches ? .fullAcceptance : .acceptance
+                let capturedEvent = CapturedInputEvent(
+                    kind: kind,
+                    keyCode: keyCode,
+                    characters: event.unicodeString,
+                    flags: event.flags
+                )
+                guard onEvent?(capturedEvent) == true else {
+                    CotabbyLogger.app.debug(
+                        "Accept tap passed keyCode=\(keyCode) through because coordinator declined acceptance"
+                    )
                     return Unmanaged.passUnretained(event)
                 }
 
@@ -407,6 +407,14 @@ final class InputMonitor {
 }
 
 extension InputMonitor: SuggestionInputMonitoring {}
+
+private extension CapturedInputEvent.Kind {
+    /// Acceptance is the one event family that must be handled by the consuming tap, not the
+    /// listen-only observer. The observer can describe these keys, but it cannot stop them.
+    var isAcceptance: Bool {
+        self == .acceptance || self == .fullAcceptance
+    }
+}
 
 private extension CGEvent {
     var unicodeString: String {

--- a/CotabbyTests/InputMonitorTests.swift
+++ b/CotabbyTests/InputMonitorTests.swift
@@ -1,0 +1,105 @@
+import ApplicationServices
+import CoreGraphics
+import XCTest
+@testable import Cotabby
+
+/// Tests for the event-tap boundary around acceptance.
+///
+/// The important invariant is ownership: the listen-only observer may classify ordinary typing, but
+/// it must not perform acceptance because it cannot consume the original key event. The active
+/// default tap owns acceptance so "insert suggestion" and "swallow this Tab" stay one decision.
+final class InputMonitorTests: XCTestCase {
+    func test_observerTapIgnoresAcceptanceKeySoConsumingTapOwnsIt() throws {
+        try runOnMainActor {
+            let monitor = makeMonitor()
+            let event = try makeKeyboardEvent(keyCode: 48)
+            var observedKinds: [CapturedInputEvent.Kind] = []
+            monitor.onEvent = { event in
+                observedKinds.append(event.kind)
+                return true
+            }
+
+            let callbackResult = monitor.handleObserverTap(type: .keyDown, event: event)
+
+            XCTAssertNotNil(callbackResult)
+            XCTAssertTrue(observedKinds.isEmpty)
+        }
+    }
+
+    func test_acceptTapConsumesOriginalKeyWhenCoordinatorAccepts() throws {
+        try runOnMainActor {
+            let monitor = makeMonitor()
+            let event = try makeKeyboardEvent(keyCode: 48)
+            var observedKinds: [CapturedInputEvent.Kind] = []
+            monitor.shouldConsumeAcceptKeyProvider = { true }
+            monitor.onEvent = { event in
+                observedKinds.append(event.kind)
+                return true
+            }
+
+            let callbackResult = monitor.handleAcceptTap(type: .keyDown, event: event)
+
+            XCTAssertNil(callbackResult)
+            XCTAssertEqual(observedKinds, [.acceptance])
+        }
+    }
+
+    func test_acceptTapPassesOriginalKeyThroughWhenCoordinatorDeclines() throws {
+        try runOnMainActor {
+            let monitor = makeMonitor()
+            let event = try makeKeyboardEvent(keyCode: 48)
+            var observedKinds: [CapturedInputEvent.Kind] = []
+            monitor.shouldConsumeAcceptKeyProvider = { true }
+            monitor.onEvent = { event in
+                observedKinds.append(event.kind)
+                return false
+            }
+
+            let callbackResult = monitor.handleAcceptTap(type: .keyDown, event: event)
+
+            XCTAssertNotNil(callbackResult)
+            XCTAssertEqual(observedKinds, [.acceptance])
+        }
+    }
+
+    func test_acceptTapPassesOriginalKeyThroughWhenPreflightFails() throws {
+        try runOnMainActor {
+            let monitor = makeMonitor()
+            let event = try makeKeyboardEvent(keyCode: 48)
+            monitor.shouldConsumeAcceptKeyProvider = { false }
+            monitor.onEvent = { _ in
+                XCTFail("Stale accept taps should not invoke coordinator acceptance.")
+                return true
+            }
+
+            let callbackResult = monitor.handleAcceptTap(type: .keyDown, event: event)
+
+            XCTAssertNotNil(callbackResult)
+        }
+    }
+
+    @MainActor
+    private func makeMonitor() -> InputMonitor {
+        InputMonitor(
+            permissionProvider: { true },
+            suppressionController: InputSuppressionController()
+        )
+    }
+
+    @MainActor
+    private func makeKeyboardEvent(keyCode: CGKeyCode) throws -> CGEvent {
+        try XCTUnwrap(CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: true))
+    }
+}
+
+private func runOnMainActor<Result>(
+    _ body: @MainActor () throws -> Result
+) rethrows -> Result {
+    if Thread.isMainThread {
+        return try MainActor.assumeIsolated(body)
+    }
+
+    return try DispatchQueue.main.sync {
+        try MainActor.assumeIsolated(body)
+    }
+}


### PR DESCRIPTION
## Summary

Route accept-key handling through the active consuming event tap so insertion and original Tab suppression are decided in the same callback. This fixes the final-token case where accepting a punctuation-only tail could hide/exhaust the suggestion before the accept tap decided whether to swallow the original Tab.

Also removes the synthetic replay fallback and aligns accept preflight with the actual user-visible invariant: a visible overlay with an active session, even if background refresh work has moved coordinator state out of `.ready`.

## Validation

- `xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build`
  - `** BUILD SUCCEEDED **`
- `xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build-for-testing`
  - `** TEST BUILD SUCCEEDED **`
- `xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' test -only-testing:CotabbyTests/InputMonitorTests`
  - Build completed, but test execution was blocked before tests ran because the app-hosted `CotabbyTests.xctest` bundle could not be loaded: `mapping process and mapped file (non-platform) have different Team IDs`.

## Linked issues

- None.

## Risk / rollout notes

- Acceptance now does coordinator validation inside the consuming event-tap callback, but only while ghost text is visible and only for configured accept keys. That tradeoff keeps insertion and original-key suppression atomic, which is the important correctness boundary for this bug.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the final-token Tab acceptance bug by making the consuming accept tap the sole owner of both insertion and original-key suppression, eliminating the race where the observer tap could hide the overlay before the accept tap decided whether to swallow the Tab. The synthetic replay path (`replayConsumedAcceptKey`) is also removed since a `false` return from `onEvent` now naturally passes the original event through without any re-posting.

- `handleAcceptTap` now constructs the `CapturedInputEvent` itself and calls `onEvent` directly; the result (`true` = consume, `false` = pass through) is used atomically to decide the callback's return value.
- `handleObserverTap` explicitly skips acceptance events with a new `isAcceptance` guard, keeping the observer strictly listen-only for all non-acceptance keys.
- `shouldConsumeAcceptKeyProvider` drops the `.ready` state requirement, allowing acceptance while a background OCR refresh has moved `state` to `.debouncing` — the full AX/session validation inside `acceptSuggestion` still rejects stale sessions.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the fix correctly unifies insertion and Tab suppression into a single atomic callback, and the relaxed preflight still has a full AX/session validation backstop inside acceptSuggestion.

The architectural change is well-reasoned and the new design eliminates the race it targets. The two findings are style/efficiency issues only — a minor classify() call that runs unnecessarily for every Tab event, and concatenated doc-comments on the two tap handlers. No logic correctness concerns were identified.

InputMonitor.swift deserves a second look for the classify() placement and the doc-comment concatenation; all other files are straightforward parameter removals and routing simplifications.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Services/Input/InputMonitor.swift | Core architectural change: acceptance now flows entirely through the consuming accept tap rather than the listen-only observer. Observer explicitly skips acceptance events; accept tap creates CapturedInputEvent and calls onEvent directly. replayConsumedAcceptKey removed. handleObserverTap/handleAcceptTap promoted to internal for testability. Minor: classify() is still called in handleObserverTap before the isAcceptance guard, doing work that is immediately discarded for every Tab keystroke. |
| Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift | acceptCurrentSuggestion/acceptEntireSuggestion/acceptSuggestion lose originalEvent parameter; passTabThrough loses replay parameter and the replayConsumedAcceptKey call. Return values (true/false) now carry the consume-or-pass-through signal back to the accept tap callback. |
| Cotabby/App/Coordinators/SuggestionCoordinator.swift | shouldConsumeAcceptKeyProvider drops the state == .ready guard, now gating only on activeSession != nil and overlayState.isVisible. Intentional: a background OCR refresh can move state to .debouncing while ghost text remains valid. |
| Cotabby/Models/SuggestionSubsystemContracts.swift | replayConsumedAcceptKey removed from SuggestionInputMonitoring protocol; docstring for shouldConsumeAcceptKeyProvider updated to reflect the relaxed preflight semantics. |
| CotabbyTests/InputMonitorTests.swift | New test file covering observer-tap/accept-tap ownership invariants. Tests verify observer skips onEvent for Tab, accept tap consumes when coordinator accepts, passes through when coordinator declines, and stale accept taps never invoke onEvent. |
| Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift | acceptCurrentSuggestion() and acceptEntireSuggestion() calls updated to drop the originalEvent parameter; all other routing logic unchanged. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as User (Tab key)
    participant ObsTap as Observer Tap (head, listen-only)
    participant AccTap as Accept Tap (tail, consuming)
    participant Coord as SuggestionCoordinator
    participant App as Focused App

    User->>ObsTap: keyDown (Tab)
    ObsTap->>ObsTap: classify() → .acceptance
    ObsTap->>ObsTap: guard !isAcceptance → skip onEvent
    ObsTap-->>AccTap: event passes through (listen-only)

    AccTap->>AccTap: matches acceptanceKeyCode?
    AccTap->>AccTap: shouldConsumeAcceptKeyProvider()

    alt Preflight fails (stale tap / no session)
        AccTap-->>App: passUnretained(event) — Tab reaches app
    else Preflight passes
        AccTap->>Coord: onEvent(CapturedInputEvent(.acceptance))
        Coord->>Coord: handleInputEvent → acceptCurrentSuggestion()

        alt Acceptance succeeds
            Coord-->>AccTap: return true
            AccTap-->>App: return nil (Tab consumed)
        else Acceptance declined (passTabThrough)
            Coord->>Coord: clearSuggestion + hideOverlay → destroyAcceptTap
            Coord-->>AccTap: return false
            AccTap-->>App: passUnretained(event) — Tab reaches app
        end
    end
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22codex%2Ffix-tab-acceptance-routing%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ffix-tab-acceptance-routing%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FServices%2FInput%2FInputMonitor.swift%3A247-255%0AThe%20%60isAcceptance%60%20guard%20fires%20after%20%60classify%28%29%60%20has%20already%20done%20its%20work%20%E2%80%94%20reading%20provider%20closures%2C%20comparing%20key%20codes%2C%20and%20constructing%20a%20%60CapturedInputEvent%60.%20Because%20every%20Tab%20keystroke%20reaches%20both%20taps%20and%20the%20observer%20always%20skips%20acceptance%20events%2C%20this%20is%20wasted%20per-keystroke%20classification%20work%20on%20a%20hot%20path.%20Moving%20the%20comment%20before%20%60classify%28%29%60%20avoids%20the%20allocation%20for%20the%20one%20event%20class%20that%20most%20frequently%20arrives%20while%20the%20overlay%20is%20visible.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Acceptance%20is%20handled%20by%20the%20active%20default%20tap%2C%20because%20only%20that%20callback%20can%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20make%20insertion%20and%20%22consume%20the%20original%20key%22%20one%20atomic%20decision.%20If%20the%20active%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20tap%20is%20absent%2C%20the%20Tab%20naturally%20belongs%20to%20the%20focused%20app.%0A%20%20%20%20%20%20%20%20%20%20%20%20let%20capturedEvent%20%3D%20classify%28event%3A%20event%29%0A%20%20%20%20%20%20%20%20%20%20%20%20guard%20!capturedEvent.kind.isAcceptance%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%20Unmanaged.passUnretained%28event%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20_%20%3D%20onEvent%3F%28capturedEvent%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FServices%2FInput%2FInputMonitor.swift%3A220-228%0A**Concatenated%20doc-comments%20on%20both%20tap%20handlers**%0A%0A%60handleObserverTap%60%20and%20%60handleAcceptTap%60%20each%20have%20two%20independent%20doc-comment%20paragraphs%20pasted%20together%20without%20a%20blank%20%60%2F%2F%2F%60%20separator%20%E2%80%94%20the%20original%20functional%20description%20followed%20immediately%20by%20the%20new%20%22Internal%20so%20tests%20can%E2%80%A6%22%20sentence.%20Adding%20a%20blank%20%60%2F%2F%2F%60%20line%20between%20them%20or%20merging%20into%20a%20single%20coherent%20paragraph%20would%20fix%20the%20readability%20break.%20The%20same%20issue%20exists%20for%20%60handleAcceptTap%60%20at%20its%20corresponding%20location.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FServices%2FInput%2FInputMonitor.swift%3A247-255%0AThe%20%60isAcceptance%60%20guard%20fires%20after%20%60classify%28%29%60%20has%20already%20done%20its%20work%20%E2%80%94%20reading%20provider%20closures%2C%20comparing%20key%20codes%2C%20and%20constructing%20a%20%60CapturedInputEvent%60.%20Because%20every%20Tab%20keystroke%20reaches%20both%20taps%20and%20the%20observer%20always%20skips%20acceptance%20events%2C%20this%20is%20wasted%20per-keystroke%20classification%20work%20on%20a%20hot%20path.%20Moving%20the%20comment%20before%20%60classify%28%29%60%20avoids%20the%20allocation%20for%20the%20one%20event%20class%20that%20most%20frequently%20arrives%20while%20the%20overlay%20is%20visible.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Acceptance%20is%20handled%20by%20the%20active%20default%20tap%2C%20because%20only%20that%20callback%20can%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20make%20insertion%20and%20%22consume%20the%20original%20key%22%20one%20atomic%20decision.%20If%20the%20active%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20tap%20is%20absent%2C%20the%20Tab%20naturally%20belongs%20to%20the%20focused%20app.%0A%20%20%20%20%20%20%20%20%20%20%20%20let%20capturedEvent%20%3D%20classify%28event%3A%20event%29%0A%20%20%20%20%20%20%20%20%20%20%20%20guard%20!capturedEvent.kind.isAcceptance%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%20Unmanaged.passUnretained%28event%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20_%20%3D%20onEvent%3F%28capturedEvent%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FServices%2FInput%2FInputMonitor.swift%3A220-228%0A**Concatenated%20doc-comments%20on%20both%20tap%20handlers**%0A%0A%60handleObserverTap%60%20and%20%60handleAcceptTap%60%20each%20have%20two%20independent%20doc-comment%20paragraphs%20pasted%20together%20without%20a%20blank%20%60%2F%2F%2F%60%20separator%20%E2%80%94%20the%20original%20functional%20description%20followed%20immediately%20by%20the%20new%20%22Internal%20so%20tests%20can%E2%80%A6%22%20sentence.%20Adding%20a%20blank%20%60%2F%2F%2F%60%20line%20between%20them%20or%20merging%20into%20a%20single%20coherent%20paragraph%20would%20fix%20the%20readability%20break.%20The%20same%20issue%20exists%20for%20%60handleAcceptTap%60%20at%20its%20corresponding%20location.%0A%0A&repo=fujacob%2Fcotabby&pr=387&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Fix final Tab acceptance routing"](https://github.com/fujacob/cotabby/commit/5cc3c83278744ff3d5491dab21d8a2d793be3ada) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34432708)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->