### PR TITLE
Remove Display and Allow Multi-line Suggestions from menu bar popup

### DIFF
--- a/Cotabby/UI/MenuBarView.swift
+++ b/Cotabby/UI/MenuBarView.swift
@@ -104,15 +104,9 @@ struct MenuBarView: View {
             Divider()
 
             // Context-shaping toggles that change what the model is fed.
-            Group {
-                Toggle("Include Clipboard Context", isOn: clipboardContextEnabledBinding)
-                    .toggleStyle(.switch)
-                    .controlSize(.small)
-
-                Toggle("Allow Multi-line Suggestions", isOn: multiLineEnabledBinding)
-                    .toggleStyle(.switch)
-                    .controlSize(.small)
-            }
+            Toggle("Include Clipboard Context", isOn: clipboardContextEnabledBinding)
+                .toggleStyle(.switch)
+                .controlSize(.small)
 
             Divider()
 
@@ -153,16 +147,6 @@ struct MenuBarView: View {
                     .pickerStyle(.menu)
                 }
 
-                MenuBarPickerRow(title: "Display") {
-                    Picker("Display", selection: mirrorPreferenceBinding) {
-                        ForEach(MirrorPreference.allCases) { preference in
-                            Text(preference.displayLabel)
-                                .tag(preference)
-                        }
-                    }
-                    .labelsHidden()
-                    .pickerStyle(.menu)
-                }
             }
         }
         .padding(.bottom, 12)
@@ -322,26 +306,12 @@ struct MenuBarView: View {
         )
     }
 
-    private var multiLineEnabledBinding: Binding<Bool> {
-        Binding(
-            get: { suggestionSettings.isMultiLineEnabled },
-            set: { suggestionSettings.setMultiLineEnabled($0) }
-        )
-    }
-
     private var selectedWordCountPresetBinding: Binding<SuggestionWordCountPreset> {
         Binding(
             get: { suggestionSettings.selectedWordCountPreset },
             set: { preset in
                 suggestionSettings.selectWordCountPreset(preset)
             }
-        )
-    }
-
-    private var mirrorPreferenceBinding: Binding<MirrorPreference> {
-        Binding(
-            get: { suggestionSettings.mirrorPreference },
-            set: { suggestionSettings.setMirrorPreference($0) }
         )
     }
 


### PR DESCRIPTION
## Summary

Two controls removed from the menu bar popup because they are set-it-and-forget-it preferences that don't change mid-session:

- **Display** (Auto / Inline / Mirror) -- most users stay on Auto permanently; the rare override is a one-time decision made in Settings.
- **Allow Multi-line Suggestions** -- a niche power-user toggle that does not change session to session.

Both remain fully accessible in Settings. The popup now stays focused on controls users actually reach for mid-work: Fast Mode, Enable Globally / per-app, Clipboard Context, Engine, Model, and Length.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby \
  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
# ** BUILD SUCCEEDED **

swiftlint lint --quiet
# exit 0
```

## Linked issues

## Risk / rollout notes

Both settings remain in Settings > Writing / Advanced. No data migration needed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes two "set-and-forget" controls — **Allow Multi-line Suggestions** (toggle) and **Display** (picker) — from the menu bar popup, leaving them accessible only through the Settings window. The corresponding `multiLineEnabledBinding` and `mirrorPreferenceBinding` computed properties are also deleted.

- The `Group` wrapping both clipboard and multi-line toggles is replaced by the single remaining `Toggle("Include Clipboard Context")`, which is structurally correct and stays under SwiftUI's 10-child `ViewBuilder` limit.
- The `mirrorPreferenceBinding` and `multiLineEnabledBinding` Bindings are cleanly removed with no dangling references, and the `Group` enclosing the remaining picker rows is properly preserved.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are purely subtractive UI removals with no functional side effects.

The two removed controls and their backing Binding properties are cleanly excised with no remaining references. The underlying settings remain writable through the Settings window, so no user data or behavior is lost. The only issue found is a stale plural comment.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/MenuBarView.swift | Removed the "Allow Multi-line Suggestions" toggle and "Display" picker from the menu bar popup, along with their backing Binding computed properties; only a stale plural comment remains as a minor nit. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant MenuBarView
    participant SuggestionSettingsModel
    participant SettingsWindow

    Note over MenuBarView: Controls removed from popup
    User->>MenuBarView: Opens menu bar popup
    MenuBarView-->>User: "Shows: Fast Mode, Enable Globally,<br/>Include Clipboard Context, Engine, Model, Length"

    Note over MenuBarView,SettingsWindow: Removed controls now Settings-only
    User->>SettingsWindow: Opens Settings
    SettingsWindow-->>SuggestionSettingsModel: Read/write Allow Multi-line Suggestions
    SettingsWindow-->>SuggestionSettingsModel: Read/write Display (MirrorPreference)
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Ftrim-menubar-controls%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Ftrim-menubar-controls%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FMenuBarView.swift%3A106-107%0AThe%20comment%20says%20%22toggles%22%20%28plural%29%2C%20but%20after%20removing%20%22Allow%20Multi-line%20Suggestions%22%2C%20only%20a%20single%20toggle%20remains%20in%20this%20section.%20The%20comment%20should%20be%20updated%20to%20reflect%20the%20singular%20form.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Context-shaping%20toggle%20that%20changes%20what%20the%20model%20is%20fed.%0A%20%20%20%20%20%20%20%20%20%20%20%20Toggle%28%22Include%20Clipboard%20Context%22%2C%20isOn%3A%20clipboardContextEnabledBinding%29%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FMenuBarView.swift%3A106-107%0AThe%20comment%20says%20%22toggles%22%20%28plural%29%2C%20but%20after%20removing%20%22Allow%20Multi-line%20Suggestions%22%2C%20only%20a%20single%20toggle%20remains%20in%20this%20section.%20The%20comment%20should%20be%20updated%20to%20reflect%20the%20singular%20form.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Context-shaping%20toggle%20that%20changes%20what%20the%20model%20is%20fed.%0A%20%20%20%20%20%20%20%20%20%20%20%20Toggle%28%22Include%20Clipboard%20Context%22%2C%20isOn%3A%20clipboardContextEnabledBinding%29%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=456&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Remove Display and Allow Multi-line Sugg..."](https://github.com/fujacob/cotabby/commit/58d4c72ffa214895ff23c399eca198804db2964f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34760949)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->