### PR TITLE
Commit :emoji: on Tab even while a suggestion overlay is visible

### DIFF
--- a/Cotabby/App/Coordinators/EmojiPickerController.swift
+++ b/Cotabby/App/Coordinators/EmojiPickerController.swift
@@ -1,6 +1,7 @@
 import Combine
 import CoreGraphics
 import Foundation
+import Logging
 
 /// File overview:
 /// Orchestrates the inline `:emoji:` picker. It is a sibling to `SuggestionCoordinator`, not part of
@@ -196,6 +197,11 @@ final class EmojiPickerController {
 
     private func beginCapture(query: String) {
         guard canTrigger(), let context = focusModel.snapshot.context else {
+            // A `:` opened the trigger but the field is unsupported/secure or its AX context has not
+            // resolved yet (AX is eventually consistent right after a focus change). Aborting here
+            // looks to the user like "the picker did nothing on the first try"; log it so that
+            // first-keystroke failure is distinguishable from a commit-path failure.
+            CotabbyLogger.suggestion.debug("emoji capture aborted at open: no triggerable focus context")
             machine.reset()
             return
         }
@@ -205,6 +211,7 @@ final class EmojiPickerController {
         refreshMatches(query: query)
         presentPanel()
         armLongPauseTimer()
+        CotabbyLogger.suggestion.debug("emoji capture opened query=\"\(query)\" matches=\(matches.count)")
     }
 
     private func updateQuery(_ query: String) {
@@ -240,11 +247,13 @@ final class EmojiPickerController {
     /// insert the highlighted glyph.
     private func commitSelectedMatch() {
         guard selectedIndex >= 0, selectedIndex < matches.count else {
+            CotabbyLogger.suggestion.debug("emoji commit (key) skipped: no selectable match query=\"\(currentQuery)\"")
             cancelCapture()
             return
         }
         let glyph = matches[selectedIndex].glyph
         let fallback = currentQuery.utf16.count + 1   // ":" + query
+        CotabbyLogger.suggestion.debug("emoji commit (key) glyph=\(glyph) query=\"\(currentQuery)\"")
         teardownCapture()
         scheduleReplaceEmojiQuery(with: glyph, fallbackUTF16: fallback)
     }
@@ -324,7 +333,11 @@ final class EmojiPickerController {
         // NOT force a fresh AX resolve + `focusChangeSequence` guard here: the resolve re-stamped the
         // sequence and made the guard abort legitimate commits (the panel vanished with no emoji).
         let preceding = focusModel.snapshot.context?.precedingText ?? ""
-        let deleteCount = EmojiQueryRun.trailingRunUTF16Length(in: preceding) ?? fallbackUTF16
+        let measured = EmojiQueryRun.trailingRunUTF16Length(in: preceding)
+        let deleteCount = measured ?? fallbackUTF16
+        CotabbyLogger.suggestion.debug(
+            "emoji replace glyph=\(glyph) deleteUTF16=\(deleteCount) measured=\(measured != nil)"
+        )
         _ = inserter.replace(deletingUTF16Count: deleteCount, with: glyph)
         // Let the focus pipeline re-read the field so any pending suggestion uses the post-insertion
         // text instead of the stale `:query` we just removed.
@@ -345,6 +358,9 @@ final class EmojiPickerController {
         guard let context = snapshot.context,
               !context.isSecure,
               context.focusChangeSequence == captureFocusSequence else {
+            // The field changed (or went secure) under an open capture. This is the other common
+            // "panel vanished mid-query" cause, so record it distinctly from a user cancel.
+            CotabbyLogger.suggestion.debug("emoji capture cancelled: focus changed during capture")
             cancelCapture()
             return
         }

--- a/Cotabby/Services/Input/InputMonitor.swift
+++ b/Cotabby/Services/Input/InputMonitor.swift
@@ -122,7 +122,10 @@ final class InputMonitor {
     /// keys. Tracking them separately means neither feature removes the tap while the other still
     /// needs it, and the tap is gone entirely when both are idle (the issue #328 invariant).
     private var suggestionInterceptionActive = false
-    private var captureInterceptionActive = false
+    /// Internal (not private) for the same reason as `isAcceptTapOwningAcceptKeys`: tests stage the
+    /// "emoji capture open" state directly to exercise observer routing without installing real taps.
+    /// Production only mutates this through `setCaptureInterceptionActive(_:)`.
+    var captureInterceptionActive = false
 
     init(
         permissionProvider: @escaping @MainActor () -> Bool,
@@ -606,7 +609,15 @@ final class InputMonitor {
     }
 
     private func routeObserverKeyDown(_ keyEvent: InputMonitorKeyEvent) -> CapturedInputEvent? {
-        let capturedEvent = classify(keyEvent: keyEvent, recognizesAcceptance: isAcceptTapOwningAcceptKeys)
+        // While an emoji capture is open, the accept key must reach the observer's `onEvent` so the
+        // emoji controller can commit on it. The emoji commit fires from the listen-only observer pass
+        // (the accept tap only swallows the key afterward), so suppressing the accept key here — which
+        // we do whenever a ghost suggestion is concurrently visible (`isAcceptTapOwningAcceptKeys`) —
+        // would freeze the emoji controller out of its own commit key and route Tab to the suggestion
+        // accept path instead. Excluding capture from acceptance recognition keeps the emoji picker's
+        // "first look at every keystroke" invariant intact even when a suggestion overlay is showing.
+        let recognizesAcceptance = isAcceptTapOwningAcceptKeys && !captureInterceptionActive
+        let capturedEvent = classify(keyEvent: keyEvent, recognizesAcceptance: recognizesAcceptance)
         guard !capturedEvent.kind.isAcceptance else {
             // Acceptance is handled by the active default tap, because only that callback can
             // make insertion and "consume the original key" one atomic decision. If the active

--- a/CotabbyTests/InputMonitorTests.swift
+++ b/CotabbyTests/InputMonitorTests.swift
@@ -30,6 +30,36 @@ final class InputMonitorTests: XCTestCase {
         }
     }
 
+    /// Regression: while an emoji `:query` capture is open, the observer must keep routing the accept
+    /// key (Tab) to `onEvent` even when a ghost suggestion is concurrently visible (which sets
+    /// `isAcceptTapOwningAcceptKeys`). The emoji commit fires from this observer pass; suppressing the
+    /// key here let a late async suggestion steal the first Tab, so the emoji never landed on the first
+    /// try and only worked once the suggestion had cleared.
+    func test_observerTapRoutesAcceptKeyToEmojiObserverWhileCapturingDespiteVisibleSuggestion() {
+        runOnMainActor {
+            let monitor = makeMonitor()
+            monitor.acceptanceKeyCodeProvider = { 48 }   // Tab is the word-accept key
+            // Stage both conditions: a visible suggestion owns the accept key, AND an emoji capture is
+            // open. (Set after the capture flag because `setCaptureInterceptionActive` recomputes
+            // ownership; we stage it directly to avoid installing real CGEvent taps in the test host.)
+            monitor.captureInterceptionActive = true
+            monitor.isAcceptTapOwningAcceptKeys = true
+            var observedKinds: [CapturedInputEvent.Kind] = []
+            monitor.onEvent = { event in
+                observedKinds.append(event.kind)
+                return false
+            }
+
+            let capturedEvent = monitor.handleObserverKeyDown(InputMonitorKeyEvent(keyCode: 48))
+
+            // The key must reach the emoji observer and must NOT be classified as acceptance.
+            XCTAssertNotNil(capturedEvent)
+            XCTAssertNotEqual(capturedEvent?.kind, .acceptance)
+            XCTAssertEqual(observedKinds.count, 1)
+            XCTAssertNotEqual(observedKinds.first, .acceptance)
+        }
+    }
+
     func test_observerTapIgnoresFullAcceptKeyWhenConsumingTapOwnsIt() {
         runOnMainActor {
             let monitor = makeMonitor()


### PR DESCRIPTION
## Summary

The inline `:emoji:` picker would ignore the first Tab and only start working on later attempts. Root cause: the emoji **commit** fires from the listen-only observer pass (`EmojiPickerController.observe()` → `machine.reduce(.commitKey)`); the consuming accept tap only *swallows* the key afterward. But `InputMonitor.routeObserverKeyDown` suppressed the accept key (returned before calling `onEvent`) whenever `isAcceptTapOwningAcceptKeys` was true, which is the case whenever a ghost suggestion is concurrently visible. So if a late async suggestion became visible while the emoji panel was open (most likely on the slow first generation after focusing a field), Tab was classified as `.acceptance`, never reached the emoji controller, and was routed to the suggestion-accept path instead. Once the suggestion cleared, the emoji committed normally, which is why it "worked afterwards."

Fix: exclude an open emoji capture from accept-key recognition at the observer, so the emoji picker keeps its intended "first look at every keystroke" even with a suggestion overlay showing:

```swift
let recognizesAcceptance = isAcceptTapOwningAcceptKeys && !captureInterceptionActive
```

The consuming tap's `emojiCaptureKeyDecider` then swallows the Tab (the head-inserted observer runs before the tail-appended accept tap, so `pendingDecision` is already set to consume). When no capture is open, `captureInterceptionActive` is false and behavior is identical to before.

Also adds the previously-missing `EmojiPickerController` logging (capture open / abort-on-nil-context / commit / focus-change cancel / replace) so this path is diagnosable from `cotabby.jsonl`, and a regression test.

## Validation

```
swiftlint lint --quiet   # exit 0 on changed files
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -configuration Debug \
  -destination 'platform=macOS' build              # ** BUILD SUCCEEDED **
xcodebuild ... build-for-testing                   # ** TEST BUILD SUCCEEDED **
```

The app-hosted unit-test *run* could not execute locally due to the known Team ID signing mismatch (test bundle signed "Sign to Run Locally" vs the host app's Apple Development identity → `dlopen` rejects the bundle). `build-for-testing` confirms the new test compiles; CI runs the suite with consistent signing.

New test: `test_observerTapRoutesAcceptKeyToEmojiObserverWhileCapturingDespiteVisibleSuggestion` asserts that with both `captureInterceptionActive` and `isAcceptTapOwningAcceptKeys` set, the accept key reaches `onEvent` and is not classified as `.acceptance`.

## Linked issues

(none filed)

## Risk / rollout notes

- The diagnosis was adversarially verified against the code (the suppression mechanism, the async ownership flip, and the fix's tap-ordering/no-regression properties all confirmed). The one thing **not** proven from logs is that the suggestion-visible race is exactly what the user hit, because `EmojiPickerController` had no logging until this PR. A second candidate cause exists: on the very first `:` after focusing a field, the AX focus context can still be nil, so `beginCapture` aborts and no panel opens. The added logging now distinguishes the two; if reports persist, check `cotabby.jsonl` for "emoji capture aborted at open".
- `InputMonitor.captureInterceptionActive` widened from `private` to internal (mirrors `isAcceptTapOwningAcceptKeys`) so the test can stage state without installing real CGEvent taps. Production still mutates it only via `setCaptureInterceptionActive(_:)`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a race condition where pressing Tab to commit an inline `:emoji:` would silently misfire on the first attempt whenever a ghost suggestion happened to be visible concurrently. The single-line logic fix in `routeObserverKeyDown` (`recognizesAcceptance = isAcceptTapOwningAcceptKeys && !captureInterceptionActive`) ensures the accept key still flows through to the emoji controller's observer pass even when the suggestion overlay is also claiming the accept key.

- **`InputMonitor.swift`**: The core fix — excludes an active emoji capture from accept-key suppression at the observer, so `EmojiPickerController.observe()` always gets \"first look\" at the commit key. `captureInterceptionActive` is widened to `internal` (matching the existing `isAcceptTapOwningAcceptKeys` pattern) so tests can stage the concurrent-ownership state without installing real CGEvent taps.
- **`EmojiPickerController.swift`**: Adds `import Logging` and five debug log points (aborted open, capture opened, commit skipped/proceeding, focus-change cancel, replace operation) so the emoji commit path is now fully observable from `cotabby.jsonl`.
- **`InputMonitorTests.swift`**: Adds a targeted regression test that stages both flags (`captureInterceptionActive = true`, `isAcceptTapOwningAcceptKeys = true`) and verifies Tab reaches `onEvent` and is not classified as `.acceptance`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, well-scoped single-expression fix with a direct regression test, and no existing behavior is altered when capture is not active.

The fix is exactly one boolean expression change in `routeObserverKeyDown`. All three combinations of the two flags produce correct routing. Logging is purely additive.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Services/Input/InputMonitor.swift | Core fix: adds `&& !captureInterceptionActive` to `recognizesAcceptance` so Tab is not silently dropped when both emoji capture and a ghost suggestion are active simultaneously. |
| Cotabby/App/Coordinators/EmojiPickerController.swift | Adds `import Logging` and targeted debug-log lines at five previously-silent points. No logic changes. |
| CotabbyTests/InputMonitorTests.swift | Adds regression test staging both `captureInterceptionActive = true` and `isAcceptTapOwningAcceptKeys = true`, verifying Tab reaches `onEvent` and is not classified as `.acceptance`. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Commit :emoji: on Tab even while a sugge..."](https://github.com/fujacob/cotabby/commit/287bbf0fff737c13b46261e926cfb909749e7dac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34761133)</sub>

<!-- /greptile_comment -->