### PR TITLE
Fix large text field AX polling lag

### DIFF
--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
@@ -214,15 +214,28 @@ extension SuggestionCoordinator {
     /// at `hostPublishWaitCeilingMs` so a silent host can't hang the pipeline — once the cap is
     /// reached we generate against whatever's there, matching the old fixed-delay behavior.
     /// `schedulePrediction()` internally `replaceDebouncedWork`s, so back-to-back keystrokes
-    /// still collapse cleanly.
+    /// still collapse cleanly. The `hostPublishPollGeneration` token adds the missing outer
+    /// coalescing layer: only the newest keystroke's polling chain may keep reading AX.
     func schedulePredictionAfterHostPublishDelay() {
+        hostPublishPollGeneration &+= 1
+        let pollGeneration = hostPublishPollGeneration
         let baseline = focusModel.snapshot.context
-        pollForHostPublish(
-            baselineText: baseline?.precedingText,
-            baselineElementID: baseline?.elementIdentifier,
-            baselineSelectionLocation: baseline?.selection.location,
-            elapsedMs: 0
-        )
+
+        // The event tap fires before the host processes the key, so an immediate `refreshNow()`
+        // almost always reads the pre-keystroke value while still paying the full AX cost. Start at
+        // the first retry instead; this keeps fast native fields responsive and removes one
+        // guaranteed-stale read from every keypress.
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + .milliseconds(Self.hostPublishFirstPollIntervalMs)
+        ) { [weak self] in
+            self?.pollForHostPublish(
+                baselineText: baseline?.precedingText,
+                baselineElementID: baseline?.elementIdentifier,
+                baselineSelectionLocation: baseline?.selection.location,
+                pollGeneration: pollGeneration,
+                elapsedMs: Self.hostPublishFirstPollIntervalMs
+            )
+        }
     }
 
     /// Drives the snapshot-changed gate. Reads the live focus snapshot, fires `schedulePrediction`
@@ -232,9 +245,18 @@ extension SuggestionCoordinator {
         baselineText: String?,
         baselineElementID: String?,
         baselineSelectionLocation: Int?,
+        pollGeneration: UInt64,
         elapsedMs: Int
     ) {
+        guard pollGeneration == hostPublishPollGeneration else {
+            return
+        }
+
         focusModel.refreshNow()
+        guard pollGeneration == hostPublishPollGeneration else {
+            return
+        }
+
         let currentContext = focusModel.snapshot.context
 
         // No focus context at all means the user moved away from any editable field — let
@@ -250,10 +272,9 @@ extension SuggestionCoordinator {
         // Ceiling: stop polling and generate anyway. Without this fallback a host that genuinely
         // produces no AX change (rare but possible — e.g. dead-key composition) would never get
         // its next prediction.
-        // Short first retry, then steady cadence: the immediate poll above always misses (it runs
-        // before the host processed the key), so a 10ms first retry shaves ~20ms off every
-        // fast-publishing host without doubling AX queries across the slow-Chromium tail.
-        let interval = elapsedMs == 0 ? Self.hostPublishFirstPollIntervalMs : Self.hostPublishPollIntervalMs
+        // We already waited the short first interval before entering this method; remaining polls
+        // use the steady cadence until the ceiling.
+        let interval = Self.hostPublishPollIntervalMs
         let nextElapsed = elapsedMs + interval
         guard nextElapsed < Self.hostPublishWaitCeilingMs else {
             schedulePrediction()
@@ -265,6 +286,7 @@ extension SuggestionCoordinator {
                 baselineText: baselineText,
                 baselineElementID: baselineElementID,
                 baselineSelectionLocation: baselineSelectionLocation,
+                pollGeneration: pollGeneration,
                 elapsedMs: nextElapsed
             )
         }

--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
@@ -438,6 +438,7 @@ extension SuggestionCoordinator {
 
     /// Cancels debounce/generation tasks and advances the work id so late completions are ignored.
     func cancelPredictionWork() {
+        hostPublishPollGeneration &+= 1
         workController.cancelAll()
     }
 

--- a/Cotabby/App/Coordinators/SuggestionCoordinator.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator.swift
@@ -68,6 +68,13 @@ final class SuggestionCoordinator: ObservableObject {
     // barrier task that the next generation must cross before it can ask the runtime for output.
     var cacheResetSequence: UInt64 = 0
     var pendingCacheReset: (sequence: UInt64, task: Task<Void, Never>)?
+    /// Monotonic cancellation token for the "wait until the host publishes typed text to AX" loop.
+    ///
+    /// Keystrokes can arrive faster than Chromium publishes contenteditable updates. Without this
+    /// token, every key starts its own delayed polling chain and those chains stack up, each doing
+    /// synchronous `refreshNow()` calls on the main actor. Bumping the token makes older chains
+    /// no-op before they can perform another expensive AX read.
+    var hostPublishPollGeneration: UInt64 = 0
     /// Correlation ID for the most recently built `SuggestionRequest`. Stamped onto every
     /// state-transition log line so all events tied to one suggestion (debounce → generating →
     /// ready → accepted/rejected) can be joined with a single `jq` filter on `request_id`.

--- a/Cotabby/Services/Focus/AXTextGeometryResolver.swift
+++ b/Cotabby/Services/Focus/AXTextGeometryResolver.swift
@@ -53,8 +53,11 @@ struct AXTextGeometryResolver {
         supportsBoundsForRange: Bool,
         supportsFrame: Bool,
         cocoaAnchorFrame: CGRect?,
-        textValue: String? = nil
+        textValue: String? = nil,
+        textSelection: NSRange? = nil
     ) -> CaretGeometryResult? {
+        let selectionInTextValue = textSelection ?? selection
+
         // Branch 1: Zero-length BoundsForRange at the caret position — ideal case.
         // Gated on `supportsBoundsForRange` because the API is a synchronous cross-process
         // call into the focused app's AX implementation. In Chrome that's a round-trip into
@@ -123,7 +126,7 @@ struct AXTextGeometryResolver {
         if let parentText = textValue, !parentText.isEmpty {
             if let result = resolveCaretFromChildTextRuns(
                 element: element,
-                parentSelection: selection,
+                parentSelection: selectionInTextValue,
                 parentText: parentText
             ) {
                 return result
@@ -138,7 +141,7 @@ struct AXTextGeometryResolver {
                 let estimatedX = conservativeEstimatedCaretX(
                     in: cocoaRect,
                     text: text,
-                    selection: selection
+                    selection: selectionInTextValue
                 )
                 let clampedX = min(estimatedX, cocoaRect.maxX)
                 return CaretGeometryResult(

--- a/Cotabby/Services/Focus/FocusSnapshotResolver.swift
+++ b/Cotabby/Services/Focus/FocusSnapshotResolver.swift
@@ -14,6 +14,13 @@ struct FocusSnapshotResolver {
     /// Throttle window for the deep caret BFS. ~100ms keeps the walk off the per-keystroke hot path
     /// in Chromium editors while staying short enough that caret lag during fast typing stays minor.
     private static let deepWalkThrottleInterval: TimeInterval = 0.1
+    /// Maximum UTF-16 units kept on each side of the caret in focus snapshots.
+    ///
+    /// The prompt builder uses a much smaller suffix of `precedingText`, and autocomplete only needs
+    /// a short trailing window for normalization. Keeping the focus snapshot bounded prevents a
+    /// large editor buffer from flowing through equality checks, Combine publishes, and stale-result
+    /// signatures on every AX refresh.
+    private static let focusedTextContextWindowUTF16 = 4096
 
     /// Carries deep-walk throttle state across the value-typed resolver's non-mutating polls.
     private let deepWalkThrottle = DeepGeometryWalkThrottle()
@@ -74,30 +81,25 @@ struct FocusSnapshotResolver {
         // apps we additionally search descendants for the editable node.
         let deepDescendants = BrowserAppDetector.needsWebAccessibilityPriming(
             bundleIdentifier: bundleIdentifier)
-        let candidates = candidateElements(
-            around: focusedElement, deepDescendants: deepDescendants
-        ).map {
-            candidateSnapshot(for: $0, bundleIdentifier: bundleIdentifier)
-        }
-        let resolution = FocusCapabilityResolver.resolve(
-            candidates: candidates.map(\.resolverCandidate))
-        let selectedCandidate = resolution.bestDiagnosticCandidate.flatMap { candidate in
-            candidates.first(where: { $0.elementIdentifier == candidate.elementIdentifier })
-        }
+        let candidateResolution = resolveCandidate(
+            around: focusedElement,
+            bundleIdentifier: bundleIdentifier,
+            deepDescendants: deepDescendants
+        )
+        let resolution = candidateResolution.resolution
+        let diagnosticCandidate = candidateResolution.diagnosticCandidate
         let inspection = FocusInspectionSnapshot(
             focusedElementIdentifier: focusedElementIdentifier,
             focusedRole: focusedRole,
             focusedSubrole: focusedSubrole,
-            resolvedElementIdentifier: selectedCandidate?.elementIdentifier,
-            resolvedRole: selectedCandidate?.role,
-            resolvedSubrole: selectedCandidate?.subrole,
+            resolvedElementIdentifier: diagnosticCandidate?.elementIdentifier,
+            resolvedRole: diagnosticCandidate?.role,
+            resolvedSubrole: diagnosticCandidate?.subrole,
             missingCapabilities: resolution.resolvedCandidate == nil
                 ? resolution.missingCapabilities : []
         )
 
-        guard let resolvedCandidate = selectedCandidate,
-            resolution.resolvedCandidate != nil
-        else {
+        guard let resolvedCandidate = candidateResolution.resolvedCandidate else {
             CotabbyLogger.focus.trace("Focus unsupported in \(applicationName): \(resolution.unsupportedReason)")
             return FocusSnapshot(
                 applicationName: applicationName,
@@ -194,9 +196,10 @@ struct FocusSnapshotResolver {
         let caretQuality = caret.quality
         let observedCharWidth = caret.observedCharWidth
 
-        let nsValue = value as NSString
-        let safeSelectionLocation = min(selection.location, nsValue.length)
-        let trailingStart = min(selection.location + selection.length, nsValue.length)
+        let contextWindow = boundedContextWindow(text: value, selection: selection)
+        let nsValue = contextWindow.text as NSString
+        let safeSelectionLocation = min(contextWindow.selection.location, nsValue.length)
+        let trailingStart = min(contextWindow.selection.location + contextWindow.selection.length, nsValue.length)
         let context = FocusedInputSnapshot(
             applicationName: applicationName,
             bundleIdentifier: bundleIdentifier,
@@ -211,7 +214,7 @@ struct FocusSnapshotResolver {
             observedCharWidth: observedCharWidth,
             precedingText: nsValue.substring(to: safeSelectionLocation),
             trailingText: nsValue.substring(from: trailingStart),
-            selection: selection,
+            selection: contextWindow.selection,
             isSecure: resolvedCandidate.isSecure,
             focusChangeSequence: focusChangeSequence
         )
@@ -242,6 +245,84 @@ struct FocusSnapshotResolver {
             capability: .supported,
             context: context,
             inspection: inspection
+        )
+    }
+
+    /// Resolves candidate elements lazily and stops as soon as the first fully capable editable
+    /// target is found.
+    ///
+    /// The old eager map built an `AXFocusCandidate` for every nearby Chromium node before asking
+    /// `FocusCapabilityResolver` to pick the first supported one. In large web editors that meant
+    /// reading text/selection/caret data from many wrapper and static-text nodes even after the real
+    /// input target had already been discovered. This preserves the resolver's "first full
+    /// capability wins" policy while avoiding unnecessary synchronous AX IPC.
+    private func resolveCandidate(
+        around focusedElement: AXUIElement,
+        bundleIdentifier: String,
+        deepDescendants: Bool
+    ) -> FocusCandidateResolution {
+        var bestPartial: (candidate: AXFocusCandidate, evaluation: FocusCapabilityCandidateEvaluation)?
+        var inspectedCount = 0
+
+        for element in candidateElements(around: focusedElement, deepDescendants: deepDescendants) {
+            inspectedCount += 1
+            let candidate = candidateSnapshot(for: element, bundleIdentifier: bundleIdentifier)
+            let evaluation = FocusCapabilityResolver.evaluate(candidate.resolverCandidate)
+
+            if evaluation.hasFullCapabilities {
+                return FocusCandidateResolution(
+                    resolvedCandidate: candidate,
+                    diagnosticCandidate: candidate,
+                    resolution: FocusCapabilityResolution(
+                        selectedEvaluation: evaluation,
+                        inspectedCandidateCount: inspectedCount
+                    )
+                )
+            }
+
+            if bestPartial == nil || evaluation.score > bestPartial!.evaluation.score {
+                bestPartial = (candidate, evaluation)
+            }
+        }
+
+        return FocusCandidateResolution(
+            resolvedCandidate: nil,
+            diagnosticCandidate: bestPartial?.candidate,
+            resolution: FocusCapabilityResolution(
+                selectedEvaluation: bestPartial?.evaluation,
+                inspectedCandidateCount: inspectedCount
+            )
+        )
+    }
+
+    /// Returns a caret-adjacent text window and rewrites `selection` into that window's coordinate
+    /// space. `NSRange` is UTF-16 based, so all slicing goes through `NSString`.
+    private func boundedContextWindow(text: String, selection: NSRange) -> (text: String, selection: NSRange) {
+        let nsText = text as NSString
+        guard nsText.length > 0 else {
+            return (text, NSRange(location: 0, length: 0))
+        }
+
+        let safeLocation = min(max(selection.location, 0), nsText.length)
+        let requestedEnd = selection.location > Int.max - selection.length
+            ? Int.max
+            : selection.location + selection.length
+        let safeEnd = min(max(requestedEnd, safeLocation), nsText.length)
+        let beforeStart = max(0, safeLocation - Self.focusedTextContextWindowUTF16)
+        let afterEnd = min(nsText.length, safeEnd + Self.focusedTextContextWindowUTF16)
+        let rawWindow = NSRange(location: beforeStart, length: afterEnd - beforeStart)
+        let composedWindow = nsText.rangeOfComposedCharacterSequences(for: rawWindow)
+        let windowText = nsText.substring(with: composedWindow)
+
+        let adjustedLocation = max(0, safeLocation - composedWindow.location)
+        let adjustedLength = min(
+            safeEnd - safeLocation,
+            max(0, composedWindow.length - adjustedLocation)
+        )
+
+        return (
+            windowText,
+            NSRange(location: adjustedLocation, length: adjustedLength)
         )
     }
 
@@ -343,6 +424,9 @@ struct FocusSnapshotResolver {
         let role = AXHelper.stringValue(for: kAXRoleAttribute as CFString, on: element) ?? ""
         if AXHelper.isKnownEditableRole(role) {
             return true
+        }
+        if AXHelper.isKnownReadOnlyRole(role) {
+            return false
         }
         let attributes = Set(AXHelper.attributeNames(on: element))
         if attributes.contains("AXSelectedTextMarkerRange")
@@ -490,8 +574,18 @@ struct FocusSnapshotResolver {
             supportedAttributes.contains("AXEditable")
             ? AXHelper.boolValue(for: "AXEditable" as CFString, on: element)
             : nil
+        let editableHintScore = AXHelper.editabilityHintScore(
+            role: role,
+            explicitEditableFlag: explicitEditableFlag
+        )
+        let hasStrongEditabilitySignal = AXHelper.hasStrongEditabilitySignal(
+            role: role,
+            explicitEditableFlag: explicitEditableFlag
+        )
+        let isKnownReadOnlyRole = AXHelper.isKnownReadOnlyRole(role)
+        let canBeEditableTarget = hasStrongEditabilitySignal && !isKnownReadOnlyRole
         let nativeSelection =
-            supportedAttributes.contains(kAXSelectedTextRangeAttribute as String)
+            canBeEditableTarget && supportedAttributes.contains(kAXSelectedTextRangeAttribute as String)
             ? AXHelper.rangeValue(for: kAXSelectedTextRangeAttribute as CFString, on: element)
             : nil
 
@@ -500,19 +594,28 @@ struct FocusSnapshotResolver {
         // so they would otherwise fail the capability gate for a missing selection. Synthesize an
         // NSRange + caret-windowed text from the markers, but only when the native range is absent.
         let markerSelection =
-            nativeSelection == nil
+            canBeEditableTarget && nativeSelection == nil
             ? AXHelper.synthesizeMarkerSelection(
                 on: element, parameterizedAttributes: supportedParameterizedAttributes)
             : nil
-        let selection = nativeSelection ?? markerSelection?.selection
 
+        let nativeTextSelection = nativeSelection.flatMap {
+            nativeTextWindow(
+                on: element,
+                selection: $0,
+                supportedAttributes: supportedAttributes,
+                supportedParameterizedAttributes: supportedParameterizedAttributes
+            )
+        }
         // Prefer the marker-windowed text when we synthesized one so `selection` (window-relative)
-        // and `textValue` stay consistent; otherwise read the native value.
-        let textValue =
-            markerSelection?.text
-            ?? (supportedAttributes.contains(kAXValueAttribute as String)
-                ? AXHelper.stringValue(for: kAXValueAttribute as CFString, on: element)
-                : nil)
+        // and `textValue` stay consistent; otherwise use a bounded native text window when the host
+        // supports `AXStringForRange`, falling back to the full value for older/native controls.
+        let textSelection = markerSelection.map {
+            AXTextSelection(text: $0.text, selection: $0.selection)
+        } ?? nativeTextSelection
+        let selection = textSelection?.selection
+        let selectionForGeometry = nativeSelection ?? markerSelection?.selection
+        let textValue = textSelection?.text
 
         if let markerSelection {
             let textLength = (markerSelection.text as NSString).length
@@ -554,19 +657,21 @@ struct FocusSnapshotResolver {
                 height: currentFrame.height
             )
         }
-        let caretResult = selection.flatMap {
+        let caretResult = selectionForGeometry.flatMap {
             geometryResolver.resolveCaretRect(
                 for: element,
                 selection: $0,
                 // A marker-synthesized selection's location is window-relative, not a document
-                // offset, so NSRange-based BoundsForRange would resolve the wrong caret. Disable it
-                // for those so resolution falls to the text-marker geometry path (Branch 1.5).
+                // offset, so NSRange-based BoundsForRange would resolve the wrong caret. Native
+                // selections keep their document offset here, while `textSelection` below carries
+                // the bounded-window offset for text-based geometry fallbacks.
                 supportsBoundsForRange: markerSelection == nil
                     && supportedParameterizedAttributes.contains(
                         kAXBoundsForRangeParameterizedAttribute as String),
                 supportsFrame: supportedAttributes.contains("AXFrame"),
                 cocoaAnchorFrame: inputFrameRect,
-                textValue: textValue
+                textValue: textValue,
+                textSelection: selection
             )
         }
         let caretRect = caretResult?.rect
@@ -578,11 +683,9 @@ struct FocusSnapshotResolver {
             elementIdentifier: elementIdentifier,
             role: role,
             subrole: subrole,
-            editableHintScore: AXHelper.editabilityHintScore(
-                role: role, explicitEditableFlag: explicitEditableFlag),
-            hasStrongEditabilitySignal: AXHelper.hasStrongEditabilitySignal(
-                role: role, explicitEditableFlag: explicitEditableFlag),
-            isKnownReadOnlyRole: AXHelper.isKnownReadOnlyRole(role),
+            editableHintScore: editableHintScore,
+            hasStrongEditabilitySignal: hasStrongEditabilitySignal,
+            isKnownReadOnlyRole: isKnownReadOnlyRole,
             hasTextValue: textValue != nil,
             hasSelectionRange: selection != nil,
             hasCaretBounds: caretRect != nil,
@@ -602,6 +705,94 @@ struct FocusSnapshotResolver {
             inputFrameRect: inputFrameRect,
             isSecure: isSecure,
             resolverCandidate: resolverCandidate
+        )
+    }
+
+    /// Reads the smallest native text window the host can provide around the current selection.
+    ///
+    /// `AXStringForRange` is the important fast path for large Chrome and WebKit fields: instead of
+    /// pulling the whole `AXValue`, we ask for at most `focusedTextContextWindowUTF16` units before
+    /// and after the caret. Apps that do not expose the parameterized string API still fall back to
+    /// `AXValue`, preserving compatibility.
+    private func nativeTextWindow(
+        on element: AXUIElement,
+        selection: NSRange,
+        supportedAttributes: Set<String>,
+        supportedParameterizedAttributes: Set<String>
+    ) -> AXTextSelection? {
+        func fullTextSelection() -> AXTextSelection? {
+            guard supportedAttributes.contains(kAXValueAttribute as String),
+                  let value = AXHelper.stringValue(for: kAXValueAttribute as CFString, on: element)
+            else {
+                return nil
+            }
+
+            return AXTextSelection(text: value, selection: selection)
+        }
+
+        guard supportedParameterizedAttributes.contains(kAXStringForRangeParameterizedAttribute as String),
+              supportedAttributes.contains(kAXNumberOfCharactersAttribute as String),
+              let rawDocumentLength = AXHelper.intValue(
+                  for: kAXNumberOfCharactersAttribute as CFString,
+                  on: element
+              ),
+              rawDocumentLength >= 0
+        else {
+            return fullTextSelection()
+        }
+
+        let documentLength = rawDocumentLength
+        let safeLocation = min(max(selection.location, 0), documentLength)
+        let requestedEnd = selection.location > Int.max - selection.length
+            ? Int.max
+            : selection.location + selection.length
+        let safeEnd = min(max(requestedEnd, safeLocation), documentLength)
+
+        let beforeLength = min(safeLocation, Self.focusedTextContextWindowUTF16)
+        let beforeStart = safeLocation - beforeLength
+        let afterStart = safeEnd
+        let afterLength = min(max(documentLength - afterStart, 0), Self.focusedTextContextWindowUTF16)
+
+        guard let beforeText = AXHelper.parameterizedStringValue(
+            for: kAXStringForRangeParameterizedAttribute as CFString,
+            range: NSRange(location: beforeStart, length: beforeLength),
+            on: element
+        ) else {
+            return fullTextSelection()
+        }
+
+        let selectedText: String
+        if safeEnd > safeLocation {
+            guard let nativeSelectedText = AXHelper.parameterizedStringValue(
+                for: kAXStringForRangeParameterizedAttribute as CFString,
+                range: NSRange(location: safeLocation, length: safeEnd - safeLocation),
+                on: element
+            ) else {
+                return fullTextSelection()
+            }
+            selectedText = nativeSelectedText
+        } else {
+            selectedText = ""
+        }
+
+        let trailingText: String
+        if afterLength > 0 {
+            trailingText = AXHelper.parameterizedStringValue(
+                for: kAXStringForRangeParameterizedAttribute as CFString,
+                range: NSRange(location: afterStart, length: afterLength),
+                on: element
+            ) ?? ""
+        } else {
+            trailingText = ""
+        }
+
+        let text = beforeText + selectedText + trailingText
+        return AXTextSelection(
+            text: text,
+            selection: NSRange(
+                location: (beforeText as NSString).length,
+                length: (selectedText as NSString).length
+            )
         )
     }
 
@@ -793,6 +984,17 @@ final class DeepGeometryWalkThrottle {
         cachedResult = result
         return result
     }
+}
+
+private struct FocusCandidateResolution {
+    let resolvedCandidate: AXFocusCandidate?
+    let diagnosticCandidate: AXFocusCandidate?
+    let resolution: FocusCapabilityResolution
+}
+
+private struct AXTextSelection {
+    let text: String
+    let selection: NSRange
 }
 
 /// AX data read from one candidate element near the current focus.

--- a/Cotabby/Support/AXHelper.swift
+++ b/Cotabby/Support/AXHelper.swift
@@ -98,6 +98,14 @@ enum AXHelper {
         return number.boolValue
     }
 
+    static func intValue(for attribute: CFString, on element: AXUIElement) -> Int? {
+        guard let number = copyAttributeValue(attribute, on: element) as? NSNumber else {
+            return nil
+        }
+
+        return number.intValue
+    }
+
     /// Converts loosely typed Accessibility values into `AXValue` only after verifying the Core
     /// Foundation type id. This keeps the unsafe CF boundary in one place and avoids force casts in
     /// the higher-level helpers below.
@@ -163,6 +171,38 @@ enum AXHelper {
         }
 
         return rect
+    }
+
+    /// Reads a parameterized string range without asking the host app to serialize the whole field.
+    ///
+    /// Large browser editors can expose many thousands of characters through `AXValue`. Pulling the
+    /// entire value on every focus refresh is expensive because each read is synchronous IPC into
+    /// the host process. `AXStringForRange` lets callers request only the caret-adjacent window that
+    /// autocomplete actually needs, while preserving the normal full-value fallback for apps that
+    /// do not implement the parameterized string API.
+    static func parameterizedStringValue(
+        for attribute: CFString,
+        range: NSRange,
+        on element: AXUIElement
+    ) -> String? {
+        var cfRange = CFRange(location: range.location, length: range.length)
+        guard let parameter = AXValueCreate(.cfRange, &cfRange) else {
+            return nil
+        }
+
+        var value: CFTypeRef?
+        let result = AXUIElementCopyParameterizedAttributeValue(element, attribute, parameter, &value)
+        guard result == .success, let value else { return nil }
+
+        if let string = value as? String {
+            return string
+        }
+
+        if let attributedString = value as? NSAttributedString {
+            return attributedString.string
+        }
+
+        return nil
     }
 
     /// Some applications (like Chromium and WebKit browsers) do not properly support `AXBoundsForRange`


### PR DESCRIPTION
## Summary

Fixes the high CPU and typing lag seen in large text fields by coalescing stale host-publish polling chains and bounding Accessibility text reads around the caret. The focus resolver now stops after the first fully capable editable candidate and uses `AXStringForRange` when available instead of pulling the full field value on every refresh.

## Validation

- `git diff --check`
  - exit 0
- `xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build-for-testing -derivedDataPath build/DerivedData`\n  - ** TEST BUILD SUCCEEDED **\n\n## Linked issues\n\nNone.\n\n## Risk / rollout notes\n\n- Touches the AX focus snapshot hot path, so the main regression risk is host-specific focus/caret behavior. Compatibility fallback to full `AXValue` remains for apps that do not expose `AXStringForRange`.\n- Focus snapshots now keep a bounded caret-adjacent text window instead of carrying an entire large editor buffer. The prompt builder already uses a shorter context, so user-facing completions should stay the same while large fields get much cheaper refreshes.\n

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tackles AX-polling CPU overhead and typing lag in large text fields through two complementary strategies: coalescing stale polling chains with a monotonic `hostPublishPollGeneration` token, and bounding AX text reads to a `±4096` UTF-16 unit window around the caret via `AXStringForRange` (with a full-value fallback for hosts that don't support it).

- **Poll coalescing** (`SuggestionCoordinator+Input/Prediction`): each new keystroke increments `hostPublishPollGeneration`, making any older polling chain no-op on its next guard check; `cancelPredictionWork` now also bumps the token so cancellation is atomic with work teardown.
- **Lazy candidate resolution** (`FocusSnapshotResolver.resolveCandidate`): replaces the eager map-then-pick approach with an early-exit loop that stops snapshotting AX elements once the first fully capable editable is found, avoiding expensive IPC on wrapper and static-text nodes in large Chromium editors.
- **Bounded text reads** (`nativeTextWindow` + `boundedContextWindow`): `candidateSnapshot` now calls `nativeTextWindow`, which issues up to three bounded `AXStringForRange` IPC calls for the before/selected/trailing text slices and assembles a window-relative `NSRange`; the full `AXValue` path remains as a compatibility fallback; `boundedContextWindow` provides a second bounding pass for hosts that only expose `AXValue`.

<h3>Confidence Score: 4/5</h3>

Safe to merge with awareness of two edge-case caveats in the new bounded-text path.

The poll-coalescing and lazy-resolution changes are well-structured and clearly improve throughput on the hot path. The `nativeTextWindow` bounded-read path introduces two edge cases: (1) `kAXNumberOfCharactersAttribute` may return a code-point count rather than a UTF-16 unit count in some hosts, silently clamping the window bounds for documents containing emoji; and (2) the `selectionChanged` comparison in `pollForHostPublish` is effectively disabled for large documents because `selection.location` is window-relative and capped at 4096. Both have working fallbacks, so neither blocks correctness today.

`FocusSnapshotResolver.swift` — specifically the `nativeTextWindow` helper and its use of `kAXNumberOfCharactersAttribute` as a UTF-16 boundary, and the downstream effect on `selectionChanged` comparisons in the polling loop.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift | Adds `hostPublishPollGeneration` token to coalesce stale polling chains; skips the guaranteed-stale immediate AX read; simplifies `interval` logic since the first delay is now handled by `asyncAfter`. |
| Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift | Increments `hostPublishPollGeneration` in `cancelPredictionWork` so any in-flight polling chain is cancelled atomically with work cancellation. |
| Cotabby/App/Coordinators/SuggestionCoordinator.swift | Declares `hostPublishPollGeneration: UInt64 = 0` with clear doc-comment; straightforward addition to existing coordinator state. |
| Cotabby/Services/Focus/FocusSnapshotResolver.swift | Core performance changes: lazy candidate resolution (stops at first fully-capable element), `nativeTextWindow` for bounded `AXStringForRange` reads, and `boundedContextWindow` for full-value fallback. Several edge cases around UTF-16/character count mismatch and window-relative selection offsets in the polling baseline warrant attention. |
| Cotabby/Services/Focus/AXTextGeometryResolver.swift | Adds `textSelection` parameter to `resolveCaretRect` so text-based fallback branches (child text runs, AXFrame estimate) use the window-relative offset instead of the document-absolute selection; document-absolute `selection` is still passed for BoundsForRange queries. |
| Cotabby/Support/AXHelper.swift | Adds `intValue(for:on:)` and `parameterizedStringValue(for:range:on:)` helpers; mirrors the existing pattern for other AX attribute readers with safe CF type handling and NSAttributedString fallback. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant ET as EventTap
    participant SC as SuggestionCoordinator
    participant FM as FocusModel
    participant FSR as FocusSnapshotResolver
    participant AX as AX IPC (Host App)

    ET->>SC: keystroke received
    SC->>SC: "hostPublishPollGeneration &+= 1 (gen=N)"
    SC->>SC: asyncAfter(firstPollIntervalMs)
    note over SC: older chains with gen < N exit on guard check
    SC->>FM: refreshNow()
    FM->>FSR: snapshot(focusedElement:)
    FSR->>FSR: resolveCandidate() — lazy loop
    FSR->>AX: candidateSnapshot (element 1)
    alt hasFullCapabilities
        FSR-->>FSR: early return (stop iterating)
    else partial only
        FSR->>AX: candidateSnapshot (element 2..N)
    end
    alt supports AXStringForRange
        FSR->>AX: AXNumberOfCharacters
        FSR->>AX: AXStringForRange [beforeStart, caretPos)
        FSR->>AX: AXStringForRange [caretPos, safeEnd)
        FSR->>AX: AXStringForRange [safeEnd, safeEnd+4096)
        FSR-->>FM: AXTextSelection (window-relative)
    else fallback
        FSR->>AX: AXValue (full text)
        FSR-->>FM: AXTextSelection (boundedContextWindow applied)
    end
    FM-->>SC: snapshot with bounded precedingText / trailingText
    alt textChanged or selectionChanged
        SC->>SC: schedulePrediction()
    else below ceiling
        SC->>SC: asyncAfter(pollIntervalMs) — same gen N
    else ceiling hit
        SC->>SC: schedulePrediction() (fallback)
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift`, line 251-270 ([link](https://github.com/fujacob/cotabby/blob/938783f2f9959fb16a310c1fd47180ce65ea578c/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift#L251-L270)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`selectionChanged` is permanently `false` for large documents**

   `selection.location` in the focus snapshot is now window-relative and capped at `focusedTextContextWindowUTF16` (4096). For any document where the caret sits more than 4096 UTF-16 units from the start, both the baseline value captured at keystroke time and the value read on every subsequent poll will equal 4096, so `selectionChanged` is never `true`. Text mutations still fire `textChanged` (the window content shifts by one character on each poll after the host publishes), so predictions are not lost; but a pure cursor-movement event that coincidentally reaches `pollForHostPublish` in a large document will no longer be detected via the selection shortcut and must wait out `hostPublishWaitCeilingMs` before triggering `schedulePrediction`.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22codex%2Ffix-large-text-field-lag%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ffix-large-text-field-lag%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BInput.swift%0ALine%3A%20251-270%0A%0AComment%3A%0A**%60selectionChanged%60%20is%20permanently%20%60false%60%20for%20large%20documents**%0A%0A%60selection.location%60%20in%20the%20focus%20snapshot%20is%20now%20window-relative%20and%20capped%20at%20%60focusedTextContextWindowUTF16%60%20%284096%29.%20For%20any%20document%20where%20the%20caret%20sits%20more%20than%204096%20UTF-16%20units%20from%20the%20start%2C%20both%20the%20baseline%20value%20captured%20at%20keystroke%20time%20and%20the%20value%20read%20on%20every%20subsequent%20poll%20will%20equal%204096%2C%20so%20%60selectionChanged%60%20is%20never%20%60true%60.%20Text%20mutations%20still%20fire%20%60textChanged%60%20%28the%20window%20content%20shifts%20by%20one%20character%20on%20each%20poll%20after%20the%20host%20publishes%29%2C%20so%20predictions%20are%20not%20lost%3B%20but%20a%20pure%20cursor-movement%20event%20that%20coincidentally%20reaches%20%60pollForHostPublish%60%20in%20a%20large%20document%20will%20no%20longer%20be%20detected%20via%20the%20selection%20shortcut%20and%20must%20wait%20out%20%60hostPublishWaitCeilingMs%60%20before%20triggering%20%60schedulePrediction%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BInput.swift%0ALine%3A%20251-270%0A%0AComment%3A%0A**%60selectionChanged%60%20is%20permanently%20%60false%60%20for%20large%20documents**%0A%0A%60selection.location%60%20in%20the%20focus%20snapshot%20is%20now%20window-relative%20and%20capped%20at%20%60focusedTextContextWindowUTF16%60%20%284096%29.%20For%20any%20document%20where%20the%20caret%20sits%20more%20than%204096%20UTF-16%20units%20from%20the%20start%2C%20both%20the%20baseline%20value%20captured%20at%20keystroke%20time%20and%20the%20value%20read%20on%20every%20subsequent%20poll%20will%20equal%204096%2C%20so%20%60selectionChanged%60%20is%20never%20%60true%60.%20Text%20mutations%20still%20fire%20%60textChanged%60%20%28the%20window%20content%20shifts%20by%20one%20character%20on%20each%20poll%20after%20the%20host%20publishes%29%2C%20so%20predictions%20are%20not%20lost%3B%20but%20a%20pure%20cursor-movement%20event%20that%20coincidentally%20reaches%20%60pollForHostPublish%60%20in%20a%20large%20document%20will%20no%20longer%20be%20detected%20via%20the%20selection%20shortcut%20and%20must%20wait%20out%20%60hostPublishWaitCeilingMs%60%20before%20triggering%20%60schedulePrediction%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=472&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22codex%2Ffix-large-text-field-lag%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ffix-large-text-field-lag%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FServices%2FFocus%2FFocusSnapshotResolver.swift%3A733-745%0A**%60kAXNumberOfCharactersAttribute%60%20may%20count%20code%20points%2C%20not%20UTF-16%20units**%0A%0A%60AXNumberOfCharacters%60%20is%20documented%20as%20%22number%20of%20characters%22%2C%20which%20some%20hosts%20%28especially%20web%20content%20processes%29%20interpret%20as%20Unicode%20code%20points%20rather%20than%20UTF-16%20code%20units%20%28what%20%60NSRange%60%20and%20%60NSString.length%60%20use%29.%20For%20a%20document%20whose%20text%20contains%20surrogate%20pairs%20%E2%80%94%20any%20emoji%20or%20supplementary%20character%20%E2%80%94%20the%20code-point%20count%20will%20be%20smaller%20than%20the%20UTF-16%20count.%20This%20causes%20%60safeLocation%20%3D%20min%28selection.location%2C%20documentLength%29%60%20to%20silently%20clamp%20a%20valid%20UTF-16%20caret%20offset%20to%20a%20shorter%20bound%2C%20producing%20a%20window%20that%20ends%20earlier%20in%20the%20text%20than%20intended%20without%20triggering%20the%20%60fullTextSelection%28%29%60%20fallback.%20The%20window%20text%20is%20then%20correct%20%28whatever%20%60AXStringForRange%60%20returns%20for%20the%20clamped%20range%29%2C%20but%20the%20window-relative%20selection%20offset%20computed%20from%20%60%28beforeText%20as%20NSString%29.length%60%20may%20no%20longer%20agree%20with%20the%20actual%20caret%20position%20within%20that%20text.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BInput.swift%3A251-270%0A**%60selectionChanged%60%20is%20permanently%20%60false%60%20for%20large%20documents**%0A%0A%60selection.location%60%20in%20the%20focus%20snapshot%20is%20now%20window-relative%20and%20capped%20at%20%60focusedTextContextWindowUTF16%60%20%284096%29.%20For%20any%20document%20where%20the%20caret%20sits%20more%20than%204096%20UTF-16%20units%20from%20the%20start%2C%20both%20the%20baseline%20value%20captured%20at%20keystroke%20time%20and%20the%20value%20read%20on%20every%20subsequent%20poll%20will%20equal%204096%2C%20so%20%60selectionChanged%60%20is%20never%20%60true%60.%20Text%20mutations%20still%20fire%20%60textChanged%60%20%28the%20window%20content%20shifts%20by%20one%20character%20on%20each%20poll%20after%20the%20host%20publishes%29%2C%20so%20predictions%20are%20not%20lost%3B%20but%20a%20pure%20cursor-movement%20event%20that%20coincidentally%20reaches%20%60pollForHostPublish%60%20in%20a%20large%20document%20will%20no%20longer%20be%20detected%20via%20the%20selection%20shortcut%20and%20must%20wait%20out%20%60hostPublishWaitCeilingMs%60%20before%20triggering%20%60schedulePrediction%60.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FServices%2FFocus%2FFocusSnapshotResolver.swift%3A733-745%0A**%60kAXNumberOfCharactersAttribute%60%20may%20count%20code%20points%2C%20not%20UTF-16%20units**%0A%0A%60AXNumberOfCharacters%60%20is%20documented%20as%20%22number%20of%20characters%22%2C%20which%20some%20hosts%20%28especially%20web%20content%20processes%29%20interpret%20as%20Unicode%20code%20points%20rather%20than%20UTF-16%20code%20units%20%28what%20%60NSRange%60%20and%20%60NSString.length%60%20use%29.%20For%20a%20document%20whose%20text%20contains%20surrogate%20pairs%20%E2%80%94%20any%20emoji%20or%20supplementary%20character%20%E2%80%94%20the%20code-point%20count%20will%20be%20smaller%20than%20the%20UTF-16%20count.%20This%20causes%20%60safeLocation%20%3D%20min%28selection.location%2C%20documentLength%29%60%20to%20silently%20clamp%20a%20valid%20UTF-16%20caret%20offset%20to%20a%20shorter%20bound%2C%20producing%20a%20window%20that%20ends%20earlier%20in%20the%20text%20than%20intended%20without%20triggering%20the%20%60fullTextSelection%28%29%60%20fallback.%20The%20window%20text%20is%20then%20correct%20%28whatever%20%60AXStringForRange%60%20returns%20for%20the%20clamped%20range%29%2C%20but%20the%20window-relative%20selection%20offset%20computed%20from%20%60%28beforeText%20as%20NSString%29.length%60%20may%20no%20longer%20agree%20with%20the%20actual%20caret%20position%20within%20that%20text.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BInput.swift%3A251-270%0A**%60selectionChanged%60%20is%20permanently%20%60false%60%20for%20large%20documents**%0A%0A%60selection.location%60%20in%20the%20focus%20snapshot%20is%20now%20window-relative%20and%20capped%20at%20%60focusedTextContextWindowUTF16%60%20%284096%29.%20For%20any%20document%20where%20the%20caret%20sits%20more%20than%204096%20UTF-16%20units%20from%20the%20start%2C%20both%20the%20baseline%20value%20captured%20at%20keystroke%20time%20and%20the%20value%20read%20on%20every%20subsequent%20poll%20will%20equal%204096%2C%20so%20%60selectionChanged%60%20is%20never%20%60true%60.%20Text%20mutations%20still%20fire%20%60textChanged%60%20%28the%20window%20content%20shifts%20by%20one%20character%20on%20each%20poll%20after%20the%20host%20publishes%29%2C%20so%20predictions%20are%20not%20lost%3B%20but%20a%20pure%20cursor-movement%20event%20that%20coincidentally%20reaches%20%60pollForHostPublish%60%20in%20a%20large%20document%20will%20no%20longer%20be%20detected%20via%20the%20selection%20shortcut%20and%20must%20wait%20out%20%60hostPublishWaitCeilingMs%60%20before%20triggering%20%60schedulePrediction%60.%0A%0A&repo=fujacob%2Fcotabby&pr=472&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Fix large text field AX polling lag"](https://github.com/fujacob/cotabby/commit/938783f2f9959fb16a310c1fd47180ce65ea578c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34769951)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->