### PR TITLE
Showcase autocomplete + inline emoji on the final onboarding screen

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -100,6 +100,7 @@
 		6014B31E2570EFFE45557E33 /* TickMarkSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67586807ACE8EB13C9014535 /* TickMarkSlider.swift */; };
 		6106B16C0DBA94EBF838D93E /* PermissionOverlayTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6423D6CC8CC371D2DA899DE /* PermissionOverlayTracker.swift */; };
 		61EC9D635D416115E7C96E0F /* PermissionOverlayWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C6EB9FDA48ADF425A116A9 /* PermissionOverlayWindowController.swift */; };
+		62DBCF429B7F464A6B467725 /* OnboardingFeatureShowcase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 926B332E7B4CFEE42C4CAA75 /* OnboardingFeatureShowcase.swift */; };
 		63054CBDCA87560130BF5ADC /* ExtendedContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54BC85605541E913EE57B258 /* ExtendedContextTests.swift */; };
 		644EEF959D07D54CC779BBF6 /* SettingsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3350EDE01ED5125520C79D53 /* SettingsCoordinator.swift */; };
 		65478B0DABF5460C32D4C458 /* ModelFileValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A829F28F01FAE76CA7244BBC /* ModelFileValidatorTests.swift */; };
@@ -333,6 +334,7 @@
 		8F961F5DF2A392F6F5F94F8A /* SuggestionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionCoordinator.swift; sourceTree = "<group>"; };
 		907549CB913B40C28B953A5D /* SettingsRowLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRowLabel.swift; sourceTree = "<group>"; };
 		90B0D133AB77A2503FB08827 /* ClipboardRelevanceFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardRelevanceFilterTests.swift; sourceTree = "<group>"; };
+		926B332E7B4CFEE42C4CAA75 /* OnboardingFeatureShowcase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFeatureShowcase.swift; sourceTree = "<group>"; };
 		92C6EB9FDA48ADF425A116A9 /* PermissionOverlayWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOverlayWindowController.swift; sourceTree = "<group>"; };
 		944065A858D9BC936CB12B23 /* LlamaRuntimeCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LlamaRuntimeCore.swift; sourceTree = "<group>"; };
 		9458F0820B3161FE9CF1DDAF /* GhostFontSizeStabilizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostFontSizeStabilizer.swift; sourceTree = "<group>"; };
@@ -634,6 +636,14 @@
 			path = Models;
 			sourceTree = "<group>";
 		};
+		A2C5A783B8B991CE3F3176CC /* Onboarding */ = {
+			isa = PBXGroup;
+			children = (
+				926B332E7B4CFEE42C4CAA75 /* OnboardingFeatureShowcase.swift */,
+			);
+			path = Onboarding;
+			sourceTree = "<group>";
+		};
 		A8A141E1F2137943476D0C82 /* CotabbyTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -702,6 +712,7 @@
 		B0EBE873B895FB333A0BC26F /* UI */ = {
 			isa = PBXGroup;
 			children = (
+				A2C5A783B8B991CE3F3176CC /* Onboarding */,
 				DCBC24D605EC0CBA1DD6097D /* Settings */,
 				82F7F7355967725162DF2D1B /* CustomRulesEditor.swift */,
 				BB5C2AE9A7E55495D26AD074 /* DownloadableModelCatalogView.swift */,
@@ -1029,6 +1040,7 @@
 				31515DDD173535C4AC777853 /* MirrorOverlayLayout.swift in Sources */,
 				2F227738D7834B1A7A81D1D6 /* ModelDownloadManager.swift in Sources */,
 				317883210D1D1D5CD654E562 /* ModelFileValidator.swift in Sources */,
+				62DBCF429B7F464A6B467725 /* OnboardingFeatureShowcase.swift in Sources */,
 				FC6B0524B774F20C18BD6889 /* OnboardingTemplate.swift in Sources */,
 				DF8794793110A8ED234CBA96 /* OnboardingTemplateRecommender.swift in Sources */,
 				0DDC0CFF5558A8F4355836B2 /* OverlayController.swift in Sources */,

--- a/Cotabby/UI/Onboarding/OnboardingFeatureShowcase.swift
+++ b/Cotabby/UI/Onboarding/OnboardingFeatureShowcase.swift
@@ -1,0 +1,343 @@
+import SwiftUI
+
+/// File overview:
+/// Decorative, self-playing demos shown on the final onboarding screen ("You're all set"). They
+/// mimic Cotabby's two flagship features, inline autocomplete ghost text and the inline `:emoji:`
+/// picker, using hardcoded strings and local state only.
+///
+/// Nothing here touches the real suggestion pipeline, settings, Accessibility, the event tap, or the
+/// emoji catalog. The cards are inert content, so they can never steal focus or affect a real
+/// suggestion. The keycap and popup styling is replicated (not shared) from `OverlayController` and
+/// `EmojiPickerView`, whose own keycap views are `private`.
+///
+/// Lifecycle: each card owns its `@State` and drives a looping animation from a `.task`, which
+/// SwiftUI cancels automatically when the view leaves the hierarchy. Each card also keeps a *fixed*
+/// height so the onboarding window never resizes mid-loop. Continuous looping is skipped when the
+/// system Reduce Motion setting is on, in which case the card shows a static accepted state.
+struct OnboardingFeatureShowcase: View {
+    var body: some View {
+        VStack(spacing: 12) {
+            GhostTextDemoCard()
+            EmojiPickerDemoCard()
+        }
+    }
+}
+
+/// One millisecond expressed in nanoseconds, so the demo timings below read in milliseconds.
+private let nsPerMillisecond: UInt64 = 1_000_000
+
+// MARK: - Shared card chrome
+
+/// A captioned "mock text field" panel. Mirrors the onboarding `PermissionCard` look (regular
+/// material plus a hairline stroke) at a tighter corner radius. The content area is pinned to a fixed
+/// height so a card whose inner popup appears and disappears never changes the window's height.
+private struct DemoCard<Content: View>: View {
+    let caption: String
+    let contentHeight: CGFloat
+    @ViewBuilder var content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(caption)
+                .font(.system(size: 11, weight: .medium, design: .rounded))
+                .foregroundStyle(.secondary)
+
+            content
+                .frame(maxWidth: .infinity, minHeight: contentHeight, maxHeight: contentHeight, alignment: .topLeading)
+                .padding(12)
+                .background(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .fill(.regularMaterial)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .stroke(.white.opacity(0.08), lineWidth: 0.5)
+                )
+        }
+    }
+}
+
+// MARK: - Demo 1: inline autocomplete ghost text
+
+private struct GhostTextDemoCard: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// Number of base characters revealed so far (the "typed" portion).
+    @State private var typedCount = 0
+    /// Whether the gray ghost continuation and its keycap are visible.
+    @State private var showGhost = false
+    /// Whether the ghost has been "accepted" and turned solid.
+    @State private var accepted = false
+
+    private let base = "Thanks for the"
+    private let ghost = " quick reply!"
+
+    var body: some View {
+        DemoCard(caption: "Autocomplete", contentHeight: 40) {
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                HStack(alignment: .firstTextBaseline, spacing: 0) {
+                    Text(String(base.prefix(typedCount)))
+                        .foregroundStyle(.primary)
+                    if showGhost {
+                        Text(ghost)
+                            .foregroundStyle(accepted ? Color.primary : ghostColor)
+                    }
+                }
+                .font(.system(size: 16))
+
+                if showGhost && !accepted {
+                    DemoGhostKeycap(label: "Tab")
+                }
+
+                Spacer(minLength: 0)
+            }
+        }
+        .task(id: reduceMotion) {
+            await runLoop()
+        }
+    }
+
+    /// The default inline ghost-text color (no user customization in a demo): `Color(white:)` gated
+    /// on the color scheme, matching `GhostSuggestionView`'s fallback in `OverlayController`.
+    private var ghostColor: Color {
+        colorScheme == .dark ? Color(white: 0.65) : Color(white: 0.45)
+    }
+
+    private func runLoop() async {
+        guard !reduceMotion else {
+            typedCount = base.count
+            showGhost = true
+            accepted = true
+            return
+        }
+
+        while !Task.isCancelled {
+            typedCount = 0
+            showGhost = false
+            accepted = false
+            try? await Task.sleep(nanoseconds: 350 * nsPerMillisecond)
+            if Task.isCancelled { return }
+
+            for index in 1...base.count {
+                typedCount = index
+                try? await Task.sleep(nanoseconds: 55 * nsPerMillisecond)
+                if Task.isCancelled { return }
+            }
+
+            withAnimation(.easeInOut(duration: 0.18)) { showGhost = true }
+            try? await Task.sleep(nanoseconds: 1300 * nsPerMillisecond)
+            if Task.isCancelled { return }
+
+            withAnimation(.easeInOut(duration: 0.22)) { accepted = true }
+            try? await Task.sleep(nanoseconds: 900 * nsPerMillisecond)
+            if Task.isCancelled { return }
+
+            withAnimation(.easeInOut(duration: 0.30)) {
+                showGhost = false
+                accepted = false
+            }
+            try? await Task.sleep(nanoseconds: 600 * nsPerMillisecond)
+        }
+    }
+}
+
+/// Replicates the private `GhostKeycap` from `OverlayController` (the small "Tab" pill after ghost
+/// text). Colors are `Color(white:)` gated on the color scheme, byte-for-byte with the original.
+private struct DemoGhostKeycap: View {
+    let label: String
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        Text(label)
+            .font(.system(size: 10, weight: .medium, design: .rounded))
+            .foregroundStyle(textColor)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 2)
+            .background(
+                RoundedRectangle(cornerRadius: 6, style: .continuous).fill(backgroundColor)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 6, style: .continuous).stroke(borderColor, lineWidth: 1)
+            )
+            .fixedSize()
+    }
+
+    private var textColor: Color { colorScheme == .dark ? Color(white: 0.65) : Color(white: 0.45) }
+    private var backgroundColor: Color { colorScheme == .dark ? Color(white: 0.18) : Color(white: 0.95) }
+    private var borderColor: Color { colorScheme == .dark ? Color(white: 0.3) : Color(white: 0.8) }
+}
+
+// MARK: - Demo 2: inline emoji picker
+
+private struct EmojiPickerDemoCard: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// Number of trigger characters (":smi") revealed so far.
+    @State private var triggerCount = 0
+    /// Whether the candidate popup is open.
+    @State private var showPopup = false
+    /// Whether the chosen emoji has replaced the trigger text.
+    @State private var committed = false
+
+    private let leadIn = "Nice work "
+    private let trigger = ":smi"
+    private let chosenGlyph = "😄"
+    private let candidates: [(glyph: String, alias: String)] = [("😄", "smile"), ("😁", "smiley")]
+
+    var body: some View {
+        DemoCard(caption: "Inline emoji", contentHeight: 124) {
+            ZStack(alignment: .topLeading) {
+                Text(fieldText)
+                    .font(.system(size: 16))
+                    .foregroundStyle(.primary)
+
+                if showPopup {
+                    DemoEmojiPopup(query: "smi", candidates: candidates)
+                        .offset(x: 84, y: 26)
+                        .transition(.opacity.combined(with: .scale(scale: 0.96, anchor: .topLeading)))
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+        }
+        .task(id: reduceMotion) {
+            await runLoop()
+        }
+    }
+
+    private var fieldText: String {
+        if committed {
+            return leadIn + chosenGlyph
+        }
+        return leadIn + String(trigger.prefix(triggerCount))
+    }
+
+    private func runLoop() async {
+        guard !reduceMotion else {
+            triggerCount = trigger.count
+            committed = true
+            showPopup = false
+            return
+        }
+
+        // Offset the first iteration so the two demos do not animate in lockstep.
+        try? await Task.sleep(nanoseconds: 700 * nsPerMillisecond)
+        if Task.isCancelled { return }
+
+        while !Task.isCancelled {
+            triggerCount = 0
+            committed = false
+            showPopup = false
+            try? await Task.sleep(nanoseconds: 350 * nsPerMillisecond)
+            if Task.isCancelled { return }
+
+            for index in 1...trigger.count {
+                triggerCount = index
+                try? await Task.sleep(nanoseconds: 70 * nsPerMillisecond)
+                if Task.isCancelled { return }
+            }
+
+            withAnimation(.easeInOut(duration: 0.16)) { showPopup = true }
+            try? await Task.sleep(nanoseconds: 1500 * nsPerMillisecond)
+            if Task.isCancelled { return }
+
+            withAnimation(.easeInOut(duration: 0.20)) {
+                showPopup = false
+                committed = true
+            }
+            try? await Task.sleep(nanoseconds: 900 * nsPerMillisecond)
+            if Task.isCancelled { return }
+
+            withAnimation(.easeInOut(duration: 0.30)) {
+                committed = false
+                triggerCount = 0
+            }
+            try? await Task.sleep(nanoseconds: 600 * nsPerMillisecond)
+        }
+    }
+}
+
+/// Scaled-down replica of the real inline emoji popup (`EmojiPickerView`): a `.regularMaterial`
+/// panel with a monospaced query header, a divider, and the candidate rows.
+private struct DemoEmojiPopup: View {
+    let query: String
+    let candidates: [(glyph: String, alias: String)]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 0) {
+                Text(":").foregroundStyle(.secondary)
+                Text(query).foregroundStyle(.primary)
+                Spacer(minLength: 0)
+            }
+            .font(.system(size: 12, weight: .medium, design: .monospaced))
+            .padding(.horizontal, 10)
+            .frame(height: 26)
+
+            Divider()
+
+            VStack(spacing: 0) {
+                ForEach(Array(candidates.enumerated()), id: \.offset) { index, candidate in
+                    DemoEmojiRow(glyph: candidate.glyph, alias: candidate.alias, isSelected: index == 0)
+                }
+            }
+            .padding(.vertical, 4)
+        }
+        .frame(width: 210)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous).fill(.regularMaterial)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .stroke(Color.primary.opacity(0.1), lineWidth: 0.5)
+        )
+        .shadow(color: .black.opacity(0.18), radius: 8, y: 4)
+    }
+}
+
+private struct DemoEmojiRow: View {
+    let glyph: String
+    let alias: String
+    let isSelected: Bool
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text(glyph).font(.system(size: 18))
+            Text(":\(alias):")
+                .font(.system(size: 13))
+                .foregroundStyle(isSelected ? Color.white : Color.primary)
+                .lineLimit(1)
+            Spacer(minLength: 0)
+            if isSelected {
+                DemoEmojiKeycap(label: "Tab")
+            }
+        }
+        .padding(.horizontal, 10)
+        .frame(height: 30)
+        .background(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(isSelected ? Color.accentColor : Color.clear)
+        )
+        .padding(.horizontal, 4)
+    }
+}
+
+/// The on-accent keycap variant from `EmojiPickerView` (shown only on the highlighted row).
+private struct DemoEmojiKeycap: View {
+    let label: String
+
+    var body: some View {
+        Text(label)
+            .font(.system(size: 10, weight: .medium, design: .rounded))
+            .foregroundStyle(Color.white)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 2)
+            .background(
+                RoundedRectangle(cornerRadius: 6, style: .continuous).fill(Color.white.opacity(0.22))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 6, style: .continuous).stroke(Color.white.opacity(0.35), lineWidth: 1)
+            )
+            .fixedSize()
+    }
+}

--- a/Cotabby/UI/WelcomeView.swift
+++ b/Cotabby/UI/WelcomeView.swift
@@ -280,7 +280,7 @@ private enum WelcomeStep: Int, Comparable {
         case .keybind:
             return NSSize(width: 540, height: 520)
         case .done:
-            return NSSize(width: 500, height: 380)
+            return NSSize(width: 520, height: 672)
         }
     }
 }
@@ -534,6 +534,8 @@ extension WelcomeView {
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
             }
+
+            OnboardingFeatureShowcase()
 
             doneStepModelStatus
 


### PR DESCRIPTION
## Summary

The final onboarding step ("You're all set") was a static checkmark and reassurance copy that never showed what Cotabby actually does. It now demonstrates the two flagship features with self-playing animations a new user sees right before they click "Start Using Cotabby":

- **Autocomplete**: a mock field types "Thanks for the", a gray ghost continuation (" quick reply!") fades in with a "Tab" keycap, then the ghost turns solid (accepted).
- **Inline emoji**: a mock field types ":smi", a candidate popup (`:smile:` 😄 highlighted / `:smiley:` 😁) appears with a "Tab" keycap, then 😄 is inserted.

Both loop continuously and respect the system **Reduce Motion** setting (falling back to a static accepted state). Layout is stacked under the existing headline; the `.done` window grows from 500x380 to 520x672 to fit the two cards.

## Implementation notes

- New `Cotabby/UI/Onboarding/OnboardingFeatureShowcase.swift`: a self-contained, zero-argument view with two demo cards. It is **purely decorative** and built from local `@State` + hardcoded strings only. It never touches the suggestion pipeline, `SuggestionSettingsModel`, `EmojiPickerController`, `OverlayController`, Accessibility, or the emoji catalog, so it cannot steal focus or affect real suggestions.
- Each card owns a `.task(id: reduceMotion)`-driven loop using the repo's `while !Task.isCancelled { ... try? await Task.sleep(...) }` idiom (no `Timer`/`TimelineView`). `.task` auto-cancels on disappear, so the loops can't leak.
- Each card has a **fixed height** and the emoji popup is drawn as a `ZStack` overlay over reserved space, so the showcase block's height is constant across the animation. That keeps `preferredWindowSize` stable and prevents the window from pulsing taller/shorter each loop.
- The ghost-text "Tab" keycap and the emoji popup/keycap replicate the exact specs from `OverlayController`'s `GhostKeycap` and `EmojiPickerView`'s `EmojiKeycap`. Those originals are `private`, so they are replicated (not extracted) to avoid making a hot AppKit/suggestion-path file `internal` for a decorative demo. Light/dark fidelity comes from the same `Color(white:)` + `colorScheme` and semantic-color mix as the originals.
- `WelcomeView.swift`: inserts `OnboardingFeatureShowcase()` into `doneStep` and bumps the `.done` `preferredWindowSize`.

## Validation

```
xcodegen generate   # new file added to the project
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **  (project treats warnings as errors)

xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO
# ** TEST SUCCEEDED **  566 tests, 0 failures (4 skipped)

swiftlint lint --strict --quiet Cotabby/UI/Onboarding/OnboardingFeatureShowcase.swift Cotabby/UI/WelcomeView.swift
# exit 0
```

**Visual pass not yet done.** This is an animated UI change verified by build, strict lint, and the full test suite (no onboarding test asserts on `doneStep` or the window size). I could not drive the wizard to the final step headlessly (it is gated behind the `cotabbyOnboardingCompleted` default and several click-through steps). Recommended manual check before merge: run onboarding to "You're all set" and confirm both demos animate and loop; toggle System Settings > Accessibility > Display > Reduce Motion (static accepted state, no loop); toggle Light/Dark; confirm the window does not pulse in height across loops.

## Linked issues

None.

## Risk / rollout notes

- Onboarding-only, and the new view is decorative and dependency-free, so blast radius is limited to the final screen's layout. No behavior change to suggestions, settings, or any service.
- First use of `@Environment(\.accessibilityReduceMotion)` in the repo; handled per-card with a static fallback.
- `Cotabby.xcodeproj` was regenerated with XcodeGen to pick up the new file (no `project.yml` change).
- Tuning knobs if review wants adjustments: the emoji popup's horizontal offset (`x: 84`) and the per-card `contentHeight`/`.done` window height are the values most likely to want a nudge after the visual pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `OnboardingFeatureShowcase`, a new decorative SwiftUI view placed on the final onboarding \"You're all set\" screen that self-plays looping animations demonstrating Cotabby's autocomplete ghost-text and inline emoji-picker features. The `.done` window height is bumped from 380 to 672 to accommodate the new cards.

- **New file** `OnboardingFeatureShowcase.swift` (343 lines): two independent demo cards (`GhostTextDemoCard`, `EmojiPickerDemoCard`), each using `@State` + a `.task`-driven `while !Task.isCancelled` loop; `accessibilityReduceMotion` is respected with a static fallback; popup and keycap widgets replicate their private originals without touching the real suggestion pipeline.
- **`WelcomeView.swift`**: inserts `OnboardingFeatureShowcase()` into `doneStep` and adjusts `preferredWindowSize` for `.done`.
- **`project.pbxproj`**: new file reference and build file entry added via XcodeGen.

<h3>Confidence Score: 4/5</h3>

Safe to merge — change is confined to the final onboarding screen and is purely decorative with no connection to the suggestion pipeline or any shared state.

Both cards are well-structured: loops use the repo's established cancellation idiom, reduceMotion is respected, and the fixed contentHeight prevents window resizing during animation. The two findings are cosmetic: decorative content that skips accessibilityHidden(true) will surface meaningless animating text to VoiceOver users, and GhostTextDemoCard snaps its typed text to blank between loops rather than fading, inconsistent with the emoji card. Neither affects real suggestions, settings, or any other screen.

OnboardingFeatureShowcase.swift — accessibility opt-out and the loop-reset animation inconsistency between the two demo cards.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/Onboarding/OnboardingFeatureShowcase.swift | New 343-line decorative view with two self-animating demo cards; loops are well-structured with cancellation guards; minor issues: accessibility tree not opted out, and typedCount resets without animation in GhostTextDemoCard causing a visual snap between loops. |
| Cotabby/UI/WelcomeView.swift | Minimal two-line change: inserts OnboardingFeatureShowcase() into doneStep and bumps the .done window size from 500x380 to 520x672; no logic changes. |
| Cotabby.xcodeproj/project.pbxproj | XcodeGen-regenerated entries for OnboardingFeatureShowcase.swift; new PBXFileReference, PBXBuildFile, and PBXGroup for the Onboarding subfolder — all look correct. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant SW as SwiftUI .task
    participant GC as GhostTextDemoCard
    participant EC as EmojiPickerDemoCard
    participant WV as WelcomeView (doneStep)

    WV->>GC: init (OnboardingFeatureShowcase inserted)
    WV->>EC: init

    GC->>SW: ".task(id: reduceMotion) -> runLoop()"
    EC->>SW: ".task(id: reduceMotion) -> runLoop() + 700ms offset"

    loop every ~4s (GhostText)
        SW->>GC: typedCount 0 to 14 (55ms/char)
        SW->>GC: "showGhost = true (fade in ghost + Tab keycap)"
        SW->>GC: "accepted = true (ghost turns solid)"
        SW->>GC: "showGhost/accepted = false (fade out)"
    end

    loop every ~4.4s (EmojiPicker)
        SW->>EC: triggerCount 0 to 4 (70ms/char)
        SW->>EC: "showPopup = true (popup + Tab keycap)"
        SW->>EC: "showPopup=false, committed=true (emoji inserted)"
        SW->>EC: "committed=false, triggerCount=0 (fade out)"
    end

    Note over GC,EC: reduceMotion=true -> static accepted state, no loop
    Note over GC,EC: view disappears -> .task auto-cancelled
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fonboarding-feature-showcase%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fonboarding-feature-showcase%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0ACotabby%2FUI%2FOnboarding%2FOnboardingFeatureShowcase.swift%3A17-24%0AThe%20showcase%20is%20described%20as%20%22purely%20decorative%22%20in%20both%20the%20PR%20description%20and%20the%20file%20doc-comment%2C%20but%20it%20has%20no%20accessibility%20opt-out.%20VoiceOver%20will%20traverse%20the%20two%20cards%2C%20reading%20out%20animating%20text%20fragments%20%28%22T%22%2C%20%22Th%22%2C%20%22Tha%22%E2%80%A6%29%20and%20emoji%20candidate%20rows%20that%20have%20no%20actionable%20meaning%20for%20an%20assistive-technology%20user.%20Adding%20%60.accessibilityHidden%28true%29%60%20to%20%60OnboardingFeatureShowcase%60%20suppresses%20the%20entire%20subtree%20from%20the%20accessibility%20tree%20in%20one%20place.%0A%0A%60%60%60suggestion%0Astruct%20OnboardingFeatureShowcase%3A%20View%20%7B%0A%20%20%20%20var%20body%3A%20some%20View%20%7B%0A%20%20%20%20%20%20%20%20VStack%28spacing%3A%2012%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20GhostTextDemoCard%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20EmojiPickerDemoCard%28%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20.accessibilityHidden%28true%29%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0ACotabby%2FUI%2FOnboarding%2FOnboardingFeatureShowcase.swift%3A136-140%0A**%60typedCount%60%20resets%20without%20animation%20between%20loops**%0A%0AAt%20the%20top%20of%20each%20loop%20iteration%20%60typedCount%60%20is%20set%20to%20%600%60%20instantly%2C%20so%20%22Thanks%20for%20the%22%20snaps%20to%20blank%20before%20the%20350%20ms%20pause.%20%60EmojiPickerDemoCard%60%20avoids%20this%20by%20resetting%20%60triggerCount%20%3D%200%60%20inside%20its%20closing%20%60withAnimation%28.easeInOut%28duration%3A%200.30%29%29%60%20block.%20Adding%20%60typedCount%20%3D%200%60%20to%20the%20%60GhostTextDemoCard%60%20equivalent%20block%20%28lines%20136%E2%80%93139%29%20would%20make%20both%20cards%20fade%20out%20consistently.%0A%0A%23%23%23%20Issue%203%20of%203%0ACotabby%2FUI%2FOnboarding%2FOnboardingFeatureShowcase.swift%3A280%0AUsing%20%60id%3A%20%5C.offset%60%20%28array%20index%29%20as%20the%20%60ForEach%60%20identity%20is%20a%20SwiftUI%20antipattern%3A%20if%20the%20array%20were%20ever%20reordered%2C%20SwiftUI%20would%20animate%20the%20wrong%20rows.%20Since%20%60candidates%60%20has%20a%20stable%20%60alias%60%20string%20per%20item%2C%20that%20makes%20a%20better%20stable%20identifier.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20ForEach%28Array%28candidates.enumerated%28%29%29%2C%20id%3A%20%5C.element.alias%29%20%7B%20index%2C%20candidate%20in%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0ACotabby%2FUI%2FOnboarding%2FOnboardingFeatureShowcase.swift%3A17-24%0AThe%20showcase%20is%20described%20as%20%22purely%20decorative%22%20in%20both%20the%20PR%20description%20and%20the%20file%20doc-comment%2C%20but%20it%20has%20no%20accessibility%20opt-out.%20VoiceOver%20will%20traverse%20the%20two%20cards%2C%20reading%20out%20animating%20text%20fragments%20%28%22T%22%2C%20%22Th%22%2C%20%22Tha%22%E2%80%A6%29%20and%20emoji%20candidate%20rows%20that%20have%20no%20actionable%20meaning%20for%20an%20assistive-technology%20user.%20Adding%20%60.accessibilityHidden%28true%29%60%20to%20%60OnboardingFeatureShowcase%60%20suppresses%20the%20entire%20subtree%20from%20the%20accessibility%20tree%20in%20one%20place.%0A%0A%60%60%60suggestion%0Astruct%20OnboardingFeatureShowcase%3A%20View%20%7B%0A%20%20%20%20var%20body%3A%20some%20View%20%7B%0A%20%20%20%20%20%20%20%20VStack%28spacing%3A%2012%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20GhostTextDemoCard%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20EmojiPickerDemoCard%28%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20.accessibilityHidden%28true%29%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0ACotabby%2FUI%2FOnboarding%2FOnboardingFeatureShowcase.swift%3A136-140%0A**%60typedCount%60%20resets%20without%20animation%20between%20loops**%0A%0AAt%20the%20top%20of%20each%20loop%20iteration%20%60typedCount%60%20is%20set%20to%20%600%60%20instantly%2C%20so%20%22Thanks%20for%20the%22%20snaps%20to%20blank%20before%20the%20350%20ms%20pause.%20%60EmojiPickerDemoCard%60%20avoids%20this%20by%20resetting%20%60triggerCount%20%3D%200%60%20inside%20its%20closing%20%60withAnimation%28.easeInOut%28duration%3A%200.30%29%29%60%20block.%20Adding%20%60typedCount%20%3D%200%60%20to%20the%20%60GhostTextDemoCard%60%20equivalent%20block%20%28lines%20136%E2%80%93139%29%20would%20make%20both%20cards%20fade%20out%20consistently.%0A%0A%23%23%23%20Issue%203%20of%203%0ACotabby%2FUI%2FOnboarding%2FOnboardingFeatureShowcase.swift%3A280%0AUsing%20%60id%3A%20%5C.offset%60%20%28array%20index%29%20as%20the%20%60ForEach%60%20identity%20is%20a%20SwiftUI%20antipattern%3A%20if%20the%20array%20were%20ever%20reordered%2C%20SwiftUI%20would%20animate%20the%20wrong%20rows.%20Since%20%60candidates%60%20has%20a%20stable%20%60alias%60%20string%20per%20item%2C%20that%20makes%20a%20better%20stable%20identifier.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20ForEach%28Array%28candidates.enumerated%28%29%29%2C%20id%3A%20%5C.element.alias%29%20%7B%20index%2C%20candidate%20in%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=459&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Showcase autocomplete + inline emoji on ..."](https://github.com/fujacob/cotabby/commit/18de15ccc2550851cd9906e8196cbedd50708531) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34761605)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->