### PR TITLE
Move Tab keycap inline onto selected emoji row, remove footer

### DIFF
--- a/Cotabby/Support/EmojiPickerPanelLayout.swift
+++ b/Cotabby/Support/EmojiPickerPanelLayout.swift
@@ -11,20 +11,16 @@ enum EmojiPickerMetrics {
     static let width: CGFloat = 300
     static let rowHeight: CGFloat = 30
     static let headerHeight: CGFloat = 26
-    static let footerHeight: CGFloat = 28
     static let dividerHeight: CGFloat = 1
     static let listVerticalPadding: CGFloat = 8
     static let maxVisibleRows = 8
 
-    /// The panel size for a given number of matches. An empty result still reserves one row for the
-    /// "type to search" / "no emoji" hint so the panel never collapses to nothing.
+    /// The panel size for a given number of matches. An empty result still reserves one row so the
+    /// panel never collapses to nothing when the query is empty.
     static func contentSize(matchCount: Int) -> CGSize {
         let rows = matchCount == 0 ? 1 : min(matchCount, maxVisibleRows)
         let listHeight = CGFloat(rows) * rowHeight + (matchCount == 0 ? 0 : listVerticalPadding)
-        return CGSize(
-            width: width,
-            height: headerHeight + dividerHeight + listHeight + dividerHeight + footerHeight
-        )
+        return CGSize(width: width, height: headerHeight + dividerHeight + listHeight)
     }
 }
 

--- a/Cotabby/UI/EmojiPickerView.swift
+++ b/Cotabby/UI/EmojiPickerView.swift
@@ -15,7 +15,7 @@ final class EmojiPickerViewModel: ObservableObject {
     @Published var query: String = ""
     @Published var matches: [EmojiMatch] = []
     @Published var selectedIndex: Int = 0
-    /// The accept-word key label shown in the footer; `nil` means there is no keyboard commit hint.
+    /// The accept-word key label shown on the highlighted row; `nil` hides the keycap.
     @Published var acceptKeyLabel: String?
 }
 
@@ -28,8 +28,6 @@ struct EmojiPickerView: View {
             header
             Divider()
             content
-            Divider()
-            footer
         }
         .frame(width: EmojiPickerMetrics.width)
         .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
@@ -73,7 +71,8 @@ struct EmojiPickerView: View {
                         ForEach(model.matches.indices, id: \.self) { index in
                             EmojiPickerRow(
                                 match: model.matches[index],
-                                isSelected: index == model.selectedIndex
+                                isSelected: index == model.selectedIndex,
+                                acceptKeyLabel: index == model.selectedIndex ? model.acceptKeyLabel : nil
                             )
                             .id(index)
                             .contentShape(Rectangle())
@@ -89,30 +88,12 @@ struct EmojiPickerView: View {
         }
     }
 
-    private var footer: some View {
-        HStack(spacing: 6) {
-            if model.matches.isEmpty {
-                Text("Keep typing to search")
-            } else if let acceptKeyLabel = model.acceptKeyLabel {
-                Text("Press")
-                EmojiKeycap(label: acceptKeyLabel)
-                Text("to insert")
-            } else {
-                Text("Click an emoji to insert")
-            }
-            Spacer(minLength: 0)
-        }
-        .font(.system(size: 11, weight: .medium))
-        .foregroundStyle(.secondary)
-        .lineLimit(1)
-        .padding(.horizontal, 10)
-        .frame(height: EmojiPickerMetrics.footerHeight)
-    }
 }
 
 private struct EmojiPickerRow: View {
     let match: EmojiMatch
     let isSelected: Bool
+    let acceptKeyLabel: String?
 
     var body: some View {
         HStack(spacing: 8) {
@@ -124,6 +105,9 @@ private struct EmojiPickerRow: View {
                 .lineLimit(1)
                 .truncationMode(.tail)
             Spacer(minLength: 0)
+            if let acceptKeyLabel {
+                EmojiKeycap(label: acceptKeyLabel, onAccent: isSelected)
+            }
         }
         .padding(.horizontal, 10)
         .frame(height: EmojiPickerMetrics.rowHeight)
@@ -135,23 +119,24 @@ private struct EmojiPickerRow: View {
     }
 }
 
-/// Small keycap pill shown in the footer, mirroring the user's configured word-accept shortcut.
+/// Small keycap pill on the highlighted row, mirroring the user's configured word-accept shortcut.
 private struct EmojiKeycap: View {
     let label: String
+    let onAccent: Bool
 
     var body: some View {
         Text(label)
             .font(.system(size: 10, weight: .medium, design: .rounded))
-            .foregroundStyle(Color.secondary)
+            .foregroundStyle(onAccent ? Color.white : Color.secondary)
             .padding(.horizontal, 5)
             .padding(.vertical, 2)
             .background(
                 RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .fill(Color.primary.opacity(0.08))
+                    .fill(onAccent ? Color.white.opacity(0.22) : Color.primary.opacity(0.08))
             )
             .overlay(
                 RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .stroke(Color.primary.opacity(0.15), lineWidth: 1)
+                    .stroke(onAccent ? Color.white.opacity(0.35) : Color.primary.opacity(0.15), lineWidth: 1)
             )
             .fixedSize()
     }

--- a/CotabbyTests/EmojiPickerPanelLayoutTests.swift
+++ b/CotabbyTests/EmojiPickerPanelLayoutTests.swift
@@ -15,8 +15,6 @@ final class EmojiPickerPanelLayoutTests: XCTestCase {
         let expectedHeight = EmojiPickerMetrics.headerHeight
             + EmojiPickerMetrics.dividerHeight
             + EmojiPickerMetrics.rowHeight
-            + EmojiPickerMetrics.dividerHeight
-            + EmojiPickerMetrics.footerHeight
 
         XCTAssertEqual(size.width, EmojiPickerMetrics.width)
         XCTAssertEqual(size.height, expectedHeight)
@@ -29,8 +27,6 @@ final class EmojiPickerPanelLayoutTests: XCTestCase {
         let expectedHeight = EmojiPickerMetrics.headerHeight
             + EmojiPickerMetrics.dividerHeight
             + visibleRowsHeight
-            + EmojiPickerMetrics.dividerHeight
-            + EmojiPickerMetrics.footerHeight
 
         XCTAssertEqual(size.height, expectedHeight)
     }


### PR DESCRIPTION
## Summary

The "Press Tab to insert" footer was a separate band below the match list. The Tab keycap is more useful inline on the highlighted row — right-aligned, so the eye stays on the selected emoji rather than scanning down to a footer. This also removes 28px of height from the panel on every open.

Changes:
- `EmojiPickerRow` gets `acceptKeyLabel: String?` back; the keycap renders right-aligned on the selected row only, flipping to an on-accent style (white pill) when the row is highlighted in blue.
- `EmojiPickerView`: footer var, second `Divider`, and footer references removed from `body`.
- `EmojiPickerMetrics`: `footerHeight` removed; `contentSize` no longer adds the footer + divider height.
- Layout tests updated to match the new height formula.

## Validation

```
xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby \
  -destination 'platform=macOS' \
  -only-testing:CotabbyTests/EmojiPickerPanelLayoutTests \
  CODE_SIGNING_ALLOWED=NO
# ** TEST SUCCEEDED **

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby \
  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
# ** BUILD SUCCEEDED **

swiftlint lint --quiet
# exit 0
```

## Linked issues

## Risk / rollout notes

Panel is 28px shorter (footer height removed). The keycap appearance on the selected row is identical to the pre-simplification implementation.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves the "Press Tab to insert" keycap from a dedicated footer band into the selected emoji row itself, and removes the footer entirely — shrinking the panel by 28 px on every open.

- **`EmojiPickerView`**: footer view and second `Divider` removed; `EmojiPickerRow` gains an `acceptKeyLabel: String?` parameter that is set only on the highlighted row, and `EmojiKeycap` gains an `onAccent: Bool` flag to flip to the white-pill style when the row is blue.
- **`EmojiPickerPanelLayout`**: `footerHeight` constant removed and `contentSize` no longer adds the extra divider + footer height; test expectations updated accordingly.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a clean removal of the footer with a well-scoped inline replacement.

All three changed files are internally consistent: the layout constant removal, the height formula simplification, the view hierarchy change, and the test updates all agree with one another. The keycap gating logic (nil for non-selected rows, onAccent mirrors isSelected) is correct and the old 'Click an emoji to insert' fallback text is deliberately removed per the stated design intent.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/EmojiPickerView.swift | Footer view and second Divider removed; EmojiPickerRow and EmojiKeycap updated with inline keycap logic that correctly gates rendering on acceptKeyLabel and flips style with onAccent. |
| Cotabby/Support/EmojiPickerPanelLayout.swift | footerHeight constant removed and contentSize height formula simplified; matches the updated SwiftUI layout exactly. |
| CotabbyTests/EmojiPickerPanelLayoutTests.swift | Both layout tests updated to drop the second divider and footer from expected heights; tests remain complete and correct against the new formula. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    VM[EmojiPickerViewModel\nacceptKeyLabel: String?]
    EV[EmojiPickerView.body\nheader + Divider + content]
    FE[ForEach matches.indices]
    ROW[EmojiPickerRow\nisSelected / acceptKeyLabel]
    KEYCAP[EmojiKeycap\nlabel / onAccent]
    SHOW{acceptKeyLabel\nnon-nil?}
    STYLE{isSelected?}
    ACCENT[White pill\nonAccent = true]
    DIM[Dim pill\nonAccent = false]

    VM -->|acceptKeyLabel| EV
    EV --> FE
    FE -->|"acceptKeyLabel = index == selectedIndex\n? model.acceptKeyLabel : nil"| ROW
    ROW --> SHOW
    SHOW -- yes --> KEYCAP
    SHOW -- no --> NOTHING[no keycap rendered]
    KEYCAP --> STYLE
    STYLE -- selected row --> ACCENT
    STYLE -- non-selected row --> DIM
```

<sub>Reviews (1): Last reviewed commit: ["Move Tab keycap inline onto selected emo..."](https://github.com/fujacob/cotabby/commit/2019a20bf39ee40f907c7bb0edd0b5827e137766) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34761880)</sub>

<!-- /greptile_comment -->