### PR TITLE
Add toggle to hide the menu-bar word-count badge

### DIFF
--- a/Cotabby/App/Core/CotabbyApp.swift
+++ b/Cotabby/App/Core/CotabbyApp.swift
@@ -32,7 +32,10 @@ struct CotabbyApp: App {
                 }
             )
         } label: {
-            MenuBarStatusLabelView(suggestionCoordinator: appDelegate.suggestionCoordinator)
+            MenuBarStatusLabelView(
+                suggestionCoordinator: appDelegate.suggestionCoordinator,
+                suggestionSettings: appDelegate.suggestionSettings
+            )
         }
         .menuBarExtraStyle(.window)
     }

--- a/Cotabby/Models/SuggestionSettingsModel.swift
+++ b/Cotabby/Models/SuggestionSettingsModel.swift
@@ -23,6 +23,9 @@ final class SuggestionSettingsModel: ObservableObject {
     @Published private(set) var selectedWordCountPreset: SuggestionWordCountPreset
     @Published private(set) var isClipboardContextEnabled: Bool
     @Published private(set) var isFastModeEnabled: Bool
+    /// Whether the accepted-word counter is drawn next to the menu bar icon. Off hides the badge
+    /// entirely; the count itself keeps accruing so toggling it back on restores the running total.
+    @Published private(set) var isMenuBarWordCountVisible: Bool
     /// How suggestions are presented (inline ghost text vs popup card vs auto).
     @Published private(set) var mirrorPreference: MirrorPreference
     @Published private(set) var userName: String
@@ -52,6 +55,7 @@ final class SuggestionSettingsModel: ObservableObject {
     private static let selectedWordCountPresetDefaultsKey = "cotabbySelectedWordCountPreset"
     private static let clipboardContextEnabledDefaultsKey = "cotabbyClipboardContextEnabled"
     private static let fastModeEnabledDefaultsKey = "cotabbyFastModeEnabled"
+    private static let menuBarWordCountVisibleDefaultsKey = "cotabbyMenuBarWordCountVisible"
     private static let mirrorPreferenceDefaultsKey = "cotabbyMirrorPreference"
     private static let userNameDefaultsKey = "cotabbyUserName"
     private static let customRulesDefaultsKey = "cotabbyCustomRules"
@@ -126,6 +130,10 @@ final class SuggestionSettingsModel: ObservableObject {
         // into fast mode turns it off.
         let resolvedFastModeEnabled =
             userDefaults.object(forKey: Self.fastModeEnabledDefaultsKey) as? Bool ?? false
+        // Default to visible so existing installs keep the running-word-count badge they're used
+        // to seeing. The toggle lets users who find the badge noisy hide it from the menu bar.
+        let resolvedMenuBarWordCountVisible =
+            userDefaults.object(forKey: Self.menuBarWordCountVisibleDefaultsKey) as? Bool ?? true
         // Default `.auto` keeps existing users on the byte-for-byte original inline rendering for
         // hosts that report exact/derived caret geometry; only `.estimated` hosts see the new popup
         // card. Power users can pin one mode from Settings or the menu bar.
@@ -220,6 +228,7 @@ final class SuggestionSettingsModel: ObservableObject {
         selectedWordCountPreset = resolvedWordCountPreset
         isClipboardContextEnabled = resolvedClipboardContextEnabled
         isFastModeEnabled = resolvedFastModeEnabled
+        isMenuBarWordCountVisible = resolvedMenuBarWordCountVisible
         mirrorPreference = resolvedMirrorPreference
         userName = resolvedUserName
         customRules = resolvedCustomRules
@@ -246,6 +255,7 @@ final class SuggestionSettingsModel: ObservableObject {
         persistSelectedWordCountPreset(resolvedWordCountPreset)
         persistClipboardContextEnabled(resolvedClipboardContextEnabled)
         persistFastModeEnabled(resolvedFastModeEnabled)
+        persistMenuBarWordCountVisible(resolvedMenuBarWordCountVisible)
         persistMirrorPreference(resolvedMirrorPreference)
         persistUserName(resolvedUserName)
         persistCustomRules(resolvedCustomRules)
@@ -329,6 +339,15 @@ final class SuggestionSettingsModel: ObservableObject {
 
         isFastModeEnabled = enabled
         persistFastModeEnabled(enabled)
+    }
+
+    func setMenuBarWordCountVisible(_ visible: Bool) {
+        guard isMenuBarWordCountVisible != visible else {
+            return
+        }
+
+        isMenuBarWordCountVisible = visible
+        persistMenuBarWordCountVisible(visible)
     }
 
     func setMirrorPreference(_ preference: MirrorPreference) {
@@ -659,6 +678,10 @@ final class SuggestionSettingsModel: ObservableObject {
 
     private func persistFastModeEnabled(_ enabled: Bool) {
         userDefaults.set(enabled, forKey: Self.fastModeEnabledDefaultsKey)
+    }
+
+    private func persistMenuBarWordCountVisible(_ visible: Bool) {
+        userDefaults.set(visible, forKey: Self.menuBarWordCountVisibleDefaultsKey)
     }
 
     private func persistMirrorPreference(_ preference: MirrorPreference) {

--- a/Cotabby/UI/MenuBarStatusLabelView.swift
+++ b/Cotabby/UI/MenuBarStatusLabelView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 /// SwiftUI knows when to redraw the menu bar item as the accepted word count changes.
 struct MenuBarStatusLabelView: View {
     @ObservedObject var suggestionCoordinator: SuggestionCoordinator
+    @ObservedObject var suggestionSettings: SuggestionSettingsModel
 
     var body: some View {
         HStack(spacing: 2) {
@@ -18,9 +19,10 @@ struct MenuBarStatusLabelView: View {
                 .scaledToFit()
                 .frame(height: 16)
 
-            if let label = WordCountFormatter.compactLabel(
-                for: suggestionCoordinator.totalTabAcceptedWordCount
-            ) {
+            if suggestionSettings.isMenuBarWordCountVisible,
+               let label = WordCountFormatter.compactLabel(
+                   for: suggestionCoordinator.totalTabAcceptedWordCount
+               ) {
                 Text(label)
                     .font(.system(size: 10, weight: .medium).monospacedDigit())
             }

--- a/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
@@ -46,6 +46,8 @@ struct GeneralPaneView: View {
 
                 Toggle("Show Indicator", isOn: showIndicatorBinding)
 
+                Toggle("Show Word Count in Menu Bar", isOn: menuBarWordCountVisibleBinding)
+
                 Toggle(isOn: showAcceptanceHintBinding) {
                     HStack(spacing: 4) {
                         Text("Show")
@@ -155,6 +157,13 @@ struct GeneralPaneView: View {
         Binding(
             get: { suggestionSettings.isFastModeEnabled },
             set: { suggestionSettings.setFastModeEnabled($0) }
+        )
+    }
+
+    private var menuBarWordCountVisibleBinding: Binding<Bool> {
+        Binding(
+            get: { suggestionSettings.isMenuBarWordCountVisible },
+            set: { suggestionSettings.setMenuBarWordCountVisible($0) }
         )
     }
 

--- a/Cotabby/UI/SettingsView.swift
+++ b/Cotabby/UI/SettingsView.swift
@@ -146,6 +146,8 @@ struct SettingsView: View {
 
             Toggle("Show Indicator", isOn: showIndicatorBinding)
 
+            Toggle("Show Word Count in Menu Bar", isOn: menuBarWordCountVisibleBinding)
+
             Toggle(isOn: showAcceptanceHintBinding) {
                 HStack(spacing: 4) {
                     Text("Show")
@@ -689,6 +691,13 @@ struct SettingsView: View {
         Binding(
             get: { suggestionSettings.isFastModeEnabled },
             set: { suggestionSettings.setFastModeEnabled($0) }
+        )
+    }
+
+    private var menuBarWordCountVisibleBinding: Binding<Bool> {
+        Binding(
+            get: { suggestionSettings.isMenuBarWordCountVisible },
+            set: { suggestionSettings.setMenuBarWordCountVisible($0) }
         )
     }
 


### PR DESCRIPTION
## Summary

Adds a `Show Word Count in Menu Bar` toggle in Settings so users can hide the running word-count badge that sits next to the menu-bar logo. Requested in #399; some users find the counter visually noisy and want only the cat icon.

## Validation

- `xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build` — `** BUILD SUCCEEDED **`
- `swiftlint lint --quiet` — exit 0
- Manual: toggle in both Settings surfaces (redesigned `General` pane and legacy `Settings` window) hides/shows the count immediately; cat icon stays put.

## Linked issues

Fixes #399

## Risk / rollout notes

- New `UserDefaults` key `cotabbyMenuBarWordCountVisible` defaults to `true`, so existing installs see no behavior change until they flip the toggle.
- The accepted-word total keeps accruing while hidden, so re-enabling restores the running count rather than resetting it.
- Toggle is intentionally placed in the Settings panel only (not the menu-bar popup), per the issue.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `Show Word Count in Menu Bar` toggle that lets users hide the accepted-word counter badge from the menu bar icon while keeping the count accruing in the background. The toggle is wired up in both the redesigned `GeneralPaneView` and the legacy `SettingsView`, and the new `UserDefaults` key defaults to `true` so existing installs are unaffected.

- **`SuggestionSettingsModel`** gains a new `isMenuBarWordCountVisible` property with a dedicated defaults key, a public setter that guards against no-ops, and a private persist helper — all following the established pattern exactly.
- **`MenuBarStatusLabelView`** now takes `suggestionSettings` as a second `@ObservedObject` and gates the `Text` label behind `isMenuBarWordCountVisible`, short-circuiting the formatter call when the setting is off.
- Both settings surfaces add the toggle in the `Display` / `General` section immediately after the existing `Show Indicator` toggle.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is additive, defaults preserve existing behavior, and the new setting is wired consistently across both settings surfaces.

The new property follows the exact same pattern as every other boolean setting in SuggestionSettingsModel: @Published private(set), a static defaults key, a resolver with a backward-compatible default of true, a no-op-guarded setter, and a private persist helper. The MenuBarStatusLabelView correctly uses @ObservedObject so SwiftUI redraws immediately on toggle, and the compound if condition short-circuits so the formatter is skipped when the badge is hidden. Both settings surfaces are updated consistently. No existing behavior changes for users who have never touched the toggle.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Models/SuggestionSettingsModel.swift | Adds isMenuBarWordCountVisible property, defaults key, resolver, setter, and persist helper following the exact same pattern as every other boolean setting in this file. |
| Cotabby/UI/MenuBarStatusLabelView.swift | Adds a second @ObservedObject for SuggestionSettingsModel and gates the word-count Text on the new setting; short-circuit evaluation means the formatter is not called when the badge is hidden. |
| Cotabby/App/Core/CotabbyApp.swift | Passes appDelegate.suggestionSettings into the updated MenuBarStatusLabelView initializer; minimal one-argument change with no other side-effects. |
| Cotabby/UI/Settings/Panes/GeneralPaneView.swift | Adds the toggle and its Binding helper in the Display section, consistent with every other toggle binding pattern in this file. |
| Cotabby/UI/SettingsView.swift | Mirrors the same toggle addition from GeneralPaneView in the legacy settings window; pattern is identical. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant SV as SettingsView / GeneralPaneView
    participant SSM as SuggestionSettingsModel
    participant UD as UserDefaults
    participant MBSL as MenuBarStatusLabelView

    U->>SV: Toggle "Show Word Count in Menu Bar"
    SV->>SSM: setMenuBarWordCountVisible(Bool)
    SSM->>SSM: "guard isMenuBarWordCountVisible != visible"
    SSM->>SSM: "isMenuBarWordCountVisible = visible"
    SSM->>UD: set(visible, forKey: cotabbyMenuBarWordCountVisible)
    SSM-->>MBSL: "@Published change triggers redraw"
    alt "isMenuBarWordCountVisible == true AND wordCount > 0"
        MBSL->>MBSL: Show cat icon + word count label
    else
        MBSL->>MBSL: Show cat icon only
    end
```

<sub>Reviews (1): Last reviewed commit: ["Add toggle to hide the menu-bar word-cou..."](https://github.com/fujacob/cotabby/commit/96cab8a2c3bc336adb48eebd39e12214b9ff26c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34730188)</sub>

<!-- /greptile_comment -->