### PR TITLE
Add AcceptanceGranularity setting (Word / Phrase / Full) for primary accept key

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -159,6 +159,7 @@
 		D5CAF3B590E5EC2AFC72E57A /* VisualContextStartCoalescerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 050D929E13BE52E6282B64D2 /* VisualContextStartCoalescerTests.swift */; };
 		D9C51DEDF01033E276A479CE /* AXTextGeometryResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB58035EFFD65B767949BAE6 /* AXTextGeometryResolver.swift */; };
 		DD7FA343F1C21C4569F6D181 /* ScreenshotContextGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B84BAE361626891F19DC9DB /* ScreenshotContextGenerator.swift */; };
+		DDEDCBAA2196303455F6926A /* AcceptanceModePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5DAF68AEBFE334F68A65E82 /* AcceptanceModePickerView.swift */; };
 		DE236C9285635C686D66A2F6 /* TerminalAppDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E37A7E835D3BDE6265843C /* TerminalAppDetectorTests.swift */; };
 		E17CAA453B1F534D284F0D89 /* PermissionHostApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6ACCB12E4DB32D2F2BEA567 /* PermissionHostApp.swift */; };
 		E313639E71AE1374D2B9A956 /* SuggestionWorkController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B2D97BAA3618A7D0357AC44 /* SuggestionWorkController.swift */; };
@@ -348,6 +349,7 @@
 		E217A66717D78E1E49350EC8 /* DownloadOutcomeClassifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadOutcomeClassifierTests.swift; sourceTree = "<group>"; };
 		E3C84377F352140759B448C9 /* CaretGeometrySelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaretGeometrySelector.swift; sourceTree = "<group>"; };
 		E43E587E421AF544A8300CE4 /* CustomRulesCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomRulesCatalog.swift; sourceTree = "<group>"; };
+		E5DAF68AEBFE334F68A65E82 /* AcceptanceModePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcceptanceModePickerView.swift; sourceTree = "<group>"; };
 		E6423D6CC8CC371D2DA899DE /* PermissionOverlayTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOverlayTracker.swift; sourceTree = "<group>"; };
 		E7F42112F14026E6253BB865 /* PermissionAndContextModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionAndContextModelTests.swift; sourceTree = "<group>"; };
 		EAAE6B395FAB604DF059280A /* KeyCodeLabels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyCodeLabels.swift; sourceTree = "<group>"; };
@@ -503,6 +505,7 @@
 		6E1171BBC9CB74DB623C5E8B /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				E5DAF68AEBFE334F68A65E82 /* AcceptanceModePickerView.swift */,
 				19BE12C28A4AB8A4A58C2FF7 /* SettingsPaneScaffold.swift */,
 			);
 			path = Components;
@@ -830,6 +833,7 @@
 				30F3F2B6D13CD583136CD787 /* AXHelper.swift in Sources */,
 				D9C51DEDF01033E276A479CE /* AXTextGeometryResolver.swift in Sources */,
 				78FAE5DB691A1B71042B9D20 /* AboutPaneView.swift in Sources */,
+				DDEDCBAA2196303455F6926A /* AcceptanceModePickerView.swift in Sources */,
 				0A658BF137DBD0898E40B87F /* AcknowledgementsView.swift in Sources */,
 				26E0331E9E2F92FAE531BDEE /* ActivationIndicatorController.swift in Sources */,
 				0A3443AEE6540F11E5E6BF8F /* AppDelegate.swift in Sources */,

--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
@@ -53,13 +53,21 @@ extension SuggestionCoordinator {
             )
         }
 
-        let preparation = fullText
-            ? interactionState.prepareFullAcceptance(from: rawContext, overlayState: overlayState)
-            : interactionState.prepareAcceptance(
+        // `acceptEntireSuggestion` forces the full-acceptance path regardless of granularity so the
+        // dedicated full-accept key stays a per-press override. `acceptCurrentSuggestion` honors
+        // the user-selected granularity for the primary accept key.
+        let primaryGranularity = settingsSnapshot.acceptanceGranularity
+        let preparation: SuggestionAcceptancePreparation
+        if fullText || primaryGranularity == .full {
+            preparation = interactionState.prepareFullAcceptance(from: rawContext, overlayState: overlayState)
+        } else {
+            preparation = interactionState.prepareAcceptance(
                 from: rawContext,
                 overlayState: overlayState,
+                granularity: primaryGranularity,
                 autoAcceptTrailingPunctuation: settingsSnapshot.autoAcceptTrailingPunctuation
             )
+        }
 
         let liveContext: FocusedInputContext
         let sessionForAcceptance: ActiveSuggestionSession

--- a/Cotabby/Models/SuggestionEngineModels.swift
+++ b/Cotabby/Models/SuggestionEngineModels.swift
@@ -45,6 +45,17 @@ struct DisabledApplicationRule: Codable, Equatable, Identifiable, Sendable {
     var id: String { bundleIdentifier }
 }
 
+/// How much of a buffered suggestion the primary accept key takes per press. The dedicated
+/// full-accept key always takes the entire remaining tail regardless of this setting.
+enum AcceptanceGranularity: String, CaseIterable, Codable, Sendable {
+    /// One word (with the existing trailing-punctuation policy applied per chunk).
+    case word
+    /// Words accumulated until a sentence terminator (`.`, `!`, `?`, `\n`) or the tail runs out.
+    case phrase
+    /// The entire remaining suggestion at once — same outcome as the dedicated full-accept key.
+    case full
+}
+
 /// A compact snapshot of the autocomplete settings the coordinator actually needs at generation
 /// time. Keeping this as a value type makes change detection simple and deterministic.
 struct SuggestionSettingsSnapshot: Equatable, Sendable {
@@ -76,4 +87,7 @@ struct SuggestionSettingsSnapshot: Equatable, Sendable {
     /// based on caret geometry quality). Travels in the snapshot so consumers can react to changes
     /// without subscribing to the settings model directly.
     let mirrorPreference: MirrorPreference
+    /// How much of the buffered suggestion the primary accept key takes per press. Read once per
+    /// accept call so a mid-press setting change can't strand a partially-handled press.
+    let acceptanceGranularity: AcceptanceGranularity
 }

--- a/Cotabby/Models/SuggestionSettingsModel.swift
+++ b/Cotabby/Models/SuggestionSettingsModel.swift
@@ -38,6 +38,7 @@ final class SuggestionSettingsModel: ObservableObject {
     @Published private(set) var fullAcceptanceKeyCode: CGKeyCode
     @Published private(set) var fullAcceptanceKeyModifiers: ShortcutModifierMask
     @Published private(set) var fullAcceptanceKeyLabel: String
+    @Published private(set) var acceptanceGranularity: AcceptanceGranularity
     private let userDefaults: UserDefaults
 
     private static let isGloballyEnabledDefaultsKey = "cotabbyGloballyEnabled"
@@ -67,6 +68,7 @@ final class SuggestionSettingsModel: ObservableObject {
     private static let fullAcceptanceKeyCodeDefaultsKey = "cotabbyFullAcceptanceKeyCode"
     private static let fullAcceptanceKeyModifiersDefaultsKey = "cotabbyFullAcceptanceKeyModifiers"
     private static let fullAcceptanceKeyLabelDefaultsKey = "cotabbyFullAcceptanceKeyLabel"
+    private static let acceptanceGranularityDefaultsKey = "cotabbyAcceptanceGranularity"
 
     static let defaultAcceptanceKeyCode: CGKeyCode = 48
     static let defaultAcceptanceKeyLabel = "Tab"
@@ -200,6 +202,13 @@ final class SuggestionSettingsModel: ObservableObject {
         )
         let resolvedFullAcceptanceKeyLabel = userDefaults.string(forKey: Self.fullAcceptanceKeyLabelDefaultsKey)
             ?? Self.defaultFullAcceptanceKeyLabel
+        // Default `.word` preserves the pre-feature behavior for existing installs that have no
+        // value persisted yet. Invalid persisted values fall back to `.word` rather than crashing
+        // so a hand-edited UserDefault can't strand the user.
+        let resolvedAcceptanceGranularity = userDefaults
+            .string(forKey: Self.acceptanceGranularityDefaultsKey)
+            .flatMap(AcceptanceGranularity.init(rawValue:))
+            ?? .word
 
         isGloballyEnabled = resolvedGloballyEnabled
         disabledAppRules = resolvedDisabledAppRules
@@ -225,6 +234,7 @@ final class SuggestionSettingsModel: ObservableObject {
         fullAcceptanceKeyCode = resolvedFullAcceptanceKeyCode
         fullAcceptanceKeyModifiers = resolvedFullAcceptanceKeyModifiers
         fullAcceptanceKeyLabel = resolvedFullAcceptanceKeyLabel
+        acceptanceGranularity = resolvedAcceptanceGranularity
 
         userDefaults.set(resolvedGloballyEnabled, forKey: Self.isGloballyEnabledDefaultsKey)
         persistDisabledAppRules(resolvedDisabledAppRules)
@@ -253,6 +263,7 @@ final class SuggestionSettingsModel: ObservableObject {
             forKey: Self.fullAcceptanceKeyModifiersDefaultsKey
         )
         userDefaults.set(resolvedFullAcceptanceKeyLabel, forKey: Self.fullAcceptanceKeyLabelDefaultsKey)
+        userDefaults.set(resolvedAcceptanceGranularity.rawValue, forKey: Self.acceptanceGranularityDefaultsKey)
 
         // The custom indicator icon feature was removed; scrub any previously-persisted PNG so
         // users who picked one in an older build get the default cat icon back automatically.
@@ -279,7 +290,8 @@ final class SuggestionSettingsModel: ObservableObject {
             isMultiLineEnabled: isMultiLineEnabled,
             autoAcceptTrailingPunctuation: autoAcceptTrailingPunctuation,
             isFastModeEnabled: isFastModeEnabled,
-            mirrorPreference: mirrorPreference
+            mirrorPreference: mirrorPreference,
+            acceptanceGranularity: acceptanceGranularity
         )
     }
 
@@ -342,6 +354,14 @@ final class SuggestionSettingsModel: ObservableObject {
         }
         autoAcceptTrailingPunctuation = enabled
         userDefaults.set(enabled, forKey: Self.autoAcceptTrailingPunctuationDefaultsKey)
+    }
+
+    func setAcceptanceGranularity(_ granularity: AcceptanceGranularity) {
+        guard acceptanceGranularity != granularity else {
+            return
+        }
+        acceptanceGranularity = granularity
+        userDefaults.set(granularity.rawValue, forKey: Self.acceptanceGranularityDefaultsKey)
     }
 
     func setDebounceMilliseconds(_ value: Int) {
@@ -778,7 +798,10 @@ extension SuggestionSettingsModel: SuggestionSettingsProviding {
         // upstreams. Group related settings into nested combiners so the shape stays readable.
         // `presentationToggles` carries the visual-pipeline knobs (clipboard, fast mode, mirror
         // preference); they share the property of "affects how/when suggestions are shown".
-        Publishers.CombineLatest4(
+        //
+        // The outer CombineLatest4 is at the cap, so `$acceptanceGranularity` is layered above it
+        // via a second CombineLatest to avoid restructuring the existing groupings.
+        let primary = Publishers.CombineLatest4(
             Publishers.CombineLatest4(
                 $isGloballyEnabled,
                 $disabledAppRules,
@@ -794,29 +817,32 @@ extension SuggestionSettingsModel: SuggestionSettingsProviding {
                 $autoAcceptTrailingPunctuation
             )
         )
-        .map { combinedSettings, presentationToggles, profile, timing in
-            let (globallyEnabled, disabledAppRules, engine, wordCountPreset) = combinedSettings
-            let (clipboardContextEnabled, fastModeEnabled, mirrorPreference) = presentationToggles
-            let (userName, customRules, responseLanguages) = profile
-            let (debounce, focusPoll, multiLine, autoAcceptPunctuation) = timing
-            return SuggestionSettingsSnapshot(
-                isGloballyEnabled: globallyEnabled,
-                disabledAppBundleIdentifiers: Set(disabledAppRules.map(\.bundleIdentifier)),
-                selectedEngine: engine,
-                selectedWordCountPreset: wordCountPreset,
-                isClipboardContextEnabled: clipboardContextEnabled,
-                userName: userName,
-                customRules: customRules,
-                responseLanguages: responseLanguages,
-                debounceMilliseconds: debounce,
-                focusPollIntervalMilliseconds: focusPoll,
-                isMultiLineEnabled: multiLine,
-                autoAcceptTrailingPunctuation: autoAcceptPunctuation,
-                isFastModeEnabled: fastModeEnabled,
-                mirrorPreference: mirrorPreference
-            )
-        }
-        .removeDuplicates()
-        .eraseToAnyPublisher()
+        return Publishers.CombineLatest(primary, $acceptanceGranularity)
+            .map { primaryTuple, granularity in
+                let (combinedSettings, presentationToggles, profile, timing) = primaryTuple
+                let (globallyEnabled, disabledAppRules, engine, wordCountPreset) = combinedSettings
+                let (clipboardContextEnabled, fastModeEnabled, mirrorPreference) = presentationToggles
+                let (userName, customRules, responseLanguages) = profile
+                let (debounce, focusPoll, multiLine, autoAcceptPunctuation) = timing
+                return SuggestionSettingsSnapshot(
+                    isGloballyEnabled: globallyEnabled,
+                    disabledAppBundleIdentifiers: Set(disabledAppRules.map(\.bundleIdentifier)),
+                    selectedEngine: engine,
+                    selectedWordCountPreset: wordCountPreset,
+                    isClipboardContextEnabled: clipboardContextEnabled,
+                    userName: userName,
+                    customRules: customRules,
+                    responseLanguages: responseLanguages,
+                    debounceMilliseconds: debounce,
+                    focusPollIntervalMilliseconds: focusPoll,
+                    isMultiLineEnabled: multiLine,
+                    autoAcceptTrailingPunctuation: autoAcceptPunctuation,
+                    isFastModeEnabled: fastModeEnabled,
+                    mirrorPreference: mirrorPreference,
+                    acceptanceGranularity: granularity
+                )
+            }
+            .removeDuplicates()
+            .eraseToAnyPublisher()
     }
 }

--- a/Cotabby/Services/Suggestion/SuggestionInteractionState.swift
+++ b/Cotabby/Services/Suggestion/SuggestionInteractionState.swift
@@ -104,9 +104,14 @@ final class SuggestionInteractionState {
     /// Validates whether the current stored session can be accepted from the latest live AX state.
     /// The returned value gives the coordinator the exact chunk to insert and the context it should
     /// use for diagnostics and overlay updates.
+    ///
+    /// `granularity` selects between word-by-word and phrase-by-phrase acceptance. `.full` is
+    /// rejected here because the coordinator routes full accepts to `prepareFullAcceptance`, which
+    /// keeps a distinct invalid-reason message for the dedicated full-accept key.
     func prepareAcceptance(
         from snapshot: FocusedInputSnapshot,
         overlayState: OverlayState,
+        granularity: AcceptanceGranularity,
         autoAcceptTrailingPunctuation: Bool = true
     ) -> SuggestionAcceptancePreparation {
         let validated = validateSessionForAcceptance(from: snapshot, overlayState: overlayState)
@@ -114,10 +119,22 @@ final class SuggestionInteractionState {
             return .invalid(validated.failureReason ?? "Key passed through.")
         }
 
-        let chunk = SuggestionSessionReconciler.nextAcceptanceChunk(
-            from: session.remainingText,
-            autoAcceptTrailingPunctuation: autoAcceptTrailingPunctuation
-        )
+        let chunk: String
+        switch granularity {
+        case .word:
+            chunk = SuggestionSessionReconciler.nextAcceptanceChunk(
+                from: session.remainingText,
+                autoAcceptTrailingPunctuation: autoAcceptTrailingPunctuation
+            )
+        case .phrase:
+            chunk = SuggestionSessionReconciler.nextAcceptancePhrase(
+                from: session.remainingText,
+                autoAcceptTrailingPunctuation: autoAcceptTrailingPunctuation
+            )
+        case .full:
+            preconditionFailure("prepareAcceptance should not receive .full — route to prepareFullAcceptance instead")
+        }
+
         guard !chunk.isEmpty else {
             return .invalid("Key passed through because no remaining suggestion chunk was available.")
         }

--- a/Cotabby/Services/Suggestion/SuggestionInteractionState.swift
+++ b/Cotabby/Services/Suggestion/SuggestionInteractionState.swift
@@ -132,7 +132,11 @@ final class SuggestionInteractionState {
                 autoAcceptTrailingPunctuation: autoAcceptTrailingPunctuation
             )
         case .full:
-            preconditionFailure("prepareAcceptance should not receive .full — route to prepareFullAcceptance instead")
+            // The coordinator routes full accepts to `prepareFullAcceptance`, so `.full` should never
+            // reach here. Trap in debug, but degrade gracefully in release by passing the key through
+            // rather than crashing a shipping process — matching the other `.invalid` branches here.
+            assertionFailure("prepareAcceptance should not receive .full — route to prepareFullAcceptance instead")
+            return .invalid("Key passed through because .full granularity was routed incorrectly.")
         }
 
         guard !chunk.isEmpty else {

--- a/Cotabby/Support/SuggestionSessionReconciler.swift
+++ b/Cotabby/Support/SuggestionSessionReconciler.swift
@@ -255,6 +255,87 @@ enum SuggestionSessionReconciler {
         return String(remainingText[..<index])
     }
 
+    /// Accepts a full phrase up to the next sentence terminator (`.`, `!`, `?`, `\n`) or the end
+    /// of the buffered suggestion tail. Composes over `nextAcceptanceChunk` so word-boundary,
+    /// internal-punctuation, and leading-whitespace policy stay identical across the seams of a
+    /// multi-word accept.
+    ///
+    /// Newlines need an extra rule: `nextAcceptanceChunk` returns leading whitespace as part of
+    /// the next chunk, so a tail like `Hello\nworld` would surface `\n` as the leading character
+    /// of the second chunk rather than the trailing character of the first. The in-chunk newline
+    /// scan below catches that — without it, phrase mode would silently cross paragraph breaks.
+    ///
+    /// Sentence-terminating `.!?` are detected via the accumulated tail's tail-end after walking
+    /// past any closing-punctuation run. This catches both the plain case (`done.`) and the
+    /// quoted-prose case (`"done." Next` → stop after the closing quote). Without the walk-back,
+    /// the chunk's last character would be `"` rather than `.` and phrase mode would over-accept
+    /// the next sentence. Token-interior punctuation like the dots in `U.S.A` does NOT trigger
+    /// an early break because the chunk's tail (after walking) is `A`, not `.`. The known
+    /// false-positive is when the tail itself ends with `U.S.A.` — the trailing period reads as
+    /// a sentence terminator and the user has to press once more for the next phrase. Rule-based
+    /// scanners can't disambiguate that without NLP; Cursor and Copilot behave the same way.
+    ///
+    /// The `autoAcceptTrailingPunctuation` flag is passed through to each underlying chunk call
+    /// but does not change the final phrase output: a tail like `you?` with the flag off yields
+    /// chunks `"you"` then `"?"`, accumulated to `"you?"`, terminator-suffixed → stop. Net match
+    /// to the flag-on case where the first chunk is already `"you?"`.
+    static func nextAcceptancePhrase(
+        from remainingText: String,
+        autoAcceptTrailingPunctuation: Bool = true
+    ) -> String {
+        guard !remainingText.isEmpty else {
+            return ""
+        }
+
+        var accumulated = ""
+        var working = remainingText
+
+        while !working.isEmpty {
+            let chunk = nextAcceptanceChunk(
+                from: working,
+                autoAcceptTrailingPunctuation: autoAcceptTrailingPunctuation
+            )
+            guard !chunk.isEmpty else {
+                break
+            }
+
+            if let newlineIndex = chunk.firstIndex(of: "\n") {
+                accumulated += chunk[...newlineIndex]
+                return accumulated
+            }
+
+            accumulated += chunk
+            working = String(working.dropFirst(chunk.count))
+
+            if endsInSentenceTerminator(accumulated) {
+                return accumulated
+            }
+        }
+
+        return accumulated
+    }
+
+    /// Tail-end check for sentence terminators that survives closing quotes and brackets, so
+    /// `"done."` and `(yes!)` are recognized as phrase ends even though their final character is
+    /// a closer rather than `.!?`. Walks back past any run of closing punctuation, then checks
+    /// whether the character immediately before that run is a sentence terminator.
+    private static func endsInSentenceTerminator(_ text: String) -> Bool {
+        var index = text.endIndex
+        while index > text.startIndex {
+            let prev = text.index(before: index)
+            if text[prev].isPhraseClosingPunctuation {
+                index = prev
+            } else {
+                break
+            }
+        }
+        guard index > text.startIndex else {
+            return false
+        }
+        let prev = text.index(before: index)
+        return text[prev].isPhraseSentenceTerminator
+    }
+
     /// Returns the index just past a word token's final alphanumeric character when that token has
     /// trailing punctuation worth splitting off. Returns `nil` — meaning "accept the whole token" —
     /// for punctuation-only tokens and for words that already end in an alphanumeric character.
@@ -380,5 +461,21 @@ private extension Character {
     /// can be peeled into its own acceptance part when auto-accept is disabled.
     var isAcceptanceWordCharacter: Bool {
         isLetter || isNumber
+    }
+
+    /// Sentence-ending punctuation for phrase mode. `\n` is handled separately because it can
+    /// appear inside a leading-whitespace prefix of a composed chunk rather than at the chunk's
+    /// tail end.
+    var isPhraseSentenceTerminator: Bool {
+        self == "." || self == "!" || self == "?"
+    }
+
+    /// Closing punctuation that may follow a sentence terminator in prose: straight + curly
+    /// quotes, parentheses, square brackets, and braces. The phrase scanner walks back past a
+    /// run of these to find the real sentence terminator underneath, so `"done."` stops as a
+    /// complete sentence even though its final character is the closing quote.
+    var isPhraseClosingPunctuation: Bool {
+        self == "\"" || self == "'" || self == ")" || self == "]" || self == "}"
+            || self == "\u{201D}" || self == "\u{2019}"
     }
 }

--- a/Cotabby/UI/Settings/Components/AcceptanceModePickerView.swift
+++ b/Cotabby/UI/Settings/Components/AcceptanceModePickerView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+/// File overview:
+/// Shared "Acceptance Mode" picker for the primary accept key. Used by both the legacy
+/// `SettingsView.shortcutsSection` and the redesigned `ShortcutsPaneView`, so the granularity
+/// labels and cases live in one place — adding or renaming a mode can't drift between the two
+/// settings shells.
+struct AcceptanceModePickerView: View {
+    @ObservedObject var suggestionSettings: SuggestionSettingsModel
+
+    private var acceptanceGranularityBinding: Binding<AcceptanceGranularity> {
+        Binding(
+            get: { suggestionSettings.acceptanceGranularity },
+            set: { suggestionSettings.setAcceptanceGranularity($0) }
+        )
+    }
+
+    var body: some View {
+        Picker("Acceptance Mode", selection: acceptanceGranularityBinding) {
+            Text("Word").tag(AcceptanceGranularity.word)
+            Text("Phrase").tag(AcceptanceGranularity.phrase)
+            Text("Full Suggestion").tag(AcceptanceGranularity.full)
+        }
+        .pickerStyle(.menu)
+    }
+}

--- a/Cotabby/UI/Settings/Panes/ShortcutsPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/ShortcutsPaneView.swift
@@ -11,22 +11,10 @@ struct ShortcutsPaneView: View {
     @State private var isRecordingKeybind = false
     @State private var isRecordingFullAcceptKeybind = false
 
-    private var acceptanceGranularityBinding: Binding<AcceptanceGranularity> {
-        Binding(
-            get: { suggestionSettings.acceptanceGranularity },
-            set: { suggestionSettings.setAcceptanceGranularity($0) }
-        )
-    }
-
     var body: some View {
         SettingsPaneScaffold {
             Section("Shortcuts") {
-                Picker("Acceptance Mode", selection: acceptanceGranularityBinding) {
-                    Text("Word").tag(AcceptanceGranularity.word)
-                    Text("Phrase").tag(AcceptanceGranularity.phrase)
-                    Text("Full Suggestion").tag(AcceptanceGranularity.full)
-                }
-                .pickerStyle(.menu)
+                AcceptanceModePickerView(suggestionSettings: suggestionSettings)
 
                 LabeledContent("Accept Word") {
                     KeybindRow(

--- a/Cotabby/UI/Settings/Panes/ShortcutsPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/ShortcutsPaneView.swift
@@ -11,9 +11,23 @@ struct ShortcutsPaneView: View {
     @State private var isRecordingKeybind = false
     @State private var isRecordingFullAcceptKeybind = false
 
+    private var acceptanceGranularityBinding: Binding<AcceptanceGranularity> {
+        Binding(
+            get: { suggestionSettings.acceptanceGranularity },
+            set: { suggestionSettings.setAcceptanceGranularity($0) }
+        )
+    }
+
     var body: some View {
         SettingsPaneScaffold {
             Section("Shortcuts") {
+                Picker("Acceptance Mode", selection: acceptanceGranularityBinding) {
+                    Text("Word").tag(AcceptanceGranularity.word)
+                    Text("Phrase").tag(AcceptanceGranularity.phrase)
+                    Text("Full Suggestion").tag(AcceptanceGranularity.full)
+                }
+                .pickerStyle(.menu)
+
                 LabeledContent("Accept Word") {
                     KeybindRow(
                         label: suggestionSettings.acceptanceKeyLabel,

--- a/Cotabby/UI/SettingsView.swift
+++ b/Cotabby/UI/SettingsView.swift
@@ -283,12 +283,7 @@ struct SettingsView: View {
     @ViewBuilder
     private var shortcutsSection: some View {
         Section("Shortcuts") {
-            Picker("Acceptance Mode", selection: acceptanceGranularityBinding) {
-                Text("Word").tag(AcceptanceGranularity.word)
-                Text("Phrase").tag(AcceptanceGranularity.phrase)
-                Text("Full Suggestion").tag(AcceptanceGranularity.full)
-            }
-            .pickerStyle(.menu)
+            AcceptanceModePickerView(suggestionSettings: suggestionSettings)
 
             LabeledContent("Accept Word") {
                 HStack(spacing: 8) {
@@ -729,13 +724,6 @@ struct SettingsView: View {
         Binding(
             get: { suggestionSettings.autoAcceptTrailingPunctuation },
             set: { suggestionSettings.setAutoAcceptTrailingPunctuation($0) }
-        )
-    }
-
-    private var acceptanceGranularityBinding: Binding<AcceptanceGranularity> {
-        Binding(
-            get: { suggestionSettings.acceptanceGranularity },
-            set: { suggestionSettings.setAcceptanceGranularity($0) }
         )
     }
 

--- a/Cotabby/UI/SettingsView.swift
+++ b/Cotabby/UI/SettingsView.swift
@@ -283,6 +283,13 @@ struct SettingsView: View {
     @ViewBuilder
     private var shortcutsSection: some View {
         Section("Shortcuts") {
+            Picker("Acceptance Mode", selection: acceptanceGranularityBinding) {
+                Text("Word").tag(AcceptanceGranularity.word)
+                Text("Phrase").tag(AcceptanceGranularity.phrase)
+                Text("Full Suggestion").tag(AcceptanceGranularity.full)
+            }
+            .pickerStyle(.menu)
+
             LabeledContent("Accept Word") {
                 HStack(spacing: 8) {
                     Text(suggestionSettings.acceptanceKeyLabel)
@@ -722,6 +729,13 @@ struct SettingsView: View {
         Binding(
             get: { suggestionSettings.autoAcceptTrailingPunctuation },
             set: { suggestionSettings.setAutoAcceptTrailingPunctuation($0) }
+        )
+    }
+
+    private var acceptanceGranularityBinding: Binding<AcceptanceGranularity> {
+        Binding(
+            get: { suggestionSettings.acceptanceGranularity },
+            set: { suggestionSettings.setAcceptanceGranularity($0) }
         )
     }
 

--- a/CotabbyTests/CotabbyTestFixtures.swift
+++ b/CotabbyTests/CotabbyTestFixtures.swift
@@ -221,7 +221,8 @@ enum CotabbyTestFixtures {
         isMultiLineEnabled: Bool = false,
         autoAcceptTrailingPunctuation: Bool = true,
         isFastModeEnabled: Bool = false,
-        mirrorPreference: MirrorPreference = .auto
+        mirrorPreference: MirrorPreference = .auto,
+        acceptanceGranularity: AcceptanceGranularity = .word
     ) -> SuggestionSettingsSnapshot {
         SuggestionSettingsSnapshot(
             isGloballyEnabled: isGloballyEnabled,
@@ -237,7 +238,8 @@ enum CotabbyTestFixtures {
             isMultiLineEnabled: isMultiLineEnabled,
             autoAcceptTrailingPunctuation: autoAcceptTrailingPunctuation,
             isFastModeEnabled: isFastModeEnabled,
-            mirrorPreference: mirrorPreference
+            mirrorPreference: mirrorPreference,
+            acceptanceGranularity: acceptanceGranularity
         )
     }
 }

--- a/CotabbyTests/SuggestionSessionReconcilerTests.swift
+++ b/CotabbyTests/SuggestionSessionReconcilerTests.swift
@@ -131,6 +131,145 @@ final class SuggestionSessionReconcilerTests: XCTestCase {
         )
     }
 
+    // MARK: - Phrase chunker
+
+    func test_nextAcceptancePhrase_returnsEmptyForEmptyTail() {
+        XCTAssertEqual(SuggestionSessionReconciler.nextAcceptancePhrase(from: ""), "")
+    }
+
+    func test_nextAcceptancePhrase_returnsWholeTailWhenNoTerminatorPresent() {
+        XCTAssertEqual(
+            SuggestionSessionReconciler.nextAcceptancePhrase(from: "hello world again"),
+            "hello world again"
+        )
+    }
+
+    func test_nextAcceptancePhrase_stopsAtFirstPeriod() {
+        XCTAssertEqual(
+            SuggestionSessionReconciler.nextAcceptancePhrase(from: "hello world. foo bar."),
+            "hello world."
+        )
+    }
+
+    func test_nextAcceptancePhrase_stopsAtFirstQuestionMark() {
+        XCTAssertEqual(
+            SuggestionSessionReconciler.nextAcceptancePhrase(from: "how are you? fine."),
+            "how are you?"
+        )
+    }
+
+    func test_nextAcceptancePhrase_stopsAtFirstExclamation() {
+        XCTAssertEqual(
+            SuggestionSessionReconciler.nextAcceptancePhrase(from: "stop! go back"),
+            "stop!"
+        )
+    }
+
+    func test_nextAcceptancePhrase_stopsAtNewlineBetweenTokens() {
+        // Composition over the word chunker would otherwise carry the newline as leading whitespace
+        // into the next iteration's accumulated chunk; the in-chunk newline scan must catch it.
+        XCTAssertEqual(
+            SuggestionSessionReconciler.nextAcceptancePhrase(from: "hello\nworld"),
+            "hello\n"
+        )
+    }
+
+    func test_nextAcceptancePhrase_stopsAtLeadingNewline() {
+        XCTAssertEqual(
+            SuggestionSessionReconciler.nextAcceptancePhrase(from: "\nworld"),
+            "\n"
+        )
+    }
+
+    func test_nextAcceptancePhrase_stopsAtFirstOfMultipleNewlines() {
+        XCTAssertEqual(
+            SuggestionSessionReconciler.nextAcceptancePhrase(from: "\n\nbody"),
+            "\n"
+        )
+    }
+
+    func test_nextAcceptancePhrase_includesLeadingWhitespaceUpToTerminator() {
+        XCTAssertEqual(
+            SuggestionSessionReconciler.nextAcceptancePhrase(from: "  hello. world."),
+            "  hello."
+        )
+    }
+
+    func test_nextAcceptancePhrase_preservesInteriorPunctuationWithinTokens() {
+        XCTAssertEqual(
+            SuggestionSessionReconciler.nextAcceptancePhrase(from: "don't go. yes"),
+            "don't go."
+        )
+    }
+
+    func test_nextAcceptancePhrase_abbreviationFalseBreakIsKnownLimitation() {
+        // "U.S.A." ends in a period, which the rule-based scanner treats as a sentence terminator.
+        // The user accepts the abbreviation in one press and the next phrase begins with " is".
+        // Without NLP this collapse is unavoidable; Cursor and Copilot behave the same way.
+        XCTAssertEqual(
+            SuggestionSessionReconciler.nextAcceptancePhrase(from: "U.S.A. is great."),
+            "U.S.A."
+        )
+    }
+
+    func test_nextAcceptancePhrase_isInvariantToAutoAcceptTrailingPunctuationFlag() {
+        let tail = "you? Yes."
+        XCTAssertEqual(
+            SuggestionSessionReconciler.nextAcceptancePhrase(from: tail, autoAcceptTrailingPunctuation: true),
+            "you?"
+        )
+        XCTAssertEqual(
+            SuggestionSessionReconciler.nextAcceptancePhrase(from: tail, autoAcceptTrailingPunctuation: false),
+            "you?"
+        )
+    }
+
+    func test_nextAcceptancePhrase_stopsAtNewlineEvenWhenPunctuationPrecedes() {
+        // The newline must win over a sentence-terminator on the same line so paragraph breaks are
+        // never accidentally skipped past.
+        XCTAssertEqual(
+            SuggestionSessionReconciler.nextAcceptancePhrase(from: "hello world\nmore"),
+            "hello world\n"
+        )
+    }
+
+    func test_nextAcceptancePhrase_stopsAtSentenceEndInsideStraightQuotes() {
+        XCTAssertEqual(
+            SuggestionSessionReconciler.nextAcceptancePhrase(from: "\"done.\" Next sentence."),
+            "\"done.\""
+        )
+    }
+
+    func test_nextAcceptancePhrase_stopsAtSentenceEndInsideCurlyQuotes() {
+        XCTAssertEqual(
+            SuggestionSessionReconciler.nextAcceptancePhrase(from: "\u{201C}done.\u{201D} Next."),
+            "\u{201C}done.\u{201D}"
+        )
+    }
+
+    func test_nextAcceptancePhrase_stopsAtSentenceEndInsideParentheses() {
+        XCTAssertEqual(
+            SuggestionSessionReconciler.nextAcceptancePhrase(from: "(yes!) keep going"),
+            "(yes!)"
+        )
+    }
+
+    func test_nextAcceptancePhrase_walksPastMultipleClosingPunctuation() {
+        // Nested closers — quote inside parens, sentence ends inside both.
+        XCTAssertEqual(
+            SuggestionSessionReconciler.nextAcceptancePhrase(from: "(\"done.\") next"),
+            "(\"done.\")"
+        )
+    }
+
+    func test_nextAcceptancePhrase_doesNotBreakOnBareClosingQuote() {
+        // Closing quote with no preceding sentence terminator is not a phrase boundary.
+        XCTAssertEqual(
+            SuggestionSessionReconciler.nextAcceptancePhrase(from: "\"hi\" there"),
+            "\"hi\" there"
+        )
+    }
+
     func test_insertionChunk_dropsLeadingSpaceWhenPrecedingTextAlreadyEndsInWhitespace() {
         XCTAssertEqual(
             SuggestionSessionReconciler.insertionChunk(forAcceptedChunk: " you", precedingText: "How are "),

--- a/CotabbyTests/SuggestionStateHelperTests.swift
+++ b/CotabbyTests/SuggestionStateHelperTests.swift
@@ -194,6 +194,35 @@ final class SuggestionInteractionStateTests: XCTestCase {
         }
     }
 
+    func test_prepareAcceptance_phraseGranularityAcceptsThroughSentenceTerminator() {
+        runOnMainActor {
+            let state = makeState()
+            let context = CotabbyTestFixtures.focusedInputContext(precedingText: "Hello")
+            _ = state.startSession(fullText: " hello world. next", liveContext: context, latency: 0.1)
+            let snapshot = CotabbyTestFixtures.focusedInputSnapshot(precedingText: "Hello")
+
+            let preparation = state.prepareAcceptance(
+                from: snapshot,
+                overlayState: .visible(
+                    text: " hello world. next",
+                    geometry: CotabbyTestFixtures.overlayGeometry(caretRect: context.caretRect),
+                    mode: .inline
+                ),
+                granularity: .phrase
+            )
+
+            guard case let .ready(_, session, acceptedChunk) = preparation else {
+                XCTFail("Expected phrase acceptance to be ready")
+                return
+            }
+            // Phrase mode must delegate to nextAcceptancePhrase: the accepted chunk spans every word
+            // up to the sentence terminator, not just the first word a .word accept would take.
+            XCTAssertEqual(session.remainingText, " hello world. next")
+            XCTAssertEqual(acceptedChunk, " hello world.")
+            XCTAssertEqual(SuggestionSessionReconciler.nextAcceptanceChunk(from: session.remainingText), " hello")
+        }
+    }
+
     func test_commitAcceptedChunkAdvancesSessionAndSetsPendingInsertionSentinel() {
         runOnMainActor {
             let state = makeState()

--- a/CotabbyTests/SuggestionStateHelperTests.swift
+++ b/CotabbyTests/SuggestionStateHelperTests.swift
@@ -127,7 +127,8 @@ final class SuggestionInteractionStateTests: XCTestCase {
                     text: " world again",
                     geometry: CotabbyTestFixtures.overlayGeometry(caretRect: context.caretRect),
                     mode: .inline
-                )
+                ),
+                granularity: .word
             )
 
             guard case let .ready(liveContext, session, acceptedChunk) = preparation else {
@@ -152,7 +153,8 @@ final class SuggestionInteractionStateTests: XCTestCase {
                     text: " different",
                     geometry: CotabbyTestFixtures.overlayGeometry(caretRect: context.caretRect),
                     mode: .inline
-                )
+                ),
+                granularity: .word
             )
 
             guard case let .invalid(reason) = preparation else {
@@ -180,7 +182,8 @@ final class SuggestionInteractionStateTests: XCTestCase {
                     processIdentifier: 123,
                     precedingText: "Different live text"
                 ),
-                overlayState: .hidden(reason: "waiting for caret sync")
+                overlayState: .hidden(reason: "waiting for caret sync"),
+                granularity: .word
             )
 
             guard case let .ready(_, _, acceptedChunk) = preparation else {


### PR DESCRIPTION
## Summary

Adds a user-selectable acceptance granularity to the primary accept key (default Tab): **Word** (current behavior, default), **Phrase** (stops at `.!?\n` or their quoted/bracketed equivalents — Cursor-style), or **Full Suggestion** (same outcome as the dedicated full-accept key). The dedicated full-accept key (default `` ` ``) remains an unconditional per-press override regardless of the chosen granularity.

The new `nextAcceptancePhrase` chunker composes over the existing `nextAcceptanceChunk`, so word-boundary, internal-punctuation, and leading-whitespace policy stay identical across multi-word seams. Two extra rules make sentence boundaries robust:

- Newlines are scanned **inside** each composed chunk — `nextAcceptanceChunk` returns leading whitespace including `\n`, so a tail like `hello\nworld` would otherwise carry the newline forward unnoticed.
- Terminator detection walks back past closing quotes and brackets, so `"done." Next` stops at the closing quote rather than over-accepting into the next sentence. Handles `"`, `'`, `)`, `]`, `}`, and curly quotes `”`, `’`.

Known limitation: a tail ending in `U.S.A.` is treated as a sentence end (early break). Rule-based scanners can't disambiguate this without NLP; Cursor and Copilot behave the same way. Covered by a dedicated test that documents the behavior.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby \
  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
# ** TEST SUCCEEDED **  Executed 449 tests, with 1 test skipped and 0 failures
```

```
swiftlint lint --quiet
# exit 0
```

18 new `nextAcceptancePhrase` tests cover empty tail, no-terminator, `.!?` boundaries, newline-between-tokens, leading-newline, multiple newlines, leading whitespace, abbreviation false-break (documented as known limitation), `autoAcceptTrailingPunctuation` flag invariance, interior punctuation preservation, straight/curly quoted sentence ends, parenthesized sentence ends, nested closers, and bare-closing-quote (no false break).

## Linked issues

Fixes #10

## Risk / rollout notes

- **Default unchanged.** New installs and existing installs without the persisted UserDefaults key get `.word`, preserving current Tab behavior. The setting is read once per accept call from the value-typed snapshot, so a mid-press toggle in Settings can't strand a partially-handled press.
- **Settings exposed in both UIs.** Picker added to both the legacy `SettingsView.shortcutsSection` and the redesigned `ShortcutsPaneView` so the setting is reachable regardless of which Settings shell is active.
- **UI naming question for maintainer:** the "Accept Word" row label was kept as-is to stay symmetric with the WelcomeView onboarding (`WelcomeView.swift:303`) and the parallel label in the other settings pane. The new "Acceptance Mode" Picker disambiguates what the key actually does. If you'd prefer a dynamic row label ("Accept Word" / "Accept Phrase" / "Accept Full") to match the picker selection, happy to make that change in this PR or a follow-up.
- **Per-app and per-profile granularity** stay out of scope per the design discussion on the issue — those touch the rules system and warrant a separate PR.
- **`prepareAcceptance` signature change** (added required `granularity:` parameter, no default) — only 2 in-tree callers (coordinator + state-helper test); both updated. `.full` is precondition-rejected in `prepareAcceptance` because the coordinator routes full accepts to `prepareFullAcceptance` for the distinct invalid-reason message; defensive handling could be substituted if you'd prefer.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a user-selectable `AcceptanceGranularity` setting (Word / Phrase / Full) for the primary accept key, while keeping the dedicated full-accept key as an unconditional per-press override. The new `nextAcceptancePhrase` chunker composes over `nextAcceptanceChunk`, inheriting existing word-boundary and leading-whitespace policy, with extra rules for newlines (which appear as leading whitespace in the composed chunks) and closing-punctuation walk-back for quoted/parenthesised sentence ends.

- `AcceptanceGranularity` is persisted in UserDefaults with a `.word` fallback, wired into the settings snapshot publisher via an outer `CombineLatest`, and exposed in both the legacy `SettingsView` and the redesigned `ShortcutsPaneView` through a new shared `AcceptanceModePickerView` component.
- The `prepareAcceptance` signature gains a required `granularity:` parameter; `.full` is guarded with `assertionFailure` + graceful fallback since the coordinator already routes full accepts to `prepareFullAcceptance`. 18 new unit tests cover the chunker in isolation; a new integration test in `SuggestionStateHelperTests` confirms the `.phrase` branch propagates correctly through `prepareAcceptance` end-to-end.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the new phrase chunker composes cleanly over the existing word chunker, default behavior is unchanged for existing installs, and all previously flagged issues have been addressed.

The core logic in nextAcceptancePhrase is well-reasoned: newline detection correctly captures 
 from leading-whitespace chunks, the closing-punctuation walk-back handles nested quoted/parenthesised sentence ends, and autoAcceptTrailingPunctuation invariance holds. The .full guard now uses assertionFailure + graceful .invalid return instead of preconditionFailure, matching every other invalid branch. The integration test for .phrase in prepareAcceptance closes the only gap from the prior review round. No new behavioral regressions are introduced; the .word default preserves all existing acceptance behaviour for users who never touch the new setting.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/Support/SuggestionSessionReconciler.swift | Adds nextAcceptancePhrase and endsInSentenceTerminator; logic is sound — newline scan correctly captures \n from leading-whitespace chunks, closing-punc walk-back handles nested/quoted sentence ends, and autoAcceptTrailingPunctuation invariance is verified by tests. |
| Cotabby/Services/Suggestion/SuggestionInteractionState.swift | prepareAcceptance gains a required granularity: parameter; .full now uses assertionFailure + .invalid return instead of preconditionFailure, matching the graceful degradation pattern of every other invalid branch. |
| Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift | Correctly reads granularity from the settings snapshot and routes .full (and the fullText flag) to prepareFullAcceptance so .full never reaches prepareAcceptance. |
| Cotabby/Models/SuggestionSettingsModel.swift | Persists acceptanceGranularity via UserDefaults rawValue with a safe .word fallback; adds setAcceptanceGranularity with early-exit guard; layers $acceptanceGranularity into the snapshot publisher via a second CombineLatest around the existing CombineLatest4. |
| Cotabby/UI/Settings/Components/AcceptanceModePickerView.swift | New shared picker component that eliminates the verbatim duplication between SettingsView and ShortcutsPaneView; clean Binding wrapping via setAcceptanceGranularity. |
| CotabbyTests/SuggestionSessionReconcilerTests.swift | 18 new tests cover the phrase chunker thoroughly: empty input, no terminator, .!? stops, newline variants, leading whitespace, abbreviation false-break (documented known limitation), flag invariance, interior punctuation, straight/curly quotes, parentheses, nested closers, and bare closing quote non-break. |
| CotabbyTests/SuggestionStateHelperTests.swift | Adds integration test for .phrase granularity through prepareAcceptance, confirming the accepted chunk spans to the sentence terminator and that session.remainingText is unmodified before commit. |
| Cotabby/Models/SuggestionEngineModels.swift | AcceptanceGranularity enum added as String/Codable/CaseIterable/Sendable; acceptanceGranularity field added to SuggestionSettingsSnapshot. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Key press detected] --> B{fullText flag\nor granularity == .full?}
    B -- Yes --> C[prepareFullAcceptance\nreturns entire remainingText]
    B -- No --> D{granularity}
    D -- .word --> E[nextAcceptanceChunk\none word + optional trailing punct]
    D -- .phrase --> F[nextAcceptancePhrase\ncompose chunks until .!? or newline]
    F --> G{chunk contains newline?}
    G -- Yes --> H[Accumulate up to newline inclusive\nreturn early]
    G -- No --> I[Accumulate chunk\nadvance working]
    I --> J{endsInSentenceTerminator?\nwalk back past closing punct}
    J -- Yes --> K[Return phrase]
    J -- No --> F
    E --> L[guard chunk not empty]
    K --> L
    H --> L
    L -- empty --> M[.invalid — key passes through]
    L -- non-empty --> N[.ready liveContext / session / acceptedChunk]
    N --> O[Coordinator calls commitAcceptedChunk]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cotabby/UI/Settings/Panes/ShortcutsPaneView.swift`, line 381-386 ([link](https://github.com/fujacob/cotabby/blob/2a60805940f82a376ece239149dd0ad081d808e0/Cotabby/UI/Settings/Panes/ShortcutsPaneView.swift#L381-L386)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Verbatim Picker duplication across both settings UIs**

   The five-line `Picker` block and its `acceptanceGranularityBinding` helper are replicated character-for-character in `SettingsView.swift`. If the labels or cases change (e.g., renaming "Full Suggestion" or adding a fourth mode), both files need identical edits. Extracting this into a small private `AcceptanceModePickerView` or a `@ViewBuilder` helper shared by both would remove the drift risk entirely.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Facceptance-granularity-phrase%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Facceptance-granularity-phrase%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FSettings%2FPanes%2FShortcutsPaneView.swift%0ALine%3A%20381-386%0A%0AComment%3A%0A**Verbatim%20Picker%20duplication%20across%20both%20settings%20UIs**%0A%0AThe%20five-line%20%60Picker%60%20block%20and%20its%20%60acceptanceGranularityBinding%60%20helper%20are%20replicated%20character-for-character%20in%20%60SettingsView.swift%60.%20If%20the%20labels%20or%20cases%20change%20%28e.g.%2C%20renaming%20%22Full%20Suggestion%22%20or%20adding%20a%20fourth%20mode%29%2C%20both%20files%20need%20identical%20edits.%20Extracting%20this%20into%20a%20small%20private%20%60AcceptanceModePickerView%60%20or%20a%20%60%40ViewBuilder%60%20helper%20shared%20by%20both%20would%20remove%20the%20drift%20risk%20entirely.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FSettings%2FPanes%2FShortcutsPaneView.swift%0ALine%3A%20381-386%0A%0AComment%3A%0A**Verbatim%20Picker%20duplication%20across%20both%20settings%20UIs**%0A%0AThe%20five-line%20%60Picker%60%20block%20and%20its%20%60acceptanceGranularityBinding%60%20helper%20are%20replicated%20character-for-character%20in%20%60SettingsView.swift%60.%20If%20the%20labels%20or%20cases%20change%20%28e.g.%2C%20renaming%20%22Full%20Suggestion%22%20or%20adding%20a%20fourth%20mode%29%2C%20both%20files%20need%20identical%20edits.%20Extracting%20this%20into%20a%20small%20private%20%60AcceptanceModePickerView%60%20or%20a%20%60%40ViewBuilder%60%20helper%20shared%20by%20both%20would%20remove%20the%20drift%20risk%20entirely.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=388&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Harden AcceptanceGranularity: graceful ...."](https://github.com/fujacob/cotabby/commit/24233cfcdf349b1d63c840537233fd3a8b60f90e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34434025)</sub>

<!-- /greptile_comment -->