### PR TITLE
Mark pure value types nonisolated to silence Swift 6 Equatable warnings

### DIFF
--- a/Cotabby/Models/CompletionRenderMode.swift
+++ b/Cotabby/Models/CompletionRenderMode.swift
@@ -10,7 +10,7 @@ import Foundation
 /// The enum lives in `Models/` rather than `Support/` because both the policy (which picks the mode)
 /// and `OverlayState` (which records which mode the panel is currently in) need to spell out the
 /// same case names without depending on rendering code.
-enum CompletionRenderMode: Equatable, Sendable {
+nonisolated enum CompletionRenderMode: Equatable, Sendable {
     /// Ghost text drawn next to the live caret. The default for hosts with trustworthy AX geometry.
     case inline
 
@@ -21,7 +21,7 @@ enum CompletionRenderMode: Equatable, Sendable {
 
     /// Why mirror mode was chosen for this presentation. Surfaced in the focus debug overlay and
     /// in `OverlayState.detail` so operators can confirm the policy is firing as expected.
-    enum MirrorReason: String, Equatable, Sendable {
+    nonisolated enum MirrorReason: String, Equatable, Sendable {
         /// Caret quality came back `.estimated`, meaning the host did not expose `AXBoundsForRange`
         /// or any of the derived geometry paths. Inline rendering would land at a guessed X that
         /// drifts as the user types.

--- a/Cotabby/Models/FocusModels.swift
+++ b/Cotabby/Models/FocusModels.swift
@@ -21,7 +21,7 @@ struct FocusedInputIdentity: Equatable, Sendable {
 /// the same way. Exact and derived rects are safe to anchor UI to aggressively. Estimated rects
 /// are useful for "there is a field here" signaling, but should be handled conservatively to avoid
 /// visibly marching away from the real insertion point.
-enum CaretGeometryQuality: Equatable, Sendable {
+nonisolated enum CaretGeometryQuality: Equatable, Sendable {
     case exact
     case derived
     case estimated

--- a/Cotabby/Models/PermissionModels.swift
+++ b/Cotabby/Models/PermissionModels.swift
@@ -7,7 +7,7 @@ import Foundation
 /// spread across multiple views and services. Pulling that information into a model gives the app
 /// a single source of truth for permission semantics, while leaving the actual permission checks in
 /// `PermissionManager`.
-enum PermissionGuidanceStyle: Sendable {
+nonisolated enum PermissionGuidanceStyle: Equatable, Sendable {
     /// Launch System Settings and show Cotabby's drag-and-drop helper overlay.
     case guidedOverlay
 

--- a/Cotabby/Models/VisualContextModels.swift
+++ b/Cotabby/Models/VisualContextModels.swift
@@ -32,7 +32,7 @@ struct VisualContextConfiguration: Equatable, Sendable {
 /// High-level lifecycle for screenshot-derived prompt context.
 /// The coordinator publishes this directly so the menu can surface useful progress without
 /// dumping low-level OCR or capture internals into the UI.
-enum VisualContextStatus: Equatable, Sendable {
+nonisolated enum VisualContextStatus: Equatable, Sendable {
     case idle
     case capturing
     case extractingText
@@ -62,14 +62,14 @@ enum VisualContextStatus: Equatable, Sendable {
 /// The final visual-context excerpt eventually injected into the completion prompt.
 /// This may be a model-generated summary when a summarizer is configured, or bounded normalized
 /// OCR text in tests/fallback wiring where no summarizer exists.
-struct VisualContextExcerpt: Equatable, Sendable {
+nonisolated struct VisualContextExcerpt: Equatable, Sendable {
     let text: String
 }
 
 /// Session-scoped state for screenshot-derived context tied to one focused field.
 /// This is separate from `ActiveSuggestionSession` because the screenshot context belongs to the
 /// focused input session itself, not to any one individual completion result.
-struct FocusedInputAugmentationSession: Equatable, Sendable {
+nonisolated struct FocusedInputAugmentationSession: Equatable, Sendable {
     let sessionID: UUID
     let elementIdentifier: String
     /// Mirrors the monotonic counter from `FocusedInputSnapshot`. The coordinator compares this

--- a/Cotabby/Support/GhostTextColorPreset.swift
+++ b/Cotabby/Support/GhostTextColorPreset.swift
@@ -9,7 +9,7 @@ import Foundation
 /// real editors while still satisfying the request. Each preset is just the hex string the settings
 /// model already persists (`nil` for the adaptive "Automatic" gray the overlay falls back to), so no
 /// new persistence format is introduced.
-struct GhostTextColorPreset: Identifiable, Equatable {
+nonisolated struct GhostTextColorPreset: Identifiable, Equatable {
     let id: String
     let name: String
     /// Persisted hex (uppercased, 6 digits), or `nil` for the adaptive automatic gray.

--- a/Cotabby/Support/PermissionOverlayTracker.swift
+++ b/Cotabby/Support/PermissionOverlayTracker.swift
@@ -10,7 +10,7 @@ import CoreGraphics
 /// macOS permission dialog, and Cotabby's own windows. Keeping the rule pure makes the no-op paths
 /// cheap to test.
 nonisolated enum PermissionOverlayTracker {
-    enum Transition: Equatable {
+    nonisolated enum Transition: Equatable {
         /// First appearance this session — the controller plays the fly-in animation.
         case present
         /// Move to / ensure visible at a new frame, without replaying the animation.

--- a/Cotabby/Support/PermissionOverlayTracker.swift
+++ b/Cotabby/Support/PermissionOverlayTracker.swift
@@ -9,7 +9,7 @@ import CoreGraphics
 /// the window on *every* tick, so the helper flickered as focus bounced between System Settings, the
 /// macOS permission dialog, and Cotabby's own windows. Keeping the rule pure makes the no-op paths
 /// cheap to test.
-enum PermissionOverlayTracker {
+nonisolated enum PermissionOverlayTracker {
     enum Transition: Equatable {
         /// First appearance this session — the controller plays the fly-in animation.
         case present

--- a/Cotabby/Support/VisualContextStartCoalescer.swift
+++ b/Cotabby/Support/VisualContextStartCoalescer.swift
@@ -3,13 +3,13 @@ import Foundation
 /// A focused field's identity for visual-context coalescing: the AX element plus the monotonic
 /// focus-change counter the tracker assigns. `elementIdentifier` alone is unreliable (macOS recycles
 /// `CFHash` values across unrelated elements), so both are compared together.
-struct VisualContextFieldIdentity: Equatable {
+nonisolated struct VisualContextFieldIdentity: Equatable {
     let elementIdentifier: String
     let focusChangeSequence: UInt64
 }
 
 /// What `VisualContextCoordinator.startSessionIfNeeded` should do for an incoming focus.
-enum VisualContextStartDecision: Equatable {
+nonisolated enum VisualContextStartDecision: Equatable {
     /// Same field is already capturing or already waiting out its settle window — do nothing.
     case ignore
     /// The active session for this field was blocked on Screen Recording permission that is now


### PR DESCRIPTION
## Summary

The app target sets `SWIFT_DEFAULT_ACTOR_ISOLATION: MainActor` (`project.yml:127`), so every type without explicit isolation gets a main-actor-isolated `Equatable` synthesis. The `CotabbyTests` target does not set that flag, so its `XCTestCase` methods are nonisolated and trip `main actor-isolated conformance of '<Type>' to 'Equatable' cannot be used in nonisolated context` — an error in the Swift 6 language mode. Marking the affected pure value types `nonisolated` lets their conformance be reached from any actor without changing runtime behavior; the types are already `Sendable` and hold no main-actor-bound state.

Types touched:

- `CompletionRenderMode` and nested `MirrorReason` (`Cotabby/Models/CompletionRenderMode.swift`)
- `CaretGeometryQuality` (`Cotabby/Models/FocusModels.swift`)
- `PermissionGuidanceStyle` (`Cotabby/Models/PermissionModels.swift`) — `Equatable` added (it was already required by the tests via synthesis)
- `VisualContextStatus`, `VisualContextExcerpt`, `FocusedInputAugmentationSession` (`Cotabby/Models/VisualContextModels.swift`)
- `PermissionOverlayTracker` and nested `Transition` (`Cotabby/Support/PermissionOverlayTracker.swift`)
- `GhostTextColorPreset` (`Cotabby/Support/GhostTextColorPreset.swift`)
- `VisualContextFieldIdentity`, `VisualContextStartDecision` (`Cotabby/Support/VisualContextStartCoalescer.swift`)

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby \
  -destination 'platform=macOS' build-for-testing
# ** TEST BUILD SUCCEEDED ** — every "main actor-isolated conformance ... Equatable" warning is gone.

swiftlint lint --quiet
# exit 0
```

App-hosted test execution not run locally (signing). Build-for-testing confirms the warnings are cleared and the code still compiles under the project's MainActor-default isolation.

## Linked issues

None.

## Risk / rollout notes

Behavior-neutral: `nonisolated` on a value type only changes where its members and conformances can be referenced from, not what they do. No public API renames; existing call sites already used these types from non-main-actor contexts (tests, `Sendable` payloads), which is why the warnings surfaced.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR marks pure value-type enums and structs as `nonisolated` to resolve Swift 6 compile errors where `SWIFT_DEFAULT_ACTOR_ISOLATION: MainActor` in the app target produced main-actor-isolated `Equatable` syntheses that cannot be reached from the nonisolated `XCTestCase` methods in the test target. `PermissionGuidanceStyle` also receives an explicit `Equatable` conformance that was already exercised by tests via synthesis.

- Seven files are touched with mechanical `nonisolated` additions to pure value types (`enum`/`struct` with only `Sendable`-compatible stored properties and no `@MainActor`-bound state).
- `PermissionOverlayTracker` and its nested `Transition` enum are both explicitly annotated, and `VisualContextStartCoalescer`'s helper types (`VisualContextFieldIdentity`, `VisualContextStartDecision`) are likewise annotated so the coalescer tests compile cleanly.
- The previous review concern about `PermissionOverlayTracker.Transition` not having an explicit `nonisolated` annotation has been addressed in this revision.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are additive keyword annotations on pure value types with no runtime behavior change.

Every touched type holds only value-typed stored properties with no main-actor-bound state, so `nonisolated` changes where conformances can be referenced from without altering what they do. The previously flagged inconsistency (nested `Transition` lacking an explicit annotation) is now resolved. The validation section confirms a clean `build-for-testing` pass.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Models/CompletionRenderMode.swift | Both `CompletionRenderMode` and its nested `MirrorReason` are marked `nonisolated`; change is correct and consistent with the nested-type pattern in the PR. |
| Cotabby/Models/FocusModels.swift | `CaretGeometryQuality` correctly marked `nonisolated`; no other types in this file were in scope for the PR's Equatable-conformance fix. |
| Cotabby/Models/PermissionModels.swift | `PermissionGuidanceStyle` gains both `nonisolated` and an explicit `Equatable` conformance that was already required by tests; `CotabbyPermissionKind` is unaffected. |
| Cotabby/Models/VisualContextModels.swift | `VisualContextStatus`, `VisualContextExcerpt`, and `FocusedInputAugmentationSession` all correctly marked `nonisolated`; `VisualContextConfiguration` is intentionally left unchanged as it is not tested from nonisolated contexts. |
| Cotabby/Support/GhostTextColorPreset.swift | `GhostTextColorPreset` correctly marked `nonisolated`; all stored properties are value types, so no main-actor-bound state is affected. |
| Cotabby/Support/PermissionOverlayTracker.swift | Both `PermissionOverlayTracker` and nested `Transition` now have explicit `nonisolated`; addresses the previously raised inconsistency with `CompletionRenderMode.MirrorReason`. |
| Cotabby/Support/VisualContextStartCoalescer.swift | `VisualContextFieldIdentity` and `VisualContextStartDecision` marked `nonisolated`, unblocking the six nonisolated XCTest methods in `VisualContextStartCoalescerTests`; the caseless-enum namespace `VisualContextStartCoalescer` itself is unchanged, consistent with the build succeeding. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["App target\nSWIFT_DEFAULT_ACTOR_ISOLATION: MainActor"] -->|"synthesises @MainActor Equatable\non every un-annotated type"| B["Value types\n(before this PR)"]
    B -->|"Equatable conformance\nis @MainActor-isolated"| C["XCTestCase nonisolated methods\n(test target — no default isolation)"]
    C -->|"Swift 6 error:\nmain actor-isolated conformance\ncannot be used in nonisolated context"| D["❌ Build fails"]

    A2["App target\nSWIFT_DEFAULT_ACTOR_ISOLATION: MainActor"] -->|"nonisolated annotation\noverrides default isolation"| E["nonisolated value types\n(after this PR)"]
    E -->|"Equatable conformance\nis nonisolated"| F["XCTestCase nonisolated methods\n(test target)"]
    F -->|"conformance reachable\nfrom any actor"| G["✅ Build succeeds"]
```

<sub>Reviews (2): Last reviewed commit: ["Mark nested PermissionOverlayTracker.Tra..."](https://github.com/fujacob/cotabby/commit/5f303a117d90f6213c7fb02c9b520551ef5543c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34730902)</sub>

<!-- /greptile_comment -->