### PR TITLE
Address Greptile review on onboarding feature showcase

### DIFF
--- a/Cotabby/UI/Onboarding/OnboardingFeatureShowcase.swift
+++ b/Cotabby/UI/Onboarding/OnboardingFeatureShowcase.swift
@@ -20,6 +20,9 @@ struct OnboardingFeatureShowcase: View {
             GhostTextDemoCard()
             EmojiPickerDemoCard()
         }
+        // Purely decorative looping demo: hide it from VoiceOver so the
+        // mid-animation text fragments are never read out to AT users.
+        .accessibilityHidden(true)
     }
 }
 
@@ -136,6 +139,7 @@ private struct GhostTextDemoCard: View {
             withAnimation(.easeInOut(duration: 0.30)) {
                 showGhost = false
                 accepted = false
+                typedCount = 0
             }
             try? await Task.sleep(nanoseconds: 600 * nsPerMillisecond)
         }
@@ -277,7 +281,7 @@ private struct DemoEmojiPopup: View {
             Divider()
 
             VStack(spacing: 0) {
-                ForEach(Array(candidates.enumerated()), id: \.offset) { index, candidate in
+                ForEach(Array(candidates.enumerated()), id: \.element.alias) { index, candidate in
                     DemoEmojiRow(glyph: candidate.glyph, alias: candidate.alias, isSelected: index == 0)
                 }
             }


### PR DESCRIPTION
## Summary

Follow-up to #459 addressing the three Greptile findings on `OnboardingFeatureShowcase`:

- The showcase is purely decorative, so it now sets `.accessibilityHidden(true)` to keep mid-animation text fragments out of VoiceOver.
- `GhostTextDemoCard` now resets `typedCount = 0` inside its closing fade-out animation, matching `EmojiPickerDemoCard` so the typed text fades instead of snapping blank between loops.
- The emoji candidate `ForEach` now keys on the stable `alias` string instead of the array index (`\.offset`).

## Validation

```
swiftlint lint --strict --quiet Cotabby/UI/Onboarding/OnboardingFeatureShowcase.swift
# exit 0

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **
```

## Linked issues

Refs #459.

## Risk / rollout notes

Onboarding-only, decorative view. No behavior change to suggestions, settings, or any service.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a follow-up cleanup to #459, applying three targeted fixes to `OnboardingFeatureShowcase.swift` based on a prior review. All changes are isolated to a single decorative, onboarding-only file with no impact on the real suggestion pipeline, settings, or services.

- **Accessibility**: `.accessibilityHidden(true)` is now applied to the top-level `VStack` in `OnboardingFeatureShowcase`, preventing mid-animation text fragments from being read by VoiceOver.
- **Ghost text reset fix**: `typedCount = 0` is moved inside the closing `withAnimation` block in `GhostTextDemoCard`, matching `EmojiPickerDemoCard` so the typed text fades out smoothly instead of snapping blank between loops.
- **Stable ForEach ID**: The `DemoEmojiPopup` candidate list now uses `id: \.element.alias` (a stable string) instead of `id: \.offset` (an array index), avoiding potential SwiftUI identity churn.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three changes are correct, confined to a single decorative onboarding view, and have no effect on any real app functionality.

The three changes are straightforward and well-matched to the problems they solve. Moving `typedCount = 0` into the animation block is consistent with how `EmojiPickerDemoCard` already handles its own reset. The `ForEach` key change from `\.offset` to `\.element.alias` is valid given the hardcoded, distinct alias values. The `.accessibilityHidden(true)` placement on the top-level `VStack` correctly covers both child cards. No logic errors, no regressions, no edge cases left unaddressed.

No files require special attention — the single changed file is a self-contained decorative view.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/Onboarding/OnboardingFeatureShowcase.swift | Three targeted fixes: accessibility hidden on the top-level view, typedCount reset moved into the fade-out animation block, and ForEach ID changed from offset to stable alias string. All changes are correct and consistent with sibling patterns in the file. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Task as .task loop
    participant State as @State (typedCount / showGhost / accepted)
    participant View as SwiftUI View

    Note over Task,View: GhostTextDemoCard animation loop
    Task->>State: "typedCount = 0, showGhost = false, accepted = false (direct)"
    loop type each character
        Task->>State: "typedCount += 1"
        View-->>View: re-render typed text
    end
    Task->>State: "withAnimation { showGhost = true }"
    View-->>View: ghost text fades in
    Task->>State: "withAnimation { accepted = true }"
    View-->>View: ghost turns primary color
    Task->>State: "withAnimation { showGhost=false, accepted=false, typedCount=0 } NEW"
    View-->>View: typed text + ghost fade out smoothly
    Note right of State: Previously typedCount=0 was bare assignment at loop top
```

<sub>Reviews (1): Last reviewed commit: ["Address Greptile review on onboarding sh..."](https://github.com/fujacob/cotabby/commit/9263dac40cf14e967bf03921e4500864419fd67a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34761849)</sub>

<!-- /greptile_comment -->