### PR TITLE
Strip hallucinated prompt-scaffolding labels from suggestions

### DIFF
--- a/Cotabby/Support/SuggestionTextNormalizer.swift
+++ b/Cotabby/Support/SuggestionTextNormalizer.swift
@@ -53,6 +53,18 @@ enum SuggestionTextNormalizer {
         // continuation that followed.
         normalized = normalized.trimmingCharacters(in: .newlines)
 
+        // Backstop for prompt-scaffolding hallucination. Small instruct models sometimes parrot the
+        // prompt's section headers ("App:", "Text before caret:", "Continuation:") as the first
+        // thing they emit: sometimes as their own line, sometimes inline before the real text, and
+        // sometimes as labels the model invents that were never in our prompt at all. None of these
+        // are valid ghost text. Stripping a leading run of known labels runs before the single-line
+        // collapse so a model that stacks "Task:\nText before caret:\nreal continuation" still
+        // surfaces the real continuation instead of collapsing to the first label line. This is a
+        // best-effort catch, not the fix: the durable fix is feeding instruct models their own chat
+        // template so instructions never read as content in the first place.
+        normalized = stripLeadingScaffoldingLabels(normalized)
+        normalized = normalized.trimmingCharacters(in: .newlines)
+
         if request.isMultiLineEnabled {
             // Multi-line mode: keep content up to the first blank-line boundary (double newline)
             // to prevent runaway paragraph generation while still allowing multi-line completions.
@@ -143,5 +155,48 @@ enum SuggestionTextNormalizer {
         let lastEchoedWord = suggestionWords[bestOverlap - 1]
         let afterLastEchoed = lastEchoedWord.endIndex
         return String(suggestion[afterLastEchoed...])
+    }
+
+    /// Section-header labels Cotabby's prompts use, plus close variants small models tend to
+    /// hallucinate. Matching is anchored to this known set so legitimate user text that merely
+    /// contains a colon ("Note: buy milk", "TODO: ship it") is never treated as scaffolding.
+    /// Ordered longest-first at match time so "Text before the caret:" wins over "Text before".
+    private static let scaffoldingLabels: [String] = [
+        "Text before the caret:",
+        "Text before caret:",
+        "Text after the caret:",
+        "Text after caret:",
+        "User Profile Context:",
+        "Your style preferences:",
+        "Final instruction:",
+        "Screen context:",
+        "Screen content:",
+        "User's clipboard:",
+        "Continuation:",
+        "Application:",
+        "Task:",
+        "App:"
+    ]
+
+    /// Removes a leading run of known prompt-scaffolding labels (see `scaffoldingLabels`), whether
+    /// each sits on its own line or inline before the continuation. Only labels at the very start
+    /// are stripped; a label appearing later in the text is left alone because by then it is far
+    /// more likely to be real user content than echoed scaffolding.
+    private static func stripLeadingScaffoldingLabels(_ text: String) -> String {
+        let labelsByLengthDescending = scaffoldingLabels.sorted { $0.count > $1.count }
+        var working = text
+
+        while true {
+            // Look past leading whitespace/newlines to find the first real token. We only commit to
+            // dropping that whitespace if a label actually matches; otherwise `working` is returned
+            // untouched so the caller's existing leading-space handling still sees the original.
+            let leading = String(working.drop(while: { $0.isWhitespace }))
+            guard let label = labelsByLengthDescending.first(where: {
+                leading.range(of: $0, options: [.caseInsensitive, .anchored]) != nil
+            }) else {
+                return working
+            }
+            working = String(leading.dropFirst(label.count))
+        }
     }
 }

--- a/CotabbyTests/SuggestionTextNormalizerTests.swift
+++ b/CotabbyTests/SuggestionTextNormalizerTests.swift
@@ -134,4 +134,86 @@ final class SuggestionTextNormalizerTests: XCTestCase {
 
         XCTAssertEqual(normalized, "")
     }
+
+    func test_normalize_stripsLeadingInlineScaffoldingLabel() {
+        // Caret sits right after a space, so the exposed leading space is dropped and the
+        // continuation surfaces cleanly without the echoed "Text before caret:" header.
+        let request = CotabbyTestFixtures.suggestionRequest(
+            prefixText: "I am ",
+            prompt: "PROMPT",
+            precedingText: "I am "
+        )
+
+        let normalized = SuggestionTextNormalizer.normalize(
+            "Text before caret: going to the store",
+            for: request
+        )
+
+        XCTAssertEqual(normalized, "going to the store")
+    }
+
+    func test_normalize_stripsHallucinatedAppLabel() {
+        let request = CotabbyTestFixtures.suggestionRequest(
+            prefixText: "send the ",
+            prompt: "PROMPT",
+            precedingText: "send the "
+        )
+
+        let normalized = SuggestionTextNormalizer.normalize(
+            "App: report by Friday",
+            for: request
+        )
+
+        XCTAssertEqual(normalized, "report by Friday")
+    }
+
+    func test_normalize_stripsStackedScaffoldingLabelLines() {
+        // Stacked labels across newlines must be peeled before the single-line collapse, otherwise
+        // the collapse would keep only the first label line ("Task:") and the real text would be
+        // lost.
+        let request = CotabbyTestFixtures.suggestionRequest(
+            prefixText: "The ",
+            prompt: "PROMPT",
+            precedingText: "The "
+        )
+
+        let normalized = SuggestionTextNormalizer.normalize(
+            "Task:\nText before caret:\nquick brown fox",
+            for: request
+        )
+
+        XCTAssertEqual(normalized, "quick brown fox")
+    }
+
+    func test_normalize_keepsLegitimateNonLabelColon() {
+        // A colon that is not a known scaffolding label is real user content and must survive.
+        let request = CotabbyTestFixtures.suggestionRequest(
+            prefixText: "my list ",
+            prompt: "PROMPT",
+            precedingText: "my list "
+        )
+
+        let normalized = SuggestionTextNormalizer.normalize(
+            "TODO: buy milk",
+            for: request
+        )
+
+        XCTAssertEqual(normalized, "TODO: buy milk")
+    }
+
+    func test_normalize_keepsLabelLikeTextWhenNotLeading() {
+        // "Task:" appears mid-continuation, not at the start, so it is real text and stays.
+        let request = CotabbyTestFixtures.suggestionRequest(
+            prefixText: "finish the ",
+            prompt: "PROMPT",
+            precedingText: "finish the "
+        )
+
+        let normalized = SuggestionTextNormalizer.normalize(
+            "first Task: review",
+            for: request
+        )
+
+        XCTAssertEqual(normalized, "first Task: review")
+    }
 }


### PR DESCRIPTION
## Summary

Small instruct models on the local llama path sometimes parrot the prompt's section headers ("App:", "Text before caret:", "Continuation:") as the first thing they emit, and sometimes invent labels that were never in the prompt at all. Those labels leaked into the ghost text. This adds a leading-label backstop in `SuggestionTextNormalizer` that peels a run of known scaffolding labels (each on its own line, or inline before the continuation) before the single-line collapse, so the real continuation surfaces instead.

Matching is anchored to a known label set, so a legitimate colon ("TODO: buy milk") or a label that appears mid-continuation is preserved.

## Validation

- `xcodebuild ... build-for-testing` — `** BUILD SUCCEEDED **` (the 5 new tests compile against the implementation).
- `swiftlint lint --quiet` — clean on both changed files.
- **Unit tests were NOT executed on my machine:** the app-hosted `CotabbyTests` bundle fails to load locally with a Team ID code-signing mismatch (the local-signing limitation called out in CLAUDE.md). The 5 new cases (inline label stripped, hallucinated `App:` stripped, stacked label lines peeled, legitimate non-label colon preserved, mid-text label preserved) are written but need CI / a correctly-signed run to confirm green. Please rely on CI here.

## Linked issues

Addresses the in-product report of suggestions repeating section headers like `Text before caret:` and `App:`.

## Risk / rollout notes

- Behavior change is confined to the start of a raw suggestion and gated on an explicit known-label list, so normal completions are unaffected.
- This is a **best-effort catch, not the root-cause fix.** The durable fix is feeding instruct models their own chat template so prompt instructions never read as content. That is a separate cross-repo change: CotabbyInference PR #6 (https://github.com/FuJacob/cotabbyinference/pull/6) adds the C++ chat-template + special-token tokenize API, and a follow-up tabby-1 PR will bump the inference pin and rewrite `LlamaPromptRenderer` to emit role-structured messages (with a raw fallback for base models). This backstop stands on its own and keeps helping after that lands.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a label-stripping backstop in `SuggestionTextNormalizer` to peel known prompt-scaffolding headers (e.g. `"App:"`, `"Text before caret:"`) that small instruct models sometimes parrot at the start of their output before the real ghost text surfaces. Five new unit tests cover the inline, hallucinated, stacked, preserved-colon, and mid-text cases.

- `stripLeadingScaffoldingLabels` iterates a `while true` loop anchored at the start of the string, skipping leading whitespace and matching against a closed set of known labels (longest-first), terminating as soon as no label matches.
- The stripping step is inserted before the single-line collapse so stacked multi-line label runs like `"Task:\
Text before caret:\
real text"` surface the real continuation rather than collapsing to the first label line.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The change is self-contained: behavior is gated on an explicit known-label set anchored to the very start of the suggestion, so normal completions are structurally unaffected.

The stripping logic terminates deterministically (each iteration consumes at least label.count ≥ 1 characters), the label set is closed and ASCII-only (no Unicode length-mismatch risk with dropFirst), and the insertion point before the single-line collapse is exactly correct for the stacked-label case. The five new tests exercise all named edge cases. The two residual implementation nits (runtime re-sort and dropFirst vs range) were surfaced in previous review threads.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/SuggestionTextNormalizer.swift | Adds scaffoldingLabels static list and stripLeadingScaffoldingLabels private method; inserts call in normalize before the single-line collapse. Logic is correct; runtime sort and dropFirst concerns were flagged in prior threads. |
| CotabbyTests/SuggestionTextNormalizerTests.swift | Five new test cases added, covering inline label strip, hallucinated label strip, stacked label lines, preserved legitimate colon, and mid-text label preservation. All test logic appears correct. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[rawSuggestion] --> B[Strip r, chat-template markers, think-blocks]
    B --> C[Strip prompt echo / prefix echo]
    C --> D[trimCharacters in .controlCharacters union .newlines]
    D --> E[trimCharacters in .newlines]
    E --> F{stripLeadingScaffoldingLabels}
    F --> G[drop leading whitespace to leading]
    G --> H{leading starts with known label?}
    H -- Yes --> I[working = leading.dropFirst label.count, next iteration]
    I --> G
    H -- No --> J[return working]
    J --> K[trimCharacters in .newlines]
    K --> L{isMultiLineEnabled?}
    L -- No --> M[split on newline, take first line]
    L -- Yes --> N[truncate at double-newline]
    M --> O[Echo suppression + space management]
    N --> O
    O --> P[Return ghost text]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22normalizer-label-backstop%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22normalizer-label-backstop%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FSupport%2FSuggestionTextNormalizer.swift%3A190-192%0AWhen%20no%20label%20matches%2C%20the%20function%20returns%20%60working%60%20%28which%20still%20carries%20the%20leading%20whitespace%20that%20was%20consumed%20by%20%60drop%28while%3A%29%60%20in%20the%20previous%20iteration%29.%20On%20the%20first%20iteration%20%60working%60%20equals%20the%20original%20%60text%60%2C%20so%20no%20whitespace%20is%20silently%20dropped%20%E2%80%94%20that%20is%20correct%20and%20intentional.%20But%20on%20a%20*subsequent*%20iteration%20%28i.e.%20after%20at%20least%20one%20label%20has%20already%20been%20peeled%29%2C%20%60working%60%20is%20the%20tail%20left%20by%20the%20prior%20%60dropFirst%60%2C%20which%20may%20start%20with%20%60%0A%60%20or%20spaces.%20Returning%20%60working%60%20in%20that%20case%20is%20still%20fine%20because%20the%20caller%20immediately%20calls%20%60trimmingCharacters%28in%3A%20.newlines%29%60%20and%20then%20the%20space-management%20block%20handles%20any%20remaining%20leading%20space.%20The%20comment%20above%20the%20guard%20only%20describes%20the%20first-iteration%20invariant%20though%2C%20which%20can%20mislead%20a%20reader%20into%20thinking%20%60working%60%20is%20always%20the%20%22original%22%20text.%20A%20small%20wording%20update%20makes%20the%20intent%20clearer%20across%20all%20iterations.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Look%20past%20leading%20whitespace%2Fnewlines%20to%20find%20the%20first%20real%20token.%20We%20only%20commit%20to%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20dropping%20that%20whitespace%20if%20a%20label%20actually%20matches%3B%20otherwise%20%60working%60%20is%20returned%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20as-is%20so%20the%20caller's%20existing%20leading-space%20%2F%20newline-trimming%20handling%20still%20applies.%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FSupport%2FSuggestionTextNormalizer.swift%3A190-192%0AWhen%20no%20label%20matches%2C%20the%20function%20returns%20%60working%60%20%28which%20still%20carries%20the%20leading%20whitespace%20that%20was%20consumed%20by%20%60drop%28while%3A%29%60%20in%20the%20previous%20iteration%29.%20On%20the%20first%20iteration%20%60working%60%20equals%20the%20original%20%60text%60%2C%20so%20no%20whitespace%20is%20silently%20dropped%20%E2%80%94%20that%20is%20correct%20and%20intentional.%20But%20on%20a%20*subsequent*%20iteration%20%28i.e.%20after%20at%20least%20one%20label%20has%20already%20been%20peeled%29%2C%20%60working%60%20is%20the%20tail%20left%20by%20the%20prior%20%60dropFirst%60%2C%20which%20may%20start%20with%20%60%0A%60%20or%20spaces.%20Returning%20%60working%60%20in%20that%20case%20is%20still%20fine%20because%20the%20caller%20immediately%20calls%20%60trimmingCharacters%28in%3A%20.newlines%29%60%20and%20then%20the%20space-management%20block%20handles%20any%20remaining%20leading%20space.%20The%20comment%20above%20the%20guard%20only%20describes%20the%20first-iteration%20invariant%20though%2C%20which%20can%20mislead%20a%20reader%20into%20thinking%20%60working%60%20is%20always%20the%20%22original%22%20text.%20A%20small%20wording%20update%20makes%20the%20intent%20clearer%20across%20all%20iterations.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Look%20past%20leading%20whitespace%2Fnewlines%20to%20find%20the%20first%20real%20token.%20We%20only%20commit%20to%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20dropping%20that%20whitespace%20if%20a%20label%20actually%20matches%3B%20otherwise%20%60working%60%20is%20returned%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20as-is%20so%20the%20caller's%20existing%20leading-space%20%2F%20newline-trimming%20handling%20still%20applies.%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=434&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Strip hallucinated prompt-scaffolding la..."](https://github.com/fujacob/cotabby/commit/e121b620a9fdfc07ba75b1415a64d54a2cfa40de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34750938)</sub>

<!-- /greptile_comment -->