### PR TITLE
Greedy latency cut: focus poll 50ms, debounce 20ms, visual settle 250ms

### DIFF
--- a/Cotabby/Models/SuggestionModels.swift
+++ b/Cotabby/Models/SuggestionModels.swift
@@ -98,9 +98,9 @@ struct SuggestionConfiguration: Equatable, Sendable {
     static let standard = SuggestionConfiguration(
         // Keep completions short so ghost text stays fast and easy to accept.
         maxPredictionTokens: 8,
-        // Aggressive debounce: 30ms keeps time-to-first-suggestion low while still collapsing
+        // Aggressive debounce: 20ms keeps time-to-first-suggestion low while still collapsing
         // bursts (superseded generations are cancelled; the host-publish poll absorbs AX lag).
-        debounceMilliseconds: 30,
+        debounceMilliseconds: 20,
         // Low temperature keeps inline completions stable and less likely to drift.
         temperature: 0.1,
         topK: 20,
@@ -122,7 +122,7 @@ struct SuggestionConfiguration: Equatable, Sendable {
         // Seed the profile settings with lightweight defaults on first launch.
         defaultUserName: "Jacob",
         defaultWordCountPreset: .twelveToTwenty,
-        focusPollIntervalMilliseconds: 80
+        focusPollIntervalMilliseconds: 50
     )
 }
 

--- a/Cotabby/Models/SuggestionSettingsModel.swift
+++ b/Cotabby/Models/SuggestionSettingsModel.swift
@@ -231,11 +231,12 @@ final class SuggestionSettingsModel: ObservableObject {
         let resolvedFocusPollIntervalMilliseconds: Int = {
             let raw = userDefaults.object(forKey: Self.focusPollIntervalMillisecondsDefaultsKey) as? Int
                 ?? configuration.focusPollIntervalMilliseconds
-            // Existing installs may have the old 50ms first-launch default persisted. Floor at the
-            // shipped default so the hotfix bump reaches them — the stepper is hidden from the UI,
-            // so the persisted value is always the previous default, never a user-chosen override.
-            let floored = max(raw, configuration.focusPollIntervalMilliseconds)
-            return max(10, min(500, floored))
+            // Cap persisted values at the shipped default so a default lowering reaches existing
+            // installs (anyone on the previous 80ms default gets the 50ms speedup on next launch).
+            // The stepper is hidden from the UI today, so any persisted value is a previous default
+            // rather than a user-chosen override.
+            let capped = min(raw, configuration.focusPollIntervalMilliseconds)
+            return max(10, min(500, capped))
         }()
 
         let resolvedMultiLineEnabled = userDefaults.object(forKey: Self.multiLineEnabledDefaultsKey) as? Bool ?? false

--- a/Cotabby/Services/Visual/VisualContextCoordinator.swift
+++ b/Cotabby/Services/Visual/VisualContextCoordinator.swift
@@ -26,7 +26,7 @@ final class VisualContextCoordinator {
     /// doesn't keep re-arming the timer.
     private var pendingStartTask: Task<Void, Never>?
     private var pendingStartContext: FocusedInputSnapshot?
-    private static let sessionStartSettleNanoseconds: UInt64 = 350_000_000
+    private static let sessionStartSettleNanoseconds: UInt64 = 250_000_000
 
     private static let permissionMissingReason =
         "Screen Recording permission is required for screenshot-derived prompt context."

--- a/docs/POLLING_AND_DELAYS.md
+++ b/docs/POLLING_AND_DELAYS.md
@@ -11,7 +11,7 @@ Update this file whenever you add, remove, or change a timing constant.
 
 | Location | Value | Purpose |
 |----------|-------|---------|
-| `Cotabby/Services/Focus/FocusTracker.swift:41` | 80 ms | Base focus poll interval (AX tree walk). Backed off automatically by `FocusPollBackoff` up to ~800 ms during idle. |
+| `Cotabby/Services/Focus/FocusTracker.swift:41` (default from `SuggestionModels.swift:125`) | 50 ms | Base focus poll interval (AX tree walk). Backed off automatically by `FocusPollBackoff` up to ~800 ms during idle. Persisted values are capped at this default on load (`SuggestionSettingsModel.swift:231`) so anyone still on the old 80 ms default gets the speedup; the stepper is hidden from the UI today, so any persisted value is a previous default rather than a user choice. |
 | `Cotabby/Services/Focus/FocusSnapshotResolver.swift:16` | 100 ms | Deep-walk throttle. Caps the expensive caret BFS used in Chromium-style contenteditable trees. |
 | `Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift:180` | 400 ms | Chromium AX-publish wait ceiling. Maximum time we wait for the host app to publish its updated contenteditable text after a keystroke before giving up on this prediction cycle. |
 | `Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift:185` | 30 ms | Host-publish poll interval (steady cadence). AX is requeried at this interval while waiting up to the 400 ms ceiling above. |
@@ -22,7 +22,7 @@ Update this file whenever you add, remove, or change a timing constant.
 
 | Location | Value | Purpose |
 |----------|-------|---------|
-| `Cotabby/Models/SuggestionModels.swift:103` | 30 ms | Default suggestion debounce. Persisted values are capped to this default on load (`SuggestionSettingsModel.swift:181`) so existing installs with the old 50 ms default get the improvement; the stepper is hidden from the UI today, so any persisted value is a previous default rather than a user choice. Clamped to [10, 500]. |
+| `Cotabby/Models/SuggestionModels.swift:103` | 20 ms | Default suggestion debounce. Persisted values are capped to this default on load (`SuggestionSettingsModel.swift:222`) so a default lowering reaches existing installs; the stepper is hidden from the UI today, so any persisted value is a previous default rather than a user choice. Clamped to [10, 500]. |
 | `Cotabby/Services/Suggestion/SuggestionWorkController.swift:32` | (configured) | Converts the user debounce setting from ms to nanoseconds for `Task.sleep`. |
 
 ## Acceptance and Input
@@ -36,7 +36,7 @@ Update this file whenever you add, remove, or change a timing constant.
 
 | Location | Value | Purpose |
 |----------|-------|---------|
-| `Cotabby/Services/Visual/VisualContextCoordinator.swift:29` | 350 ms | Session-start settle delay. Debounces visual context capture on focus change so a flapping Chromium focus doesn't retrigger screenshots and OCR. |
+| `Cotabby/Services/Visual/VisualContextCoordinator.swift:29` | 250 ms | Session-start settle delay. Debounces visual context capture on focus change so a flapping Chromium focus doesn't retrigger screenshots and OCR. |
 | `Cotabby/Services/Visual/LlamaVisualContextSummarizer.swift:20` | 3 s | Llama visual context summarization soft timeout. Cancels generation after 3 s and returns whatever partial text was produced. |
 
 ## Permissions
@@ -64,7 +64,7 @@ The hottest loops, ordered by CPU impact:
    publishes) then a 30 ms steady cadence. Raising the steady interval to
    50 to 60 ms roughly halves AX queries during the wait with minimal added
    latency; leave the short first retry alone.
-2. **80 ms focus poll base** in `FocusTracker`. Already protected by
+2. **50 ms focus poll base** in `FocusTracker`. Already protected by
    `FocusPollBackoff` once idle, so this is the active-typing cadence.
 3. **400 ms Chromium ceiling**. Raising it reduces the rate at which we give
    up on slow Chromium publishes, at the cost of longer worst-case latency


### PR DESCRIPTION
## Summary

Three timing values on the keystroke-to-ghost-text path lowered together. Worst-case savings cap at roughly 30 + 10 + 100 ms; sustained typing also benefits from the focus-poll change because every AX refresh during active typing now runs at 50 ms instead of 80.

- **Focus poll:** 80 → 50 ms (`SuggestionConfiguration.standard` in `SuggestionModels.swift:125`).
- **Default suggestion debounce:** 30 → 20 ms (`SuggestionModels.swift:103`).
- **Visual context session-start settle:** 350 → 250 ms (`VisualContextCoordinator.swift:29`).

Existing-install migration: the focus-poll migration in `SuggestionSettingsModel.swift` flips from a floor (only raises) to a cap (forces existing 80 ms users down to 50 ms on next launch), matching the debounce-default migration shipped in #418. The stepper is still hidden from the UI today, so any persisted value is a previous default rather than a user-chosen override.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build-for-testing \
  -derivedDataPath build/DerivedData
# ** TEST BUILD SUCCEEDED **

swiftlint lint --quiet
# 0 issues
```

App-hosted test run blocked locally by the documented Team ID signing mismatch.

## Linked issues

Refs #418 (the debounce-default migration this mirrors), #381 (the Chromium AX-publish bug the host-publish ceiling protects against and which this PR deliberately does not touch).

## Risk / rollout notes

- **Floors that hold the line:** focus poll bottoms out near AX call cost (5–15 ms each), so 50 ms is the productive floor. Debounce at 20 ms is well above perceptible cancellation churn. Visual settle still debounces Chromium focus flap; 250 ms is well over a typical focus-publish.
- **Deliberately untouched:**
  - The 400 ms Chromium AX-publish wait ceiling. Lowering it would generate against pre-keystroke text more often — the #381 failure mode.
  - The 30 ms host-publish poll inside the ceiling. Halving it would double AX queries during the wait for a sub-10 ms tail-case win — bad ratio.
  - The 30 ms post-insertion refresh and 50 ms accept-tap teardown. Both protect synthetic-keystroke delivery; lowering risks dropping the keystroke or snapping the caret on stale geometry.
- `docs/POLLING_AND_DELAYS.md` updated in the same commit per the inventory's own rule.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR lowers three timing constants on the keystroke-to-ghost-text path: the suggestion debounce (30 → 20 ms), the focus-poll base interval (80 → 50 ms), and the visual-context session-start settle delay (350 → 250 ms). The focus-poll migration in `SuggestionSettingsModel` is also flipped from a floor (`max`) to a cap (`min`), so existing installs still on the old 80 ms default are brought down to 50 ms on next launch — mirroring the debounce migration pattern from #418.

- **`SuggestionModels.swift`**: Two constant changes — `debounceMilliseconds` 30 → 20 and `focusPollIntervalMilliseconds` 80 → 50 in `SuggestionConfiguration.standard`.
- **`SuggestionSettingsModel.swift`**: Focus-poll migration semantics inverted from `max(raw, default)` to `min(raw, default)`, ensuring a default reduction propagates to existing installs; justified by the stepper being hidden from UI.
- **`VisualContextCoordinator.swift` + `docs/POLLING_AND_DELAYS.md`**: Single nanosecond constant updated (350 ms → 250 ms) and the timing inventory kept current, including a corrected line-number reference for the debounce migration.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are isolated timing-constant reductions with no logic restructuring beyond the well-justified migration flip.

Each of the three constants has a clear rationale, documented floor (AX call cost, perceptible churn, Chromium focus-flap envelope), and is independently verifiable. The migration inversion in SuggestionSettingsModel correctly mirrors the existing debounce pattern and is guarded by the same [10, 500] clamp. The 250 ms visual-context settle remains comfortably above typical Chromium focus-publish latency, and all deliberately-untouched constants are called out explicitly in the PR description. The docs inventory is kept current with accurate line references.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Models/SuggestionModels.swift | Debounce default lowered from 30 ms to 20 ms and focus-poll default from 80 ms to 50 ms in SuggestionConfiguration.standard; both are straightforward constant changes with accurate comments. |
| Cotabby/Models/SuggestionSettingsModel.swift | Focus-poll migration logic flipped from max (floor) to min (cap), matching the debounce migration pattern from #418; correctly forces existing 80 ms users down to 50 ms since the stepper is UI-hidden. |
| Cotabby/Services/Visual/VisualContextCoordinator.swift | Visual context session-start settle delay reduced from 350 ms to 250 ms; single-constant change, well within the documented Chromium focus-flap debounce envelope. |
| docs/POLLING_AND_DELAYS.md | All three timing entries updated to reflect new values; debounce migration line-number reference corrected from :181 to :222 and the hot-loop inventory updated from 80 ms to 50 ms for the focus-poll base. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User (keystroke)
    participant FT as FocusTracker
    participant SC as SuggestionCoordinator
    participant VCC as VisualContextCoordinator
    participant LLM as LLM / FoundationModel

    U->>FT: keystroke / focus change
    FT->>SC: AX snapshot (poll every 50ms, was 80ms)
    SC->>SC: debounce 20ms (was 30ms)
    alt Focus change (new field)
        SC->>VCC: startSessionIfNeeded()
        VCC->>VCC: settle delay 250ms (was 350ms)
        VCC->>VCC: screenshot + OCR
        VCC-->>SC: onInjectedContextReady
    end
    SC->>LLM: generate suggestion
    LLM-->>SC: ghost text tokens
    SC-->>U: render inline completion
```

<sub>Reviews (1): Last reviewed commit: ["Greedy latency cut: focus poll 50ms, deb..."](https://github.com/fujacob/cotabby/commit/aad860db779684a493e1c745677c07a58ec22f2b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34763469)</sub>

<!-- /greptile_comment -->