### PR TITLE
Fix :emoji: commit: reliable deferred insert, commit only on the accept-word key

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		0A3443AEE6540F11E5E6BF8F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E8E86A14090BC7BD13BA76 /* AppDelegate.swift */; };
 		0A658BF137DBD0898E40B87F /* AcknowledgementsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7A28471B8526C2693FFF65 /* AcknowledgementsView.swift */; };
 		0AF568AB234033BA2DE4CAA7 /* SuggestionModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 386C98FFCF76EC1C8C7E82BB /* SuggestionModels.swift */; };
+		0B6E28D1CBDF657F71548A3C /* EmojiPickerControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62BD2ADED33249F5BA53D0AD /* EmojiPickerControllerTests.swift */; };
 		0C06CAD62975E87B2C852191 /* ScreenTextExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59E299BE2E9D42A33D5D2F5D /* ScreenTextExtractor.swift */; };
 		0C98ECB5BCEBA72C693AC1C9 /* SuggestionTextNormalizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B55A4362AB7F0528C661C4C /* SuggestionTextNormalizerTests.swift */; };
 		0D15CBF45EB1DB725B9F1A6A /* EmojiQueryRunTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75396860978E81EFAA506CD4 /* EmojiQueryRunTests.swift */; };
@@ -294,6 +295,7 @@
 		5F2C764D29C8D50D0C854FF8 /* PermissionGuidanceController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionGuidanceController.swift; sourceTree = "<group>"; };
 		5F34AE24BB7C99D66E1F3904 /* InputModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputModels.swift; sourceTree = "<group>"; };
 		60629DFE309C1A4BD8A7FB3B /* RuntimeBootstrapModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimeBootstrapModel.swift; sourceTree = "<group>"; };
+		62BD2ADED33249F5BA53D0AD /* EmojiPickerControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiPickerControllerTests.swift; sourceTree = "<group>"; };
 		62EDF1199CC5E18BD7651661 /* EmojiPickerPanelLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiPickerPanelLayout.swift; sourceTree = "<group>"; };
 		656F58E56FE9BC087B6F1D33 /* PermissionReminderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionReminderView.swift; sourceTree = "<group>"; };
 		67586807ACE8EB13C9014535 /* TickMarkSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TickMarkSlider.swift; sourceTree = "<group>"; };
@@ -639,6 +641,7 @@
 				D2F46767D9D1F0D44E239CA8 /* DownloadFileRescuerTests.swift */,
 				E217A66717D78E1E49350EC8 /* DownloadOutcomeClassifierTests.swift */,
 				292DC9D4D9D5D26AE882E39B /* EmojiCatalogMatcherTests.swift */,
+				62BD2ADED33249F5BA53D0AD /* EmojiPickerControllerTests.swift */,
 				B7B185BA246A526CBA85E581 /* EmojiPickerPanelLayoutTests.swift */,
 				75396860978E81EFAA506CD4 /* EmojiQueryRunTests.swift */,
 				723E1EFA85D2E61B6C5F33E8 /* EmojiTriggerStateMachineTests.swift */,
@@ -1095,6 +1098,7 @@
 				E994FE418A961FB234D9057A /* DownloadFileRescuerTests.swift in Sources */,
 				FAC7FFC78BEBF62D5B7A2EFB /* DownloadOutcomeClassifierTests.swift in Sources */,
 				96498E097A5899AFC9F0C853 /* EmojiCatalogMatcherTests.swift in Sources */,
+				0B6E28D1CBDF657F71548A3C /* EmojiPickerControllerTests.swift in Sources */,
 				D46A0DB70B07F487431F48F6 /* EmojiPickerPanelLayoutTests.swift in Sources */,
 				0D15CBF45EB1DB725B9F1A6A /* EmojiQueryRunTests.swift in Sources */,
 				ED0843752B297D7E9DB2C468 /* EmojiTriggerStateMachineTests.swift in Sources */,

--- a/Cotabby/App/Coordinators/EmojiPickerController.swift
+++ b/Cotabby/App/Coordinators/EmojiPickerController.swift
@@ -131,11 +131,19 @@ final class EmojiPickerController {
             return .dismissExternally
         }
 
+        // Commit only on the user's configured word-accept binding (keyCode + modifiers), matched the
+        // same way the suggestion accept path matches it, so the picker stays consistent with
+        // accepting a word. Checked before the keyCode switch so a rebind wins (Tab by default), and
+        // so Return is no longer a commit key.
+        if inputMonitor.isWordAcceptKey(InputMonitorKeyEvent(keyCode: event.keyCode, flags: event.flags)) {
+            return .commitKey
+        }
+
         switch event.keyCode {
         case 53:
             return .escape
-        case 36, 76, 48:                  // Return, Keypad Enter, Tab
-            return .commitKey
+        case 36, 76:                      // Return, Keypad Enter: dismiss and pass through, never commit
+            return .dismissExternally
         case 126:
             return .navigate(.up)
         case 125:
@@ -226,9 +234,8 @@ final class EmojiPickerController {
         }
         let glyph = matches[selectedIndex].glyph
         let fallback = currentQuery.utf16.count + 1   // ":" + query
-        let focusSequence = captureFocusSequence
         teardownCapture()
-        scheduleReplaceEmojiQuery(with: glyph, fallbackUTF16: fallback, expectedFocusSequence: focusSequence)
+        scheduleReplaceEmojiQuery(with: glyph, fallbackUTF16: fallback)
     }
 
     /// Mode B: the passed-through closing `:`. The field will hold `:query:` once the colon lands, so
@@ -237,10 +244,9 @@ final class EmojiPickerController {
         let query = currentQuery
         let glyph = bestGlyphForClosingColon(query: query)
         let fallback = query.utf16.count + 2   // ":" + query + ":"
-        let focusSequence = captureFocusSequence
         teardownCapture()
         guard let glyph else { return }   // no match: leave the literal ":query:" untouched
-        scheduleReplaceEmojiQuery(with: glyph, fallbackUTF16: fallback, expectedFocusSequence: focusSequence)
+        scheduleReplaceEmojiQuery(with: glyph, fallbackUTF16: fallback)
     }
 
     private func cancelCapture() {
@@ -288,25 +294,23 @@ final class EmojiPickerController {
     /// callback (EMOJI.md §4.4, §5.5). Posting them synchronously from the observer pass was the
     /// source of the flaky "panel vanished but no emoji landed" Enter/Tab commits; deferring also
     /// lets the field settle before we measure the run to delete.
-    private func scheduleReplaceEmojiQuery(with glyph: String, fallbackUTF16: Int, expectedFocusSequence: UInt64?) {
+    private func scheduleReplaceEmojiQuery(with glyph: String, fallbackUTF16: Int) {
         DispatchQueue.main.async { [weak self] in
-            self?.replaceEmojiQuery(with: glyph, fallbackUTF16: fallbackUTF16, expectedFocusSequence: expectedFocusSequence)
+            self?.replaceEmojiQuery(with: glyph, fallbackUTF16: fallbackUTF16)
         }
     }
 
-    private func replaceEmojiQuery(with glyph: String, fallbackUTF16: Int, expectedFocusSequence: UInt64?) {
-        // Read the field fresh: this runs a tick after teardown and the focus poll may not yet reflect
-        // the user's latest query characters. Measuring a stale snapshot deletes the wrong unit count.
-        focusModel.refreshNow()
-        guard let context = focusModel.snapshot.context,
-              context.focusChangeSequence == expectedFocusSequence else {
-            // Focus moved during the deferral tick: deleting in a field we no longer own would corrupt
-            // unrelated text, so abort rather than guess at the run length.
-            return
-        }
-        let deleteCount = EmojiQueryRun.trailingRunUTF16Length(in: context.precedingText) ?? fallbackUTF16
+    private func replaceEmojiQuery(with glyph: String, fallbackUTF16: Int) {
+        // Measure the literal run from the field and replace it. `trailingRunUTF16Length` returns nil
+        // when the field no longer ends in a `:query` run, so we fall back to the known typed length;
+        // that nil-check is what keeps a stray commit from deleting unrelated text. We deliberately do
+        // NOT force a fresh AX resolve + `focusChangeSequence` guard here: the resolve re-stamped the
+        // sequence and made the guard abort legitimate commits (the panel vanished with no emoji).
+        let preceding = focusModel.snapshot.context?.precedingText ?? ""
+        let deleteCount = EmojiQueryRun.trailingRunUTF16Length(in: preceding) ?? fallbackUTF16
         _ = inserter.replace(deletingUTF16Count: deleteCount, with: glyph)
-        // Re-read so any pending suggestion uses the post-insertion text instead of the stale `:query`.
+        // Let the focus pipeline re-read the field so any pending suggestion uses the post-insertion
+        // text instead of the stale `:query` we just removed.
         focusModel.refreshNow()
     }
 

--- a/Cotabby/App/Coordinators/EmojiPickerController.swift
+++ b/Cotabby/App/Coordinators/EmojiPickerController.swift
@@ -18,7 +18,7 @@ import Foundation
 final class EmojiPickerController {
     private var machine = EmojiTriggerStateMachine()
     private let matcher: EmojiMatcher
-    private let panel: EmojiPickerPanelController
+    private let panel: any EmojiPickerPanelPresenting
     private let focusModel: any SuggestionFocusProviding
     private let inputMonitor: any EmojiInputIntercepting
     private let inserter: any EmojiTextInserting
@@ -47,7 +47,7 @@ final class EmojiPickerController {
 
     init(
         matcher: EmojiMatcher,
-        panel: EmojiPickerPanelController,
+        panel: any EmojiPickerPanelPresenting,
         focusModel: any SuggestionFocusProviding,
         inputMonitor: any EmojiInputIntercepting,
         inserter: any EmojiTextInserting,
@@ -226,8 +226,9 @@ final class EmojiPickerController {
         }
         let glyph = matches[selectedIndex].glyph
         let fallback = currentQuery.utf16.count + 1   // ":" + query
+        let focusSequence = captureFocusSequence
         teardownCapture()
-        replaceEmojiQuery(with: glyph, fallbackUTF16: fallback)
+        scheduleReplaceEmojiQuery(with: glyph, fallbackUTF16: fallback, expectedFocusSequence: focusSequence)
     }
 
     /// Mode B: the passed-through closing `:`. The field will hold `:query:` once the colon lands, so
@@ -236,11 +237,10 @@ final class EmojiPickerController {
         let query = currentQuery
         let glyph = bestGlyphForClosingColon(query: query)
         let fallback = query.utf16.count + 2   // ":" + query + ":"
+        let focusSequence = captureFocusSequence
         teardownCapture()
         guard let glyph else { return }   // no match: leave the literal ":query:" untouched
-        DispatchQueue.main.async { [weak self] in
-            self?.replaceEmojiQuery(with: glyph, fallbackUTF16: fallback)
-        }
+        scheduleReplaceEmojiQuery(with: glyph, fallbackUTF16: fallback, expectedFocusSequence: focusSequence)
     }
 
     private func cancelCapture() {
@@ -283,12 +283,30 @@ final class EmojiPickerController {
         return results.first?.glyph
     }
 
-    private func replaceEmojiQuery(with glyph: String, fallbackUTF16: Int) {
-        let preceding = focusModel.snapshot.context?.precedingText ?? ""
-        let deleteCount = EmojiQueryRun.trailingRunUTF16Length(in: preceding) ?? fallbackUTF16
+    /// Posts the delete+glyph replace on the next runloop tick. Both commit modes defer through here
+    /// so the synthetic events are never posted re-entrantly from inside the keystroke's own tap
+    /// callback (EMOJI.md §4.4, §5.5). Posting them synchronously from the observer pass was the
+    /// source of the flaky "panel vanished but no emoji landed" Enter/Tab commits; deferring also
+    /// lets the field settle before we measure the run to delete.
+    private func scheduleReplaceEmojiQuery(with glyph: String, fallbackUTF16: Int, expectedFocusSequence: UInt64?) {
+        DispatchQueue.main.async { [weak self] in
+            self?.replaceEmojiQuery(with: glyph, fallbackUTF16: fallbackUTF16, expectedFocusSequence: expectedFocusSequence)
+        }
+    }
+
+    private func replaceEmojiQuery(with glyph: String, fallbackUTF16: Int, expectedFocusSequence: UInt64?) {
+        // Read the field fresh: this runs a tick after teardown and the focus poll may not yet reflect
+        // the user's latest query characters. Measuring a stale snapshot deletes the wrong unit count.
+        focusModel.refreshNow()
+        guard let context = focusModel.snapshot.context,
+              context.focusChangeSequence == expectedFocusSequence else {
+            // Focus moved during the deferral tick: deleting in a field we no longer own would corrupt
+            // unrelated text, so abort rather than guess at the run length.
+            return
+        }
+        let deleteCount = EmojiQueryRun.trailingRunUTF16Length(in: context.precedingText) ?? fallbackUTF16
         _ = inserter.replace(deletingUTF16Count: deleteCount, with: glyph)
-        // Let the focus pipeline re-read the field immediately so any pending suggestion uses the
-        // post-insertion text instead of the stale `:query` we just removed.
+        // Re-read so any pending suggestion uses the post-insertion text instead of the stale `:query`.
         focusModel.refreshNow()
     }
 

--- a/Cotabby/Models/SuggestionSubsystemContracts.swift
+++ b/Cotabby/Models/SuggestionSubsystemContracts.swift
@@ -1,4 +1,5 @@
 import Combine
+import CoreGraphics
 import Foundation
 
 /// File overview:
@@ -114,6 +115,18 @@ protocol SuggestionInserting: AnyObject {
 @MainActor
 protocol EmojiTextInserting: AnyObject {
     func replace(deletingUTF16Count: Int, with text: String) -> Bool
+}
+
+/// The emoji picker's slice of its floating panel: present/move/hide the match list. Behind a
+/// protocol so `EmojiPickerController` can be unit-tested without constructing a real `NSPanel`.
+@MainActor
+protocol EmojiPickerPanelPresenting: AnyObject {
+    var onSelectIndex: ((Int) -> Void)? { get set }
+    var onClickOutside: (() -> Void)? { get set }
+
+    func show(query: String, matches: [EmojiMatch], selectedIndex: Int, caretRect: CGRect)
+    func setSelectedIndex(_ index: Int)
+    func hide()
 }
 
 @MainActor

--- a/Cotabby/Models/SuggestionSubsystemContracts.swift
+++ b/Cotabby/Models/SuggestionSubsystemContracts.swift
@@ -58,6 +58,10 @@ protocol EmojiInputIntercepting: AnyObject {
     /// Keeps the active tap installed for the emoji-capture reason (parallel to the suggestion
     /// overlay's `setAcceptInterceptionActive`).
     func setCaptureInterceptionActive(_ active: Bool)
+
+    /// True when the key matches the user's configured word-accept binding. The emoji picker commits
+    /// on this key so its commit stays consistent with accepting a suggestion word.
+    func isWordAcceptKey(_ keyEvent: InputMonitorKeyEvent) -> Bool
 }
 
 @MainActor

--- a/Cotabby/Services/Input/InputMonitor.swift
+++ b/Cotabby/Services/Input/InputMonitor.swift
@@ -668,6 +668,13 @@ final class InputMonitor {
         return CapturedInputEvent(kind: .other, keyCode: keyCode, characters: characters, flags: flags)
     }
 
+    /// True when the key matches the user's configured word-accept binding (keyCode + modifiers),
+    /// using the same match the suggestion accept path uses. The emoji picker commits on this key so
+    /// its commit stays consistent with accepting a suggestion word instead of hardcoding Tab/Return.
+    func isWordAcceptKey(_ keyEvent: InputMonitorKeyEvent) -> Bool {
+        acceptanceKind(for: keyEvent) == .acceptance
+    }
+
     private func acceptanceKind(for keyEvent: InputMonitorKeyEvent) -> CapturedInputEvent.Kind? {
         let eventModifiers = ShortcutModifierMask(eventFlags: keyEvent.flags)
 

--- a/Cotabby/Services/UI/EmojiPickerPanelController.swift
+++ b/Cotabby/Services/UI/EmojiPickerPanelController.swift
@@ -11,7 +11,7 @@ import SwiftUI
 /// the controller, so the picker works while the user keeps typing in another app. This controller is
 /// a thin AppKit shell: all selection and lifecycle logic lives in `EmojiPickerController`.
 @MainActor
-final class EmojiPickerPanelController {
+final class EmojiPickerPanelController: EmojiPickerPanelPresenting {
     /// Called with the row index when the user clicks a match.
     var onSelectIndex: ((Int) -> Void)?
 

--- a/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
@@ -58,7 +58,7 @@ struct GeneralPaneView: View {
                     SettingsRowLabel(
                         title: "Inline Emoji Picker",
                         description: "Type a colon and a name like :smile to pick an emoji inline, " +
-                            "then press Tab or Return to insert it."
+                            "then press your accept-word key (Tab by default) to insert it."
                     )
                 }
             }

--- a/CotabbyTests/EmojiPickerControllerTests.swift
+++ b/CotabbyTests/EmojiPickerControllerTests.swift
@@ -1,7 +1,10 @@
 import Combine
 import CoreGraphics
 import XCTest
-@testable import Cotabby
+// `@preconcurrency`: the fakes conform to `@MainActor` protocols whose closure properties (e.g.
+// `emojiCaptureKeyDecider`) are not `@Sendable`, which trips a cross-module Swift 6 sendability
+// warning on the conformance. The suppression is test-only and does not affect production code.
+@preconcurrency @testable import Cotabby
 
 /// Composition tests for the inline `:emoji:` commit path. The pure machine/matcher/run are covered
 /// elsewhere; these lock down the controller <-> focus <-> inserter seam where the commit flakiness
@@ -15,14 +18,14 @@ final class EmojiPickerControllerTests: XCTestCase {
         super.tearDown()
     }
 
-    func test_enterCommitInsertsSelectedGlyphAfterRunloopTick() {
+    func test_acceptKeyCommitInsertsSelectedGlyphAfterRunloopTick() {
         runOnMainActor {
-            let harness = Harness(precedingText: ":smile")
+            let harness = Harness(precedingText: ":smile")   // accept-word key defaults to Tab (48)
             harness.openAndType(":smile")
 
-            // Enter is handled and consumed, but the replace must be deferred, not posted
-            // synchronously from inside the keystroke's tap callback.
-            XCTAssertTrue(harness.controller.observe(Harness.keyEvent(36)))
+            // The accept-word key commits, but the replace must be deferred, not posted synchronously
+            // from inside the keystroke's tap callback.
+            XCTAssertTrue(harness.controller.observe(Harness.keyEvent(48)))
             XCTAssertTrue(
                 harness.inserter.calls.isEmpty,
                 "The replace must be deferred off the keystroke's tap callback."
@@ -36,34 +39,47 @@ final class EmojiPickerControllerTests: XCTestCase {
         }
     }
 
-    func test_commitAbortsWhenFocusChangesDuringDeferral() {
+    func test_returnDoesNotCommitAndPassesThroughEvenWithMatches() {
         runOnMainActor {
             let harness = Harness(precedingText: ":smile")
-            harness.openAndType(":smile")
-            XCTAssertTrue(harness.controller.observe(Harness.keyEvent(36)))
+            harness.openAndType(":smile")   // matches present
 
-            // The focused field changes before the deferred replace runs.
-            harness.focus.update(precedingText: "different", focusChangeSequence: 99)
+            // Return is no longer a commit key: it dismisses the picker and reaches the host.
+            XCTAssertTrue(harness.controller.observe(Harness.keyEvent(36)))
             harness.flushMainQueue()
 
-            XCTAssertTrue(
-                harness.inserter.calls.isEmpty,
-                "A focus change during the deferral must abort the replace so we never edit the wrong field."
-            )
+            XCTAssertTrue(harness.inserter.calls.isEmpty, "Return must not insert the emoji.")
+            XCTAssertEqual(harness.controller.decideCaptureKey(Harness.monitorKey(36)), .passThrough)
+            XCTAssertTrue(harness.panel.isHidden)
         }
     }
 
-    func test_enterWithNoMatchesPassesThroughWithoutInserting() {
+    func test_rebindingAcceptKeyIsHonoredForCommit() {
+        runOnMainActor {
+            let harness = Harness(precedingText: ":smile")
+            harness.monitor.wordAcceptKeyCode = 50          // user rebinds accept-word to backtick (50)
+            harness.openAndType(":smile")
+
+            XCTAssertTrue(harness.controller.observe(Harness.keyEvent(50)))
+            harness.flushMainQueue()
+
+            XCTAssertEqual(harness.inserter.calls.map(\.text), ["😄"])
+            XCTAssertEqual(harness.inserter.calls.first?.deleteCount, 6)
+        }
+    }
+
+    func test_acceptKeyWithNoMatchesPassesThroughWithoutInserting() {
         runOnMainActor {
             let harness = Harness(precedingText: ":zzzzz")
             harness.openAndType(":zzzzz")   // no catalog match
 
-            XCTAssertTrue(harness.controller.observe(Harness.keyEvent(36)))
+            // The accept key with no match must not be stolen from the host, so a real word-accept
+            // still reaches the suggestion pipeline.
+            XCTAssertTrue(harness.controller.observe(Harness.keyEvent(48)))
             harness.flushMainQueue()
 
             XCTAssertTrue(harness.inserter.calls.isEmpty, "Nothing to commit, so nothing is inserted.")
-            // The picker must not steal Enter from the host when there is no match to commit.
-            XCTAssertEqual(harness.controller.decideCaptureKey(Harness.monitorKey(36)), .passThrough)
+            XCTAssertEqual(harness.controller.decideCaptureKey(Harness.monitorKey(48)), .passThrough)
         }
     }
 
@@ -144,10 +160,6 @@ private final class FakeFocus: SuggestionFocusProviding {
 
     func refreshNow() {}
 
-    func update(precedingText: String, focusChangeSequence: UInt64) {
-        snapshot = FakeFocus.make(precedingText: precedingText, focusChangeSequence: focusChangeSequence)
-    }
-
     private static func make(precedingText: String, focusChangeSequence: UInt64) -> FocusSnapshot {
         let context = CotabbyTestFixtures.focusedInputSnapshot(
             precedingText: precedingText,
@@ -166,8 +178,14 @@ private final class FakeFocus: SuggestionFocusProviding {
 @MainActor
 private final class FakeInputMonitor: EmojiInputIntercepting {
     var emojiCaptureKeyDecider: (@MainActor (InputMonitorKeyEvent) -> InputMonitorAcceptTapDecision)?
+    var wordAcceptKeyCode: CGKeyCode = 48   // default Tab, matching the shipped accept-word default
     private(set) var captureActiveCalls: [Bool] = []
+
     func setCaptureInterceptionActive(_ active: Bool) { captureActiveCalls.append(active) }
+
+    func isWordAcceptKey(_ keyEvent: InputMonitorKeyEvent) -> Bool {
+        keyEvent.keyCode == wordAcceptKeyCode
+    }
 }
 
 @MainActor

--- a/CotabbyTests/EmojiPickerControllerTests.swift
+++ b/CotabbyTests/EmojiPickerControllerTests.swift
@@ -1,0 +1,215 @@
+import Combine
+import CoreGraphics
+import XCTest
+@testable import Cotabby
+
+/// Composition tests for the inline `:emoji:` commit path. The pure machine/matcher/run are covered
+/// elsewhere; these lock down the controller <-> focus <-> inserter seam where the commit flakiness
+/// lived: the replace must be deferred off the keystroke's tap callback, and it must not fire into a
+/// field the user has navigated away from during that deferral.
+final class EmojiPickerControllerTests: XCTestCase {
+    @MainActor private static var retained: [EmojiPickerController] = []
+
+    override func tearDown() {
+        runOnMainActor { Self.retained.removeAll() }
+        super.tearDown()
+    }
+
+    func test_enterCommitInsertsSelectedGlyphAfterRunloopTick() {
+        runOnMainActor {
+            let harness = Harness(precedingText: ":smile")
+            harness.openAndType(":smile")
+
+            // Enter is handled and consumed, but the replace must be deferred, not posted
+            // synchronously from inside the keystroke's tap callback.
+            XCTAssertTrue(harness.controller.observe(Harness.keyEvent(36)))
+            XCTAssertTrue(
+                harness.inserter.calls.isEmpty,
+                "The replace must be deferred off the keystroke's tap callback."
+            )
+
+            harness.flushMainQueue()
+
+            XCTAssertEqual(harness.inserter.calls.map(\.text), ["😄"])
+            XCTAssertEqual(harness.inserter.calls.first?.deleteCount, 6)   // ":smile"
+            XCTAssertTrue(harness.panel.isHidden)
+        }
+    }
+
+    func test_commitAbortsWhenFocusChangesDuringDeferral() {
+        runOnMainActor {
+            let harness = Harness(precedingText: ":smile")
+            harness.openAndType(":smile")
+            XCTAssertTrue(harness.controller.observe(Harness.keyEvent(36)))
+
+            // The focused field changes before the deferred replace runs.
+            harness.focus.update(precedingText: "different", focusChangeSequence: 99)
+            harness.flushMainQueue()
+
+            XCTAssertTrue(
+                harness.inserter.calls.isEmpty,
+                "A focus change during the deferral must abort the replace so we never edit the wrong field."
+            )
+        }
+    }
+
+    func test_enterWithNoMatchesPassesThroughWithoutInserting() {
+        runOnMainActor {
+            let harness = Harness(precedingText: ":zzzzz")
+            harness.openAndType(":zzzzz")   // no catalog match
+
+            XCTAssertTrue(harness.controller.observe(Harness.keyEvent(36)))
+            harness.flushMainQueue()
+
+            XCTAssertTrue(harness.inserter.calls.isEmpty, "Nothing to commit, so nothing is inserted.")
+            // The picker must not steal Enter from the host when there is no match to commit.
+            XCTAssertEqual(harness.controller.decideCaptureKey(Harness.monitorKey(36)), .passThrough)
+        }
+    }
+
+    // MARK: - Harness
+
+    @MainActor
+    private final class Harness {
+        let focus: FakeFocus
+        let monitor = FakeInputMonitor()
+        let inserter = RecordingInserter()
+        let panel = FakePanel()
+        let controller: EmojiPickerController
+
+        init(precedingText: String) {
+            let catalog = EmojiCatalog(entries: [
+                EmojiEntry(
+                    glyph: "😄",
+                    name: "smiling face",
+                    aliases: ["smile"],
+                    keywords: [],
+                    group: "Smileys & Emotion",
+                    unicodeVersion: "6.0"
+                )
+            ])
+            focus = FakeFocus(precedingText: precedingText, focusChangeSequence: 1)
+            controller = EmojiPickerController(
+                matcher: EmojiMatcher(catalog: catalog),
+                panel: panel,
+                focusModel: focus,
+                inputMonitor: monitor,
+                inserter: inserter,
+                isEnabled: { true }
+            )
+            controller.start()
+            EmojiPickerControllerTests.retained.append(controller)
+        }
+
+        func openAndType(_ text: String) {
+            for character in text {
+                _ = controller.observe(Harness.charEvent(character))
+            }
+        }
+
+        /// Enqueues a fence after the controller's deferred replace (GCD main queue is FIFO) and
+        /// spins the runloop until it drains, so the deferred work has run before assertions.
+        func flushMainQueue() {
+            let fence = XCTestExpectation(description: "flush main queue")
+            DispatchQueue.main.async { fence.fulfill() }
+            _ = XCTWaiter().wait(for: [fence], timeout: 1.0)
+        }
+
+        static func charEvent(_ character: Character) -> CapturedInputEvent {
+            // Any non-special keyCode; the trigger/query is driven by the character, not the code.
+            CapturedInputEvent(kind: .textMutation, keyCode: 41, characters: String(character), flags: [])
+        }
+
+        static func keyEvent(_ keyCode: CGKeyCode) -> CapturedInputEvent {
+            CapturedInputEvent(kind: .textMutation, keyCode: keyCode, characters: "", flags: [])
+        }
+
+        static func monitorKey(_ keyCode: CGKeyCode) -> InputMonitorKeyEvent {
+            InputMonitorKeyEvent(keyCode: keyCode)
+        }
+    }
+}
+
+// MARK: - Fakes
+
+@MainActor
+private final class FakeFocus: SuggestionFocusProviding {
+    private(set) var snapshot: FocusSnapshot
+    private let subject = PassthroughSubject<FocusSnapshot, Never>()
+    var snapshotPublisher: AnyPublisher<FocusSnapshot, Never> { subject.eraseToAnyPublisher() }
+
+    init(precedingText: String, focusChangeSequence: UInt64) {
+        snapshot = FakeFocus.make(precedingText: precedingText, focusChangeSequence: focusChangeSequence)
+    }
+
+    func refreshNow() {}
+
+    func update(precedingText: String, focusChangeSequence: UInt64) {
+        snapshot = FakeFocus.make(precedingText: precedingText, focusChangeSequence: focusChangeSequence)
+    }
+
+    private static func make(precedingText: String, focusChangeSequence: UInt64) -> FocusSnapshot {
+        let context = CotabbyTestFixtures.focusedInputSnapshot(
+            precedingText: precedingText,
+            focusChangeSequence: focusChangeSequence
+        )
+        return FocusSnapshot(
+            applicationName: "TestApp",
+            bundleIdentifier: "com.test.app",
+            capability: .supported,
+            context: context,
+            inspection: nil
+        )
+    }
+}
+
+@MainActor
+private final class FakeInputMonitor: EmojiInputIntercepting {
+    var emojiCaptureKeyDecider: (@MainActor (InputMonitorKeyEvent) -> InputMonitorAcceptTapDecision)?
+    private(set) var captureActiveCalls: [Bool] = []
+    func setCaptureInterceptionActive(_ active: Bool) { captureActiveCalls.append(active) }
+}
+
+@MainActor
+private final class RecordingInserter: EmojiTextInserting {
+    struct Call: Equatable {
+        let deleteCount: Int
+        let text: String
+    }
+
+    private(set) var calls: [Call] = []
+
+    func replace(deletingUTF16Count: Int, with text: String) -> Bool {
+        calls.append(Call(deleteCount: deletingUTF16Count, text: text))
+        return true
+    }
+}
+
+@MainActor
+private final class FakePanel: EmojiPickerPanelPresenting {
+    var onSelectIndex: ((Int) -> Void)?
+    var onClickOutside: (() -> Void)?
+    private(set) var isHidden = false
+
+    func show(query: String, matches: [EmojiMatch], selectedIndex: Int, caretRect: CGRect) {
+        isHidden = false
+    }
+
+    func setSelectedIndex(_ index: Int) {}
+
+    func hide() {
+        isHidden = true
+    }
+}
+
+private func runOnMainActor<Result>(
+    _ body: @MainActor () throws -> Result
+) rethrows -> Result {
+    if Thread.isMainThread {
+        return try MainActor.assumeIsolated(body)
+    }
+
+    return try DispatchQueue.main.sync {
+        try MainActor.assumeIsolated(body)
+    }
+}

--- a/CotabbyTests/InputMonitorTests.swift
+++ b/CotabbyTests/InputMonitorTests.swift
@@ -213,6 +213,25 @@ final class InputMonitorTests: XCTestCase {
         }
     }
 
+    func test_isWordAcceptKey_matchesOnlyTheConfiguredWordAcceptBinding() {
+        runOnMainActor {
+            let monitor = makeMonitor()
+            monitor.acceptanceKeyCodeProvider = { 48 }          // Tab is the word-accept key
+            monitor.acceptanceKeyModifiersProvider = { [] }
+            monitor.fullAcceptanceKeyCodeProvider = { 50 }      // backtick is full-accept
+
+            XCTAssertTrue(monitor.isWordAcceptKey(InputMonitorKeyEvent(keyCode: 48)))
+            XCTAssertFalse(
+                monitor.isWordAcceptKey(InputMonitorKeyEvent(keyCode: 50)),
+                "The full-accept key must not count as the word-accept key."
+            )
+            XCTAssertFalse(
+                monitor.isWordAcceptKey(InputMonitorKeyEvent(keyCode: 36)),
+                "Return must not count as the word-accept key."
+            )
+        }
+    }
+
     @MainActor
     private func makeMonitor() -> InputMonitor {
         let monitor = InputMonitor(


### PR DESCRIPTION
## Summary

Makes the inline `:emoji:` picker (#417) commit reliably and only on the user's configured **accept-word** shortcut. Two parts: (1) fix the commit so the highlighted emoji actually inserts, and (2) stop Enter/Return from committing so the picker is consistent with whatever key accepts a suggestion word (Tab by default).

## What was wrong and how it's fixed

- **Flaky / empty commits.** The keyboard commit posted the synthetic delete+glyph synchronously from inside the keystroke's own event-tap callback (re-entrant posting, which EMOJI.md §4.4/§5.5 warn against). The fix defers the replace one runloop tick (matching the closing-colon path). An earlier attempt on this branch also added a `focusChangeSequence` abort guard fed by a pre-measure `refreshNow()`; that forced AX resolve re-stamped the sequence (notably in Chromium/Electron contenteditables, where the picker is most used), so the guard aborted legitimate commits and the panel vanished with no emoji. That guard and the pre-measure refresh are removed. `EmojiQueryRun`'s `:[alias]:?$` regex already refuses to delete when the field no longer ends in a `:query` run, so no sequence guard is needed.
- **Commit key.** `EmojiPickerController` now asks `InputMonitor.isWordAcceptKey` (which reuses the existing `acceptanceKind` keyCode+modifier match) instead of hardcoding Tab/Return. The picker follows whatever the user bound for accepting a word; Return and Keypad Enter no longer commit, they dismiss the picker and pass through to the host.

## Validation

```
xcodebuild ... build              # ** BUILD SUCCEEDED **
xcodebuild ... build-for-testing  # ** TEST BUILD SUCCEEDED ** (no warnings)
swiftlint lint --quiet            # 0 issues
```

Tests: `isWordAcceptKey` in `InputMonitorTests`; in `EmojiPickerControllerTests`, the accept key commits (deferred), Return does not commit and passes through, a rebound accept key is honored, and the accept key with no match passes through. The app-hosted test **runner** is blocked locally by the Team ID signing mismatch the repo documents, so verification is via `build-for-testing`.

## Linked issues

Refs #417 (inline :emoji: picker).

## Risk / rollout notes

- Behavior change on the emoji commit path: **Enter/Return no longer inserts an emoji**; the configured accept-word key does (Tab by default, follows a rebind automatically). The General settings toggle copy is updated to match ("your accept-word key (Tab by default)"). The existing on/off toggle for the picker is unchanged.
- The one-runloop-tick deferral is kept; it is the part that keeps synthetic events off the tap callback. The Tab/accept key is still consumed via `pendingDecision`, independent of replace timing, and a no-match accept key still passes through to the suggestion accept path, so the two-tap ownership model is unaffected.
- Introduces `EmojiPickerPanelPresenting` (testability seam) and `EmojiInputIntercepting.isWordAcceptKey`; the concrete types conform with no wiring changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a flaky `:emoji:` Enter/Tab commit by routing both commit modes (key-press and closing-colon) through a shared `scheduleReplaceEmojiQuery` helper that defers the synthetic delete+insert one runloop tick, eliminating re-entrant CGEvent posting from inside the keystroke's own tap callback. It also tightens the commit trigger: instead of hardcoding Return/Tab, the picker now commits on the user's configured accept-word binding via `isWordAcceptKey`, and Return is demoted to a dismiss-only key.

- `EmojiPickerPanelPresenting` protocol is extracted from `EmojiPickerPanelController` so the controller can be unit-tested with a `FakePanel`; four new `EmojiPickerControllerTests` cover deferred commit, Return pass-through, rebind honoring, and no-match passthrough.
- `InputMonitor.isWordAcceptKey` is added to `EmojiInputIntercepting`, reusing the existing `acceptanceKind` helper and preserving full-accept-key priority.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the deferred-replace path is well-reasoned and the behavior change is confined to the emoji commit flow.

The core fix is sound: deferring synthetic events off the tap callback is the correct approach, both commit modes now share the same deferred path, and the new tests lock down the key invariants. The only notable gap is that the PR description claims a focus-change abort guard exists in the deferred path, while the code explicitly removes it — a documentation inaccuracy rather than a runtime defect.

EmojiPickerController.swift — the description/code discrepancy around the focus-abort guard is worth a quick read to confirm the trade-off is intentional.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/App/Coordinators/EmojiPickerController.swift | Core fix: both commit modes now defer through `scheduleReplaceEmojiQuery`; commit key switched from hardcoded Return/Tab to the user's configured accept-word binding via `isWordAcceptKey`. The deferred path has no focus-change abort guard (explicitly removed), which the PR description incorrectly implies it does. |
| CotabbyTests/EmojiPickerControllerTests.swift | New test file covering deferred-commit deferral, Return pass-through, accept-key rebind, and no-match passthrough. `FakePanel.isHidden` starts as `false` (noted in previous review thread). No test for Mode B (`commitClosingColon`) path (noted in previous review thread). |
| Cotabby/Models/SuggestionSubsystemContracts.swift | Adds `EmojiPickerPanelPresenting` protocol (panel slice for testability) and `isWordAcceptKey` to `EmojiInputIntercepting`. Both are narrow, well-scoped additions. |
| Cotabby/Services/Input/InputMonitor.swift | Adds `isWordAcceptKey` delegating to the existing `acceptanceKind` helper; returns `true` only for `.acceptance` (not `.fullAcceptance`), keeping full-accept-key priority intact. |
| Cotabby/Services/UI/EmojiPickerPanelController.swift | Single-line change: adds `EmojiPickerPanelPresenting` conformance. No behavioral change to the concrete panel. |
| Cotabby/UI/Settings/Panes/GeneralPaneView.swift | UI label updated from 'Tab or Return' to 'your accept-word key (Tab by default)' to reflect the behavior change. |
| CotabbyTests/InputMonitorTests.swift | New test verifies `isWordAcceptKey` matches only the configured word-accept binding and rejects the full-accept key and Return. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Tap as Event Tap (sync)
    participant Ctrl as EmojiPickerController
    participant Machine as EmojiTriggerStateMachine
    participant Queue as DispatchQueue.main
    participant Inserter as EmojiTextInserting

    Tap->>Ctrl: observe(tabEvent)
    Ctrl->>Machine: reduce(.commitKey)
    Machine-->>Ctrl: "actions=[.commit(.key)]"
    Ctrl->>Ctrl: commitSelectedMatch()
    Ctrl->>Ctrl: teardownCapture() — panel hides
    Ctrl->>Queue: "async { replaceEmojiQuery(glyph, fallback) }"
    Ctrl-->>Tap: "involved=true, pendingDecision(consume=true)"
    Tap->>Ctrl: decideCaptureKey(tab)
    Ctrl-->>Tap: .consume (key swallowed)
    Note over Tap,Queue: one runloop tick later
    Queue->>Ctrl: replaceEmojiQuery(glyph, fallback)
    Ctrl->>Ctrl: trailingRunUTF16Length(precedingText) ?? fallback
    Ctrl->>Inserter: replace(deleteCount, glyph)
    Ctrl->>Ctrl: focusModel.refreshNow()
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22jafu%2Ffix-emoji-commit-flakiness%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22jafu%2Ffix-emoji-commit-flakiness%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FApp%2FCoordinators%2FEmojiPickerController.swift%3A297-314%0A**PR%20description%20claims%20a%20focus-abort%20guard%20that%20isn't%20there**%0A%0AThe%20PR%20description's%20risk%2Frollout%20notes%20state%3A%20*%22New%20%60focusChangeSequence%60%20guard%20means%20a%20commit%20whose%20focus%20genuinely%20changed%20within%20the%20deferral%20tick%20now%20aborts%20instead%20of%20editing%20the%20wrong%20field.%22*%20The%20code%20inside%20%60replaceEmojiQuery%60%20says%20the%20opposite%3A%20*%22We%20deliberately%20do%20NOT%20force%20a%20fresh%20AX%20resolve%20%2B%20%60focusChangeSequence%60%20guard%20here.%22*%0A%0AIn%20practice%20the%20window%20is%20tiny%20%28one%20runloop%20tick%29%2C%20but%20the%20scenario%20is%20real%3A%20user%20presses%20Tab%2C%20%60teardownCapture%28%29%60%20fires%2C%20the%20deferred%20block%20is%20enqueued%3B%20if%20a%20focus-change%20AX%20notification%20is%20dispatched%20to%20the%20main%20queue%20before%20that%20block%20executes%2C%20%60focusModel.snapshot%60%20reflects%20the%20new%20field.%20%60trailingRunUTF16Length%60%20returns%20%60nil%60%20for%20unrelated%20text%2C%20so%20the%20code%20falls%20back%20to%20deleting%20%60fallbackUTF16%60%20characters%20%28e.g.%206%20for%20%60%3Asmile%60%29%20from%20the%20newly%20focused%20field.%0A%0AThe%20guard%20was%20deliberately%20removed%20because%20it%20caused%20false%20aborts%20%E2%80%94%20that's%20a%20valid%20trade-off%20%E2%80%94%20but%20the%20description's%20safety%20claim%20should%20be%20updated%20to%20match%20what%20the%20code%20actually%20does.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FApp%2FCoordinators%2FEmojiPickerController.swift%3A297-314%0A**PR%20description%20claims%20a%20focus-abort%20guard%20that%20isn't%20there**%0A%0AThe%20PR%20description's%20risk%2Frollout%20notes%20state%3A%20*%22New%20%60focusChangeSequence%60%20guard%20means%20a%20commit%20whose%20focus%20genuinely%20changed%20within%20the%20deferral%20tick%20now%20aborts%20instead%20of%20editing%20the%20wrong%20field.%22*%20The%20code%20inside%20%60replaceEmojiQuery%60%20says%20the%20opposite%3A%20*%22We%20deliberately%20do%20NOT%20force%20a%20fresh%20AX%20resolve%20%2B%20%60focusChangeSequence%60%20guard%20here.%22*%0A%0AIn%20practice%20the%20window%20is%20tiny%20%28one%20runloop%20tick%29%2C%20but%20the%20scenario%20is%20real%3A%20user%20presses%20Tab%2C%20%60teardownCapture%28%29%60%20fires%2C%20the%20deferred%20block%20is%20enqueued%3B%20if%20a%20focus-change%20AX%20notification%20is%20dispatched%20to%20the%20main%20queue%20before%20that%20block%20executes%2C%20%60focusModel.snapshot%60%20reflects%20the%20new%20field.%20%60trailingRunUTF16Length%60%20returns%20%60nil%60%20for%20unrelated%20text%2C%20so%20the%20code%20falls%20back%20to%20deleting%20%60fallbackUTF16%60%20characters%20%28e.g.%206%20for%20%60%3Asmile%60%29%20from%20the%20newly%20focused%20field.%0A%0AThe%20guard%20was%20deliberately%20removed%20because%20it%20caused%20false%20aborts%20%E2%80%94%20that's%20a%20valid%20trade-off%20%E2%80%94%20but%20the%20description's%20safety%20claim%20should%20be%20updated%20to%20match%20what%20the%20code%20actually%20does.%0A%0A&repo=fujacob%2Fcotabby&pr=428&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Correct emoji commit: fix the deferred r..."](https://github.com/fujacob/cotabby/commit/7a2b352f13429823c56e15b1b25117f3d60a3659) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34749143)</sub>

<!-- /greptile_comment -->