### PR TITLE
Allow contributors to run app-hosted tests locally

### DIFF
--- a/Cotabby-Debug.entitlements
+++ b/Cotabby-Debug.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.get-task-allow</key>
+    <true/>
+</dict>
+</plist>

--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -1149,6 +1149,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "Cotabby-Debug.entitlements";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -1310,7 +1311,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGNING_ALLOWED = NO;
 				CODE_SIGNING_REQUIRED = NO;
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
@@ -1374,7 +1374,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGNING_ALLOWED = NO;
 				CODE_SIGNING_REQUIRED = NO;
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;

--- a/project.yml
+++ b/project.yml
@@ -129,6 +129,9 @@ targets:
         SWIFT_OBJC_INTEROP_MODE: objcxx
         SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY: YES
         SWIFT_VERSION: "5.0"
+      configs:
+        Debug:
+          CODE_SIGN_ENTITLEMENTS: Cotabby-Debug.entitlements
   CotabbyTests:
     type: bundle.unit-test
     platform: macOS
@@ -141,7 +144,6 @@ targets:
       base:
         BUNDLE_LOADER: $(TEST_HOST)
         CODE_SIGN_IDENTITY: "-"
-        CODE_SIGNING_ALLOWED: NO
         CODE_SIGNING_REQUIRED: NO
         CODE_SIGN_STYLE: Automatic
         GENERATE_INFOPLIST_FILE: YES


### PR DESCRIPTION
## Summary

App-hosted unit tests (`CotabbyTests`) were unrunnable for any contributor who does not hold the `G946M8K23B` Apple Developer certificate. The root cause is a combination of two settings on the Cotabby target:

- `ENABLE_HARDENED_RUNTIME: YES` — macOS enforces that bundles dynamically loaded into a Hardened Runtime process must be signed, and by default requires a matching Team ID.
- `CODE_SIGNING_ALLOWED: NO` on the test bundle — prevented even ad-hoc signing, so macOS rejected the injection.

Fix: add `Cotabby-Debug.entitlements` with `com.apple.security.get-task-allow = true` and wire it into the app target's Debug config. This entitlement tells macOS to relax Hardened Runtime injection restrictions for debug/test builds. Also remove `CODE_SIGNING_ALLOWED: NO` from `CotabbyTests` so the bundle receives ad-hoc signing and can be loaded by the relaxed host.

Release/Archive builds are unaffected: the entitlements file is only applied in Debug config, and CI continues to sign with the full team certificate.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby \
  -destination 'platform=macOS' build-for-testing
# ** TEST BUILD SUCCEEDED **

swiftlint lint --quiet
# exit 0

xcodegen generate
# Created project at Cotabby.xcodeproj  (no drift)
```

End-to-end `test` action requires the team certificate locally; `build-for-testing` confirms the test bundle compiles and links correctly against the host app.

## Linked issues

Refs the note in CLAUDE.md: "If app-hosted tests fail because of local signing or Team ID mismatch, report the exact failure and still run `build-for-testing`."

## Risk / rollout notes

- `Cotabby-Debug.entitlements` is only applied to Debug builds via the `configs.Debug.CODE_SIGN_ENTITLEMENTS` key in `project.yml`. Release/Archive builds have no entitlements file change.
- `get-task-allow` is a standard Apple-blessed entitlement for test hosts; Xcode adds it automatically when managing entitlements for app-hosted tests. We are making it explicit so XcodeGen propagates it correctly.
- Removing `CODE_SIGNING_ALLOWED: NO` from `CotabbyTests` allows ad-hoc signing (`CODE_SIGN_IDENTITY: "-"`) to proceed, which is benign for a test bundle that is never distributed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes app-hosted test execution for contributors without the `G946M8K23B` team certificate by adding a `Cotabby-Debug.entitlements` file with `com.apple.security.get-task-allow` and wiring it into the Debug build config, while also removing `CODE_SIGNING_ALLOWED: NO` from the test bundle so ad-hoc signing can proceed.

- **`Cotabby-Debug.entitlements`**: Minimal entitlements plist containing only `com.apple.security.get-task-allow = true`, scoped exclusively to the Debug configuration via `project.yml` and `project.pbxproj`.
- **`project.yml` / `project.pbxproj`**: `CODE_SIGN_ENTITLEMENTS` is set under `configs.Debug` for the Cotabby app target only; the Release config remains unchanged. `CODE_SIGNING_ALLOWED: NO` is removed from `CotabbyTests` base settings, allowing ad-hoc signing (`CODE_SIGN_IDENTITY: \"-\"`) to proceed for the test bundle in both Debug and Release.

<h3>Confidence Score: 5/5</h3>

Safe to merge; changes are correctly scoped to Debug builds and do not touch Release or Archive signing.

The entitlements file contains only the single get-task-allow key Apple explicitly designates for debug/test hosts, and it is wired exclusively to the Debug build configuration in both project.yml and the generated project.pbxproj. The Release XCBuildConfiguration block for the Cotabby target has no CODE_SIGN_ENTITLEMENTS entry, so distribution builds are untouched. Removing CODE_SIGNING_ALLOWED: NO from the test bundle is safe because CODE_SIGNING_REQUIRED: NO remains and the bundle is never distributed. The project.yml and project.pbxproj are in sync.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby-Debug.entitlements | New file containing only com.apple.security.get-task-allow; minimal, correct, and scoped to Debug builds only. |
| project.yml | Adds CODE_SIGN_ENTITLEMENTS under configs.Debug for the app target (correctly scoped) and removes CODE_SIGNING_ALLOWED: NO from CotabbyTests base settings; both changes look correct. |
| Cotabby.xcodeproj/project.pbxproj | Reflects project.yml changes: entitlements file added only in the Debug XCBuildConfiguration block for Cotabby; CODE_SIGNING_ALLOWED: NO removed from both Debug and Release blocks of CotabbyTests. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[xcodebuild test / build-for-testing] --> B{Build Config?}
    B -- Debug --> C[Cotabby app signed with Cotabby-Debug.entitlements]
    C --> D[get-task-allow = true
Relaxes Hardened Runtime injection restrictions]
    D --> E[CotabbyTests bundle ad-hoc signed via CODE_SIGN_IDENTITY = '-']
    E --> F[macOS loads test bundle into app process]
    B -- Release / Archive --> G[Cotabby app signed with team certificate only]
    G --> H[Full Hardened Runtime enforcement]
```

<sub>Reviews (1): Last reviewed commit: ["Allow contributors to run app-hosted tes..."](https://github.com/fujacob/cotabby/commit/84e1ea2611f989446be937a0f4aea2f60ab41c45) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34752563)</sub>

<!-- /greptile_comment -->