### PR TITLE
Add 2-4 word length preset (closes #475)

### DIFF
--- a/Cotabby/Models/OnboardingTemplate.swift
+++ b/Cotabby/Models/OnboardingTemplate.swift
@@ -70,7 +70,7 @@ enum OnboardingTemplate: String, CaseIterable, Identifiable, Equatable, Sendable
     var wordCountPreset: SuggestionWordCountPreset {
         switch self {
         case .quick:
-            return .threeToSeven
+            return .fourToSeven
         case .everyday:
             return .sevenToTwelve
         case .powerful:

--- a/Cotabby/Models/SuggestionModels.swift
+++ b/Cotabby/Models/SuggestionModels.swift
@@ -12,7 +12,8 @@ import Foundation
 /// User-facing presets that bound how long one inline suggestion may be.
 /// Treating this as an enum keeps the UI and prompt policy in one source of truth.
 enum SuggestionWordCountPreset: String, CaseIterable, Equatable, Hashable, Sendable, Identifiable {
-    case threeToSeven = "3-7"
+    case twoToFour = "2-4"
+    case fourToSeven = "4-7"
     case sevenToTwelve = "7-12"
     case twelveToTwenty = "12-20"
 
@@ -30,8 +31,10 @@ enum SuggestionWordCountPreset: String, CaseIterable, Equatable, Hashable, Senda
 
     var promptInstruction: String {
         switch self {
-        case .threeToSeven:
-            return "Return only the next 3 to 7 words."
+        case .twoToFour:
+            return "Return only the next 2 to 4 words."
+        case .fourToSeven:
+            return "Return only the next 4 to 7 words."
         case .sevenToTwelve:
             return "Return only the next 7 to 12 words."
         case .twelveToTwenty:
@@ -43,10 +46,12 @@ enum SuggestionWordCountPreset: String, CaseIterable, Equatable, Hashable, Senda
     /// word-range cue was removed), so it must track the upper word bound closely. Sized at
     /// ~1.5x the upper word count to leave headroom for multi-token words (contractions, proper
     /// nouns, punctuation) without overrunning the preset. The earlier 50% bump (17/27/45) let
-    /// completions blow past the setting — e.g. ~12 words on the 3-7 preset (#271).
+    /// completions blow past the setting, e.g. ~12 words on the shortest preset (#271).
     var suggestedPredictionTokenBudget: Int {
         switch self {
-        case .threeToSeven:
+        case .twoToFour:
+            return 6
+        case .fourToSeven:
             return 11
         case .sevenToTwelve:
             return 18

--- a/Cotabby/Models/SuggestionSettingsModel.swift
+++ b/Cotabby/Models/SuggestionSettingsModel.swift
@@ -88,6 +88,9 @@ final class SuggestionSettingsModel: ObservableObject {
     private static let ghostTextOpacityDefaultsKey = "cotabbyGhostTextOpacity"
     private static let selectedEngineDefaultsKey = "cotabbySelectedEngine"
     private static let selectedWordCountPresetDefaultsKey = "cotabbySelectedWordCountPreset"
+    /// Pre-#475 raw value for the shortest length tier. Kept here only so the read path can
+    /// rewrite it to `.fourToSeven` on launch; never re-emitted to UserDefaults.
+    private static let legacyShortPresetRawValue = "3-7"
     private static let clipboardContextEnabledDefaultsKey = "cotabbyClipboardContextEnabled"
     private static let fastModeEnabledDefaultsKey = "cotabbyFastModeEnabled"
     private static let performanceTrackingEnabledDefaultsKey = "cotabbyPerformanceTrackingEnabled"
@@ -170,10 +173,17 @@ final class SuggestionSettingsModel: ObservableObject {
             .string(forKey: Self.selectedEngineDefaultsKey)
             .flatMap(SuggestionEngineKind.init(rawValue:))
             ?? .llamaOpenSource
-        let resolvedWordCountPreset = userDefaults
-            .string(forKey: Self.selectedWordCountPresetDefaultsKey)
-            .flatMap(SuggestionWordCountPreset.init(rawValue:))
-            ?? configuration.defaultWordCountPreset
+        let resolvedWordCountPreset: SuggestionWordCountPreset = {
+            let storedRaw = userDefaults.string(forKey: Self.selectedWordCountPresetDefaultsKey)
+            // Migrate the retired "3-7" raw value to its replacement "4-7" so users who picked
+            // the short preset don't silently jump to the default after #475 split the short
+            // tier into 2-4 and 4-7.
+            if storedRaw == Self.legacyShortPresetRawValue {
+                return .fourToSeven
+            }
+            return storedRaw.flatMap(SuggestionWordCountPreset.init(rawValue:))
+                ?? configuration.defaultWordCountPreset
+        }()
         let resolvedClipboardContextEnabled =
             userDefaults.object(forKey: Self.clipboardContextEnabledDefaultsKey) as? Bool ?? false
         // Defaults to false so the visual-context pipeline keeps running for existing users; opting

--- a/CotabbyTests/ModelAndPresentationValueTests.swift
+++ b/CotabbyTests/ModelAndPresentationValueTests.swift
@@ -39,8 +39,11 @@ final class SuggestionTextColorCodecTests: XCTestCase {
 
 final class SuggestionModelValueTests: XCTestCase {
     func test_wordCountPresetsExposeMatchingPromptInstructionsAndTokenBudgets() {
-        XCTAssertEqual(SuggestionWordCountPreset.threeToSeven.promptInstruction, "Return only the next 3 to 7 words.")
-        XCTAssertEqual(SuggestionWordCountPreset.threeToSeven.suggestedPredictionTokenBudget, 11)
+        XCTAssertEqual(SuggestionWordCountPreset.twoToFour.promptInstruction, "Return only the next 2 to 4 words.")
+        XCTAssertEqual(SuggestionWordCountPreset.twoToFour.suggestedPredictionTokenBudget, 6)
+
+        XCTAssertEqual(SuggestionWordCountPreset.fourToSeven.promptInstruction, "Return only the next 4 to 7 words.")
+        XCTAssertEqual(SuggestionWordCountPreset.fourToSeven.suggestedPredictionTokenBudget, 11)
 
         XCTAssertEqual(SuggestionWordCountPreset.sevenToTwelve.promptInstruction, "Return only the next 7 to 12 words.")
         XCTAssertEqual(SuggestionWordCountPreset.sevenToTwelve.suggestedPredictionTokenBudget, 18)

--- a/CotabbyTests/OnboardingTemplateRecommenderTests.swift
+++ b/CotabbyTests/OnboardingTemplateRecommenderTests.swift
@@ -26,7 +26,7 @@ final class OnboardingTemplateRecommenderTests: XCTestCase {
 
     func testAppleIntelligenceStillCarriesTierBehaviorFlags() {
         let quick = OnboardingTemplateRecommender.resolvePlan(for: .quick, engine: .appleIntelligence)
-        XCTAssertEqual(quick.wordCountPreset, .threeToSeven)
+        XCTAssertEqual(quick.wordCountPreset, .fourToSeven)
         XCTAssertTrue(quick.enablesFastMode)
         XCTAssertFalse(quick.enablesMultiLine)
         XCTAssertFalse(quick.enablesClipboardContext)


### PR DESCRIPTION
## Summary

Adds a new "2-4 words" option to the suggestion length picker (settings + menu bar), as requested in #475. The previous "3-7" tier is renamed to "4-7" so the lower bound of each tier matches the upper bound of the previous tier, keeping the chain consistent with the existing 7-12 and 12-20 tiers. The 4-7 tier keeps the same 11-token budget the old 3-7 had, so its behavior is unchanged.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby \
  -destination 'platform=macOS' \
  -only-testing:CotabbyTests/SuggestionModelValueTests \
  -only-testing:CotabbyTests/OnboardingTemplateRecommenderTests \
  CODE_SIGNING_ALLOWED=NO
# ** TEST SUCCEEDED ** 19 tests, 0 failures

swiftlint lint --quiet Cotabby/Models/SuggestionModels.swift \
  Cotabby/Models/SuggestionSettingsModel.swift \
  Cotabby/Models/OnboardingTemplate.swift \
  CotabbyTests/ModelAndPresentationValueTests.swift \
  CotabbyTests/OnboardingTemplateRecommenderTests.swift
# exit 0
```

## Linked issues

Closes #475.

## Risk / rollout notes

- Persisted-settings migration: `SuggestionSettingsModel` now rewrites the legacy `"3-7"` raw value to `.fourToSeven` on launch. Without this users on the short tier would silently fall back to the default `12-20` after the rename, which would be a worse experience than the issue is trying to add.
- The "Quick" onboarding template now maps to `.fourToSeven` instead of `.threeToSeven`. Same token budget (11) and same upper word bound (7), so behavior is preserved for users completing onboarding after this lands. Deliberately did not retarget Quick to the new shorter `.twoToFour` to keep this PR scoped to the issue.
- Token budget for the new `.twoToFour` tier is 6 (matches the existing ~1.5x upper-bound rule documented in the enum).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new `2-4` word-count preset (`twoToFour`) to the suggestion length picker and renames the old `3-7` tier to `4-7` (`fourToSeven`) so tier boundaries chain cleanly. A UserDefaults migration in `SuggestionSettingsModel` silently upgrades any persisted `\"3-7\"` raw value to `.fourToSeven` on launch, preventing existing users from falling back to the default preset.

- **New enum case** `twoToFour = \"2-4\"` with a token budget of 6 (consistent with the ~1.5× upper-bound rule); `fourToSeven` inherits the old `threeToSeven` budget of 11.
- **Migration** reads the legacy `\"3-7\"` key and rewrites it to `\"4-7\"` in-process at init, then persists the new value — a one-shot, invisible upgrade.
- **Onboarding \"Quick\" template** re-targets to `.fourToSeven` (same token budget and upper word bound as before), keeping new-user behavior unchanged.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the enum rename, migration, and onboarding re-targeting are all correct and consistent.

The migration in SuggestionSettingsModel is the most sensitive part of the change — existing users who had selected the old shortest tier depend on it to land on .fourToSeven rather than the app default. The logic itself is correct, but there is no dedicated unit test exercising this UserDefaults upgrade path. If the guard were accidentally removed in a future refactor, the test suite would not catch it. Everything else — the enum, token budgets, onboarding template, and updated tests — is well-structured and internally consistent.

The migration block in SuggestionSettingsModel.swift (lines 176-186) would benefit from a companion test seeding "3-7" into an isolated UserDefaults suite and asserting the loaded preset is .fourToSeven.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Models/SuggestionModels.swift | Adds twoToFour = "2-4" and renames threeToSeven to fourToSeven = "4-7"; token budgets follow the ~1.5x upper-bound rule consistently (6, 11, 18, 30). |
| Cotabby/Models/SuggestionSettingsModel.swift | Adds a one-shot migration of the legacy "3-7" raw value to .fourToSeven at init time; the migration is correct but has no unit test covering the path. |
| Cotabby/Models/OnboardingTemplate.swift | Re-targets the Quick onboarding template from threeToSeven to fourToSeven; behavior is preserved as the token budget and upper word bound are unchanged. |
| CotabbyTests/ModelAndPresentationValueTests.swift | Adds assertions for both new/renamed presets (twoToFour and fourToSeven); exhaustively covers all four tiers' prompt instructions and token budgets. |
| CotabbyTests/OnboardingTemplateRecommenderTests.swift | Updates the Quick preset assertion from .threeToSeven to .fourToSeven; remaining test assertions are unchanged and still pass. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SuggestionSettingsModel init] --> B{Read UserDefaults selectedWordCountPreset}
    B -- nil --> E[Use configuration.defaultWordCountPreset]
    B -- storedRaw == 3-7 legacy --> C[Resolve to .fourToSeven]
    B -- valid current raw value --> D[Resolve via SuggestionWordCountPreset.init]
    B -- unknown invalid value --> E
    C --> F[persistSelectedWordCountPreset writes 4-7 back]
    D --> F
    E --> F
    F --> G[Published selectedWordCountPreset]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fword-count-2-4-preset%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fword-count-2-4-preset%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FModels%2FSuggestionSettingsModel.swift%3A176-186%0A**Missing%20test%20coverage%20for%20the%20%223-7%22%20migration%20path**%0A%0AThe%20migration%20of%20%60%223-7%22%60%20%E2%86%92%20%60.fourToSeven%60%20is%20described%20in%20the%20PR%20description%20as%20the%20most%20important%20rollout%20concern%20%28users%20silently%20jumping%20to%20the%20default%20preset%29%2C%20but%20there%20is%20no%20test%20that%20exercises%20this%20path%20in%20%60SuggestionSettingsModel%60.%20If%20someone%20accidentally%20removes%20or%20misplaces%20the%20%60if%20storedRaw%20%3D%3D%20%E2%80%A6%60%20guard%20in%20a%20future%20refactor%2C%20the%20test%20suite%20will%20still%20pass.%20The%20existing%20%60GhostTextOpacitySettingsTests%60%20already%20shows%20how%20to%20build%20an%20isolated%20%60UserDefaults%60%20suite%20and%20reload%20a%20%60SuggestionSettingsModel%60%3B%20the%20same%20pattern%20could%20seed%20%60%223-7%22%60%20into%20%60selectedWordCountPresetDefaultsKey%60%20and%20assert%20the%20model%20reads%20back%20%60.fourToSeven%60.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FModels%2FSuggestionSettingsModel.swift%3A176-186%0A**Missing%20test%20coverage%20for%20the%20%223-7%22%20migration%20path**%0A%0AThe%20migration%20of%20%60%223-7%22%60%20%E2%86%92%20%60.fourToSeven%60%20is%20described%20in%20the%20PR%20description%20as%20the%20most%20important%20rollout%20concern%20%28users%20silently%20jumping%20to%20the%20default%20preset%29%2C%20but%20there%20is%20no%20test%20that%20exercises%20this%20path%20in%20%60SuggestionSettingsModel%60.%20If%20someone%20accidentally%20removes%20or%20misplaces%20the%20%60if%20storedRaw%20%3D%3D%20%E2%80%A6%60%20guard%20in%20a%20future%20refactor%2C%20the%20test%20suite%20will%20still%20pass.%20The%20existing%20%60GhostTextOpacitySettingsTests%60%20already%20shows%20how%20to%20build%20an%20isolated%20%60UserDefaults%60%20suite%20and%20reload%20a%20%60SuggestionSettingsModel%60%3B%20the%20same%20pattern%20could%20seed%20%60%223-7%22%60%20into%20%60selectedWordCountPresetDefaultsKey%60%20and%20assert%20the%20model%20reads%20back%20%60.fourToSeven%60.%0A%0A&repo=fujacob%2Fcotabby&pr=480&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add 2-4 word length preset and re-bound ..."](https://github.com/fujacob/cotabby/commit/2407d5a82982d4371240dac6560d6b3c23092d75) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34809475)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->