### PR TITLE
Add global toggle hotkey; tidy acceptance-mode picker

### DIFF
--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
@@ -49,12 +49,14 @@ extension SuggestionCoordinator {
             )
         }
 
-        // `acceptEntireSuggestion` forces the full-acceptance path regardless of granularity so the
-        // dedicated full-accept key stays a per-press override. `acceptCurrentSuggestion` honors
-        // the user-selected granularity for the primary accept key.
+        // `acceptEntireSuggestion` forces the full-acceptance path so the dedicated full-accept key
+        // stays a per-press override. `acceptCurrentSuggestion` honors the user-selected
+        // granularity for the primary accept key — the granularity enum is intentionally limited to
+        // partial modes (`.word`, `.phrase`), since whole-suggestion acceptance is exclusively the
+        // dedicated full-accept key's job.
         let primaryGranularity = settingsSnapshot.acceptanceGranularity
         let preparation: SuggestionAcceptancePreparation
-        if fullText || primaryGranularity == .full {
+        if fullText {
             preparation = interactionState.prepareFullAcceptance(from: rawContext, overlayState: overlayState)
         } else {
             preparation = interactionState.prepareAcceptance(

--- a/Cotabby/App/Core/CotabbyAppEnvironment.swift
+++ b/Cotabby/App/Core/CotabbyAppEnvironment.swift
@@ -52,6 +52,11 @@ final class CotabbyAppEnvironment {
         inputMonitor.acceptanceKeyModifiersProvider = { suggestionSettings.acceptanceKeyModifiers }
         inputMonitor.fullAcceptanceKeyCodeProvider = { suggestionSettings.fullAcceptanceKeyCode }
         inputMonitor.fullAcceptanceKeyModifiersProvider = { suggestionSettings.fullAcceptanceKeyModifiers }
+        inputMonitor.globalToggleKeyCodeProvider = { suggestionSettings.globalToggleKeyCode }
+        inputMonitor.globalToggleKeyModifiersProvider = { suggestionSettings.globalToggleKeyModifiers }
+        inputMonitor.onGlobalToggleHotkey = { [weak suggestionSettings] in
+            suggestionSettings?.toggleGloballyEnabled()
+        }
         let focusModel = FocusTrackingModel(
             permissionProvider: { permissionManager.accessibilityGranted },
             ignoredBundleIdentifier: Bundle.main.bundleIdentifier,
@@ -179,5 +184,15 @@ final class CotabbyAppEnvironment {
 
         // Key code changes reach InputMonitor through closures that read from the model
         // at event time (set above), so no Combine subscription is needed here.
+
+        // The global-toggle hotkey is the exception: its tap is install-on-demand so a user who
+        // never binds it pays zero per-keystroke cost. Install/uninstall whenever the binding
+        // crosses the unbound/bound boundary or when the key code itself changes.
+        suggestionSettings.$globalToggleKeyCode
+            .removeDuplicates()
+            .sink { [weak inputMonitor] _ in
+                inputMonitor?.refreshToggleTap()
+            }
+            .store(in: &cancellables)
     }
 }

--- a/Cotabby/Models/SuggestionEngineModels.swift
+++ b/Cotabby/Models/SuggestionEngineModels.swift
@@ -46,14 +46,13 @@ struct DisabledApplicationRule: Codable, Equatable, Identifiable, Sendable {
 }
 
 /// How much of a buffered suggestion the primary accept key takes per press. The dedicated
-/// full-accept key always takes the entire remaining tail regardless of this setting.
+/// full-accept key always takes the entire remaining tail regardless of this setting, so this
+/// enum intentionally does not include a "full" case — that would duplicate the dedicated key.
 enum AcceptanceGranularity: String, CaseIterable, Codable, Sendable {
     /// One word (with the existing trailing-punctuation policy applied per chunk).
     case word
     /// Words accumulated until a sentence terminator (`.`, `!`, `?`, `\n`) or the tail runs out.
     case phrase
-    /// The entire remaining suggestion at once — same outcome as the dedicated full-accept key.
-    case full
 }
 
 /// A compact snapshot of the autocomplete settings the coordinator actually needs at generation

--- a/Cotabby/Models/SuggestionSettingsModel.swift
+++ b/Cotabby/Models/SuggestionSettingsModel.swift
@@ -41,6 +41,11 @@ final class SuggestionSettingsModel: ObservableObject {
     @Published private(set) var fullAcceptanceKeyCode: CGKeyCode
     @Published private(set) var fullAcceptanceKeyModifiers: ShortcutModifierMask
     @Published private(set) var fullAcceptanceKeyLabel: String
+    /// User-configurable hotkey that flips `isGloballyEnabled`. Defaults to unbound so the user has
+    /// to opt in; without a binding the listener tap for this hotkey is never installed.
+    @Published private(set) var globalToggleKeyCode: CGKeyCode
+    @Published private(set) var globalToggleKeyModifiers: ShortcutModifierMask
+    @Published private(set) var globalToggleKeyLabel: String
     @Published private(set) var acceptanceGranularity: AcceptanceGranularity
     private let userDefaults: UserDefaults
 
@@ -72,6 +77,9 @@ final class SuggestionSettingsModel: ObservableObject {
     private static let fullAcceptanceKeyCodeDefaultsKey = "cotabbyFullAcceptanceKeyCode"
     private static let fullAcceptanceKeyModifiersDefaultsKey = "cotabbyFullAcceptanceKeyModifiers"
     private static let fullAcceptanceKeyLabelDefaultsKey = "cotabbyFullAcceptanceKeyLabel"
+    private static let globalToggleKeyCodeDefaultsKey = "cotabbyGlobalToggleKeyCode"
+    private static let globalToggleKeyModifiersDefaultsKey = "cotabbyGlobalToggleKeyModifiers"
+    private static let globalToggleKeyLabelDefaultsKey = "cotabbyGlobalToggleKeyLabel"
     private static let acceptanceGranularityDefaultsKey = "cotabbyAcceptanceGranularity"
 
     static let defaultAcceptanceKeyCode: CGKeyCode = 48
@@ -210,6 +218,18 @@ final class SuggestionSettingsModel: ObservableObject {
         )
         let resolvedFullAcceptanceKeyLabel = userDefaults.string(forKey: Self.fullAcceptanceKeyLabelDefaultsKey)
             ?? Self.defaultFullAcceptanceKeyLabel
+
+        // Default is unbound. An absent UserDefaults entry must NOT fall back to a real key code —
+        // the hotkey is opt-in, and silently binding something would surprise existing users.
+        let resolvedGlobalToggleKeyCode = CGKeyCode(
+            userDefaults.object(forKey: Self.globalToggleKeyCodeDefaultsKey) as? Int
+                ?? Int(Self.disabledKeyCode)
+        )
+        let resolvedGlobalToggleKeyModifiers = ShortcutModifierMask(
+            rawValue: UInt32(userDefaults.object(forKey: Self.globalToggleKeyModifiersDefaultsKey) as? Int ?? 0)
+        )
+        let resolvedGlobalToggleKeyLabel = userDefaults.string(forKey: Self.globalToggleKeyLabelDefaultsKey)
+            ?? Self.disabledKeyLabel
         // Default `.word` preserves the pre-feature behavior for existing installs that have no
         // value persisted yet. Invalid persisted values fall back to `.word` rather than crashing
         // so a hand-edited UserDefault can't strand the user.
@@ -243,6 +263,9 @@ final class SuggestionSettingsModel: ObservableObject {
         fullAcceptanceKeyCode = resolvedFullAcceptanceKeyCode
         fullAcceptanceKeyModifiers = resolvedFullAcceptanceKeyModifiers
         fullAcceptanceKeyLabel = resolvedFullAcceptanceKeyLabel
+        globalToggleKeyCode = resolvedGlobalToggleKeyCode
+        globalToggleKeyModifiers = resolvedGlobalToggleKeyModifiers
+        globalToggleKeyLabel = resolvedGlobalToggleKeyLabel
         acceptanceGranularity = resolvedAcceptanceGranularity
 
         userDefaults.set(resolvedGloballyEnabled, forKey: Self.isGloballyEnabledDefaultsKey)
@@ -273,6 +296,12 @@ final class SuggestionSettingsModel: ObservableObject {
             forKey: Self.fullAcceptanceKeyModifiersDefaultsKey
         )
         userDefaults.set(resolvedFullAcceptanceKeyLabel, forKey: Self.fullAcceptanceKeyLabelDefaultsKey)
+        userDefaults.set(Int(resolvedGlobalToggleKeyCode), forKey: Self.globalToggleKeyCodeDefaultsKey)
+        userDefaults.set(
+            Int(resolvedGlobalToggleKeyModifiers.rawValue),
+            forKey: Self.globalToggleKeyModifiersDefaultsKey
+        )
+        userDefaults.set(resolvedGlobalToggleKeyLabel, forKey: Self.globalToggleKeyLabelDefaultsKey)
         userDefaults.set(resolvedAcceptanceGranularity.rawValue, forKey: Self.acceptanceGranularityDefaultsKey)
 
         // The custom indicator icon feature was removed; scrub any previously-persisted PNG so
@@ -662,6 +691,36 @@ final class SuggestionSettingsModel: ObservableObject {
 
     func clearFullAcceptanceKey() {
         setFullAcceptanceKey(keyCode: Self.disabledKeyCode, modifiers: [], label: Self.disabledKeyLabel)
+    }
+
+    /// Persists a new global-toggle hotkey. Modifiers are normalized to empty when the key code is
+    /// `disabledKeyCode` so the listener tap can rely on `(disabled, [])` meaning "do not install
+    /// the tap at all" without inspecting the modifier set separately.
+    func setGlobalToggleKey(keyCode: CGKeyCode, modifiers: ShortcutModifierMask, label: String) {
+        let normalizedModifiers = keyCode == Self.disabledKeyCode ? [] : modifiers
+        guard globalToggleKeyCode != keyCode
+            || globalToggleKeyModifiers != normalizedModifiers
+            || globalToggleKeyLabel != label
+        else {
+            return
+        }
+
+        globalToggleKeyCode = keyCode
+        globalToggleKeyModifiers = normalizedModifiers
+        globalToggleKeyLabel = label
+        userDefaults.set(Int(keyCode), forKey: Self.globalToggleKeyCodeDefaultsKey)
+        userDefaults.set(Int(normalizedModifiers.rawValue), forKey: Self.globalToggleKeyModifiersDefaultsKey)
+        userDefaults.set(label, forKey: Self.globalToggleKeyLabelDefaultsKey)
+    }
+
+    func clearGlobalToggleKey() {
+        setGlobalToggleKey(keyCode: Self.disabledKeyCode, modifiers: [], label: Self.disabledKeyLabel)
+    }
+
+    /// Convenience used by the hotkey callback. Wrapping the flip here keeps the InputMonitor
+    /// closure trivial and gives the menu bar / tests a single entry point.
+    func toggleGloballyEnabled() {
+        setGloballyEnabled(!isGloballyEnabled)
     }
 
     private func persistSelectedEngine(_ engine: SuggestionEngineKind) {

--- a/Cotabby/Services/Input/InputMonitor.swift
+++ b/Cotabby/Services/Input/InputMonitor.swift
@@ -65,6 +65,18 @@ final class InputMonitor {
     /// Modifier mask required alongside the full-accept key code. Empty means the bare key.
     var fullAcceptanceKeyModifiersProvider: @MainActor () -> ShortcutModifierMask = { [] }
 
+    /// Reads the global-toggle hotkey at event time. `disabledKeyCode` (UInt16.max) means unbound;
+    /// the dedicated toggle tap is torn down whenever the provider returns that sentinel so users
+    /// who never set the hotkey pay no per-keystroke cost.
+    var globalToggleKeyCodeProvider: @MainActor () -> CGKeyCode = { CGKeyCode(UInt16.max) }
+
+    /// Modifier mask required alongside the global-toggle hotkey. Empty means the bare key.
+    var globalToggleKeyModifiersProvider: @MainActor () -> ShortcutModifierMask = { [] }
+
+    /// Fired when a key event matches the configured global-toggle hotkey. Wired to flip the
+    /// `isGloballyEnabled` setting; the keystroke is then consumed so the host app never sees it.
+    var onGlobalToggleHotkey: (@MainActor () -> Void)?
+
     /// When false, the observer passes keystrokes through without classifying or notifying the
     /// coordinator. This eliminates per-keystroke overhead in apps where Cotabby will never act
     /// (terminals, globally disabled, per-app disabled).
@@ -83,6 +95,12 @@ final class InputMonitor {
 
     private var acceptTap: CFMachPort?
     private var acceptRunLoopSource: CFRunLoopSource?
+
+    /// Dedicated consuming tap for the global-toggle hotkey. Lives independently of the accept tap
+    /// because it must fire even when no suggestion is visible — and even when Cotabby is globally
+    /// disabled, since the whole purpose of the hotkey is to flip that switch back on.
+    private var toggleTap: CFMachPort?
+    private var toggleRunLoopSource: CFRunLoopSource?
 
     /// Tracks whether the consuming tap currently owns accept-key semantics. This is separate
     /// from "a suggestion exists": the observer should only suppress accept-key callbacks when a
@@ -110,6 +128,7 @@ final class InputMonitor {
     func stop() {
         CotabbyLogger.app.info("Input monitor stopping")
         destroyAcceptTap()
+        destroyToggleTap()
         destroyObserverTap()
     }
 
@@ -119,11 +138,30 @@ final class InputMonitor {
     func refresh() {
         if permissionProvider() {
             installObserverTapIfNeeded()
+            refreshToggleTap()
         } else {
             destroyAcceptTap()
+            destroyToggleTap()
             destroyObserverTap()
         }
     }
+
+    /// Installs or removes the global-toggle tap to match the current binding. Called by the
+    /// environment whenever the user changes or clears the toggle hotkey, so the tap's lifetime
+    /// tracks "binding exists" without paying for it when nothing is bound.
+    func refreshToggleTap() {
+        guard permissionProvider() else {
+            destroyToggleTap()
+            return
+        }
+        if globalToggleKeyCodeProvider() == Self.disabledKeyCode {
+            destroyToggleTap()
+        } else {
+            installToggleTapIfNeeded()
+        }
+    }
+
+    private static let disabledKeyCode: CGKeyCode = CGKeyCode(UInt16.max)
 
     /// How long the accept tap lingers (fail-open) after the overlay hides before its mach port is
     /// invalidated. A final-chunk accept runs *inside* this tap's own callback: it posts the
@@ -249,6 +287,51 @@ final class InputMonitor {
         isAcceptTapOwningAcceptKeys = true
     }
 
+    private func installToggleTapIfNeeded() {
+        guard toggleTap == nil else {
+            return
+        }
+
+        let mask = (1 << CGEventType.keyDown.rawValue)
+        let callback: CGEventTapCallBack = { _, type, event, userInfo in
+            guard let userInfo else {
+                return Unmanaged.passUnretained(event)
+            }
+
+            let monitor = Unmanaged<InputMonitor>.fromOpaque(userInfo).takeUnretainedValue()
+            return MainActor.assumeIsolated {
+                monitor.handleToggleTap(type: type, event: event)
+            }
+        }
+
+        // Head-inserted so the toggle hotkey is decided before any other tap (including the accept
+        // tap) gets a chance to consume the keystroke. The callback returns `nil` only when the
+        // event matches the bound hotkey, so unrelated keys still drain through to the rest of the
+        // chain in their normal order.
+        guard let tap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .defaultTap,
+            eventsOfInterest: CGEventMask(mask),
+            callback: callback,
+            userInfo: Unmanaged.passUnretained(self).toOpaque()
+        ) else {
+            CotabbyLogger.app.warning("Failed to create CGEvent toggle tap")
+            return
+        }
+        CotabbyLogger.app.info("CGEvent toggle tap installed (active, toggle-hotkey only)")
+
+        toggleTap = tap
+        let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        toggleRunLoopSource = source
+
+        if let source {
+            CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+        }
+
+        CGEvent.tapEnable(tap: tap, enable: true)
+    }
+
     private func destroyObserverTap() {
         if let source = observerRunLoopSource {
             CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
@@ -276,6 +359,61 @@ final class InputMonitor {
         }
         acceptTap = nil
         CotabbyLogger.app.info("CGEvent accept tap removed")
+    }
+
+    private func destroyToggleTap() {
+        guard toggleTap != nil || toggleRunLoopSource != nil else {
+            return
+        }
+        if let source = toggleRunLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
+        }
+        toggleRunLoopSource = nil
+
+        if let tap = toggleTap {
+            CFMachPortInvalidate(tap)
+        }
+        toggleTap = nil
+        CotabbyLogger.app.info("CGEvent toggle tap removed")
+    }
+
+    /// Active toggle tap: consumes a keystroke only when it matches the configured global-toggle
+    /// hotkey. The match is intentionally evaluated against the providers (not a cached snapshot)
+    /// so a settings change is picked up on the very next keystroke. Runs independently of
+    /// `shouldProcessEventsProvider` because the hotkey must work even when Cotabby is globally
+    /// disabled — that is its only job.
+    func handleToggleTap(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+        switch type {
+        case .tapDisabledByTimeout, .tapDisabledByUserInput:
+            CotabbyLogger.app.warning("Toggle tap was disabled by system, re-enabling")
+            if let toggleTap {
+                CGEvent.tapEnable(tap: toggleTap, enable: true)
+            }
+            return Unmanaged.passUnretained(event)
+
+        case .keyDown:
+            if suppressionController.isSynthetic(event) {
+                return Unmanaged.passUnretained(event)
+            }
+
+            let bound = globalToggleKeyCodeProvider()
+            guard bound != Self.disabledKeyCode else {
+                return Unmanaged.passUnretained(event)
+            }
+
+            let keyCode = keyCode(from: event)
+            let modifiers = ShortcutModifierMask(eventFlags: event.flags)
+            guard keyCode == bound, modifiers == globalToggleKeyModifiersProvider() else {
+                return Unmanaged.passUnretained(event)
+            }
+
+            onGlobalToggleHotkey?()
+            CotabbyLogger.app.debug("Toggle tap consumed keyCode=\(keyCode) modifiers=\(modifiers.rawValue)")
+            return nil
+
+        default:
+            return Unmanaged.passUnretained(event)
+        }
     }
 
     /// Listen-only observer: classifies the event and notifies the coordinator. The return value

--- a/Cotabby/Services/Suggestion/SuggestionInteractionState.swift
+++ b/Cotabby/Services/Suggestion/SuggestionInteractionState.swift
@@ -105,9 +105,9 @@ final class SuggestionInteractionState {
     /// The returned value gives the coordinator the exact chunk to insert and the context it should
     /// use for diagnostics and overlay updates.
     ///
-    /// `granularity` selects between word-by-word and phrase-by-phrase acceptance. `.full` is
-    /// rejected here because the coordinator routes full accepts to `prepareFullAcceptance`, which
-    /// keeps a distinct invalid-reason message for the dedicated full-accept key.
+    /// `granularity` selects between word-by-word and phrase-by-phrase acceptance. Whole-
+    /// suggestion acceptance is the dedicated full-accept key's responsibility and is routed
+    /// through `prepareFullAcceptance`, so the granularity enum has no case for it here.
     func prepareAcceptance(
         from snapshot: FocusedInputSnapshot,
         overlayState: OverlayState,
@@ -131,12 +131,6 @@ final class SuggestionInteractionState {
                 from: session.remainingText,
                 autoAcceptTrailingPunctuation: autoAcceptTrailingPunctuation
             )
-        case .full:
-            // The coordinator routes full accepts to `prepareFullAcceptance`, so `.full` should never
-            // reach here. Trap in debug, but degrade gracefully in release by passing the key through
-            // rather than crashing a shipping process — matching the other `.invalid` branches here.
-            assertionFailure("prepareAcceptance should not receive .full — route to prepareFullAcceptance instead")
-            return .invalid("Key passed through because .full granularity was routed incorrectly.")
         }
 
         guard !chunk.isEmpty else {

--- a/Cotabby/UI/Settings/Components/AcceptanceModePickerView.swift
+++ b/Cotabby/UI/Settings/Components/AcceptanceModePickerView.swift
@@ -17,9 +17,8 @@ struct AcceptanceModePickerView: View {
 
     var body: some View {
         Picker("Acceptance Mode", selection: acceptanceGranularityBinding) {
-            Text("Word").tag(AcceptanceGranularity.word)
+            Text("Accept Word").tag(AcceptanceGranularity.word)
             Text("Phrase").tag(AcceptanceGranularity.phrase)
-            Text("Full Suggestion").tag(AcceptanceGranularity.full)
         }
         .pickerStyle(.menu)
     }

--- a/Cotabby/UI/Settings/Panes/ShortcutsPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/ShortcutsPaneView.swift
@@ -10,6 +10,7 @@ struct ShortcutsPaneView: View {
 
     @State private var isRecordingKeybind = false
     @State private var isRecordingFullAcceptKeybind = false
+    @State private var isRecordingGlobalToggleKeybind = false
 
     var body: some View {
         SettingsPaneScaffold {
@@ -67,6 +68,29 @@ struct ShortcutsPaneView: View {
                         clearHelp: "Unbind this shortcut. No key will accept the whole suggestion at once."
                     )
                 }
+
+                // No factory default — the hotkey is opt-in, so the only "reset" gesture that
+                // makes sense is "unbind", which the Clear button already covers. Passing
+                // `onReset: nil` hides the Reset button entirely instead of making it a duplicate.
+                LabeledContent("Toggle Tabby") {
+                    KeybindRow(
+                        label: suggestionSettings.globalToggleKeyLabel,
+                        keyCode: suggestionSettings.globalToggleKeyCode,
+                        modifiers: suggestionSettings.globalToggleKeyModifiers,
+                        defaultKeyCode: SuggestionSettingsModel.disabledKeyCode,
+                        isRecording: $isRecordingGlobalToggleKeybind,
+                        onRecord: { keyCode, modifiers, label in
+                            suggestionSettings.setGlobalToggleKey(
+                                keyCode: keyCode,
+                                modifiers: modifiers,
+                                label: label
+                            )
+                        },
+                        onReset: nil,
+                        onClear: { suggestionSettings.clearGlobalToggleKey() },
+                        clearHelp: "Unbind this shortcut. No key will toggle Tabby on or off."
+                    )
+                }
             }
         }
     }
@@ -82,7 +106,9 @@ private struct KeybindRow: View {
     let defaultKeyCode: CGKeyCode
     @Binding var isRecording: Bool
     let onRecord: (CGKeyCode, ShortcutModifierMask, String) -> Void
-    let onReset: () -> Void
+    /// `nil` hides the Reset button — used by bindings whose only sensible "reset" is unbind, which
+    /// the Clear button already covers (e.g. the opt-in global-toggle hotkey).
+    let onReset: (() -> Void)?
     let onClear: () -> Void
     let clearHelp: String
 
@@ -110,7 +136,7 @@ private struct KeybindRow: View {
                 }
             }
 
-            if keyCode != defaultKeyCode || !modifiers.isEmpty {
+            if let onReset, keyCode != defaultKeyCode || !modifiers.isEmpty {
                 Button("Reset") {
                     onReset()
                     isRecording = false


### PR DESCRIPTION
## Summary

Three small, related changes to the shortcuts surface, kept in one PR so the picker, the shortcut rows, and the underlying granularity enum stay consistent.

1. **New opt-in global-toggle hotkey.** `SuggestionSettingsModel` gains `globalToggleKeyCode` / `globalToggleKeyModifiers` / `globalToggleKeyLabel`, defaulting to `disabledKeyCode` (\"None\") so nothing is bound out of the box. `InputMonitor` installs a dedicated head-inserted consuming tap only while a binding exists — installed and torn down via the new `refreshToggleTap()` in response to a Combine subscription on `$globalToggleKeyCode` in `CotabbyAppEnvironment`. Users who never bind the hotkey pay no per-keystroke cost. The tap deliberately runs outside `shouldProcessEventsProvider` because its only job is to flip the globally-disabled switch back on when Tabby is off. A new \"Toggle Tabby\" row in `ShortcutsPaneView` drives the binding. `KeybindRow.onReset` is now optional so the new row can hide the Reset button — for an opt-in hotkey, Clear already covers the only sensible \"reset\" gesture (unbind).
2. **Acceptance picker label.** The first option in `AcceptanceModePickerView` changes from \"Word\" to \"Accept Word\" so the picker reads consistently next to the adjacent \"Accept Word\" / \"Accept Entire Suggestion\" shortcut rows in the Shortcuts pane.
3. **Drop redundant `AcceptanceGranularity.full`.** The dedicated full-accept shortcut row already accepts the whole suggestion in one keystroke, so the third picker option was a second way to express the same intent. Removing the case simplifies the `prepareAcceptance` switch (no more dead `.full` arm with an `assertionFailure`) and the coordinator's accept routing (no more `|| primaryGranularity == .full`).

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby \
  -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby \
  -destination 'platform=macOS' build-for-testing
# ** TEST BUILD SUCCEEDED **

swiftlint lint --quiet
# exit 0
```

App-hosted tests not executed locally (signing). End-to-end keystroke flow not manually verified yet — the toggle tap path is structurally analogous to the existing accept tap and follows the same install/teardown discipline, but a real keystroke confirmation should happen before release.

## Linked issues

None.

## Risk / rollout notes

- The toggle tap is a new always-on (while bound) consuming tap in the session event chain. Slow main-actor callbacks could now back-pressure global keystrokes when a user has bound the hotkey, the same risk class as the existing accept tap. The callback is intentionally trivial (two int compares + a one-liner setter), and the tap is uninstalled whenever the binding is cleared.
- Default behavior is unchanged: out of the box no hotkey is bound and no tap is installed.
- Existing users on \`AcceptanceGranularity.full\` will fall back to \`.word\` on first launch after this lands, because the resolved value goes through \`AcceptanceGranularity.init(rawValue:)\` and unknown raw values land on the default. They should re-bind the dedicated full-accept shortcut if they had been using the picker option instead — calling out in changelog is recommended.
- `KeybindRow.onReset` becoming optional is a private-type change in `ShortcutsPaneView.swift`; no other call sites.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces an opt-in global-toggle hotkey that installs a dedicated head-inserted consuming CGEvent tap only while a binding exists, removes the redundant `AcceptanceGranularity.full` case (eliminating a dead `assertionFailure` branch), and tidies the acceptance-mode picker label.

- **Global toggle hotkey**: `SuggestionSettingsModel` gains three new `@Published` properties defaulting to `disabledKeyCode`; `InputMonitor` installs/tears down a separate consuming tap driven by a Combine subscription on `$globalToggleKeyCode` so users who never bind the hotkey pay no per-keystroke cost.
- **`AcceptanceGranularity.full` removal**: The dedicated full-accept key already covers whole-suggestion acceptance, so the picker option and its dead coordinator branch (`|| primaryGranularity == .full`) and `assertionFailure` arm in `prepareAcceptance` are all deleted cleanly.
- **Picker label**: \"Word\" renamed to \"Accept Word\" for consistency with the Shortcuts pane shortcut rows, though \"Phrase\" was not similarly renamed, leaving an asymmetric display.

<h3>Confidence Score: 4/5</h3>

The tap install/teardown lifecycle is sound and follows the existing accept-tap discipline; the default-off behavior ensures no regression for users who never bind the hotkey.

The toggle tap implementation is structurally correct and mirrors the existing accept tap pattern closely. The two findings are minor: an inconsistent label in the picker and a missing testability comment on handleToggleTap. No correctness or data-loss issues were found.

InputMonitor.swift for the missing testability comment on handleToggleTap, and AcceptanceModePickerView.swift for the asymmetric label rename.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Services/Input/InputMonitor.swift | Adds a dedicated head-inserted consuming CGEvent tap for the global-toggle hotkey, with install/teardown lifecycle mirroring the existing accept tap. handleToggleTap is internal without the standard testability comment that the sibling handlers carry. |
| Cotabby/Models/SuggestionSettingsModel.swift | Adds three new @Published properties for the global-toggle hotkey with correct disabledKeyCode defaults, persistence, and a toggleGloballyEnabled() convenience method. Pattern is consistent with the existing accept/full-accept key triple. |
| Cotabby/App/Core/CotabbyAppEnvironment.swift | Wires toggle-key providers into InputMonitor and installs a Combine subscription on $globalToggleKeyCode to drive tap lifecycle. Correctly uses [weak suggestionSettings] in the hotkey callback and removeDuplicates() to avoid spurious reinstalls. |
| Cotabby/Models/SuggestionEngineModels.swift | Removes AcceptanceGranularity.full, updating the doc comment to explain the intentional omission. Clean removal with no leftover switch arms. |
| Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift | Removes the || primaryGranularity == .full branch from the full-acceptance routing guard, which is now dead code since the enum case was deleted. |
| Cotabby/Services/Suggestion/SuggestionInteractionState.swift | Removes the .full case from the prepareAcceptance switch, eliminating the assertionFailure dead arm. The compiler now exhaustively covers the remaining two cases. |
| Cotabby/UI/Settings/Components/AcceptanceModePickerView.swift | Renames Word to Accept Word and removes the Full Suggestion option. The verb prefix is inconsistently applied — Phrase was not also renamed to Accept Phrase. |
| Cotabby/UI/Settings/Panes/ShortcutsPaneView.swift | Adds the Toggle Tabby keybind row and makes KeybindRow.onReset optional so the new opt-in hotkey can hide the Reset button. Both changes are self-contained to the private KeybindRow type. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as User (keypress)
    participant ToggleTap as Toggle Tap (head-inserted)
    participant AcceptTap as Accept Tap (tail-appended)
    participant Settings as SuggestionSettingsModel
    participant Env as CotabbyAppEnvironment

    Env->>Settings: subscribe to $globalToggleKeyCode
    Settings-->>Env: emits on change
    Env->>ToggleTap: refreshToggleTap() install or destroy

    User->>ToggleTap: keyDown event
    alt key matches globalToggleKey
        ToggleTap->>Settings: toggleGloballyEnabled()
        ToggleTap-->>User: consume (return nil)
    else key does not match
        ToggleTap-->>AcceptTap: pass event through
        alt key matches accept/full-accept key
            AcceptTap->>Settings: acceptance side effects
            AcceptTap-->>User: consume
        else
            AcceptTap-->>User: pass through
        end
    end
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fglobal-toggle-shortcut%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fglobal-toggle-shortcut%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FSettings%2FComponents%2FAcceptanceModePickerView.swift%3A19-22%0AInconsistent%20verb%20prefix%3A%20the%20PR%20adds%20%22Accept%22%20to%20the%20%60.word%60%20label%20but%20leaves%20%60.phrase%60%20as%20plain%20%22Phrase%22.%20The%20picker%20now%20shows%20%22Accept%20Word%22%20alongside%20%22Phrase%22%2C%20which%20is%20asymmetric.%20If%20the%20goal%20is%20consistency%20with%20the%20Shortcuts%20pane%20shortcut-row%20labels%2C%20%60.phrase%60%20should%20follow%20the%20same%20pattern.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20Picker%28%22Acceptance%20Mode%22%2C%20selection%3A%20acceptanceGranularityBinding%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20Text%28%22Accept%20Word%22%29.tag%28AcceptanceGranularity.word%29%0A%20%20%20%20%20%20%20%20%20%20%20%20Text%28%22Accept%20Phrase%22%29.tag%28AcceptanceGranularity.phrase%29%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FServices%2FInput%2FInputMonitor.swift%3A385%0A**Missing%20internal-visibility%20justification.**%20%60handleObserverTap%60%20%28line%20425%29%20and%20%60handleAcceptTap%60%20%28line%20479%29%20both%20carry%20a%20doc%20comment%20explaining%20they%20are%20%60internal%60%20rather%20than%20%60private%60%20to%20support%20unit%20tests%20that%20exercise%20tap%20ownership%20without%20installing%20real%20CGEvent%20taps.%20%60handleToggleTap%60%20follows%20the%20same%20pattern%20and%20appears%20to%20need%20the%20same%20testability%2C%20but%20the%20comment%20was%20omitted%2C%20making%20the%20non-private%20access%20look%20unintentional.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FSettings%2FComponents%2FAcceptanceModePickerView.swift%3A19-22%0AInconsistent%20verb%20prefix%3A%20the%20PR%20adds%20%22Accept%22%20to%20the%20%60.word%60%20label%20but%20leaves%20%60.phrase%60%20as%20plain%20%22Phrase%22.%20The%20picker%20now%20shows%20%22Accept%20Word%22%20alongside%20%22Phrase%22%2C%20which%20is%20asymmetric.%20If%20the%20goal%20is%20consistency%20with%20the%20Shortcuts%20pane%20shortcut-row%20labels%2C%20%60.phrase%60%20should%20follow%20the%20same%20pattern.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20Picker%28%22Acceptance%20Mode%22%2C%20selection%3A%20acceptanceGranularityBinding%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20Text%28%22Accept%20Word%22%29.tag%28AcceptanceGranularity.word%29%0A%20%20%20%20%20%20%20%20%20%20%20%20Text%28%22Accept%20Phrase%22%29.tag%28AcceptanceGranularity.phrase%29%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FServices%2FInput%2FInputMonitor.swift%3A385%0A**Missing%20internal-visibility%20justification.**%20%60handleObserverTap%60%20%28line%20425%29%20and%20%60handleAcceptTap%60%20%28line%20479%29%20both%20carry%20a%20doc%20comment%20explaining%20they%20are%20%60internal%60%20rather%20than%20%60private%60%20to%20support%20unit%20tests%20that%20exercise%20tap%20ownership%20without%20installing%20real%20CGEvent%20taps.%20%60handleToggleTap%60%20follows%20the%20same%20pattern%20and%20appears%20to%20need%20the%20same%20testability%2C%20but%20the%20comment%20was%20omitted%2C%20making%20the%20non-private%20access%20look%20unintentional.%0A%0A&repo=fujacob%2Fcotabby&pr=412&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add global toggle hotkey, rename Word pi..."](https://github.com/fujacob/cotabby/commit/7d421c880b6f98f049eb260def346c3ffac14849) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34741455)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->