### PR TITLE
Reword support banner to mention free open-source software

### DIFF
--- a/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
@@ -17,7 +17,7 @@ struct GeneralPaneView: View {
             if let kofiURL = URL(string: "https://ko-fi.com/cotabby") {
                 Section {
                     HStack(spacing: 12) {
-                        Text("Enjoying Cotabby? Please consider supporting open-source")
+                        Text("Enjoying Cotabby? Please consider supporting free open-source software")
                             .font(.subheadline)
                             .foregroundStyle(.white)
                             .lineLimit(1)


### PR DESCRIPTION
## Summary

Update the General-pane support banner copy from "supporting open-source" to "supporting free open-source software" for clearer wording.

## Validation

```
swiftlint lint --quiet Cotabby/UI/Settings/Panes/GeneralPaneView.swift
# exit 0

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **
```

Copy-only change.

## Linked issues

None.

## Risk / rollout notes

Pure string change; no behavior or layout logic altered.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the support banner copy in the General settings pane to say "supporting free open-source software" instead of "supporting open-source", making the phrasing more descriptive.

- Only `GeneralPaneView.swift` is touched; the change is confined to the string literal inside a `Text` view at line 20.
- No bindings, layout, behavior, or other UI components are modified.

<h3>Confidence Score: 5/5</h3>

This is a pure string change with no behavioral, layout, or logic impact — safe to merge.

The change touches a single string literal in a settings view. The new phrase is slightly longer, so it's worth a quick visual check that `.lineLimit(1)` doesn't clip it on narrow windows, but there is no functional risk.

No files require special attention beyond the single modified string in `GeneralPaneView.swift`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/Settings/Panes/GeneralPaneView.swift | Single-line copy change rewording the support banner from "supporting open-source" to "supporting free open-source software"; no logic, layout, or behavior altered. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant GeneralPaneView
    participant SupportBanner as Support Banner (HStack)
    participant KoFiLink as Ko-fi Link

    User->>GeneralPaneView: Opens Settings → General
    GeneralPaneView->>SupportBanner: Renders if kofiURL resolves
    SupportBanner->>SupportBanner: Text("…supporting free open-source software")
    SupportBanner->>KoFiLink: Renders "Support" button
    User->>KoFiLink: Taps Support
    KoFiLink-->>User: Opens https://ko-fi.com/cotabby
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fsupport-banner-text%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fsupport-banner-text%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FSettings%2FPanes%2FGeneralPaneView.swift%3A20-23%0A**Longer%20string%20may%20clip%20with%20%60.lineLimit%281%29%60**%0A%0AThe%20new%20text%20%28%22%E2%80%A6supporting%20free%20open-source%20software%22%29%20is%20about%2014%20characters%20longer%20than%20the%20old%20one.%20Because%20it%20lives%20in%20an%20%60HStack%60%20alongside%20a%20%60Spacer%60%20and%20the%20%22Support%22%20button%2C%20the%20%60Text%60%20view%20gets%20only%20whatever%20horizontal%20space%20remains%20after%20the%20button%20is%20laid%20out.%20With%20%60.lineLimit%281%29%60%2C%20any%20overflow%20is%20silently%20truncated%20with%20an%20ellipsis%20rather%20than%20reflowing.%20On%20narrower%20settings-window%20widths%20the%20tail%20of%20the%20string%20could%20be%20cut%20off.%20Worth%20verifying%20on%20the%20minimum%20window%20size%20that%20the%20full%20string%20is%20visible%2C%20or%20shortening%20slightly%20if%20headroom%20is%20tight.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FSettings%2FPanes%2FGeneralPaneView.swift%3A20-23%0A**Longer%20string%20may%20clip%20with%20%60.lineLimit%281%29%60**%0A%0AThe%20new%20text%20%28%22%E2%80%A6supporting%20free%20open-source%20software%22%29%20is%20about%2014%20characters%20longer%20than%20the%20old%20one.%20Because%20it%20lives%20in%20an%20%60HStack%60%20alongside%20a%20%60Spacer%60%20and%20the%20%22Support%22%20button%2C%20the%20%60Text%60%20view%20gets%20only%20whatever%20horizontal%20space%20remains%20after%20the%20button%20is%20laid%20out.%20With%20%60.lineLimit%281%29%60%2C%20any%20overflow%20is%20silently%20truncated%20with%20an%20ellipsis%20rather%20than%20reflowing.%20On%20narrower%20settings-window%20widths%20the%20tail%20of%20the%20string%20could%20be%20cut%20off.%20Worth%20verifying%20on%20the%20minimum%20window%20size%20that%20the%20full%20string%20is%20visible%2C%20or%20shortening%20slightly%20if%20headroom%20is%20tight.%0A%0A&repo=fujacob%2Fcotabby&pr=470&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Reword support banner to mention free op..."](https://github.com/fujacob/cotabby/commit/a299c647db165660a16dda1522c328d07f07bbcc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34764153)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->