### PR TITLE
Re-show onboarding for upgrading users via a versioned completion key

### DIFF
--- a/Cotabby/App/Coordinators/WelcomeCoordinator.swift
+++ b/Cotabby/App/Coordinators/WelcomeCoordinator.swift
@@ -31,7 +31,19 @@ final class WelcomeCoordinator: NSObject, NSWindowDelegate {
     private var welcomeWindowController: NSWindowController?
     private var permissionReminderWindowController: NSWindowController?
 
-    private static let onboardingCompletedDefaultsKey = "cotabbyOnboardingCompleted"
+    /// Bump whenever onboarding is revamped enough that users who already finished an older version
+    /// should experience it again. `presentIfNeeded` re-shows the wizard for anyone whose stored
+    /// completed version is below this, and completing the wizard writes this value back.
+    private static let currentOnboardingVersion = 2
+
+    /// Stores the onboarding version the user last *completed* (reached "done" and dismissed), not a
+    /// yes/no flag. An absent key reads as `0`, so both brand-new users and users who finished an
+    /// older onboarding fall below `currentOnboardingVersion` and get the current flow exactly once.
+    ///
+    /// Replaces the legacy boolean `cotabbyOnboardingCompleted` key. That key is intentionally not
+    /// migrated: reading it as "version 1 completed" would let upgrading users skip the revamped
+    /// flow, which is the opposite of what a version bump is for.
+    private static let onboardingCompletedVersionKey = "cotabbyOnboardingCompletedVersion"
 
     init(
         permissionManager: PermissionManager,
@@ -51,14 +63,14 @@ final class WelcomeCoordinator: NSObject, NSWindowDelegate {
         self.userDefaults = userDefaults
     }
 
-    /// Whether the user completed the full onboarding wizard (reached "done" and dismissed).
+    /// Whether the user completed the *current* onboarding version (reached "done" and dismissed).
     ///
-    /// The legacy `hasShownWelcomeWindow` key is intentionally NOT migrated here. That key was
-    /// set at presentation time (before the user finished), so treating it as "completed" would
-    /// skip profile and model selection for upgrading users. Forcing one more pass through the
-    /// wizard on upgrade is better than silently dropping steps.
+    /// Versioned rather than boolean so a revamp can re-show the wizard: a stored value below
+    /// `currentOnboardingVersion` (including the `0` returned for an absent key) counts as not yet
+    /// completed. The legacy `hasShownWelcomeWindow` key is likewise not migrated, since it was set
+    /// at presentation time (before the user finished) and would skip profile and model selection.
     private var isOnboardingCompleted: Bool {
-        userDefaults.bool(forKey: Self.onboardingCompletedDefaultsKey)
+        userDefaults.integer(forKey: Self.onboardingCompletedVersionKey) >= Self.currentOnboardingVersion
     }
 
     /// Presents the welcome wizard if the user has never completed onboarding.
@@ -153,10 +165,12 @@ final class WelcomeCoordinator: NSObject, NSWindowDelegate {
         }
     }
 
-    /// Called when the user completes the full onboarding wizard ("Start Using Cotabby").
-    /// Persists the completion flag so the wizard does not reappear.
+    /// Called when the user completes the full onboarding wizard ("Start Using Cotabby"). Stamps the
+    /// current onboarding version so the wizard does not reappear until the next revamp bumps it.
+    /// This is the only thing that clears the gate: closing the window mid-flow leaves the stored
+    /// version unchanged, so the wizard returns on next launch.
     private func completeOnboarding() {
-        userDefaults.set(true, forKey: Self.onboardingCompletedDefaultsKey)
+        userDefaults.set(Self.currentOnboardingVersion, forKey: Self.onboardingCompletedVersionKey)
         permissionGuidanceController.dismiss()
         welcomeWindowController?.close()
     }


### PR DESCRIPTION
## Summary

We revamped onboarding and want existing users to experience the new flow, not just new installs. Onboarding completion was a single boolean (`cotabbyOnboardingCompleted`), so there was no way to re-show it without re-triggering on every launch. This replaces that boolean with a versioned key: `WelcomeCoordinator` now stores the onboarding **version** the user last completed and re-shows the wizard whenever that stored version is below `currentOnboardingVersion` (bumped to `2` here).

- Existing users (finished the old flow) and brand-new users both read `0` for the new key, so both get the current onboarding exactly once.
- Completing the wizard ("Start Using Cotabby") is the only thing that clears the gate; it stamps `currentOnboardingVersion`. Closing the window mid-flow leaves the stored version unchanged, so the wizard returns next launch.
- Future revamps are a one-line bump of `currentOnboardingVersion`.

The legacy `cotabbyOnboardingCompleted` boolean is intentionally not migrated: treating it as "version 1 completed" would let upgrading users skip the revamped flow, which is the opposite of the goal. No other code referenced that key.

## Validation

```
swiftlint lint --quiet Cotabby/App/Coordinators/WelcomeCoordinator.swift   # exit 0
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -configuration Debug \
  -destination 'platform=macOS' build                                      # ** BUILD SUCCEEDED **
```

No `WelcomeCoordinator` unit test exists (it is `@MainActor`/AppKit and the existing onboarding tests cover pure helpers), so this relies on build + lint; the gate logic is a two-line `UserDefaults` version compare.

## Linked issues

(none filed)

## Risk / rollout notes

- One-time behavior change on upgrade: every existing user sees onboarding once after this ships. That is the intended effect of the revamp, but worth calling out for release notes.
- `UserDefaults` migration: reads/writes a new key (`cotabbyOnboardingCompletedVersion`); the old `cotabbyOnboardingCompleted` boolean is left untouched and unread (harmless stale value).
- The manual "Show Welcome" menu action is unaffected; it calls `showWelcome()` directly and never touched the gate.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the single boolean `cotabbyOnboardingCompleted` UserDefaults key with a versioned integer key (`cotabbyOnboardingCompletedVersion`), allowing future onboarding revamps to re-surface the wizard for existing users by bumping `currentOnboardingVersion`.

- `isOnboardingCompleted` now uses `integer(forKey:) >= currentOnboardingVersion` (defaulting to `0` for absent/new users), so both new installs and upgraders see the revamped flow exactly once.
- `completeOnboarding()` stamps the integer version instead of `true`; closing mid-flow leaves the key unset, so the wizard re-appears on next launch.
- Future revamps require only a one-line bump of `currentOnboardingVersion`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a minimal two-line logic change backed by clear, correct reasoning and thorough inline documentation.

The gate logic is a straightforward integer comparison against a compile-time constant. All three user populations (new installs, upgraders, users who close mid-flow) are handled correctly: absent key returns 0, completing stamps the current version, closing mid-flow leaves nothing written. The >= comparison gracefully handles any future downgrade scenario. No existing callers reference the old boolean key, and the new key is isolated to this file.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/App/Coordinators/WelcomeCoordinator.swift | Versioned onboarding gate logic — replaces boolean UserDefaults key with integer version check; logic is correct, well-commented, and isolated to two touched lines. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[App Launch] --> B[presentIfNeeded]
    B --> C{isOnboardingCompleted?}
    C -- "integer(onboardingCompletedVersionKey) >= 2" --> D[Skip — wizard hidden]
    C -- "stored value < 2 OR key absent (reads 0)" --> E[showWelcome]
    E --> F[User sees wizard]
    F --> G{User action}
    G -- "Click 'Start Using Cotabby'" --> H[completeOnboarding]
    H --> I[UserDefaults.set 2 for onboardingCompletedVersionKey]
    I --> J[Close window — wizard will NOT return]
    G -- "Close window mid-flow" --> K[windowWillClose — no version stamp]
    K --> L[Next launch: wizard returns]
    M[Manual 'Show Welcome' menu] --> E
```

<sub>Reviews (1): Last reviewed commit: ["Re-show onboarding for upgrading users v..."](https://github.com/fujacob/cotabby/commit/3672339cfb40040e6342769f462ed38b3fce4291) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34763603)</sub>

<!-- /greptile_comment -->