### PR TITLE
Harden CI: pin action SHAs, scope permissions, fix injection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,14 +30,14 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # Pin Xcode explicitly. GitHub-hosted runner images drift their default
       # Xcode without notice, which surfaces as false-red or false-green
       # builds. Bump `xcode-version` deliberately when the project is known
       # to support a newer one.
       - name: Select Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: latest-stable
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # Use the prebuilt SwiftLint on macos-latest. The image ships a recent
       # version via Homebrew; calling `swiftlint version` in the log captures

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,11 +31,6 @@ on:
         default: false
         type: boolean
 
-permissions:
-  contents: write
-  pages: write
-  id-token: write
-
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
@@ -64,6 +59,8 @@ jobs:
     name: Build, sign, and package DMG
     runs-on: macos-26
     timeout-minutes: 120
+    permissions:
+      contents: read
     outputs:
       release_version: ${{ steps.metadata.outputs.release_version }}
       release_tag: ${{ steps.metadata.outputs.release_tag }}
@@ -74,15 +71,15 @@ jobs:
       has_sparkle_key: ${{ steps.sparkle-key.outputs.has_key }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Select Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: latest-stable
 
       - name: Select Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
 
@@ -418,7 +415,7 @@ jobs:
           codesign --verify --strict --verbose=2 "${dmg_path}"
 
       - name: Upload DMG for notarization
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cotabby-dmg
           path: build/${{ env.DMG_NAME }}
@@ -427,7 +424,7 @@ jobs:
 
       - name: Upload build diagnostics
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: build-artifacts
           path: build/${{ env.APP_NAME }}.xcarchive/
@@ -445,12 +442,13 @@ jobs:
     needs: build
     runs-on: macos-26
     timeout-minutes: 90
+    permissions: {}
     outputs:
       dmg_sha256: ${{ steps.dmg-sha.outputs.dmg_sha256 }}
 
     steps:
       - name: Download DMG artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: cotabby-dmg
           path: build
@@ -630,7 +628,7 @@ jobs:
           echo "Cotabby.dmg SHA-256: ${dmg_sha256}"
 
       - name: Upload notarized DMG
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cotabby-dmg-notarized
           path: build/${{ env.DMG_NAME }}
@@ -638,7 +636,7 @@ jobs:
 
       - name: Upload notarization diagnostics
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: notarization-diagnostics
           path: build/notarization/**
@@ -657,20 +655,24 @@ jobs:
     if: needs.build.outputs.publish == 'true'
     runs-on: macos-26
     timeout-minutes: 30
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deploy-pages.outputs.page_url }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Select Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
 
       - name: Download notarized DMG
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: cotabby-dmg-notarized
           path: build
@@ -813,20 +815,20 @@ jobs:
           printf '%s\n' "${PAGES_CUSTOM_DOMAIN}" > build/pages/CNAME
 
       - name: Configure GitHub Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: build/pages
 
       - name: Deploy GitHub Pages
         id: deploy-pages
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
 
       - name: Upload release artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-artifacts
           path: |
@@ -847,6 +849,7 @@ jobs:
     needs: [build, notarize, publish]
     if: needs.build.outputs.publish == 'true'
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Dispatch cask update to the tap
         env:

--- a/.github/workflows/republish-pages.yml
+++ b/.github/workflows/republish-pages.yml
@@ -68,32 +68,36 @@ jobs:
           fi
 
       - name: Prepare Pages artifact
+        env:
+          CUSTOM_DOMAIN: ${{ inputs.custom_domain }}
         run: |
           set -euo pipefail
           mkdir -p pages/Cotabby
           cp appcast.xml pages/appcast.xml
           cp appcast.xml pages/Cotabby/appcast.xml
-          printf '%s\n' "${{ inputs.custom_domain }}" > pages/CNAME
+          printf '%s\n' "${CUSTOM_DOMAIN}" > pages/CNAME
 
       - name: Configure GitHub Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: pages
 
       - name: Deploy GitHub Pages
         id: deploy
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
 
       - name: Summary
+        env:
+          CUSTOM_DOMAIN: ${{ inputs.custom_domain }}
         run: |
           {
             echo "### Pages Republished"
             echo "| Field | Value |"
             echo "|-------|-------|"
-            echo "| Custom domain | ${{ inputs.custom_domain }} |"
-            echo "| Appcast URL | https://${{ inputs.custom_domain }}/appcast.xml |"
+            echo "| Custom domain | ${CUSTOM_DOMAIN} |"
+            echo "| Appcast URL | https://${CUSTOM_DOMAIN}/appcast.xml |"
             echo "| Pages URL | ${{ steps.deploy.outputs.page_url }} |"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,13 +34,13 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # Same Xcode pin policy as the Build workflow. Drift between these two
       # would let a test-only cert mismatch turn into spooky green-red
       # flapping; keep them in lock-step.
       - name: Select Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: latest-stable
 

--- a/.github/workflows/xcodegen.yml
+++ b/.github/workflows/xcodegen.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install / verify XcodeGen
         run: |


### PR DESCRIPTION
## Summary

Three workflow security hardening changes in one PR:

**SHA-pin all GitHub Actions** -- every `uses:` now references a full commit SHA with the version tag as a comment. If a third-party action maintainer's account is compromised and the tag is moved to malicious code, the pinned SHA is unaffected. Covers all 8 distinct actions across all 6 workflow files. Dependabot (already configured for `github-actions`) will keep the SHAs up to date going forward.

**Scope `release.yml` permissions per-job** -- removes the top-level `permissions` block that was granting `contents:write`, `pages:write`, and `id-token:write` to every job including `notarize` and `update-homebrew-cask` which need neither. New per-job grants: `build` gets `contents:read`, `notarize` and `update-homebrew-cask` get `{}`, `publish` keeps the full write set it actually uses.

**Fix expression injection in `republish-pages.yml`** -- `${{ inputs.custom_domain }}` was spliced directly into a `run:` shell string, which lets a crafted input execute arbitrary commands. Moved through an `env:` var and referenced as `${CUSTOM_DOMAIN}` in both affected steps.

## Validation

No functional changes to any workflow logic. SHA comments confirm the exact version each pin resolves to.

```
swiftlint lint --quiet
# exit 0 (no Swift files changed)
```

Concurrent GitHub settings changes applied via API (separate from this PR):
- `actions/permissions` restricted to `github_owned_allowed + maxim-lobanov/setup-xcode@*`
- `github-pages` environment now requires a reviewer (FuJacob) before Pages deploys

## Linked issues

Follows the security audit in the review conversation.

## Risk / rollout notes

- No app behavior changes. No Swift, plist, or project files touched.
- The SHA pins are the same action versions already in use -- no API changes or behavior differences.
- The per-job permissions change is a strict reduction in token grants; no step was relying on the over-broad top-level permissions for anything it actually does.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens CI security across all six workflow files with three targeted changes: SHA-pinning every third-party action reference, scoping `release.yml` permissions to per-job minimums, and fixing a shell injection vector in `republish-pages.yml` where `inputs.custom_domain` was interpolated directly into `run:` scripts.

- **SHA pins** — all 8 distinct action references across 6 files now use a full commit SHA with the version tag as a comment, preventing tag-hijack supply-chain attacks. Dependabot is already configured to keep these up to date.
- **Per-job permissions in `release.yml`** — the broad top-level `contents:write / pages:write / id-token:write` grant is removed; `build` now gets `contents:read`, `notarize` and `update-homebrew-cask` get `{}`, and `publish` retains the full write set it actually needs.
- **Injection fix in `republish-pages.yml`** — `inputs.custom_domain` is now passed through an `env:` var and referenced as `${CUSTOM_DOMAIN}` in both the \"Prepare Pages artifact\" and \"Summary\" steps; one non-user-controlled expression (`steps.deploy.outputs.page_url`) remains inline in the Summary step.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all changes are security hardening with no functional impact on workflow logic.

The SHA pins, permission scoping, and injection fix are all correct and well-scoped. The one open item is that the Summary step in republish-pages.yml still interpolates steps.deploy.outputs.page_url directly into the shell script — inconsistent with the injection-hardening pattern just applied to the same step, though the value is not user-controlled and the action producing it is now SHA-pinned.

.github/workflows/republish-pages.yml — the Summary step has one residual inline expression worth cleaning up for consistency.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/build.yml | SHA-pins actions/checkout and maxim-lobanov/setup-xcode; no logic changes. |
| .github/workflows/lint.yml | SHA-pins actions/checkout; no logic changes. |
| .github/workflows/release.yml | SHA-pins all 7 actions; removes top-level permissions block and replaces it with per-job grants — build gets contents:read, notarize and update-homebrew-cask get {}, publish keeps the full write set it actually uses. |
| .github/workflows/republish-pages.yml | Fixes expression injection for inputs.custom_domain via env vars; SHA-pins configure-pages, upload-pages-artifact, and deploy-pages. One residual inline expression (${{ steps.deploy.outputs.page_url }}) remains in the Summary run block, though it is not user-controlled. |
| .github/workflows/tests.yml | SHA-pins actions/checkout and maxim-lobanov/setup-xcode; no logic changes. |
| .github/workflows/xcodegen.yml | SHA-pins actions/checkout; no logic changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[release.yml trigger] --> B

    subgraph B[build - contents:read]
        B1[checkout SHA-pinned] --> B2[setup-xcode SHA-pinned]
        B2 --> B3[setup-python SHA-pinned]
        B3 --> B4[Build and sign DMG]
        B4 --> B5[upload-artifact - cotabby-dmg]
    end

    B --> C

    subgraph C[notarize - permissions empty]
        C1[download-artifact - cotabby-dmg] --> C2[Apple notarization]
        C2 --> C3[Staple and verify DMG]
        C3 --> C4[upload-artifact - cotabby-dmg-notarized]
    end

    C --> D

    subgraph D[publish - contents:write, pages:write, id-token:write]
        D1[download-artifact] --> D2[Build appcast and pages]
        D2 --> D3[configure-pages SHA-pinned]
        D3 --> D4[upload-pages-artifact SHA-pinned]
        D4 --> D5[deploy-pages SHA-pinned]
    end

    D --> E

    subgraph E[update-homebrew-cask - permissions empty]
        E1[dispatch cask update via PAT]
    end
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22security%2Fharden-ci-actions%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22security%2Fharden-ci-actions%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Frepublish-pages.yml%3A92-103%0A**Residual%20inline%20expression%20in%20Summary%20step**%0A%0AThe%20injection%20fix%20was%20applied%20to%20%60inputs.custom_domain%60%20but%20the%20Summary%20step%20still%20interpolates%20%60%24%7B%7B%20steps.deploy.outputs.page_url%20%7D%7D%60%20directly%20into%20the%20shell.%20This%20is%20the%20same%20pattern%20that%20was%20fixed%20for%20the%20user-controlled%20input.%20While%20%60page_url%60%20comes%20from%20the%20now-SHA-pinned%20%60actions%2Fdeploy-pages%60%20action%20%28not%20user%20input%29%2C%20routing%20it%20through%20an%20env%20var%20would%20make%20the%20hardening%20fully%20consistent.%20Consider%20adding%20%60PAGE_URL%3A%20%24%7B%7B%20steps.deploy.outputs.page_url%20%7D%7D%60%20to%20the%20step's%20%60env%3A%60%20block%20and%20referencing%20%60%24%7BPAGE_URL%7D%60%20in%20the%20%60run%3A%60%20script.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Frepublish-pages.yml%3A92-103%0A**Residual%20inline%20expression%20in%20Summary%20step**%0A%0AThe%20injection%20fix%20was%20applied%20to%20%60inputs.custom_domain%60%20but%20the%20Summary%20step%20still%20interpolates%20%60%24%7B%7B%20steps.deploy.outputs.page_url%20%7D%7D%60%20directly%20into%20the%20shell.%20This%20is%20the%20same%20pattern%20that%20was%20fixed%20for%20the%20user-controlled%20input.%20While%20%60page_url%60%20comes%20from%20the%20now-SHA-pinned%20%60actions%2Fdeploy-pages%60%20action%20%28not%20user%20input%29%2C%20routing%20it%20through%20an%20env%20var%20would%20make%20the%20hardening%20fully%20consistent.%20Consider%20adding%20%60PAGE_URL%3A%20%24%7B%7B%20steps.deploy.outputs.page_url%20%7D%7D%60%20to%20the%20step's%20%60env%3A%60%20block%20and%20referencing%20%60%24%7BPAGE_URL%7D%60%20in%20the%20%60run%3A%60%20script.%0A%0A&repo=fujacob%2Fcotabby&pr=440&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Harden CI: pin action SHAs, scope permis..."](https://github.com/fujacob/cotabby/commit/f3f4ef492412946abc24598210740ca89d3c1e19) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34757415)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->