### PR TITLE
Replace floating Clear link with a Reset button in profile editors

### DIFF
--- a/Cotabby/UI/CustomRulesEditor.swift
+++ b/Cotabby/UI/CustomRulesEditor.swift
@@ -3,14 +3,14 @@ import SwiftUI
 /// File overview:
 /// Editor for the user's custom autocomplete rules. Rules are short imperative style directives
 /// (e.g. "Use British spelling") shown as removable chips, added freeform or by tapping a suggested
-/// chip. "Clear" removes every rule (rules are opt-in, so the baseline is empty).
+/// chip. A bottom "Reset" button removes every rule (rules are opt-in, so the baseline is empty).
 ///
 /// The chip and flow-layout primitives live in `TagChip.swift`, shared with `LanguageTagsEditor`.
 struct CustomRulesEditor: View {
     @ObservedObject var suggestionSettings: SuggestionSettingsModel
 
     /// When false, the editor drops its own "Rules" title so an enclosing `Section("Rules")` can
-    /// supply the heading without duplicating it. The Clear control stays in place either way.
+    /// supply the heading without duplicating it. The Reset control stays in place either way.
     /// Defaults to true so standalone uses (e.g. onboarding) keep their inline title.
     var showsTitleHeader: Bool = true
 
@@ -32,22 +32,9 @@ struct CustomRulesEditor: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
-            if showsTitleHeader || canClear {
-                HStack {
-                    if showsTitleHeader {
-                        Text("Rules")
-                            .font(.system(size: 13, weight: .medium))
-                    }
-                    Spacer()
-                    if canClear {
-                        Button("Clear") {
-                            suggestionSettings.clearRules()
-                        }
-                        .buttonStyle(.plain)
-                        .font(.system(size: 12))
-                        .foregroundStyle(.secondary)
-                    }
-                }
+            if showsTitleHeader {
+                Text("Rules")
+                    .font(.system(size: 13, weight: .medium))
             }
 
             if !rules.isEmpty {
@@ -85,6 +72,18 @@ struct CustomRulesEditor: View {
                             suggestionSettings.addRule(suggestion)
                         }
                     }
+                }
+            }
+
+            if canClear {
+                HStack {
+                    Spacer()
+                    Button {
+                        suggestionSettings.clearRules()
+                    } label: {
+                        Label("Reset", systemImage: "arrow.counterclockwise")
+                    }
+                    .controlSize(.small)
                 }
             }
         }

--- a/Cotabby/UI/LanguageTagsEditor.swift
+++ b/Cotabby/UI/LanguageTagsEditor.swift
@@ -3,13 +3,13 @@ import SwiftUI
 /// File overview:
 /// Editor for the languages the user writes in. Mirrors `CustomRulesEditor`: declared languages are
 /// removable chips, added by tapping a suggestion (shown with its native name) or typing a custom
-/// one. "Clear" removes them all. The baseline is empty, which means "just follow the surrounding
-/// text." The chip and flow-layout primitives are shared via `TagChip.swift`.
+/// one. A bottom "Reset" button restores the default language set. The chip and flow-layout
+/// primitives are shared via `TagChip.swift`.
 struct LanguageTagsEditor: View {
     @ObservedObject var suggestionSettings: SuggestionSettingsModel
 
     /// When false, the editor drops its own "Languages" title so an enclosing `Section("Languages")`
-    /// can supply the heading without duplicating it. The Clear control stays in place either way.
+    /// can supply the heading without duplicating it. The Reset control stays in place either way.
     /// Defaults to true so standalone uses (e.g. onboarding) keep their inline title.
     var showsTitleHeader: Bool = true
 
@@ -31,22 +31,9 @@ struct LanguageTagsEditor: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
-            if showsTitleHeader || canClear {
-                HStack {
-                    if showsTitleHeader {
-                        Text("Languages")
-                            .font(.system(size: 13, weight: .medium))
-                    }
-                    Spacer()
-                    if canClear {
-                        Button("Clear") {
-                            suggestionSettings.clearLanguages()
-                        }
-                        .buttonStyle(.plain)
-                        .font(.system(size: 12))
-                        .foregroundStyle(.secondary)
-                    }
-                }
+            if showsTitleHeader {
+                Text("Languages")
+                    .font(.system(size: 13, weight: .medium))
             }
 
             if !languages.isEmpty {
@@ -93,6 +80,18 @@ struct LanguageTagsEditor: View {
                 + "set of languages, and local models vary, so some languages may not work.")
                 .font(.caption2)
                 .foregroundStyle(.tertiary)
+
+            if canClear {
+                HStack {
+                    Spacer()
+                    Button {
+                        suggestionSettings.clearLanguages()
+                    } label: {
+                        Label("Reset", systemImage: "arrow.counterclockwise")
+                    }
+                    .controlSize(.small)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

In the writing-profile settings, the "Clear" control sat alone in the top-right corner of the Languages and Rules cards. Because the section title comes from the enclosing `Section`, nothing balanced it, so it read as a stray link in empty space. Replace it with a proper bordered **Reset** button (with an `arrow.counterclockwise` icon) at the bottom-right of each editor. Behavior is unchanged: it restores the default language set / clears all rules, and still only appears when there's something to reset.

## Validation

```
swiftlint lint --strict --quiet
# exit 0

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **
```

Visual change; confirm in Settings → Writing: the Reset button appears at the bottom-right of the Languages and Rules cards once they differ from defaults, and disappears after resetting. The inline-title (onboarding) layout still renders its title and the same bottom Reset.

## Linked issues

<!-- none -->

## Risk / rollout notes

- UI-only, no model/settings changes; reuses the existing `clearLanguages()` / `clearRules()` actions.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Moves the \"Clear\" affordance in both `CustomRulesEditor` and `LanguageTagsEditor` from a plain link in the card header to a small bordered \"Reset\" button (`Label` + `arrow.counterclockwise`) anchored at the bottom-right of each editor. The visibility gating (`canClear`) and the underlying actions (`clearRules()` / `clearLanguages()`) are unchanged.

- **CustomRulesEditor**: Old `HStack` header that combined the title and the Clear link is split into a standalone title block and a new bottom-of-VStack Reset button guarded by `canClear`.
- **LanguageTagsEditor**: Identical restructuring; Reset button is placed after the model-support disclaimer text rather than before the content, which is a slight ordering change worth confirming looks right visually.

<h3>Confidence Score: 5/5</h3>

UI-only restructuring with no model or persistence changes; safe to merge.

Both files touch only view layout code. The `canClear` gating logic and the underlying `clearRules()`/`clearLanguages()` calls are untouched, so functional behavior is identical to before. The only loose ends are a stale private variable name (`canClear`) and doc comments in non-diff files that still say "Clear".

The stale doc comments in `SuggestionSettingsModel.swift` and `CustomRulesCatalog.swift` (both outside the diff) are worth a follow-up pass to update "Clear" to "Reset" in the prose.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/UI/CustomRulesEditor.swift | Replaces header-level plain "Clear" button with a bottom-aligned "Reset" button using a Label+icon; logic is unchanged but `canClear` naming is now slightly stale. |
| Cotabby/UI/LanguageTagsEditor.swift | Same "Clear→Reset" relocation as CustomRulesEditor; Reset button now sits below the model-support disclaimer text; logic and canClear gating are correct. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Editor renders] --> B{showsTitleHeader?}
    B -- Yes --> C[Show inline title text]
    B -- No --> D[Title omitted - Section heading provides it]
    C --> E[Render chip flow layout if list non-empty]
    D --> E
    E --> F[TextField for new entry]
    F --> G{Suggestions available and under cap?}
    G -- Yes --> H[Suggestions row]
    G -- No --> I{canClear? current != defaults}
    H --> I
    I -- Yes --> J[Bottom-right Reset button - Label + arrow.counterclockwise]
    I -- No --> K[Button hidden]
    J --> L[User clicks Reset]
    L --> M[clearRules / clearLanguages sets defaults]
    M --> N[canClear becomes false - Button disappears]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `Cotabby/UI/CustomRulesEditor.swift`, line 29-31 ([link](https://github.com/fujacob/cotabby/blob/92317e364cffb4d05c6eac7688748d439c58fe7c/Cotabby/UI/CustomRulesEditor.swift#L29-L31)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The private variable is named `canClear` but the button it gates is now labelled "Reset". This creates a small cognitive mismatch for future readers who may expect `canClear` to guard a "Clear" action. Renaming it to `canReset` keeps the code consistent with the visible UI affordance.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22jafu%2Fprofile-reset-buttons%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22jafu%2Fprofile-reset-buttons%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FCustomRulesEditor.swift%0ALine%3A%2029-31%0A%0AComment%3A%0AThe%20private%20variable%20is%20named%20%60canClear%60%20but%20the%20button%20it%20gates%20is%20now%20labelled%20%22Reset%22.%20This%20creates%20a%20small%20cognitive%20mismatch%20for%20future%20readers%20who%20may%20expect%20%60canClear%60%20to%20guard%20a%20%22Clear%22%20action.%20Renaming%20it%20to%20%60canReset%60%20keeps%20the%20code%20consistent%20with%20the%20visible%20UI%20affordance.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20var%20canReset%3A%20Bool%20%7B%0A%20%20%20%20%20%20%20%20suggestionSettings.customRules%20!%3D%20CustomRulesCatalog.defaultRules%0A%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FCustomRulesEditor.swift%0ALine%3A%2029-31%0A%0AComment%3A%0AThe%20private%20variable%20is%20named%20%60canClear%60%20but%20the%20button%20it%20gates%20is%20now%20labelled%20%22Reset%22.%20This%20creates%20a%20small%20cognitive%20mismatch%20for%20future%20readers%20who%20may%20expect%20%60canClear%60%20to%20guard%20a%20%22Clear%22%20action.%20Renaming%20it%20to%20%60canReset%60%20keeps%20the%20code%20consistent%20with%20the%20visible%20UI%20affordance.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20var%20canReset%3A%20Bool%20%7B%0A%20%20%20%20%20%20%20%20suggestionSettings.customRules%20!%3D%20CustomRulesCatalog.defaultRules%0A%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=433&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>


2. `Cotabby/UI/LanguageTagsEditor.swift`, line 28-30 ([link](https://github.com/fujacob/cotabby/blob/92317e364cffb4d05c6eac7688748d439c58fe7c/Cotabby/UI/LanguageTagsEditor.swift#L28-L30)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Same naming drift as in `CustomRulesEditor`: `canClear` guards a "Reset" button. Renaming it to `canReset` (and updating the two usage sites below) keeps the variable name aligned with the visible UI label.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22jafu%2Fprofile-reset-buttons%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22jafu%2Fprofile-reset-buttons%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FLanguageTagsEditor.swift%0ALine%3A%2028-30%0A%0AComment%3A%0ASame%20naming%20drift%20as%20in%20%60CustomRulesEditor%60%3A%20%60canClear%60%20guards%20a%20%22Reset%22%20button.%20Renaming%20it%20to%20%60canReset%60%20%28and%20updating%20the%20two%20usage%20sites%20below%29%20keeps%20the%20variable%20name%20aligned%20with%20the%20visible%20UI%20label.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20var%20canReset%3A%20Bool%20%7B%0A%20%20%20%20%20%20%20%20suggestionSettings.responseLanguages%20!%3D%20LanguageCatalog.defaultLanguages%0A%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FLanguageTagsEditor.swift%0ALine%3A%2028-30%0A%0AComment%3A%0ASame%20naming%20drift%20as%20in%20%60CustomRulesEditor%60%3A%20%60canClear%60%20guards%20a%20%22Reset%22%20button.%20Renaming%20it%20to%20%60canReset%60%20%28and%20updating%20the%20two%20usage%20sites%20below%29%20keeps%20the%20variable%20name%20aligned%20with%20the%20visible%20UI%20label.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20var%20canReset%3A%20Bool%20%7B%0A%20%20%20%20%20%20%20%20suggestionSettings.responseLanguages%20!%3D%20LanguageCatalog.defaultLanguages%0A%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=433&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>


3. `Cotabby/UI/CustomRulesEditor.swift`, line 29-31 ([link](https://github.com/fujacob/cotabby/blob/92317e364cffb4d05c6eac7688748d439c58fe7c/Cotabby/UI/CustomRulesEditor.swift#L29-L31)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Stale "Clear" references in companion files**

   `SuggestionSettingsModel.clearRules()` still carries the doc comment `Named for the UI affordance ("Clear")`, and `CustomRulesCatalog.swift` lines 8 and 18 both say `"Clear" action / "Clear" in the editor`. Now that the button is labelled "Reset", these comments are misleading to future readers. They're not part of the current diff but are directly coupled to the rename done here.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22jafu%2Fprofile-reset-buttons%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22jafu%2Fprofile-reset-buttons%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FCustomRulesEditor.swift%0ALine%3A%2029-31%0A%0AComment%3A%0A**Stale%20%22Clear%22%20references%20in%20companion%20files**%0A%0A%60SuggestionSettingsModel.clearRules%28%29%60%20still%20carries%20the%20doc%20comment%20%60Named%20for%20the%20UI%20affordance%20%28%22Clear%22%29%60%2C%20and%20%60CustomRulesCatalog.swift%60%20lines%208%20and%2018%20both%20say%20%60%22Clear%22%20action%20%2F%20%22Clear%22%20in%20the%20editor%60.%20Now%20that%20the%20button%20is%20labelled%20%22Reset%22%2C%20these%20comments%20are%20misleading%20to%20future%20readers.%20They're%20not%20part%20of%20the%20current%20diff%20but%20are%20directly%20coupled%20to%20the%20rename%20done%20here.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FCustomRulesEditor.swift%0ALine%3A%2029-31%0A%0AComment%3A%0A**Stale%20%22Clear%22%20references%20in%20companion%20files**%0A%0A%60SuggestionSettingsModel.clearRules%28%29%60%20still%20carries%20the%20doc%20comment%20%60Named%20for%20the%20UI%20affordance%20%28%22Clear%22%29%60%2C%20and%20%60CustomRulesCatalog.swift%60%20lines%208%20and%2018%20both%20say%20%60%22Clear%22%20action%20%2F%20%22Clear%22%20in%20the%20editor%60.%20Now%20that%20the%20button%20is%20labelled%20%22Reset%22%2C%20these%20comments%20are%20misleading%20to%20future%20readers.%20They're%20not%20part%20of%20the%20current%20diff%20but%20are%20directly%20coupled%20to%20the%20rename%20done%20here.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=433&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22jafu%2Fprofile-reset-buttons%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22jafu%2Fprofile-reset-buttons%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0ACotabby%2FUI%2FCustomRulesEditor.swift%3A29-31%0AThe%20private%20variable%20is%20named%20%60canClear%60%20but%20the%20button%20it%20gates%20is%20now%20labelled%20%22Reset%22.%20This%20creates%20a%20small%20cognitive%20mismatch%20for%20future%20readers%20who%20may%20expect%20%60canClear%60%20to%20guard%20a%20%22Clear%22%20action.%20Renaming%20it%20to%20%60canReset%60%20keeps%20the%20code%20consistent%20with%20the%20visible%20UI%20affordance.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20var%20canReset%3A%20Bool%20%7B%0A%20%20%20%20%20%20%20%20suggestionSettings.customRules%20!%3D%20CustomRulesCatalog.defaultRules%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0ACotabby%2FUI%2FLanguageTagsEditor.swift%3A28-30%0ASame%20naming%20drift%20as%20in%20%60CustomRulesEditor%60%3A%20%60canClear%60%20guards%20a%20%22Reset%22%20button.%20Renaming%20it%20to%20%60canReset%60%20%28and%20updating%20the%20two%20usage%20sites%20below%29%20keeps%20the%20variable%20name%20aligned%20with%20the%20visible%20UI%20label.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20var%20canReset%3A%20Bool%20%7B%0A%20%20%20%20%20%20%20%20suggestionSettings.responseLanguages%20!%3D%20LanguageCatalog.defaultLanguages%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0ACotabby%2FUI%2FCustomRulesEditor.swift%3A29-31%0A**Stale%20%22Clear%22%20references%20in%20companion%20files**%0A%0A%60SuggestionSettingsModel.clearRules%28%29%60%20still%20carries%20the%20doc%20comment%20%60Named%20for%20the%20UI%20affordance%20%28%22Clear%22%29%60%2C%20and%20%60CustomRulesCatalog.swift%60%20lines%208%20and%2018%20both%20say%20%60%22Clear%22%20action%20%2F%20%22Clear%22%20in%20the%20editor%60.%20Now%20that%20the%20button%20is%20labelled%20%22Reset%22%2C%20these%20comments%20are%20misleading%20to%20future%20readers.%20They're%20not%20part%20of%20the%20current%20diff%20but%20are%20directly%20coupled%20to%20the%20rename%20done%20here.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0ACotabby%2FUI%2FCustomRulesEditor.swift%3A29-31%0AThe%20private%20variable%20is%20named%20%60canClear%60%20but%20the%20button%20it%20gates%20is%20now%20labelled%20%22Reset%22.%20This%20creates%20a%20small%20cognitive%20mismatch%20for%20future%20readers%20who%20may%20expect%20%60canClear%60%20to%20guard%20a%20%22Clear%22%20action.%20Renaming%20it%20to%20%60canReset%60%20keeps%20the%20code%20consistent%20with%20the%20visible%20UI%20affordance.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20var%20canReset%3A%20Bool%20%7B%0A%20%20%20%20%20%20%20%20suggestionSettings.customRules%20!%3D%20CustomRulesCatalog.defaultRules%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0ACotabby%2FUI%2FLanguageTagsEditor.swift%3A28-30%0ASame%20naming%20drift%20as%20in%20%60CustomRulesEditor%60%3A%20%60canClear%60%20guards%20a%20%22Reset%22%20button.%20Renaming%20it%20to%20%60canReset%60%20%28and%20updating%20the%20two%20usage%20sites%20below%29%20keeps%20the%20variable%20name%20aligned%20with%20the%20visible%20UI%20label.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20var%20canReset%3A%20Bool%20%7B%0A%20%20%20%20%20%20%20%20suggestionSettings.responseLanguages%20!%3D%20LanguageCatalog.defaultLanguages%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0ACotabby%2FUI%2FCustomRulesEditor.swift%3A29-31%0A**Stale%20%22Clear%22%20references%20in%20companion%20files**%0A%0A%60SuggestionSettingsModel.clearRules%28%29%60%20still%20carries%20the%20doc%20comment%20%60Named%20for%20the%20UI%20affordance%20%28%22Clear%22%29%60%2C%20and%20%60CustomRulesCatalog.swift%60%20lines%208%20and%2018%20both%20say%20%60%22Clear%22%20action%20%2F%20%22Clear%22%20in%20the%20editor%60.%20Now%20that%20the%20button%20is%20labelled%20%22Reset%22%2C%20these%20comments%20are%20misleading%20to%20future%20readers.%20They're%20not%20part%20of%20the%20current%20diff%20but%20are%20directly%20coupled%20to%20the%20rename%20done%20here.%0A%0A&repo=fujacob%2Fcotabby&pr=433&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Replace floating Clear link with a Reset..."](https://github.com/fujacob/cotabby/commit/92317e364cffb4d05c6eac7688748d439c58fe7c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34750643)</sub>

<!-- /greptile_comment -->