### PR TITLE
Split release pipeline into build / notarize / publish jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,14 @@
 # Tag-driven release pipeline for Cotabby.
 #
-# Release ordering matters:
-# 1. build and Developer ID sign the app
-# 2. package and notarize the DMG
-# 3. Sparkle-sign the final bytes
-# 4. create the GitHub Release with the DMG attached
-# 5. publish appcast.xml to Pages last
+# Discrete jobs so a failure at one stage doesn't force a full re-run:
 #
-# The appcast is the update pointer Sparkle clients poll. Publishing it before
-# the release asset exists would expose users to a broken update.
+# 1. build:    validate metadata, archive + Developer ID sign, package DMG
+# 2. notarize: submit DMG to Apple notarization, poll, staple
+# 3. publish:  Sparkle-sign appcast, create GitHub Release, deploy Pages
+# 4. update-homebrew-cask: dispatch version bump to the tap (publish only)
+#
+# The DMG flows between jobs as a GitHub Actions artifact. Sparkle tools are
+# re-downloaded in publish (fast curl) rather than carried as an artifact.
 
 name: Release
 
@@ -54,17 +54,24 @@ env:
   SPARKLE_SHA256: c0dde519fd2a43ddfc6a1eb76aec284d7d888fe281414f9177de3164d98ba4c7
 
 jobs:
-  release:
-    name: Build, notarize, sign, and publish
+  # ---------------------------------------------------------------------------
+  # 1. BUILD
+  # Validate metadata, import certificates, xcodebuild archive, re-sign nested
+  # code, package the DMG. Uploads the unsigned-but-signed DMG as an artifact
+  # for the notarize job.
+  # ---------------------------------------------------------------------------
+  build:
+    name: Build, sign, and package DMG
     runs-on: macos-26
-    timeout-minutes: 180
+    timeout-minutes: 120
     outputs:
       release_version: ${{ steps.metadata.outputs.release_version }}
+      release_tag: ${{ steps.metadata.outputs.release_tag }}
+      build_number: ${{ steps.metadata.outputs.build_number }}
       publish: ${{ steps.metadata.outputs.publish }}
-      dmg_sha256: ${{ steps.dmg-sha.outputs.dmg_sha256 }}
-    environment:
-      name: github-pages
-      url: ${{ steps.deploy-pages.outputs.page_url }}
+      is_prerelease: ${{ steps.metadata.outputs.is_prerelease }}
+      sparkle_version: ${{ steps.sparkle-version.outputs.sparkle_version }}
+      has_sparkle_key: ${{ steps.sparkle-key.outputs.has_key }}
 
     steps:
       - uses: actions/checkout@v6
@@ -291,19 +298,6 @@ jobs:
             -k "${keychain_password}" \
             "${keychain_path}"
 
-      - name: Configure Apple notarization credentials
-        env:
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-        run: |
-          set -euo pipefail
-
-          xcrun notarytool store-credentials "cotabby-notarytool-profile" \
-            --apple-id "${APPLE_ID}" \
-            --team-id "${APPLE_TEAM_ID}" \
-            --password "${APPLE_APP_SPECIFIC_PASSWORD}"
-
       - name: Archive signed app
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
@@ -422,6 +416,57 @@ jobs:
             "${dmg_path}"
 
           codesign --verify --strict --verbose=2 "${dmg_path}"
+
+      - name: Upload DMG for notarization
+        uses: actions/upload-artifact@v7
+        with:
+          name: cotabby-dmg
+          path: build/${{ env.DMG_NAME }}
+          # Short retention — the notarized copy is what matters long-term.
+          retention-days: 1
+
+      - name: Upload build diagnostics
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: build-artifacts
+          path: build/${{ env.DMG_NAME }}
+          if-no-files-found: ignore
+
+  # ---------------------------------------------------------------------------
+  # 2. NOTARIZE
+  # Downloads the signed DMG, submits to Apple notarization, polls until
+  # Accepted (or times out / is rejected), staples the ticket, then uploads
+  # the stapled DMG for the publish job. Separated so a notarization rejection
+  # or Apple-server timeout can be retried without rebuilding.
+  # ---------------------------------------------------------------------------
+  notarize:
+    name: Notarize and staple DMG
+    needs: build
+    runs-on: macos-26
+    timeout-minutes: 90
+    outputs:
+      dmg_sha256: ${{ steps.dmg-sha.outputs.dmg_sha256 }}
+
+    steps:
+      - name: Download DMG artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: cotabby-dmg
+          path: build
+
+      - name: Configure Apple notarization credentials
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          xcrun notarytool store-credentials "cotabby-notarytool-profile" \
+            --apple-id "${APPLE_ID}" \
+            --team-id "${APPLE_TEAM_ID}" \
+            --password "${APPLE_APP_SPECIFIC_PASSWORD}"
 
       - name: Notarize and staple DMG
         run: |
@@ -584,12 +629,95 @@ jobs:
           echo "dmg_sha256=${dmg_sha256}" >> "$GITHUB_OUTPUT"
           echo "Cotabby.dmg SHA-256: ${dmg_sha256}"
 
+      - name: Upload notarized DMG
+        uses: actions/upload-artifact@v7
+        with:
+          name: cotabby-dmg-notarized
+          path: build/${{ env.DMG_NAME }}
+          retention-days: 1
+
+      - name: Upload notarization diagnostics
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: notarization-diagnostics
+          path: build/notarization/**
+          if-no-files-found: ignore
+
+  # ---------------------------------------------------------------------------
+  # 3. PUBLISH
+  # Downloads the stapled DMG, Sparkle-signs the appcast, creates the GitHub
+  # Release, and deploys the appcast to Pages. Only runs when publish=true.
+  # Separated so a Pages deploy failure or appcast signing hiccup doesn't
+  # require a full rebuild + re-notarization.
+  # ---------------------------------------------------------------------------
+  publish:
+    name: Sign appcast, create release, and deploy Pages
+    needs: [build, notarize]
+    if: needs.build.outputs.publish == 'true'
+    runs-on: macos-26
+    timeout-minutes: 30
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy-pages.outputs.page_url }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Select Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Download notarized DMG
+        uses: actions/download-artifact@v4
+        with:
+          name: cotabby-dmg-notarized
+          path: build
+
+      - name: Download Sparkle tools
+        id: sparkle-tools
+        env:
+          SPARKLE_VERSION: ${{ needs.build.outputs.sparkle_version }}
+        run: |
+          set -euo pipefail
+
+          sparkle_dir="${RUNNER_TEMP}/sparkle-tools"
+          mkdir -p "${sparkle_dir}"
+
+          curl -fsSL \
+            "https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_VERSION}/Sparkle-${SPARKLE_VERSION}.tar.xz" \
+            -o "${sparkle_dir}/Sparkle.tar.xz"
+
+          echo "${SPARKLE_SHA256}  ${sparkle_dir}/Sparkle.tar.xz" | shasum -a 256 --check
+
+          tar -xf "${sparkle_dir}/Sparkle.tar.xz" -C "${sparkle_dir}"
+
+          sign_update="${sparkle_dir}/bin/sign_update"
+          if [[ ! -x "${sign_update}" ]]; then
+            echo "sign_update tool not found in Sparkle ${SPARKLE_VERSION} archive." >&2
+            ls -la "${sparkle_dir}/bin/" >&2 || true
+            exit 1
+          fi
+
+          echo "sign_update=${sign_update}" >> "$GITHUB_OUTPUT"
+
+      - name: Write Sparkle private key
+        env:
+          SPARKLE_ED25519_PRIVATE_KEY: ${{ secrets.SPARKLE_ED25519_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+
+          sparkle_key_file="${RUNNER_TEMP}/sparkle-ed25519-private-key.txt"
+          printf '%s' "${SPARKLE_ED25519_PRIVATE_KEY}" > "${sparkle_key_file}"
+          chmod 600 "${sparkle_key_file}"
+          echo "SPARKLE_KEY_FILE=${sparkle_key_file}" >> "$GITHUB_ENV"
+
       - name: Generate signed appcast
-        if: steps.sparkle-key.outputs.has_key == 'true'
         env:
           SIGN_UPDATE_TOOL: ${{ steps.sparkle-tools.outputs.sign_update }}
-          RELEASE_VERSION: ${{ steps.metadata.outputs.release_version }}
-          BUILD_NUMBER: ${{ steps.metadata.outputs.build_number }}
+          RELEASE_VERSION: ${{ needs.build.outputs.release_version }}
+          BUILD_NUMBER: ${{ needs.build.outputs.build_number }}
         run: |
           set -euo pipefail
 
@@ -609,7 +737,6 @@ jobs:
           grep -q 'length="' build/appcast.xml
 
       - name: Verify Sparkle signature against final DMG
-        if: steps.sparkle-key.outputs.has_key == 'true'
         env:
           SIGN_UPDATE_TOOL: ${{ steps.sparkle-tools.outputs.sign_update }}
         run: |
@@ -628,12 +755,11 @@ jobs:
             "${signature}"
 
       - name: Create GitHub Release
-        if: steps.metadata.outputs.publish == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ steps.metadata.outputs.release_tag }}
-          RELEASE_VERSION: ${{ steps.metadata.outputs.release_version }}
-          IS_PRERELEASE: ${{ steps.metadata.outputs.is_prerelease }}
+          RELEASE_TAG: ${{ needs.build.outputs.release_tag }}
+          RELEASE_VERSION: ${{ needs.build.outputs.release_version }}
+          IS_PRERELEASE: ${{ needs.build.outputs.is_prerelease }}
         run: |
           set -euo pipefail
 
@@ -652,13 +778,13 @@ jobs:
             "${release_flags[@]}"
 
       - name: Release summary
-        if: always() && steps.metadata.outputs.release_version != ''
+        if: always()
         env:
-          RELEASE_TAG: ${{ steps.metadata.outputs.release_tag }}
-          RELEASE_VERSION: ${{ steps.metadata.outputs.release_version }}
-          BUILD_NUMBER: ${{ steps.metadata.outputs.build_number }}
-          IS_PRERELEASE: ${{ steps.metadata.outputs.is_prerelease }}
-          PUBLISH: ${{ steps.metadata.outputs.publish }}
+          RELEASE_TAG: ${{ needs.build.outputs.release_tag }}
+          RELEASE_VERSION: ${{ needs.build.outputs.release_version }}
+          BUILD_NUMBER: ${{ needs.build.outputs.build_number }}
+          IS_PRERELEASE: ${{ needs.build.outputs.is_prerelease }}
+          PUBLISH: ${{ needs.build.outputs.publish }}
         run: |
           {
             echo "### Release"
@@ -673,7 +799,6 @@ jobs:
           } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Prepare Pages artifact
-        if: steps.metadata.outputs.publish == 'true'
         run: |
           set -euo pipefail
 
@@ -683,21 +808,18 @@ jobs:
           printf '%s\n' "${PAGES_CUSTOM_DOMAIN}" > build/pages/CNAME
 
       - name: Configure GitHub Pages
-        if: steps.metadata.outputs.publish == 'true'
         uses: actions/configure-pages@v5
 
       - name: Upload GitHub Pages artifact
-        if: steps.metadata.outputs.publish == 'true'
         uses: actions/upload-pages-artifact@v5
         with:
           path: build/pages
 
       - name: Deploy GitHub Pages
-        if: steps.metadata.outputs.publish == 'true'
         id: deploy-pages
         uses: actions/deploy-pages@v5
 
-      - name: Upload local release artifacts
+      - name: Upload release artifacts
         if: always()
         uses: actions/upload-artifact@v7
         with:
@@ -705,17 +827,20 @@ jobs:
           path: |
             build/${{ env.DMG_NAME }}
             build/appcast.xml
-            build/notarization/**
           if-no-files-found: ignore
 
-  # Tell the Homebrew tap to point at the DMG this run just published. The tap's
-  # own update-cask.yml workflow listens for this repository_dispatch and rewrites
-  # Casks/cotabby.rb from the payload, so the cask-editing logic stays in the tap.
-  # Runs only after a real publish so dry-run validation builds never bump the cask.
+  # ---------------------------------------------------------------------------
+  # 4. UPDATE HOMEBREW CASK
+  # Tell the Homebrew tap to point at the DMG this run just published. The
+  # tap's own update-cask.yml workflow listens for this repository_dispatch
+  # and rewrites Casks/cotabby.rb from the payload, so the cask-editing logic
+  # stays in the tap. Runs only after a real publish so dry-run validation
+  # builds never bump the cask.
+  # ---------------------------------------------------------------------------
   update-homebrew-cask:
     name: Update Homebrew cask
-    needs: release
-    if: needs.release.outputs.publish == 'true'
+    needs: [build, notarize, publish]
+    if: needs.build.outputs.publish == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch cask update to the tap
@@ -723,13 +848,13 @@ jobs:
           # PAT with contents:write on FuJacob/homebrew-cotabby — the built-in
           # GITHUB_TOKEN cannot reach another repository.
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          VERSION: ${{ needs.release.outputs.release_version }}
-          DMG_SHA256: ${{ needs.release.outputs.dmg_sha256 }}
+          VERSION: ${{ needs.build.outputs.release_version }}
+          DMG_SHA256: ${{ needs.notarize.outputs.dmg_sha256 }}
         run: |
           set -euo pipefail
 
           if [[ -z "${DMG_SHA256}" ]]; then
-            echo "The release job did not produce a DMG checksum." >&2
+            echo "The notarize job did not produce a DMG checksum." >&2
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -430,7 +430,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: build-artifacts
-          path: build/${{ env.DMG_NAME }}
+          path: build/${{ env.APP_NAME }}.xcarchive/
           if-no-files-found: ignore
 
   # ---------------------------------------------------------------------------
@@ -450,7 +450,7 @@ jobs:
 
     steps:
       - name: Download DMG artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: cotabby-dmg
           path: build
@@ -670,7 +670,7 @@ jobs:
           python-version: "3.13"
 
       - name: Download notarized DMG
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: cotabby-dmg-notarized
           path: build
@@ -707,6 +707,11 @@ jobs:
           SPARKLE_ED25519_PRIVATE_KEY: ${{ secrets.SPARKLE_ED25519_PRIVATE_KEY }}
         run: |
           set -euo pipefail
+
+          if [[ -z "${SPARKLE_ED25519_PRIVATE_KEY}" ]]; then
+            echo "SPARKLE_ED25519_PRIVATE_KEY is not configured — cannot publish." >&2
+            exit 1
+          fi
 
           sparkle_key_file="${RUNNER_TEMP}/sparkle-ed25519-private-key.txt"
           printf '%s' "${SPARKLE_ED25519_PRIVATE_KEY}" > "${sparkle_key_file}"


### PR DESCRIPTION
## Summary

The monolithic \`release\` job was a single 180-minute step. A failure at notarization (Apple server rejection, timeout) forced a full rebuild from scratch. This PR breaks it into three discrete jobs so only the failed stage needs to be re-run:

- **build** (120 min cap): metadata validation, cert import, \`xcodebuild archive\`, nested re-sign, package DMG. Uploads the signed DMG as an artifact.
- **notarize** (90 min cap): downloads the DMG, submits to Apple notarization, polls, staples. Uploads the stapled DMG + diagnostics. This is the most failure-prone stage (Apple server variability, potential rejection) and is now independently re-runnable.
- **publish** (30 min cap): downloads the stapled DMG, Sparkle-signs the appcast, creates the GitHub Release, deploys Pages. Only runs when \`publish=true\`.
- **update-homebrew-cask**: unchanged, now \`needs: [build, notarize, publish]\` instead of \`needs: release\`.

The DMG flows between jobs via \`actions/upload-artifact\` / \`actions/download-artifact\`. Sparkle tools are re-downloaded in \`publish\` (fast curl + SHA verify) rather than carried as an artifact. Metadata (version, tag, build number, Sparkle version) flows via job outputs.

## Validation

CI-only change — no Swift source files touched. SwiftLint exited clean.

End-to-end validation requires a real tag push or \`workflow_dispatch\` with credentials. The job graph structure has been manually verified against the GitHub Actions dependency model. Note: \`upload-artifact@v7\` (existing) is paired with \`download-artifact@v4\` (new) — both use the same underlying Artifacts V2 service and are compatible; bump to matching majors if a future runner image requires it.

## Linked issues

Refs #381

## Risk / rollout notes

- No change to what gets built, signed, notarized, or published — only job boundaries changed.
- The \`environment: github-pages\` protection is now on \`publish\` instead of the old \`release\` job, which is where Pages deployment actually lives.
- Artifact retention for intermediate DMGs is set to 1 day to avoid storage bloat; the final \`release-artifacts\` upload in \`publish\` preserves the stapled DMG + appcast at default retention.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Splits the 180-minute monolithic `release` job into three discrete jobs — `build`, `notarize`, and `publish` — so that notarization failures (the most Apple-server-dependent stage) can be retried independently without rebuilding from scratch.

- **`build`** (120 min): validates metadata, imports certificates, runs `xcodebuild archive`, re-signs nested code, packages the DMG, and uploads it as a 1-day artifact. Job outputs carry version, tag, build number, and Sparkle version to downstream jobs.
- **`notarize`** (90 min): downloads the signed DMG, stores Apple notarization credentials, polls until Accepted/Rejected, staples the ticket, computes the SHA-256, and uploads the stapled DMG + diagnostics.
- **`publish`** (30 min, gated on `publish=true`): re-downloads Sparkle tools (curl + SHA verify), writes the private key, Sparkle-signs the appcast, creates the GitHub Release, and deploys to Pages. `update-homebrew-cask` is now listed under `needs: [build, notarize, publish]`.

<h3>Confidence Score: 5/5</h3>

CI-only refactor with no Swift source changes; job wiring, artifact hand-off, and conditionals are all correct.

The change reorganises job boundaries without altering what gets built, signed, notarized, or published. Job outputs, needs chains, artifact names, retention windows, and the publish gate are consistently applied.

No files require special attention — the single changed file is .github/workflows/release.yml.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Monolithic release job split into build / notarize / publish with artifact hand-off; job outputs, dependencies, and conditionals are correctly wired. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([workflow_dispatch / tag push]) --> B
    B[build]
    B -->|upload cotabby-dmg| C
    C[notarize]
    C -->|upload cotabby-dmg-notarized| D
    D{publish == true?}
    D -->|yes| E
    D -->|no| F([skipped])
    E[publish]
    E --> G[update-homebrew-cask]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22chore%2Fsplit-release-pipeline%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2Fsplit-release-pipeline%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Frelease.yml%3A443-448%0A**%60notarize%60%20runs%20unconditionally%2C%20burning%20Apple%20quota%20on%20every%20dry-run%20build**%0A%0AThe%20%60notarize%60%20job%20has%20no%20%60if%3A%60%20guard%2C%20so%20every%20%60workflow_dispatch%60%20with%20%60publish%3Dfalse%60%20%28a%20validation%20build%29%20still%20submits%20the%20DMG%20to%20Apple%20notarization%2C%20polls%20for%20up%20to%2090%20minutes%2C%20and%20staples%20%E2%80%94%20producing%20a%20stapled%20artifact%20that%20%60publish%60%20never%20consumes%20because%20it's%20skipped.%20Adding%20%60if%3A%20needs.build.outputs.publish%20%3D%3D%20'true'%60%20%28mirroring%20the%20%60publish%60%20job%29%20would%20let%20dry-run%20builds%20stop%20after%20%60build%60%20completes%2C%20which%20matches%20the%20intent%20of%20a%20validation-only%20run%20and%20avoids%20unnecessary%20quota%20usage.%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Frelease.yml%3A428-434%0AThe%20%60build-artifacts%60%20upload%20has%20no%20%60continue-on-error%3A%20true%60%2C%20so%20if%20the%20xcarchive%20is%20too%20large%20to%20upload%20%28the%20archive%20includes%20the%20app%2C%20Sparkle.framework%2C%20and%20llama.framework%2C%20and%20can%20be%20several%20hundred%20MB%29%2C%20the%20step%20fails%20and%20the%20entire%20%60build%60%20job%20fails%20%E2%80%94%20after%20all%20the%20expensive%20build%20work%20has%20already%20completed.%20Since%20this%20is%20diagnostics-only%2C%20a%20failed%20upload%20shouldn't%20block%20the%20release%20pipeline.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20name%3A%20Upload%20build%20diagnostics%0A%20%20%20%20%20%20%20%20if%3A%20always%28%29%0A%20%20%20%20%20%20%20%20continue-on-error%3A%20true%0A%20%20%20%20%20%20%20%20uses%3A%20actions%2Fupload-artifact%40v7%0A%20%20%20%20%20%20%20%20with%3A%0A%20%20%20%20%20%20%20%20%20%20name%3A%20build-artifacts%0A%20%20%20%20%20%20%20%20%20%20path%3A%20build%2F%24%7B%7B%20env.APP_NAME%20%7D%7D.xcarchive%2F%0A%20%20%20%20%20%20%20%20%20%20if-no-files-found%3A%20ignore%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Frelease.yml%3A443-448%0A**%60notarize%60%20runs%20unconditionally%2C%20burning%20Apple%20quota%20on%20every%20dry-run%20build**%0A%0AThe%20%60notarize%60%20job%20has%20no%20%60if%3A%60%20guard%2C%20so%20every%20%60workflow_dispatch%60%20with%20%60publish%3Dfalse%60%20%28a%20validation%20build%29%20still%20submits%20the%20DMG%20to%20Apple%20notarization%2C%20polls%20for%20up%20to%2090%20minutes%2C%20and%20staples%20%E2%80%94%20producing%20a%20stapled%20artifact%20that%20%60publish%60%20never%20consumes%20because%20it's%20skipped.%20Adding%20%60if%3A%20needs.build.outputs.publish%20%3D%3D%20'true'%60%20%28mirroring%20the%20%60publish%60%20job%29%20would%20let%20dry-run%20builds%20stop%20after%20%60build%60%20completes%2C%20which%20matches%20the%20intent%20of%20a%20validation-only%20run%20and%20avoids%20unnecessary%20quota%20usage.%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Frelease.yml%3A428-434%0AThe%20%60build-artifacts%60%20upload%20has%20no%20%60continue-on-error%3A%20true%60%2C%20so%20if%20the%20xcarchive%20is%20too%20large%20to%20upload%20%28the%20archive%20includes%20the%20app%2C%20Sparkle.framework%2C%20and%20llama.framework%2C%20and%20can%20be%20several%20hundred%20MB%29%2C%20the%20step%20fails%20and%20the%20entire%20%60build%60%20job%20fails%20%E2%80%94%20after%20all%20the%20expensive%20build%20work%20has%20already%20completed.%20Since%20this%20is%20diagnostics-only%2C%20a%20failed%20upload%20shouldn't%20block%20the%20release%20pipeline.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20name%3A%20Upload%20build%20diagnostics%0A%20%20%20%20%20%20%20%20if%3A%20always%28%29%0A%20%20%20%20%20%20%20%20continue-on-error%3A%20true%0A%20%20%20%20%20%20%20%20uses%3A%20actions%2Fupload-artifact%40v7%0A%20%20%20%20%20%20%20%20with%3A%0A%20%20%20%20%20%20%20%20%20%20name%3A%20build-artifacts%0A%20%20%20%20%20%20%20%20%20%20path%3A%20build%2F%24%7B%7B%20env.APP_NAME%20%7D%7D.xcarchive%2F%0A%20%20%20%20%20%20%20%20%20%20if-no-files-found%3A%20ignore%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=410&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Fix Greptile review findings: xcarchive ..."](https://github.com/fujacob/cotabby/commit/a88c116f355e9b50e69910018d6a6ce6a52efcd1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34735115)</sub>

<!-- /greptile_comment -->