### PR TITLE
Stack About > Support button below the copy

### DIFF
--- a/Cotabby/UI/Settings/Panes/AboutPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/AboutPaneView.swift
@@ -55,15 +55,11 @@ struct AboutPaneView: View {
 
     @ViewBuilder
     private var supportRow: some View {
-        LabeledContent {
-            if let supportURL = URL(string: "https://ko-fi.com/cotabby") {
-                Link(destination: supportURL) {
-                    Label("Support Cotabby", systemImage: "heart.fill")
-                }
-                .buttonStyle(.borderedProminent)
-                .tint(.blue)
-            }
-        } label: {
+        // Stack the support copy and the call-to-action vertically so the button sits below the
+        // paragraphs instead of competing with them on the right edge of the row. `LabeledContent`
+        // placed the value column next to the label, which made the wall of text visually compete
+        // with a small button — the natural reading order is paragraphs first, then action.
+        VStack(alignment: .leading, spacing: 12) {
             VStack(alignment: .leading, spacing: 8) {
                 Text(
                     "Cotabby started from a simple belief: AI should run on your device, "
@@ -77,6 +73,14 @@ struct AboutPaneView: View {
             }
             .foregroundStyle(.secondary)
             .fixedSize(horizontal: false, vertical: true)
+
+            if let supportURL = URL(string: "https://ko-fi.com/cotabby") {
+                Link(destination: supportURL) {
+                    Label("Support Cotabby", systemImage: "heart.fill")
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.blue)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

The Ko-fi button on the About pane's Support section sat in `LabeledContent`'s value column, placing it to the right of a two-paragraph mission statement. The wall of text visually competed with a small action and read awkwardly. Move the section to a plain `VStack` so the copy reads top-down and the call-to-action lands underneath it.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby \
  -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **
```

Visual layout change only; verified locally by reading the diff against the screenshot the user attached.

## Linked issues

None.

## Risk / rollout notes

Layout only; no behavior change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Restructures the Support section of the About pane by replacing `LabeledContent` with a `VStack`, so the Ko-fi button renders below the two-paragraph mission statement rather than alongside it in the value column. No logic or behavioral changes are introduced.

- Removes `LabeledContent` wrapper in `supportRow` and replaces it with `VStack(alignment: .leading, spacing: 12)`, grouping the text copy and the `Link` button vertically.
- The URL guard (`if let supportURL = URL(string:)`) and button styling are preserved unchanged from the original implementation.

<h3>Confidence Score: 5/5</h3>

Layout-only change with no behavioral, logic, or data-handling modifications — safe to merge.

The diff moves a single SwiftUI button from the value column of a LabeledContent into a VStack below the text copy. All URL construction, button styling, and section structure are preserved intact. There is nothing here that could affect runtime behavior.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/Settings/Panes/AboutPaneView.swift | Replaced LabeledContent with a VStack in supportRow, moving the Ko-fi button below the mission-statement copy instead of beside it. Pure layout refactor — no logic, data, or behavior changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Before["Before (LabeledContent)"]
        LC[LabeledContent]
        LC -->|label column| TXT["VStack — mission text\n(two paragraphs)"]
        LC -->|value column| BTN["Link — Support Cotabby\n(borderedProminent button)"]
    end

    subgraph After["After (VStack)"]
        VS[VStack spacing=12]
        VS --> TXT2["VStack spacing=8 — mission text\n(two paragraphs)"]
        VS --> BTN2["Link — Support Cotabby\n(borderedProminent button)"]
    end

    Before -.->|"layout refactor"| After
```

<sub>Reviews (1): Last reviewed commit: ["Stack About &gt; Support button below the c..."](https://github.com/fujacob/cotabby/commit/ed88c5875ef7034dd7d0976b67222d55ae3d1dc4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34748593)</sub>

<!-- /greptile_comment -->