### PR TITLE
Widen Settings sidebar from 260pt to 340pt

### DIFF
--- a/Cotabby/App/Coordinators/SettingsCoordinator.swift
+++ b/Cotabby/App/Coordinators/SettingsCoordinator.swift
@@ -70,15 +70,14 @@ final class SettingsCoordinator: NSObject, NSWindowDelegate {
                 )
             )
         )
-        // Sized to fit the actual content: a fixed 260pt sidebar (see `SettingsSidebarView`)
-        // plus a ~600pt detail column for the grouped form. The previous 1320x820 default with
-        // a 1180 minimum was far wider than any pane's content, which is exactly what left the
-        // detail area looking stretched and the window feeling empty.
-        let initialFrame = CGRect(x: 0, y: 0, width: 860, height: 700)
-        let minSize = NSSize(width: 820, height: 560)
-        // Bump the autosave name so anyone holding a saved 1320-wide V3 frame gets the new
-        // right-sized default once, instead of restoring the oversized window.
-        let autosaveName = "CotabbySettingsWindowV4"
+        // Sized to fit the actual content: a fixed 340pt sidebar (see `SettingsSidebarView`)
+        // plus a ~600pt detail column for the grouped form.
+        let initialFrame = CGRect(x: 0, y: 0, width: 940, height: 700)
+        let minSize = NSSize(width: 900, height: 560)
+        // Bump the autosave name so anyone holding a saved frame from the previous default gets
+        // the new right-sized default once, instead of restoring a window where the wider sidebar
+        // squeezes the detail column.
+        let autosaveName = "CotabbySettingsWindowV5"
 
         let window = NSWindow(
             contentRect: initialFrame,

--- a/Cotabby/UI/Settings/SettingsSidebarView.swift
+++ b/Cotabby/UI/Settings/SettingsSidebarView.swift
@@ -27,8 +27,7 @@ struct SettingsSidebarView: View {
         }
         // A single fixed width (not a min/ideal/max range) so `.balanced` can't squeeze the column
         // down to where labels truncate — the exact failure mode of the previous ranged width.
-        // 260pt comfortably fits the longest label ("Engine & Model") with room to spare.
-        .navigationSplitViewColumnWidth(260)
+        .navigationSplitViewColumnWidth(340)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary

The sidebar in the redesigned Settings window felt cramped — at 260pt every row label had a lot of empty space to its right and the list looked stranded inside the column. Widens it to 340pt and grows the window default (940 wide, 900 min) so the detail column keeps its ~600pt budget.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build \
  -derivedDataPath build/DerivedData
# ** BUILD SUCCEEDED **

swiftlint lint --quiet
# 0 issues
```

## Linked issues

None.

## Risk / rollout notes

- Window autosave name bumped to `CotabbySettingsWindowV5` so users holding a saved V4 frame get the new default once. Without this they would restore a 860-wide window with the new 340pt sidebar squeezing the detail column.
- The `.balanced` split-view style is unchanged; the sidebar still has a single fixed width (no min/ideal/max range) so the column can't truncate labels.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR widens the Settings sidebar from 260pt to 340pt and adjusts the window dimensions proportionally so the detail column retains its ~600pt budget. The autosave key is bumped to `CotabbySettingsWindowV5` to force users off any saved V4 frame that would be too narrow for the new sidebar.

- `SettingsSidebarView.swift`: `.navigationSplitViewColumnWidth` changed from 260 to 340; comment updated.
- `SettingsCoordinator.swift`: initial window width 860→940, minimum width 820→900 (both +80pt, matching the sidebar delta); autosave name incremented to V5 to reset persisted frames.

<h3>Confidence Score: 5/5</h3>

Safe to merge — two small, consistent layout changes with no logic or behavioral risk.

Both changes are purely numeric constants. The +80pt sidebar delta is applied consistently to the initial window width, the minimum window width, and the column width modifier, leaving the detail column at exactly 600pt as documented. The autosave name bump correctly forces a frame reset for existing users.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/Settings/SettingsSidebarView.swift | Single-line change: `.navigationSplitViewColumnWidth` updated from 260 to 340. No logic changes; comment updated to match. |
| Cotabby/App/Coordinators/SettingsCoordinator.swift | Initial window width 860→940, minimum width 820→900 (both +80pt to match the sidebar growth), autosave name bumped to V5. Math is consistent: 940–340=600pt detail budget preserved. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[showSettings called] --> B{Window already open?}
    B -- Yes --> C[Bring existing window to front]
    B -- No --> D[Create NSHostingController\nwith SettingsContainerView]
    D --> E[Set initialFrame\n940 x 700]
    E --> F[Set minSize\n900 x 560]
    F --> G[Set autosaveName\nCotabbySettingsWindowV5]
    G --> H[Create & configure NSWindow]
    H --> I[SettingsContainerView\nNavigationSplitView]
    I --> J[Sidebar\n340pt fixed width]
    I --> K[Detail column\n~600pt]
```

<sub>Reviews (1): Last reviewed commit: ["Widen Settings sidebar from 260pt to 340..."](https://github.com/fujacob/cotabby/commit/83070b1436ff6473c2fb9d33929132cd72f31c8e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34758153)</sub>

<!-- /greptile_comment -->