### PR TITLE
Expand About support copy to two excerpts

### DIFF
--- a/Cotabby/UI/SettingsView.swift
+++ b/Cotabby/UI/SettingsView.swift
@@ -544,10 +544,20 @@ struct SettingsView: View {
                 .buttonStyle(.borderedProminent)
                 .tint(.blue)
             } label: {
-                Text(
-                    "Cotabby is free and open source, maintained by two university students in our free time. "
-                    + "If it's useful to you, please consider supporting development."
-                )
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(
+                        "Cotabby started from a simple belief: AI should run on your device, respect your privacy, "
+                        + "and remain open to everyone. That's why Cotabby is open source, local-first, and built "
+                        + "to give users full control over their own hardware and data."
+                    )
+
+                    Text(
+                        "We're building Cotabby in our spare time, one release at a time. Every feature, bug fix, "
+                        + "and support reply takes real time and care from two university students trying to keep "
+                        + "this project alive. If Cotabby has been useful to you, please consider supporting our "
+                        + "mission."
+                    )
+                }
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
             }


### PR DESCRIPTION
## Summary

Replaces the single-sentence Support blurb in Settings → About with two short paragraphs: one on the project's open-source, local-first mission, and one on the two-student maintainer team and the ask to support.

## Validation

Skipped per request.

## Linked issues

## Risk / rollout notes

Copy-only change in `SettingsView.supportSection`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Expands the Settings → About support blurb from a single sentence into two short paragraphs describing the project's open-source/local-first mission and the two-student maintainer team, with an ask to support. The old `Text` view is replaced by a `VStack(alignment: .leading, spacing: 8)` holding two `Text` views; `.foregroundStyle(.secondary)` and `.fixedSize(horizontal: false, vertical: true)` are moved to the container and will propagate correctly to both children.

- Copy-only content change in `SettingsView.supportSection` — no logic, data, or API surface is affected.
- SwiftUI modifier placement on the `VStack` is correct; both environment-based (`.foregroundStyle`) and layout (`.fixedSize`) modifiers propagate as expected.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a copy-only update with no logic changes.

The change only touches static display text in one @ViewBuilder property. SwiftUI modifiers are correctly applied to the new VStack container and will propagate to both child Text views, so the visual presentation is consistent with the original.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/SettingsView.swift | Replaces a single Text label in supportSection with a VStack of two Text paragraphs; modifiers (.foregroundStyle, .fixedSize) are correctly moved to the container and propagate to children. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Before
        A[LabeledContent] --> B[label: Text - single paragraph]
        A --> C[content: Link / Support button]
        B --> D[.foregroundStyle .secondary]
        D --> E[.fixedSize horizontal false vertical true]
    end

    subgraph After
        F[LabeledContent] --> G[label: VStack alignment leading spacing 8]
        F --> H[content: Link / Support button]
        G --> I[Text - mission paragraph]
        G --> J[Text - maintainer ask paragraph]
        G --> K[.foregroundStyle .secondary]
        K --> L[.fixedSize horizontal false vertical true]
    end
```

<sub>Reviews (1): Last reviewed commit: ["Expand About support copy to two excerpt..."](https://github.com/fujacob/cotabby/commit/9c27fa1c2f289bb2016da543b8c8dfaa1c217e35) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34740488)</sub>

<!-- /greptile_comment -->