### PR TITLE
Add category checkboxes to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,6 +6,14 @@ labels: bug
 assignees: ""
 ---
 
+## Category
+
+Check all that apply:
+
+- [ ] Keystroke / Input (Tab not working, keystrokes swallowed, input blocked)
+- [ ] App Compatibility (bug only in a specific app: Word, Outlook, Mail, browser, etc.)
+- [ ] Performance / Crash (slow response, hang, or crash)
+
 ## Summary
 
 Describe the bug in one or two sentences.


### PR DESCRIPTION
## Summary

Adds a Category section to the GitHub bug report template with three user-friendly checkboxes (Keystroke / Input, App Compatibility, Performance / Crash). This lets reporters self-triage before writing, making it easier to filter and prioritize issues without relying entirely on maintainer labelling.

## Validation

Template-only change — no Swift code. SwiftLint exited clean (no Swift files touched).

## Linked issues

Refs #389, #308, #381, #396

## Risk / rollout notes

No behavior change for existing issues or code paths. The checkboxes are informational — maintainers still apply `area:*` labels manually (or via the feedback form which was updated separately).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `## Category` section with three self-triage checkboxes (Keystroke / Input, App Compatibility, Performance / Crash) to the GitHub bug report template, placed before the Summary field. It is a template-only change with no code impact.

- The three categories cover the most common Cotabby bug types and are clearly labelled with inline examples, which should meaningfully lower the bar for reporters to categorise their issue.
- There is no \"Other\" option, so reporters whose bug doesn't fit any of the three buckets have no clean escape hatch — they may leave the section blank or mis-tag their issue, reducing the triage signal the section is intended to provide.

<h3>Confidence Score: 4/5</h3>

Safe to merge — template-only change with no effect on code paths or existing issues.

The change is purely additive to a markdown issue template. The only gap is the absence of an "Other" category, which means reporters with bugs outside the three defined buckets have no matching option and may leave the section blank or select an inaccurate category.

`bug_report.md` — worth adding an Other checkbox before merging to ensure full coverage of bug types.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/ISSUE_TEMPLATE/bug_report.md | Adds a Category section with three triage checkboxes before the Summary section; no code changes. Missing an "Other" option for bugs outside the three defined categories. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([Reporter opens bug template]) --> B[Category section]
    B --> C{Selects category}
    C --> D["☑ Keystroke / Input"]
    C --> E["☑ App Compatibility"]
    C --> F["☑ Performance / Crash"]
    C --> G["❌ None apply\n(no Other option — gap)"]
    D & E & F --> H[Fills out Summary / Environment / Steps]
    G -->|forced to skip or mis-tag| H
    H --> I[Submits issue]
    I --> J[Maintainer reviews &\napplies area:* label manually]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22chore%2Fbug-report-category-checkboxes%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2Fbug-report-category-checkboxes%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2FISSUE_TEMPLATE%2Fbug_report.md%3A13-15%0AConsider%20adding%20an%20%60Other%60%20option%20so%20reporters%20whose%20bug%20doesn't%20fall%20into%20the%20three%20named%20categories%20can%20still%20engage%20with%20the%20section%20meaningfully%20rather%20than%20skipping%20it%20or%20mis-tagging%20their%20issue.%0A%0A%60%60%60suggestion%0A-%20%5B%20%5D%20Keystroke%20%2F%20Input%20%28Tab%20not%20working%2C%20keystrokes%20swallowed%2C%20input%20blocked%29%0A-%20%5B%20%5D%20App%20Compatibility%20%28bug%20only%20in%20a%20specific%20app%3A%20Word%2C%20Outlook%2C%20Mail%2C%20browser%2C%20etc.%29%0A-%20%5B%20%5D%20Performance%20%2F%20Crash%20%28slow%20response%2C%20hang%2C%20or%20crash%29%0A-%20%5B%20%5D%20Other%20%28please%20describe%20in%20Notes%29%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2FISSUE_TEMPLATE%2Fbug_report.md%3A13-15%0AConsider%20adding%20an%20%60Other%60%20option%20so%20reporters%20whose%20bug%20doesn't%20fall%20into%20the%20three%20named%20categories%20can%20still%20engage%20with%20the%20section%20meaningfully%20rather%20than%20skipping%20it%20or%20mis-tagging%20their%20issue.%0A%0A%60%60%60suggestion%0A-%20%5B%20%5D%20Keystroke%20%2F%20Input%20%28Tab%20not%20working%2C%20keystrokes%20swallowed%2C%20input%20blocked%29%0A-%20%5B%20%5D%20App%20Compatibility%20%28bug%20only%20in%20a%20specific%20app%3A%20Word%2C%20Outlook%2C%20Mail%2C%20browser%2C%20etc.%29%0A-%20%5B%20%5D%20Performance%20%2F%20Crash%20%28slow%20response%2C%20hang%2C%20or%20crash%29%0A-%20%5B%20%5D%20Other%20%28please%20describe%20in%20Notes%29%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=408&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add category checkboxes to bug report te..."](https://github.com/fujacob/cotabby/commit/882fddb780e719be6d47b6e8bbb39dcb21c172e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34733074)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->