### PR TITLE
Run SwiftLint in --strict mode

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,14 +1,12 @@
 # SwiftLint style gate on every PR.
 #
-# Starts in warnings-only mode (no `--strict`). The existing codebase is
-# unaudited, so flipping to strict immediately would block unrelated PRs on
-# style noise the author didn't introduce. Graduation plan: once `main` is
-# warning-free under the ruleset in `.swiftlint.yml`, flip the step below
-# to `--strict` and fail the check on any warning.
+# Runs in `--strict` mode: any warning fails the check. `main` is warning-free
+# under the ruleset in `.swiftlint.yml`, so this keeps it that way instead of
+# letting style warnings quietly accumulate over time.
 #
-# The output goes through `--reporter github-actions-logging` so warnings
-# land as inline annotations on the PR diff — much easier to read than
-# scrolling the run log.
+# The output goes through `--reporter github-actions-logging` so findings land
+# as inline annotations on the PR diff, which is easier to read than scrolling
+# the run log.
 
 name: Lint
 
@@ -42,5 +40,5 @@ jobs:
           swiftlint version
 
       - name: Run SwiftLint
-        # Warnings-only today (see file header for graduation plan).
-        run: swiftlint --reporter github-actions-logging
+        # Strict: any warning fails the check (see file header).
+        run: swiftlint --strict --reporter github-actions-logging


### PR DESCRIPTION
## Summary

Flip the Lint workflow to `swiftlint --strict` so any warning fails the check. `main` is warning-free today, so this changes no current behavior; it only stops future style warnings from accumulating silently.

## Validation

```
swiftlint lint --strict --quiet
# exit 0, no output on current main
```

No Swift code changed, only `.github/workflows/lint.yml`.

## Linked issues

None.

## Risk / rollout notes

- Lint is now a required status check on `main`, so a future PR that introduces a warning will be blocked until it's fixed. That is the intent.
- Rollback is a one-line change (drop `--strict`).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Graduates the SwiftLint workflow from warnings-only to `--strict` mode, so any warning now causes the lint check to fail. Only `.github/workflows/lint.yml` is changed; no Swift source files are modified.

- Appends `--strict` to the `swiftlint --reporter github-actions-logging` run command on line 44, turning warnings into hard failures.
- Rewrites the file-header comment block to reflect the new enforcement policy and removes the now-obsolete \"graduation plan\" note.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the change is a one-flag addition to a CI workflow that intentionally tightens the lint gate.

The only change is adding --strict to an already-working SwiftLint invocation. The PR description confirms main is warning-free, the flag is a standard SwiftLint option, and actions/checkout@v6 is the current latest release. There is nothing in the diff that could break the build or affect runtime behaviour.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/lint.yml | Adds --strict flag to the SwiftLint run step so any warning fails the check; updates the file-header comment to match; no other logic changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR / push to main] --> B[Lint workflow triggered]
    B --> C[Checkout repo\nactions/checkout@v6]
    C --> D{swiftlint installed?}
    D -- No --> E[brew install swiftlint]
    D -- Yes --> F[swiftlint version]
    E --> F
    F --> G[swiftlint --strict\n--reporter github-actions-logging]
    G --> H{Warnings or errors?}
    H -- None --> I[Check passes]
    H -- Any warning\nor error --> J[Check fails\nInline annotations on PR diff]
```

<sub>Reviews (1): Last reviewed commit: ["Run SwiftLint in --strict mode"](https://github.com/fujacob/cotabby/commit/f840e090b11819f146f2d22ef2fb0bce44994233) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34749977)</sub>

<!-- /greptile_comment -->