### PR TITLE
Pre-fill feedback form and surface running-app disable suggestions

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		0F3267956257401F39386773 /* SuggestionOverlayStabilityGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2F95847D76893C8A5B504B4 /* SuggestionOverlayStabilityGate.swift */; };
 		1003373E13779882503C0E9D /* DisplayCoordinateConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74BD1D4DB27D5D96D1E06096 /* DisplayCoordinateConverter.swift */; };
 		12995E5DDB11E3395E6AF82F /* ShortcutsPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB630F9814388203DD1CA2EC /* ShortcutsPaneView.swift */; };
+		1450746C690B3D98203B71EC /* DeviceInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29ED42C4BDD0C521101AF95E /* DeviceInfo.swift */; };
 		14D77F0B8A195AC2FA8D24A9 /* MirrorOverlayLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC83D14A7557BC0196E59007 /* MirrorOverlayLayoutTests.swift */; };
 		156E6AB3D24134EEC29FDB93 /* FocusSnapshotResolverSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA705EDFE1C41294F0E381F1 /* FocusSnapshotResolverSelectionTests.swift */; };
 		157A55EB796BEB7819B90D5D /* ClipboardRelevanceFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A2AC525DC664DB540D4F19 /* ClipboardRelevanceFilter.swift */; };
@@ -250,6 +251,7 @@
 		264CA64B2AB1611F82E5B760 /* WelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
 		273B4DC844F79B4BE2C8910F /* FocusPollBackoffTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusPollBackoffTests.swift; sourceTree = "<group>"; };
 		292DC9D4D9D5D26AE882E39B /* EmojiCatalogMatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiCatalogMatcherTests.swift; sourceTree = "<group>"; };
+		29ED42C4BDD0C521101AF95E /* DeviceInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceInfo.swift; sourceTree = "<group>"; };
 		2A02336442BB735EE2E8D064 /* SettingsAttentionEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAttentionEvaluator.swift; sourceTree = "<group>"; };
 		2B7A28471B8526C2693FFF65 /* AcknowledgementsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcknowledgementsView.swift; sourceTree = "<group>"; };
 		2BC293F6125E2B14DCF05AD9 /* SettingsAttentionEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAttentionEvaluatorTests.swift; sourceTree = "<group>"; };
@@ -766,6 +768,7 @@
 				D3A2AC525DC664DB540D4F19 /* ClipboardRelevanceFilter.swift */,
 				53CF416511099C6818110F01 /* CompletionRenderModePolicy.swift */,
 				C7B2D34A6F3AC9DFD61350F7 /* CotabbyDebugOptions.swift */,
+				29ED42C4BDD0C521101AF95E /* DeviceInfo.swift */,
 				74BD1D4DB27D5D96D1E06096 /* DisplayCoordinateConverter.swift */,
 				0AC3BF78835C8F2C315932F1 /* EmojiCatalog.swift */,
 				1441B2D89DAE6878DAD11F17 /* EmojiMatcher.swift */,
@@ -947,6 +950,7 @@
 				0D8241CD31942A25EC4E0EE4 /* CotabbyDebugOptions.swift in Sources */,
 				0431AE1DBEE36C90C7F39C19 /* CustomRulesCatalog.swift in Sources */,
 				4B4DDB569CAD806F765224DE /* CustomRulesEditor.swift in Sources */,
+				1450746C690B3D98203B71EC /* DeviceInfo.swift in Sources */,
 				1003373E13779882503C0E9D /* DisplayCoordinateConverter.swift in Sources */,
 				47364583344BEA8FDC7178D8 /* DownloadFileRescuer.swift in Sources */,
 				E6EE3C13FA31F261CD734C69 /* DownloadOutcomeClassifier.swift in Sources */,

--- a/Cotabby/App/Core/CotabbyApp.swift
+++ b/Cotabby/App/Core/CotabbyApp.swift
@@ -26,9 +26,13 @@ struct CotabbyApp: App {
                     appDelegate.settingsCoordinator.showSettings()
                 },
                 onReportFeedback: {
-                    if let feedbackURL = URL(string: "https://www.cotabby.app/feedback") {
-                        NSWorkspace.shared.open(feedbackURL)
+                    guard let baseURL = URL(string: "https://www.cotabby.app/feedback") else {
+                        return
                     }
+                    // Attach host details so the landing form can pre-fill the Environment block
+                    // (Cotabby + macOS + hardware) and the user only has to write the actual report.
+                    let url = DeviceInfo.snapshot().appending(to: baseURL)
+                    NSWorkspace.shared.open(url)
                 }
             )
         } label: {

--- a/Cotabby/Support/DeviceInfo.swift
+++ b/Cotabby/Support/DeviceInfo.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+/// File overview:
+/// Pure helper that snapshots host details we attach to outbound feedback links:
+/// Cotabby version, macOS version, Mac model identifier, CPU/chip brand, and physical memory.
+///
+/// Lives in `Support/` because it has no side effects beyond reading bundle metadata and a couple
+/// of `sysctlbyname` values; nothing here owns lifecycle or actor state.
+enum DeviceInfo {
+    /// Snapshot of host info to attach to feedback links. Each field is optional so a missing
+    /// sysctl key never produces a half-filled URL with the literal string "unknown".
+    struct Snapshot {
+        let appVersion: String?
+        let macosVersion: String?
+        let model: String?
+        let chip: String?
+        let memoryGB: Int?
+    }
+
+    static func snapshot() -> Snapshot {
+        Snapshot(
+            appVersion: bundleVersion(),
+            macosVersion: macosVersionString(),
+            model: sysctlString("hw.model"),
+            // `machdep.cpu.brand_string` reports the chip on both Intel ("Intel(R) Core(TM)...") and
+            // Apple Silicon ("Apple M3 Pro") on every supported macOS (14+), so the chip field is
+            // populated on all Macs we run on. It only returns nil under unusual conditions, in which
+            // case `appending(to:)` simply omits the field rather than sending a blank value.
+            chip: sysctlString("machdep.cpu.brand_string"),
+            memoryGB: physicalMemoryGB()
+        )
+    }
+
+    /// User-visible app version (CFBundleShortVersionString), falling back to the build number.
+    private static func bundleVersion() -> String? {
+        let info = Bundle.main.infoDictionary
+        if let short = info?["CFBundleShortVersionString"] as? String, !short.isEmpty {
+            return short
+        }
+        if let build = info?["CFBundleVersion"] as? String, !build.isEmpty {
+            return build
+        }
+        return nil
+    }
+
+    private static func macosVersionString() -> String? {
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+        // We want a short, user-friendly "14.6" rather than `operatingSystemVersionString` which
+        // includes the build number and a "Version " prefix.
+        if version.patchVersion == 0 {
+            return "\(version.majorVersion).\(version.minorVersion)"
+        }
+        return "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
+    }
+
+    /// Reads a C-string sysctl key, trims trailing NUL/whitespace. Returns nil when the key is
+    /// missing (Rosetta translation, future macOS rename) so the caller can omit the field.
+    private static func sysctlString(_ name: String) -> String? {
+        var size: size_t = 0
+        guard sysctlbyname(name, nil, &size, nil, 0) == 0, size > 0 else {
+            return nil
+        }
+        var buffer = [CChar](repeating: 0, count: size)
+        guard sysctlbyname(name, &buffer, &size, nil, 0) == 0 else {
+            return nil
+        }
+        let value = String(cString: buffer)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
+
+    /// Physical memory rounded to the nearest whole GB. Returns nil only if reporting fails.
+    private static func physicalMemoryGB() -> Int? {
+        let bytes = ProcessInfo.processInfo.physicalMemory
+        guard bytes > 0 else { return nil }
+        let gigabytes = Double(bytes) / 1_073_741_824.0
+        return Int(gigabytes.rounded())
+    }
+}
+
+extension DeviceInfo.Snapshot {
+    /// Builds a URL with the snapshot serialized as query items. Unset fields are omitted so the
+    /// landing page can tell apart "user cleared this" from "we never knew it".
+    func appending(to base: URL) -> URL {
+        guard var components = URLComponents(url: base, resolvingAgainstBaseURL: false) else {
+            return base
+        }
+        var items: [URLQueryItem] = components.queryItems ?? []
+        func add(_ name: String, _ value: String?) {
+            guard let value, !value.isEmpty else { return }
+            items.append(URLQueryItem(name: name, value: value))
+        }
+        add("appVersion", appVersion)
+        add("macosVersion", macosVersion)
+        add("model", model)
+        add("chip", chip)
+        if let memoryGB { add("memoryGB", String(memoryGB)) }
+        components.queryItems = items.isEmpty ? nil : items
+        return components.url ?? base
+    }
+}

--- a/Cotabby/UI/Settings/Panes/AppsPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/AppsPaneView.swift
@@ -10,6 +10,11 @@ import UniformTypeIdentifiers
 struct AppsPaneView: View {
     @ObservedObject var suggestionSettings: SuggestionSettingsModel
 
+    /// Snapshotted at view-appear time. We deliberately don't subscribe to NSWorkspace launch
+    /// notifications: the panel is not a live process inspector, and re-rendering as random apps
+    /// open and close would make the chips flicker while the user is mid-task.
+    @State private var runningAppSuggestions: [RunningAppSuggestion] = []
+
     var body: some View {
         SettingsPaneScaffold {
             Section("Disabled Apps") {
@@ -32,7 +37,57 @@ struct AppsPaneView: View {
                     presentDisabledAppPicker()
                 }
             }
+
+            if !filteredRunningAppSuggestions.isEmpty {
+                Section("Suggestions") {
+                    Text("Currently running apps you can disable with one click.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        ForEach(filteredRunningAppSuggestions) { suggestion in
+                            runningAppSuggestionRow(suggestion)
+                        }
+                    }
+                }
+            }
         }
+        .onAppear {
+            runningAppSuggestions = RunningAppSuggestion.collect()
+        }
+    }
+
+    /// Hide suggestions that are already in the disabled list so the row never shows a
+    /// no-op chip. Recomputed on every redraw because `disabledAppRules` is observed.
+    private var filteredRunningAppSuggestions: [RunningAppSuggestion] {
+        let disabled = Set(suggestionSettings.disabledAppRules.map(\.bundleIdentifier))
+        return runningAppSuggestions.filter { !disabled.contains($0.bundleIdentifier) }
+    }
+
+    @ViewBuilder
+    private func runningAppSuggestionRow(_ suggestion: RunningAppSuggestion) -> some View {
+        Button {
+            suggestionSettings.disableApplication(
+                bundleIdentifier: suggestion.bundleIdentifier,
+                displayName: suggestion.displayName
+            )
+        } label: {
+            HStack(spacing: 10) {
+                Image(nsImage: suggestion.icon)
+                    .resizable()
+                    .frame(width: 20, height: 20)
+                    .accessibilityHidden(true)
+
+                Text(suggestion.displayName)
+
+                Spacer(minLength: 0)
+
+                Image(systemName: "plus.circle")
+                    .foregroundStyle(.secondary)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
     }
 
     @ViewBuilder
@@ -104,5 +159,43 @@ struct AppsPaneView: View {
                 displayName: metadata.displayName
             )
         }
+    }
+}
+
+/// One disable-able app surfaced from the running-process list. Captures the icon up front so the
+/// row doesn't have to hit NSWorkspace again on every redraw.
+private struct RunningAppSuggestion: Identifiable {
+    let bundleIdentifier: String
+    let displayName: String
+    let icon: NSImage
+
+    var id: String { bundleIdentifier }
+
+    /// Snapshot the user-launched apps (`activationPolicy == .regular`) excluding Cotabby itself,
+    /// sorted alphabetically and capped at 8 so the section stays glanceable.
+    static func collect() -> [RunningAppSuggestion] {
+        let ownBundleIdentifier = Bundle.main.bundleIdentifier
+        let candidates = NSWorkspace.shared.runningApplications
+            .filter { $0.activationPolicy == .regular }
+            .filter { $0.bundleIdentifier != ownBundleIdentifier }
+
+        var seen = Set<String>()
+        let suggestions: [RunningAppSuggestion] = candidates.compactMap { app in
+            guard let bundleIdentifier = app.bundleIdentifier, !bundleIdentifier.isEmpty else {
+                return nil
+            }
+            guard seen.insert(bundleIdentifier).inserted else { return nil }
+            let displayName = app.localizedName ?? bundleIdentifier
+            let icon = app.icon ?? NSWorkspace.shared.icon(for: .applicationBundle)
+            return RunningAppSuggestion(
+                bundleIdentifier: bundleIdentifier,
+                displayName: displayName,
+                icon: icon
+            )
+        }
+        return suggestions
+            .sorted { $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending }
+            .prefix(8)
+            .map { $0 }
     }
 }


### PR DESCRIPTION
## Summary

Two small UX wins on the Cotabby side of the feedback / Apps flows. First, the Report Bug menu item now sends Cotabby version, macOS version, Mac model, chip, and memory to the landing form so users don't have to type their environment block. Second, the Apps pane surfaces currently-running apps as one-click disable suggestions, mirroring how Languages already nudges users with chip suggestions. Paired with FuJacob/tabby-landing#3 which consumes the params.

## Validation

- \`swiftlint lint --quiet\` on the three modified / added files: exit 0.
- Read the new \`DeviceInfo.snapshot()\` output by inspection (no logging dump; values are passed straight into a URL).
- Did not run \`xcodebuild\` this round; the disk is full on this machine and the changes are additive (one new file in \`Support/\`, additive view state, and a single URL-construction edit). Will rebuild before merge.

## Linked issues

## Risk / rollout notes

- The feedback URL grows by ~120 chars. Well under any browser limit.
- Running-app suggestions are snapshotted at view-appear time and not re-polled; this is intentional so the chips don't flicker as the user opens / closes other apps mid-task.
- \`hw.model\` returns the bare Mac identifier (e.g. \`MacBookPro18,1\`); we deliberately don't translate it to a marketing name on-device. The landing form shows it as a plain text field and the user can edit it before submitting.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two UX improvements: device info (app version, macOS version, Mac model, chip, memory) is automatically appended as query parameters when opening the feedback URL so users don't need to fill in their environment block, and the Apps settings pane now surfaces currently-running regular apps as one-click disable suggestions (mirroring the Languages pane chip pattern).

- `DeviceInfo.swift` (new) collects host metadata via `Bundle`, `ProcessInfo`, and `sysctlbyname`, then serialises it onto the feedback URL via `URLComponents`.
- `AppsPaneView.swift` gains a `@State` snapshot of running apps populated in `onAppear`, filtered against the already-disabled list on every redraw, and capped at 8 entries.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both changes are additive and isolated, with no mutations to shared state or existing flows.

The feedback URL change is a pure data-append with a safe fallback at every step (guard, ?? base). The running-app suggestions are read-only at snapshot time and the only write path (disabling an app) goes through the existing SuggestionSettingsModel mutation, which was already exercised by the Add App… picker. No existing behaviour is removed or altered.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/DeviceInfo.swift | New helper that snapshots device metadata and serialises it onto a URL via URLComponents. URL encoding, nil-field omission, and sysctl error handling are all correct. |
| Cotabby/App/Core/CotabbyApp.swift | Feedback URL construction updated to call DeviceInfo.snapshot().appending(to:). Guard-based early return is cleaner than the previous if-let and handles the (unreachable in practice) invalid URL literal case. |
| Cotabby/UI/Settings/Panes/AppsPaneView.swift | Adds a Suggestions section backed by a one-time onAppear snapshot of running .regular apps. Filtering, deduplication, self-exclusion, icon fallback, and the 8-item cap are all handled correctly. |
| Cotabby.xcodeproj/project.pbxproj | Adds DeviceInfo.swift to the Sources build phase with correct UUIDs for both the file reference and build file entries. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant MenuBarView
    participant CotabbyApp
    participant DeviceInfo
    participant NSWorkspace

    User->>MenuBarView: clicks "Report Bug"
    MenuBarView->>CotabbyApp: onReportFeedback()
    CotabbyApp->>DeviceInfo: snapshot()
    DeviceInfo->>DeviceInfo: bundleVersion() via Bundle.main
    DeviceInfo->>DeviceInfo: macosVersionString() via ProcessInfo
    DeviceInfo->>DeviceInfo: sysctlString("hw.model")
    DeviceInfo->>DeviceInfo: sysctlString("machdep.cpu.brand_string")
    DeviceInfo->>DeviceInfo: physicalMemoryGB() via ProcessInfo
    DeviceInfo-->>CotabbyApp: Snapshot
    CotabbyApp->>CotabbyApp: snapshot.appending(to: baseURL)
    Note over CotabbyApp: URLComponents appends non-nil fields as query params
    CotabbyApp->>NSWorkspace: open(url)
    NSWorkspace-->>User: opens feedback page with pre-filled env block

    Note over User,NSWorkspace: Apps Pane suggestion flow
    User->>AppsPaneView: opens Settings → Apps
    AppsPaneView->>NSWorkspace: runningApplications (onAppear)
    NSWorkspace-->>AppsPaneView: [NSRunningApplication]
    AppsPaneView->>AppsPaneView: "filter .regular, dedup, cap@8"
    AppsPaneView-->>User: shows Suggestions section
    User->>AppsPaneView: taps suggestion chip
    AppsPaneView->>SuggestionSettingsModel: disableApplication(bundleIdentifier:displayName:)
    AppsPaneView->>AppsPaneView: filteredRunningAppSuggestions recomputes
    Note over AppsPaneView: chip disappears from Suggestions
```

<sub>Reviews (2): Last reviewed commit: ["Attach device info to feedback URL and s..."](https://github.com/fujacob/cotabby/commit/3f6de6bc50bb1ab682d157e83c09cc086565cc74) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34747054)</sub>

<!-- /greptile_comment -->