### PR TITLE
Release: keep prereleases off the auto-update feed and Homebrew cask

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -793,6 +793,14 @@ jobs:
           IS_PRERELEASE: ${{ needs.build.outputs.is_prerelease }}
           PUBLISH: ${{ needs.build.outputs.publish }}
         run: |
+          # Prereleases do not publish to the appcast feed (see the Pages steps above), so report
+          # the feed as untouched rather than printing a URL that was not actually updated.
+          if [[ "${IS_PRERELEASE}" == "true" ]]; then
+            appcast_status="not published (prerelease — download-only)"
+          else
+            appcast_status="https://${PAGES_CUSTOM_DOMAIN}/appcast.xml"
+          fi
+
           {
             echo "### Release"
             echo "| Field | Value |"
@@ -802,10 +810,17 @@ jobs:
             echo "| Build number | ${BUILD_NUMBER} |"
             echo "| Prerelease | ${IS_PRERELEASE} |"
             echo "| Published | ${PUBLISH} |"
-            echo "| Appcast URL | https://${PAGES_CUSTOM_DOMAIN}/appcast.xml |"
+            echo "| Appcast | ${appcast_status} |"
           } >> "${GITHUB_STEP_SUMMARY}"
 
+      # Prereleases are download-only GitHub releases: they must NOT overwrite the production
+      # appcast at updates.cotabby.app, or every auto-update user (who all sit on Sparkle's
+      # default channel, with no channel opt-in) would be force-updated to the beta. So the
+      # appcast deploy and the Homebrew cask bump are gated to stable releases. The appcast is
+      # still generated above for prereleases (it validates signing and is kept as an artifact),
+      # it just is not published to the feed.
       - name: Prepare Pages artifact
+        if: needs.build.outputs.is_prerelease != 'true'
         run: |
           set -euo pipefail
 
@@ -815,15 +830,18 @@ jobs:
           printf '%s\n' "${PAGES_CUSTOM_DOMAIN}" > build/pages/CNAME
 
       - name: Configure GitHub Pages
+        if: needs.build.outputs.is_prerelease != 'true'
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Upload GitHub Pages artifact
+        if: needs.build.outputs.is_prerelease != 'true'
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: build/pages
 
       - name: Deploy GitHub Pages
         id: deploy-pages
+        if: needs.build.outputs.is_prerelease != 'true'
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
 
       - name: Upload release artifacts
@@ -847,7 +865,8 @@ jobs:
   update-homebrew-cask:
     name: Update Homebrew cask
     needs: [build, notarize, publish]
-    if: needs.build.outputs.publish == 'true'
+    # Stable only: a prerelease must not bump the Homebrew cask that `brew install` resolves.
+    if: needs.build.outputs.publish == 'true' && needs.build.outputs.is_prerelease != 'true'
     runs-on: ubuntu-latest
     permissions: {}
     steps:

--- a/scripts/generate_appcast.py
+++ b/scripts/generate_appcast.py
@@ -25,7 +25,10 @@ import sys
 
 
 DEFAULT_OWNER = "FuJacob"
-DEFAULT_REPOSITORY = "Cotabby"
+# Canonical (lowercase) repository name. GitHub redirects mixed-case paths, but the enclosure URL
+# lands in a signed appcast that ships to every user, so pin the canonical name rather than relying
+# on a redirect that a repo rename or transfer could one day drop.
+DEFAULT_REPOSITORY = "cotabby"
 # Sparkle's <releaseNotesLink> is fetched by the update alert's embedded WKWebView.
 # Point it at the dedicated slim route on the landing site rather than GitHub's
 # full release page, which pulls in GitHub's chrome and is unreadable in the small


### PR DESCRIPTION
## Summary

Review of `release.yml` found the stable release path solid, but the prerelease path had a material gap: a prerelease tag (`v1.2.3-beta`) ran the full publish flow, which **overwrote the production Sparkle appcast** at `updates.cotabby.app/appcast.xml` and **bumped the Homebrew cask**. Because every user sits on Sparkle's default channel (single `SUFeedURL`, no `allowedChannels` opt-in anywhere) and the appcast carries no `<sparkle:channel>`, that beta would be force-offered to all auto-update users and become the `brew install` target. The `--prerelease` flag only controls GitHub's "Latest" badge, not Sparkle.

This makes prereleases download-only: they still create a GitHub prerelease (and still build + notarize + sign + generate the appcast as an artifact, so signing is validated), but they no longer publish the appcast to Pages or bump the cask. The stable release path is behaviorally unchanged: every new gate is `is_prerelease != 'true'`, which is always true for a stable tag.

Also canonicalizes the appcast enclosure repo name (`Cotabby` -> `cotabby`) so the signed download URL no longer depends on GitHub's mixed-case redirect surviving a future rename/transfer.

Changes:
- `release.yml`: gate the four Pages steps (Prepare/Configure/Upload/Deploy) and the `update-homebrew-cask` job to stable releases; make the run summary report the appcast as "not published (prerelease)" instead of printing a feed URL that was not updated.
- `generate_appcast.py`: `DEFAULT_REPOSITORY` -> `cotabby`.

Not changed, by decision:
- `sparkle:minimumSystemVersion` is still omitted. The app requires macOS 14, so there is no <14 population to mis-offer; a hardcoded value would only add a drift coupling for ~zero safety.
- No `<sparkle:channel>` / `allowedChannels` beta channel was added. That is a larger product feature (opt-in beta track); this PR just stops betas from leaking to stable users. If you later want a real beta channel, that is the follow-up.

## Validation

```
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"   # YAML OK, 4 jobs intact
python3 -m py_compile scripts/generate_appcast.py                                  # OK
```
Confirmed: `Create GitHub Release` and `Generate signed appcast` remain ungated (run for both channels); the four Pages steps and the Homebrew job are gated to stable; enclosure URL renders as `https://github.com/FuJacob/cotabby/releases/download/v1.2.3/Cotabby.dmg`.

A release workflow can only be fully exercised by cutting a tag, so this was validated by YAML/Python parse and gating inspection rather than an end-to-end run.

## Linked issues

(none filed)

## Risk / rollout notes

- Stable releases: no behavior change (all gates evaluate true).
- Prereleases: now download-only. Pushing a `-beta` tag creates a GitHub prerelease but does not move the auto-update feed or the cask. This is the intended fix.
- Because release infra cannot be dry-run end-to-end, recommend watching the next prerelease tag (if any) to confirm the Pages/Homebrew steps skip as expected.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes the gap where a prerelease tag (`v1.2.3-beta`) ran the full publish flow, overwriting the production Sparkle appcast and bumping the Homebrew cask. Prereleases now create a GitHub release and retain the signed appcast as an artifact for signing validation, but skip the Pages deploy and Homebrew dispatch.

- `.github/workflows/release.yml`: four GitHub Pages steps and the `update-homebrew-cask` job are gated with `is_prerelease != 'true'`; the run summary now reports the appcast as "not published (prerelease)" instead of a URL that was not updated.
- `scripts/generate_appcast.py`: `DEFAULT_REPOSITORY` changed from `"Cotabby"` to `"cotabby"` to canonicalize the enclosure URL in signed appcasts, removing dependence on GitHub's mixed-case redirect.

<h3>Confidence Score: 5/5</h3>

Safe to merge — stable release behavior is unchanged; prereleases correctly skip the Pages deploy and Homebrew dispatch.

The gating logic is straightforward: `is_prerelease` is deterministically set to the string `"true"` or `"false"` in the metadata step, and every new `if:` condition compares against that string using the same expression syntax already used throughout the rest of the workflow. The `update-homebrew-cask` job condition correctly extends the pre-existing `publish == 'true'` guard. The `generate_appcast.py` change is a single-constant rename with no logic impact. No pre-existing paths are altered.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Gates four Pages steps and the Homebrew cask job to stable releases via `is_prerelease != 'true'`; adds a conditional summary line reporting the appcast as unpublished for prereleases. Logic, expression syntax, and job dependency ordering are all correct. |
| scripts/generate_appcast.py | Canonicalizes `DEFAULT_REPOSITORY` to lowercase `cotabby`, eliminating reliance on GitHub's case-redirect for the enclosure URL baked into signed appcasts. No logic changes; the rest of the script is unchanged. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Tag push / workflow_dispatch] --> B[build job]
    B -->|is_prerelease = version contains '-'| C{is_prerelease?}
    B --> D[notarize job]
    D --> E[publish job]
    E --> F[Create GitHub Release]
    E --> G[Generate signed appcast artifact]
    C -->|true / prerelease| H[Summary: appcast not published]
    C -->|false / stable| I[Prepare Pages artifact]
    I --> J[Configure GitHub Pages]
    J --> K[Upload Pages artifact]
    K --> L[Deploy GitHub Pages\nupdates.cotabby.app/appcast.xml]
    E --> M{publish == 'true'\nAND is_prerelease != 'true'?}
    M -->|yes| N[update-homebrew-cask job\ndispatch to FuJacob/homebrew-cotabby]
    M -->|no - prerelease or dry-run| O[skip cask update]
    F -.->|both paths| H
    G -.->|both paths| H
```

<sub>Reviews (1): Last reviewed commit: ["Release: keep prereleases off the auto-u..."](https://github.com/fujacob/cotabby/commit/893799f0567740c3f5ad370005e791cd825c5992) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34763931)</sub>

<!-- /greptile_comment -->