### PR TITLE
Add polling and delay inventory doc

### DIFF
--- a/docs/POLLING_AND_DELAYS.md
+++ b/docs/POLLING_AND_DELAYS.md
@@ -1,0 +1,73 @@
+# Polling, Debounce, and Hardcoded Delay Inventory
+
+A living catalog of every hardcoded timing value in Cotabby: poll intervals,
+debounce/throttle windows, sleeps, timeouts, and animation durations. The goal
+is to make it cheap to audit CPU-hot loops and tune values without grepping
+the whole tree.
+
+Update this file whenever you add, remove, or change a timing constant.
+
+## Focus and Accessibility
+
+| Location | Value | Purpose |
+|----------|-------|---------|
+| `Cotabby/Services/Focus/FocusTracker.swift:41` | 80 ms | Base focus poll interval (AX tree walk). Backed off automatically by `FocusPollBackoff` up to ~800 ms during idle. |
+| `Cotabby/Services/Focus/FocusSnapshotResolver.swift:16` | 100 ms | Deep-walk throttle. Caps the expensive caret BFS used in Chromium-style contenteditable trees. |
+| `Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift:180` | 400 ms | Chromium AX-publish wait ceiling. Maximum time we wait for the host app to publish its updated contenteditable text after a keystroke before giving up on this prediction cycle. |
+| `Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift:185` | 30 ms | Host-publish poll interval. AX is requeried every 30 ms while waiting up to the 400 ms ceiling above. |
+| `Cotabby/Support/FocusPollBackoff.swift:17` | 60 ticks | Idle capture cap for focus poll backoff. After this many unchanged polls the stride saturates. |
+
+## Suggestion Pipeline
+
+| Location | Value | Purpose |
+|----------|-------|---------|
+| `Cotabby/Models/SuggestionModels.swift:103` | 50 ms | Default suggestion debounce. User-configurable. Wait after the last keystroke before triggering generation. |
+| `Cotabby/Services/Suggestion/SuggestionWorkController.swift:32` | (configured) | Converts the user debounce setting from ms to nanoseconds for `Task.sleep`. |
+
+## Acceptance and Input
+
+| Location | Value | Purpose |
+|----------|-------|---------|
+| `Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift:354` | 30 ms | Post-insertion refresh delay. Gives the host app time to process the synthetic keystroke before we snap the overlay caret to the new position. |
+| `Cotabby/Services/Input/InputMonitor.swift:137` | 50 ms | Accept-tap teardown delay. Defers mach-port invalidation so a final-chunk accept's synthetic keystroke can drain before the tap is removed. |
+
+## Visual Context
+
+| Location | Value | Purpose |
+|----------|-------|---------|
+| `Cotabby/Services/Visual/VisualContextCoordinator.swift:29` | 350 ms | Session-start settle delay. Debounces visual context capture on focus change so a flapping Chromium focus doesn't retrigger screenshots and OCR. |
+| `Cotabby/Services/Visual/LlamaVisualContextSummarizer.swift:20` | 3 s | Llama visual context summarization soft timeout. Cancels generation after 3 s and returns whatever partial text was produced. |
+
+## Permissions
+
+| Location | Value | Purpose |
+|----------|-------|---------|
+| `Cotabby/Services/Permission/PermissionManager.swift:24` | 2.0 s | Permission polling interval. Periodic refresh of system permission state (Accessibility, screen recording, input monitoring) since macOS doesn't notify on grant. |
+| `Cotabby/Services/Permission/PermissionGuidanceController.swift:105` | 300 ms | Overlay tracking timer. Polls overlay window position during the guided permission flow. |
+| `Cotabby/Services/Permission/PermissionOverlayWindowController.swift:14-15` | 720 ms / 0.72 | Permission overlay launch animation duration and response curve parameter. |
+
+## Networking, Runtime, Utilities
+
+| Location | Value | Purpose |
+|----------|-------|---------|
+| `Cotabby/Services/Utilities/HuggingFaceAPIClient.swift:74` | 15 s | HuggingFace API request timeout (model search/fetch). |
+| `Cotabby/App/Core/AppDelegate.swift:161` | 1.5 s | Llama runtime graceful shutdown timeout before force-kill. |
+| `Cotabby/Support/ClipboardRelevanceFilter.swift:23` | 5 min | Clipboard staleness threshold. Clipboard content older than this is not injected into the prompt. |
+
+## Tuning Notes
+
+The hottest loops, ordered by CPU impact:
+
+1. **30 ms host-publish poll** inside the 400 ms Chromium ceiling. Bumping to
+   50 to 60 ms roughly halves AX queries during the wait window with minimal
+   added latency.
+2. **80 ms focus poll base** in `FocusTracker`. Already protected by
+   `FocusPollBackoff` once idle, so this is the active-typing cadence.
+3. **400 ms Chromium ceiling**. Raising it reduces the rate at which we give
+   up on slow Chromium publishes, at the cost of longer worst-case latency
+   when the host genuinely never publishes.
+4. **100 ms deep-walk throttle**. Protects the expensive caret BFS in
+   contenteditable trees. Safe to raise to ~150 ms.
+
+When changing any of these, update both the constant and this table in the
+same commit so the inventory stays accurate.


### PR DESCRIPTION
## Summary

Adds `docs/POLLING_AND_DELAYS.md`, a single catalog of every hardcoded polling interval, debounce window, sleep, and timeout in the app. The goal is to make it cheap to audit CPU-hot loops (focus polling, AX-publish wait, etc.) and tune values without grepping the whole tree. The doc also flags the highest-impact tuning candidates.

## Validation

Docs-only change; no code paths touched.

- `git diff --stat origin/main...` confirms a single new markdown file under `docs/`.

## Linked issues

None.

## Risk / rollout notes

- Pure documentation. No runtime, build, or settings impact.
- Convention introduced: update the table in the same commit that changes a timing constant, so the inventory stays accurate.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `docs/POLLING_AND_DELAYS.md`, a reference catalog of every hardcoded timing constant in the app — poll intervals, debounce windows, sleeps, timeouts, and animation durations — with source file line anchors and tuning guidance.

- Every entry was verified against its referenced source file and line number; all values and line anchors are accurate.
- Tuning notes rank the hottest loops by CPU impact and include a brief analysis of trade-offs for each candidate.

<h3>Confidence Score: 5/5</h3>

Pure documentation addition with no runtime, build, or settings changes — safe to merge.

Every entry in the new catalog was cross-checked against its referenced source file and line number. All 15 timing constants and their line anchors are accurate. The tuning notes correctly identify the hottest loops and the trade-offs involved. No code paths are touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/POLLING_AND_DELAYS.md | New documentation file cataloging all hardcoded timing constants; all 15 entries verified accurate against their source file line references. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Keystroke] --> B[SuggestionDebounce\n50 ms default]
    B --> C[FocusTracker Poll\n80 ms base → 800 ms idle]
    C --> D{Chromium\ncontenteditable?}
    D -- Yes --> E[Host-publish wait loop\n30 ms poll / 400 ms ceiling]
    D -- No --> F[Generate suggestion]
    E --> F
    F --> G[Suggestion accepted?]
    G -- Yes --> H[Post-insertion refresh\n30 ms delay]
    G -- Yes --> I[Accept-tap teardown\n50 ms delay]
    H --> J[Overlay snaps to caret]
    I --> J
    K[Focus change] --> L[VisualContext settle\n350 ms debounce]
    L --> M[Screenshot + OCR]
    M --> N[Llama summarization\n3 s soft timeout]
    O[App permissions] --> P[PermissionManager poll\n2.0 s interval]
    O --> Q[Permission guidance\nOverlay tracking: 300 ms]
```

<sub>Reviews (1): Last reviewed commit: ["Add polling and delay inventory doc"](https://github.com/fujacob/cotabby/commit/8ad86b0ae219c65cfa924a266d1f28050d7617b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34742288)</sub>

<!-- /greptile_comment -->