### PR TITLE
Key ghost font stabilizer on field identity, not focus sequence

### DIFF
--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
@@ -374,7 +374,8 @@ extension SuggestionCoordinator {
             caretQuality: context.caretQuality,
             observedCharWidth: context.observedCharWidth,
             isRightToLeft: isRightToLeft,
-            focusChangeSequence: context.focusChangeSequence
+            focusChangeSequence: context.focusChangeSequence,
+            focusedInputIdentityKey: context.focusedInputIdentityKey
         )
         if let message = overlayPresenter.present(
             text: text,

--- a/Cotabby/Models/SuggestionModels.swift
+++ b/Cotabby/Models/SuggestionModels.swift
@@ -177,6 +177,21 @@ struct FocusedInputContext: Equatable, Sendable {
         )
     }
 
+    /// Stable per-process key for the focused field, intentionally NOT including the input frame
+    /// rect. The polling signature in `FocusTracker` bumps `focusChangeSequence` whenever the
+    /// field's frame changes (e.g., a chat composer growing taller as the user types wraps onto a
+    /// second line). For consumers that should treat self-resizing as "same field" — chief among
+    /// them ghost-font stabilization — this key gives them a session identity that survives field
+    /// growth. `hashValue` is randomized per process, which is fine: the key is only ever compared
+    /// within one process's lifetime.
+    var focusedInputIdentityKey: UInt64 {
+        var hasher = Hasher()
+        hasher.combine(bundleIdentifier)
+        hasher.combine(processIdentifier)
+        hasher.combine(elementIdentifier)
+        return UInt64(bitPattern: Int64(hasher.finalize()))
+    }
+
     /// Content-only fingerprint — mirrors `FocusedInputSnapshot.contentSignature`.
     /// See that type's doc comment for why `elementIdentifier` is excluded.
     var contentSignature: String {
@@ -431,6 +446,12 @@ struct SuggestionOverlayGeometry: Equatable, Sendable {
     /// per-session font-size stabilization on this value, so a field switch (or focus loss) starts
     /// a fresh size baseline. Defaults to 0 for tests that do not exercise session-scoped behavior.
     let focusChangeSequence: UInt64
+    /// Stable identity for the focused input field, used to scope ghost-font stabilization.
+    /// Unlike `focusChangeSequence`, this does NOT change when the field resizes (e.g., a chat
+    /// composer growing taller as text wraps), so the stabilizer's per-session minimum survives
+    /// self-growing inputs. It DOES change when the user focuses a genuinely different field.
+    /// Defaults to 0 for tests that do not exercise session-scoped behavior.
+    let focusedInputIdentityKey: UInt64
 
     init(
         caretRect: CGRect,
@@ -438,7 +459,8 @@ struct SuggestionOverlayGeometry: Equatable, Sendable {
         caretQuality: CaretGeometryQuality,
         observedCharWidth: CGFloat?,
         isRightToLeft: Bool,
-        focusChangeSequence: UInt64 = 0
+        focusChangeSequence: UInt64 = 0,
+        focusedInputIdentityKey: UInt64 = 0
     ) {
         self.caretRect = caretRect
         self.inputFrameRect = inputFrameRect
@@ -446,6 +468,7 @@ struct SuggestionOverlayGeometry: Equatable, Sendable {
         self.observedCharWidth = observedCharWidth
         self.isRightToLeft = isRightToLeft
         self.focusChangeSequence = focusChangeSequence
+        self.focusedInputIdentityKey = focusedInputIdentityKey
     }
 }
 

--- a/Cotabby/Services/UI/OverlayController.swift
+++ b/Cotabby/Services/UI/OverlayController.swift
@@ -135,9 +135,14 @@ final class OverlayController: SuggestionOverlayControlling {
     /// Inline ghost text drawn next to the caret. This is the original rendering path; the body
     /// stays unchanged from the pre-mirror behavior aside from being extracted into its own method.
     private func showInline(text: String, geometry: SuggestionOverlayGeometry) {
+        // Key the stabilizer on the field's identity rather than `focusChangeSequence`. The polling
+        // signature in `FocusTracker` bumps `focusChangeSequence` whenever the field's frame
+        // changes, which includes the common "input grew taller as text wrapped" case. Using the
+        // identity key keeps the per-session caret-height minimum alive across that growth and
+        // still resets on genuine field switches.
         let stabilizedCaretHeight = ghostFontStabilizer.stabilizedCaretHeight(
             geometry.caretRect.height,
-            focusSessionKey: geometry.focusChangeSequence
+            focusSessionKey: geometry.focusedInputIdentityKey
         )
         let fontSize = resolvedGhostFontSize(
             forCaretHeight: stabilizedCaretHeight,


### PR DESCRIPTION
## Summary

Ghost text was doubling in size in chat composers like Slack and iMessage when the input field grew to a second line. The `GhostFontSizeStabilizer` already clamps caret height to the smallest reading observed during a focus session, but it was keyed on `focusChangeSequence`, which `FocusTracker` bumps whenever the focused-input polling signature changes — and that signature includes the field's `inputFrameRect`. So as soon as the field grew taller (text wrapping onto line 2), the stabilizer treated it as a brand-new focus session, lost its minimum, and the first post-wrap caret reading (often the coarse field-height fallback) became the new baseline.

Add a stable `focusedInputIdentityKey` derived from `(bundleIdentifier, processIdentifier, elementIdentifier)` on `FocusedInputContext`, plumb it through `SuggestionOverlayGeometry`, and key the stabilizer on it instead. The key survives self-resizing inputs but still resets on genuine field switches. `focusChangeSequence` keeps its existing meaning for other consumers (e.g., `VisualContextCoordinator`).

## Validation

- xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build (** BUILD SUCCEEDED **)
- xcodebuild test ... -only-testing:CotabbyTests/GhostFontSizeStabilizerTests -only-testing:CotabbyTests/SuggestionOverlayStabilityGateTests (16 tests, 0 failures)
- swiftlint lint --quiet (exit 0)

Manual verification (chat composer wrap) is best done with `-cotabby-debug` running on real hardware; I haven't done that in this session.

## Linked issues

None.

## Risk / rollout notes

- The hash uses Swift's `Hasher`, which is randomized per process. That's fine here — the key is only ever compared within one process's lifetime.
- `elementIdentifier` is CFHash-derived and can theoretically collide across genuinely different fields in the same process. In that pathological case the stabilizer would carry the previous field's minimum into the new field, capping the new field's ghost font slightly small. The downstream `minimumGhostFontSize` floor bounds how small it can get, so the failure mode is "ghost text a touch smaller than ideal" rather than the current "ghost text doubles." Net trade is strongly positive.
- `focusChangeSequence` is unchanged; other consumers that depend on it (notably `VisualContextCoordinator`) are unaffected.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes ghost-text doubling in self-resizing chat composers (Slack, iMessage) by keying `GhostFontSizeStabilizer` on a new `focusedInputIdentityKey` — derived from `(bundleIdentifier, processIdentifier, elementIdentifier)` — instead of `focusChangeSequence`, which was inadvertently reset whenever a growing input field changed its frame rect.

- `FocusedInputContext` gains a computed `focusedInputIdentityKey: UInt64` that omits the input frame from its hash, so the key is stable across field growth but distinct across genuine field switches.
- `SuggestionOverlayGeometry` carries the new key as a stored property (defaulting to 0 for tests), and `SuggestionCoordinator+Acceptance.swift` threads it through to the geometry at construction time.
- Note: the class-level doc comment inside `GhostFontSizeStabilizer.swift` (not in this diff) still describes the session key as "`FocusTracker`'s `focusChangeSequence`" — it should be updated to reference `focusedInputIdentityKey` to stay accurate.

<h3>Confidence Score: 4/5</h3>

The change is targeted and well-reasoned; the only loose end is a stale doc comment.

The logic change is confined to a single call site in `showInline`, the new identity key correctly excludes the frame rect that was causing spurious session resets, and the fallback behavior (a slightly-too-small ghost font on hash collision) is clearly bounded. The doc comment on `focusChangeSequence` in `SuggestionOverlayGeometry` now incorrectly claims `OverlayController` keys stabilization on it, which could mislead future maintainers. The parallel stale comment in `GhostFontSizeStabilizer.swift` (outside the diff) compounds this slightly.

The `focusChangeSequence` doc comment in `SuggestionModels.swift` needs updating; `GhostFontSizeStabilizer.swift` (not in this diff) has a matching stale comment worth cleaning up in a follow-up.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/Models/SuggestionModels.swift | Adds `focusedInputIdentityKey` computed property on `FocusedInputContext` (hashing bundle ID, PID, element ID) and a matching stored property on `SuggestionOverlayGeometry`; doc comment on the existing `focusChangeSequence` field is now stale. |
| Cotabby/Services/UI/OverlayController.swift | Single-line change in `showInline`: passes `focusedInputIdentityKey` instead of `focusChangeSequence` as the `focusSessionKey` to the ghost-font stabilizer; change is isolated and well-commented. |
| Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift | Mechanical plumbing change: passes the new `focusedInputIdentityKey` from `FocusedInputContext` into `SuggestionOverlayGeometry`; no logic change. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant FT as FocusTracker
    participant FIC as FocusedInputContext
    participant SC as SuggestionCoordinator
    participant SOG as SuggestionOverlayGeometry
    participant OC as OverlayController
    participant GFSS as GhostFontSizeStabilizer

    FT->>FIC: snapshot (bumps focusChangeSequence on frame change)
    FIC->>FIC: compute focusedInputIdentityKey\n(bundleId + pid + elementId, no frame)
    FIC->>SC: context with focusedInputIdentityKey
    SC->>SOG: build geometry(focusChangeSequence, focusedInputIdentityKey)
    SOG->>OC: geometry
    OC->>GFSS: stabilizedCaretHeight(caretHeight, focusSessionKey: focusedInputIdentityKey)
    GFSS-->>OC: clamped height (session min survives field growth)
    OC->>OC: resolvedGhostFontSize → render inline ghost text
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cotabby/Models/SuggestionModels.swift`, line 445-448 ([link](https://github.com/fujacob/cotabby/blob/0f18d906e9e53ca25622f894234d12590ac980bb/Cotabby/Models/SuggestionModels.swift#L445-L448)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `focusChangeSequence` doc comment still says "OverlayController keys its per-session font-size stabilization on this value" — that claim is now false. After this PR, `OverlayController` drives stabilization from `focusedInputIdentityKey`; `focusChangeSequence` is consumed by other paths (e.g., `VisualContextCoordinator`). Leaving the stale claim will mislead the next reader about which key actually governs ghost-font session scoping.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fghost-stabilizer-survives-field-grow%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fghost-stabilizer-survives-field-grow%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FModels%2FSuggestionModels.swift%0ALine%3A%20445-448%0A%0AComment%3A%0AThe%20%60focusChangeSequence%60%20doc%20comment%20still%20says%20%22OverlayController%20keys%20its%20per-session%20font-size%20stabilization%20on%20this%20value%22%20%E2%80%94%20that%20claim%20is%20now%20false.%20After%20this%20PR%2C%20%60OverlayController%60%20drives%20stabilization%20from%20%60focusedInputIdentityKey%60%3B%20%60focusChangeSequence%60%20is%20consumed%20by%20other%20paths%20%28e.g.%2C%20%60VisualContextCoordinator%60%29.%20Leaving%20the%20stale%20claim%20will%20mislead%20the%20next%20reader%20about%20which%20key%20actually%20governs%20ghost-font%20session%20scoping.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Identifies%20the%20focus%20session%20that%20produced%20this%20geometry.%20Other%20consumers%20such%20as%0A%20%20%20%20%2F%2F%2F%20%60VisualContextCoordinator%60%20use%20this%20to%20detect%20field%20switches%3B%20ghost-font%20stabilization%0A%20%20%20%20%2F%2F%2F%20now%20keys%20on%20%60focusedInputIdentityKey%60%20instead.%20Defaults%20to%200%20for%20tests%20that%20do%20not%0A%20%20%20%20%2F%2F%2F%20exercise%20session-scoped%20behavior.%0A%20%20%20%20let%20focusChangeSequence%3A%20UInt64%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FModels%2FSuggestionModels.swift%0ALine%3A%20445-448%0A%0AComment%3A%0AThe%20%60focusChangeSequence%60%20doc%20comment%20still%20says%20%22OverlayController%20keys%20its%20per-session%20font-size%20stabilization%20on%20this%20value%22%20%E2%80%94%20that%20claim%20is%20now%20false.%20After%20this%20PR%2C%20%60OverlayController%60%20drives%20stabilization%20from%20%60focusedInputIdentityKey%60%3B%20%60focusChangeSequence%60%20is%20consumed%20by%20other%20paths%20%28e.g.%2C%20%60VisualContextCoordinator%60%29.%20Leaving%20the%20stale%20claim%20will%20mislead%20the%20next%20reader%20about%20which%20key%20actually%20governs%20ghost-font%20session%20scoping.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Identifies%20the%20focus%20session%20that%20produced%20this%20geometry.%20Other%20consumers%20such%20as%0A%20%20%20%20%2F%2F%2F%20%60VisualContextCoordinator%60%20use%20this%20to%20detect%20field%20switches%3B%20ghost-font%20stabilization%0A%20%20%20%20%2F%2F%2F%20now%20keys%20on%20%60focusedInputIdentityKey%60%20instead.%20Defaults%20to%200%20for%20tests%20that%20do%20not%0A%20%20%20%20%2F%2F%2F%20exercise%20session-scoped%20behavior.%0A%20%20%20%20let%20focusChangeSequence%3A%20UInt64%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=432&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fghost-stabilizer-survives-field-grow%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fghost-stabilizer-survives-field-grow%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FModels%2FSuggestionModels.swift%3A445-448%0AThe%20%60focusChangeSequence%60%20doc%20comment%20still%20says%20%22OverlayController%20keys%20its%20per-session%20font-size%20stabilization%20on%20this%20value%22%20%E2%80%94%20that%20claim%20is%20now%20false.%20After%20this%20PR%2C%20%60OverlayController%60%20drives%20stabilization%20from%20%60focusedInputIdentityKey%60%3B%20%60focusChangeSequence%60%20is%20consumed%20by%20other%20paths%20%28e.g.%2C%20%60VisualContextCoordinator%60%29.%20Leaving%20the%20stale%20claim%20will%20mislead%20the%20next%20reader%20about%20which%20key%20actually%20governs%20ghost-font%20session%20scoping.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Identifies%20the%20focus%20session%20that%20produced%20this%20geometry.%20Other%20consumers%20such%20as%0A%20%20%20%20%2F%2F%2F%20%60VisualContextCoordinator%60%20use%20this%20to%20detect%20field%20switches%3B%20ghost-font%20stabilization%0A%20%20%20%20%2F%2F%2F%20now%20keys%20on%20%60focusedInputIdentityKey%60%20instead.%20Defaults%20to%200%20for%20tests%20that%20do%20not%0A%20%20%20%20%2F%2F%2F%20exercise%20session-scoped%20behavior.%0A%20%20%20%20let%20focusChangeSequence%3A%20UInt64%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FModels%2FSuggestionModels.swift%3A445-448%0AThe%20%60focusChangeSequence%60%20doc%20comment%20still%20says%20%22OverlayController%20keys%20its%20per-session%20font-size%20stabilization%20on%20this%20value%22%20%E2%80%94%20that%20claim%20is%20now%20false.%20After%20this%20PR%2C%20%60OverlayController%60%20drives%20stabilization%20from%20%60focusedInputIdentityKey%60%3B%20%60focusChangeSequence%60%20is%20consumed%20by%20other%20paths%20%28e.g.%2C%20%60VisualContextCoordinator%60%29.%20Leaving%20the%20stale%20claim%20will%20mislead%20the%20next%20reader%20about%20which%20key%20actually%20governs%20ghost-font%20session%20scoping.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Identifies%20the%20focus%20session%20that%20produced%20this%20geometry.%20Other%20consumers%20such%20as%0A%20%20%20%20%2F%2F%2F%20%60VisualContextCoordinator%60%20use%20this%20to%20detect%20field%20switches%3B%20ghost-font%20stabilization%0A%20%20%20%20%2F%2F%2F%20now%20keys%20on%20%60focusedInputIdentityKey%60%20instead.%20Defaults%20to%200%20for%20tests%20that%20do%20not%0A%20%20%20%20%2F%2F%2F%20exercise%20session-scoped%20behavior.%0A%20%20%20%20let%20focusChangeSequence%3A%20UInt64%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=432&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Key ghost font stabilizer on field ident..."](https://github.com/fujacob/cotabby/commit/0f18d906e9e53ca25622f894234d12590ac980bb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34750605)</sub>

<!-- /greptile_comment -->