### PR TITLE
Add Toggle Tabby row to onboarding Keybinds step

### DIFF
--- a/Cotabby/UI/WelcomeView.swift
+++ b/Cotabby/UI/WelcomeView.swift
@@ -29,6 +29,7 @@ struct WelcomeView: View {
     @State private var selectedTemplate: OnboardingTemplate?
     @State private var isRecordingOnboardingKeybind = false
     @State private var isRecordingOnboardingFullAcceptKeybind = false
+    @State private var isRecordingOnboardingGlobalToggleKeybind = false
 
     /// Probed once for the view's lifetime: installed memory and architecture don't change during
     /// onboarding. `@State` (not a stored `let`) ensures `ProcessInfo` is read a single time rather
@@ -404,6 +405,22 @@ extension WelcomeView {
                             label: SuggestionSettingsModel.defaultFullAcceptanceKeyLabel
                         )
                     } : nil
+                )
+
+                // No `onReset` here: the toggle hotkey is opt-in and has no factory default, so the
+                // only meaningful "reset" is unbind, which the Clear gesture in the recorder covers.
+                keybindRow(
+                    title: "Toggle Tabby",
+                    keyLabel: suggestionSettings.globalToggleKeyLabel,
+                    isRecording: $isRecordingOnboardingGlobalToggleKeybind,
+                    onKeyRecorded: { keyCode, modifiers, label in
+                        suggestionSettings.setGlobalToggleKey(
+                            keyCode: keyCode,
+                            modifiers: modifiers,
+                            label: label
+                        )
+                    },
+                    onReset: nil
                 )
             }
         }


### PR DESCRIPTION
## Summary

The redesigned Shortcuts settings pane already exposes the new global-toggle hotkey, but the onboarding Keybinds step still only offered the two accept-key rows. New users would finish onboarding without ever seeing the toggle binding and would have to find it in Settings later. This adds a third \"Toggle Tabby\" row to the onboarding step so it shows up alongside Accept Word / Accept Entire Suggestion in the same place. Wiring matches the Settings pane row: opt-in default (no factory binding), no `onReset` since unbind is the only meaningful reset and the recorder already handles it.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby \
  -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

swiftlint lint --quiet
# exit 0
```

Not run end-to-end in the onboarding window; mechanical UI addition that reuses the same `keybindRow` helper as the two adjacent rows.

## Linked issues

None.

## Risk / rollout notes

Onboarding UI only; reuses the existing `keybindRow` helper and the public `SuggestionSettingsModel.setGlobalToggleKey` from #412. No persistence change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a third "Toggle Tabby" keybind row to the onboarding Keybinds step so new users see the global-toggle hotkey alongside Accept Word and Accept Entire Suggestion, matching the existing Settings pane layout.

- Adds `@State private var isRecordingOnboardingGlobalToggleKeybind` and a new `keybindRow` call wired to `suggestionSettings.setGlobalToggleKey`, consistent with how the two existing rows are implemented.
- `onReset: nil` is correctly justified: the toggle key has no factory default, and the recorder's Clear gesture handles unbinding.
- The step's subtitle copy ("Choose keys to accept suggestions") and the preferred window height (520) were not updated to reflect the wider scope of the step now that a non-accept-suggestion row is present.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is a mechanical addition that reuses the existing `keybindRow` helper and a public model setter with no persistence changes.

The wiring is correct and consistent with the two adjacent rows. The only issues are a stale subtitle that now undersells the step's scope and an un-updated preferred window height that leaves the new row just below the fold — neither prevents the feature from working.

Cotabby/UI/WelcomeView.swift — specifically the `keybindStep` subtitle and the `.keybind` entry in `preferredWindowSize`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/UI/WelcomeView.swift | Adds a third "Toggle Tabby" keybind row to the onboarding Keybinds step, wiring it to `SuggestionSettingsModel.setGlobalToggleKey` with `onReset: nil`; stale subtitle copy and un-updated preferred window height are minor concerns. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[keybindStep] --> B[keybindRow: Accept Word]
    A --> C[keybindRow: Accept Entire Suggestion]
    A --> D[keybindRow: Toggle Tabby NEW]

    B --> E[isRecordingOnboardingKeybind]
    C --> F[isRecordingOnboardingFullAcceptKeybind]
    D --> G[isRecordingOnboardingGlobalToggleKeybind NEW]

    E -->|key recorded| H[suggestionSettings.setAcceptanceKey]
    F -->|key recorded| I[suggestionSettings.setFullAcceptanceKey]
    G -->|key recorded| J[suggestionSettings.setGlobalToggleKey]

    B -->|onReset| K[Restore default key]
    C -->|onReset| L[Restore default key]
    D -->|onReset: nil| M[No reset — unbind via Clear gesture only]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `Cotabby/UI/WelcomeView.swift`, line 357 ([link](https://github.com/fujacob/cotabby/blob/bce1f188cab6814e280c9ee6eee95bf01dfce327/Cotabby/UI/WelcomeView.swift#L357)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The subtitle still reads "Choose keys to accept suggestions" but the step now contains a "Toggle Tabby" row that enables/disables the extension globally — unrelated to accepting suggestions. A user reading this description would be confused about what the toggle row is for.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fonboarding-toggle-keybind%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fonboarding-toggle-keybind%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FWelcomeView.swift%0ALine%3A%20357%0A%0AComment%3A%0AThe%20subtitle%20still%20reads%20%22Choose%20keys%20to%20accept%20suggestions%22%20but%20the%20step%20now%20contains%20a%20%22Toggle%20Tabby%22%20row%20that%20enables%2Fdisables%20the%20extension%20globally%20%E2%80%94%20unrelated%20to%20accepting%20suggestions.%20A%20user%20reading%20this%20description%20would%20be%20confused%20about%20what%20the%20toggle%20row%20is%20for.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Text%28%22Set%20up%20your%20shortcut%20keys.%5CnYou%20can%20change%20these%20later%20in%20Settings.%22%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FWelcomeView.swift%0ALine%3A%20357%0A%0AComment%3A%0AThe%20subtitle%20still%20reads%20%22Choose%20keys%20to%20accept%20suggestions%22%20but%20the%20step%20now%20contains%20a%20%22Toggle%20Tabby%22%20row%20that%20enables%2Fdisables%20the%20extension%20globally%20%E2%80%94%20unrelated%20to%20accepting%20suggestions.%20A%20user%20reading%20this%20description%20would%20be%20confused%20about%20what%20the%20toggle%20row%20is%20for.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Text%28%22Set%20up%20your%20shortcut%20keys.%5CnYou%20can%20change%20these%20later%20in%20Settings.%22%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=420&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>


2. `Cotabby/UI/WelcomeView.swift`, line 247-248 ([link](https://github.com/fujacob/cotabby/blob/bce1f188cab6814e280c9ee6eee95bf01dfce327/Cotabby/UI/WelcomeView.swift#L247-L248)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The preferred window height for `.keybind` is 520. Adding a third row increases the content height by roughly 56 px (row height) + 16 px (spacing), pushing total content past the window height and requiring the user to scroll before they can see all three rows. Since the layout already uses a `ScrollView`, this is not a breakage, but bumping the target height would avoid the extra scroll.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fonboarding-toggle-keybind%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fonboarding-toggle-keybind%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FWelcomeView.swift%0ALine%3A%20247-248%0A%0AComment%3A%0AThe%20preferred%20window%20height%20for%20%60.keybind%60%20is%20520.%20Adding%20a%20third%20row%20increases%20the%20content%20height%20by%20roughly%2056%20px%20%28row%20height%29%20%2B%2016%20px%20%28spacing%29%2C%20pushing%20total%20content%20past%20the%20window%20height%20and%20requiring%20the%20user%20to%20scroll%20before%20they%20can%20see%20all%20three%20rows.%20Since%20the%20layout%20already%20uses%20a%20%60ScrollView%60%2C%20this%20is%20not%20a%20breakage%2C%20but%20bumping%20the%20target%20height%20would%20avoid%20the%20extra%20scroll.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20case%20.keybind%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20NSSize%28width%3A%20540%2C%20height%3A%20590%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FWelcomeView.swift%0ALine%3A%20247-248%0A%0AComment%3A%0AThe%20preferred%20window%20height%20for%20%60.keybind%60%20is%20520.%20Adding%20a%20third%20row%20increases%20the%20content%20height%20by%20roughly%2056%20px%20%28row%20height%29%20%2B%2016%20px%20%28spacing%29%2C%20pushing%20total%20content%20past%20the%20window%20height%20and%20requiring%20the%20user%20to%20scroll%20before%20they%20can%20see%20all%20three%20rows.%20Since%20the%20layout%20already%20uses%20a%20%60ScrollView%60%2C%20this%20is%20not%20a%20breakage%2C%20but%20bumping%20the%20target%20height%20would%20avoid%20the%20extra%20scroll.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20case%20.keybind%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20NSSize%28width%3A%20540%2C%20height%3A%20590%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=420&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fonboarding-toggle-keybind%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fonboarding-toggle-keybind%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FWelcomeView.swift%3A357%0AThe%20subtitle%20still%20reads%20%22Choose%20keys%20to%20accept%20suggestions%22%20but%20the%20step%20now%20contains%20a%20%22Toggle%20Tabby%22%20row%20that%20enables%2Fdisables%20the%20extension%20globally%20%E2%80%94%20unrelated%20to%20accepting%20suggestions.%20A%20user%20reading%20this%20description%20would%20be%20confused%20about%20what%20the%20toggle%20row%20is%20for.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Text%28%22Set%20up%20your%20shortcut%20keys.%5CnYou%20can%20change%20these%20later%20in%20Settings.%22%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FUI%2FWelcomeView.swift%3A247-248%0AThe%20preferred%20window%20height%20for%20%60.keybind%60%20is%20520.%20Adding%20a%20third%20row%20increases%20the%20content%20height%20by%20roughly%2056%20px%20%28row%20height%29%20%2B%2016%20px%20%28spacing%29%2C%20pushing%20total%20content%20past%20the%20window%20height%20and%20requiring%20the%20user%20to%20scroll%20before%20they%20can%20see%20all%20three%20rows.%20Since%20the%20layout%20already%20uses%20a%20%60ScrollView%60%2C%20this%20is%20not%20a%20breakage%2C%20but%20bumping%20the%20target%20height%20would%20avoid%20the%20extra%20scroll.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20case%20.keybind%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20NSSize%28width%3A%20540%2C%20height%3A%20590%29%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FWelcomeView.swift%3A357%0AThe%20subtitle%20still%20reads%20%22Choose%20keys%20to%20accept%20suggestions%22%20but%20the%20step%20now%20contains%20a%20%22Toggle%20Tabby%22%20row%20that%20enables%2Fdisables%20the%20extension%20globally%20%E2%80%94%20unrelated%20to%20accepting%20suggestions.%20A%20user%20reading%20this%20description%20would%20be%20confused%20about%20what%20the%20toggle%20row%20is%20for.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Text%28%22Set%20up%20your%20shortcut%20keys.%5CnYou%20can%20change%20these%20later%20in%20Settings.%22%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FUI%2FWelcomeView.swift%3A247-248%0AThe%20preferred%20window%20height%20for%20%60.keybind%60%20is%20520.%20Adding%20a%20third%20row%20increases%20the%20content%20height%20by%20roughly%2056%20px%20%28row%20height%29%20%2B%2016%20px%20%28spacing%29%2C%20pushing%20total%20content%20past%20the%20window%20height%20and%20requiring%20the%20user%20to%20scroll%20before%20they%20can%20see%20all%20three%20rows.%20Since%20the%20layout%20already%20uses%20a%20%60ScrollView%60%2C%20this%20is%20not%20a%20breakage%2C%20but%20bumping%20the%20target%20height%20would%20avoid%20the%20extra%20scroll.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20case%20.keybind%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20NSSize%28width%3A%20540%2C%20height%3A%20590%29%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=420&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add Toggle Tabby row to onboarding Keybi..."](https://github.com/fujacob/cotabby/commit/bce1f188cab6814e280c9ee6eee95bf01dfce327) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34746064)</sub>

<!-- /greptile_comment -->