### PR TITLE
Add compact support banner to General settings pane

### DIFF
--- a/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
@@ -185,7 +185,7 @@ struct GeneralPaneView: View {
             if let kofiURL = URL(string: "https://ko-fi.com/cotabby") {
                 Section {
                     HStack(spacing: 12) {
-                        Text("Free & open source. Love it? Support us.")
+                        Text("Enjoying Cotabby? Please consider supporting open-source")
                             .font(.subheadline)
                             .foregroundStyle(.white)
                             .lineLimit(1)

--- a/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
@@ -181,6 +181,33 @@ struct GeneralPaneView: View {
                     }
                 }
             }
+
+            if let kofiURL = URL(string: "https://ko-fi.com/cotabby") {
+                Section {
+                    HStack(spacing: 12) {
+                        Text("Free & open source. Love it? Support us.")
+                            .font(.subheadline)
+                            .foregroundStyle(.white)
+                            .lineLimit(1)
+                        Spacer(minLength: 0)
+                        Link(destination: kofiURL) {
+                            HStack(spacing: 5) {
+                                Image(systemName: "heart.fill")
+                                    .foregroundStyle(.pink)
+                                Text("Support")
+                                    .fontWeight(.semibold)
+                            }
+                            .font(.subheadline)
+                            .foregroundStyle(Color.accentColor)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 6)
+                            .background(Color.white, in: Capsule())
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    .listRowBackground(Color.accentColor)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Adds a single-line blue support banner at the bottom of the General pane. Blue card background, white text, white pill button with a pink heart that opens the Ko-fi page. The whole section fits on one row so it's a quick glance nudge rather than a wall of copy.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby \
  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
# ** BUILD SUCCEEDED **

swiftlint lint --quiet
# exit 0
```

## Linked issues

## Risk / rollout notes

Read-only UI addition. The Ko-fi URL is hardcoded as a constant — if it fails to parse as a URL the section simply does not render (guarded by `if let kofiURL`).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a compact one-row support banner at the bottom of the General settings pane with a Ko-fi link. The change is read-only UI with no state mutations.

- The banner's row background is set to `Color.accentColor` while the text and button use hardcoded white colors; on macOS this breaks when users select Yellow or Graphite as their system accent color, making all text and the button label invisible.
- The `if let kofiURL` guard is always-true for a valid string literal, and the decorative heart icon is not hidden from VoiceOver.

<h3>Confidence Score: 3/5</h3>

Safe to merge for most users, but will render unreadably on non-blue system accent colors.

The banner hardcodes white text against `Color.accentColor` — a color the user fully controls via macOS System Settings. Anyone using Yellow, Orange, or Graphite as their accent color will see white text on a nearly-white or low-contrast background, making the banner label and the Support button text invisible. The issue is reproducible on stock macOS settings and affects legibility for a meaningful subset of users.

Cotabby/UI/Settings/Panes/GeneralPaneView.swift — specifically the new support-banner section and its foreground/background color pairing.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/Settings/Panes/GeneralPaneView.swift | Adds a support banner section at the bottom of the General pane; text and button readability breaks when the macOS system accent color is set to Yellow or another light color due to hardcoded white foreground against a dynamic `Color.accentColor` background. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[GeneralPaneView renders] --> B[Existing Sections
Status / Behavior / Display / Appearance / Help]
    B --> C{if let kofiURL
always true}
    C -->|always succeeds| D[Support Banner Section
listRowBackground: Color.accentColor]
    D --> E[HStack
Text label + Spacer + Link button]
    E --> F[Text: white foreground
⚠️ invisible on light accent colors]
    E --> G[Link capsule: white background
Text: Color.accentColor]
    G --> H{User taps Support}
    H --> I[openURL kofiURL
https://ko-fi.com/cotabby]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fgeneral-support-banner%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fgeneral-support-banner%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0ACotabby%2FUI%2FSettings%2FPanes%2FGeneralPaneView.swift%3A185-209%0A**White%20text%20invisible%20when%20accent%20color%20is%20light**%0A%0AThe%20banner%20uses%20%60.foregroundStyle%28.white%29%60%20on%20text%20and%20a%20white%20capsule%20while%20painting%20the%20row%20background%20with%20%60Color.accentColor%60.%20macOS%20lets%20users%20pick%20any%20accent%20color%20%E2%80%94%20including%20Yellow%20and%20Graphite%20%E2%80%94%20where%20white-on-yellow%20or%20white-on-light-gray%20fails%20WCAG%20contrast%20requirements%20entirely%2C%20making%20the%20label%20and%20button%20text%20invisible.%20The%20PR%20description%20calls%20this%20a%20%22Blue%20card%22%20but%20the%20actual%20background%20will%20match%20whatever%20the%20user%20has%20chosen%20in%20System%20Settings.%0A%0A%23%23%23%20Issue%202%20of%203%0ACotabby%2FUI%2FSettings%2FPanes%2FGeneralPaneView.swift%3A185-186%0AThe%20%60URL%28string%3A%29%60%20initializer%20always%20succeeds%20for%20a%20valid%20hardcoded%20literal%2C%20so%20this%20%60if%20let%60%20branch%20is%20always%20taken.%20Consider%20either%20extracting%20the%20constant%20to%20a%20clearly-named%20%60static%20let%60%20or%20removing%20the%20conditional%20entirely%20%E2%80%94%20the%20guard%20adds%20a%20false%20sense%20of%20runtime%20protection%20that%20can%20mislead%20future%20readers.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20let%20kofiURL%20%3D%20URL%28string%3A%20%22https%3A%2F%2Fko-fi.com%2Fcotabby%22%29!%0A%20%20%20%20%20%20%20%20%20%20%20%20Section%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0ACotabby%2FUI%2FSettings%2FPanes%2FGeneralPaneView.swift%3A195-196%0AThe%20%60Image%28systemName%3A%20%22heart.fill%22%29%60%20is%20a%20purely%20decorative%20element%20alongside%20the%20%22Support%22%20label%2C%20but%20VoiceOver%20will%20still%20announce%20it%20by%20its%20SF%20Symbol%20name%20%28%22heart%20fill%22%29.%20Hiding%20it%20from%20accessibility%20prevents%20double-reading%20and%20avoids%20confusing%20screen%20reader%20output.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Image%28systemName%3A%20%22heart.fill%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.foregroundStyle%28.pink%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.accessibilityHidden%28true%29%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0ACotabby%2FUI%2FSettings%2FPanes%2FGeneralPaneView.swift%3A185-209%0A**White%20text%20invisible%20when%20accent%20color%20is%20light**%0A%0AThe%20banner%20uses%20%60.foregroundStyle%28.white%29%60%20on%20text%20and%20a%20white%20capsule%20while%20painting%20the%20row%20background%20with%20%60Color.accentColor%60.%20macOS%20lets%20users%20pick%20any%20accent%20color%20%E2%80%94%20including%20Yellow%20and%20Graphite%20%E2%80%94%20where%20white-on-yellow%20or%20white-on-light-gray%20fails%20WCAG%20contrast%20requirements%20entirely%2C%20making%20the%20label%20and%20button%20text%20invisible.%20The%20PR%20description%20calls%20this%20a%20%22Blue%20card%22%20but%20the%20actual%20background%20will%20match%20whatever%20the%20user%20has%20chosen%20in%20System%20Settings.%0A%0A%23%23%23%20Issue%202%20of%203%0ACotabby%2FUI%2FSettings%2FPanes%2FGeneralPaneView.swift%3A185-186%0AThe%20%60URL%28string%3A%29%60%20initializer%20always%20succeeds%20for%20a%20valid%20hardcoded%20literal%2C%20so%20this%20%60if%20let%60%20branch%20is%20always%20taken.%20Consider%20either%20extracting%20the%20constant%20to%20a%20clearly-named%20%60static%20let%60%20or%20removing%20the%20conditional%20entirely%20%E2%80%94%20the%20guard%20adds%20a%20false%20sense%20of%20runtime%20protection%20that%20can%20mislead%20future%20readers.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20let%20kofiURL%20%3D%20URL%28string%3A%20%22https%3A%2F%2Fko-fi.com%2Fcotabby%22%29!%0A%20%20%20%20%20%20%20%20%20%20%20%20Section%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0ACotabby%2FUI%2FSettings%2FPanes%2FGeneralPaneView.swift%3A195-196%0AThe%20%60Image%28systemName%3A%20%22heart.fill%22%29%60%20is%20a%20purely%20decorative%20element%20alongside%20the%20%22Support%22%20label%2C%20but%20VoiceOver%20will%20still%20announce%20it%20by%20its%20SF%20Symbol%20name%20%28%22heart%20fill%22%29.%20Hiding%20it%20from%20accessibility%20prevents%20double-reading%20and%20avoids%20confusing%20screen%20reader%20output.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Image%28systemName%3A%20%22heart.fill%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.foregroundStyle%28.pink%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.accessibilityHidden%28true%29%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=464&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Update GeneralPaneView.swift"](https://github.com/fujacob/cotabby/commit/e868a2366c43f26c66215ef05674293b938d4d91) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34762495)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->