### PR TITLE
Simplify emoji suggestion settings

### DIFF
--- a/Cotabby/App/Core/CotabbyAppEnvironment.swift
+++ b/Cotabby/App/Core/CotabbyAppEnvironment.swift
@@ -176,7 +176,7 @@ final class CotabbyAppEnvironment {
             inserter: suggestionInserter,
             isEnabled: { suggestionSettings.isEmojiPickerEnabled },
             emojiPreferences: { suggestionSettings.emojiVariantPreferences },
-            acceptKeyLabel: { suggestionSettings.acceptanceHintLabel }
+            acceptKeyLabel: { suggestionSettings.emojiPickerAcceptKeyLabel }
         )
         // Give the picker first look at every keystroke the coordinator receives, so it can detect the
         // `:` trigger and drive its state machine without changing who owns `inputMonitor.onEvent`.

--- a/Cotabby/Models/EmojiPickerModels.swift
+++ b/Cotabby/Models/EmojiPickerModels.swift
@@ -66,17 +66,23 @@ enum EmojiSkinTone: String, CaseIterable, Equatable, Sendable {
 
     var displayName: String {
         switch self {
-        case .neutral: return "Neutral"
+        case .neutral: return "Default"
         case .light: return "Light"
-        case .mediumLight: return "Medium-Light"
+        case .mediumLight: return "Medium Light"
         case .medium: return "Medium"
-        case .mediumDark: return "Medium-Dark"
+        case .mediumDark: return "Medium Dark"
         case .dark: return "Dark"
         }
     }
 
-    /// A waving hand rendered in this tone, for the settings picker label.
-    var sampleGlyph: String { "\u{1F44B}" + (modifier ?? "") }
+    /// A victory hand rendered in this tone, used by the settings swatch row. The neutral glyph
+    /// needs the emoji variation selector so macOS does not fall back to the plain text symbol.
+    var sampleGlyph: String {
+        guard let modifier else {
+            return "\u{270C}\u{FE0F}"
+        }
+        return "\u{270C}" + modifier
+    }
 }
 
 /// User-selectable gender preference for emoji that ship neutral / man / woman variants.
@@ -85,9 +91,9 @@ enum EmojiGender: String, CaseIterable, Equatable, Sendable {
 
     var displayName: String {
         switch self {
-        case .neutral: return "Gender-Neutral"
-        case .male: return "Male"
-        case .female: return "Female"
+        case .neutral: return "Person"
+        case .male: return "Man"
+        case .female: return "Woman"
         }
     }
 
@@ -103,10 +109,9 @@ enum EmojiGender: String, CaseIterable, Equatable, Sendable {
 /// Snapshot of the emoji-customization settings the variant resolver reads at match time.
 struct EmojiVariantPreferences: Equatable, Sendable {
     let skinTone: EmojiSkinTone
-    let includeNeutral: Bool
     let gender: EmojiGender
 
-    static let `default` = EmojiVariantPreferences(skinTone: .neutral, includeNeutral: false, gender: .neutral)
+    static let `default` = EmojiVariantPreferences(skinTone: .neutral, gender: .neutral)
 }
 
 // MARK: - Trigger state machine vocabulary

--- a/Cotabby/Models/SuggestionSettingsModel.swift
+++ b/Cotabby/Models/SuggestionSettingsModel.swift
@@ -43,7 +43,6 @@ final class SuggestionSettingsModel: ObservableObject {
     @Published private(set) var isEmojiPickerEnabled: Bool
     /// Emoji-customization preferences, read live by the picker's variant resolver at match time.
     @Published private(set) var preferredEmojiSkinTone: EmojiSkinTone
-    @Published private(set) var includeNeutralEmojiVariant: Bool
     @Published private(set) var preferredEmojiGender: EmojiGender
     @Published private(set) var autoAcceptTrailingPunctuation: Bool
     @Published private(set) var acceptanceKeyCode: CGKeyCode
@@ -84,7 +83,6 @@ final class SuggestionSettingsModel: ObservableObject {
     private static let multiLineEnabledDefaultsKey = "cotabbyMultiLineEnabled"
     private static let emojiPickerEnabledDefaultsKey = "cotabbyEmojiPickerEnabled"
     private static let preferredEmojiSkinToneDefaultsKey = "cotabbyPreferredEmojiSkinTone"
-    private static let includeNeutralEmojiVariantDefaultsKey = "cotabbyIncludeNeutralEmojiVariant"
     private static let preferredEmojiGenderDefaultsKey = "cotabbyPreferredEmojiGender"
     private static let autoAcceptTrailingPunctuationDefaultsKey = "cotabbyAutoAcceptTrailingPunctuation"
     private static let acceptanceKeyCodeDefaultsKey = "cotabbyAcceptanceKeyCode"
@@ -228,8 +226,6 @@ final class SuggestionSettingsModel: ObservableObject {
         let resolvedEmojiPickerEnabled = userDefaults.object(forKey: Self.emojiPickerEnabledDefaultsKey) as? Bool ?? true
         let resolvedPreferredEmojiSkinTone = userDefaults.string(forKey: Self.preferredEmojiSkinToneDefaultsKey)
             .flatMap(EmojiSkinTone.init(rawValue:)) ?? .neutral
-        let resolvedIncludeNeutralEmojiVariant =
-            userDefaults.object(forKey: Self.includeNeutralEmojiVariantDefaultsKey) as? Bool ?? false
         let resolvedPreferredEmojiGender = userDefaults.string(forKey: Self.preferredEmojiGenderDefaultsKey)
             .flatMap(EmojiGender.init(rawValue:)) ?? .neutral
         let resolvedAutoAcceptTrailingPunctuation =
@@ -297,7 +293,6 @@ final class SuggestionSettingsModel: ObservableObject {
         isMultiLineEnabled = resolvedMultiLineEnabled
         isEmojiPickerEnabled = resolvedEmojiPickerEnabled
         preferredEmojiSkinTone = resolvedPreferredEmojiSkinTone
-        includeNeutralEmojiVariant = resolvedIncludeNeutralEmojiVariant
         preferredEmojiGender = resolvedPreferredEmojiGender
         autoAcceptTrailingPunctuation = resolvedAutoAcceptTrailingPunctuation
         acceptanceKeyCode = resolvedAcceptanceKeyCode
@@ -332,7 +327,6 @@ final class SuggestionSettingsModel: ObservableObject {
         userDefaults.set(resolvedMultiLineEnabled, forKey: Self.multiLineEnabledDefaultsKey)
         userDefaults.set(resolvedEmojiPickerEnabled, forKey: Self.emojiPickerEnabledDefaultsKey)
         userDefaults.set(resolvedPreferredEmojiSkinTone.rawValue, forKey: Self.preferredEmojiSkinToneDefaultsKey)
-        userDefaults.set(resolvedIncludeNeutralEmojiVariant, forKey: Self.includeNeutralEmojiVariantDefaultsKey)
         userDefaults.set(resolvedPreferredEmojiGender.rawValue, forKey: Self.preferredEmojiGenderDefaultsKey)
         userDefaults.set(resolvedAutoAcceptTrailingPunctuation, forKey: Self.autoAcceptTrailingPunctuationDefaultsKey)
         userDefaults.set(Int(resolvedAcceptanceKeyCode), forKey: Self.acceptanceKeyCodeDefaultsKey)
@@ -459,12 +453,6 @@ final class SuggestionSettingsModel: ObservableObject {
         userDefaults.set(tone.rawValue, forKey: Self.preferredEmojiSkinToneDefaultsKey)
     }
 
-    func setIncludeNeutralEmojiVariant(_ included: Bool) {
-        guard includeNeutralEmojiVariant != included else { return }
-        includeNeutralEmojiVariant = included
-        userDefaults.set(included, forKey: Self.includeNeutralEmojiVariantDefaultsKey)
-    }
-
     func setPreferredEmojiGender(_ gender: EmojiGender) {
         guard preferredEmojiGender != gender else { return }
         preferredEmojiGender = gender
@@ -475,7 +463,6 @@ final class SuggestionSettingsModel: ObservableObject {
     var emojiVariantPreferences: EmojiVariantPreferences {
         EmojiVariantPreferences(
             skinTone: preferredEmojiSkinTone,
-            includeNeutral: includeNeutralEmojiVariant,
             gender: preferredEmojiGender
         )
     }
@@ -637,6 +624,12 @@ final class SuggestionSettingsModel: ObservableObject {
             return fullAcceptanceKeyLabel
         }
         return nil
+    }
+
+    /// The emoji picker commits with the word-accept shortcut specifically. This is separate from
+    /// `acceptanceHintLabel` because hiding ghost-text hints should not hide the picker instruction.
+    var emojiPickerAcceptKeyLabel: String? {
+        acceptanceKeyCode == Self.disabledKeyCode ? nil : acceptanceKeyLabel
     }
 
     func setCustomSuggestionTextColorHex(_ hex: String?) {

--- a/Cotabby/Support/EmojiPickerPanelLayout.swift
+++ b/Cotabby/Support/EmojiPickerPanelLayout.swift
@@ -11,6 +11,7 @@ enum EmojiPickerMetrics {
     static let width: CGFloat = 300
     static let rowHeight: CGFloat = 30
     static let headerHeight: CGFloat = 26
+    static let footerHeight: CGFloat = 28
     static let dividerHeight: CGFloat = 1
     static let listVerticalPadding: CGFloat = 8
     static let maxVisibleRows = 8
@@ -20,7 +21,10 @@ enum EmojiPickerMetrics {
     static func contentSize(matchCount: Int) -> CGSize {
         let rows = matchCount == 0 ? 1 : min(matchCount, maxVisibleRows)
         let listHeight = CGFloat(rows) * rowHeight + (matchCount == 0 ? 0 : listVerticalPadding)
-        return CGSize(width: width, height: headerHeight + dividerHeight + listHeight)
+        return CGSize(
+            width: width,
+            height: headerHeight + dividerHeight + listHeight + dividerHeight + footerHeight
+        )
     }
 }
 

--- a/Cotabby/Support/EmojiVariantResolver.swift
+++ b/Cotabby/Support/EmojiVariantResolver.swift
@@ -3,17 +3,15 @@ import Foundation
 /// File overview:
 /// Pure rules that turn raw matcher results into the variant-aware rows the picker shows: prefer the
 /// configured gender variant (collapsing neutral/man/woman siblings of the same concept), then
-/// compose the configured skin tone onto emoji that support it. Dependency-free so it is trivially
-/// unit testable; the bundled catalog carries no skin-tone/gender metadata, so the policy lives here.
+/// compose the configured skin tone onto emoji that support it. When a non-default skin tone exists,
+/// the default glyph remains available as the next row so users can still choose the unmodified
+/// variant. Dependency-free so it is trivially unit testable; the bundled catalog carries no
+/// skin-tone/gender metadata, so the policy lives here.
 enum EmojiVariantResolver {
     /// Applies gender preference first (so skin tone composes onto the chosen variant), then skin tone.
     static func resolve(_ matches: [EmojiMatch], preferences: EmojiVariantPreferences) -> [EmojiMatch] {
         let genderResolved = applyGender(matches, gender: preferences.gender)
-        return applySkinTone(
-            genderResolved,
-            skinTone: preferences.skinTone,
-            includeNeutral: preferences.includeNeutral
-        )
+        return applySkinTone(genderResolved, skinTone: preferences.skinTone)
     }
 
     // MARK: - Gender
@@ -57,8 +55,7 @@ enum EmojiVariantResolver {
 
     private static func applySkinTone(
         _ matches: [EmojiMatch],
-        skinTone: EmojiSkinTone,
-        includeNeutral: Bool
+        skinTone: EmojiSkinTone
     ) -> [EmojiMatch] {
         guard let modifier = skinTone.modifier else { return matches }   // neutral: nothing to apply
 
@@ -67,7 +64,7 @@ enum EmojiVariantResolver {
                 return [match]   // emoji does not support skin tone
             }
             let tonedMatch = EmojiMatch(entry: match.entry, displayGlyph: toned)
-            return includeNeutral ? [tonedMatch, match] : [tonedMatch]
+            return [tonedMatch, match]
         }
     }
 

--- a/Cotabby/UI/EmojiPickerView.swift
+++ b/Cotabby/UI/EmojiPickerView.swift
@@ -15,7 +15,7 @@ final class EmojiPickerViewModel: ObservableObject {
     @Published var query: String = ""
     @Published var matches: [EmojiMatch] = []
     @Published var selectedIndex: Int = 0
-    /// The accept-word key label shown as a keycap on the highlighted row; `nil` hides it.
+    /// The accept-word key label shown in the footer; `nil` means there is no keyboard commit hint.
     @Published var acceptKeyLabel: String?
 }
 
@@ -28,6 +28,8 @@ struct EmojiPickerView: View {
             header
             Divider()
             content
+            Divider()
+            footer
         }
         .frame(width: EmojiPickerMetrics.width)
         .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
@@ -67,8 +69,7 @@ struct EmojiPickerView: View {
                         ForEach(model.matches.indices, id: \.self) { index in
                             EmojiPickerRow(
                                 match: model.matches[index],
-                                isSelected: index == model.selectedIndex,
-                                acceptKeyLabel: index == model.selectedIndex ? model.acceptKeyLabel : nil
+                                isSelected: index == model.selectedIndex
                             )
                             .id(index)
                             .contentShape(Rectangle())
@@ -83,14 +84,31 @@ struct EmojiPickerView: View {
             }
         }
     }
+
+    private var footer: some View {
+        HStack(spacing: 6) {
+            if model.matches.isEmpty {
+                Text("Keep typing to search")
+            } else if let acceptKeyLabel = model.acceptKeyLabel {
+                Text("Press")
+                EmojiKeycap(label: acceptKeyLabel)
+                Text("to insert")
+            } else {
+                Text("Click an emoji to insert")
+            }
+            Spacer(minLength: 0)
+        }
+        .font(.system(size: 11, weight: .medium))
+        .foregroundStyle(.secondary)
+        .lineLimit(1)
+        .padding(.horizontal, 10)
+        .frame(height: EmojiPickerMetrics.footerHeight)
+    }
 }
 
 private struct EmojiPickerRow: View {
     let match: EmojiMatch
     let isSelected: Bool
-    /// When non-nil (the highlighted row), a right-aligned keycap tells the user which key inserts
-    /// this emoji, mirroring the ghost-text acceptance hint.
-    let acceptKeyLabel: String?
 
     var body: some View {
         HStack(spacing: 8) {
@@ -102,9 +120,6 @@ private struct EmojiPickerRow: View {
                 .lineLimit(1)
                 .truncationMode(.tail)
             Spacer(minLength: 0)
-            if let acceptKeyLabel {
-                EmojiKeycap(label: acceptKeyLabel, onAccent: isSelected)
-            }
         }
         .padding(.horizontal, 10)
         .frame(height: EmojiPickerMetrics.rowHeight)
@@ -116,26 +131,23 @@ private struct EmojiPickerRow: View {
     }
 }
 
-/// Small keycap pill shown on the highlighted picker row, mirroring the ghost-text acceptance hint so
-/// the user knows which key inserts the highlighted emoji.
+/// Small keycap pill shown in the footer, mirroring the user's configured word-accept shortcut.
 private struct EmojiKeycap: View {
     let label: String
-    /// `true` when the row has the accent highlight, so the pill flips to a legible on-accent style.
-    let onAccent: Bool
 
     var body: some View {
         Text(label)
             .font(.system(size: 10, weight: .medium, design: .rounded))
-            .foregroundStyle(onAccent ? Color.white : Color.secondary)
+            .foregroundStyle(Color.secondary)
             .padding(.horizontal, 5)
             .padding(.vertical, 2)
             .background(
                 RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .fill(onAccent ? Color.white.opacity(0.22) : Color.primary.opacity(0.08))
+                    .fill(Color.primary.opacity(0.08))
             )
             .overlay(
                 RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .stroke(onAccent ? Color.white.opacity(0.35) : Color.primary.opacity(0.15), lineWidth: 1)
+                    .stroke(Color.primary.opacity(0.15), lineWidth: 1)
             )
             .fixedSize()
     }

--- a/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
@@ -57,30 +57,25 @@ struct GeneralPaneView: View {
                 Toggle(isOn: emojiPickerEnabledBinding) {
                     SettingsRowLabel(
                         title: "Inline Emoji Picker",
-                        description: "Type a colon and a name like :smile to pick an emoji inline, " +
-                            "then press your accept-word key (Tab by default) to insert it."
+                        description: "Type a name like :smile to search inline, then press your accept-word " +
+                            "shortcut to insert the selected emoji."
                     )
                 }
             }
 
             if suggestionSettings.isEmojiPickerEnabled {
-                Section("Emoji Customization") {
-                    Picker(selection: emojiSkinToneBinding) {
-                        ForEach(EmojiSkinTone.allCases, id: \.self) { tone in
-                            Text("\(tone.displayName)  \(tone.sampleGlyph)").tag(tone)
+                Section("Emoji Suggestions") {
+                    LabeledContent {
+                        HStack(spacing: 8) {
+                            ForEach(EmojiSkinTone.allCases, id: \.self) { tone in
+                                skinToneOption(for: tone)
+                            }
                         }
                     } label: {
                         SettingsRowLabel(
-                            title: "Preferred Skin Tone",
-                            description: "Applied to emoji that support skin tone modifiers."
-                        )
-                    }
-
-                    Toggle(isOn: includeNeutralEmojiVariantBinding) {
-                        SettingsRowLabel(
-                            title: "Include Neutral Variant",
-                            description: "When enabled, the neutral (default) skin tone variant is included " +
-                                "alongside your preferred skin tone in emoji suggestions."
+                            title: "Skin Tone",
+                            description: "For non-default tones, suggestions show your selected tone first " +
+                                "and keep the default emoji next."
                         )
                     }
 
@@ -90,9 +85,8 @@ struct GeneralPaneView: View {
                         }
                     } label: {
                         SettingsRowLabel(
-                            title: "Preferred Gender",
-                            description: "Applies to people emoji that have separate male/female variants " +
-                                "(e.g., firefighters, doctors, artists)."
+                            title: "People Emoji Style",
+                            description: "Choose person, man, or woman variants when an emoji offers them."
                         )
                     }
                 }
@@ -239,13 +233,6 @@ struct GeneralPaneView: View {
         )
     }
 
-    private var includeNeutralEmojiVariantBinding: Binding<Bool> {
-        Binding(
-            get: { suggestionSettings.includeNeutralEmojiVariant },
-            set: { suggestionSettings.setIncludeNeutralEmojiVariant($0) }
-        )
-    }
-
     private var emojiGenderBinding: Binding<EmojiGender> {
         Binding(
             get: { suggestionSettings.preferredEmojiGender },
@@ -323,6 +310,45 @@ struct GeneralPaneView: View {
                 )
         }
         .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private func skinToneOption(for tone: EmojiSkinTone) -> some View {
+        let isSelected = suggestionSettings.preferredEmojiSkinTone == tone
+
+        Button {
+            suggestionSettings.setPreferredEmojiSkinTone(tone)
+        } label: {
+            ZStack(alignment: .bottomTrailing) {
+                Text(tone.sampleGlyph)
+                    .font(.system(size: 19))
+                    .frame(width: 34, height: 30)
+                    .background(
+                        RoundedRectangle(cornerRadius: 7, style: .continuous)
+                            .fill(isSelected ? Color.accentColor.opacity(0.16) : Color.primary.opacity(0.06))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 7, style: .continuous)
+                            .strokeBorder(
+                                isSelected ? Color.accentColor : Color.primary.opacity(0.16),
+                                lineWidth: isSelected ? 2 : 1
+                            )
+                    )
+
+                if isSelected {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(Color.accentColor)
+                        .background(Circle().fill(Color(nsColor: .controlBackgroundColor)))
+                        .offset(x: 3, y: 3)
+                }
+            }
+            .contentShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .help("\(tone.displayName) skin tone")
+        .accessibilityLabel("\(tone.displayName) skin tone")
+        .accessibilityValue(isSelected ? "Selected" : "")
     }
 
     private func swatchFill(for preset: GhostTextColorPreset) -> Color {

--- a/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
@@ -79,9 +79,11 @@ struct GeneralPaneView: View {
                         )
                     }
 
-                    Picker(selection: emojiGenderBinding) {
-                        ForEach(EmojiGender.allCases, id: \.self) { gender in
-                            Text("\(gender.displayName)  \(gender.sampleGlyph)").tag(gender)
+                    LabeledContent {
+                        HStack(spacing: 8) {
+                            ForEach(EmojiGender.allCases, id: \.self) { gender in
+                                emojiGenderOption(for: gender)
+                            }
                         }
                     } label: {
                         SettingsRowLabel(
@@ -233,13 +235,6 @@ struct GeneralPaneView: View {
         )
     }
 
-    private var emojiGenderBinding: Binding<EmojiGender> {
-        Binding(
-            get: { suggestionSettings.preferredEmojiGender },
-            set: { suggestionSettings.setPreferredEmojiGender($0) }
-        )
-    }
-
     private var autoAcceptTrailingPunctuationBinding: Binding<Bool> {
         Binding(
             get: { suggestionSettings.autoAcceptTrailingPunctuation },
@@ -348,6 +343,45 @@ struct GeneralPaneView: View {
         .buttonStyle(.plain)
         .help("\(tone.displayName) skin tone")
         .accessibilityLabel("\(tone.displayName) skin tone")
+        .accessibilityValue(isSelected ? "Selected" : "")
+    }
+
+    @ViewBuilder
+    private func emojiGenderOption(for gender: EmojiGender) -> some View {
+        let isSelected = suggestionSettings.preferredEmojiGender == gender
+
+        Button {
+            suggestionSettings.setPreferredEmojiGender(gender)
+        } label: {
+            ZStack(alignment: .bottomTrailing) {
+                Text(gender.sampleGlyph)
+                    .font(.system(size: 19))
+                    .frame(width: 34, height: 30)
+                    .background(
+                        RoundedRectangle(cornerRadius: 7, style: .continuous)
+                            .fill(isSelected ? Color.accentColor.opacity(0.16) : Color.primary.opacity(0.06))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 7, style: .continuous)
+                            .strokeBorder(
+                                isSelected ? Color.accentColor : Color.primary.opacity(0.16),
+                                lineWidth: isSelected ? 2 : 1
+                            )
+                    )
+
+                if isSelected {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(Color.accentColor)
+                        .background(Circle().fill(Color(nsColor: .controlBackgroundColor)))
+                        .offset(x: 3, y: 3)
+                }
+            }
+            .contentShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .help("\(gender.displayName) variant")
+        .accessibilityLabel("\(gender.displayName) variant")
         .accessibilityValue(isSelected ? "Selected" : "")
     }
 

--- a/CotabbyTests/EmojiPickerPanelLayoutTests.swift
+++ b/CotabbyTests/EmojiPickerPanelLayoutTests.swift
@@ -12,16 +12,27 @@ final class EmojiPickerPanelLayoutTests: XCTestCase {
 
     func test_contentSize_reservesOneRowWhenEmpty() {
         let size = EmojiPickerMetrics.contentSize(matchCount: 0)
+        let expectedHeight = EmojiPickerMetrics.headerHeight
+            + EmojiPickerMetrics.dividerHeight
+            + EmojiPickerMetrics.rowHeight
+            + EmojiPickerMetrics.dividerHeight
+            + EmojiPickerMetrics.footerHeight
 
         XCTAssertEqual(size.width, EmojiPickerMetrics.width)
-        XCTAssertEqual(size.height, 26 + 1 + 30)
+        XCTAssertEqual(size.height, expectedHeight)
     }
 
     func test_contentSize_capsAtMaxVisibleRows() {
         let size = EmojiPickerMetrics.contentSize(matchCount: 20)
+        let visibleRowsHeight = CGFloat(EmojiPickerMetrics.maxVisibleRows) * EmojiPickerMetrics.rowHeight
+            + EmojiPickerMetrics.listVerticalPadding
+        let expectedHeight = EmojiPickerMetrics.headerHeight
+            + EmojiPickerMetrics.dividerHeight
+            + visibleRowsHeight
+            + EmojiPickerMetrics.dividerHeight
+            + EmojiPickerMetrics.footerHeight
 
-        // header + divider + 8 rows + list padding
-        XCTAssertEqual(size.height, 26 + 1 + (8 * 30 + 8))
+        XCTAssertEqual(size.height, expectedHeight)
     }
 
     func test_frame_sitsBelowCaretWhenItFits() {

--- a/CotabbyTests/EmojiVariantResolverTests.swift
+++ b/CotabbyTests/EmojiVariantResolverTests.swift
@@ -19,30 +19,23 @@ final class EmojiVariantResolverTests: XCTestCase {
 
     private func prefs(
         skinTone: EmojiSkinTone = .neutral,
-        includeNeutral: Bool = false,
         gender: EmojiGender = .neutral
     ) -> EmojiVariantPreferences {
-        EmojiVariantPreferences(skinTone: skinTone, includeNeutral: includeNeutral, gender: gender)
+        EmojiVariantPreferences(skinTone: skinTone, gender: gender)
     }
 
     // MARK: - Skin tone
 
-    func test_skinTone_composesModifierOntoSupportedEmoji() {
+    func test_skinTone_keepsDefaultVariantAfterPreferredTone() {
         let wave = match(glyph: "\u{1F44B}", name: "waving hand", aliases: ["wave"])
         let resolved = EmojiVariantResolver.resolve([wave], preferences: prefs(skinTone: .medium))
-        XCTAssertEqual(resolved.map(\.glyph), ["\u{1F44B}\u{1F3FD}"])
+        XCTAssertEqual(resolved.map(\.glyph), ["\u{1F44B}\u{1F3FD}", "\u{1F44B}"])
     }
 
     func test_skinTone_leavesUnsupportedEmojiUntoned() {
         let dog = match(glyph: "\u{1F436}", name: "dog face", aliases: ["dog"])
         let resolved = EmojiVariantResolver.resolve([dog], preferences: prefs(skinTone: .dark))
         XCTAssertEqual(resolved.map(\.glyph), ["\u{1F436}"])
-    }
-
-    func test_skinTone_includeNeutralKeepsBothVariantsTonedFirst() {
-        let wave = match(glyph: "\u{1F44B}", name: "waving hand", aliases: ["wave"])
-        let resolved = EmojiVariantResolver.resolve([wave], preferences: prefs(skinTone: .light, includeNeutral: true))
-        XCTAssertEqual(resolved.map(\.glyph), ["\u{1F44B}\u{1F3FB}", "\u{1F44B}"])
     }
 
     func test_skinTone_neutralLeavesGlyphsUnchanged() {
@@ -55,7 +48,10 @@ final class EmojiVariantResolverTests: XCTestCase {
         // 🧑‍🚒 -> 🧑🏽‍🚒: modifier after the person scalar, before the ZWJ.
         let firefighter = match(glyph: "\u{1F9D1}\u{200D}\u{1F692}", name: "firefighter", aliases: ["firefighter"])
         let resolved = EmojiVariantResolver.resolve([firefighter], preferences: prefs(skinTone: .medium))
-        XCTAssertEqual(resolved.map(\.glyph), ["\u{1F9D1}\u{1F3FD}\u{200D}\u{1F692}"])
+        XCTAssertEqual(
+            resolved.map(\.glyph),
+            ["\u{1F9D1}\u{1F3FD}\u{200D}\u{1F692}", "\u{1F9D1}\u{200D}\u{1F692}"]
+        )
     }
 
     // MARK: - Gender

--- a/CotabbyTests/SuggestionAvailabilityEvaluatorTests.swift
+++ b/CotabbyTests/SuggestionAvailabilityEvaluatorTests.swift
@@ -648,6 +648,18 @@ final class SuggestionSettingsModelDisabledAppsTests: XCTestCase {
         }
     }
 
+    func test_emojiPickerAcceptKeyLabel_ignoresGhostHintToggleAndRequiresWordAccept() {
+        runOnMainActor {
+            let model = makeModel()
+
+            model.setShowAcceptanceHint(false)
+            XCTAssertEqual(model.emojiPickerAcceptKeyLabel, SuggestionSettingsModel.defaultAcceptanceKeyLabel)
+
+            model.clearAcceptanceKey()
+            XCTAssertNil(model.emojiPickerAcceptKeyLabel)
+        }
+    }
+
     @MainActor
     private func makeModel(
         userDefaults: UserDefaults? = nil


### PR DESCRIPTION
## Summary

Simplifies emoji suggestion settings by removing the Include Neutral Variant toggle and making the default emoji variant always appear after a preferred skin-tone variant. Replaces the skin tone dropdown with a horizontal row of victory-hand tone buttons, refreshes the option labels/copy, and adds an emoji picker footer that shows the configured word-accept shortcut.

## Validation

- `swiftlint lint --quiet 2>&1 | tail -20` — exit 0
- `xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' -only-testing:CotabbyTests/EmojiVariantResolverTests -only-testing:CotabbyTests/EmojiPickerPanelLayoutTests -only-testing:CotabbyTests/SuggestionAvailabilityEvaluatorTests CODE_SIGNING_ALLOWED=NO -derivedDataPath build/DerivedDataEmojiUx` — **TEST SUCCEEDED**, 32 tests, 0 failures
- `xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build -derivedDataPath build/DerivedDataEmojiUx` — **BUILD SUCCEEDED**

No screenshot captured; this is a native macOS settings UI change, and the validation above covers compilation plus the changed pure behavior.

## Linked issues

N/A

## Risk / rollout notes

- Existing `cotabbyIncludeNeutralEmojiVariant` user defaults are now ignored because the behavior is fixed: preferred tone first, default variant next.
- The emoji picker footer intentionally uses the word-accept shortcut even when the ghost-text key hint setting is hidden, because picker instructions should remain visible.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR simplifies the emoji suggestion settings by removing the "Include Neutral Variant" toggle (making the default variant always follow a preferred skin-tone variant), replacing the skin-tone and gender `Picker` dropdowns with horizontal swatch-button rows, and adding a persistent footer to the emoji picker panel that shows the configured word-accept shortcut.

- **`EmojiVariantResolver`** now unconditionally appends the untoned glyph after every toned glyph, replacing the old `includeNeutral` flag; `EmojiVariantPreferences` loses the `includeNeutral` field accordingly.
- **`EmojiPickerView`** gains a footer bar (header + divider + list + divider + footer), and the per-row `EmojiKeycap` is removed in favour of a single static hint in the footer; `EmojiPickerPanelLayout` adds a `footerHeight` constant and includes it in `contentSize`.
- **`SuggestionSettingsModel`** adds `emojiPickerAcceptKeyLabel`, which returns the word-accept label regardless of the ghost-hint toggle, so the picker instruction is always shown when a key is bound.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The behavior changes are intentional and well-scoped, existing user defaults for the removed toggle are gracefully ignored, and all 32 tests pass.

All changed logic paths are covered by the updated test suite. The removals (include-neutral toggle, per-row keycap, gender/neutral binding) are clean and consistent across model, resolver, UI, and tests. The one leftover binding is inert dead code with no runtime impact.

`GeneralPaneView.swift` has a leftover `emojiSkinToneBinding` that was not removed when the Picker was replaced.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/Settings/Panes/GeneralPaneView.swift | Replaces skin-tone and gender Pickers with horizontal swatch rows; removes Include Neutral toggle; renames section and labels. One leftover binding (`emojiSkinToneBinding`) is now unreferenced. |
| Cotabby/Support/EmojiVariantResolver.swift | Hardcodes the "include default variant" behaviour that was previously toggled via `includeNeutral`; `applySkinTone` now always appends the untoned match after the toned one. |
| Cotabby/UI/EmojiPickerView.swift | Moves accept-key hint from per-row keycap to a persistent footer; simplifies `EmojiKeycap` by dropping accent-state colouring; cleans up `EmojiPickerRow`. |
| Cotabby/Models/SuggestionSettingsModel.swift | Drops `includeNeutralEmojiVariant` property, defaults key, and setter; adds `emojiPickerAcceptKeyLabel` computed property that bypasses the ghost-hint toggle. |
| Cotabby/Support/EmojiPickerPanelLayout.swift | Adds `footerHeight` constant and includes it (plus a second divider) in `contentSize`; tests updated to match. |
| Cotabby/App/Core/CotabbyAppEnvironment.swift | Single-line change: wires `emojiPickerAcceptKeyLabel` instead of `acceptanceHintLabel` so the picker footer is unaffected by the ghost-hint toggle. |
| CotabbyTests/EmojiVariantResolverTests.swift | Updates resolver tests: removes `includeNeutral` cases, verifies that a non-neutral skin tone now always yields both toned and untoned glyphs. |
| CotabbyTests/EmojiPickerPanelLayoutTests.swift | Layout tests rewritten to use named constants instead of magic numbers; cover the new footer height in both empty and capped-row scenarios. |
| CotabbyTests/SuggestionAvailabilityEvaluatorTests.swift | Adds a test confirming `emojiPickerAcceptKeyLabel` ignores the ghost-hint toggle and returns `nil` only when the word-accept key is cleared. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User types :smile] --> B[EmojiPickerViewModel\nmatches + selectedIndex]
    B --> C{matches empty?}
    C -- yes --> D[Content: 'Type to search'\nor 'No emoji found']
    C -- no --> E[ScrollView\nEmojiPickerRow list]
    D --> F[Footer: 'Keep typing to search']
    E --> G{acceptKeyLabel set?}
    G -- yes --> H[Footer: Press keycap to insert]
    G -- no --> I[Footer: Click an emoji to insert]

    B --> J[EmojiVariantResolver.resolve]
    J --> K[applyGender\ncollapses neutral/man/woman]
    K --> L[applySkinTone]
    L --> M{skinTone == neutral?}
    M -- yes --> N[return match unchanged]
    M -- no --> O[tonedMatch + match\nalways both]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Femoji-suggestion-copy%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Femoji-suggestion-copy%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FSettings%2FPanes%2FGeneralPaneView.swift%3A231-243%0A%60emojiSkinToneBinding%60%20is%20now%20dead%20code.%20The%20%60Picker%60%20that%20consumed%20it%20was%20replaced%20with%20the%20%60skinToneOption%60%20helper%2C%20which%20calls%20%60suggestionSettings.setPreferredEmojiSkinTone%28tone%29%60%20directly.%20The%20parallel%20%60emojiGenderBinding%60%20was%20correctly%20removed%20in%20this%20PR%2C%20but%20this%20binding%20was%20left%20behind.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20var%20autoAcceptTrailingPunctuationBinding%3A%20Binding%3CBool%3E%20%7B%0A%20%20%20%20%20%20%20%20Binding%28%0A%20%20%20%20%20%20%20%20%20%20%20%20get%3A%20%7B%20suggestionSettings.autoAcceptTrailingPunctuation%20%7D%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20set%3A%20%7B%20suggestionSettings.setAutoAcceptTrailingPunctuation%28%240%29%20%7D%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FSettings%2FPanes%2FGeneralPaneView.swift%3A231-243%0A%60emojiSkinToneBinding%60%20is%20now%20dead%20code.%20The%20%60Picker%60%20that%20consumed%20it%20was%20replaced%20with%20the%20%60skinToneOption%60%20helper%2C%20which%20calls%20%60suggestionSettings.setPreferredEmojiSkinTone%28tone%29%60%20directly.%20The%20parallel%20%60emojiGenderBinding%60%20was%20correctly%20removed%20in%20this%20PR%2C%20but%20this%20binding%20was%20left%20behind.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20var%20autoAcceptTrailingPunctuationBinding%3A%20Binding%3CBool%3E%20%7B%0A%20%20%20%20%20%20%20%20Binding%28%0A%20%20%20%20%20%20%20%20%20%20%20%20get%3A%20%7B%20suggestionSettings.autoAcceptTrailingPunctuation%20%7D%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20set%3A%20%7B%20suggestionSettings.setAutoAcceptTrailingPunctuation%28%240%29%20%7D%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=451&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Make People Emoji Style a swatch row mat..."](https://github.com/fujacob/cotabby/commit/49d3cfe6c8ed24bc17b5067c5408529d2feae90e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34760457)</sub>

<!-- /greptile_comment -->