### PR TITLE
Group Settings panes into clearer subsections

### DIFF
--- a/Cotabby/UI/CustomRulesEditor.swift
+++ b/Cotabby/UI/CustomRulesEditor.swift
@@ -9,6 +9,11 @@ import SwiftUI
 struct CustomRulesEditor: View {
     @ObservedObject var suggestionSettings: SuggestionSettingsModel
 
+    /// When false, the editor drops its own "Rules" title so an enclosing `Section("Rules")` can
+    /// supply the heading without duplicating it. The Clear control stays in place either way.
+    /// Defaults to true so standalone uses (e.g. onboarding) keep their inline title.
+    var showsTitleHeader: Bool = true
+
     @State private var inputText: String = ""
 
     private var rules: [String] { suggestionSettings.customRules }
@@ -27,17 +32,21 @@ struct CustomRulesEditor: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
-            HStack {
-                Text("Rules")
-                    .font(.system(size: 13, weight: .medium))
-                Spacer()
-                if canClear {
-                    Button("Clear") {
-                        suggestionSettings.clearRules()
+            if showsTitleHeader || canClear {
+                HStack {
+                    if showsTitleHeader {
+                        Text("Rules")
+                            .font(.system(size: 13, weight: .medium))
                     }
-                    .buttonStyle(.plain)
-                    .font(.system(size: 12))
-                    .foregroundStyle(.secondary)
+                    Spacer()
+                    if canClear {
+                        Button("Clear") {
+                            suggestionSettings.clearRules()
+                        }
+                        .buttonStyle(.plain)
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                    }
                 }
             }
 

--- a/Cotabby/UI/LanguageTagsEditor.swift
+++ b/Cotabby/UI/LanguageTagsEditor.swift
@@ -8,6 +8,11 @@ import SwiftUI
 struct LanguageTagsEditor: View {
     @ObservedObject var suggestionSettings: SuggestionSettingsModel
 
+    /// When false, the editor drops its own "Languages" title so an enclosing `Section("Languages")`
+    /// can supply the heading without duplicating it. The Clear control stays in place either way.
+    /// Defaults to true so standalone uses (e.g. onboarding) keep their inline title.
+    var showsTitleHeader: Bool = true
+
     @State private var inputText: String = ""
 
     private var languages: [String] { suggestionSettings.responseLanguages }
@@ -26,17 +31,21 @@ struct LanguageTagsEditor: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
-            HStack {
-                Text("Languages")
-                    .font(.system(size: 13, weight: .medium))
-                Spacer()
-                if canClear {
-                    Button("Clear") {
-                        suggestionSettings.clearLanguages()
+            if showsTitleHeader || canClear {
+                HStack {
+                    if showsTitleHeader {
+                        Text("Languages")
+                            .font(.system(size: 13, weight: .medium))
                     }
-                    .buttonStyle(.plain)
-                    .font(.system(size: 12))
-                    .foregroundStyle(.secondary)
+                    Spacer()
+                    if canClear {
+                        Button("Clear") {
+                            suggestionSettings.clearLanguages()
+                        }
+                        .buttonStyle(.plain)
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                    }
                 }
             }
 

--- a/Cotabby/UI/Settings/Panes/AppsPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/AppsPaneView.swift
@@ -13,7 +13,7 @@ struct AppsPaneView: View {
 
     var body: some View {
         SettingsPaneScaffold {
-            Section("Apps") {
+            Section("Disabled Apps") {
                 Text("Cotabby won't autocomplete in these apps. Add an app you can't disable from the "
                     + "menu bar, like a launcher that closes the moment it loses focus.")
                     .font(.caption)

--- a/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
@@ -14,7 +14,7 @@ struct GeneralPaneView: View {
 
     var body: some View {
         SettingsPaneScaffold {
-            Section {
+            Section("Status") {
                 Toggle("Enable Globally", isOn: globallyEnabledBinding)
 
                 // Fast Mode is the most user-facing performance lever, so it gets prime real
@@ -92,7 +92,7 @@ struct GeneralPaneView: View {
                 }
             }
 
-            Section {
+            Section("Help") {
                 LabeledContent("Onboarding") {
                     Button("Open Welcome Guide") {
                         onShowWelcome()

--- a/Cotabby/UI/Settings/Panes/ShortcutsPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/ShortcutsPaneView.swift
@@ -13,9 +13,11 @@ struct ShortcutsPaneView: View {
 
     var body: some View {
         SettingsPaneScaffold {
-            Section("Shortcuts") {
+            Section("Mode") {
                 AcceptanceModePickerView(suggestionSettings: suggestionSettings)
+            }
 
+            Section("Keys") {
                 LabeledContent("Accept Word") {
                     KeybindRow(
                         label: suggestionSettings.acceptanceKeyLabel,

--- a/Cotabby/UI/Settings/Panes/WritingPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/WritingPaneView.swift
@@ -20,9 +20,12 @@ struct WritingPaneView: View {
 
             Section("Profile") {
                 VStack(alignment: .leading, spacing: 16) {
-                    Text("This information is passed to the AI to help personalize your completions.")
+                    // The caption introduces all three personalization inputs (name, languages,
+                    // rules) since each is passed to the AI, even though they live in separate cards.
+                    Text("Your name, languages, and rules are passed to the AI to help personalize your completions.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
 
                     VStack(alignment: .leading, spacing: 8) {
                         Text("Name")
@@ -38,13 +41,15 @@ struct WritingPaneView: View {
                 .padding(.vertical, 6)
             }
 
-            Section {
-                LanguageTagsEditor(suggestionSettings: suggestionSettings)
+            // The editors suppress their own titles here so the Section headers ("Languages"/"Rules")
+            // carry the heading, matching the explicit-header pattern used across the pane.
+            Section("Languages") {
+                LanguageTagsEditor(suggestionSettings: suggestionSettings, showsTitleHeader: false)
                     .padding(.vertical, 6)
             }
 
-            Section {
-                CustomRulesEditor(suggestionSettings: suggestionSettings)
+            Section("Rules") {
+                CustomRulesEditor(suggestionSettings: suggestionSettings, showsTitleHeader: false)
                     .padding(.vertical, 6)
             }
         }

--- a/Cotabby/UI/Settings/Panes/WritingPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/WritingPaneView.swift
@@ -10,7 +10,7 @@ struct WritingPaneView: View {
 
     var body: some View {
         SettingsPaneScaffold {
-            Section("Writing") {
+            Section("Length") {
                 Picker("Length", selection: selectedWordCountPresetBinding) {
                     ForEach(SuggestionWordCountPreset.allCases) { preset in
                         Text(preset.displayLabel).tag(preset)
@@ -19,7 +19,7 @@ struct WritingPaneView: View {
             }
 
             Section("Profile") {
-                VStack(alignment: .leading, spacing: 24) {
+                VStack(alignment: .leading, spacing: 16) {
                     Text("This information is passed to the AI to help personalize your completions.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -34,12 +34,18 @@ struct WritingPaneView: View {
                         ))
                         .textFieldStyle(.roundedBorder)
                     }
-
-                    LanguageTagsEditor(suggestionSettings: suggestionSettings)
-
-                    CustomRulesEditor(suggestionSettings: suggestionSettings)
                 }
-                .padding(.vertical, 10)
+                .padding(.vertical, 6)
+            }
+
+            Section {
+                LanguageTagsEditor(suggestionSettings: suggestionSettings)
+                    .padding(.vertical, 6)
+            }
+
+            Section {
+                CustomRulesEditor(suggestionSettings: suggestionSettings)
+                    .padding(.vertical, 6)
             }
         }
     }


### PR DESCRIPTION
## Summary

Tightens the Settings layout so every grouped card has a meaningful header and related controls live together.

- **General**: the top toggles (Enable Globally, Fast Mode) now sit under a `Status` header, and the trailing Open Welcome Guide row gets a `Help` header instead of floating below Appearance.
- **Writing**: the top section is renamed `Length` (the pane itself is already titled Writing), and the Profile mega-card is split into three cards: `Profile` (caption + Name), Languages, and Rules. Each editor renders its own internal label and Clear control.
- **Apps**: the section header is renamed `Disabled Apps` so it doesn't duplicate the tab title.
- **Shortcuts**: split into `Mode` (acceptance mode picker) and `Keys` (Accept Word, Accept Entire Suggestion).

Copy-only / layout-only change. No behavior, persistence, or binding changes.

## Validation

Local SwiftLint pass (`swiftlint lint --quiet` on the four modified files): exit 0. Did not run xcodebuild this round; changes are pure SwiftUI section rearrangement.

## Linked issues

## Risk / rollout notes

Low risk; affects only the redesigned Settings panes under `Cotabby/UI/Settings/Panes/`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a pure SwiftUI layout reorganisation across the four Settings panes and the two shared editor components (`LanguageTagsEditor`, `CustomRulesEditor`). No bindings, persistence, or business logic are touched.

- **General / Shortcuts / Apps**: previously anonymous or redundantly-named `Section` headers are given explicit labels (\"Status\", \"Help\", \"Mode\", \"Keys\", \"Disabled Apps\"); the Shortcuts pane is split from one section into two.
- **Writing**: the \"Profile\" mega-card is broken into three separate `Section`s (Profile, Languages, Rules); a new `showsTitleHeader: Bool = true` parameter on both editor components lets the Section header carry the label while preserving the Clear button, with the default `true` keeping existing callers (`SettingsView`, `WelcomeProfileStepView`) unchanged.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are SwiftUI Section header renames and card splits with no logic, binding, or persistence modifications.

Every file touched is a pure layout reorganisation: string literals for Section headers are renamed or added, one pane is split into two sections, and two shared editor components gain an opt-in `showsTitleHeader` parameter that defaults to `true`, leaving all existing call sites (`SettingsView`, `WelcomeProfileStepView`) behaviorally identical. There are no data model, persistence, or control-flow changes anywhere in the diff.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/Settings/Panes/WritingPaneView.swift | Splits the old 'Profile' mega-card into Profile (name only), Languages, and Rules sections; renames 'Writing' → 'Length'; passes showsTitleHeader: false to the two editors so Section headers carry the title. |
| Cotabby/UI/CustomRulesEditor.swift | Adds showsTitleHeader: Bool = true param; wraps the header HStack in `if showsTitleHeader || canClear` so the 'Rules' label is suppressed when an enclosing Section supplies it, while the Clear button is preserved whenever needed. |
| Cotabby/UI/LanguageTagsEditor.swift | Mirrors the showsTitleHeader addition from CustomRulesEditor. Existing callers in SettingsView and WelcomeProfileStepView omit the param and keep the default true, so they are unaffected. |
| Cotabby/UI/Settings/Panes/GeneralPaneView.swift | Adds explicit 'Status' and 'Help' headers to the two previously anonymous Sections; no control or binding changes. |
| Cotabby/UI/Settings/Panes/ShortcutsPaneView.swift | Splits the single 'Shortcuts' Section into 'Mode' (AcceptanceModePickerView) and 'Keys' (keybind rows); no logic changes. |
| Cotabby/UI/Settings/Panes/AppsPaneView.swift | One-line rename: 'Apps' → 'Disabled Apps' to avoid duplicating the tab title. No other changes. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Address review: broaden Writing caption,..."](https://github.com/fujacob/cotabby/commit/86da06b48c26c63c107ee4ac4f4f87eeb70fc818) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34741516)</sub>

<!-- /greptile_comment -->