### PR TITLE
Fix accept tap race

### DIFF
--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
@@ -92,6 +92,9 @@ extension SuggestionCoordinator {
             clearSuggestion(clearDiagnostics: true)
             hideOverlay(reason: "Overlay hidden because suggestion insertion failed.")
             state = .idle
+            if let originalEvent, originalEvent.replaysWhenAcceptanceRejected {
+                inputMonitor.replayConsumedAcceptKey(keyCode: originalEvent.keyCode, flags: originalEvent.flags)
+            }
             logStage(
                 "insert-failed",
                 workID: currentWorkID,
@@ -159,19 +162,16 @@ extension SuggestionCoordinator {
 
     /// Returns control of the accept key to the host app and clears stale suggestion UI.
     ///
-    /// When `replay` is supplied (the original captured event from `handleInputEvent`), this
-    /// re-posts that key to the focused app *after* hiding the overlay — `hideOverlay` flips the
-    /// overlay state to `.hidden`, which tears down the active accept tap, so the replay reaches
-    /// the focused app without the tap re-consuming it. This is the only thing standing between
-    /// the user and a silently-swallowed Tab when the coordinator bails on acceptance after the
-    /// accept tap already consumed the keystroke (notably Gmail / browser AX races).
+    /// When the active accept tap has already consumed the original key, a rejected accept must
+    /// replay that key after clearing stale UI. Listen-only observations do not request replay
+    /// because the host app still receives the original event.
     func passTabThrough(reason: String, replay: CapturedInputEvent? = nil) -> Bool {
         let generation = latestGenerationNumber
         cancelPredictionWork()
         clearSuggestion(clearDiagnostics: true)
         hideOverlay(reason: reason)
         state = .idle
-        if let replay {
+        if let replay, replay.replaysWhenAcceptanceRejected {
             inputMonitor.replayConsumedAcceptKey(keyCode: replay.keyCode, flags: replay.flags)
         }
         logStage(

--- a/Cotabby/App/Coordinators/SuggestionCoordinator.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator.swift
@@ -137,14 +137,11 @@ final class SuggestionCoordinator: ObservableObject {
 
         // Fail-open authorization for the active accept tap. The tap will only consume a
         // keystroke when this predicate returns `true` at the moment the event arrives — i.e.,
-        // when the coordinator currently holds a ready, valid, visible suggestion session. Any
-        // lifecycle gap (tap left over after invalidate, stale settings race, etc.) collapses to
-        // "no" and the keystroke falls through to the host. Without this, the accept tap's
-        // matching predicate could swallow a keystroke based on stale state — exactly the
-        // "letter never reaches Chrome" report.
+        // when the coordinator currently holds a valid, visible suggestion session. We avoid
+        // checking `state == .ready` here because background refreshes can move the debug state to
+        // `.debouncing` while the old ghost text is still visible and intentionally acceptable.
         inputMonitor.shouldConsumeAcceptKeyProvider = { [weak self] in
             guard let self else { return false }
-            guard case .ready = self.state else { return false }
             guard self.interactionState.activeSession != nil else { return false }
             guard self.overlayState.isVisible else { return false }
             return true

--- a/Cotabby/Models/InputModels.swift
+++ b/Cotabby/Models/InputModels.swift
@@ -54,6 +54,36 @@ struct CapturedInputEvent: Equatable {
     let keyCode: CGKeyCode
     let characters: String
     let flags: CGEventFlags
+    /// True only for accept-key events already swallowed by the active event tap.
+    ///
+    /// A listen-only observer should never replay input because the host app still receives the
+    /// original event. The active accept tap is different: it must consume first, then ask the
+    /// coordinator to insert. If the coordinator later rejects the accept because AX state went
+    /// stale, replaying the original key preserves the user's Tab instead of silently dropping it.
+    let replaysWhenAcceptanceRejected: Bool
+
+    init(
+        kind: Kind,
+        keyCode: CGKeyCode,
+        characters: String,
+        flags: CGEventFlags,
+        replaysWhenAcceptanceRejected: Bool = false
+    ) {
+        self.kind = kind
+        self.keyCode = keyCode
+        self.characters = characters
+        self.flags = flags
+        self.replaysWhenAcceptanceRejected = replaysWhenAcceptanceRejected
+    }
+
+    var isAcceptanceKeyEvent: Bool {
+        switch kind {
+        case .acceptance, .fullAcceptance:
+            return true
+        case .textMutation, .navigation, .shortcutMutation, .dismissal, .other:
+            return false
+        }
+    }
 
     var shouldSchedulePrediction: Bool {
         switch kind {

--- a/Cotabby/Services/Input/InputMonitor.swift
+++ b/Cotabby/Services/Input/InputMonitor.swift
@@ -16,9 +16,9 @@ import Logging
 ///   in unrelated apps (DaVinci Resolve's Spacebar play/pause is the canonical victim of an active
 ///   tap here — see issue #328).
 /// - A narrow `.defaultTap` accept tap at the tail, installed only while a suggestion is visible.
-///   This is the only path that consumes events, and it only exists for the brief window a
-///   suggestion is on screen. When no overlay is showing, Cotabby is fully out of the keystroke
-///   critical path.
+///   This is the only path that consumes events, and it also owns accept-key delivery to the
+///   coordinator. Keeping acceptance in the consuming tap avoids relying on cross-tap callback
+///   ordering, which macOS can disrupt when a tap is briefly disabled or re-enabled.
 @MainActor
 final class InputMonitor {
     var onEvent: ((CapturedInputEvent) -> Bool)?
@@ -45,7 +45,7 @@ final class InputMonitor {
     /// Fail-open authorization for the active accept tap. The tap only consumes a keystroke
     /// when this returns `true` at the moment the event arrives. Default returns `false` so
     /// stale or misinstalled taps never eat input. The coordinator wires this to a real check
-    /// (ready state + live active session + visible overlay) at construction time.
+    /// (live active session + visible overlay) at construction time.
     var shouldConsumeAcceptKeyProvider: @MainActor () -> Bool = { false }
 
     private let permissionProvider: @MainActor () -> Bool
@@ -56,12 +56,6 @@ final class InputMonitor {
 
     private var acceptTap: CFMachPort?
     private var acceptRunLoopSource: CFRunLoopSource?
-    // The listen-only observer runs before the tail accept tap. If accepting the final chunk hides
-    // the overlay during the observer callback, we must keep the tail tap alive long enough to
-    // swallow that same physical Tab; otherwise Chrome receives Tab after Cotabby inserts text.
-    private var pendingObserverAcceptedKeyEvent: PendingAcceptedKeyEvent?
-    private var isHandlingAcceptKeyObserverEvent = false
-    private var shouldRemoveAcceptTapAfterPendingEvent = false
 
     init(
         permissionProvider: @escaping @MainActor () -> Bool,
@@ -80,7 +74,7 @@ final class InputMonitor {
     /// Removes both taps and stops observing keyboard events.
     func stop() {
         CotabbyLogger.app.info("Input monitor stopping")
-        destroyAcceptTap(deferDuringCurrentAcceptKeyEvent: false)
+        destroyAcceptTap()
         destroyObserverTap()
     }
 
@@ -91,7 +85,7 @@ final class InputMonitor {
         if permissionProvider() {
             installObserverTapIfNeeded()
         } else {
-            destroyAcceptTap(deferDuringCurrentAcceptKeyEvent: false)
+            destroyAcceptTap()
             destroyObserverTap()
         }
     }
@@ -102,7 +96,7 @@ final class InputMonitor {
     /// during the brief window when there is actually something to accept.
     func setAcceptInterceptionActive(_ active: Bool) {
         guard permissionProvider() else {
-            destroyAcceptTap(deferDuringCurrentAcceptKeyEvent: false)
+            destroyAcceptTap()
             return
         }
         if active {
@@ -190,10 +184,9 @@ final class InputMonitor {
             }
         }
 
-        // Tail-append so this tap runs *after* the head-inserted observer. The observer is
-        // listen-only and never drops events, so the accept tap reliably sees the accept key
-        // even though it runs second; the order guarantees the observer's classification fires
-        // before this tap consumes the event.
+        // Tail-append keeps the listen-only observer out of the blocking path for ordinary
+        // typing. Acceptance itself no longer depends on observer ordering; this tap owns the
+        // accept callback and either consumes intentionally or fails open.
         guard let tap = CGEvent.tapCreate(
             tap: .cgSessionEventTap,
             place: .tailAppendEventTap,
@@ -230,17 +223,7 @@ final class InputMonitor {
         observerTap = nil
     }
 
-    private func destroyAcceptTap(deferDuringCurrentAcceptKeyEvent: Bool = true) {
-        if deferDuringCurrentAcceptKeyEvent, isHandlingAcceptKeyObserverEvent {
-            shouldRemoveAcceptTapAfterPendingEvent = true
-            CotabbyLogger.app.trace("Deferring accept tap removal until current accept key finishes")
-            return
-        }
-
-        destroyAcceptTapImmediately()
-    }
-
-    private func destroyAcceptTapImmediately() {
+    private func destroyAcceptTap() {
         guard acceptTap != nil || acceptRunLoopSource != nil else {
             return
         }
@@ -253,14 +236,14 @@ final class InputMonitor {
             CFMachPortInvalidate(tap)
         }
         acceptTap = nil
-        pendingObserverAcceptedKeyEvent = nil
-        shouldRemoveAcceptTapAfterPendingEvent = false
         CotabbyLogger.app.info("CGEvent accept tap removed")
     }
 
-    /// Listen-only observer: classifies the event and notifies the coordinator. The return value
-    /// of `onEvent` is ignored here because a listen-only tap cannot drop or modify events.
-    /// Consumption of the accept key is handled by the separate active accept tap.
+    /// Listen-only observer: classifies normal typing/navigation and notifies the coordinator.
+    /// The return value of `onEvent` is ignored here because a listen-only tap cannot drop or
+    /// modify events. Accept keys are intentionally skipped here and handled by `handleAcceptTap`;
+    /// otherwise a successful accept would race the later consuming tap and a rejected accept could
+    /// replay a key the host app was already going to receive.
     private func handleObserverTap(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         switch type {
         case .tapDisabledByTimeout, .tapDisabledByUserInput:
@@ -284,28 +267,11 @@ final class InputMonitor {
             }
 
             let capturedEvent = classify(event: event)
-            let isAcceptKeyEvent = capturedEvent.kind == .acceptance || capturedEvent.kind == .fullAcceptance
-
-            if isAcceptKeyEvent {
-                isHandlingAcceptKeyObserverEvent = true
-            }
-            defer {
-                if isAcceptKeyEvent {
-                    isHandlingAcceptKeyObserverEvent = false
-                    if shouldRemoveAcceptTapAfterPendingEvent, pendingObserverAcceptedKeyEvent == nil {
-                        destroyAcceptTapImmediately()
-                    }
-                }
+            if capturedEvent.isAcceptanceKeyEvent {
+                return Unmanaged.passUnretained(event)
             }
 
-            let shouldConsume = onEvent?(capturedEvent) ?? false
-
-            if isAcceptKeyEvent, shouldConsume, acceptTap != nil {
-                pendingObserverAcceptedKeyEvent = PendingAcceptedKeyEvent(
-                    keyCode: capturedEvent.keyCode,
-                    modifiers: ShortcutModifierMask(eventFlags: capturedEvent.flags)
-                )
-            }
+            _ = onEvent?(capturedEvent)
             return Unmanaged.passUnretained(event)
 
         default:
@@ -315,8 +281,10 @@ final class InputMonitor {
 
     /// Active accept tap: only consumes the configured accept keys, so the focused application
     /// never sees them when a suggestion is on screen. All other keys pass through unchanged.
-    /// This tap intentionally does not invoke `onEvent` — the observer tap is the single source
-    /// of classification, and it has already fired for this keystroke by the time we run.
+    ///
+    /// This tap is the source of truth for acceptance. The listen-only observer may be disabled by
+    /// macOS under load, and relying on it to run before this consuming tap creates the exact
+    /// failure mode where Tab is swallowed but no insertion is attempted.
     private func handleAcceptTap(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         switch type {
         case .tapDisabledByTimeout, .tapDisabledByUserInput:
@@ -342,18 +310,6 @@ final class InputMonitor {
                 && eventModifiers == acceptanceKeyModifiersProvider()
 
             if fullAcceptMatches || acceptMatches {
-                if let pendingObserverAcceptedKeyEvent,
-                   pendingObserverAcceptedKeyEvent.matches(keyCode: keyCode, modifiers: eventModifiers) {
-                    self.pendingObserverAcceptedKeyEvent = nil
-                    CotabbyLogger.app.debug(
-                        "Accept tap consumed keyCode=\(keyCode) modifiers=\(eventModifiers.rawValue)"
-                    )
-                    if shouldRemoveAcceptTapAfterPendingEvent {
-                        destroyAcceptTapImmediately()
-                    }
-                    return nil
-                }
-
                 // Layer 1 — never consume a bare printable character. The recorder can store
                 // bindings like (keyCode: 0, modifiers: []) which is the 'a' key. Without this
                 // guard the bound character would silently disappear every time the user typed
@@ -369,20 +325,35 @@ final class InputMonitor {
                 }
 
                 // Layer 2 — fail-open. The accept tap is only allowed to swallow when the
-                // coordinator confirms IN-THE-MOMENT that a ready, valid, visible session exists.
+                // coordinator confirms IN-THE-MOMENT that a valid, visible session exists.
                 // Any stale install, lifecycle gap, or settings race causes the predicate to
                 // return false, the key falls through to the host, and the user never loses
                 // input. This is the "if Cotabby is unsure, pass through" rule.
                 guard shouldConsumeAcceptKeyProvider() else {
                     let message = "Accept tap declining to consume keyCode=\(keyCode): "
-                        + "coordinator reports no ready session"
+                        + "coordinator reports no visible active session"
                     CotabbyLogger.app.debug("\(message)")
+                    return Unmanaged.passUnretained(event)
+                }
+
+                guard let onEvent else {
+                    CotabbyLogger.app.debug("Accept tap declining to consume keyCode=\(keyCode): no event handler")
                     return Unmanaged.passUnretained(event)
                 }
 
                 CotabbyLogger.app.debug(
                     "Accept tap consumed keyCode=\(keyCode) modifiers=\(eventModifiers.rawValue)"
                 )
+                let capturedEvent = CapturedInputEvent(
+                    kind: fullAcceptMatches ? .fullAcceptance : .acceptance,
+                    keyCode: keyCode,
+                    characters: event.unicodeString,
+                    flags: event.flags,
+                    replaysWhenAcceptanceRejected: true
+                )
+                DispatchQueue.main.async {
+                    _ = onEvent(capturedEvent)
+                }
                 return nil
             }
             return Unmanaged.passUnretained(event)
@@ -458,15 +429,6 @@ final class InputMonitor {
 }
 
 extension InputMonitor: SuggestionInputMonitoring {}
-
-private struct PendingAcceptedKeyEvent {
-    let keyCode: CGKeyCode
-    let modifiers: ShortcutModifierMask
-
-    func matches(keyCode: CGKeyCode, modifiers: ShortcutModifierMask) -> Bool {
-        self.keyCode == keyCode && self.modifiers == modifiers
-    }
-}
 
 private extension CGEvent {
     var unicodeString: String {


### PR DESCRIPTION
## Summary

Fixes the accept-key race by making the active consuming tap own acceptance delivery instead of relying on the listen-only observer to run first. The observer now ignores accept keys, and consumed accept events carry an explicit replay flag so rejected or failed accepts can safely pass Tab back to the host app without double-replaying observed keys.

## Validation

- `xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build`
  - `** BUILD SUCCEEDED **`
- `xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build-for-testing`
  - `** TEST BUILD SUCCEEDED **`
- `xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' -only-testing:CotabbyTests/SuggestionStateHelperTests -only-testing:CotabbyTests/SuggestionSessionReconcilerTests`
  - Did not execute tests locally: the app-hosted test bundle failed to load because the mapped `CotabbyTests.xctest` bundle and host process had different Team IDs.

## Linked issues

None.

## Risk / rollout notes

This changes accept-key ownership in the event-tap pipeline. Manual smoke testing should cover partial accept, final-chunk accept, stale-session pass-through, and browser/editor Tab behavior.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restructures the accept-key event pipeline so the active consuming tap (not the listen-only observer) is the single source of truth for acceptance delivery. The observer now silently skips accept keys, the accept tap creates the `CapturedInputEvent` with `replaysWhenAcceptanceRejected: true` and dispatches `onEvent` asynchronously, and all rejection paths in `acceptSuggestion` have been updated to replay the consumed key back to the host app.

- **`InputMonitor.swift`**: Removes the `pendingObserverAcceptedKeyEvent` / `isHandlingAcceptKeyObserverEvent` / deferred-teardown machinery; observer tap early-returns on accept keys; accept tap now constructs the event and calls `onEvent` via `DispatchQueue.main.async` before returning `nil`.
- **`InputModels.swift`**: Adds `replaysWhenAcceptanceRejected` field (default `false`) and `isAcceptanceKeyEvent` helper to `CapturedInputEvent`.
- **`SuggestionCoordinator+Acceptance.swift`**: Guards `replayConsumedAcceptKey` calls behind `replay.replaysWhenAcceptanceRejected`; adds replay in the insert-failed path; removes `state == .ready` gate from `shouldConsumeAcceptKeyProvider`.

<h3>Confidence Score: 3/5</h3>

Safe on the happy path, but the early-exit in handleInputEvent for disabled reasons does not replay the consumed Tab, which breaks the replay contract introduced by this PR.

All rejection branches inside acceptSuggestion correctly call passTabThrough(replay:) or replayConsumedAcceptKey directly. However, handleInputEvent has a prior early-exit — the disabledReason check — that bypasses acceptSuggestion entirely and returns false without checking event.replaysWhenAcceptanceRejected. If that branch runs for an event the accept tap already consumed (because the coordinator's disabled state changed between the tap callback and the async dispatch), the user's Tab is silently dropped. The timing window is narrow, but the code path is real and the omission is inconsistent with the rest of the replay design.

SuggestionCoordinator+Input.swift — the disabledReason early-exit at the top of handleInputEvent needs a replay check to match the pattern used everywhere else in acceptSuggestion.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Services/Input/InputMonitor.swift | Major rework: accept-key delivery moved from observer tap to consuming accept tap. Observer now skips accept keys entirely; accept tap creates CapturedInputEvent and posts onEvent via DispatchQueue.main.async before returning nil. Removed pendingObserverAcceptedKeyEvent, isHandlingAcceptKeyObserverEvent, shouldRemoveAcceptTapAfterPendingEvent, and deferDuringCurrentAcceptKeyEvent logic. |
| Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift | handleInputEvent's disabled-reason early-exit path does not check event.replaysWhenAcceptanceRejected, leaving a gap where an accept-tap-consumed Tab can be silently dropped if the coordinator's disabled state changes in the async window. |
| Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift | Added replay call in the insert-failed path and tightened passTabThrough to guard on replaysWhenAcceptanceRejected before calling replayConsumedAcceptKey. All rejection branches in acceptSuggestion correctly handle replay. |
| Cotabby/Models/InputModels.swift | Added replaysWhenAcceptanceRejected field (default false) and isAcceptanceKeyEvent computed property. Explicit memberwise initializer preserves backward-compatible default. Model change is clean. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant HID as HID Event System
    participant ObsTap as Observer Tap (listenOnly, head)
    participant AccTap as Accept Tap (defaultTap, tail)
    participant Main as Main Queue (async)
    participant Coord as SuggestionCoordinator
    participant HostApp as Host App

    HID->>ObsTap: keyDown (Tab)
    Note over ObsTap: isAcceptanceKeyEvent → skip onEvent
    ObsTap-->>HID: passUnretained (not consumed)

    HID->>AccTap: keyDown (Tab)
    AccTap->>AccTap: shouldConsumeAcceptKeyProvider()?
    alt session active and overlay visible
        AccTap->>Main: "async { onEvent(capturedEvent) }"
        AccTap-->>HID: nil (consumed)
        Main->>Coord: "onEvent [replaysWhenAcceptanceRejected=true]"
        alt acceptance succeeds
            Coord->>Coord: insertSuggestion / advanceSession
        else acceptance rejected
            Coord->>HostApp: synthesized Tab replayed
        end
    else no valid session
        AccTap-->>HID: passUnretained
        HID->>HostApp: Tab delivered normally
    end
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22codex%2Finvestigate-tab-accept-race%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Finvestigate-tab-accept-race%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FServices%2FInput%2FInputMonitor.swift%3A354-356%0A%60DispatchQueue.main.async%60%20is%20used%20from%20an%20%60%40MainActor%60-isolated%20method.%20While%20this%20works%20because%20%60DispatchQueue.main%60%20and%20%60%40MainActor%60%20share%20the%20same%20underlying%20thread%2C%20it%20bypasses%20Swift's%20concurrency%20type-system%20guarantees%20and%20can%20produce%20warnings%20under%20strict%20concurrency%20checks.%20%60Task%20%7B%20%40MainActor%20in%20%E2%80%A6%20%7D%60%20is%20the%20idiomatic%20form%20here%20and%20makes%20the%20isolation%20explicit.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Task%20%7B%20%40MainActor%20in%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20_%20%3D%20onEvent%28capturedEvent%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FServices%2FInput%2FInputMonitor.swift%3A354-356%0A%60DispatchQueue.main.async%60%20is%20used%20from%20an%20%60%40MainActor%60-isolated%20method.%20While%20this%20works%20because%20%60DispatchQueue.main%60%20and%20%60%40MainActor%60%20share%20the%20same%20underlying%20thread%2C%20it%20bypasses%20Swift's%20concurrency%20type-system%20guarantees%20and%20can%20produce%20warnings%20under%20strict%20concurrency%20checks.%20%60Task%20%7B%20%40MainActor%20in%20%E2%80%A6%20%7D%60%20is%20the%20idiomatic%20form%20here%20and%20makes%20the%20isolation%20explicit.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Task%20%7B%20%40MainActor%20in%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20_%20%3D%20onEvent%28capturedEvent%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=391&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Fix accept tap race"](https://github.com/fujacob/cotabby/commit/5d1d3acb54b37a2adc570863940c605b47c05a68) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34498581)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->