### PR TITLE
Scope xcodebuild output to repo build/DerivedData in agent instructions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -168,9 +168,18 @@ Prefer the narrowest useful validation first, then broaden when the change touch
 shared behavior:
 
 ```bash
-xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
-xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build-for-testing
+xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build \
+  -derivedDataPath build/DerivedData
+xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build-for-testing \
+  -derivedDataPath build/DerivedData
 ```
+
+Always pass `-derivedDataPath build/DerivedData` so output lands in the
+repo-scoped `build/` (already gitignored) instead of accumulating under
+`~/Library/Developer/Xcode/DerivedData/Cotabby-*`, where every build leaves a
+fresh multi-GB module cache and SwiftPM checkout that nothing trims. When a
+task is done and the build artifacts are no longer needed, `rm -rf
+build/DerivedData` before reporting completion.
 
 Run targeted tests when possible. If app-hosted tests fail because of local signing
 or Team ID mismatch, report the exact failure and still run `build-for-testing`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,9 +254,17 @@ Use the narrowest meaningful validation first, then broaden if the change touche
 Common commands:
 
 ```bash
-xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
-xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build-for-testing
+xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build \
+  -derivedDataPath build/DerivedData
+xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build-for-testing \
+  -derivedDataPath build/DerivedData
 ```
+
+Always pass `-derivedDataPath build/DerivedData` so the output lands in the repo-scoped `build/`
+directory (already gitignored) instead of accumulating under
+`~/Library/Developer/Xcode/DerivedData/Cotabby-*`, where every build leaves a fresh multi-GB module
+cache and SwiftPM checkout that nothing trims. When a task is done and the artifacts are no longer
+needed, `rm -rf build/DerivedData` before reporting completion.
 
 Run targeted tests for changed pure logic when available. If `xcodebuild test` fails locally because
 of app-hosted test bundle signing or Team ID mismatch, report the exact failure and still provide the


### PR DESCRIPTION
## Summary

Tell Claude and Codex to always pass `-derivedDataPath build/DerivedData` on `xcodebuild` invocations, and to `rm -rf build/DerivedData` at the end of a task. Default `xcodebuild` output lands in `~/Library/Developer/Xcode/DerivedData/Cotabby-*` where every build leaves a fresh multi-GB module cache and SwiftPM checkout that nothing trims, which has been filling local disks during agent work.

`build/` is already in `.gitignore:6`, so no .gitignore change is needed.

## Validation

Docs-only change.

## Linked issues

None.

## Risk / rollout notes

- Affects only the validation commands the agents are instructed to run; humans running Xcode through the IDE are unaffected.
- CI workflows (`.github/workflows/build.yml`, `tests.yml`, `release.yml`) set their own paths explicitly and are not touched.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This docs-only PR updates both `.claude/CLAUDE.md` and `AGENTS.md` to instruct AI agents to always pass `-derivedDataPath build/DerivedData` when running `xcodebuild`, scoping build artifacts to the repo-local `build/` directory (which is already gitignored) instead of letting them accumulate in `~/Library/Developer/Xcode/DerivedData/`.

- Both agent instruction files receive identical intent: example `xcodebuild` commands are updated with the new flag, plus an explanatory paragraph and a `rm -rf build/DerivedData` cleanup step to run before reporting task completion.
- CI workflow files are explicitly left untouched as they already manage their own paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely documentation changes that do not touch any source code, CI workflows, or build configuration.

Both changed files are agent instruction documents. The xcodebuild flag and cleanup instruction are straightforward and correctly scoped to the repo-local build directory. The only observation is that the xcodebuild test action is referenced in prose but not shown with the new flag in the example block, which could lead an agent to miss it in practice.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .claude/CLAUDE.md | Validation section updated: xcodebuild examples now include -derivedDataPath build/DerivedData, plus an explanatory paragraph and cleanup instruction. |
| AGENTS.md | Validation section updated identically to CLAUDE.md: xcodebuild examples get -derivedDataPath build/DerivedData and a cleanup/rationale paragraph. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Agent starts task] --> B[Run xcodebuild with -derivedDataPath build/DerivedData]
    B --> C{Build succeeds?}
    C -- Yes --> D[Run tests with -derivedDataPath build/DerivedData]
    C -- No --> E[Report failure]
    D --> F{Tests pass?}
    F -- Yes --> G[Task complete]
    F -- No --> H[Report failure + provide build-for-testing result]
    G --> I[rm -rf build/DerivedData]
    H --> I
    E --> I
    I --> J[Report completion]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22docs%2Fscope-derived-data-path%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Fscope-derived-data-path%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AAGENTS.md%3A269-271%0A**%60xcodebuild%20test%60%20example%20missing%20the%20new%20flag**%0A%0ABoth%20files%20reference%20%60xcodebuild%20test%60%20in%20prose%20but%20only%20update%20the%20%60build%60%20and%20%60build-for-testing%60%20example%20commands.%20An%20agent%20following%20the%20examples%20literally%20could%20invoke%20%60xcodebuild%20test%60%20without%20%60-derivedDataPath%60%2C%20silently%20writing%20GBs%20back%20to%20%60~%2FLibrary%2FDeveloper%2FXcode%2FDerivedData%2F%60.%20The%20%22always%20pass%22%20wording%20partially%20covers%20this%2C%20but%20adding%20a%20%60test%60%20example%20alongside%20the%20other%20two%20would%20make%20it%20unambiguous%20%E2%80%94%20especially%20for%20agents%20that%20learn%20primarily%20from%20the%20code%20block%20rather%20than%20the%20surrounding%20prose.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AAGENTS.md%3A269-271%0A**%60xcodebuild%20test%60%20example%20missing%20the%20new%20flag**%0A%0ABoth%20files%20reference%20%60xcodebuild%20test%60%20in%20prose%20but%20only%20update%20the%20%60build%60%20and%20%60build-for-testing%60%20example%20commands.%20An%20agent%20following%20the%20examples%20literally%20could%20invoke%20%60xcodebuild%20test%60%20without%20%60-derivedDataPath%60%2C%20silently%20writing%20GBs%20back%20to%20%60~%2FLibrary%2FDeveloper%2FXcode%2FDerivedData%2F%60.%20The%20%22always%20pass%22%20wording%20partially%20covers%20this%2C%20but%20adding%20a%20%60test%60%20example%20alongside%20the%20other%20two%20would%20make%20it%20unambiguous%20%E2%80%94%20especially%20for%20agents%20that%20learn%20primarily%20from%20the%20code%20block%20rather%20than%20the%20surrounding%20prose.%0A%0A&repo=fujacob%2Fcotabby&pr=443&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Scope xcodebuild output to repo build/De..."](https://github.com/fujacob/cotabby/commit/6b5c54875837db2b7bc1b66123551e0c15ade625) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34758050)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->