### PR TITLE
Lay out onboarding Keybinds step as a 2x2 grid

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"87be731f-eb61-4656-9ac3-78b612fbc071","pid":73265,"procStart":"Sun May 31 00:57:26 2026","acquiredAt":1780192918141}

--- a/Cotabby/UI/WelcomeView.swift
+++ b/Cotabby/UI/WelcomeView.swift
@@ -278,7 +278,7 @@ private enum WelcomeStep: Int, Comparable {
         case .writingStyle:
             return NSSize(width: 560, height: 560)
         case .keybind:
-            return NSSize(width: 540, height: 520)
+            return NSSize(width: 640, height: 460)
         case .done:
             return NSSize(width: 520, height: 672)
         }
@@ -393,52 +393,57 @@ extension WelcomeView {
                     .multilineTextAlignment(.center)
             }
 
-            VStack(spacing: 16) {
-                keybindRow(
-                    title: "Accept Word",
-                    keyLabel: suggestionSettings.acceptanceKeyLabel,
-                    isRecording: $isRecordingOnboardingKeybind,
-                    onKeyRecorded: { keyCode, modifiers, label in
-                        suggestionSettings.setAcceptanceKey(
-                            keyCode: keyCode,
-                            modifiers: modifiers,
-                            label: label
-                        )
-                    },
-                    onReset: (
-                        suggestionSettings.acceptanceKeyCode != SuggestionSettingsModel.defaultAcceptanceKeyCode
-                            || !suggestionSettings.acceptanceKeyModifiers.isEmpty
-                    ) ? {
-                        suggestionSettings.setAcceptanceKey(
-                            keyCode: SuggestionSettingsModel.defaultAcceptanceKeyCode,
-                            modifiers: [],
-                            label: SuggestionSettingsModel.defaultAcceptanceKeyLabel
-                        )
-                    } : nil
-                )
+            // 2x2 layout: the two suggestion-acceptance keys stack in the left column, while the
+            // opt-in Toggle Tabby hotkey sits on the right. `.top` alignment keeps the left column's
+            // first row visually aligned with the single right-column row.
+            HStack(alignment: .top, spacing: 32) {
+                VStack(spacing: 16) {
+                    keybindRow(
+                        title: "Accept Word",
+                        keyLabel: suggestionSettings.acceptanceKeyLabel,
+                        isRecording: $isRecordingOnboardingKeybind,
+                        onKeyRecorded: { keyCode, modifiers, label in
+                            suggestionSettings.setAcceptanceKey(
+                                keyCode: keyCode,
+                                modifiers: modifiers,
+                                label: label
+                            )
+                        },
+                        onReset: (
+                            suggestionSettings.acceptanceKeyCode != SuggestionSettingsModel.defaultAcceptanceKeyCode
+                                || !suggestionSettings.acceptanceKeyModifiers.isEmpty
+                        ) ? {
+                            suggestionSettings.setAcceptanceKey(
+                                keyCode: SuggestionSettingsModel.defaultAcceptanceKeyCode,
+                                modifiers: [],
+                                label: SuggestionSettingsModel.defaultAcceptanceKeyLabel
+                            )
+                        } : nil
+                    )
 
-                keybindRow(
-                    title: "Accept Entire Suggestion",
-                    keyLabel: suggestionSettings.fullAcceptanceKeyLabel,
-                    isRecording: $isRecordingOnboardingFullAcceptKeybind,
-                    onKeyRecorded: { keyCode, modifiers, label in
-                        suggestionSettings.setFullAcceptanceKey(
-                            keyCode: keyCode,
-                            modifiers: modifiers,
-                            label: label
-                        )
-                    },
-                    onReset: (
-                        suggestionSettings.fullAcceptanceKeyCode != SuggestionSettingsModel.defaultFullAcceptanceKeyCode
-                            || !suggestionSettings.fullAcceptanceKeyModifiers.isEmpty
-                    ) ? {
-                        suggestionSettings.setFullAcceptanceKey(
-                            keyCode: SuggestionSettingsModel.defaultFullAcceptanceKeyCode,
-                            modifiers: [],
-                            label: SuggestionSettingsModel.defaultFullAcceptanceKeyLabel
-                        )
-                    } : nil
-                )
+                    keybindRow(
+                        title: "Accept Entire Suggestion",
+                        keyLabel: suggestionSettings.fullAcceptanceKeyLabel,
+                        isRecording: $isRecordingOnboardingFullAcceptKeybind,
+                        onKeyRecorded: { keyCode, modifiers, label in
+                            suggestionSettings.setFullAcceptanceKey(
+                                keyCode: keyCode,
+                                modifiers: modifiers,
+                                label: label
+                            )
+                        },
+                        onReset: (
+                            suggestionSettings.fullAcceptanceKeyCode != SuggestionSettingsModel.defaultFullAcceptanceKeyCode
+                                || !suggestionSettings.fullAcceptanceKeyModifiers.isEmpty
+                        ) ? {
+                            suggestionSettings.setFullAcceptanceKey(
+                                keyCode: SuggestionSettingsModel.defaultFullAcceptanceKeyCode,
+                                modifiers: [],
+                                label: SuggestionSettingsModel.defaultFullAcceptanceKeyLabel
+                            )
+                        } : nil
+                    )
+                }
 
                 // No `onReset` here: the toggle hotkey is opt-in and has no factory default, so the
                 // only meaningful "reset" is unbind, which the Clear gesture in the recorder covers.

--- a/Cotabby/UI/WelcomeView.swift
+++ b/Cotabby/UI/WelcomeView.swift
@@ -387,7 +387,7 @@ extension WelcomeView {
                 Text("Keybinds")
                     .font(.system(size: 24, weight: .semibold, design: .rounded))
 
-                Text("Choose keys to accept suggestions.\nYou can change these later in Settings.")
+                Text("You can change these later in Settings.")
                     .font(.system(size: 14, design: .rounded))
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)


### PR DESCRIPTION
## Summary

The onboarding "Keybinds" step stacked all three keybind rows vertically, making the screen tall and lopsided. This arranges them in a 2x2 layout: Accept Word and Accept Entire Suggestion stack in a left column, and Toggle Tabby sits in a right column. The step window is widened (and shortened) to fit the new layout.

## Validation

```
swiftlint lint --strict --quiet Cotabby/UI/WelcomeView.swift
# exit 0

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **
```

Layout-only change; no keybind recording logic was modified.

## Linked issues

None.

## Risk / rollout notes

Onboarding-only presentation change. No behavior change to keybind recording, settings, or any service. The `.keybind` step `preferredWindowSize` changed from 540x520 to 640x460.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Rearranges the onboarding Keybinds step from a single vertical stack into a 2×2 `HStack` layout — "Accept Word" and "Accept Entire Suggestion" in the left column, "Toggle Tabby" on the right — and adjusts the step window size from 540×520 to 640×460.

- The layout refactor is a presentation-only change; no keybind recording logic, settings storage, or service code was modified.
- A runtime lock file (`.claude/scheduled_tasks.lock`) was accidentally included in the commit and should be gitignored.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a presentation-only layout change with no logic modifications.

All three keybind rows are wired to the same state bindings as before; only their visual arrangement changed. The window-size tweak is self-contained and the build is confirmed passing. The only notable item is an accidentally committed lock file, which is harmless at runtime.

`.claude/scheduled_tasks.lock` should be removed and gitignored before merging.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/UI/WelcomeView.swift | Keybinds step layout refactored from a single VStack to an HStack+VStack 2x2 grid; subtitle text shortened; window size adjusted to 640×460. |
| .claude/scheduled_tasks.lock | Runtime lock file with a hardcoded session ID, PID, and timestamp was accidentally committed; should be gitignored rather than tracked. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Keybinds Step] --> B[Icon + Title Header]
    B --> C[HStack - 2x2 Grid]
    C --> D[Left VStack]
    C --> E[Right Column]
    D --> F[keybindRow: Accept Word]
    D --> G[keybindRow: Accept Entire Suggestion]
    E --> H[keybindRow: Toggle Tabby]
    F --> I[isRecordingOnboardingKeybind]
    G --> J[isRecordingOnboardingFullAcceptKeybind]
    H --> K[isRecordingOnboardingGlobalToggleKeybind]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cotabby/UI/WelcomeView.swift`, line 399-463 ([link](https://github.com/fujacob/cotabby/blob/59277bee932ae182316db5df0bd774a133a943ef/Cotabby/UI/WelcomeView.swift#L399-L463)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Unequal column widths in the HStack**

   Neither column has an explicit width constraint, so SwiftUI sizes each to its natural content width. The left `VStack` will grow to fit the "Accept Entire Suggestion" title, while the right "Toggle Tabby" column will be noticeably narrower — producing an asymmetric result rather than the intended balanced grid. Adding `.frame(maxWidth: .infinity, alignment: .leading)` to both the inner `VStack` and the right `keybindRow` call would make the `HStack` distribute available space evenly between them.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fkeybinds-2x2-layout%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fkeybinds-2x2-layout%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FWelcomeView.swift%0ALine%3A%20399-463%0A%0AComment%3A%0A**Unequal%20column%20widths%20in%20the%20HStack**%0A%0ANeither%20column%20has%20an%20explicit%20width%20constraint%2C%20so%20SwiftUI%20sizes%20each%20to%20its%20natural%20content%20width.%20The%20left%20%60VStack%60%20will%20grow%20to%20fit%20the%20%22Accept%20Entire%20Suggestion%22%20title%2C%20while%20the%20right%20%22Toggle%20Tabby%22%20column%20will%20be%20noticeably%20narrower%20%E2%80%94%20producing%20an%20asymmetric%20result%20rather%20than%20the%20intended%20balanced%20grid.%20Adding%20%60.frame%28maxWidth%3A%20.infinity%2C%20alignment%3A%20.leading%29%60%20to%20both%20the%20inner%20%60VStack%60%20and%20the%20right%20%60keybindRow%60%20call%20would%20make%20the%20%60HStack%60%20distribute%20available%20space%20evenly%20between%20them.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FWelcomeView.swift%0ALine%3A%20399-463%0A%0AComment%3A%0A**Unequal%20column%20widths%20in%20the%20HStack**%0A%0ANeither%20column%20has%20an%20explicit%20width%20constraint%2C%20so%20SwiftUI%20sizes%20each%20to%20its%20natural%20content%20width.%20The%20left%20%60VStack%60%20will%20grow%20to%20fit%20the%20%22Accept%20Entire%20Suggestion%22%20title%2C%20while%20the%20right%20%22Toggle%20Tabby%22%20column%20will%20be%20noticeably%20narrower%20%E2%80%94%20producing%20an%20asymmetric%20result%20rather%20than%20the%20intended%20balanced%20grid.%20Adding%20%60.frame%28maxWidth%3A%20.infinity%2C%20alignment%3A%20.leading%29%60%20to%20both%20the%20inner%20%60VStack%60%20and%20the%20right%20%60keybindRow%60%20call%20would%20make%20the%20%60HStack%60%20distribute%20available%20space%20evenly%20between%20them.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=463&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fkeybinds-2x2-layout%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fkeybinds-2x2-layout%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.claude%2Fscheduled_tasks.lock%3A1%0A**Accidental%20lock%20file%20committed**%0A%0A%60.claude%2Fscheduled_tasks.lock%60%20is%20a%20runtime%20artefact%20generated%20by%20the%20Claude%20Code%20session%20scheduler%20%E2%80%94%20it%20holds%20a%20session%20ID%2C%20process%20ID%2C%20and%20timestamp%20specific%20to%20one%20developer's%20local%20machine.%20Committing%20it%20adds%20churn%20on%20every%20session%20start%2Fstop%20and%20will%20cause%20spurious%20conflicts%20for%20other%20contributors.%20Consider%20adding%20%60.claude%2Fscheduled_tasks.lock%60%20%28or%20%60.claude%2F*.lock%60%29%20to%20%60.gitignore%60.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.claude%2Fscheduled_tasks.lock%3A1%0A**Accidental%20lock%20file%20committed**%0A%0A%60.claude%2Fscheduled_tasks.lock%60%20is%20a%20runtime%20artefact%20generated%20by%20the%20Claude%20Code%20session%20scheduler%20%E2%80%94%20it%20holds%20a%20session%20ID%2C%20process%20ID%2C%20and%20timestamp%20specific%20to%20one%20developer's%20local%20machine.%20Committing%20it%20adds%20churn%20on%20every%20session%20start%2Fstop%20and%20will%20cause%20spurious%20conflicts%20for%20other%20contributors.%20Consider%20adding%20%60.claude%2Fscheduled_tasks.lock%60%20%28or%20%60.claude%2F*.lock%60%29%20to%20%60.gitignore%60.%0A%0A&repo=fujacob%2Fcotabby&pr=463&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["remove-sentence"](https://github.com/fujacob/cotabby/commit/fce5380639c3b10d335e3811ea346e94a651ba9a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34761944)</sub>

<!-- /greptile_comment -->