### PR TITLE
Add 'Support Us' Ko-fi link; shorten menu-bar 'Report Bug' label

### DIFF
--- a/Cotabby/UI/MenuBarView.swift
+++ b/Cotabby/UI/MenuBarView.swift
@@ -55,9 +55,16 @@ struct MenuBarView: View {
             Text("Cotabby")
                 .font(.headline)
 
+            // Ko-fi tip jar lives next to the title because the menu bar surface is the most
+            // frequented entry point. Using a Link lets SwiftUI hand the URL to NSWorkspace and
+            // dismiss the popover; a Button would need its own handler plumbing for the same effect.
+            Link("Support Us", destination: URL(string: "https://ko-fi.com/cotabby")!)
+                .buttonStyle(.borderless)
+                .font(.subheadline)
+
             Spacer(minLength: 0)
 
-            Button("Report Bug / Feedback", action: onReportFeedback)
+            Button("Report Bug", action: onReportFeedback)
                 .buttonStyle(.borderless)
                 .font(.subheadline)
         }

--- a/Cotabby/UI/MenuBarView.swift
+++ b/Cotabby/UI/MenuBarView.swift
@@ -58,9 +58,11 @@ struct MenuBarView: View {
             // Ko-fi tip jar lives next to the title because the menu bar surface is the most
             // frequented entry point. Using a Link lets SwiftUI hand the URL to NSWorkspace and
             // dismiss the popover; a Button would need its own handler plumbing for the same effect.
-            Link("Support Us", destination: URL(string: "https://ko-fi.com/cotabby")!)
-                .buttonStyle(.borderless)
-                .font(.subheadline)
+            if let kofiURL = URL(string: "https://ko-fi.com/cotabby") {
+                Link("Support Us", destination: kofiURL)
+                    .buttonStyle(.borderless)
+                    .font(.subheadline)
+            }
 
             Spacer(minLength: 0)
 


### PR DESCRIPTION
## Summary

Two small menu-bar header tweaks. \"Report Bug / Feedback\" shortens to \"Report Bug\" so the trailing button stays compact next to the title. A new \"Support Us\" link sits right after the \"Cotabby\" title and opens the project's Ko-fi page (`https://ko-fi.com/cotabby`) — the same URL already used by the About pane and the legacy Settings view, so contributors hit the same destination from any entry point. Implemented as a SwiftUI `Link` so URL dispatch and popover dismissal go through `NSWorkspace` without extra plumbing.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby \
  -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

swiftlint lint --quiet Cotabby/UI/MenuBarView.swift
# exit 0
```

Visual check in the real menu bar not run; trivial layout change.

## Linked issues

None.

## Risk / rollout notes

Header layout only; no behavior change. Ko-fi URL matches the existing `AboutPaneView` and `SettingsView` references, so all three entry points stay in sync.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes two small header tweaks to `MenuBarView`: it shortens the "Report Bug / Feedback" button label to "Report Bug" for a more compact look, and adds a "Support Us" `Link` that opens the project's Ko-fi page immediately after the title.

- The Ko-fi URL is guarded with `if let URL(string:)` — addressing the force-unwrap concern raised in prior review — and the `Link` relies on SwiftUI dispatching through `NSWorkspace`, consistent with the PR's stated rationale.
- The label change from "Report Bug / Feedback" to "Report Bug" removes the "/ Feedback" suffix; feedback submission through that entry point may now be less discoverable to new users.

<h3>Confidence Score: 5/5</h3>

Safe to merge — header-only layout change with no behaviour or state modifications.

The change is confined to two lines in the header: a label shortening and an externally-dispatched URL link guarded by `if let`. No logic, bindings, or data flow are altered, and the URL dispatch path through SwiftUI/NSWorkspace is idiomatic for this pattern.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/MenuBarView.swift | Adds a safe `if let`-guarded Ko-fi `Link` after the title and shortens the "Report Bug / Feedback" button label; no logic or state changes. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant MenuBarView
    participant SwiftUI Link
    participant NSWorkspace
    participant Browser

    User->>MenuBarView: clicks "Support Us"
    MenuBarView->>SwiftUI Link: tap event
    SwiftUI Link->>NSWorkspace: open(URL("https://ko-fi.com/cotabby"))
    NSWorkspace->>Browser: launch URL
    Browser-->>User: Ko-fi page opens
    Note over MenuBarView: panel loses focus → auto-dismisses
```

<sub>Reviews (2): Last reviewed commit: ["Update Cotabby/UI/MenuBarView.swift"](https://github.com/fujacob/cotabby/commit/98aa0d57a1e1175f48cbcd2aff7fe4c2f391cc53) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34745998)</sub>

<!-- /greptile_comment -->