### PR TITLE
Add Open at Login toggle to General settings

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -189,6 +189,7 @@
 		DE236C9285635C686D66A2F6 /* TerminalAppDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E37A7E835D3BDE6265843C /* TerminalAppDetectorTests.swift */; };
 		DF8794793110A8ED234CBA96 /* OnboardingTemplateRecommender.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA878B447441BB4F3E327CC8 /* OnboardingTemplateRecommender.swift */; };
 		E17CAA453B1F534D284F0D89 /* PermissionHostApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6ACCB12E4DB32D2F2BEA567 /* PermissionHostApp.swift */; };
+		E27E6377D36D4981301568DD /* LaunchAtLoginStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5807E8508D9355D0271A00C5 /* LaunchAtLoginStateTests.swift */; };
 		E313639E71AE1374D2B9A956 /* SuggestionWorkController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B2D97BAA3618A7D0357AC44 /* SuggestionWorkController.swift */; };
 		E51FA12B690428CA431328FC /* WritingPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D48B95B6665109B6C6A63B42 /* WritingPaneView.swift */; };
 		E6EE3C13FA31F261CD734C69 /* DownloadOutcomeClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DE1975F3B5F4A70478DBF41 /* DownloadOutcomeClassifier.swift */; };
@@ -288,6 +289,7 @@
 		54BC85605541E913EE57B258 /* ExtendedContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtendedContextTests.swift; sourceTree = "<group>"; };
 		54EF3C7F5D9D6F3FA50FD51C /* ContextBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextBuffer.swift; sourceTree = "<group>"; };
 		5664E34B23FBDF69292FEF43 /* FoundationModelSuggestionEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoundationModelSuggestionEngine.swift; sourceTree = "<group>"; };
+		5807E8508D9355D0271A00C5 /* LaunchAtLoginStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchAtLoginStateTests.swift; sourceTree = "<group>"; };
 		58C0F017699EE44C81C095CA /* TagsInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagsInputView.swift; sourceTree = "<group>"; };
 		5976600F428C1265121D4C0C /* SystemSettingsWindowLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemSettingsWindowLocator.swift; sourceTree = "<group>"; };
 		59E299BE2E9D42A33D5D2F5D /* ScreenTextExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenTextExtractor.swift; sourceTree = "<group>"; };
@@ -664,6 +666,7 @@
 				5AD3F4F9FBE82007E4E15F58 /* GhostSuggestionLayoutTests.swift */,
 				BAC01317B0B68E3C4125E421 /* InputMonitorTests.swift */,
 				4793D4EA5D36D7E5CC216C27 /* LanguageSupportTests.swift */,
+				5807E8508D9355D0271A00C5 /* LaunchAtLoginStateTests.swift */,
 				3009812A35A1CDEF16295AB7 /* LlamaPromptRendererTests.swift */,
 				52BAFA2F989C3C4F7FB892B5 /* MarkerSelectionSynthesizerTests.swift */,
 				FC83D14A7557BC0196E59007 /* MirrorOverlayLayoutTests.swift */,
@@ -1126,6 +1129,7 @@
 				A0BB87E3665EF6C209034798 /* GhostSuggestionLayoutTests.swift in Sources */,
 				07D046D406411ED85AC5758A /* InputMonitorTests.swift in Sources */,
 				E912D4617AE1376061DF1F00 /* LanguageSupportTests.swift in Sources */,
+				E27E6377D36D4981301568DD /* LaunchAtLoginStateTests.swift in Sources */,
 				190C571B3CDFE117F4D15484 /* LlamaPromptRendererTests.swift in Sources */,
 				87806DE08881D11F2608A13D /* MarkerSelectionSynthesizerTests.swift in Sources */,
 				14D77F0B8A195AC2FA8D24A9 /* MirrorOverlayLayoutTests.swift in Sources */,

--- a/Cotabby/Services/Utilities/LaunchAtLoginService.swift
+++ b/Cotabby/Services/Utilities/LaunchAtLoginService.swift
@@ -56,15 +56,28 @@ final class LaunchAtLoginService: ObservableObject {
         state = Self.map(appService.status)
     }
 
-    /// Re-reads the current login-item status from macOS.
-    /// This lets the Settings UI reflect out-of-band changes made in System Settings.
+    /// Re-reads the login-item status from macOS for an out-of-band refresh (e.g. the Settings
+    /// window reopened after the user changed the item in System Settings).
+    ///
+    /// Clears any prior `lastErrorMessage` first: that message described an *earlier* toggle attempt,
+    /// and the freshly read status is now authoritative. Without this, a one-time failure (such as
+    /// registering while outside /Applications) would keep showing as the row's subtext even after
+    /// the user fixes the cause and macOS reports the item enabled or cleanly disabled.
     func refresh() {
+        lastErrorMessage = nil
+        reloadState()
+    }
+
+    /// Re-reads status from macOS *without* touching `lastErrorMessage`. `setEnabled` uses this so a
+    /// failure it just captured survives the post-mutation re-read — routing through `refresh()`
+    /// would wipe the error before the UI could explain why the toggle did not take effect.
+    private func reloadState() {
         state = Self.map(appService.status)
     }
 
     /// Registers or unregisters the main app as a login item.
-    /// We immediately refresh after mutation so the UI reflects the actual OS state rather than
-    /// assuming the request succeeded.
+    /// We re-read OS state after mutation (rather than assuming the request succeeded) via
+    /// `reloadState()` — deliberately not `refresh()`, so a freshly captured error is preserved.
     func setEnabled(_ enabled: Bool) {
         do {
             if enabled {
@@ -78,7 +91,7 @@ final class LaunchAtLoginService: ObservableObject {
             lastErrorMessage = error.localizedDescription
         }
 
-        refresh()
+        reloadState()
     }
 
     private static func map(_ status: SMAppService.Status) -> LaunchAtLoginState {

--- a/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 /// menu-bar quick control so users can connect the two.
 struct GeneralPaneView: View {
     @ObservedObject var suggestionSettings: SuggestionSettingsModel
+    @ObservedObject var launchAtLoginService: LaunchAtLoginService
     let onShowWelcome: () -> Void
 
     @Environment(\.colorScheme) private var colorScheme
@@ -29,6 +30,16 @@ struct GeneralPaneView: View {
                             "Suggestions rely only on the text you've typed."
                     )
                 }
+
+                Toggle(isOn: launchAtLoginBinding) {
+                    SettingsRowLabel(
+                        title: "Open at Login",
+                        description: launchAtLoginDescription
+                    )
+                }
+                // Disabled only when macOS reports the login item as unavailable (e.g. the app isn't
+                // in /Applications); the description then explains how to fix it.
+                .disabled(!launchAtLoginService.state.canToggle)
             }
 
             Section("Behavior") {
@@ -272,6 +283,22 @@ struct GeneralPaneView: View {
             get: { suggestionSettings.isFastModeEnabled },
             set: { suggestionSettings.setFastModeEnabled($0) }
         )
+    }
+
+    private var launchAtLoginBinding: Binding<Bool> {
+        Binding(
+            get: { launchAtLoginService.state.isEnabled },
+            set: { launchAtLoginService.setEnabled($0) }
+        )
+    }
+
+    /// Prefers the OS-provided status detail (approval needed / unavailable) and then any
+    /// registration error, falling back to the plain explanation, so the row always reflects the
+    /// real login-item state rather than just the toggle position.
+    private var launchAtLoginDescription: String {
+        launchAtLoginService.state.detail
+            ?? launchAtLoginService.lastErrorMessage
+            ?? "Start Cotabby automatically when you log in to your Mac."
     }
 
     private var menuBarWordCountVisibleBinding: Binding<Bool> {

--- a/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
@@ -292,11 +292,15 @@ struct GeneralPaneView: View {
         )
     }
 
-    /// Prefers the OS-provided status detail (approval needed / unavailable) and then any
-    /// registration error, falling back to the plain explanation, so the row always reflects the
-    /// real login-item state rather than just the toggle position.
+    /// An enabled login item has nothing to explain, so never surface a leftover detail/error string
+    /// under a working toggle. Otherwise prefer the OS-provided status detail (approval needed / move
+    /// to Applications), then any registration error from the most recent toggle attempt, falling back
+    /// to the plain explanation — so the row reflects real login-item state, not just the switch.
     private var launchAtLoginDescription: String {
-        launchAtLoginService.state.detail
+        if launchAtLoginService.state.isEnabled {
+            return "Start Cotabby automatically when you log in to your Mac."
+        }
+        return launchAtLoginService.state.detail
             ?? launchAtLoginService.lastErrorMessage
             ?? "Start Cotabby automatically when you log in to your Mac."
     }

--- a/Cotabby/UI/Settings/SettingsContainerView.swift
+++ b/Cotabby/UI/Settings/SettingsContainerView.swift
@@ -97,6 +97,7 @@ struct SettingsContainerView: View {
         case .general:
             GeneralPaneView(
                 suggestionSettings: suggestionSettings,
+                launchAtLoginService: launchAtLoginService,
                 onShowWelcome: onShowWelcome
             )
         case .engineAndModel:

--- a/CotabbyTests/LaunchAtLoginStateTests.swift
+++ b/CotabbyTests/LaunchAtLoginStateTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import Cotabby
+
+/// Tests the pure presentation logic of `LaunchAtLoginState` — the flags the General settings row
+/// uses to decide the toggle position, whether it is interactive, and what explanatory copy to show.
+/// The OS registration itself (`SMAppService`) is not exercised here; only the state mapping is.
+final class LaunchAtLoginStateTests: XCTestCase {
+    func testIsEnabledOnlyForEnabled() {
+        XCTAssertTrue(LaunchAtLoginState.enabled.isEnabled)
+        XCTAssertFalse(LaunchAtLoginState.disabled.isEnabled)
+        XCTAssertFalse(LaunchAtLoginState.requiresApproval.isEnabled)
+        XCTAssertFalse(LaunchAtLoginState.unavailable("x").isEnabled)
+    }
+
+    func testCanToggleForEveryStateExceptUnavailable() {
+        XCTAssertTrue(LaunchAtLoginState.enabled.canToggle)
+        XCTAssertTrue(LaunchAtLoginState.disabled.canToggle)
+        XCTAssertTrue(LaunchAtLoginState.requiresApproval.canToggle)
+        XCTAssertFalse(LaunchAtLoginState.unavailable("x").canToggle)
+    }
+
+    func testDetailOnlyForNonTrivialStates() {
+        XCTAssertNil(LaunchAtLoginState.enabled.detail)
+        XCTAssertNil(LaunchAtLoginState.disabled.detail)
+        XCTAssertNotNil(LaunchAtLoginState.requiresApproval.detail)
+        XCTAssertEqual(LaunchAtLoginState.unavailable("Move me").detail, "Move me")
+    }
+}


### PR DESCRIPTION
## Summary

Adds an **Open at Login** toggle so Cotabby can start automatically when the user logs in. The SMAppService-backed `LaunchAtLoginService` already existed and was wired through the app's dependency graph (constructed in `CotabbyAppEnvironment`, retained in `AppDelegate`, passed into `SettingsContainerView`), but it was never surfaced in any settings pane, so there was no way to actually turn launch-at-login on. This exposes it in the General pane's Status section.

- `GeneralPaneView` observes `LaunchAtLoginService` and binds the toggle to its `state.isEnabled` / `setEnabled`.
- The toggle is disabled only when macOS reports the login item as unavailable (e.g. the app isn't in /Applications), and the row description surfaces the OS status detail (approval required / move-to-Applications) or any registration error, so the row reflects real OS state rather than just the switch position.
- `SettingsContainerView` threads the already-available service into the pane.
- Added pure unit tests for `LaunchAtLoginState`'s presentation flags.

## Validation

```
swiftlint lint --strict --quiet
# exit 0

xcodegen generate && git diff --quiet -- Cotabby.xcodeproj/project.pbxproj
# regenerated to register the new test file (committed)

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  CODE_SIGNING_ALLOWED=NO -only-testing:CotabbyTests/LaunchAtLoginStateTests
# ** TEST SUCCEEDED **  Executed 3 tests, with 0 failures
```

The toggle's live registration behavior depends on a signed build installed in /Applications (SMAppService requires the app's real code identity), so the end-to-end enable/approve flow is best confirmed manually in a release-style build; the state/presentation logic is covered by tests.

## Linked issues

<!-- none -->

## Risk / rollout notes

- UI-only wiring of an existing service; no new system permissions or entitlements (SMAppService relies on the app's code identity, and the app is non-sandboxed with macOS 14 deployment target, well above SMAppService's macOS 13 requirement).
- `Cotabby.xcodeproj/project.pbxproj` is regenerated via `xcodegen generate` to register the new test file (project.yml is the source of truth).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR surfaces the already-wired `LaunchAtLoginService` in the General settings pane by adding an **Open at Login** toggle to the Status section, and simultaneously fixes a stale-error-message bug identified in a prior review by splitting `refresh()` into two methods.

- `LaunchAtLoginService` gains a private `reloadState()` for post-mutation re-reads (preserves a just-captured error) while the public `refresh()` — called when Settings opens — clears `lastErrorMessage` first, so old failure strings no longer persist after an out-of-band fix.
- `GeneralPaneView` adds the toggle bound to `launchAtLoginService.state.isEnabled` / `setEnabled`, disabled when `canToggle` is false, with `launchAtLoginDescription` correctly preferring `state.detail` over `lastErrorMessage` and suppressing both when the item is enabled.
- Three pure unit tests cover all `LaunchAtLoginState` cases for `isEnabled`, `canToggle`, and `detail`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — UI-only wiring of an existing service with no new system permissions, and the stale-error fix from the prior review is correctly addressed.

The change introduces no new entitlements or system calls beyond what SMAppService already required. The refresh()/reloadState() split is a minimal, targeted fix for the previously identified stale-error scenario, and the description logic in launchAtLoginDescription correctly handles all four LaunchAtLoginState cases. Unit tests cover all state presentation flags. No edge cases appear unhandled.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Services/Utilities/LaunchAtLoginService.swift | Adds refresh()/reloadState() split to address the previously flagged stale-error-message bug; setEnabled now uses the private reloadState() to preserve freshly captured errors while refresh() (called on Settings open) clears them first. |
| Cotabby/UI/Settings/Panes/GeneralPaneView.swift | Adds the Open at Login toggle to the Status section; launchAtLoginDescription correctly prioritises state.detail over lastErrorMessage, and suppresses both when the item is enabled. |
| Cotabby/UI/Settings/SettingsContainerView.swift | One-line threading of the already-available launchAtLoginService into GeneralPaneView; no new logic introduced. |
| CotabbyTests/LaunchAtLoginStateTests.swift | Covers all four LaunchAtLoginState cases for isEnabled, canToggle, and detail; tests are pure and accurate against the implementation. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant GeneralPaneView
    participant LaunchAtLoginService
    participant SMAppService

    User->>GeneralPaneView: Opens Settings window
    GeneralPaneView->>LaunchAtLoginService: refresh()
    LaunchAtLoginService->>LaunchAtLoginService: "lastErrorMessage = nil"
    LaunchAtLoginService->>SMAppService: read .status
    SMAppService-->>LaunchAtLoginService: status
    LaunchAtLoginService->>LaunchAtLoginService: "state = map(status)"
    LaunchAtLoginService-->>GeneralPaneView: "@Published state updates toggle + description"

    User->>GeneralPaneView: Flips toggle ON
    GeneralPaneView->>LaunchAtLoginService: setEnabled(true)
    LaunchAtLoginService->>SMAppService: register()
    alt success
        SMAppService-->>LaunchAtLoginService: (no throw)
        LaunchAtLoginService->>LaunchAtLoginService: "lastErrorMessage = nil"
    else failure
        SMAppService-->>LaunchAtLoginService: throws error
        LaunchAtLoginService->>LaunchAtLoginService: "lastErrorMessage = error.localizedDescription"
    end
    LaunchAtLoginService->>SMAppService: read .status (reloadState)
    SMAppService-->>LaunchAtLoginService: status
    LaunchAtLoginService->>LaunchAtLoginService: "state = map(status)"
    LaunchAtLoginService-->>GeneralPaneView: "@Published state + lastErrorMessage update UI"
```

<sub>Reviews (2): Last reviewed commit: ["Clear stale Open at Login error on out-o..."](https://github.com/fujacob/cotabby/commit/72a7d07eb9f70d3a946c37fe913b9a7ed68e3d54) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34760423)</sub>

<!-- /greptile_comment -->