### PR TITLE
Add a default-on toggle for automatic update checks

### DIFF
--- a/Cotabby/Services/Utilities/AppUpdateManager.swift
+++ b/Cotabby/Services/Utilities/AppUpdateManager.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import Logging
 import Sparkle
@@ -10,7 +11,7 @@ import Sparkle
 /// We keep it in `Services/` so the rest of the app only depends on a tiny, explicit surface:
 /// `start()` for lifecycle wiring and `checkForUpdates()` for a future settings screen.
 @MainActor
-final class AppUpdateManager {
+final class AppUpdateManager: ObservableObject {
     /// The updater is created once and retained for the lifetime of the process, just like the
     /// runtime manager and the focus tracker. Sparkle expects its controller to stay alive.
     private let updaterController: SPUStandardUpdaterController
@@ -54,7 +55,14 @@ final class AppUpdateManager {
         // `checkForUpdates()`, which always shows a result dialog and is reserved for the manual
         // "Check for Updates" button. The daily `SUScheduledCheckInterval` then covers long-running
         // sessions where the app stays open for days.
-        updaterController.updater.checkForUpdatesInBackground()
+        // Respect the user's "Automatically check for updates" preference: when they have turned
+        // automatic checks off, skip even this launch check so the toggle fully governs background
+        // update activity. Sparkle's daily scheduled check already honors the same flag.
+        if automaticallyChecksForUpdates {
+            updaterController.updater.checkForUpdatesInBackground()
+        } else {
+            log("Skipping launch update check because automatic checks are disabled.")
+        }
 
         #if DEBUG
         if ProcessInfo.processInfo.arguments.contains(Self.debugCheckForUpdatesOnLaunchArgument) {
@@ -73,6 +81,23 @@ final class AppUpdateManager {
         }
 
         updaterController.checkForUpdates(nil)
+    }
+
+    /// Whether Sparkle performs automatic update checks: the once-per-launch background check in
+    /// `start()` and Sparkle's daily scheduled check. This proxies Sparkle's own persisted
+    /// preference (`SUEnableAutomaticChecks`, defaulted to `true` in Info.plist) instead of storing a
+    /// second copy, so the Settings toggle and the updater can never disagree. The setter notifies
+    /// SwiftUI observers so a bound toggle re-renders, and Sparkle persists the value for next launch.
+    var automaticallyChecksForUpdates: Bool {
+        get { updaterController.updater.automaticallyChecksForUpdates }
+        set {
+            guard newValue != updaterController.updater.automaticallyChecksForUpdates else {
+                return
+            }
+            objectWillChange.send()
+            updaterController.updater.automaticallyChecksForUpdates = newValue
+            log("Automatic update checks \(newValue ? "enabled" : "disabled") by user preference.")
+        }
     }
 
     private var hasUsableConfiguration: Bool {

--- a/Cotabby/UI/Settings/Panes/AboutPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/AboutPaneView.swift
@@ -6,13 +6,14 @@ import SwiftUI
 /// three legacy sections (header, support CTA, uninstall) plus a new Acknowledgements modal that
 /// lists the third-party packages Cotabby ships with.
 struct AboutPaneView: View {
-    let appUpdateManager: AppUpdateManager
+    @ObservedObject var appUpdateManager: AppUpdateManager
 
     @State private var isShowingAcknowledgements = false
 
     var body: some View {
         SettingsPaneScaffold {
             Section { aboutHeader }
+            Section("Updates") { updatesRow }
             Section("Support") { supportRow }
             Section("Resources") { linksRow }
             Section("Uninstall") { uninstallText }
@@ -51,6 +52,26 @@ struct AboutPaneView: View {
             }
         }
         .padding(.vertical, 4)
+    }
+
+    @ViewBuilder
+    private var updatesRow: some View {
+        Toggle(isOn: automaticUpdateChecksBinding) {
+            SettingsRowLabel(
+                title: "Automatically Check for Updates",
+                description: "Let Cotabby check for new versions in the background on launch and once " +
+                    "a day. Turn this off to only update when you press Check for Updates."
+            )
+        }
+    }
+
+    /// Reads and writes Sparkle's own persisted preference through `AppUpdateManager` so the toggle
+    /// reflects the real updater state instead of a separate mirror that could drift out of sync.
+    private var automaticUpdateChecksBinding: Binding<Bool> {
+        Binding(
+            get: { appUpdateManager.automaticallyChecksForUpdates },
+            set: { appUpdateManager.automaticallyChecksForUpdates = $0 }
+        )
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary

Cotabby checks for updates on launch and once a day through Sparkle (`SUEnableAutomaticChecks` is already `true` in `CotabbyInfo.plist`), but users had no way to turn that off. This adds an "Automatically Check for Updates" toggle to the About settings pane. It is on by default, matching the existing behavior, and lets a user opt out of all background update activity while still being able to press "Check for Updates" manually.

`AppUpdateManager` now exposes Sparkle's own `automaticallyChecksForUpdates` as the single source of truth (a computed proxy, not a second persisted copy), so the toggle and the updater can never drift apart. The once-per-launch background check is now gated on that flag, and Sparkle's daily scheduled check already honors it, so turning the toggle off genuinely stops background checks.

The toggle lives in the About pane because that pane already owns `AppUpdateManager` and the "Check for Updates" button, so update controls stay together.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO
# ** TEST SUCCEEDED **  566 tests, 0 failures (4 skipped)

swiftlint lint --strict --quiet Cotabby/Services/Utilities/AppUpdateManager.swift Cotabby/UI/Settings/Panes/AboutPaneView.swift
# exit 0
```

Manual check: open Settings > About. The "Updates" section shows the toggle on by default. Turning it off persists across relaunch (Sparkle writes `SUEnableAutomaticChecks` to user defaults) and suppresses the launch background check; "Check for Updates" still works.

## Linked issues

None.

## Risk / rollout notes

- Default is unchanged for existing users: automatic checks stay on. The new control only adds the ability to opt out.
- The preference is Sparkle's own (`SUEnableAutomaticChecks`), read and written through `AppUpdateManager`. No new settings key or migration.
- `AppUpdateManager` now conforms to `ObservableObject` (added `import Combine`) so the About pane can bind a toggle to it. It has no `@Published` state; the setter calls `objectWillChange.send()` so a bound toggle re-renders.
- Scope is auto-check only. Silent auto-download and install (`SUAutomaticallyUpdate`) stays off, so an available update still prompts before installing, which is the existing behavior.
- No new files, so `project.yml` and the generated project are unchanged.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an "Automatically Check for Updates" toggle to the About settings pane, backed by a computed proxy on `AppUpdateManager` that reads and writes Sparkle's own `SUEnableAutomaticChecks` preference directly — avoiding a duplicate persisted copy that could drift out of sync.

- `AppUpdateManager` gains `ObservableObject` conformance and an `automaticallyChecksForUpdates` computed property whose setter calls `objectWillChange.send()` before writing to Sparkle, so a bound SwiftUI toggle re-renders correctly.
- The once-per-launch `checkForUpdatesInBackground()` call in `start()` is now gated on the flag, making the toggle a complete opt-out of all background update activity.
- `AboutPaneView` changes `appUpdateManager` to `@ObservedObject` and adds the toggle via a lightweight `Binding` helper.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the toggle correctly proxies Sparkle's own preference with no duplicated state and the launch check is properly gated.

The design is solid — single source of truth, correct objectWillChange ordering, and @ObservedObject usage are all right. The two suggestions are about a missing isStarted guard in the new setter (inconsistent with the existing checkForUpdates() pattern) and a missing .disabled modifier on the toggle, both of which only matter in misconfigured development builds and have no production impact.

No files require special attention for production. The isStarted guard omission in AppUpdateManager and the always-enabled toggle in AboutPaneView are worth a second look if the misconfigured-Sparkle path ever gains more test coverage.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Services/Utilities/AppUpdateManager.swift | Adds ObservableObject conformance and an automaticallyChecksForUpdates computed proxy; correctly gates the launch background check on the flag. The setter lacks an isStarted guard (unlike checkForUpdates()), which is harmless in production but inconsistent. |
| Cotabby/UI/Settings/Panes/AboutPaneView.swift | Adds Updates section with an automatic-check toggle bound through a custom Binding. @ObservedObject is the correct attribute here. Toggle has no disabled modifier for the misconfigured-Sparkle case, but this is development-only. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant AboutPaneView
    participant AppUpdateManager
    participant SPUUpdater
    participant UserDefaults

    User->>AboutPaneView: toggles "Automatically Check for Updates"
    AboutPaneView->>AppUpdateManager: "automaticallyChecksForUpdates = newValue"
    AppUpdateManager->>SPUUpdater: read automaticallyChecksForUpdates (guard check)
    SPUUpdater-->>AppUpdateManager: current value
    AppUpdateManager->>AppUpdateManager: objectWillChange.send()
    AppUpdateManager->>SPUUpdater: "automaticallyChecksForUpdates = newValue"
    SPUUpdater->>UserDefaults: persist SUEnableAutomaticChecks
    AppUpdateManager->>AppUpdateManager: log change
    AboutPaneView-->>User: toggle re-renders (SwiftUI diff)

    Note over AppUpdateManager,SPUUpdater: On next app launch
    AppUpdateManager->>AppUpdateManager: start() called
    AppUpdateManager->>SPUUpdater: startUpdater()
    AppUpdateManager->>SPUUpdater: read automaticallyChecksForUpdates
    SPUUpdater->>UserDefaults: read SUEnableAutomaticChecks
    UserDefaults-->>SPUUpdater: stored value
    alt "automaticallyChecksForUpdates == true"
        AppUpdateManager->>SPUUpdater: checkForUpdatesInBackground()
    else "automaticallyChecksForUpdates == false"
        AppUpdateManager->>AppUpdateManager: log skip
    end
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fauto-update-toggle%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fauto-update-toggle%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FServices%2FUtilities%2FAppUpdateManager.swift%3A91-101%0A%60checkForUpdates%28%29%60%20guards%20on%20%60isStarted%60%20and%20logs%20a%20diagnostic%20when%20the%20updater%20hasn't%20been%20started%2C%20but%20%60automaticallyChecksForUpdates%60's%20setter%20has%20no%20equivalent%20guard.%20In%20the%20%28development-only%29%20path%20where%20%60hasUsableConfiguration%60%20returns%20%60false%60%2C%20Sparkle%20never%20starts%20but%20the%20setter%20is%20still%20reachable%20from%20the%20UI%20%E2%80%94%20it%20writes%20to%20%60UserDefaults%60%20silently%20with%20no%20indication%20that%20the%20change%20has%20no%20effect%20this%20session.%20Adding%20the%20guard%20keeps%20the%20surface%20area%20consistent%20and%20makes%20misconfiguration%20easier%20to%20diagnose.%0A%0A%60%60%60suggestion%0A%20%20%20%20var%20automaticallyChecksForUpdates%3A%20Bool%20%7B%0A%20%20%20%20%20%20%20%20get%20%7B%20updaterController.updater.automaticallyChecksForUpdates%20%7D%0A%20%20%20%20%20%20%20%20set%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20guard%20isStarted%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20log%28%22Ignoring%20automatic-checks%20preference%20change%20because%20the%20updater%20has%20not%20started.%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20guard%20newValue%20!%3D%20updaterController.updater.automaticallyChecksForUpdates%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20objectWillChange.send%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20updaterController.updater.automaticallyChecksForUpdates%20%3D%20newValue%0A%20%20%20%20%20%20%20%20%20%20%20%20log%28%22Automatic%20update%20checks%20%5C%28newValue%20%3F%20%22enabled%22%20%3A%20%22disabled%22%29%20by%20user%20preference.%22%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FUI%2FSettings%2FPanes%2FAboutPaneView.swift%3A57-66%0AThe%20toggle%20is%20always%20interactive%2C%20even%20in%20configurations%20where%20Sparkle%20never%20starts%20%28i.e.%20development%20builds%20where%20%60hasUsableConfiguration%60%20is%20%60false%60%29.%20Exposing%20%60isStarted%60%20through%20%60AppUpdateManager%60%20%28or%20a%20dedicated%20%60isAvailable%60%20flag%29%20and%20wiring%20it%20to%20%60.disabled%28!appUpdateManager.isStarted%29%60%20on%20the%20toggle%20would%20prevent%20a%20confusing%20state%20where%20the%20toggle%20moves%20but%20has%20no%20observable%20effect%20during%20that%20session.%0A%0A%60%60%60suggestion%0A%20%20%20%20%40ViewBuilder%0A%20%20%20%20private%20var%20updatesRow%3A%20some%20View%20%7B%0A%20%20%20%20%20%20%20%20Toggle%28isOn%3A%20automaticUpdateChecksBinding%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20SettingsRowLabel%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20title%3A%20%22Automatically%20Check%20for%20Updates%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20description%3A%20%22Let%20Cotabby%20check%20for%20new%20versions%20in%20the%20background%20on%20launch%20and%20once%20%22%20%2B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22a%20day.%20Turn%20this%20off%20to%20only%20update%20when%20you%20press%20Check%20for%20Updates.%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20.disabled%28!appUpdateManager.isStarted%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FServices%2FUtilities%2FAppUpdateManager.swift%3A91-101%0A%60checkForUpdates%28%29%60%20guards%20on%20%60isStarted%60%20and%20logs%20a%20diagnostic%20when%20the%20updater%20hasn't%20been%20started%2C%20but%20%60automaticallyChecksForUpdates%60's%20setter%20has%20no%20equivalent%20guard.%20In%20the%20%28development-only%29%20path%20where%20%60hasUsableConfiguration%60%20returns%20%60false%60%2C%20Sparkle%20never%20starts%20but%20the%20setter%20is%20still%20reachable%20from%20the%20UI%20%E2%80%94%20it%20writes%20to%20%60UserDefaults%60%20silently%20with%20no%20indication%20that%20the%20change%20has%20no%20effect%20this%20session.%20Adding%20the%20guard%20keeps%20the%20surface%20area%20consistent%20and%20makes%20misconfiguration%20easier%20to%20diagnose.%0A%0A%60%60%60suggestion%0A%20%20%20%20var%20automaticallyChecksForUpdates%3A%20Bool%20%7B%0A%20%20%20%20%20%20%20%20get%20%7B%20updaterController.updater.automaticallyChecksForUpdates%20%7D%0A%20%20%20%20%20%20%20%20set%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20guard%20isStarted%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20log%28%22Ignoring%20automatic-checks%20preference%20change%20because%20the%20updater%20has%20not%20started.%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20guard%20newValue%20!%3D%20updaterController.updater.automaticallyChecksForUpdates%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20objectWillChange.send%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20updaterController.updater.automaticallyChecksForUpdates%20%3D%20newValue%0A%20%20%20%20%20%20%20%20%20%20%20%20log%28%22Automatic%20update%20checks%20%5C%28newValue%20%3F%20%22enabled%22%20%3A%20%22disabled%22%29%20by%20user%20preference.%22%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FUI%2FSettings%2FPanes%2FAboutPaneView.swift%3A57-66%0AThe%20toggle%20is%20always%20interactive%2C%20even%20in%20configurations%20where%20Sparkle%20never%20starts%20%28i.e.%20development%20builds%20where%20%60hasUsableConfiguration%60%20is%20%60false%60%29.%20Exposing%20%60isStarted%60%20through%20%60AppUpdateManager%60%20%28or%20a%20dedicated%20%60isAvailable%60%20flag%29%20and%20wiring%20it%20to%20%60.disabled%28!appUpdateManager.isStarted%29%60%20on%20the%20toggle%20would%20prevent%20a%20confusing%20state%20where%20the%20toggle%20moves%20but%20has%20no%20observable%20effect%20during%20that%20session.%0A%0A%60%60%60suggestion%0A%20%20%20%20%40ViewBuilder%0A%20%20%20%20private%20var%20updatesRow%3A%20some%20View%20%7B%0A%20%20%20%20%20%20%20%20Toggle%28isOn%3A%20automaticUpdateChecksBinding%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20SettingsRowLabel%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20title%3A%20%22Automatically%20Check%20for%20Updates%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20description%3A%20%22Let%20Cotabby%20check%20for%20new%20versions%20in%20the%20background%20on%20launch%20and%20once%20%22%20%2B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22a%20day.%20Turn%20this%20off%20to%20only%20update%20when%20you%20press%20Check%20for%20Updates.%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20.disabled%28!appUpdateManager.isStarted%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=452&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add a default-on toggle to control autom..."](https://github.com/fujacob/cotabby/commit/f7d901689b00be2e1781fc9331b9d006b9bbeba0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34760551)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->