### PR TITLE
Remove redundant 'Type to search emoji' label from emoji picker

### DIFF
--- a/Cotabby/UI/EmojiPickerView.swift
+++ b/Cotabby/UI/EmojiPickerView.swift
@@ -56,12 +56,16 @@ struct EmojiPickerView: View {
     @ViewBuilder
     private var content: some View {
         if model.matches.isEmpty {
-            Text(model.query.isEmpty ? "Type to search emoji" : "No emoji found")
-                .font(.system(size: 12))
-                .foregroundStyle(.secondary)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, 10)
-                .frame(height: EmojiPickerMetrics.rowHeight)
+            if model.query.isEmpty {
+                Color.clear.frame(height: EmojiPickerMetrics.rowHeight)
+            } else {
+                Text("No emoji found")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 10)
+                    .frame(height: EmojiPickerMetrics.rowHeight)
+            }
         } else {
             ScrollViewReader { proxy in
                 ScrollView {


### PR DESCRIPTION
## Summary

When `:` is typed to trigger the emoji picker, two affordances were shown simultaneously: the `:` prefix in the header and the "Type to search emoji" hint in the content area. The header already makes the search context obvious, so the text label was redundant noise.

The empty-query state now shows a silent `Color.clear` placeholder of the same height, keeping the panel geometry unchanged. "No emoji found" still appears when the user has typed a query that matches nothing.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby \
  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
# ** BUILD SUCCEEDED **

swiftlint lint --quiet
# exit 0
```

## Linked issues

## Risk / rollout notes

Panel sizing is unchanged — `EmojiPickerPanelLayout.contentSize` still reserves one row for the empty state.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the "Type to search emoji" hint text from the emoji picker's content area when the query is empty, replacing it with a transparent `Color.clear` spacer of identical height. The header's `:` prefix already provides sufficient context, making the hint redundant.

- The empty-query content branch now renders a silent `Color.clear` placeholder that preserves `EmojiPickerMetrics.rowHeight`, keeping panel geometry unchanged.
- The "No emoji found" message in the non-empty-query/zero-results branch is unaffected, and the footer's "Keep typing to search" hint continues to guide the user in the empty state.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change touches only one view branch, preserves panel geometry, and does not alter any logic or state.

The diff is a minimal, self-contained UI tweak: one branch of a @ViewBuilder property replaces a Text view with a same-sized Color.clear spacer. The footer still guides users via 'Keep typing to search,' and the 'No emoji found' path is unchanged. No layout, data, or behavioral regressions are plausible here.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/EmojiPickerView.swift | Replaces the 'Type to search emoji' Text with a Color.clear spacer in the empty-query branch; panel height is preserved and all other states are unaffected. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[content computed property] --> B{model.matches.isEmpty?}
    B -- No --> C[ScrollView with LazyVStack of EmojiPickerRow items]
    B -- Yes --> D{model.query.isEmpty?}
    D -- Yes --> E["Color.clear\n(height: rowHeight)\n← new: silent placeholder"]
    D -- No --> F["Text: 'No emoji found'\n(height: rowHeight)"]

    style E fill:#d4edda,stroke:#28a745
```

<sub>Reviews (1): Last reviewed commit: ["Remove redundant &#39;Type to search emoji&#39; ..."](https://github.com/fujacob/cotabby/commit/43359c954e7615241aa54f9018ec3487199dd8a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34761758)</sub>

<!-- /greptile_comment -->