### PR TITLE
Tighten About pane copy and rename Links to Resources

### DIFF
--- a/Cotabby/UI/Settings/Panes/AboutPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/AboutPaneView.swift
@@ -14,7 +14,7 @@ struct AboutPaneView: View {
         SettingsPaneScaffold {
             Section { aboutHeader }
             Section("Support") { supportRow }
-            Section("Links") { linksRow }
+            Section("Resources") { linksRow }
             Section("Uninstall") { uninstallText }
         }
         .sheet(isPresented: $isShowingAcknowledgements) {
@@ -58,7 +58,7 @@ struct AboutPaneView: View {
         LabeledContent {
             if let supportURL = URL(string: "https://ko-fi.com/cotabby") {
                 Link(destination: supportURL) {
-                    Label("Support", systemImage: "heart.fill")
+                    Label("Support Cotabby", systemImage: "heart.fill")
                 }
                 .buttonStyle(.borderedProminent)
                 .tint(.blue)
@@ -66,16 +66,13 @@ struct AboutPaneView: View {
         } label: {
             VStack(alignment: .leading, spacing: 8) {
                 Text(
-                    "Cotabby started from a simple belief: AI should run on your device, respect your privacy, "
-                    + "and remain open to everyone. That's why Cotabby is open source, local-first, and built "
-                    + "to give users full control over their own hardware and data."
+                    "Cotabby started from a simple belief: AI should run on your device, "
+                    + "respect your privacy, and remain open to everyone."
                 )
 
                 Text(
-                    "We're building Cotabby in our spare time, one release at a time. Every feature, bug fix, "
-                    + "and support reply takes real time and care from two university students trying to keep "
-                    + "this project alive. If Cotabby has been useful to you, please consider supporting our "
-                    + "mission."
+                    "We're building Cotabby in our spare time, one release at a time. "
+                    + "If Cotabby has helped you, your support helps us keep improving it."
                 )
             }
             .foregroundStyle(.secondary)
@@ -108,9 +105,8 @@ struct AboutPaneView: View {
     @ViewBuilder
     private var uninstallText: some View {
         Text(
-            "Drag Cotabby.app from Applications to the Trash. "
-            + "To remove leftover data, also delete ~/Library/Application Support/Cotabby. "
-            + "Privacy permissions can only be revoked in System Settings → Privacy & Security."
+            "Remove Cotabby from Applications. To fully clean up app data, "
+            + "delete ~/Library/Application Support/Cotabby."
         )
         .font(.caption)
         .foregroundStyle(.secondary)


### PR DESCRIPTION
## Summary

Trim the Support section copy in the About pane to two short sentences, relabel the Support button to "Support Cotabby" (heart icon already present), rename the "Links" section to "Resources", and shorten the Uninstall text. Brings the pane in line with the latest design mockup.

## Validation

- swiftlint lint --quiet (exit 0)
- xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build (** BUILD SUCCEEDED **)

## Linked issues

None.

## Risk / rollout notes

Copy and label changes only; no behavior change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens the copy in the About pane: the Support section blurb is condensed to two shorter sentences, the \"Links\" section is relabeled \"Resources\", the support button gains the \"Cotabby\" suffix, and the uninstall instructions are shortened. No logic or behavior changes are introduced.

- The `linksRow` view builder retains its old name despite the section being renamed \"Resources\", creating a minor naming inconsistency.
- The revised uninstall text drops the original note about manually revoking privacy permissions in System Settings, which is non-obvious macOS behavior that users attempting a full uninstall would benefit from knowing.

<h3>Confidence Score: 4/5</h3>

Safe to merge — all changes are pure UI copy with no logic, data, or behavior impact.

The change is entirely copy and label edits in a single SwiftUI view. The only notable omission is the removal of the macOS privacy-permissions reminder from the uninstall instructions, which could leave users unaware that grants like Accessibility or Input Monitoring persist after the app is deleted. The `linksRow` naming mismatch after the "Resources" rename is a minor readability concern for future contributors.

Cotabby/UI/Settings/Panes/AboutPaneView.swift — specifically the uninstall text block and the `linksRow` naming.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/Settings/Panes/AboutPaneView.swift | Copy-only changes: trims support section text, renames "Links" section to "Resources", relabels support button, and shortens uninstall instructions — the private view builder `linksRow` retains its old name after the section rename, and the uninstall text drops a user-facing note about manually revoking privacy permissions in System Settings. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[AboutPaneView] --> B[Section: About Header]
    A --> C[Section: Support]
    A --> D["Section: Resources (was: Links)"]
    A --> E[Section: Uninstall]

    C --> C1["Label: trimmed 2-sentence copy"]
    C --> C2["Button: 'Support Cotabby' ❤️ (was: 'Support')"]

    D --> D1[GitHub Repository link]
    D --> D2[Wiki & Contributor Guide link]
    D --> D3[Acknowledgements button]

    E --> E1["'Remove Cotabby from Applications…' (shortened)"]
    E --> E2["⚠️ Privacy permissions note removed"]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22about-redesign%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22about-redesign%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FSettings%2FPanes%2FAboutPaneView.swift%3A17%0AThe%20section%20label%20was%20renamed%20to%20%22Resources%22%20but%20the%20private%20view%20builder%20is%20still%20called%20%60linksRow%60.%20This%20is%20a%20minor%20naming%20inconsistency%20that%20could%20cause%20confusion%20for%20future%20contributors.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20Section%28%22Resources%22%29%20%7B%20resourcesRow%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FUI%2FSettings%2FPanes%2FAboutPaneView.swift%3A107-110%0A**Dropped%20macOS%20privacy-permissions%20guidance**%0A%0AThe%20original%20text%20included%20%22Privacy%20permissions%20can%20only%20be%20revoked%20in%20System%20Settings%20%E2%86%92%20Privacy%20%26%20Security.%22%20On%20macOS%2C%20dragging%20an%20app%20to%20the%20Trash%20does%20**not**%20automatically%20revoke%20permissions%20like%20Accessibility%2C%20Input%20Monitoring%2C%20or%20Full%20Disk%20Access.%20Without%20this%20note%2C%20users%20who%20want%20a%20clean%20uninstall%20won't%20know%20those%20grants%20persist%20until%20they%20find%20them%20manually.%20Consider%20keeping%20at%20least%20a%20short%20mention%2C%20e.g.%20%22Privacy%20permissions%20granted%20in%20System%20Settings%20are%20not%20removed%20automatically.%22%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FSettings%2FPanes%2FAboutPaneView.swift%3A17%0AThe%20section%20label%20was%20renamed%20to%20%22Resources%22%20but%20the%20private%20view%20builder%20is%20still%20called%20%60linksRow%60.%20This%20is%20a%20minor%20naming%20inconsistency%20that%20could%20cause%20confusion%20for%20future%20contributors.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20Section%28%22Resources%22%29%20%7B%20resourcesRow%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FUI%2FSettings%2FPanes%2FAboutPaneView.swift%3A107-110%0A**Dropped%20macOS%20privacy-permissions%20guidance**%0A%0AThe%20original%20text%20included%20%22Privacy%20permissions%20can%20only%20be%20revoked%20in%20System%20Settings%20%E2%86%92%20Privacy%20%26%20Security.%22%20On%20macOS%2C%20dragging%20an%20app%20to%20the%20Trash%20does%20**not**%20automatically%20revoke%20permissions%20like%20Accessibility%2C%20Input%20Monitoring%2C%20or%20Full%20Disk%20Access.%20Without%20this%20note%2C%20users%20who%20want%20a%20clean%20uninstall%20won't%20know%20those%20grants%20persist%20until%20they%20find%20them%20manually.%20Consider%20keeping%20at%20least%20a%20short%20mention%2C%20e.g.%20%22Privacy%20permissions%20granted%20in%20System%20Settings%20are%20not%20removed%20automatically.%22%0A%0A&repo=fujacob%2Fcotabby&pr=426&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Tighten About pane copy and rename Links..."](https://github.com/fujacob/cotabby/commit/dfbb772133f12540e730f668b631f0dcb528a4a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34748345)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->