### PR TITLE
Stop focus polling from dismissing Calendar's event popover (closes #476)

### DIFF
--- a/Cotabby/App/Core/CotabbyAppEnvironment.swift
+++ b/Cotabby/App/Core/CotabbyAppEnvironment.swift
@@ -64,9 +64,22 @@ final class CotabbyAppEnvironment {
         inputMonitor.onGlobalToggleHotkey = { [weak suggestionSettings] in
             suggestionSettings?.toggleGloballyEnabled()
         }
+        // Stop the deep AX walk when Cotabby is disabled for the focused app. Without this the
+        // focus poll keeps enumerating the frontmost app's AX attributes every 50-80ms even after
+        // the user toggles Cotabby off, which can dismiss transient popovers in apps like Calendar
+        // (#476). Gating here also makes the "I disabled it but the bug remained" symptom go away:
+        // the disable toggles now actually stop touching the focused app.
         let focusModel = FocusTrackingModel(
             permissionProvider: { permissionManager.accessibilityGranted },
             ignoredBundleIdentifier: Bundle.main.bundleIdentifier,
+            isCaptureSuppressedForBundle: { bundleIdentifier in
+                guard suggestionSettings.isGloballyEnabled else { return true }
+                if let bundleIdentifier,
+                   suggestionSettings.isApplicationDisabled(bundleIdentifier: bundleIdentifier) {
+                    return true
+                }
+                return false
+            },
             publishesPollingEvents: FocusDebugOverlayController.isEnabled
         )
         // The snapshot is poll-based, so after a fast app switch the closure may briefly

--- a/Cotabby/Models/FocusTrackingModel.swift
+++ b/Cotabby/Models/FocusTrackingModel.swift
@@ -20,12 +20,14 @@ final class FocusTrackingModel: ObservableObject {
     init(
         permissionProvider: @escaping @MainActor () -> Bool,
         ignoredBundleIdentifier: String?,
+        isCaptureSuppressedForBundle: @escaping @MainActor (String?) -> Bool = { _ in false },
         publishesPollingEvents: Bool = false
     ) {
         self.ignoredBundleIdentifier = ignoredBundleIdentifier
         tracker = FocusTracker(
             permissionProvider: permissionProvider,
-            ignoredBundleIdentifier: ignoredBundleIdentifier
+            ignoredBundleIdentifier: ignoredBundleIdentifier,
+            isCaptureSuppressedForBundle: isCaptureSuppressedForBundle
         )
         snapshot = tracker.snapshot
         latestExternalApplication = tracker.snapshot.externalApplicationIdentity(

--- a/Cotabby/Services/Focus/FocusTracker.swift
+++ b/Cotabby/Services/Focus/FocusTracker.swift
@@ -23,6 +23,13 @@ final class FocusTracker {
     private var pollInterval: TimeInterval
     private let permissionProvider: @MainActor () -> Bool
     private let ignoredBundleIdentifier: String?
+    /// Returns true when the focused app's bundle should NOT have its AX tree deep-walked. The
+    /// gate runs after the cheap system-wide focused-element query but before the expensive
+    /// candidate-elements walk in `FocusSnapshotResolver`. macOS popovers (Calendar's event-detail
+    /// popover, in particular) self-dismiss when AX attribute enumeration runs against them, so
+    /// disabling Cotabby globally or for a specific app must actually stop the walk, not just
+    /// stop generating suggestions on top of it (#476).
+    private let isCaptureSuppressedForBundle: @MainActor (String?) -> Bool
     private let snapshotResolver: FocusSnapshotResolver
 
     private var timer: Timer?
@@ -45,6 +52,10 @@ final class FocusTracker {
     private var chromiumHitTestCache: (element: AXUIElement, pid: pid_t)?
     private var lastChromeProbeSignature: String?
 
+    // Last bundle identifier we logged as suppressed. Used to emit one log line per
+    // suppression transition instead of one per 50-80ms poll tick.
+    private var lastSuppressedBundleIdentifier: String?
+
     // Wakes Chromium/Electron web-accessibility trees so their web text becomes readable. Priming
     // is what turns a Chrome renderer from "AX-unaware" (omnibox-only) into a tree the focus
     // queries and hit-test fallback can actually resolve.
@@ -54,11 +65,13 @@ final class FocusTracker {
         pollInterval: TimeInterval = 0.08,
         permissionProvider: @escaping @MainActor () -> Bool,
         ignoredBundleIdentifier: String?,
+        isCaptureSuppressedForBundle: @escaping @MainActor (String?) -> Bool = { _ in false },
         snapshotResolver: FocusSnapshotResolver? = nil
     ) {
         self.pollInterval = pollInterval
         self.permissionProvider = permissionProvider
         self.ignoredBundleIdentifier = ignoredBundleIdentifier
+        self.isCaptureSuppressedForBundle = isCaptureSuppressedForBundle
         // Default resolver construction must happen inside the actor-isolated initializer body.
         // Swift evaluates default parameter expressions before entering the `@MainActor` context.
         self.snapshotResolver = snapshotResolver ?? FocusSnapshotResolver()
@@ -217,6 +230,21 @@ final class FocusTracker {
             )
         }
 
+        // Bail before any AX deep-walk when Cotabby is disabled for the focused app. Stops
+        // `FocusSnapshotResolver.resolveSnapshot` from enumerating attributes on transient popover
+        // windows (Calendar's event-detail popover dismisses itself when its AX tree is read out
+        // from underneath it — #476). The cheap `AXHelper.focusedElement()` query above is fine to
+        // run; only the candidate-elements walk hits the popover.
+        if isCaptureSuppressedForBundle(application.bundleIdentifier) {
+            noteCaptureSuppressed(for: application)
+            return inactiveCapture(
+                applicationName: application.localizedName ?? "?",
+                bundleIdentifier: application.bundleIdentifier,
+                capability: .blocked("Cotabby is disabled for this app.")
+            )
+        }
+        noteCaptureResumedIfNeeded()
+
         let resolveStart = ContinuousClock.now
         let firstPassSnapshot = snapshotResolver.resolveSnapshot(
             focusedElement: focusedElement,
@@ -321,6 +349,28 @@ final class FocusTracker {
         let line = "Resolve timing: app=\(application.localizedName ?? "?") "
             + "resolveMs=\(String(format: "%.1f", millis)) caret=\(source) cache=[\(stats)]"
         CotabbyLogger.focus.debug("\(line)")
+    }
+
+    /// Emits one log line per suppression transition. The gate is consulted on every poll tick, so
+    /// without dedupe this would write ~12-20 lines/second for as long as the user stays in the
+    /// disabled app.
+    private func noteCaptureSuppressed(for application: NSRunningApplication) {
+        let bundleIdentifier = application.bundleIdentifier
+        guard lastSuppressedBundleIdentifier != bundleIdentifier else {
+            return
+        }
+        lastSuppressedBundleIdentifier = bundleIdentifier
+        let name = application.localizedName ?? "?"
+        let id = bundleIdentifier ?? "no bundle id"
+        CotabbyLogger.focus.info("Focus capture suppressed for \(name) (\(id))")
+    }
+
+    private func noteCaptureResumedIfNeeded() {
+        guard lastSuppressedBundleIdentifier != nil else {
+            return
+        }
+        lastSuppressedBundleIdentifier = nil
+        CotabbyLogger.focus.info("Focus capture resumed")
     }
 
     private func inactiveCapture(


### PR DESCRIPTION
## Summary

`FocusTracker` polls the frontmost app's AX tree every 50-80ms and runs `FocusSnapshotResolver.resolveSnapshot`, which enumerates AX attributes on the focused element and its candidates. Apple Calendar's event-creation popover self-dismisses when its AX tree is read out from underneath it, which is the cause of #476.

The polling loop is _ungated_: it does the deep AX walk regardless of `isGloballyEnabled` and `disabledAppRules`. This is why the reporter saw the bug persist after toggling both off; only quitting Cotabby stopped the polling. Gate the walk on the same two flags the input layer already checks, and publish an inactive snapshot (with the bundle identifier preserved) on suppressed ticks so downstream consumers stay coherent.

Investigation was done with a fan-out of 6 read-only investigators (Workflow). Five of six landed on FocusTracker as the most likely cause. The other prong they suggested (CGEvent tap teardown on disable) was ruled out by reading `InputMonitor`: the steady-state tap is `.listenOnly`, which cannot drop or modify events (the active accept tap is only installed when an overlay is visible). So the fix is just the focus gate.

Draft because I want a maintainer with a Calendar repro to confirm before merging, but I'm confident in the root cause.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO
# ** TEST SUCCEEDED ** 578 tests, 4 skipped, 0 failures

swiftlint lint --quiet Cotabby/Services/Focus/FocusTracker.swift \
  Cotabby/Models/FocusTrackingModel.swift \
  Cotabby/App/Core/CotabbyAppEnvironment.swift
# exit 0
```

Manual repro the reporter (or a maintainer) can run:
1. With Cotabby up and Calendar in `disabledAppRules`, create a new event in Calendar. The detail popover should now stay open and date/time/alerts should be editable.
2. Tail `~/Library/Logs/Cotabby/cotabby.jsonl` and filter for category=focus. While Calendar is focused you should see one `Focus capture suppressed for Calendar (com.apple.iCal)` line on entry and one `Focus capture resumed` line when switching to another app. If those lines do not appear, the gate is not engaging.
3. Sanity: TextEdit / Notes should still get ghost text as before (the gate only triggers when the focused app is disabled).

## Linked issues

Closes #476.

## Risk / rollout notes

- New plumbing flows through `FocusTracker.init` -> `FocusTrackingModel.init` -> `CotabbyAppEnvironment`. The new parameter is defaulted to `{ _ in false }` everywhere, so any caller that does not pass it (none exist outside the env) keeps the previous behavior.
- On a suppressed tick the tracker now returns `.blocked("Cotabby is disabled for this app.")` instead of `.supported`. The menu bar status label now reads "Blocked" (the existing capability shortLabel) when the user is focused inside a disabled app. This is arguably correct, but flagging it as a small user-visible behavior change.
- Per-tick log line is deduped to one entry per suppression transition (entering / leaving the disabled-app state). No log spam under normal use.
- I did NOT change InputMonitor lifecycle. After reading the file the steady-state observer tap is `.listenOnly` (#328 explicitly chose this design so a slow main actor cannot stall global keystrokes), so it cannot affect popover behavior. The active accept tap is gated on overlay visibility, which already respects the disable flags via `shouldProcessEventsProvider`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Gates the `FocusTracker` polling loop on `isGloballyEnabled` and per-app disabled rules before the expensive `FocusSnapshotResolver.resolveSnapshot` AX walk, fixing Apple Calendar's event-creation popover being dismissed by Cotabby's 50-80 ms background polling (#476). The gate is threaded through `FocusTrackingModel` and wired in `CotabbyAppEnvironment` using the same checks already applied to the input layer.

- **`FocusTracker.swift`**: Adds `isCaptureSuppressedForBundle` closure property; when true, returns an inactive `.blocked` snapshot before touching the AX candidate-element tree, with deduped log transitions to avoid log spam.
- **`FocusTrackingModel.swift`**: Forwards the new closure to `FocusTracker` with a `{ _ in false }` default so existing call sites are unaffected.
- **`CotabbyAppEnvironment.swift`**: Provides the real suppression logic — suppress when globally disabled or when the focused bundle is in the per-app disabled list.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the reported Calendar bug; the fix is well-contained and does not change any existing call sites.

The core suppression gate is correct and the Calendar popover fix is sound. Two small gaps exist: the Chromium OOPIF fallback path still executes a handful of AX queries before the gate fires (harmless for Calendar, could theoretically affect disabled Electron apps), and the suppression-logging deduplication silently skips nil-bundle-ID apps due to a String? != String? nil comparison. Neither affects the reported bug or normal operation.

FocusTracker.swift around the Chromium fallback path (lines 197-207) and the noteCaptureSuppressed logging helper (lines 357-366).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/Services/Focus/FocusTracker.swift | Core change: adds `isCaptureSuppressedForBundle` gate before the expensive `FocusSnapshotResolver.resolveSnapshot` call; includes deduped logging transitions. The Chromium OOPIF fallback path runs a few AX queries before the gate can fire, which is a minor gap for disabled Electron apps. |
| Cotabby/Models/FocusTrackingModel.swift | Pass-through plumbing: forwards `isCaptureSuppressedForBundle` to `FocusTracker` with a safe default of `{ _ in false }`, preserving existing behaviour for callers that don't pass it. |
| Cotabby/App/Core/CotabbyAppEnvironment.swift | Provides the suppression closure, correctly checking `isGloballyEnabled` then per-app disabled rules; mirrors the existing `shouldProcessEventsProvider` logic. Strong capture of `suggestionSettings` is intentional and consistent with the existing pattern. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Timer
    participant FocusTracker
    participant isCaptureSuppressedForBundle
    participant SuggestionSettings
    participant FocusSnapshotResolver
    participant Downstream

    Timer->>FocusTracker: handleTimerTick()
    FocusTracker->>FocusTracker: captureSnapshot()
    FocusTracker->>FocusTracker: AXHelper.focusedElement() [cheap]
    alt focused element found
        FocusTracker->>isCaptureSuppressedForBundle: isCaptureSuppressedForBundle(bundleId)
        isCaptureSuppressedForBundle->>SuggestionSettings: isGloballyEnabled?
        SuggestionSettings-->>isCaptureSuppressedForBundle: bool
        isCaptureSuppressedForBundle->>SuggestionSettings: isApplicationDisabled(bundleId)?
        SuggestionSettings-->>isCaptureSuppressedForBundle: bool
        isCaptureSuppressedForBundle-->>FocusTracker: "suppressed = true/false"
        alt suppressed
            FocusTracker->>FocusTracker: noteCaptureSuppressed() [log once]
            FocusTracker-->>Downstream: inactiveCapture(.blocked)
        else not suppressed
            FocusTracker->>FocusTracker: noteCaptureResumedIfNeeded() [log once]
            FocusTracker->>FocusSnapshotResolver: resolveSnapshot() [deep AX walk]
            FocusSnapshotResolver-->>FocusTracker: FocusSnapshot
            FocusTracker-->>Downstream: FocusSnapshot (.supported)
        end
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cotabby/Services/Focus/FocusTracker.swift`, line 197-207 ([link](https://github.com/fujacob/cotabby/blob/a0856369a9f0287b3b68afcab79611e36c10c63e/Cotabby/Services/Focus/FocusTracker.swift#L197-L207)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Chromium fallback AX queries bypass the suppression gate**

   `resolveChromiumFocusFallback()` is invoked before `isCaptureSuppressedForBundle` is checked, so for a disabled Electron/Chromium-family app it still runs `AXHelper.isFocused`, `AXHelper.focusedElement(forApplicationPID:)`, and (worst case) `AXHelper.element(atCocoaPoint:)` + `AXHelper.nearestEditable` on every suppressed tick. The Calendar fix is unaffected because `BrowserAppDetector.needsWebAccessibilityPriming` returns false for `com.apple.iCal` and the fallback exits immediately — but any Electron app added to the disabled list would still get those intermediate AX attribute reads, which could reproduce the same popover-dismissal symptom for that class of apps. Moving the initial bundle-identity check (or at least skipping the OOPIF fallback path) to before `resolveChromiumFocusFallback` would close this gap.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fcalendar-popover-disable-gates%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fcalendar-popover-disable-gates%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FServices%2FFocus%2FFocusTracker.swift%0ALine%3A%20197-207%0A%0AComment%3A%0A**Chromium%20fallback%20AX%20queries%20bypass%20the%20suppression%20gate**%0A%0A%60resolveChromiumFocusFallback%28%29%60%20is%20invoked%20before%20%60isCaptureSuppressedForBundle%60%20is%20checked%2C%20so%20for%20a%20disabled%20Electron%2FChromium-family%20app%20it%20still%20runs%20%60AXHelper.isFocused%60%2C%20%60AXHelper.focusedElement%28forApplicationPID%3A%29%60%2C%20and%20%28worst%20case%29%20%60AXHelper.element%28atCocoaPoint%3A%29%60%20%2B%20%60AXHelper.nearestEditable%60%20on%20every%20suppressed%20tick.%20The%20Calendar%20fix%20is%20unaffected%20because%20%60BrowserAppDetector.needsWebAccessibilityPriming%60%20returns%20false%20for%20%60com.apple.iCal%60%20and%20the%20fallback%20exits%20immediately%20%E2%80%94%20but%20any%20Electron%20app%20added%20to%20the%20disabled%20list%20would%20still%20get%20those%20intermediate%20AX%20attribute%20reads%2C%20which%20could%20reproduce%20the%20same%20popover-dismissal%20symptom%20for%20that%20class%20of%20apps.%20Moving%20the%20initial%20bundle-identity%20check%20%28or%20at%20least%20skipping%20the%20OOPIF%20fallback%20path%29%20to%20before%20%60resolveChromiumFocusFallback%60%20would%20close%20this%20gap.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FServices%2FFocus%2FFocusTracker.swift%0ALine%3A%20197-207%0A%0AComment%3A%0A**Chromium%20fallback%20AX%20queries%20bypass%20the%20suppression%20gate**%0A%0A%60resolveChromiumFocusFallback%28%29%60%20is%20invoked%20before%20%60isCaptureSuppressedForBundle%60%20is%20checked%2C%20so%20for%20a%20disabled%20Electron%2FChromium-family%20app%20it%20still%20runs%20%60AXHelper.isFocused%60%2C%20%60AXHelper.focusedElement%28forApplicationPID%3A%29%60%2C%20and%20%28worst%20case%29%20%60AXHelper.element%28atCocoaPoint%3A%29%60%20%2B%20%60AXHelper.nearestEditable%60%20on%20every%20suppressed%20tick.%20The%20Calendar%20fix%20is%20unaffected%20because%20%60BrowserAppDetector.needsWebAccessibilityPriming%60%20returns%20false%20for%20%60com.apple.iCal%60%20and%20the%20fallback%20exits%20immediately%20%E2%80%94%20but%20any%20Electron%20app%20added%20to%20the%20disabled%20list%20would%20still%20get%20those%20intermediate%20AX%20attribute%20reads%2C%20which%20could%20reproduce%20the%20same%20popover-dismissal%20symptom%20for%20that%20class%20of%20apps.%20Moving%20the%20initial%20bundle-identity%20check%20%28or%20at%20least%20skipping%20the%20OOPIF%20fallback%20path%29%20to%20before%20%60resolveChromiumFocusFallback%60%20would%20close%20this%20gap.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=483&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fcalendar-popover-disable-gates%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fcalendar-popover-disable-gates%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FServices%2FFocus%2FFocusTracker.swift%3A197-207%0A**Chromium%20fallback%20AX%20queries%20bypass%20the%20suppression%20gate**%0A%0A%60resolveChromiumFocusFallback%28%29%60%20is%20invoked%20before%20%60isCaptureSuppressedForBundle%60%20is%20checked%2C%20so%20for%20a%20disabled%20Electron%2FChromium-family%20app%20it%20still%20runs%20%60AXHelper.isFocused%60%2C%20%60AXHelper.focusedElement%28forApplicationPID%3A%29%60%2C%20and%20%28worst%20case%29%20%60AXHelper.element%28atCocoaPoint%3A%29%60%20%2B%20%60AXHelper.nearestEditable%60%20on%20every%20suppressed%20tick.%20The%20Calendar%20fix%20is%20unaffected%20because%20%60BrowserAppDetector.needsWebAccessibilityPriming%60%20returns%20false%20for%20%60com.apple.iCal%60%20and%20the%20fallback%20exits%20immediately%20%E2%80%94%20but%20any%20Electron%20app%20added%20to%20the%20disabled%20list%20would%20still%20get%20those%20intermediate%20AX%20attribute%20reads%2C%20which%20could%20reproduce%20the%20same%20popover-dismissal%20symptom%20for%20that%20class%20of%20apps.%20Moving%20the%20initial%20bundle-identity%20check%20%28or%20at%20least%20skipping%20the%20OOPIF%20fallback%20path%29%20to%20before%20%60resolveChromiumFocusFallback%60%20would%20close%20this%20gap.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FServices%2FFocus%2FFocusTracker.swift%3A357-366%0A**Suppression%20logging%20silently%20drops%20when%20%60bundleIdentifier%60%20is%20%60nil%60**%0A%0A%60lastSuppressedBundleIdentifier%60%20is%20%60String%3F%60.%20When%20%60application.bundleIdentifier%60%20is%20%60nil%60%2C%20the%20comparison%20%60lastSuppressedBundleIdentifier%20!%3D%20bundleIdentifier%60%20evaluates%20as%20%60nil%20!%3D%20nil%60%20%E2%86%92%20%60false%60%2C%20so%20the%20guard%20exits%20immediately%20and%20%60lastSuppressedBundleIdentifier%60%20is%20never%20updated.%20Two%20consequences%3A%20%281%29%20%22Focus%20capture%20suppressed%20for%20%E2%80%A6%22%20is%20never%20logged%20for%20a%20nil-bundle-ID%20app%20even%20on%20the%20first%20entry%2C%20and%20%282%29%20because%20%60lastSuppressedBundleIdentifier%60%20stays%20%60nil%60%2C%20%60noteCaptureResumedIfNeeded%60%20also%20silently%20skips%20the%20%22Focus%20capture%20resumed%22%20line%20when%20leaving%20that%20app.%20In%20practice%20this%20only%20fires%20when%20Cotabby%20is%20globally%20disabled%20and%20the%20frontmost%20app%20has%20no%20bundle%20ID%20%E2%80%94%20an%20uncommon%20edge%20case%20%E2%80%94%20but%20the%20manual%20validation%20step%20in%20the%20PR%20description%20that%20asks%20devs%20to%20%60tail%60%20the%20log%20could%20be%20misleading%20if%20they%20hit%20this%20path.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FServices%2FFocus%2FFocusTracker.swift%3A197-207%0A**Chromium%20fallback%20AX%20queries%20bypass%20the%20suppression%20gate**%0A%0A%60resolveChromiumFocusFallback%28%29%60%20is%20invoked%20before%20%60isCaptureSuppressedForBundle%60%20is%20checked%2C%20so%20for%20a%20disabled%20Electron%2FChromium-family%20app%20it%20still%20runs%20%60AXHelper.isFocused%60%2C%20%60AXHelper.focusedElement%28forApplicationPID%3A%29%60%2C%20and%20%28worst%20case%29%20%60AXHelper.element%28atCocoaPoint%3A%29%60%20%2B%20%60AXHelper.nearestEditable%60%20on%20every%20suppressed%20tick.%20The%20Calendar%20fix%20is%20unaffected%20because%20%60BrowserAppDetector.needsWebAccessibilityPriming%60%20returns%20false%20for%20%60com.apple.iCal%60%20and%20the%20fallback%20exits%20immediately%20%E2%80%94%20but%20any%20Electron%20app%20added%20to%20the%20disabled%20list%20would%20still%20get%20those%20intermediate%20AX%20attribute%20reads%2C%20which%20could%20reproduce%20the%20same%20popover-dismissal%20symptom%20for%20that%20class%20of%20apps.%20Moving%20the%20initial%20bundle-identity%20check%20%28or%20at%20least%20skipping%20the%20OOPIF%20fallback%20path%29%20to%20before%20%60resolveChromiumFocusFallback%60%20would%20close%20this%20gap.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FServices%2FFocus%2FFocusTracker.swift%3A357-366%0A**Suppression%20logging%20silently%20drops%20when%20%60bundleIdentifier%60%20is%20%60nil%60**%0A%0A%60lastSuppressedBundleIdentifier%60%20is%20%60String%3F%60.%20When%20%60application.bundleIdentifier%60%20is%20%60nil%60%2C%20the%20comparison%20%60lastSuppressedBundleIdentifier%20!%3D%20bundleIdentifier%60%20evaluates%20as%20%60nil%20!%3D%20nil%60%20%E2%86%92%20%60false%60%2C%20so%20the%20guard%20exits%20immediately%20and%20%60lastSuppressedBundleIdentifier%60%20is%20never%20updated.%20Two%20consequences%3A%20%281%29%20%22Focus%20capture%20suppressed%20for%20%E2%80%A6%22%20is%20never%20logged%20for%20a%20nil-bundle-ID%20app%20even%20on%20the%20first%20entry%2C%20and%20%282%29%20because%20%60lastSuppressedBundleIdentifier%60%20stays%20%60nil%60%2C%20%60noteCaptureResumedIfNeeded%60%20also%20silently%20skips%20the%20%22Focus%20capture%20resumed%22%20line%20when%20leaving%20that%20app.%20In%20practice%20this%20only%20fires%20when%20Cotabby%20is%20globally%20disabled%20and%20the%20frontmost%20app%20has%20no%20bundle%20ID%20%E2%80%94%20an%20uncommon%20edge%20case%20%E2%80%94%20but%20the%20manual%20validation%20step%20in%20the%20PR%20description%20that%20asks%20devs%20to%20%60tail%60%20the%20log%20could%20be%20misleading%20if%20they%20hit%20this%20path.%0A%0A&repo=fujacob%2Fcotabby&pr=483&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Stop focus polling from dismissing Calen..."](https://github.com/fujacob/cotabby/commit/a0856369a9f0287b3b68afcab79611e36c10c63e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34849191)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->