### PR TITLE
Write both prompt paths as prose, not Label: blocks

### DIFF
--- a/Cotabby/Support/LlamaPromptRenderer.swift
+++ b/Cotabby/Support/LlamaPromptRenderer.swift
@@ -23,71 +23,63 @@ enum LlamaPromptRenderer {
         clipboardContext: String? = nil,
         visualContextSummary: String? = nil
     ) -> String {
-        var sections = [
-            "Task:",
-            "- Continue the user's existing text exactly at the caret position.",
-            "- This is autocomplete, not chat. Do not answer the user or start a conversation.",
-            "- Never repeat, restate, or quote the text before the caret.",
-            "- Use clipboard context only when it directly helps the inline continuation.",
-            "- Return plain text only with no thinking, labels, bullets, markdown, quotes, or explanation."
+        // Composed entirely as prose, with no standalone `Label:` lines. Small instruct models echo
+        // a lone "Task:" / "Screen context:" / "Text before caret:" line straight into the ghost
+        // text — they read a bare label as content to continue. Folding everything into sentences
+        // removes that surface. The one invariant that actually locates the caret is preserved:
+        // `prefixText` is the LAST thing in the string, so the model (templated or base) continues
+        // from where the user stopped. The instruction sentences sit before it; the declared-language
+        // hint stays last among the instructions so it keeps its high-attention slot right before the
+        // prefix. `completionLengthInstruction` remains intentionally unused — length is governed by
+        // the token budget (`SuggestionWordCountPreset.suggestedPredictionTokenBudget`).
+        var sentences = [
+            "You complete partially-typed text. The user is the author; produce the next few words "
+                + "they would type, continuing directly from where their text stops.",
+            "This is autocomplete, not chat. Do not answer the user or start a conversation.",
+            "Never repeat, restate, or quote the text the user has already typed.",
+            "Use clipboard or screen context only when it directly helps the inline continuation.",
+            "Return plain text only, with no thinking, labels, bullets, markdown, quotes, or explanation."
         ]
 
-        var profileSections: [String] = []
         if let name = userName, !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            profileSections.append("- The user's name is \(name).")
-        }
-        if !profileSections.isEmpty {
-            sections.append("")
-            sections.append("User Profile Context:")
-            sections.append(contentsOf: profileSections)
+            sentences.append("The user's name is \(name).")
         }
 
-        // User style rules render after the base task rules and profile, with an explicit
-        // subordination line so a user "rule" can never override the autocomplete/output contract
-        // above (prompt-injection guard).
+        // User style rules are folded into a single sentence with an explicit subordination clause so
+        // a user "rule" can never override the autocomplete/output contract above (prompt-injection
+        // guard), matching the prior labeled form's intent.
         let trimmedRules = customRules
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
         if !trimmedRules.isEmpty {
-            sections.append("")
-            sections.append("Your style preferences:")
-            sections.append(contentsOf: trimmedRules.map { "- \($0)" })
-            sections.append("Apply these only when they fit the continuation naturally; never break the rules above.")
+            let joinedRules = trimmedRules.joined(separator: "; ")
+            sentences.append(
+                "When it fits the continuation naturally, also honor the user's own writing "
+                    + "preferences (\(joinedRules)), but never break the rules above."
+            )
         }
 
-        sections.append("")
-        sections.append("Screen context:")
-        sections.append("User is on \(applicationName).")
+        sentences.append("The user is writing in \(applicationName).")
         if let summary = visualContextSummary, !summary.isEmpty {
-            sections.append("Screen content:")
-            sections.append(summary)
+            sentences.append("Nearby on screen, the user can see \(summary)")
         }
         if let clipboardContext, !clipboardContext.isEmpty {
-            sections.append("User's clipboard:")
-            sections.append(clipboardContext)
+            sentences.append("The user's clipboard currently contains \(clipboardContext)")
         }
 
-        // The final task cue sits immediately before the prefix so small instruct models see the
-        // current length policy right before the text they must continue, while the prefix itself
-        // still remains the last payload in the prompt.
-        sections.append("")
-        sections.append("Final instruction:")
-        // The declared-language hint sits in the late, high-attention block right before the prefix
-        // so small instruct models actually weigh it — without it they tend to drift to English when
-        // the surrounding text is short or ambiguous.
-        if let languageInstruction, !languageInstruction.isEmpty {
-            sections.append("- \(languageInstruction)")
-        }
-        // Experiment: the explicit word-range line (`completionLengthInstruction`) is intentionally
-        // omitted from the local-model prompt so length is governed purely by the token budget
-        // (`SuggestionWordCountPreset.suggestedPredictionTokenBudget`). The parameter stays wired so
-        // re-enabling the in-prompt cue is a one-line change. Apple Intelligence still gets the cue.
         _ = completionLengthInstruction
-        sections.append("- The next line must begin directly with the continuation text.")
-        sections.append("Text before caret:")
-        sections.append(prefixText)
+        // The declared-language hint sits last among the instructions (highest attention, right
+        // before the prefix) — without it small models drift to English when the surrounding text is
+        // short or ambiguous.
+        if let languageInstruction, !languageInstruction.isEmpty {
+            sentences.append(languageInstruction)
+        }
 
-        return sections.joined(separator: "\n")
+        // Blank line then the bare prefix as the final payload: the model continues from the last
+        // text, and the blank line keeps the prefix visually distinct from the instructions without
+        // a label the model could echo.
+        let instructions = sentences.joined(separator: "\n")
+        return instructions + "\n\n" + prefixText
     }
 
     /// A system/user message pair for the chat-template path. The system turn carries every rule
@@ -105,9 +97,11 @@ enum LlamaPromptRenderer {
     ///
     /// Why the split matters: the single-string `prompt(...)` ends on a `Text before caret:` label
     /// because a raw model needs that scaffolding to know where the continuation begins. A templated
-    /// model instead gets the rules in the system turn and the bare prefix in the user turn, so the
-    /// label scaffolding (the thing small models echo back as `App:` / `Text before caret:`) is gone
-    /// entirely. The framing mirrors `FoundationModelPromptRenderer`: continue, do not converse.
+    /// model instead gets the rules and context in the system turn and the bare prefix in the user
+    /// turn. The system turn is deliberately written as prose with no standalone `Label:` lines:
+    /// small instruct models echo a lone `Screen context:` / `App:` line straight into the ghost
+    /// text, so removing the label surface (not just the trailing prefix label) is what stops the
+    /// scaffolding leak. The framing mirrors `FoundationModelPromptRenderer`: continue, do not converse.
     static func messages(
         prefixText: String,
         applicationName: String,
@@ -118,7 +112,7 @@ enum LlamaPromptRenderer {
         clipboardContext: String? = nil,
         visualContextSummary: String? = nil
     ) -> ChatPrompt {
-        var sections = [
+        var sentences = [
             "You complete partially-typed text. The user is the author; produce the next few words "
                 + "they would type, continuing directly from where their text stops.",
             "This is autocomplete, not chat. Do not answer the user, greet them, or start a "
@@ -126,45 +120,44 @@ enum LlamaPromptRenderer {
             "Never repeat, restate, or quote the text the user has already typed.",
             "Match the existing language, register, casing, and punctuation.",
             "Use clipboard or screen context only when it directly helps the inline continuation.",
-            "Return plain text only: no thinking, labels, bullets, markdown, quotes, or explanation."
+            "Return plain text only, with no thinking, labels, bullets, markdown, quotes, or explanation."
         ]
 
+        // Context is written as plain sentences rather than "Label:" blocks. The earlier labeled
+        // form (a standalone line reading e.g. "Screen context:") was the thing small instruct
+        // models echoed verbatim into ghost text — they treat a lone "Label:" line as content to
+        // continue. Folding the same information into prose removes the label surface entirely while
+        // keeping every value the model needs, so there is nothing label-shaped left to copy.
         if let name = userName, !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            sections.append("")
-            sections.append("User Profile Context:")
-            sections.append("- The user's name is \(name).")
+            sentences.append("The user's name is \(name).")
         }
 
         let trimmedRules = customRules
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
         if !trimmedRules.isEmpty {
-            sections.append("")
-            sections.append("Your style preferences:")
-            sections.append(contentsOf: trimmedRules.map { "- \($0)" })
-            sections.append("Apply these only when they fit the continuation naturally; never break the rules above.")
+            let joinedRules = trimmedRules.joined(separator: "; ")
+            sentences.append(
+                "When it fits the continuation naturally, also honor the user's own writing "
+                    + "preferences (\(joinedRules)), but never break the rules above."
+            )
         }
 
-        sections.append("")
-        sections.append("Screen context:")
-        sections.append("User is on \(applicationName).")
+        sentences.append("The user is writing in \(applicationName).")
         if let summary = visualContextSummary, !summary.isEmpty {
-            sections.append("Screen content:")
-            sections.append(summary)
+            sentences.append("Nearby on screen, the user can see \(summary)")
         }
         if let clipboardContext, !clipboardContext.isEmpty {
-            sections.append("User's clipboard:")
-            sections.append(clipboardContext)
+            sentences.append("The user's clipboard currently contains \(clipboardContext)")
         }
 
         // Length is governed by the token budget for the local path (see `prompt(...)`), so the
         // explicit word-range cue stays omitted here too; the parameter is kept wired for symmetry.
         _ = completionLengthInstruction
         if let languageInstruction, !languageInstruction.isEmpty {
-            sections.append("")
-            sections.append(languageInstruction)
+            sentences.append(languageInstruction)
         }
 
-        return ChatPrompt(system: sections.joined(separator: "\n"), user: prefixText)
+        return ChatPrompt(system: sentences.joined(separator: "\n"), user: prefixText)
     }
 }

--- a/CotabbyTests/CustomRulesTests.swift
+++ b/CotabbyTests/CustomRulesTests.swift
@@ -46,14 +46,15 @@ final class CustomRulesTests: XCTestCase {
             customRules: ["Use British spelling", "Never use em dashes"]
         )
 
-        XCTAssertTrue(prompt.contains("Your style preferences:"))
-        XCTAssertTrue(prompt.contains("- Use British spelling"))
-        XCTAssertTrue(prompt.contains("- Never use em dashes"))
+        // The prompt is prose now (no "Your style preferences:" label block), but the user's rules
+        // and the subordination clause must still be present.
+        XCTAssertTrue(prompt.contains("Use British spelling"))
+        XCTAssertTrue(prompt.contains("Never use em dashes"))
         XCTAssertTrue(prompt.contains("never break the rules above"))
 
-        // The base task rules must precede the user style section.
-        let baseIndex = try? XCTUnwrap(prompt.range(of: "Task:"))
-        let rulesIndex = try? XCTUnwrap(prompt.range(of: "Your style preferences:"))
+        // The base autocomplete rules must precede the user style preferences.
+        let baseIndex = try? XCTUnwrap(prompt.range(of: "autocomplete, not chat"))
+        let rulesIndex = try? XCTUnwrap(prompt.range(of: "Use British spelling"))
         if let baseIndex, let rulesIndex {
             XCTAssertLessThan(baseIndex.lowerBound, rulesIndex.lowerBound)
         }
@@ -68,6 +69,8 @@ final class CustomRulesTests: XCTestCase {
             customRules: []
         )
 
+        // No user rules → no style-preferences sentence (and no leftover label form either).
+        XCTAssertFalse(prompt.contains("writing preferences"))
         XCTAssertFalse(prompt.contains("Your style preferences:"))
     }
 

--- a/CotabbyTests/LanguageSupportTests.swift
+++ b/CotabbyTests/LanguageSupportTests.swift
@@ -69,9 +69,11 @@ final class LanguageSupportTests: XCTestCase {
 
     // MARK: - rendering
 
-    func test_llamaRenderer_placesLanguageHintInFinalBlock() {
-        // The length cue is no longer rendered (token-budget-only experiment), so this guards that
-        // the language hint still lands in the late, high-attention final-instruction block.
+    func test_llamaRenderer_placesLanguageHintLateRightBeforePrefix() {
+        // The length cue is no longer rendered (token-budget-only experiment), and the prompt is now
+        // prose with no "Final instruction:" header. This guards that the language hint still lands
+        // late — after the app-context sentence and immediately before the prefix, its
+        // high-attention slot — so small models actually weigh it.
         let prompt = LlamaPromptRenderer.prompt(
             prefixText: "Hola",
             applicationName: "Notes",
@@ -82,12 +84,16 @@ final class LanguageSupportTests: XCTestCase {
 
         XCTAssertFalse(prompt.contains("UNIQUE_LENGTH_CUE"))
 
-        guard let finalRange = prompt.range(of: "Final instruction:"),
-              let langRange = prompt.range(of: "Spanish") else {
-            XCTFail("Expected final instruction header and language hint in the prompt")
+        guard let contextRange = prompt.range(of: "writing in Notes"),
+              let langRange = prompt.range(of: "Spanish"),
+              let prefixRange = prompt.range(of: "Hola") else {
+            XCTFail("Expected app-context sentence, language hint, and prefix in the prompt")
             return
         }
-        XCTAssertLessThan(finalRange.lowerBound, langRange.lowerBound)
+        // Order: app context → language hint → prefix (last).
+        XCTAssertLessThan(contextRange.lowerBound, langRange.lowerBound)
+        XCTAssertLessThan(langRange.lowerBound, prefixRange.lowerBound)
+        XCTAssertTrue(prompt.hasSuffix("Hola"))
     }
 
     func test_llamaRenderer_emitsNoLanguageLineWhenNoneDeclared() {

--- a/CotabbyTests/LlamaPromptRendererTests.swift
+++ b/CotabbyTests/LlamaPromptRendererTests.swift
@@ -60,10 +60,11 @@ final class LlamaPromptRendererTests: XCTestCase {
 
     // MARK: - instruction prompt
 
-    /// The structural contract for local instruct models: stable task rules first, supporting
-    /// context in the middle, then a late length cue right before the prefix the model must
-    /// continue. Losing one of these sections tends to degrade prompt-following without throwing.
-    func test_instructionPrompt_containsTaskScreenContextAndFinalInstruction() {
+    /// The prose contract for the raw single-string prompt: autocomplete rules, then context as
+    /// sentences, then the bare prefix as the final payload. No standalone `Label:` lines (the
+    /// thing small models echo into ghost text), and the prefix stays last so the model continues
+    /// from where the user stopped.
+    func test_instructionPrompt_carriesAutocompleteRulesAndAppContextAsProse() {
         let prompt = LlamaPromptRenderer.prompt(
             prefixText: "Once upon",
             applicationName: "Messages",
@@ -71,16 +72,32 @@ final class LlamaPromptRendererTests: XCTestCase {
             userName: nil
         )
 
-        XCTAssertTrue(prompt.contains("Task:"), "instruction prompt should include Task section")
-        XCTAssertTrue(
-            prompt.contains("Screen context:"),
-            "instruction prompt should include Screen context section"
+        XCTAssertTrue(prompt.contains("autocomplete, not chat"))
+        XCTAssertTrue(prompt.contains("writing in Messages"))
+    }
+
+    /// No standalone `Label:` line may appear, even with every context block populated — those are
+    /// exactly what small instruct models parrot back as ghost text.
+    func test_instructionPrompt_containsNoLabelScaffolding() {
+        let prompt = LlamaPromptRenderer.prompt(
+            prefixText: "Once upon",
+            applicationName: "Messages",
+            completionLengthInstruction: "Keep completion short.",
+            userName: "Jacob",
+            customRules: ["Be concise"],
+            languageInstruction: "Respond in German.",
+            clipboardContext: "clip",
+            visualContextSummary: "a form"
         )
-        XCTAssertTrue(
-            prompt.contains("Final instruction:"),
-            "instruction prompt should include a late final instruction section"
-        )
-        XCTAssertTrue(prompt.contains("Text before caret:"), "instruction prompt should include the prefix header")
+
+        XCTAssertFalse(prompt.contains("Task:"))
+        XCTAssertFalse(prompt.contains("Screen context:"))
+        XCTAssertFalse(prompt.contains("Screen content:"))
+        XCTAssertFalse(prompt.contains("Final instruction:"))
+        XCTAssertFalse(prompt.contains("Text before caret:"))
+        XCTAssertFalse(prompt.contains("User Profile Context:"))
+        XCTAssertFalse(prompt.contains("Your style preferences:"))
+        XCTAssertFalse(prompt.contains("User's clipboard:"))
     }
 
     func test_instructionPrompt_includesApplicationNameAndPrefix() {
@@ -91,16 +108,13 @@ final class LlamaPromptRendererTests: XCTestCase {
             userName: nil
         )
 
-        XCTAssertTrue(prompt.contains("User is on Slack."))
+        XCTAssertTrue(prompt.contains("writing in Slack"))
         XCTAssertTrue(prompt.contains("My prefix text here"))
     }
 
     /// Length is enforced by the token budget, not by an in-prompt word range, so the
     /// completion-length cue must never reach the local-model prompt even if a caller passes one.
     func test_instructionPrompt_omitsCompletionLengthInstruction() {
-        // Experiment: the local-model prompt no longer carries the word-range cue; length is
-        // governed solely by the token budget. The cue must not leak into the prompt even when a
-        // caller still passes one.
         let prompt = LlamaPromptRenderer.prompt(
             prefixText: "PREFIX_BODY_XYZ",
             applicationName: "App",
@@ -109,14 +123,8 @@ final class LlamaPromptRendererTests: XCTestCase {
         )
 
         XCTAssertFalse(prompt.contains("UNIQUE_LENGTH_MARKER_7_TO_12_WORDS"))
-
-        guard let finalInstructionRange = prompt.range(of: "Final instruction:"),
-              let prefixRange = prompt.range(of: "PREFIX_BODY_XYZ") else {
-            XCTFail("Expected final instruction header and prefix in the prompt")
-            return
-        }
-
-        XCTAssertLessThan(finalInstructionRange.lowerBound, prefixRange.lowerBound)
+        // The prefix is still the last payload regardless.
+        XCTAssertTrue(prompt.hasSuffix("PREFIX_BODY_XYZ"))
     }
 
     func test_instructionPrompt_includesProfileContextWhenProvided() {
@@ -131,9 +139,9 @@ final class LlamaPromptRendererTests: XCTestCase {
                       "instruction prompt should carry user-provided profile name")
     }
 
-    /// The prefix remains the last payload in the prompt so the model still ends on the actual
-    /// text it must continue, even though the length cue is moved later in the prompt.
-    func test_instructionPrompt_prefixAppearsAfterScreenContextAndEndsPrompt() {
+    /// The prefix remains the last payload in the prompt so the model ends on the actual text it
+    /// must continue. This is the one structural invariant the prose rewrite must preserve.
+    func test_instructionPrompt_prefixAppearsAfterContextAndEndsPrompt() {
         let prompt = LlamaPromptRenderer.prompt(
             prefixText: "PREFIX_BODY_XYZ",
             applicationName: "App",
@@ -141,14 +149,14 @@ final class LlamaPromptRendererTests: XCTestCase {
             userName: nil
         )
 
-        guard let contextRange = prompt.range(of: "Screen context:"),
+        guard let contextRange = prompt.range(of: "writing in App"),
               let prefixRange = prompt.range(of: "PREFIX_BODY_XYZ") else {
-            XCTFail("Expected both Screen context: and PREFIX_BODY_XYZ in the prompt")
+            XCTFail("Expected both the app-context sentence and PREFIX_BODY_XYZ in the prompt")
             return
         }
 
         XCTAssertLessThan(contextRange.lowerBound, prefixRange.lowerBound,
-                          "prefix must appear after the Screen context header")
+                          "prefix must appear after the app-context sentence")
         XCTAssertTrue(prompt.hasSuffix("PREFIX_BODY_XYZ"))
     }
 
@@ -161,7 +169,7 @@ final class LlamaPromptRendererTests: XCTestCase {
             visualContextSummary: "A window describing a cat."
         )
 
-        XCTAssertTrue(prompt.contains("Screen content:"))
+        XCTAssertTrue(prompt.contains("Nearby on screen, the user can see"))
         XCTAssertTrue(prompt.contains("A window describing a cat."))
     }
 
@@ -174,7 +182,7 @@ final class LlamaPromptRendererTests: XCTestCase {
             clipboardContext: "UNIQUE_CLIPBOARD_MARKER"
         )
 
-        XCTAssertTrue(prompt.contains("User's clipboard:"))
+        XCTAssertTrue(prompt.contains("clipboard currently contains"))
         XCTAssertTrue(prompt.contains("UNIQUE_CLIPBOARD_MARKER"))
     }
 
@@ -187,7 +195,7 @@ final class LlamaPromptRendererTests: XCTestCase {
             visualContextSummary: nil
         )
 
-        XCTAssertFalse(prompt.contains("Screen content:"))
+        XCTAssertFalse(prompt.contains("Nearby on screen"))
     }
 
     // MARK: - messages() chat-template path
@@ -245,7 +253,9 @@ final class LlamaPromptRendererTests: XCTestCase {
         )
 
         XCTAssertTrue(chat.system.contains("autocomplete, not chat"))
-        XCTAssertTrue(chat.system.contains("User is on TextEdit"))
+        // App context is now prose ("The user is writing in TextEdit."), not a "Screen context:"
+        // label block — but the application name itself must still be present.
+        XCTAssertTrue(chat.system.contains("writing in TextEdit"))
     }
 
     func test_messages_systemTurnIncludesProfileRulesContextWhenProvided() {
@@ -265,6 +275,14 @@ final class LlamaPromptRendererTests: XCTestCase {
         XCTAssertTrue(chat.system.contains("Respond in German."))
         XCTAssertTrue(chat.system.contains("copied text"))
         XCTAssertTrue(chat.system.contains("a login form"))
+
+        // The prose invariant: even with every context block populated, the system turn must carry
+        // no standalone "Label:" lines — those are exactly what small models echoed into ghost text.
+        XCTAssertFalse(chat.system.contains("User Profile Context:"))
+        XCTAssertFalse(chat.system.contains("Your style preferences:"))
+        XCTAssertFalse(chat.system.contains("Screen context:"))
+        XCTAssertFalse(chat.system.contains("Screen content:"))
+        XCTAssertFalse(chat.system.contains("User's clipboard:"))
     }
 
     func test_messages_omitsOptionalContextWhenAbsent() {

--- a/CotabbyTests/SuggestionRequestFactoryTests.swift
+++ b/CotabbyTests/SuggestionRequestFactoryTests.swift
@@ -239,7 +239,7 @@ final class SuggestionRequestFactoryTests: XCTestCase {
         )
 
         XCTAssertEqual(result.request.clipboardContext, "Copied project notes.")
-        XCTAssertTrue(result.promptPreview.contains("User's clipboard:"))
+        XCTAssertTrue(result.promptPreview.contains("clipboard currently contains"))
         XCTAssertTrue(result.promptPreview.contains("Copied project notes."))
     }
 
@@ -272,7 +272,7 @@ final class SuggestionRequestFactoryTests: XCTestCase {
         )
 
         XCTAssertNil(result.request.clipboardContext)
-        XCTAssertFalse(result.promptPreview.contains("User's clipboard:"))
+        XCTAssertFalse(result.promptPreview.contains("clipboard currently contains"))
         XCTAssertFalse(result.promptPreview.contains("Copied project notes."))
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #438. Both local-model prompt builders carried standalone `Label:` lines (`Task:`, `Screen context:`, `Screen content:`, `User's clipboard:`, `Final instruction:`, `Text before caret:`, `User Profile Context:`, `Your style preferences:`). Small instruct models echo a lone `Label:` line straight into the ghost text — the same class of bug as the `App:` / `Text before caret:` echo this whole effort targets.

This converts **both** `LlamaPromptRenderer` paths to plain prose with zero standalone labels:

- **`messages()`** (chat-template path, instruct models) — system turn is now sentences.
- **`prompt()`** (raw single-string path, base / drag-and-drop GGUFs) — also sentences.

Example mappings (both paths):
| Before | After |
|---|---|
| `Screen context:` + `User is on X.` | `The user is writing in X.` |
| `Screen content:` + summary | `Nearby on screen, the user can see <summary>` |
| `User's clipboard:` + text | `The user's clipboard currently contains <text>` |
| `Your style preferences:` + bulleted rules | one sentence honoring the rules, subordinate to the base rules |
| trailing `Text before caret:` label | (removed) |

**The one invariant preserved:** in both paths the bare prefix is still the very last thing in the string, so the model continues from where the user stopped. In `prompt()` the prefix follows a blank line with no label.

## Why both paths (updated from the earlier draft)

The earlier version only did `messages()`, on the assumption the raw `prompt()` labels were load-bearing for base models. On review that assumption didn't hold — what locates the caret is the prefix being **last**, not the label — so per your call this now applies prose to the raw path too. A base/web-text model is arguably *less* confused by prose than by a labeled instruction blob.

## Validation

- `xcodebuild ... build` and `... build-for-testing` — both `SUCCEEDED`.
- `swiftlint --quiet` — clean across all five changed files.
- Tests updated to the prose contract: renderer tests assert the new wording and that **no** standalone `Label:` line survives (with every context block populated); CustomRules / LanguageSupport / SuggestionRequestFactory llama-path assertions updated to prose; **Foundation Models tests deliberately untouched** — `FoundationModelPromptRenderer` keeps its labels (separate Apple path, out of scope). Full suite runs on CI.
- **Not yet validated on a real model** — like #438, the actual echo reduction wants a Qwen/Gemma + base-GGUF smoke test before merge.

## Stacking

Based on `chat-template-prompts` (#438). Merge #438 first; I'll retarget this to `main` once it lands.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR converts the context blocks in `LlamaPromptRenderer` from standalone `Label:` lines (`Screen context:`, `User's clipboard:`, etc.) to inline prose sentences, eliminating the label-shaped surface that small instruct models echo verbatim into ghost text.

- `messages()` system turn is rewritten as prose sentences (e.g. `\"The user is writing in X.\"`, `\"The user's clipboard currently contains …\"`), with no blank-line-separated label headers remaining.
- `prompt()` (the single-string path, documented as the base-model fallback) was also converted to the same prose format, removing `Task:`, `Screen context:`, `Final instruction:`, and `Text before caret:` labels.
- Tests across four files are updated to assert prose phrases and the absence of every old label string.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the instruct/chat-template path; the `prompt()` change needs a quick confirmation that it is intentional before merging.

The PR description devotes an entire section to explaining why `prompt()` is deliberately left labeled for base completion models, yet the code converts `prompt()` to prose as well, removing the `Text before caret:` scaffold the description says those models depend on. The tests explicitly verify the label-free format for `prompt()`, so the change appears intentional — but the description and title both imply only `messages()` was in scope.

Cotabby/Support/LlamaPromptRenderer.swift — specifically the `prompt()` function and whether its label removal is intentional given the PR description's stated rationale for keeping it labeled.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/LlamaPromptRenderer.swift | Both `prompt()` and `messages()` converted to prose — contradicts the PR description which says `prompt()` is deliberately left labeled for base completion models. |
| CotabbyTests/LlamaPromptRendererTests.swift | Tests updated to match prose format; `test_messages_omitsOptionalContextWhenAbsent` still asserts absence of old label strings that the new code never emits, so those assertions are vacuous. |
| CotabbyTests/CustomRulesTests.swift | Assertion anchors updated from 'Task:' / 'Your style preferences:' to 'autocomplete, not chat' / rule text — correctly validates the new prose ordering. |
| CotabbyTests/LanguageSupportTests.swift | Language-hint ordering test updated to check context → hint → prefix order directly, without relying on the removed 'Final instruction:' header. |
| CotabbyTests/SuggestionRequestFactoryTests.swift | Clipboard presence/absence checks updated from 'User's clipboard:' label to 'clipboard currently contains' prose phrase — correct and sufficient. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SuggestionRequestFactory] --> B{hasChatTemplate?}
    B -->|Yes| C["messages()"]
    B -->|No| D["prompt()"]
    C --> E["System turn: prose sentences, no Label: lines"]
    C --> F["User turn: bare prefixText"]
    D --> G["All prose sentences, no Label: lines, blank line + prefixText at end"]
    E --> H[ChatPrompt.system]
    F --> I[ChatPrompt.user]
    G --> J[Single prompt string]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22chat-template-prose-context%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chat-template-prose-context%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FSupport%2FLlamaPromptRenderer.swift%3A26-82%0A**%60prompt%28%29%60%20converted%20to%20prose%20despite%20PR%20description%20saying%20it%20was%20left%20labeled**%0A%0AThe%20PR%20description's%20%22Why%20only%20%60messages%28%29%60%2C%20not%20%60prompt%28%29%60%22%20section%20states%3A%20*%22The%20raw%20%60prompt%28%29%60%20path%20is%20deliberately%20left%20labeled.%20Base%20completion%20models%20have%20**no**%20chat%20template%20and%20rely%20on%20that%20scaffolding%20%28%60Text%20before%20caret%3A%5Cn%3Cprefix%3E%60%29%20to%20locate%20the%20caret%3B%20making%20it%20prose%20would%20hurt%20their%20completion%20quality.%22*%0A%0ABut%20this%20function%20was%20fully%20converted%20to%20prose%20too%20%E2%80%94%20%60Task%3A%60%2C%20%60Screen%20context%3A%60%2C%20%60Final%20instruction%3A%60%2C%20and%20%60Text%20before%20caret%3A%60%20are%20all%20gone%2C%20and%20the%20caret%20is%20now%20located%20only%20by%20a%20blank-line%20separator%20before%20the%20prefix.%20If%20%60prompt%28%29%60%20is%20still%20routed%20to%20non-instruct%20base%20models%2C%20those%20models%20lose%20the%20explicit%20scaffold%20the%20description%20says%20they%20need.%20The%20tests%20%60test_instructionPrompt_containsNoLabelScaffolding%60%20and%20the%20in-code%20comment%20%28%22Composed%20entirely%20as%20prose%22%29%20confirm%20this%20was%20intentional%2C%20so%20either%20the%20description%20is%20stale%20or%20%60prompt%28%29%60%20is%20no%20longer%20used%20with%20raw%20base%20models%20%E2%80%94%20worth%20confirming%20before%20merge.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FSupport%2FLlamaPromptRenderer.swift%3A26-82%0A**%60prompt%28%29%60%20converted%20to%20prose%20despite%20PR%20description%20saying%20it%20was%20left%20labeled**%0A%0AThe%20PR%20description's%20%22Why%20only%20%60messages%28%29%60%2C%20not%20%60prompt%28%29%60%22%20section%20states%3A%20*%22The%20raw%20%60prompt%28%29%60%20path%20is%20deliberately%20left%20labeled.%20Base%20completion%20models%20have%20**no**%20chat%20template%20and%20rely%20on%20that%20scaffolding%20%28%60Text%20before%20caret%3A%5Cn%3Cprefix%3E%60%29%20to%20locate%20the%20caret%3B%20making%20it%20prose%20would%20hurt%20their%20completion%20quality.%22*%0A%0ABut%20this%20function%20was%20fully%20converted%20to%20prose%20too%20%E2%80%94%20%60Task%3A%60%2C%20%60Screen%20context%3A%60%2C%20%60Final%20instruction%3A%60%2C%20and%20%60Text%20before%20caret%3A%60%20are%20all%20gone%2C%20and%20the%20caret%20is%20now%20located%20only%20by%20a%20blank-line%20separator%20before%20the%20prefix.%20If%20%60prompt%28%29%60%20is%20still%20routed%20to%20non-instruct%20base%20models%2C%20those%20models%20lose%20the%20explicit%20scaffold%20the%20description%20says%20they%20need.%20The%20tests%20%60test_instructionPrompt_containsNoLabelScaffolding%60%20and%20the%20in-code%20comment%20%28%22Composed%20entirely%20as%20prose%22%29%20confirm%20this%20was%20intentional%2C%20so%20either%20the%20description%20is%20stale%20or%20%60prompt%28%29%60%20is%20no%20longer%20used%20with%20raw%20base%20models%20%E2%80%94%20worth%20confirming%20before%20merge.%0A%0A&repo=fujacob%2Fcotabby&pr=444&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Write chat-template system turn as prose..."](https://github.com/fujacob/cotabby/commit/c6e9505e88c1b10e37262fdff96357891a3f548a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34758121)</sub>

<!-- /greptile_comment -->