### PR TITLE
Reduce time-to-first-suggestion latency on the typing path

### DIFF
--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
@@ -184,6 +184,12 @@ extension SuggestionCoordinator {
     /// burning CPU on AX queries that are themselves 5–15ms each.
     private static let hostPublishPollIntervalMs = 30
 
+    /// First-retry interval after the immediate (elapsed 0) poll, which runs inside the keystroke's
+    /// own tap callback before the host has even processed the key and therefore always misses. A
+    /// short first retry catches fast-publishing native apps in ~10ms instead of making them wait a
+    /// full steady interval; slow Chromium hosts fall through to `hostPublishPollIntervalMs` below.
+    private static let hostPublishFirstPollIntervalMs = 10
+
     /// Schedules a fresh prediction once the host app has actually published the new
     /// contenteditable text to AX. The previous fix waited a fixed 150ms — see PR #376 — but the
     /// logs in #381 showed Chromium's publish lag can exceed that ceiling on a busy page, so the
@@ -231,13 +237,17 @@ extension SuggestionCoordinator {
         // Ceiling: stop polling and generate anyway. Without this fallback a host that genuinely
         // produces no AX change (rare but possible — e.g. dead-key composition) would never get
         // its next prediction.
-        let nextElapsed = elapsedMs + Self.hostPublishPollIntervalMs
+        // Short first retry, then steady cadence: the immediate poll above always misses (it runs
+        // before the host processed the key), so a 10ms first retry shaves ~20ms off every
+        // fast-publishing host without doubling AX queries across the slow-Chromium tail.
+        let interval = elapsedMs == 0 ? Self.hostPublishFirstPollIntervalMs : Self.hostPublishPollIntervalMs
+        let nextElapsed = elapsedMs + interval
         guard nextElapsed < Self.hostPublishWaitCeilingMs else {
             schedulePrediction()
             return
         }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(Self.hostPublishPollIntervalMs)) { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(interval)) { [weak self] in
             self?.pollForHostPublish(
                 baselineText: baselineText,
                 baselineElementID: baselineElementID,

--- a/Cotabby/Models/SuggestionModels.swift
+++ b/Cotabby/Models/SuggestionModels.swift
@@ -98,9 +98,9 @@ struct SuggestionConfiguration: Equatable, Sendable {
     static let standard = SuggestionConfiguration(
         // Keep completions short so ghost text stays fast and easy to accept.
         maxPredictionTokens: 8,
-        // Aggressive debounce: 50ms is enough for most apps to publish AX state. The KV cache
-        // reuse path handles prefix changes gracefully if AX is occasionally one char stale.
-        debounceMilliseconds: 50,
+        // Aggressive debounce: 30ms keeps time-to-first-suggestion low while still collapsing
+        // bursts (superseded generations are cancelled; the host-publish poll absorbs AX lag).
+        debounceMilliseconds: 30,
         // Low temperature keeps inline completions stable and less likely to drift.
         temperature: 0.1,
         topK: 20,

--- a/Cotabby/Models/SuggestionSettingsModel.swift
+++ b/Cotabby/Models/SuggestionSettingsModel.swift
@@ -181,7 +181,11 @@ final class SuggestionSettingsModel: ObservableObject {
         let resolvedDebounceMilliseconds: Int = {
             let raw = userDefaults.object(forKey: Self.debounceMillisecondsDefaultsKey) as? Int
                 ?? configuration.debounceMilliseconds
-            return max(10, min(500, raw))
+            // Existing installs may have the old 50ms first-launch default persisted. Cap at the
+            // shipped default so the latency improvement reaches them — the stepper is hidden from
+            // the UI today, so any persisted value is a previous default rather than a user choice.
+            let capped = min(raw, configuration.debounceMilliseconds)
+            return max(10, min(500, capped))
         }()
         let resolvedFocusPollIntervalMilliseconds: Int = {
             let raw = userDefaults.object(forKey: Self.focusPollIntervalMillisecondsDefaultsKey) as? Int

--- a/docs/POLLING_AND_DELAYS.md
+++ b/docs/POLLING_AND_DELAYS.md
@@ -14,14 +14,15 @@ Update this file whenever you add, remove, or change a timing constant.
 | `Cotabby/Services/Focus/FocusTracker.swift:41` | 80 ms | Base focus poll interval (AX tree walk). Backed off automatically by `FocusPollBackoff` up to ~800 ms during idle. |
 | `Cotabby/Services/Focus/FocusSnapshotResolver.swift:16` | 100 ms | Deep-walk throttle. Caps the expensive caret BFS used in Chromium-style contenteditable trees. |
 | `Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift:180` | 400 ms | Chromium AX-publish wait ceiling. Maximum time we wait for the host app to publish its updated contenteditable text after a keystroke before giving up on this prediction cycle. |
-| `Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift:185` | 30 ms | Host-publish poll interval. AX is requeried every 30 ms while waiting up to the 400 ms ceiling above. |
+| `Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift:185` | 30 ms | Host-publish poll interval (steady cadence). AX is requeried at this interval while waiting up to the 400 ms ceiling above. |
+| `Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift:191` | 10 ms | Host-publish first-retry interval. The immediate poll always misses (it runs before the host processes the key), so the first retry is short to catch fast native-app publishes; later retries use the 30 ms steady cadence. |
 | `Cotabby/Support/FocusPollBackoff.swift:17` | 60 ticks | Idle capture cap for focus poll backoff. After this many unchanged polls the stride saturates. |
 
 ## Suggestion Pipeline
 
 | Location | Value | Purpose |
 |----------|-------|---------|
-| `Cotabby/Models/SuggestionModels.swift:103` | 50 ms | Default suggestion debounce. User-configurable. Wait after the last keystroke before triggering generation. |
+| `Cotabby/Models/SuggestionModels.swift:103` | 30 ms | Default suggestion debounce (fresh-install fallback; persisted per install, so existing users keep their value). User-configurable, clamped to [10, 500]. Wait after the last keystroke before triggering generation. |
 | `Cotabby/Services/Suggestion/SuggestionWorkController.swift:32` | (configured) | Converts the user debounce setting from ms to nanoseconds for `Task.sleep`. |
 
 ## Acceptance and Input
@@ -58,9 +59,11 @@ Update this file whenever you add, remove, or change a timing constant.
 
 The hottest loops, ordered by CPU impact:
 
-1. **30 ms host-publish poll** inside the 400 ms Chromium ceiling. Bumping to
-   50 to 60 ms roughly halves AX queries during the wait window with minimal
-   added latency.
+1. **Host-publish poll** inside the 400 ms Chromium ceiling: a 10 ms first
+   retry (the immediate poll always misses, so this catches fast native-app
+   publishes) then a 30 ms steady cadence. Raising the steady interval to
+   50 to 60 ms roughly halves AX queries during the wait with minimal added
+   latency; leave the short first retry alone.
 2. **80 ms focus poll base** in `FocusTracker`. Already protected by
    `FocusPollBackoff` once idle, so this is the active-typing cadence.
 3. **400 ms Chromium ceiling**. Raising it reduces the rate at which we give

--- a/docs/POLLING_AND_DELAYS.md
+++ b/docs/POLLING_AND_DELAYS.md
@@ -22,7 +22,7 @@ Update this file whenever you add, remove, or change a timing constant.
 
 | Location | Value | Purpose |
 |----------|-------|---------|
-| `Cotabby/Models/SuggestionModels.swift:103` | 30 ms | Default suggestion debounce (fresh-install fallback; persisted per install, so existing users keep their value). User-configurable, clamped to [10, 500]. Wait after the last keystroke before triggering generation. |
+| `Cotabby/Models/SuggestionModels.swift:103` | 30 ms | Default suggestion debounce. Persisted values are capped to this default on load (`SuggestionSettingsModel.swift:181`) so existing installs with the old 50 ms default get the improvement; the stepper is hidden from the UI today, so any persisted value is a previous default rather than a user choice. Clamped to [10, 500]. |
 | `Cotabby/Services/Suggestion/SuggestionWorkController.swift:32` | (configured) | Converts the user debounce setting from ms to nanoseconds for `Task.sleep`. |
 
 ## Acceptance and Input


### PR DESCRIPTION
## Summary

Suggestions feel slow to appear. This lowers the two timing values on the keystroke-to-ghost-text critical path that are safe to reduce: the suggestion debounce default (50ms to 30ms) and a new short first retry (10ms) on the host-publish poll before its 30ms steady cadence. Together they shave roughly 20 to 40ms of fixed overhead before generation starts, on every suggestion.

The debounce change now also reaches existing installs: persisted values are capped at the shipped default on load, matching the existing `focusPollIntervalMilliseconds` pattern. The stepper is hidden from the UI today, so any persisted value is a previous default rather than a user-chosen override.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

swiftlint lint --quiet
# 0 issues
```

No new tests: these are timing-constant tweaks, and `pollForHostPublish` is private and timer-driven (not unit-tested today). App-hosted test run is blocked locally by the Team ID signing mismatch the repo already documents.

## Linked issues

No tracked issue. Refs internal reports that suggestions take too long to appear.

## Risk / rollout notes

- **Debounce migration is one-way.** Existing installs with a persisted 50 ms (or any higher) value will be silently lowered to 30 ms on next launch and re-persisted at that value. This is safe today because the stepper is hidden from settings, so no user has an explicit override. If/when we expose the stepper, we will need to remove this cap.
- **The poll first-retry affects all users immediately** (hardcoded constant, not persisted). It adds at most one extra early AX query per keystroke on the typing path, only inside the existing wait window.
- **Left alone on purpose:** the 400ms Chromium publish ceiling (lowering it would generate against stale, pre-keystroke text, the class of bug just fixed in #409), and the 80ms focus poll / 100ms deep-walk throttle (not on the first-suggestion path; the inventory flags them as the hottest loops).
- **This is a modest win.** The dominant latency is the local model decode, which is not in this file. `maxPredictionTokens` (8) and model/fast-mode choice are the real levers for "too slow," and are left as a product decision.
- `docs/POLLING_AND_DELAYS.md` updated in the same change set per the inventory's own rule.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR shaves ~20–40 ms of fixed overhead from the typing-to-ghost-text path by reducing the suggestion debounce default from 50 ms to 30 ms and introducing a short 10 ms first-retry in the host-publish poll before the 30 ms steady cadence takes over.

- **Debounce default** (`SuggestionModels.swift`) lowered from 50 → 30 ms; existing installs are silently migrated via a new `min(raw, configuration.debounceMilliseconds)` cap applied on every launch in `SuggestionSettingsModel.init`, with the capped value written back to UserDefaults.
- **Host-publish first-retry** (`SuggestionCoordinator+Input.swift`) adds `hostPublishFirstPollIntervalMs = 10`. The immediate poll (`elapsedMs == 0`) always misses because the tap fires before the host processes the key; the 10 ms retry catches fast native-app publishes without increasing total AX query count vs. the old code.
- **Documentation** (`docs/POLLING_AND_DELAYS.md`) updated in the same commit to reflect both changed constants.

<h3>Confidence Score: 5/5</h3>

Safe to merge; changes are scoped to two small timing constants and a deliberate one-time migration of the persisted debounce default.

The polling change is a single ternary that substitutes a 10 ms first-retry for the 30 ms steady interval only on the initial (always-miss) poll call. The debounce change is a constant update plus a well-understood load-time cap. The migration reasoning (stepper is UI-hidden, so any stored value is a previous default) is sound for today's codebase. The one asymmetry — setDebounceMilliseconds not applying the same cap — is a future-proofing concern rather than a current defect.

SuggestionSettingsModel.swift — the debounce cap is applied at load time but not in setDebounceMilliseconds, so the two paths diverge if the setter is ever called above the new default.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift | Adds hostPublishFirstPollIntervalMs = 10 and a single ternary to use it on the first retry only; the steady cadence and ceiling guard are unchanged. Logic is correct. |
| Cotabby/Models/SuggestionModels.swift | Default debounceMilliseconds lowered from 50 to 30; comment updated to reflect the new rationale. |
| Cotabby/Models/SuggestionSettingsModel.swift | Introduces a min(raw, configuration.debounceMilliseconds) cap at load time to migrate existing installs to the new 30 ms default, but setDebounceMilliseconds does not apply the same cap, creating a write-read asymmetry. |
| docs/POLLING_AND_DELAYS.md | Timing inventory correctly updated to reflect the two changed constants and their new descriptions. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant KT as Keystroke Tap
    participant SC as SuggestionCoordinator
    participant AX as AX / FocusModel
    participant DQ as DispatchQueue.main

    KT->>SC: handleInputEvent()
    SC->>SC: schedulePredictionAfterHostPublishDelay()
    SC->>AX: "pollForHostPublish(elapsedMs=0) — synchronous"
    AX-->>SC: text unchanged (tap runs before host processes key)
    Note over SC: interval = 10 ms (first-retry)<br/>nextElapsed = 10 < 400 → schedule
    SC->>DQ: asyncAfter(+10 ms)
    DQ->>SC: "pollForHostPublish(elapsedMs=10)"
    SC->>AX: refreshNow()
    alt Fast native app published
        AX-->>SC: text changed
        SC->>SC: schedulePrediction() ✓ (~10 ms saved)
    else Still no change
        Note over SC: interval = 30 ms (steady cadence)<br/>nextElapsed = 40
        SC->>DQ: asyncAfter(+30 ms)
        DQ->>SC: "pollForHostPublish(elapsedMs=40)"
        Note over SC: … repeats every 30 ms …
        SC->>AX: refreshNow()
        alt Slow Chromium published
            AX-->>SC: text changed
            SC->>SC: schedulePrediction() ✓
        else Ceiling reached (nextElapsed ≥ 400)
            SC->>SC: schedulePrediction() — fallback
        end
    end
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22jafu%2Freduce-suggestion-latency%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22jafu%2Freduce-suggestion-latency%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FModels%2FSuggestionSettingsModel.swift%3A419-427%0AWrite-time%20%2F%20read-time%20asymmetry%20in%20the%20debounce%20cap.%20%60setDebounceMilliseconds%60%20clamps%20only%20to%20%60%5B10%2C%20500%5D%60%2C%20so%20a%20call%20with%20e.g.%20%60100%60%20persists%20%60100%60%20to%20UserDefaults.%20On%20the%20next%20launch%20%60init%60%20applies%20%60min%28raw%2C%20configuration.debounceMilliseconds%29%60%20and%20silently%20writes%20%6030%60%20back%2C%20discarding%20the%20caller's%20value.%20If%20the%20stepper%20is%20un-hidden%20or%20the%20setter%20is%20called%20programmatically%20above%20the%20new%20default%2C%20users%20will%20see%20their%20preference%20reset%20on%20restart%20with%20no%20indication%20why.%20Mirroring%20the%20same%20cap%20in%20the%20setter%20keeps%20the%20two%20code%20paths%20in%20sync.%0A%0A%60%60%60suggestion%0A%20%20%20%20func%20setDebounceMilliseconds%28_%20value%3A%20Int%29%20%7B%0A%20%20%20%20%20%20%20%20let%20capped%20%3D%20min%28value%2C%20configuration.debounceMilliseconds%29%0A%20%20%20%20%20%20%20%20let%20clamped%20%3D%20max%2810%2C%20min%28500%2C%20capped%29%29%0A%20%20%20%20%20%20%20%20guard%20debounceMilliseconds%20!%3D%20clamped%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20debounceMilliseconds%20%3D%20clamped%0A%20%20%20%20%20%20%20%20userDefaults.set%28clamped%2C%20forKey%3A%20Self.debounceMillisecondsDefaultsKey%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FModels%2FSuggestionSettingsModel.swift%3A419-427%0AWrite-time%20%2F%20read-time%20asymmetry%20in%20the%20debounce%20cap.%20%60setDebounceMilliseconds%60%20clamps%20only%20to%20%60%5B10%2C%20500%5D%60%2C%20so%20a%20call%20with%20e.g.%20%60100%60%20persists%20%60100%60%20to%20UserDefaults.%20On%20the%20next%20launch%20%60init%60%20applies%20%60min%28raw%2C%20configuration.debounceMilliseconds%29%60%20and%20silently%20writes%20%6030%60%20back%2C%20discarding%20the%20caller's%20value.%20If%20the%20stepper%20is%20un-hidden%20or%20the%20setter%20is%20called%20programmatically%20above%20the%20new%20default%2C%20users%20will%20see%20their%20preference%20reset%20on%20restart%20with%20no%20indication%20why.%20Mirroring%20the%20same%20cap%20in%20the%20setter%20keeps%20the%20two%20code%20paths%20in%20sync.%0A%0A%60%60%60suggestion%0A%20%20%20%20func%20setDebounceMilliseconds%28_%20value%3A%20Int%29%20%7B%0A%20%20%20%20%20%20%20%20let%20capped%20%3D%20min%28value%2C%20configuration.debounceMilliseconds%29%0A%20%20%20%20%20%20%20%20let%20clamped%20%3D%20max%2810%2C%20min%28500%2C%20capped%29%29%0A%20%20%20%20%20%20%20%20guard%20debounceMilliseconds%20!%3D%20clamped%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20debounceMilliseconds%20%3D%20clamped%0A%20%20%20%20%20%20%20%20userDefaults.set%28clamped%2C%20forKey%3A%20Self.debounceMillisecondsDefaultsKey%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=418&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Force migrate persisted debounce to 30ms..."](https://github.com/fujacob/cotabby/commit/930cb19252c788738658153247acdb138808a19b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34743617)</sub>

<!-- /greptile_comment -->