### PR TITLE
Restore native Settings split view defaults

### DIFF
--- a/Cotabby/App/Coordinators/SettingsCoordinator.swift
+++ b/Cotabby/App/Coordinators/SettingsCoordinator.swift
@@ -70,14 +70,13 @@ final class SettingsCoordinator: NSObject, NSWindowDelegate {
                 )
             )
         )
-        // Sized to fit the actual content: a fixed 340pt sidebar (see `SettingsSidebarView`)
-        // plus a ~600pt detail column for the grouped form.
-        let initialFrame = CGRect(x: 0, y: 0, width: 940, height: 700)
+        // Sized so the native split view opens with a readable sidebar and a comfortable grouped
+        // detail form. The user can still resize from here; the sidebar provides its own range.
+        let initialFrame = CGRect(x: 0, y: 0, width: 980, height: 700)
         let minSize = NSSize(width: 900, height: 560)
-        // Bump the autosave name so anyone holding a saved frame from the previous default gets
-        // the new right-sized default once, instead of restoring a window where the wider sidebar
-        // squeezes the detail column.
-        let autosaveName = "CotabbySettingsWindowV5"
+        // Bump the autosave name to reset everyone onto the current default instead of restoring
+        // any narrower frame saved by the previous sidebar experiments.
+        let autosaveName = "CotabbySettingsWindowV6"
 
         let window = NSWindow(
             contentRect: initialFrame,

--- a/Cotabby/UI/Settings/SettingsContainerView.swift
+++ b/Cotabby/UI/Settings/SettingsContainerView.swift
@@ -3,9 +3,9 @@ import SwiftUI
 
 /// File overview:
 /// Root of the redesigned Settings window. A `NavigationSplitView` with a sidebar of categorized
-/// rows on the left and a switching detail pane on the right. The detail body is built from
-/// `SettingsCategory`, so adding a new pane is a matter of adding an enum case and a `case` in the
-/// switch below.
+/// rows sits on the left and a switching detail pane fills the right side. The detail body is built
+/// from `SettingsCategory`, so adding a new pane is a matter of adding an enum case and a `case` in
+/// the switch below.
 ///
 /// Selection is persisted via `@AppStorage` so reopening Settings lands on the last-used pane.
 /// `.id(selection)` on the detail body is the documented workaround for the macOS 14 split-view
@@ -27,11 +27,8 @@ struct SettingsContainerView: View {
     private var storedCategoryRawValue: String = SettingsCategory.general.rawValue
 
     @State private var selection: SettingsCategory = .general
-    // Pinning visibility to `.all` and binding it as constant tells NavigationSplitView the user
-    // is never allowed to collapse the sidebar. That removes the default toggle button from the
-    // title bar (which otherwise teleports between the sidebar header and the content header as
-    // the column collapses) and keeps the sidebar always present, which is what users expect from
-    // a Settings window.
+    // Settings should behave like a traditional two-column preferences window: the sidebar is
+    // always visible, but SwiftUI can still manage the native navigation/split-view chrome.
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
 
     var body: some View {
@@ -47,18 +44,10 @@ struct SettingsContainerView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .toolbar(removing: .sidebarToggle)
         }
-        .navigationSplitViewStyle(.balanced)
-        // The window owns the size (see `SettingsCoordinator`): a sensible 860pt default the user
-        // can still resize. The split view just fills it — a fixed 260pt sidebar and the remainder
-        // for the detail pane.
+        // Keep the native split view, but pin the outer Settings window to a practical minimum.
+        // The sidebar itself provides a width range, so the default opens readable without forcing
+        // an exact column size forever.
         .frame(maxWidth: .infinity, minHeight: 560, maxHeight: .infinity)
-        .onChange(of: columnVisibility) { _, newValue in
-            // Snap back to `.all` if something tries to collapse the sidebar. Cheaper than wiring
-            // a custom binding and reads as the same intent: the sidebar is never optional here.
-            if newValue != .all {
-                columnVisibility = .all
-            }
-        }
         .onAppear {
             // Migration: the previous sidebar had two engine sub-rows (`appleIntelligence`,
             // `openSource`). Users whose persisted selection still points to either should land on
@@ -73,6 +62,11 @@ struct SettingsContainerView: View {
         .onChange(of: selection) { _, newValue in
             storedCategoryRawValue = newValue.rawValue
             syncWindowTitle(for: newValue)
+        }
+        .onChange(of: columnVisibility) { _, newValue in
+            if newValue != .all {
+                columnVisibility = .all
+            }
         }
     }
 

--- a/Cotabby/UI/Settings/SettingsSidebarView.swift
+++ b/Cotabby/UI/Settings/SettingsSidebarView.swift
@@ -25,8 +25,13 @@ struct SettingsSidebarView: View {
         .safeAreaInset(edge: .top, spacing: 0) {
             Color.clear.frame(height: 12)
         }
-        // This is a range instead of a fixed width: the default opens wide enough for labels like
-        // "Engine & Model", but users and SwiftUI still get normal split-view flexibility.
+        // `.navigationSplitViewColumnWidth` is only a hint — AppKit's underlying split view ignores
+        // it when the window is at or near its minimum, which is what truncated labels like
+        // "Engine &..." and "Permissio..." in the small-window screenshots. A direct `.frame()` is a
+        // real SwiftUI layout constraint, so the split view has to give the sidebar at least the
+        // minWidth. Keep the column-width hint as a paired ideal so a fresh window opens at the
+        // right size before the user resizes.
+        .frame(minWidth: 300, idealWidth: 340)
         .navigationSplitViewColumnWidth(min: 300, ideal: 340, max: 420)
     }
 

--- a/Cotabby/UI/Settings/SettingsSidebarView.swift
+++ b/Cotabby/UI/Settings/SettingsSidebarView.swift
@@ -25,9 +25,9 @@ struct SettingsSidebarView: View {
         .safeAreaInset(edge: .top, spacing: 0) {
             Color.clear.frame(height: 12)
         }
-        // A single fixed width (not a min/ideal/max range) so `.balanced` can't squeeze the column
-        // down to where labels truncate — the exact failure mode of the previous ranged width.
-        .navigationSplitViewColumnWidth(340)
+        // This is a range instead of a fixed width: the default opens wide enough for labels like
+        // "Engine & Model", but users and SwiftUI still get normal split-view flexibility.
+        .navigationSplitViewColumnWidth(min: 300, ideal: 340, max: 420)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary

Keep the Settings window on the native SwiftUI `NavigationSplitView` while making its default size readable again. The sidebar now uses a flexible 300/340/420 width range, the window opens wider by default, and the frame autosave key is bumped so users do not restore a narrow frame saved by the prior sidebar experiments.

## Validation

```bash
swiftlint lint --quiet
# exit 0

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build -derivedDataPath build/DerivedData
# ** BUILD SUCCEEDED **
```

## Linked issues

Refs #445

## Risk / rollout notes

This intentionally resets the Settings window frame autosave key to `CotabbySettingsWindowV6`, so users get the new readable default once instead of carrying forward the narrower V5 frame.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Restores native SwiftUI `NavigationSplitView` defaults in the Settings window: `.balanced` style is removed, the sidebar column width switches from a fixed 340pt to a flexible 300/340/420pt range, the default window width grows from 940pt to 980pt, and the autosave key advances to `V6` so existing users receive the new default frame.

- **`SettingsSidebarView`**: replaces the single fixed `navigationSplitViewColumnWidth(340)` with a ranged `(min: 300, ideal: 340, max: 420)` hint paired with a `.frame(minWidth: 300, idealWidth: 340)` content constraint.
- **`SettingsContainerView`**: removes `.navigationSplitViewStyle(.balanced)` (leaving the default `.automatic`/`.prominentDetail` style on macOS) and relocates the `columnVisibility` snap-back guard after the `selection` observer.
- **`SettingsCoordinator`**: bumps `initialFrame` width to 980pt and the autosave name to `CotabbySettingsWindowV6`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are limited to layout hints, window sizing defaults, and an autosave key bump with no logic or data-handling impact.

All three files contain intentional, well-commented cosmetic and sizing adjustments. The autosave key bump is a one-time migration that resets user window frames cleanly. The columnVisibility snap-back guard is preserved. No business logic, data persistence beyond the autosave name, or API surfaces are touched.

SettingsSidebarView.swift — the pairing of .frame(minWidth:) and navigationSplitViewColumnWidth(min:ideal:max:) is a novel approach worth verifying renders correctly at the 900pt minimum window width.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/Settings/SettingsSidebarView.swift | Fixed-width column hint replaced with a flexible range (min:300, ideal:340, max:420) plus a paired .frame() content constraint; the interaction between the two modifiers at minimum window widths is worth monitoring. |
| Cotabby/UI/Settings/SettingsContainerView.swift | Removed .balanced split view style and relocated columnVisibility snap-back; columnVisibility guard is still present and functional. |
| Cotabby/App/Coordinators/SettingsCoordinator.swift | Default window width bumped to 980pt and autosave key advanced to V6; straightforward, intentional change. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[showSettings called] --> B{Window already open?}
    B -- Yes --> C[makeKeyAndOrderFront]
    B -- No --> D[Build SettingsContainerView]
    D --> E[NSHostingController wraps view]
    E --> F[NSWindow
initialFrame: 980x700
minSize: 900x560
autosave: V6]
    F --> G[NavigationSplitView
style: .automatic]
    G --> H[SettingsSidebarView
column: min:300 ideal:340 max:420
frame: minWidth:300 idealWidth:340]
    G --> I[Detail Pane
selection-driven]
    H --> J{columnVisibility != .all?}
    J -- Yes --> K[Snap back to .all]
    J -- No --> L[Sidebar stays visible]
```

<sub>Reviews (2): Last reviewed commit: ["Constrain sidebar width with .frame() so..."](https://github.com/fujacob/cotabby/commit/fa96088a7e5a4c446fc51389292acd748f15a637) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34758963)</sub>

<!-- /greptile_comment -->