### PR TITLE
Update AGENTS.md to reference Settings panes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,8 +144,8 @@ the core should own native correctness.
 - `ActivationIndicatorController` owns the optional caret/field-edge indicator.
 - `FocusDebugOverlayController` is for developer visibility and should stay gated behind debug
   options, not normal user settings.
-- `SettingsView` and onboarding views should remain presentation-focused. Push behavior into
-  services, models, or support helpers.
+- Settings panes (under `Cotabby/UI/Settings/Panes/`) and onboarding views should remain
+  presentation-focused. Push behavior into services, models, or support helpers.
 
 ## Swift And Concurrency Rules
 


### PR DESCRIPTION
## Summary

`SettingsView` was removed in #422. Update the AGENTS.md guidance to point at the current Settings panes under `Cotabby/UI/Settings/Panes/` so the doc matches the code.

## Validation

- Doc-only change, no build needed.

## Linked issues

None.

## Risk / rollout notes

None.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates `AGENTS.md` to replace the removed `SettingsView` reference with a pointer to the current Settings panes directory after the refactor in #422.

- The old `SettingsView` no longer exists; the new path `Cotabby/UI/Settings/Panes/` is confirmed present with eight pane views.
- The guidance itself (keep panes presentation-focused, push behavior into services/models) is unchanged and still accurate.

<h3>Confidence Score: 5/5</h3>

Documentation-only change that corrects a stale file reference; no code paths are affected.

The edit swaps a removed class name for a verified existing directory path. The guidance prose is unchanged, the referenced path exists in the repo, and no logic or configuration is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| AGENTS.md | Two-line doc update replacing the removed SettingsView reference with the correct Cotabby/UI/Settings/Panes/ path; verified the directory exists. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[AGENTS.md guidance] --> B{Settings UI}
    B -->|Before PR - removed| C[SettingsView ❌]
    B -->|After PR - current| D[Cotabby/UI/Settings/Panes/]
    D --> E[GeneralPaneView]
    D --> F[AppsPaneView]
    D --> G[ShortcutsPaneView]
    D --> H[WritingPaneView]
    D --> I[EngineAndModelPaneView]
    D --> J[PermissionsPaneView]
    D --> K[AboutPaneView]
    D --> L[AcknowledgementsView]
```

<sub>Reviews (1): Last reviewed commit: ["Update AGENTS.md to reference Settings p..."](https://github.com/fujacob/cotabby/commit/d5caded579db48d1a98d9e6d1411ec5e0a988e6d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34749717)</sub>

<!-- /greptile_comment -->