### PR TITLE
Block assigning one shortcut to multiple keybindings

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		7E99F5676A1D1DF7EA7D7702 /* SuggestionCoordinator+Prediction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ED1EA9282E0AC7592E60889 /* SuggestionCoordinator+Prediction.swift */; };
 		7FC103944F4EF39DB965F469 /* InMemoryLogging in Frameworks */ = {isa = PBXBuildFile; productRef = 88921938DC814625ED57D605 /* InMemoryLogging */; };
 		82D4ADEAF05337ABDE4C586C /* RuntimeBootstrapModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60629DFE309C1A4BD8A7FB3B /* RuntimeBootstrapModel.swift */; };
+		8441299082E6B68F7F88911B /* ShortcutConflictTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0850B07CCDBA67C756C6EC59 /* ShortcutConflictTests.swift */; };
 		84A4CA05AF6885AE4FA4C13A /* SettingsAttentionEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A02336442BB735EE2E8D064 /* SettingsAttentionEvaluator.swift */; };
 		87806DE08881D11F2608A13D /* MarkerSelectionSynthesizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52BAFA2F989C3C4F7FB892B5 /* MarkerSelectionSynthesizerTests.swift */; };
 		8865B95FE84198D70390DF80 /* ClipboardContentDistillerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFD89799BB82AF7A92559AEB /* ClipboardContentDistillerTests.swift */; };
@@ -237,6 +238,7 @@
 		04E25414C307A20B6F9F20EC /* FocusSnapshotResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusSnapshotResolver.swift; sourceTree = "<group>"; };
 		050D929E13BE52E6282B64D2 /* VisualContextStartCoalescerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualContextStartCoalescerTests.swift; sourceTree = "<group>"; };
 		07480CE96ED0EBD94817C6B1 /* GeneralPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralPaneView.swift; sourceTree = "<group>"; };
+		0850B07CCDBA67C756C6EC59 /* ShortcutConflictTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutConflictTests.swift; sourceTree = "<group>"; };
 		09FADF683BE7B3558377FA76 /* FocusPollBackoff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusPollBackoff.swift; sourceTree = "<group>"; };
 		0A3D1125B962CBE0269EEDDB /* SuggestionInserter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionInserter.swift; sourceTree = "<group>"; };
 		0AC3BF78835C8F2C315932F1 /* EmojiCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiCatalog.swift; sourceTree = "<group>"; };
@@ -690,6 +692,7 @@
 				0D80CC2CCAAFE3F23FB8C37A /* PromptContextSanitizerTests.swift */,
 				4696A84D17890B154533A08F /* PromptPolicyTests.swift */,
 				2BC293F6125E2B14DCF05AD9 /* SettingsAttentionEvaluatorTests.swift */,
+				0850B07CCDBA67C756C6EC59 /* ShortcutConflictTests.swift */,
 				C05B0439348261163B37C508 /* SuggestionAvailabilityEvaluatorTests.swift */,
 				C375227649689775275AA4B3 /* SuggestionCoordinatorAcceptanceTests.swift */,
 				CDB25ABC4FFB0E63477CDCB0 /* SuggestionOverlayStabilityGateTests.swift */,
@@ -1157,6 +1160,7 @@
 				934885ACC2DEA20B27F10948 /* PromptContextSanitizerTests.swift in Sources */,
 				3CF1A4E39F24917DF0470A7D /* PromptPolicyTests.swift in Sources */,
 				C618C5595DA9C57C806A3E03 /* SettingsAttentionEvaluatorTests.swift in Sources */,
+				8441299082E6B68F7F88911B /* ShortcutConflictTests.swift in Sources */,
 				88BCD795A14E1C9308F7BB31 /* SuggestionAvailabilityEvaluatorTests.swift in Sources */,
 				5B404450B412A6102F514250 /* SuggestionCoordinatorAcceptanceTests.swift in Sources */,
 				4C6D8ED0A7B45D2EADF06DA5 /* SuggestionOverlayStabilityGateTests.swift in Sources */,

--- a/Cotabby/Models/SuggestionSettingsModel.swift
+++ b/Cotabby/Models/SuggestionSettingsModel.swift
@@ -2,6 +2,22 @@ import ApplicationServices
 import Combine
 import Foundation
 
+/// Identifies one of the three user-configurable keyboard shortcuts so the recorder can ask which
+/// other action (if any) already owns a proposed key combination before committing it.
+enum ShortcutAction: CaseIterable {
+    case acceptWord
+    case acceptEntireSuggestion
+    case toggleTabby
+
+    var displayName: String {
+        switch self {
+        case .acceptWord: return "Accept Word"
+        case .acceptEntireSuggestion: return "Accept Entire Suggestion"
+        case .toggleTabby: return "Toggle Tabby"
+        }
+    }
+}
+
 /// File overview:
 /// Owns the durable autocomplete preferences that are shared across the app:
 /// engine selection, completion length, indicator appearance, and profile
@@ -817,6 +833,42 @@ final class SuggestionSettingsModel: ObservableObject {
     /// closure trivial and gives the menu bar / tests a single entry point.
     func toggleGloballyEnabled() {
         setGloballyEnabled(!isGloballyEnabled)
+    }
+
+    /// Returns the user-facing name of the shortcut action already bound to `(keyCode, modifiers)`,
+    /// excluding `action` itself, or `nil` when the combo is free.
+    ///
+    /// This is the single source of truth the recorder consults before committing a new binding.
+    /// Without it the global-toggle hotkey can silently collide with an accept key: the toggle tap
+    /// is head-inserted but the accept tap (installed later while a suggestion is visible) sits ahead
+    /// of it and consumes the shared key first, so the toggle never fires. Blocking the duplicate up
+    /// front keeps every binding unambiguous. The disabled sentinel never conflicts — several actions
+    /// may be left unbound at once.
+    func conflictingShortcutName(
+        keyCode: CGKeyCode,
+        modifiers: ShortcutModifierMask,
+        excluding action: ShortcutAction
+    ) -> String? {
+        guard keyCode != Self.disabledKeyCode else { return nil }
+
+        for other in ShortcutAction.allCases where other != action {
+            let binding = shortcutBinding(for: other)
+            if binding.keyCode == keyCode, binding.modifiers == modifiers {
+                return other.displayName
+            }
+        }
+        return nil
+    }
+
+    private func shortcutBinding(for action: ShortcutAction) -> (keyCode: CGKeyCode, modifiers: ShortcutModifierMask) {
+        switch action {
+        case .acceptWord:
+            return (acceptanceKeyCode, acceptanceKeyModifiers)
+        case .acceptEntireSuggestion:
+            return (fullAcceptanceKeyCode, fullAcceptanceKeyModifiers)
+        case .toggleTabby:
+            return (globalToggleKeyCode, globalToggleKeyModifiers)
+        }
     }
 
     private func persistSelectedEngine(_ engine: SuggestionEngineKind) {

--- a/Cotabby/UI/KeyRecorderView.swift
+++ b/Cotabby/UI/KeyRecorderView.swift
@@ -11,18 +11,26 @@ import SwiftUI
 struct KeyRecorderView: View {
     let onKeyRecorded: (CGKeyCode, ShortcutModifierMask, String) -> Void
     var onCancelled: (() -> Void)?
+    /// Returns the name of the action already bound to a proposed combo, or `nil` if it's free.
+    /// When it reports a conflict the recorder refuses to commit and keeps listening, so a shortcut
+    /// can never be assigned to two actions at once.
+    var conflictChecker: ((CGKeyCode, ShortcutModifierMask) -> String?)?
 
     @State private var monitor: Any?
     @State private var liveModifiers: ShortcutModifierMask = []
+    @State private var conflictMessage: String?
 
     var body: some View {
         Text(promptText)
-            .foregroundStyle(.secondary)
+            .foregroundStyle(conflictMessage == nil ? .secondary : Color.red)
             .onAppear { installMonitor() }
             .onDisappear { removeMonitor() }
     }
 
     private var promptText: String {
+        if let conflictMessage {
+            return conflictMessage
+        }
         let glyphs = KeyCodeLabels.modifierGlyphs(liveModifiers)
         return glyphs.isEmpty ? "Press a key…" : "\(glyphs) + key…"
     }
@@ -60,6 +68,14 @@ struct KeyRecorderView: View {
         // consumes the key while a suggestion is visible (otherwise it passes through and does
         // its normal job). So even Return/Delete or `⌘V` are safe to bind — they only intercept
         // in the moment a suggestion is showing.
+        // Reject a combo that another action already owns. Staying in recording mode (rather than
+        // committing or cancelling) lets the user immediately try a different key, and the red
+        // prompt explains why the press was ignored.
+        if let conflict = conflictChecker?(keyCode, modifiers) {
+            conflictMessage = "Already used by \(conflict). Try another key."
+            return nil
+        }
+
         let label = KeyCodeLabels.label(
             for: keyCode,
             modifiers: modifiers,

--- a/Cotabby/UI/Settings/Panes/ShortcutsPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/ShortcutsPaneView.swift
@@ -39,7 +39,14 @@ struct ShortcutsPaneView: View {
                             )
                         },
                         onClear: { suggestionSettings.clearAcceptanceKey() },
-                        clearHelp: "Unbind this shortcut. No key will accept word-by-word."
+                        clearHelp: "Unbind this shortcut. No key will accept word-by-word.",
+                        conflictChecker: { keyCode, modifiers in
+                            suggestionSettings.conflictingShortcutName(
+                                keyCode: keyCode,
+                                modifiers: modifiers,
+                                excluding: .acceptWord
+                            )
+                        }
                     )
                 } label: {
                     SettingsRowLabel(
@@ -70,7 +77,14 @@ struct ShortcutsPaneView: View {
                             )
                         },
                         onClear: { suggestionSettings.clearFullAcceptanceKey() },
-                        clearHelp: "Unbind this shortcut. No key will accept the whole suggestion at once."
+                        clearHelp: "Unbind this shortcut. No key will accept the whole suggestion at once.",
+                        conflictChecker: { keyCode, modifiers in
+                            suggestionSettings.conflictingShortcutName(
+                                keyCode: keyCode,
+                                modifiers: modifiers,
+                                excluding: .acceptEntireSuggestion
+                            )
+                        }
                     )
                 } label: {
                     SettingsRowLabel(
@@ -98,7 +112,14 @@ struct ShortcutsPaneView: View {
                         },
                         onReset: nil,
                         onClear: { suggestionSettings.clearGlobalToggleKey() },
-                        clearHelp: "Unbind this shortcut. No key will toggle Tabby on or off."
+                        clearHelp: "Unbind this shortcut. No key will toggle Tabby on or off.",
+                        conflictChecker: { keyCode, modifiers in
+                            suggestionSettings.conflictingShortcutName(
+                                keyCode: keyCode,
+                                modifiers: modifiers,
+                                excluding: .toggleTabby
+                            )
+                        }
                     )
                 } label: {
                     SettingsRowLabel(
@@ -126,6 +147,8 @@ private struct KeybindRow: View {
     let onReset: (() -> Void)?
     let onClear: () -> Void
     let clearHelp: String
+    /// Names the action that already owns a proposed combo so the recorder can block duplicates.
+    let conflictChecker: (CGKeyCode, ShortcutModifierMask) -> String?
 
     var body: some View {
         HStack(spacing: 8) {
@@ -143,7 +166,8 @@ private struct KeybindRow: View {
                         onRecord(keyCode, modifiers, label)
                         isRecording = false
                     },
-                    onCancelled: { isRecording = false }
+                    onCancelled: { isRecording = false },
+                    conflictChecker: conflictChecker
                 )
             } else {
                 Button("Change") {

--- a/Cotabby/UI/WelcomeView.swift
+++ b/Cotabby/UI/WelcomeView.swift
@@ -401,6 +401,7 @@ extension WelcomeView {
                     keybindRow(
                         title: "Accept Word",
                         keyLabel: suggestionSettings.acceptanceKeyLabel,
+                        action: .acceptWord,
                         isRecording: $isRecordingOnboardingKeybind,
                         onKeyRecorded: { keyCode, modifiers, label in
                             suggestionSettings.setAcceptanceKey(
@@ -424,6 +425,7 @@ extension WelcomeView {
                     keybindRow(
                         title: "Accept Entire Suggestion",
                         keyLabel: suggestionSettings.fullAcceptanceKeyLabel,
+                        action: .acceptEntireSuggestion,
                         isRecording: $isRecordingOnboardingFullAcceptKeybind,
                         onKeyRecorded: { keyCode, modifiers, label in
                             suggestionSettings.setFullAcceptanceKey(
@@ -450,6 +452,7 @@ extension WelcomeView {
                 keybindRow(
                     title: "Toggle Tabby",
                     keyLabel: suggestionSettings.globalToggleKeyLabel,
+                    action: .toggleTabby,
                     isRecording: $isRecordingOnboardingGlobalToggleKeybind,
                     onKeyRecorded: { keyCode, modifiers, label in
                         suggestionSettings.setGlobalToggleKey(
@@ -468,6 +471,7 @@ extension WelcomeView {
     fileprivate func keybindRow(
         title: String,
         keyLabel: String,
+        action: ShortcutAction,
         isRecording: Binding<Bool>,
         onKeyRecorded: @escaping (CGKeyCode, ShortcutModifierMask, String) -> Void,
         onReset: (() -> Void)? = nil
@@ -495,6 +499,13 @@ extension WelcomeView {
                         },
                         onCancelled: {
                             isRecording.wrappedValue = false
+                        },
+                        conflictChecker: { keyCode, modifiers in
+                            suggestionSettings.conflictingShortcutName(
+                                keyCode: keyCode,
+                                modifiers: modifiers,
+                                excluding: action
+                            )
                         }
                     )
                 } else {

--- a/CotabbyTests/ShortcutConflictTests.swift
+++ b/CotabbyTests/ShortcutConflictTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import Cotabby
+
+/// Locks down the duplicate-shortcut guard that keeps the three keybindings unambiguous.
+///
+/// The original bug: the global-toggle hotkey was excluded from any conflict check, so a user could
+/// bind it to a key already used by an accept binding (the default full-accept key is backtick). The
+/// head-inserted accept tap then consumed the shared key before the toggle tap saw it, so Toggle
+/// Tabby silently did nothing. `conflictingShortcutName` is the single source of truth the recorder
+/// consults to refuse such a binding up front.
+@MainActor
+final class ShortcutConflictTests: XCTestCase {
+
+    /// A combo already owned by another action is reported, keyed by that action's display name.
+    func test_conflict_reportsActionOwningTheCombo() {
+        let model = makeModel()
+        // Default full-accept is backtick (keyCode 50). Binding the toggle to the same key must
+        // be flagged as a conflict with "Accept Entire Suggestion".
+        let conflict = model.conflictingShortcutName(
+            keyCode: 50,
+            modifiers: [],
+            excluding: .toggleTabby
+        )
+        XCTAssertEqual(conflict, "Accept Entire Suggestion")
+    }
+
+    /// An action never conflicts with itself, so re-recording the same key for the same binding is
+    /// allowed (e.g. confirming the current value).
+    func test_conflict_excludesTheActionBeingEdited() {
+        let model = makeModel()
+        let conflict = model.conflictingShortcutName(
+            keyCode: model.acceptanceKeyCode,
+            modifiers: model.acceptanceKeyModifiers,
+            excluding: .acceptWord
+        )
+        XCTAssertNil(conflict)
+    }
+
+    /// A free combo (default Accept Word is Tab; some other key is unused) reports no conflict.
+    func test_conflict_allowsUnusedCombo() {
+        let model = makeModel()
+        // keyCode 49 is Space, unused by any default binding.
+        let conflict = model.conflictingShortcutName(
+            keyCode: 49,
+            modifiers: [],
+            excluding: .toggleTabby
+        )
+        XCTAssertNil(conflict)
+    }
+
+    /// The disabled sentinel never conflicts: multiple actions may be left unbound at once.
+    func test_conflict_ignoresDisabledSentinel() {
+        let model = makeModel()
+        let conflict = model.conflictingShortcutName(
+            keyCode: SuggestionSettingsModel.disabledKeyCode,
+            modifiers: [],
+            excluding: .toggleTabby
+        )
+        XCTAssertNil(conflict)
+    }
+
+    /// Same key but different modifiers is a distinct binding and must not be flagged.
+    func test_conflict_treatsModifierSetsAsDistinct() {
+        let model = makeModel()
+        // Full-accept default is bare backtick; backtick + shift is a different binding.
+        let conflict = model.conflictingShortcutName(
+            keyCode: 50,
+            modifiers: [.shift],
+            excluding: .toggleTabby
+        )
+        XCTAssertNil(conflict)
+    }
+
+    // MARK: - Helpers
+
+    private func makeModel() -> SuggestionSettingsModel {
+        let suiteName = "cotabby.test.shortcutConflict.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return SuggestionSettingsModel(configuration: .standard, userDefaults: defaults)
+    }
+}


### PR DESCRIPTION
## Summary

**Bug:** Toggle Tabby's hotkey appeared to do nothing. Root cause is a binding collision, not the tap wiring. The default Accept Entire Suggestion key is backtick (\`), the same key a user naturally assigns to the toggle. Nothing guarded the global toggle against duplicating another action's shortcut, so both ended up on the same key. The accept tap is head-inserted into the event chain ahead of the toggle tap, so it consumes the shared key first and the toggle callback never fires. The runtime logs confirm it: `Accept tap consumed keyCode=50` (backtick) appears while the toggle-tap install/consume lines never do.

**Fix:** Prevent the collision at the source. A new single source of truth, `SuggestionSettingsModel.conflictingShortcutName(keyCode:modifiers:excluding:)`, reports which action already owns a proposed combo. `KeyRecorderView` consults it and refuses to commit a duplicate, staying in recording mode with a red "Already used by X" prompt so the user can immediately try another key. Wired into both the Settings shortcuts pane and the onboarding Keybinds step.

Notes:
- The disabled ("None") sentinel never conflicts, so multiple actions may stay unbound.
- Same key with a different modifier set stays a distinct binding (e.g. \` and ⇧\`).

## Validation

```
swiftlint lint --strict --quiet <changed files>
# exit 0

xcodegen generate   # new test file added to the project

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  -only-testing:CotabbyTests/ShortcutConflictTests CODE_SIGNING_ALLOWED=NO
# ** TEST SUCCEEDED **  5 tests, 0 failures
```

Diagnosis was driven from `~/Library/Logs/Cotabby/cotabby.jsonl*`: across the captured sessions the toggle tap install message never appears while the accept tap (33x) and observer tap (8x) do, and backtick (keyCode 50) is logged as consumed by the accept tap.

## Linked issues

None.

## Risk / rollout notes

- Pure guard added at the recording layer; the existing setters and their silent same-key clear between the two accept bindings are unchanged, so no migration of existing stored bindings. A user who already saved a colliding toggle can now re-record it onto a free key.
- `Cotabby.xcodeproj` was regenerated with XcodeGen to pick up the new test file (no `project.yml` change).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a guard against binding two shortcuts to the same key combination. A new `conflictingShortcutName(keyCode:modifiers:excluding:)` method on `SuggestionSettingsModel` serves as the single source of truth; `KeyRecorderView` consults it before committing a new binding and shows a red \"Already used by X\" message instead of accepting the duplicate.

- `SuggestionSettingsModel` gains a `ShortcutAction` enum and `conflictingShortcutName` / `shortcutBinding` helpers to centralise conflict detection across all three configurable shortcuts.
- `KeyRecorderView` gains an optional `conflictChecker` closure that blocks commitment and surfaces a red conflict prompt, while keeping the monitor active so the user can immediately try another key.
- `ShortcutsPaneView` and `WelcomeView` are wired up to pass the appropriate `conflictChecker`, and five unit tests in `ShortcutConflictTests` cover the key cases.

<h3>Confidence Score: 4/5</h3>

Safe to merge. The change is a pure UI-layer guard with no migrations or mutations to stored bindings, so existing user settings are unaffected.

The conflict-detection logic is correct and well-tested. The two observations — installMonitor() not clearing conflictMessage, and a test relying on a hardcoded key code assumption — are both benign today but worth addressing before the view or defaults evolve.

KeyRecorderView.swift and ShortcutConflictTests.swift have the minor hardening gaps noted in the comments; all other files are straightforward wiring.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/Models/SuggestionSettingsModel.swift | Adds ShortcutAction enum and conflictingShortcutName/shortcutBinding — logic is correct; disabled-sentinel guard prevents false positives; modifier distinctness is preserved. |
| Cotabby/UI/KeyRecorderView.swift | Gains conflictChecker closure and conflictMessage state; conflict detection is wired correctly; conflictMessage is never reset inside installMonitor(), though in practice the view is always recreated per session. |
| Cotabby/UI/Settings/Panes/ShortcutsPaneView.swift | All three KeybindRow usages wired with the correct excluding: action; conflictChecker promoted to a required property on KeybindRow. |
| Cotabby/UI/WelcomeView.swift | All three keybindRow call sites updated with the new action: parameter and conflictChecker closure; no missed usages. |
| CotabbyTests/ShortcutConflictTests.swift | Five tests cover the main cases; some hardcode key codes (49, 50) as assumptions about default bindings, which could silently become stale if defaults change. |
| Cotabby.xcodeproj/project.pbxproj | Adds ShortcutConflictTests.swift to both the file references and test target sources — mechanical XcodeGen regeneration, no concerns. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant KeyRecorderView
    participant conflictChecker
    participant SuggestionSettingsModel

    User->>KeyRecorderView: Press key combo
    KeyRecorderView->>conflictChecker: (keyCode, modifiers)
    conflictChecker->>SuggestionSettingsModel: conflictingShortcutName(keyCode:modifiers:excluding:)
    alt another action owns this combo
        SuggestionSettingsModel-->>conflictChecker: Accept Entire Suggestion
        conflictChecker-->>KeyRecorderView: conflict name
        KeyRecorderView-->>User: Red Already used by X. Try another key.
    else combo is free
        SuggestionSettingsModel-->>conflictChecker: nil
        conflictChecker-->>KeyRecorderView: nil
        KeyRecorderView->>KeyRecorderView: removeMonitor()
        KeyRecorderView-->>User: Recording committed, onKeyRecorded called
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cotabby/UI/KeyRecorderView.swift`, line 38-41 ([link](https://github.com/fujacob/cotabby/blob/65defab45a31266c3792718b018935a1a88c7bef/Cotabby/UI/KeyRecorderView.swift#L38-L41)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `installMonitor()` resets `liveModifiers` but leaves any stale `conflictMessage` in place. Today this is harmless because `KeyRecorderView` lives behind an `if isRecording` branch so it is always torn down and recreated, resetting `@State`. If that conditional is ever relaxed (e.g. the view is kept alive between sessions), the red "Already used by…" message from the previous recording attempt would be visible the moment the new one starts. A one-line reset here makes the method self-contained.

   

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fshortcut-conflict-guard%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fshortcut-conflict-guard%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FKeyRecorderView.swift%0ALine%3A%2038-41%0A%0AComment%3A%0A%60installMonitor%28%29%60%20resets%20%60liveModifiers%60%20but%20leaves%20any%20stale%20%60conflictMessage%60%20in%20place.%20Today%20this%20is%20harmless%20because%20%60KeyRecorderView%60%20lives%20behind%20an%20%60if%20isRecording%60%20branch%20so%20it%20is%20always%20torn%20down%20and%20recreated%2C%20resetting%20%60%40State%60.%20If%20that%20conditional%20is%20ever%20relaxed%20%28e.g.%20the%20view%20is%20kept%20alive%20between%20sessions%29%2C%20the%20red%20%22Already%20used%20by%E2%80%A6%22%20message%20from%20the%20previous%20recording%20attempt%20would%20be%20visible%20the%20moment%20the%20new%20one%20starts.%20A%20one-line%20reset%20here%20makes%20the%20method%20self-contained.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20func%20installMonitor%28%29%20%7B%0A%20%20%20%20%20%20%20%20removeMonitor%28%29%0A%20%20%20%20%20%20%20%20liveModifiers%20%3D%20%5B%5D%0A%20%20%20%20%20%20%20%20conflictMessage%20%3D%20nil%0A%20%20%20%20%20%20%20%20monitor%20%3D%20NSEvent.addLocalMonitorForEvents%28matching%3A%20%5B.keyDown%2C%20.flagsChanged%5D%29%20%7B%20%5Bself%5D%20event%20in%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FKeyRecorderView.swift%0ALine%3A%2038-41%0A%0AComment%3A%0A%60installMonitor%28%29%60%20resets%20%60liveModifiers%60%20but%20leaves%20any%20stale%20%60conflictMessage%60%20in%20place.%20Today%20this%20is%20harmless%20because%20%60KeyRecorderView%60%20lives%20behind%20an%20%60if%20isRecording%60%20branch%20so%20it%20is%20always%20torn%20down%20and%20recreated%2C%20resetting%20%60%40State%60.%20If%20that%20conditional%20is%20ever%20relaxed%20%28e.g.%20the%20view%20is%20kept%20alive%20between%20sessions%29%2C%20the%20red%20%22Already%20used%20by%E2%80%A6%22%20message%20from%20the%20previous%20recording%20attempt%20would%20be%20visible%20the%20moment%20the%20new%20one%20starts.%20A%20one-line%20reset%20here%20makes%20the%20method%20self-contained.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20func%20installMonitor%28%29%20%7B%0A%20%20%20%20%20%20%20%20removeMonitor%28%29%0A%20%20%20%20%20%20%20%20liveModifiers%20%3D%20%5B%5D%0A%20%20%20%20%20%20%20%20conflictMessage%20%3D%20nil%0A%20%20%20%20%20%20%20%20monitor%20%3D%20NSEvent.addLocalMonitorForEvents%28matching%3A%20%5B.keyDown%2C%20.flagsChanged%5D%29%20%7B%20%5Bself%5D%20event%20in%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=465&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fshortcut-conflict-guard%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fshortcut-conflict-guard%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FKeyRecorderView.swift%3A38-41%0A%60installMonitor%28%29%60%20resets%20%60liveModifiers%60%20but%20leaves%20any%20stale%20%60conflictMessage%60%20in%20place.%20Today%20this%20is%20harmless%20because%20%60KeyRecorderView%60%20lives%20behind%20an%20%60if%20isRecording%60%20branch%20so%20it%20is%20always%20torn%20down%20and%20recreated%2C%20resetting%20%60%40State%60.%20If%20that%20conditional%20is%20ever%20relaxed%20%28e.g.%20the%20view%20is%20kept%20alive%20between%20sessions%29%2C%20the%20red%20%22Already%20used%20by%E2%80%A6%22%20message%20from%20the%20previous%20recording%20attempt%20would%20be%20visible%20the%20moment%20the%20new%20one%20starts.%20A%20one-line%20reset%20here%20makes%20the%20method%20self-contained.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20func%20installMonitor%28%29%20%7B%0A%20%20%20%20%20%20%20%20removeMonitor%28%29%0A%20%20%20%20%20%20%20%20liveModifiers%20%3D%20%5B%5D%0A%20%20%20%20%20%20%20%20conflictMessage%20%3D%20nil%0A%20%20%20%20%20%20%20%20monitor%20%3D%20NSEvent.addLocalMonitorForEvents%28matching%3A%20%5B.keyDown%2C%20.flagsChanged%5D%29%20%7B%20%5Bself%5D%20event%20in%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabbyTests%2FShortcutConflictTests.swift%3A40-49%0AThe%20%22allows%20unused%20combo%22%20test%20hard-codes%20keyCode%2049%20%28Space%29%20with%20a%20comment%20that%20it%20is%20%22unused%20by%20any%20default%20binding.%22%20If%20the%20default%20bindings%20ever%20change%20and%20Space%20is%20assigned%2C%20the%20test%20would%20still%20pass%20but%20for%20a%20subtly%20wrong%20reason.%20Adding%20precondition%20assertions%20makes%20the%20assumption%20explicit%20and%20the%20test%20self-documenting.%0A%0A%60%60%60suggestion%0A%20%20%20%20func%20test_conflict_allowsUnusedCombo%28%29%20%7B%0A%20%20%20%20%20%20%20%20let%20model%20%3D%20makeModel%28%29%0A%20%20%20%20%20%20%20%20%2F%2F%20keyCode%2049%20is%20Space.%20Verify%20it%20isn't%20already%20taken%20by%20any%20of%20the%20other%20defaults%20before%0A%20%20%20%20%20%20%20%20%2F%2F%20using%20it%20as%20the%20%22free%20combo%22%20probe%2C%20so%20a%20future%20default-binding%20change%20won't%20silently%0A%20%20%20%20%20%20%20%20%2F%2F%20make%20this%20test%20pass%20for%20the%20wrong%20reason.%0A%20%20%20%20%20%20%20%20let%20spaceKeyCode%3A%20CGKeyCode%20%3D%2049%0A%20%20%20%20%20%20%20%20XCTAssertNil%28model.conflictingShortcutName%28keyCode%3A%20spaceKeyCode%2C%20modifiers%3A%20%5B%5D%2C%20excluding%3A%20.acceptWord%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22Precondition%3A%20Space%20must%20not%20be%20a%20default%20binding%20for%20acceptWord%22%29%0A%20%20%20%20%20%20%20%20XCTAssertNil%28model.conflictingShortcutName%28keyCode%3A%20spaceKeyCode%2C%20modifiers%3A%20%5B%5D%2C%20excluding%3A%20.acceptEntireSuggestion%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22Precondition%3A%20Space%20must%20not%20be%20a%20default%20binding%20for%20acceptEntireSuggestion%22%29%0A%20%20%20%20%20%20%20%20let%20conflict%20%3D%20model.conflictingShortcutName%28%0A%20%20%20%20%20%20%20%20%20%20%20%20keyCode%3A%20spaceKeyCode%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20modifiers%3A%20%5B%5D%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20excluding%3A%20.toggleTabby%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20XCTAssertNil%28conflict%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FKeyRecorderView.swift%3A38-41%0A%60installMonitor%28%29%60%20resets%20%60liveModifiers%60%20but%20leaves%20any%20stale%20%60conflictMessage%60%20in%20place.%20Today%20this%20is%20harmless%20because%20%60KeyRecorderView%60%20lives%20behind%20an%20%60if%20isRecording%60%20branch%20so%20it%20is%20always%20torn%20down%20and%20recreated%2C%20resetting%20%60%40State%60.%20If%20that%20conditional%20is%20ever%20relaxed%20%28e.g.%20the%20view%20is%20kept%20alive%20between%20sessions%29%2C%20the%20red%20%22Already%20used%20by%E2%80%A6%22%20message%20from%20the%20previous%20recording%20attempt%20would%20be%20visible%20the%20moment%20the%20new%20one%20starts.%20A%20one-line%20reset%20here%20makes%20the%20method%20self-contained.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20func%20installMonitor%28%29%20%7B%0A%20%20%20%20%20%20%20%20removeMonitor%28%29%0A%20%20%20%20%20%20%20%20liveModifiers%20%3D%20%5B%5D%0A%20%20%20%20%20%20%20%20conflictMessage%20%3D%20nil%0A%20%20%20%20%20%20%20%20monitor%20%3D%20NSEvent.addLocalMonitorForEvents%28matching%3A%20%5B.keyDown%2C%20.flagsChanged%5D%29%20%7B%20%5Bself%5D%20event%20in%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabbyTests%2FShortcutConflictTests.swift%3A40-49%0AThe%20%22allows%20unused%20combo%22%20test%20hard-codes%20keyCode%2049%20%28Space%29%20with%20a%20comment%20that%20it%20is%20%22unused%20by%20any%20default%20binding.%22%20If%20the%20default%20bindings%20ever%20change%20and%20Space%20is%20assigned%2C%20the%20test%20would%20still%20pass%20but%20for%20a%20subtly%20wrong%20reason.%20Adding%20precondition%20assertions%20makes%20the%20assumption%20explicit%20and%20the%20test%20self-documenting.%0A%0A%60%60%60suggestion%0A%20%20%20%20func%20test_conflict_allowsUnusedCombo%28%29%20%7B%0A%20%20%20%20%20%20%20%20let%20model%20%3D%20makeModel%28%29%0A%20%20%20%20%20%20%20%20%2F%2F%20keyCode%2049%20is%20Space.%20Verify%20it%20isn't%20already%20taken%20by%20any%20of%20the%20other%20defaults%20before%0A%20%20%20%20%20%20%20%20%2F%2F%20using%20it%20as%20the%20%22free%20combo%22%20probe%2C%20so%20a%20future%20default-binding%20change%20won't%20silently%0A%20%20%20%20%20%20%20%20%2F%2F%20make%20this%20test%20pass%20for%20the%20wrong%20reason.%0A%20%20%20%20%20%20%20%20let%20spaceKeyCode%3A%20CGKeyCode%20%3D%2049%0A%20%20%20%20%20%20%20%20XCTAssertNil%28model.conflictingShortcutName%28keyCode%3A%20spaceKeyCode%2C%20modifiers%3A%20%5B%5D%2C%20excluding%3A%20.acceptWord%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22Precondition%3A%20Space%20must%20not%20be%20a%20default%20binding%20for%20acceptWord%22%29%0A%20%20%20%20%20%20%20%20XCTAssertNil%28model.conflictingShortcutName%28keyCode%3A%20spaceKeyCode%2C%20modifiers%3A%20%5B%5D%2C%20excluding%3A%20.acceptEntireSuggestion%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22Precondition%3A%20Space%20must%20not%20be%20a%20default%20binding%20for%20acceptEntireSuggestion%22%29%0A%20%20%20%20%20%20%20%20let%20conflict%20%3D%20model.conflictingShortcutName%28%0A%20%20%20%20%20%20%20%20%20%20%20%20keyCode%3A%20spaceKeyCode%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20modifiers%3A%20%5B%5D%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20excluding%3A%20.toggleTabby%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20XCTAssertNil%28conflict%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=465&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Block assigning one shortcut to multiple..."](https://github.com/fujacob/cotabby/commit/65defab45a31266c3792718b018935a1a88c7bef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34762816)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->