### PR TITLE
Onboarding: choose engine above the tier picker

### DIFF
--- a/Cotabby/Models/OnboardingTemplate.swift
+++ b/Cotabby/Models/OnboardingTemplate.swift
@@ -42,15 +42,17 @@ enum OnboardingTemplate: String, CaseIterable, Identifiable, Equatable, Sendable
         }
     }
 
-    /// Longer supporting copy describing the trade-off the user is opting into.
+    /// Longer supporting copy describing the trade-off the user is opting into. Kept engine-neutral
+    /// because the engine (and any download size) is now chosen separately above the tier and shown
+    /// in the per-tier footer; the tier itself only tunes speed/length.
     var detail: String {
         switch self {
         case .quick:
-            return "A small local model that keeps up with your typing and is gentle on memory and battery."
+            return "Short, snappy completions that keep up with fast typing and stay light on resources."
         case .everyday:
-            return "A good balance of speed and quality. Uses Apple Intelligence when your Mac supports it."
+            return "A balance of speed and quality for everyday writing."
         case .powerful:
-            return "The largest local model for the most capable suggestions. Best on Macs with lots of memory."
+            return "Longer, multi-line suggestions for the most capable completions."
         }
     }
 
@@ -86,14 +88,7 @@ enum OnboardingTemplate: String, CaseIterable, Identifiable, Equatable, Sendable
         self == .powerful
     }
 
-    /// Whether this template should use Apple Intelligence when it is available. Only Everyday does;
-    /// Quick and Powerful are deliberately tied to specific local models so their size/quality
-    /// trade-off is predictable regardless of the host.
-    var prefersAppleIntelligence: Bool {
-        self == .everyday
-    }
-
-    /// The local GGUF this template installs when it is not using Apple Intelligence.
+    /// The local GGUF this template installs when the Open Source engine is selected.
     var openSourceModelFilename: String {
         switch self {
         case .quick:

--- a/Cotabby/Support/OnboardingTemplateRecommender.swift
+++ b/Cotabby/Support/OnboardingTemplateRecommender.swift
@@ -16,14 +16,17 @@ enum OnboardingTemplateRecommender {
     /// relevant when Apple Intelligence is unavailable; the Apple Intelligence path has no such cost.
     static let everydayWarnBelowGigabytes = 8.0
 
-    /// Resolves the engine, model, and behavior flags for a template given runtime facts.
+    /// Resolves the model and behavior flags for a template under an explicitly chosen engine.
+    ///
+    /// The engine is now picked by the user at the top of the onboarding step rather than inferred
+    /// from the tier, so a tier only contributes its behavior flags. Apple Intelligence downloads
+    /// nothing; Open Source maps each tier to its local GGUF.
     static func resolvePlan(
         for template: OnboardingTemplate,
-        appleIntelligenceAvailable: Bool
+        engine: SuggestionEngineKind
     ) -> ResolvedTemplatePlan {
-        let usesAppleIntelligence = template.prefersAppleIntelligence && appleIntelligenceAvailable
-        let engine: SuggestionEngineKind = usesAppleIntelligence ? .appleIntelligence : .llamaOpenSource
-        let model = usesAppleIntelligence
+        let model: DownloadableRuntimeModel? =
+            engine == .appleIntelligence
             ? nil
             : downloadableModel(filename: template.openSourceModelFilename)
 
@@ -37,34 +40,37 @@ enum OnboardingTemplateRecommender {
         )
     }
 
-    /// Whether a template should be recommended, disabled, or warned about on this Mac.
+    /// Whether a template should be recommended, disabled, or warned about under the chosen engine.
+    ///
+    /// Apple Intelligence has no per-tier download, so every tier is available there. The hardware
+    /// disable/warn rules only apply to the Open Source engine, where each tier is a local model of
+    /// a specific size.
     static func availability(
         for template: OnboardingTemplate,
         hardware: HardwareCapability,
-        appleIntelligenceAvailable: Bool
+        engine: SuggestionEngineKind
     ) -> OnboardingTemplateAvailability {
         let gigabytes = hardware.physicalMemoryGigabytes
-        let recommended = recommendedTemplate(
-            hardware: hardware,
-            appleIntelligenceAvailable: appleIntelligenceAvailable
-        )
+        let recommended = recommendedTemplate(hardware: hardware, engine: engine)
 
         var isDisabled = false
         var warning: String?
 
-        switch template {
-        case .quick:
-            break
-        case .everyday:
-            if !appleIntelligenceAvailable, gigabytes < everydayWarnBelowGigabytes {
-                warning = "Uses a ~3 GB model, which may run slowly on this Mac."
-            }
-        case .powerful:
-            if gigabytes < powerfulDisableBelowGigabytes {
-                isDisabled = true
-                warning = "Needs more memory than this Mac has (uses a ~5 GB model)."
-            } else if gigabytes < powerfulWarnBelowGigabytes {
-                warning = "Uses a ~5 GB model; may run slowly with less than 16 GB of memory."
+        if engine == .llamaOpenSource {
+            switch template {
+            case .quick:
+                break
+            case .everyday:
+                if gigabytes < everydayWarnBelowGigabytes {
+                    warning = "Uses a ~3 GB model, which may run slowly on this Mac."
+                }
+            case .powerful:
+                if gigabytes < powerfulDisableBelowGigabytes {
+                    isDisabled = true
+                    warning = "Needs more memory than this Mac has (uses a ~5 GB model)."
+                } else if gigabytes < powerfulWarnBelowGigabytes {
+                    warning = "Uses a ~5 GB model; may run slowly with less than 16 GB of memory."
+                }
             }
         }
 
@@ -76,14 +82,15 @@ enum OnboardingTemplateRecommender {
         )
     }
 
-    /// The single template to highlight as the safe default. Apple Intelligence makes Everyday the
-    /// obvious choice; otherwise we keep low-memory Macs on Quick and everyone else on Everyday.
-    /// Powerful is never the default — it is an opt-in for users who deliberately want the big model.
+    /// The single tier to highlight as the safe default under the chosen engine. Apple Intelligence
+    /// has no size cost, so Everyday is the obvious balance; on Open Source we keep low-memory Macs
+    /// on Quick and everyone else on Everyday. Powerful is never the default — it is an opt-in for
+    /// users who deliberately want the big model.
     static func recommendedTemplate(
         hardware: HardwareCapability,
-        appleIntelligenceAvailable: Bool
+        engine: SuggestionEngineKind
     ) -> OnboardingTemplate {
-        if appleIntelligenceAvailable {
+        if engine == .appleIntelligence {
             return .everyday
         }
         if hardware.physicalMemoryGigabytes < everydayWarnBelowGigabytes {

--- a/Cotabby/UI/WelcomeTemplateStepView.swift
+++ b/Cotabby/UI/WelcomeTemplateStepView.swift
@@ -14,7 +14,9 @@ struct WelcomeTemplateStepView: View {
     @ObservedObject var foundationModelAvailabilityService: FoundationModelAvailabilityService
 
     let hardware: HardwareCapability
+    @Binding var selectedEngine: SuggestionEngineKind
     @Binding var selectedTemplate: OnboardingTemplate?
+    let onSelectEngine: (SuggestionEngineKind) -> Void
     let onSelect: (OnboardingTemplate) -> Void
 
     var body: some View {
@@ -29,16 +31,18 @@ struct WelcomeTemplateStepView: View {
                     .multilineTextAlignment(.center)
             }
 
+            engineSelector
+
             VStack(spacing: 10) {
                 ForEach(OnboardingTemplate.allCases) { template in
                     let availability = OnboardingTemplateRecommender.availability(
                         for: template,
                         hardware: hardware,
-                        appleIntelligenceAvailable: foundationModelAvailabilityService.isAvailable
+                        engine: selectedEngine
                     )
                     let plan = OnboardingTemplateRecommender.resolvePlan(
                         for: template,
-                        appleIntelligenceAvailable: foundationModelAvailabilityService.isAvailable
+                        engine: selectedEngine
                     )
 
                     TemplateCard(
@@ -51,6 +55,34 @@ struct WelcomeTemplateStepView: View {
                     )
                 }
             }
+        }
+    }
+
+    /// The top-level engine choice: the two cards that decide whether every tier below runs on
+    /// Apple Intelligence or a local open-source model. Apple Intelligence is disabled (with the
+    /// availability reason as its subtitle) when the Mac cannot run it.
+    private var engineSelector: some View {
+        let appleAvailable = foundationModelAvailabilityService.isAvailable
+        return HStack(spacing: 10) {
+            EngineChoiceCard(
+                title: SuggestionEngineKind.appleIntelligence.displayLabel,
+                subtitle: appleAvailable
+                    ? "Built into macOS"
+                    : foundationModelAvailabilityService.userVisibleMessage,
+                systemImageName: "apple.logo",
+                isSelected: selectedEngine == .appleIntelligence,
+                isDisabled: !appleAvailable,
+                onTap: { onSelectEngine(.appleIntelligence) }
+            )
+
+            EngineChoiceCard(
+                title: SuggestionEngineKind.llamaOpenSource.displayLabel,
+                subtitle: "Local models on your Mac",
+                systemImageName: "internaldrive",
+                isSelected: selectedEngine == .llamaOpenSource,
+                isDisabled: false,
+                onTap: { onSelectEngine(.llamaOpenSource) }
+            )
         }
     }
 
@@ -213,6 +245,71 @@ private struct TemplateCard: View {
                 .foregroundStyle(.orange)
                 .fixedSize(horizontal: false, vertical: true)
         }
+    }
+}
+
+// MARK: - Engine Choice Card
+
+/// One of the two top-level engine cards (Apple Intelligence / Open Source). Visually lighter than
+/// `TemplateCard` so the tier cards below stay the primary focus, but selectable in the same way.
+private struct EngineChoiceCard: View {
+    let title: String
+    let subtitle: String
+    let systemImageName: String
+    let isSelected: Bool
+    let isDisabled: Bool
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 8) {
+                    Image(systemName: systemImageName)
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(iconStyle)
+
+                    Text(title)
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(isDisabled ? .tertiary : .primary)
+
+                    Spacer(minLength: 0)
+
+                    if isSelected && !isDisabled {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.system(size: 15))
+                            .foregroundColor(.accentColor)
+                    }
+                }
+
+                Text(subtitle)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.leading)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(.regularMaterial)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .stroke(
+                        isSelected && !isDisabled
+                            ? Color.accentColor.opacity(0.45) : Color.white.opacity(0.08),
+                        lineWidth: isSelected && !isDisabled ? 1.5 : 0.5
+                    )
+            )
+            .opacity(isDisabled ? 0.55 : 1.0)
+        }
+        .buttonStyle(.plain)
+        .disabled(isDisabled)
+    }
+
+    private var iconStyle: HierarchicalShapeStyle {
+        // `.primary` when selected reads as active without introducing a second accent color.
+        isSelected && !isDisabled ? .primary : .secondary
     }
 }
 

--- a/Cotabby/UI/WelcomeTemplateStepView.swift
+++ b/Cotabby/UI/WelcomeTemplateStepView.swift
@@ -14,7 +14,7 @@ struct WelcomeTemplateStepView: View {
     @ObservedObject var foundationModelAvailabilityService: FoundationModelAvailabilityService
 
     let hardware: HardwareCapability
-    @Binding var selectedEngine: SuggestionEngineKind
+    let selectedEngine: SuggestionEngineKind
     @Binding var selectedTemplate: OnboardingTemplate?
     let onSelectEngine: (SuggestionEngineKind) -> Void
     let onSelect: (OnboardingTemplate) -> Void

--- a/Cotabby/UI/WelcomeView.swift
+++ b/Cotabby/UI/WelcomeView.swift
@@ -27,11 +27,11 @@ struct WelcomeView: View {
 
     @State private var step: WelcomeStep = .welcome
     @State private var selectedTemplate: OnboardingTemplate?
-    /// The engine chosen at the top of the template step. Defaulted once when that step first
-    /// appears (Apple Intelligence when the Mac supports it, otherwise Open Source); the tier cards
-    /// resolve their plan against this.
-    @State private var selectedEngine: SuggestionEngineKind = .llamaOpenSource
-    @State private var didDefaultEngine = false
+    /// The engine chosen at the top of the template step. Seeded in `init` from Apple Intelligence
+    /// availability (Apple Intelligence when the Mac supports it, otherwise Open Source) so the
+    /// template step's first render already shows the right card instead of flashing the wrong one;
+    /// the tier cards resolve their plan against this.
+    @State private var selectedEngine: SuggestionEngineKind
     @State private var isRecordingOnboardingKeybind = false
     @State private var isRecordingOnboardingFullAcceptKeybind = false
     @State private var isRecordingOnboardingGlobalToggleKeybind = false
@@ -40,6 +40,32 @@ struct WelcomeView: View {
     /// onboarding. `@State` (not a stored `let`) ensures `ProcessInfo` is read a single time rather
     /// than on every struct re-creation that an `@ObservedObject` publish (e.g. a download tick) causes.
     @State private var hardware = HardwareCapabilityProbe.current()
+
+    init(
+        permissionManager: PermissionManager,
+        runtimeModel: RuntimeBootstrapModel,
+        modelDownloadManager: ModelDownloadManager,
+        suggestionSettings: SuggestionSettingsModel,
+        foundationModelAvailabilityService: FoundationModelAvailabilityService,
+        permissionGuidanceController: PermissionGuidanceController,
+        onPreferredWindowSizeChange: @escaping (NSSize) -> Void,
+        onDismiss: @escaping () -> Void
+    ) {
+        _permissionManager = ObservedObject(wrappedValue: permissionManager)
+        _runtimeModel = ObservedObject(wrappedValue: runtimeModel)
+        _modelDownloadManager = ObservedObject(wrappedValue: modelDownloadManager)
+        _suggestionSettings = ObservedObject(wrappedValue: suggestionSettings)
+        _foundationModelAvailabilityService = ObservedObject(wrappedValue: foundationModelAvailabilityService)
+        self.permissionGuidanceController = permissionGuidanceController
+        self.onPreferredWindowSizeChange = onPreferredWindowSizeChange
+        self.onDismiss = onDismiss
+        // Seed the engine before the first render so the template step never shows a frame of "Open
+        // Source" selected on an Apple Intelligence-capable Mac and then snaps to it. Availability is
+        // resolved well before onboarding appears, so reading it here is reliable.
+        _selectedEngine = State(
+            initialValue: foundationModelAvailabilityService.isAvailable ? .appleIntelligence : .llamaOpenSource
+        )
+    }
 
     private var preferredWindowSize: NSSize {
         step.preferredWindowSize
@@ -138,12 +164,11 @@ extension WelcomeView {
                 modelDownloadManager: modelDownloadManager,
                 foundationModelAvailabilityService: foundationModelAvailabilityService,
                 hardware: hardware,
-                selectedEngine: $selectedEngine,
+                selectedEngine: selectedEngine,
                 selectedTemplate: $selectedTemplate,
                 onSelectEngine: selectEngine,
                 onSelect: applyTemplate
             )
-            .onAppear(perform: applyDefaultEngineIfNeeded)
         case .aboutYou:
             aboutYouStep
         case .writingStyle:
@@ -609,18 +634,6 @@ extension WelcomeView {
 
     fileprivate func resolvedPlan(for template: OnboardingTemplate) -> ResolvedTemplatePlan {
         OnboardingTemplateRecommender.resolvePlan(for: template, engine: selectedEngine)
-    }
-
-    /// Applies the one-shot engine default when the template step first appears: Apple Intelligence
-    /// when the Mac supports it, otherwise Open Source. Guarded so a later user choice is not
-    /// overwritten if the step reappears (e.g. navigating Back then forward).
-    fileprivate func applyDefaultEngineIfNeeded() {
-        guard !didDefaultEngine else {
-            return
-        }
-        didDefaultEngine = true
-        selectedEngine = foundationModelAvailabilityService.isAvailable
-            ? .appleIntelligence : .llamaOpenSource
     }
 
     /// Switches the engine. Re-applies the already-selected tier under the new engine so the

--- a/Cotabby/UI/WelcomeView.swift
+++ b/Cotabby/UI/WelcomeView.swift
@@ -27,6 +27,11 @@ struct WelcomeView: View {
 
     @State private var step: WelcomeStep = .welcome
     @State private var selectedTemplate: OnboardingTemplate?
+    /// The engine chosen at the top of the template step. Defaulted once when that step first
+    /// appears (Apple Intelligence when the Mac supports it, otherwise Open Source); the tier cards
+    /// resolve their plan against this.
+    @State private var selectedEngine: SuggestionEngineKind = .llamaOpenSource
+    @State private var didDefaultEngine = false
     @State private var isRecordingOnboardingKeybind = false
     @State private var isRecordingOnboardingFullAcceptKeybind = false
     @State private var isRecordingOnboardingGlobalToggleKeybind = false
@@ -133,9 +138,12 @@ extension WelcomeView {
                 modelDownloadManager: modelDownloadManager,
                 foundationModelAvailabilityService: foundationModelAvailabilityService,
                 hardware: hardware,
+                selectedEngine: $selectedEngine,
                 selectedTemplate: $selectedTemplate,
+                onSelectEngine: selectEngine,
                 onSelect: applyTemplate
             )
+            .onAppear(perform: applyDefaultEngineIfNeeded)
         case .aboutYou:
             aboutYouStep
         case .writingStyle:
@@ -600,10 +608,33 @@ extension WelcomeView {
     }
 
     fileprivate func resolvedPlan(for template: OnboardingTemplate) -> ResolvedTemplatePlan {
-        OnboardingTemplateRecommender.resolvePlan(
-            for: template,
-            appleIntelligenceAvailable: foundationModelAvailabilityService.isAvailable
-        )
+        OnboardingTemplateRecommender.resolvePlan(for: template, engine: selectedEngine)
+    }
+
+    /// Applies the one-shot engine default when the template step first appears: Apple Intelligence
+    /// when the Mac supports it, otherwise Open Source. Guarded so a later user choice is not
+    /// overwritten if the step reappears (e.g. navigating Back then forward).
+    fileprivate func applyDefaultEngineIfNeeded() {
+        guard !didDefaultEngine else {
+            return
+        }
+        didDefaultEngine = true
+        selectedEngine = foundationModelAvailabilityService.isAvailable
+            ? .appleIntelligence : .llamaOpenSource
+    }
+
+    /// Switches the engine. Re-applies the already-selected tier under the new engine so the
+    /// persisted settings and any download stay consistent; switching to Open Source after a tier
+    /// is chosen starts that tier's download (the tap is the user's consent), while Apple
+    /// Intelligence needs none. No download is started until a tier has been chosen.
+    fileprivate func selectEngine(_ engine: SuggestionEngineKind) {
+        guard selectedEngine != engine else {
+            return
+        }
+        selectedEngine = engine
+        if let template = selectedTemplate {
+            applyTemplate(template)
+        }
     }
 
     /// Applies a template's settings and starts its model download (if any). Selecting a card is the

--- a/CotabbyTests/OnboardingTemplateRecommenderTests.swift
+++ b/CotabbyTests/OnboardingTemplateRecommenderTests.swift
@@ -2,8 +2,10 @@ import XCTest
 @testable import Cotabby
 
 /// Tests for the pure rules that turn an onboarding template into a concrete plan and decide which
-/// templates to recommend, warn about, or disable on a given Mac. Each case pins one product
-/// decision so a future tweak to the thresholds has to update an obvious assertion.
+/// templates to recommend, warn about, or disable on a given Mac. The engine is now an explicit
+/// input (chosen at the top of the onboarding step), so every tier follows the selected engine:
+/// Apple Intelligence downloads nothing, Open Source maps each tier to its local GGUF. Each case
+/// pins one product decision so a future tweak has to update an obvious assertion.
 final class OnboardingTemplateRecommenderTests: XCTestCase {
     private func hardware(gigabytes: Double, appleSilicon: Bool = true) -> HardwareCapability {
         HardwareCapability(
@@ -12,49 +14,49 @@ final class OnboardingTemplateRecommenderTests: XCTestCase {
         )
     }
 
-    // MARK: - resolvePlan
+    // MARK: - resolvePlan: Apple Intelligence engine (no downloads, tier tunes behavior)
 
-    func testQuickAlwaysResolvesToLocalMiniModel() {
-        let plan = OnboardingTemplateRecommender.resolvePlan(for: .quick, appleIntelligenceAvailable: true)
-
-        XCTAssertEqual(plan.engine, .llamaOpenSource)
-        XCTAssertEqual(plan.modelToDownload?.filename, "Qwen3-0.6B-Q4_K_M.gguf")
-        XCTAssertEqual(plan.wordCountPreset, .threeToSeven)
-        XCTAssertTrue(plan.enablesFastMode)
-        XCTAssertFalse(plan.enablesMultiLine)
+    func testAppleIntelligenceTiersDownloadNothing() {
+        for template in OnboardingTemplate.allCases {
+            let plan = OnboardingTemplateRecommender.resolvePlan(for: template, engine: .appleIntelligence)
+            XCTAssertEqual(plan.engine, .appleIntelligence)
+            XCTAssertNil(plan.modelToDownload, "\(template) on Apple Intelligence must download nothing.")
+        }
     }
 
-    func testEverydayUsesAppleIntelligenceWhenAvailable() {
-        let plan = OnboardingTemplateRecommender.resolvePlan(for: .everyday, appleIntelligenceAvailable: true)
+    func testAppleIntelligenceStillCarriesTierBehaviorFlags() {
+        let quick = OnboardingTemplateRecommender.resolvePlan(for: .quick, engine: .appleIntelligence)
+        XCTAssertEqual(quick.wordCountPreset, .threeToSeven)
+        XCTAssertTrue(quick.enablesFastMode)
+        XCTAssertFalse(quick.enablesMultiLine)
 
-        XCTAssertEqual(plan.engine, .appleIntelligence)
-        XCTAssertNil(plan.modelToDownload, "Apple Intelligence plans download nothing.")
-        XCTAssertEqual(plan.wordCountPreset, .sevenToTwelve)
+        let powerful = OnboardingTemplateRecommender.resolvePlan(for: .powerful, engine: .appleIntelligence)
+        XCTAssertEqual(powerful.wordCountPreset, .twelveToTwenty)
+        XCTAssertTrue(powerful.enablesMultiLine)
     }
 
-    func testEverydayFallsBackToLocalBaseModelWithoutAppleIntelligence() {
-        let plan = OnboardingTemplateRecommender.resolvePlan(for: .everyday, appleIntelligenceAvailable: false)
+    // MARK: - resolvePlan: Open Source engine (each tier maps to its GGUF)
 
-        XCTAssertEqual(plan.engine, .llamaOpenSource)
-        XCTAssertEqual(plan.modelToDownload?.filename, "gemma-4-E2B-it-Q4_K_M.gguf")
+    func testOpenSourceTiersMapToTheirLocalModels() {
+        let expected: [OnboardingTemplate: String] = [
+            .quick: "Qwen3-0.6B-Q4_K_M.gguf",
+            .everyday: "gemma-4-E2B-it-Q4_K_M.gguf",
+            .powerful: "gemma-4-E4B-it-Q4_K_M.gguf"
+        ]
+        for (template, filename) in expected {
+            let plan = OnboardingTemplateRecommender.resolvePlan(for: template, engine: .llamaOpenSource)
+            XCTAssertEqual(plan.engine, .llamaOpenSource)
+            XCTAssertEqual(plan.modelToDownload?.filename, filename)
+        }
     }
 
-    func testPowerfulAlwaysResolvesToLocalProModel() {
-        let plan = OnboardingTemplateRecommender.resolvePlan(for: .powerful, appleIntelligenceAvailable: true)
+    // MARK: - availability gating (Open Source engine)
 
-        XCTAssertEqual(plan.engine, .llamaOpenSource)
-        XCTAssertEqual(plan.modelToDownload?.filename, "gemma-4-E4B-it-Q4_K_M.gguf")
-        XCTAssertEqual(plan.wordCountPreset, .twelveToTwenty)
-        XCTAssertTrue(plan.enablesMultiLine)
-    }
-
-    // MARK: - availability gating
-
-    func testPowerfulDisabledOnLowMemoryMac() {
+    func testPowerfulDisabledOnLowMemoryMacOpenSource() {
         let availability = OnboardingTemplateRecommender.availability(
             for: .powerful,
             hardware: hardware(gigabytes: 8),
-            appleIntelligenceAvailable: false
+            engine: .llamaOpenSource
         )
 
         XCTAssertTrue(availability.isDisabled)
@@ -65,7 +67,7 @@ final class OnboardingTemplateRecommenderTests: XCTestCase {
         let availability = OnboardingTemplateRecommender.availability(
             for: .powerful,
             hardware: hardware(gigabytes: 12),
-            appleIntelligenceAvailable: false
+            engine: .llamaOpenSource
         )
 
         XCTAssertFalse(availability.isDisabled)
@@ -76,39 +78,43 @@ final class OnboardingTemplateRecommenderTests: XCTestCase {
         let availability = OnboardingTemplateRecommender.availability(
             for: .powerful,
             hardware: hardware(gigabytes: 32),
-            appleIntelligenceAvailable: false
+            engine: .llamaOpenSource
         )
 
         XCTAssertFalse(availability.isDisabled)
         XCTAssertNil(availability.warning)
     }
 
-    func testEverydayWarnsOnLowMemoryWithoutAppleIntelligence() {
+    func testEverydayWarnsOnLowMemoryUnderOpenSource() {
         let availability = OnboardingTemplateRecommender.availability(
             for: .everyday,
             hardware: hardware(gigabytes: 6),
-            appleIntelligenceAvailable: false
+            engine: .llamaOpenSource
         )
 
         XCTAssertFalse(availability.isDisabled)
         XCTAssertNotNil(availability.warning)
     }
 
-    func testEverydayNoWarningWhenAppleIntelligenceAvailableEvenOnLowMemory() {
-        let availability = OnboardingTemplateRecommender.availability(
-            for: .everyday,
-            hardware: hardware(gigabytes: 6),
-            appleIntelligenceAvailable: true
-        )
+    // MARK: - availability gating (Apple Intelligence engine: never blocked)
 
-        XCTAssertNil(availability.warning)
+    func testAppleIntelligenceNeverDisablesOrWarnsEvenOnLowMemory() {
+        for template in OnboardingTemplate.allCases {
+            let availability = OnboardingTemplateRecommender.availability(
+                for: template,
+                hardware: hardware(gigabytes: 6),
+                engine: .appleIntelligence
+            )
+            XCTAssertFalse(availability.isDisabled, "\(template) must be available on Apple Intelligence.")
+            XCTAssertNil(availability.warning, "\(template) must not warn on Apple Intelligence.")
+        }
     }
 
     func testQuickIsNeverDisabledOrWarned() {
         let availability = OnboardingTemplateRecommender.availability(
             for: .quick,
             hardware: hardware(gigabytes: 4),
-            appleIntelligenceAvailable: false
+            engine: .llamaOpenSource
         )
 
         XCTAssertFalse(availability.isDisabled)
@@ -117,28 +123,28 @@ final class OnboardingTemplateRecommenderTests: XCTestCase {
 
     // MARK: - recommendation
 
-    func testRecommendsEverydayWhenAppleIntelligenceAvailable() {
+    func testRecommendsEverydayOnAppleIntelligence() {
         let recommended = OnboardingTemplateRecommender.recommendedTemplate(
             hardware: hardware(gigabytes: 8),
-            appleIntelligenceAvailable: true
+            engine: .appleIntelligence
         )
 
         XCTAssertEqual(recommended, .everyday)
     }
 
-    func testRecommendsQuickOnLowMemoryWithoutAppleIntelligence() {
+    func testRecommendsQuickOnLowMemoryOpenSource() {
         let recommended = OnboardingTemplateRecommender.recommendedTemplate(
             hardware: hardware(gigabytes: 6),
-            appleIntelligenceAvailable: false
+            engine: .llamaOpenSource
         )
 
         XCTAssertEqual(recommended, .quick)
     }
 
-    func testRecommendsEverydayOnCapableMemoryWithoutAppleIntelligence() {
+    func testRecommendsEverydayOnCapableMemoryOpenSource() {
         let recommended = OnboardingTemplateRecommender.recommendedTemplate(
             hardware: hardware(gigabytes: 16),
-            appleIntelligenceAvailable: false
+            engine: .llamaOpenSource
         )
 
         XCTAssertEqual(recommended, .everyday)
@@ -149,7 +155,7 @@ final class OnboardingTemplateRecommenderTests: XCTestCase {
         let availability = OnboardingTemplateRecommender.availability(
             for: .everyday,
             hardware: host,
-            appleIntelligenceAvailable: false
+            engine: .llamaOpenSource
         )
 
         XCTAssertTrue(availability.isRecommended)
@@ -157,7 +163,7 @@ final class OnboardingTemplateRecommenderTests: XCTestCase {
         let quickAvailability = OnboardingTemplateRecommender.availability(
             for: .quick,
             hardware: host,
-            appleIntelligenceAvailable: false
+            engine: .llamaOpenSource
         )
         XCTAssertFalse(quickAvailability.isRecommended)
     }


### PR DESCRIPTION
## Summary

Onboarding Step 2 ("Choose a starting point") conflated two separate decisions: the engine was implied by the tier, so "Everyday" silently meant Apple Intelligence while "Quick"/"Powerful" meant local downloads, and there was no way to combine a preferred engine with a preferred tier. This surfaces the engine as an explicit top-level choice and lets the tier tune behavior within it.

Two engine cards (**Apple Intelligence** / **Open Source**) now sit above the three tier cards; the Apple Intelligence card is disabled with its availability reason when the Mac can't run it. The tiers follow the selected engine:
- **Apple Intelligence** runs every tier on the on-device model (no download; the tier only tunes word-count preset / fast mode / multi-line).
- **Open Source** maps each tier to its local GGUF, keeping the existing memory-based disable/warn rules.

Reuses the existing `SuggestionEngineKind`, `OnboardingTemplate`, `FoundationModelAvailabilityService`, `ModelDownloadManager`, and the pure `OnboardingTemplateRecommender`, and aligns onboarding with the engine-first structure already used in the post-onboarding Engine settings pane.

## Validation

```
swiftlint lint --strict --quiet
# exit 0

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  CODE_SIGNING_ALLOWED=NO -only-testing:CotabbyTests/OnboardingTemplateRecommenderTests
# ** TEST SUCCEEDED **  Executed 13 tests, with 0 failures
```

The pure rules (`resolvePlan(for:engine:)`, `availability(...,engine:)`, `recommendedTemplate(hardware:engine:)`) are covered by the updated unit tests. The two-card layout itself is a UI change best confirmed by eye in a debug build at Step 2: Apple Intelligence selected by default on a supported Mac with all tiers downloadless; switching to Open Source restores per-tier sizes and memory gating; on an unsupported Mac the Apple Intelligence card is disabled with its reason and Open Source is the default.

## Linked issues

<!-- none -->

## Risk / rollout notes

- Behavior parity: the previous default (AI-capable Mac → Everyday on Apple Intelligence) is preserved as the default engine + tier, so the common path is unchanged.
- No download starts without an explicit tap; switching to Open Source after a tier is chosen starts that tier's download (the tap is consent), and an in-flight download is not cancelled when toggling back to Apple Intelligence (harmless).
- `OnboardingTemplate.prefersAppleIntelligence` was removed and `OnboardingTemplateRecommender` signatures now take the engine explicitly; the only callers are the two onboarding views and the unit tests, all updated. No `project.yml`/pbxproj changes (no files added or removed).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors onboarding Step 2 to surface the AI engine as a top-level explicit choice (two engine cards: Apple Intelligence / Open Source) above the three existing tier cards, replacing the previous implicit coupling where the tier implied the engine.

- **`OnboardingTemplateRecommender`** signatures now take an explicit `engine: SuggestionEngineKind` instead of `appleIntelligenceAvailable: Bool`; `OnboardingTemplate.prefersAppleIntelligence` is removed and `detail` strings are made engine-neutral.
- **`WelcomeTemplateStepView`** gains a new `EngineChoiceCard` component and an `engineSelector` row rendered above the tier list; `WelcomeView` adds a custom `init` that seeds `selectedEngine` from availability before first render (eliminating the selection flash), and a `selectEngine(_:)` helper that re-applies the active tier under the new engine.

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the engine-switch re-apply issue in selectEngine; the rest of the refactor is clean.

The selectEngine helper in WelcomeView unconditionally re-applies the active tier when the user switches engines, with no availability check. On an 8 GB Apple Silicon Mac, a user who picks Powerful on Apple Intelligence and then switches to Open Source will trigger the ~5 GB download that the powerfulDisableBelowGigabytes threshold was introduced to block.

Cotabby/UI/WelcomeView.swift — the selectEngine function needs an availability check before calling applyTemplate.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Models/OnboardingTemplate.swift | Removes prefersAppleIntelligence and updates detail strings to be engine-neutral; clean model change with no logic issues. |
| Cotabby/Support/OnboardingTemplateRecommender.swift | All three public methods now take an explicit engine parameter instead of appleIntelligenceAvailable; logic is correct and the memory-gating rules are unchanged for Open Source. |
| Cotabby/UI/WelcomeTemplateStepView.swift | Adds engineSelector with two EngineChoiceCards above the tier list; passes selectedEngine down as a plain let and routes selection upward via onSelectEngine. No logic issues in the view itself. |
| Cotabby/UI/WelcomeView.swift | Adds custom init to seed selectedEngine before first render and adds selectEngine helper, but selectEngine does not guard against re-applying a now-disabled tier when switching engines on low-memory Macs. |
| CotabbyTests/OnboardingTemplateRecommenderTests.swift | Tests updated to use the new engine parameter; new cases cover Apple Intelligence never downloading, tier behavior flags, and the never disable/warn invariant. Good coverage of the pure recommender layer. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User reaches Step 2] --> B{isAvailable?}
    B -- yes --> C[selectedEngine = .appleIntelligence]
    B -- no --> D[selectedEngine = .llamaOpenSource]
    C --> E[Render engineSelector]
    D --> E
    E --> F[Tap engine card]
    F --> G[selectEngine called]
    G --> H{engine changed?}
    H -- no --> I[no-op]
    H -- yes --> J[selectedEngine = newEngine]
    J --> K{selectedTemplate != nil?}
    K -- no --> L[done - no download]
    K -- yes --> M{check availability for template + engine}
    M -- enabled --> N[applyTemplate - start download if OS]
    M -- DISABLED --> O[applyTemplate still called - bypasses memory gate]
    N --> P[canContinueFromTemplate = true]
    O --> P
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22jafu%2Fonboarding-engine-choice%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22jafu%2Fonboarding-engine-choice%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FWelcomeView.swift%3A643-651%0A**Engine%20switch%20re-applies%20a%20disabled%20tier%20on%20low-memory%20Macs**%0A%0A%60selectEngine%60%20unconditionally%20calls%20%60applyTemplate%60%20for%20whatever%20tier%20is%20already%20selected%2C%20without%20checking%20whether%20that%20tier%20is%20available%20under%20the%20new%20engine.%20On%20an%208%20GB%20Mac%20%28Apple%20Silicon%2C%20Apple%20Intelligence%20supported%29%2C%20a%20user%20can%20pick%20%22Powerful%22%20on%20the%20Apple%20Intelligence%20card%20%28no%20memory%20restriction%20there%29%2C%20then%20switch%20to%20Open%20Source%20%E2%80%94%20at%20which%20point%20%60applyTemplate%28.powerful%29%60%20fires%2C%20starts%20the%20~5%20GB%20download%2C%20and%20%60canContinueFromTemplate%60%20returns%20%60true%60%20once%20the%20download%20is%20underway.%20This%20bypasses%20the%20%60powerfulDisableBelowGigabytes%60%20guard%20that%20was%20put%20in%20place%20precisely%20to%20block%20that%20download%20on%20low-memory%20machines.%0A%0AThe%20fix%20is%20to%20check%20%60availability.isDisabled%60%20before%20re-applying%2C%20and%20either%20skip%20the%20re-apply%20or%20fall%20back%20to%20the%20recommended%20tier%20when%20the%20current%20selection%20is%20disabled%20under%20the%20new%20engine.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FWelcomeView.swift%3A643-651%0A**Engine%20switch%20re-applies%20a%20disabled%20tier%20on%20low-memory%20Macs**%0A%0A%60selectEngine%60%20unconditionally%20calls%20%60applyTemplate%60%20for%20whatever%20tier%20is%20already%20selected%2C%20without%20checking%20whether%20that%20tier%20is%20available%20under%20the%20new%20engine.%20On%20an%208%20GB%20Mac%20%28Apple%20Silicon%2C%20Apple%20Intelligence%20supported%29%2C%20a%20user%20can%20pick%20%22Powerful%22%20on%20the%20Apple%20Intelligence%20card%20%28no%20memory%20restriction%20there%29%2C%20then%20switch%20to%20Open%20Source%20%E2%80%94%20at%20which%20point%20%60applyTemplate%28.powerful%29%60%20fires%2C%20starts%20the%20~5%20GB%20download%2C%20and%20%60canContinueFromTemplate%60%20returns%20%60true%60%20once%20the%20download%20is%20underway.%20This%20bypasses%20the%20%60powerfulDisableBelowGigabytes%60%20guard%20that%20was%20put%20in%20place%20precisely%20to%20block%20that%20download%20on%20low-memory%20machines.%0A%0AThe%20fix%20is%20to%20check%20%60availability.isDisabled%60%20before%20re-applying%2C%20and%20either%20skip%20the%20re-apply%20or%20fall%20back%20to%20the%20recommended%20tier%20when%20the%20current%20selection%20is%20disabled%20under%20the%20new%20engine.%0A%0A&repo=fujacob%2Fcotabby&pr=431&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Address review: seed onboarding engine i..."](https://github.com/fujacob/cotabby/commit/a5612c912f01efe6d212d7011da0e91e29fdf241) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34750184)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->