### PR TITLE
Move support banner to top of General settings with blue styling

### DIFF
--- a/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
@@ -14,6 +14,33 @@ struct GeneralPaneView: View {
 
     var body: some View {
         SettingsPaneScaffold {
+            if let kofiURL = URL(string: "https://ko-fi.com/cotabby") {
+                Section {
+                    HStack(spacing: 12) {
+                        Text("Enjoying Cotabby? Please consider supporting open-source")
+                            .font(.subheadline)
+                            .foregroundStyle(.white)
+                            .lineLimit(1)
+                        Spacer(minLength: 0)
+                        Link(destination: kofiURL) {
+                            HStack(spacing: 5) {
+                                Image(systemName: "heart.fill")
+                                    .foregroundStyle(.pink)
+                                Text("Support")
+                                    .fontWeight(.semibold)
+                            }
+                            .font(.subheadline)
+                            .foregroundStyle(Color.blue)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 6)
+                            .background(Color.white, in: Capsule())
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    .listRowBackground(Color.blue)
+                }
+            }
+
             Section("Status") {
                 Toggle(isOn: globallyEnabledBinding) {
                     SettingsRowLabel(
@@ -179,33 +206,6 @@ struct GeneralPaneView: View {
                     Button("Open Welcome Guide") {
                         onShowWelcome()
                     }
-                }
-            }
-
-            if let kofiURL = URL(string: "https://ko-fi.com/cotabby") {
-                Section {
-                    HStack(spacing: 12) {
-                        Text("Enjoying Cotabby? Please consider supporting open-source")
-                            .font(.subheadline)
-                            .foregroundStyle(.white)
-                            .lineLimit(1)
-                        Spacer(minLength: 0)
-                        Link(destination: kofiURL) {
-                            HStack(spacing: 5) {
-                                Image(systemName: "heart.fill")
-                                    .foregroundStyle(.pink)
-                                Text("Support")
-                                    .fontWeight(.semibold)
-                            }
-                            .font(.subheadline)
-                            .foregroundStyle(Color.accentColor)
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 6)
-                            .background(Color.white, in: Capsule())
-                        }
-                        .buttonStyle(.plain)
-                    }
-                    .listRowBackground(Color.accentColor)
                 }
             }
         }


### PR DESCRIPTION
## Summary

Promote the Ko-fi support banner from the bottom of the General settings pane to the first section so users see it without scrolling, and pin its styling to an explicit blue background with white text (and a blue "Support" label on the white capsule) instead of relying on the system accent color.

## Validation

```
swiftlint lint --quiet Cotabby/UI/Settings/Panes/GeneralPaneView.swift
# exit 0

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **
```

Visual-only change to the General pane; the banner now renders as the top section.

## Linked issues

None.

## Risk / rollout notes

Pure presentation change in `GeneralPaneView`. No settings, schema, or pbxproj migrations; no behavior change beyond banner placement and color.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Relocates the Ko-fi support banner from the bottom of the General settings pane to the very first section so it is immediately visible, and locks its background and capsule-label color to `Color.blue` / white instead of the system accent color.

- The banner block is structurally identical to the removed one; only its position (top vs. bottom) and color token (`Color.blue` instead of `Color.accentColor`) differ.
- One minor cleanup opportunity exists: the `if let kofiURL = URL(string:)` guard on a compile-time literal URL is redundant and can be simplified.

<h3>Confidence Score: 5/5</h3>

Pure visual reordering of a single SwiftUI section; no logic, settings schema, or data flow is touched.

The change is a cut-and-paste relocation of a self-contained Section block combined with swapping one color token for another. No bindings, models, or side effects are involved, and the deleted code is byte-for-byte equivalent to the added code apart from the color swap.

No files require special attention; the single changed file contains only SwiftUI view layout code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/Settings/Panes/GeneralPaneView.swift | Ko-fi banner moved to top of view and accent color replaced with explicit `Color.blue`; one redundant `if let` on a compile-time constant URL. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[GeneralPaneView body] --> B["Ko-fi Support Banner\n(Color.blue background)\n🆕 moved here"]
    B --> C[Section: Status]
    C --> D[Section: Behavior]
    D --> E{isEmojiPickerEnabled?}
    E -- yes --> F[Section: Emoji Suggestions]
    E -- no --> G[Section: Display]
    F --> G
    G --> H[Section: Appearance]
    H --> I[Section: Help]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fsupport-banner-top%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fsupport-banner-top%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FSettings%2FPanes%2FGeneralPaneView.swift%3A17%0A**Redundant%20optional%20binding%20on%20compile-time%20constant%20URL**%0A%0A%60URL%28string%3A%29%60%20only%20returns%20%60nil%60%20for%20malformed%20strings%3B%20%60%22https%3A%2F%2Fko-fi.com%2Fcotabby%22%60%20is%20a%20valid%20RFC%203986%20absolute%20URL%20and%20will%20never%20fail.%20The%20%60if%20let%60%20guard%20is%20harmless%20but%20misleads%20readers%20into%20thinking%20the%20banner%20might%20conditionally%20disappear.%20Consider%20using%20a%20%60let%60%20constant%20at%20the%20top%20of%20the%20view%20or%20replacing%20with%20%60URL%28string%3A%20%22https%3A%2F%2Fko-fi.com%2Fcotabby%22%29!%60%20%28force-unwrap%20is%20safe%20here%20because%20the%20literal%20is%20fixed%20at%20compile%20time%29.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FSettings%2FPanes%2FGeneralPaneView.swift%3A17%0A**Redundant%20optional%20binding%20on%20compile-time%20constant%20URL**%0A%0A%60URL%28string%3A%29%60%20only%20returns%20%60nil%60%20for%20malformed%20strings%3B%20%60%22https%3A%2F%2Fko-fi.com%2Fcotabby%22%60%20is%20a%20valid%20RFC%203986%20absolute%20URL%20and%20will%20never%20fail.%20The%20%60if%20let%60%20guard%20is%20harmless%20but%20misleads%20readers%20into%20thinking%20the%20banner%20might%20conditionally%20disappear.%20Consider%20using%20a%20%60let%60%20constant%20at%20the%20top%20of%20the%20view%20or%20replacing%20with%20%60URL%28string%3A%20%22https%3A%2F%2Fko-fi.com%2Fcotabby%22%29!%60%20%28force-unwrap%20is%20safe%20here%20because%20the%20literal%20is%20fixed%20at%20compile%20time%29.%0A%0A&repo=fujacob%2Fcotabby&pr=469&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Move support banner to top of General se..."](https://github.com/fujacob/cotabby/commit/4b30d92e80dc52d7966e9463075b841eb4284960) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34763964)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->