### PR TITLE
Port expanded About support copy to redesigned AboutPaneView

### DIFF
--- a/Cotabby/UI/Settings/Panes/AboutPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/AboutPaneView.swift
@@ -64,10 +64,20 @@ struct AboutPaneView: View {
                 .tint(.blue)
             }
         } label: {
-            Text(
-                "Cotabby is free and open source, maintained by two university students in our free time. "
-                + "If it's useful to you, please consider supporting development."
-            )
+            VStack(alignment: .leading, spacing: 8) {
+                Text(
+                    "Cotabby started from a simple belief: AI should run on your device, respect your privacy, "
+                    + "and remain open to everyone. That's why Cotabby is open source, local-first, and built "
+                    + "to give users full control over their own hardware and data."
+                )
+
+                Text(
+                    "We're building Cotabby in our spare time, one release at a time. Every feature, bug fix, "
+                    + "and support reply takes real time and care from two university students trying to keep "
+                    + "this project alive. If Cotabby has been useful to you, please consider supporting our "
+                    + "mission."
+                )
+            }
             .foregroundStyle(.secondary)
             .fixedSize(horizontal: false, vertical: true)
         }


### PR DESCRIPTION
## Summary

#411 expanded the support copy in About from one paragraph to two, but it edited `Cotabby/UI/SettingsView.swift`, which is the **legacy** settings root. The pane the redesigned Settings window actually shows is `Cotabby/UI/Settings/Panes/AboutPaneView.swift` (see its own file header: \"Consolidates what used to live across three legacy sections...\"). The redesign is gated by `isRedesignEnabled` in `SettingsCoordinator` and is on for users, so #411's copy never reached the UI.

This ports the same two-paragraph mission + ask into `AboutPaneView.supportRow`.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

swiftlint lint --quiet
# 0 issues
```

Visual check deferred to a screenshot on the running app; the diff is a 1-to-1 copy port from the legacy view's expanded label into a `VStack(alignment: .leading, spacing: 8)` inside the existing `LabeledContent` label, matching how the legacy view did it.

## Linked issues

Refs #411.

## Risk / rollout notes

- Copy-only change inside one `@ViewBuilder`. No control flow, no state, no new dependencies.
- Legacy `SettingsView.swift` is left untouched. It is still wired behind `isRedesignEnabled` in `SettingsCoordinator`, so deleting it is a separate decision.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ports the expanded two-paragraph support copy (introduced in #411) from the legacy `SettingsView.swift` into the redesigned `AboutPaneView.swift`, which is the pane that actually renders for users when `isRedesignEnabled` is true.

- Replaces the original single-paragraph label in `supportRow` with a `VStack(alignment: .leading, spacing: 8)` containing two `Text` views, matching the structure added to `SettingsView.swift` in #411 character-for-character.
- No logic, state, or dependency changes — copy-only edit inside a single `@ViewBuilder` property.

<h3>Confidence Score: 5/5</h3>

Safe to merge — copy-only change with no logic, state, or dependency impact.

The change is a character-for-character port of two Text strings and their VStack container from the legacy SettingsView.swift into AboutPaneView.swift. There is nothing to break: no control flow, no state mutations, no new imports, and the modifier chain is identical to the source. The legacy view is left untouched, so neither code path regresses.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/Settings/Panes/AboutPaneView.swift | Single-paragraph label in `supportRow` replaced with a two-paragraph `VStack`; copy and modifiers are a 1-to-1 match of the legacy view. No logic changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SettingsCoordinator] -->|isRedesignEnabled = true| B[AboutPaneView]
    A -->|isRedesignEnabled = false| C[SettingsView - legacy]
    B --> D[supportRow]
    D --> E["VStack(alignment: .leading, spacing: 8)"]
    E --> F["Text: mission statement (paragraph 1)"]
    E --> G["Text: support ask (paragraph 2)"]
    D --> H["Link → ko-fi.com/cotabby"]
    C --> I["supportSection (unchanged)"]
    I --> J["Same two-paragraph copy (source of truth for #411)"]
```

<sub>Reviews (1): Last reviewed commit: ["Port expanded About support copy to rede..."](https://github.com/fujacob/cotabby/commit/e5ae0a7b88372b2b0c7e3b3432fbaa466e8a16e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34746669)</sub>

<!-- /greptile_comment -->