### PR TITLE
Fix rapid Tab leaking into the host after a final-word accept

### DIFF
--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
@@ -44,6 +44,23 @@ extension SuggestionCoordinator {
         // accept. `validateSessionForAcceptance` still rejects the accept if the session no longer
         // reconciles with the live AX state.
         guard interactionState.activeSession != nil else {
+            // A final-chunk accept tears the session down and regenerates the continuation
+            // asynchronously (see the `.exhausted` branch below). While that regen is in flight we
+            // keep owning Tab instead of leaking it into the host app as a real Tab. Swallow the
+            // press and remember it: the continuation that lands next accepts its first word, so
+            // rapid Tabbing keeps inserting words across the exhaustion boundary instead of jumping
+            // focus out of the field.
+            if isPostExhaustionAcceptanceArmed {
+                hasQueuedPostExhaustionAccept = true
+                logStage(
+                    "\(keyName)-held-for-regen",
+                    workID: currentWorkID,
+                    generation: latestGenerationNumber,
+                    message: "Held a rapid \(keyName) during post-acceptance regeneration; "
+                        + "the next continuation will accept its first word."
+                )
+                return true
+            }
             return passTabThrough(
                 reason: "Key passed through because no valid suggestion was ready."
             )
@@ -134,6 +151,11 @@ extension SuggestionCoordinator {
                 message: "Inserted the final suggestion chunk and queued a refresh.",
                 normalizedOutput: acceptedChunk
             )
+            // Keep owning Tab while the continuation regenerates so a fast follow-up press is
+            // swallowed and queued instead of leaking into the host app as a real Tab. Must run
+            // *after* the `hideOverlay` above, which routes through `onStateChange(.hidden)` and
+            // turns interception off; arming re-asserts it. See `armPostExhaustionAcceptance`.
+            armPostExhaustionAcceptance()
             // Wait for the host to actually publish the inserted text before regenerating. A bare
             // `schedulePrediction()` here reads pre-insertion AX in Chromium editors (the publish lags
             // the synthetic keystroke), so the model re-proposes the word just accepted and the next
@@ -192,6 +214,72 @@ extension SuggestionCoordinator {
             message: reason
         )
         return false
+    }
+
+    // MARK: - Post-Exhaustion Acceptance Window
+
+    /// How long Cotabby keeps owning Tab after a final-chunk accept while it waits for the
+    /// continuation to regenerate. This is only a backstop: the window normally ends much sooner —
+    /// when the next suggestion shows (overlay visible) or any teardown hides the overlay. It exists
+    /// so a regeneration that silently stalls can never trap Tab in the focused field. Sized to
+    /// comfortably outlast the host-publish poll ceiling plus a debounce and a typical on-device
+    /// generation.
+    static let postExhaustionAcceptanceWindowSeconds: TimeInterval = 0.8
+
+    /// Keeps the accept tap owning Tab for a brief window after a final-chunk accept, while the
+    /// continuation regenerates asynchronously.
+    ///
+    /// Accepting the last buffered word hides the overlay synchronously (which routes through
+    /// `onStateChange(.hidden)` and turns interception off) and then reschedules generation through
+    /// the host-publish poll + debounce + engine round-trip. That leaves a gap with no active session
+    /// and no visible overlay. A fast follow-up Tab in that gap used to hit the fail-open preflight
+    /// (`shouldConsumeAcceptKeyProvider` keys on overlay visibility) and the `activeSession != nil`
+    /// guard, so the accept tap forwarded the original Tab to the host and focus jumped out of the
+    /// field. Re-asserting interception here keeps the tail tap installed and owning Tab across the
+    /// regen window (its mach port otherwise lingers only ~50ms), and `shouldConsumeAcceptKeyProvider`
+    /// also consults `isPostExhaustionAcceptanceArmed` so the key is still routed in while the overlay
+    /// is hidden. A token-keyed backstop guarantees the window can never trap Tab.
+    func armPostExhaustionAcceptance() {
+        isPostExhaustionAcceptanceArmed = true
+        hasQueuedPostExhaustionAccept = false
+        inputMonitor.setAcceptInterceptionActive(true)
+        postExhaustionAcceptanceGeneration &+= 1
+        let generation = postExhaustionAcceptanceGeneration
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + Self.postExhaustionAcceptanceWindowSeconds
+        ) { [weak self] in
+            // Only the generation that scheduled this timer may act on it; a newer accept (or an
+            // already-released window) bumped the token, so this fires as a no-op.
+            guard let self, self.postExhaustionAcceptanceGeneration == generation else { return }
+            self.releasePostExhaustionAcceptanceWindow()
+        }
+    }
+
+    /// Ends the post-exhaustion window and returns the accept key to the host unless a suggestion is
+    /// now visible (in which case the normal overlay path keeps owning it). Idempotent. This is the
+    /// backstop release; the common, prompt release is `onStateChange(.hidden)` clearing the same
+    /// flags as soon as any teardown hides the overlay.
+    func releasePostExhaustionAcceptanceWindow() {
+        guard isPostExhaustionAcceptanceArmed || hasQueuedPostExhaustionAccept else { return }
+        isPostExhaustionAcceptanceArmed = false
+        hasQueuedPostExhaustionAccept = false
+        if !overlayState.isVisible {
+            inputMonitor.setAcceptInterceptionActive(false)
+        }
+    }
+
+    /// Once a regenerated continuation is on screen, accepts its first word if the user pressed Tab
+    /// while it was still loading. Keeps rapid Tabbing inserting words across the exhaustion boundary
+    /// instead of stalling. Bounded to one queued accept so mashing Tab cannot run away. Called at the
+    /// end of `apply`'s success path, after the new session and overlay exist.
+    func flushQueuedPostExhaustionAcceptIfNeeded() {
+        let shouldAccept = isPostExhaustionAcceptanceArmed && hasQueuedPostExhaustionAccept
+        // Normal acceptance has resumed now that a fresh suggestion is visible, so leave the armed
+        // state regardless of whether a press was queued.
+        isPostExhaustionAcceptanceArmed = false
+        hasQueuedPostExhaustionAccept = false
+        guard shouldAccept else { return }
+        _ = acceptCurrentSuggestion()
     }
 
     /// Advances the active session from the user's directly typed characters when they match the

--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
@@ -255,17 +255,27 @@ extension SuggestionCoordinator {
         }
     }
 
-    /// Ends the post-exhaustion window and returns the accept key to the host unless a suggestion is
-    /// now visible (in which case the normal overlay path keeps owning it). Idempotent. This is the
-    /// backstop release; the common, prompt release is `onStateChange(.hidden)` clearing the same
-    /// flags as soon as any teardown hides the overlay.
-    func releasePostExhaustionAcceptanceWindow() {
-        guard isPostExhaustionAcceptanceArmed || hasQueuedPostExhaustionAccept else { return }
+    /// Clears the window flags and invalidates the backstop token, so a timer still pending from
+    /// `armPostExhaustionAcceptance` fires as a no-op once the window has ended. Interception is left
+    /// to the caller: whether Tab ownership should drop depends on why the window ended (a fresh
+    /// suggestion keeps owning it; a teardown or the backstop drops it).
+    func clearPostExhaustionAcceptanceWindow() {
         isPostExhaustionAcceptanceArmed = false
         hasQueuedPostExhaustionAccept = false
+        // Cancel any pending backstop, which is keyed to the generation captured at arm time.
+        postExhaustionAcceptanceGeneration &+= 1
+    }
+
+    /// Ends the post-exhaustion window and returns the accept key to the host unless a suggestion is
+    /// now visible (in which case the normal overlay path keeps owning it). Idempotent. This is the
+    /// backstop release; the common, prompt release is `onStateChange(.hidden)` ending the window as
+    /// soon as any teardown hides the overlay.
+    func releasePostExhaustionAcceptanceWindow() {
+        guard isPostExhaustionAcceptanceArmed || hasQueuedPostExhaustionAccept else { return }
         if !overlayState.isVisible {
             inputMonitor.setAcceptInterceptionActive(false)
         }
+        clearPostExhaustionAcceptanceWindow()
     }
 
     /// Once a regenerated continuation is on screen, accepts its first word if the user pressed Tab
@@ -274,12 +284,21 @@ extension SuggestionCoordinator {
     /// end of `apply`'s success path, after the new session and overlay exist.
     func flushQueuedPostExhaustionAcceptIfNeeded() {
         let shouldAccept = isPostExhaustionAcceptanceArmed && hasQueuedPostExhaustionAccept
-        // Normal acceptance has resumed now that a fresh suggestion is visible, so leave the armed
-        // state regardless of whether a press was queued.
-        isPostExhaustionAcceptanceArmed = false
-        hasQueuedPostExhaustionAccept = false
+        // Normal acceptance has resumed now that a fresh suggestion is visible, so end the window
+        // regardless of whether a press was queued (this also cancels the now-redundant backstop).
+        clearPostExhaustionAcceptanceWindow()
         guard shouldAccept else { return }
-        _ = acceptCurrentSuggestion()
+        // A queued accept can still legitimately fail (the new continuation no longer reconciles with
+        // live AX, or insertion fails). `acceptSuggestion` cleans up its own state on failure, so log
+        // the rare miss for diagnosis instead of letting the swallowed Tab vanish without a trace.
+        if !acceptCurrentSuggestion() {
+            logStage(
+                "flush-queued-accept-failed",
+                workID: currentWorkID,
+                generation: latestGenerationNumber,
+                message: "Flushed a queued post-exhaustion Tab, but the follow-up acceptance returned false."
+            )
+        }
     }
 
     /// Advances the active session from the user's directly typed characters when they match the

--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
@@ -266,6 +266,11 @@ extension SuggestionCoordinator {
             rawOutput: result.rawText,
             normalizedOutput: result.text
         )
+
+        // If the user pressed Tab while this continuation was still regenerating, accept its first
+        // word now so rapid Tabbing keeps inserting words across the exhaustion boundary instead of
+        // stalling once the previous suggestion ran out. No-op when nothing was queued.
+        flushQueuedPostExhaustionAcceptIfNeeded()
     }
 
     /// Converts a runtime or engine failure into visible coordinator state and clears stale UI.

--- a/Cotabby/App/Coordinators/SuggestionCoordinator.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator.swift
@@ -86,6 +86,22 @@ final class SuggestionCoordinator: ObservableObject {
     /// accept on the last word. See `SuggestionSessionReconciler.isStaleAcceptanceEcho`.
     var lastAcceptedTail: AcceptedSuggestionTail?
 
+    /// Monotonic token for the post-exhaustion "keep owning Tab" window. Bumped on every arm so a
+    /// stale backstop timer (or a window superseded by a newer accept) no-ops instead of releasing a
+    /// window it no longer owns. See `armPostExhaustionAcceptance`.
+    var postExhaustionAcceptanceGeneration: UInt64 = 0
+    /// True while Cotabby keeps the accept tap owning Tab in the gap between a final-chunk accept and
+    /// the regenerated continuation appearing. Accepting the last buffered word hides the overlay and
+    /// reschedules generation asynchronously; without this the fail-open accept-tap preflight (which
+    /// keys on overlay visibility) would forward a fast follow-up Tab to the host as a real Tab and
+    /// focus would jump out of the field. The window self-releases when the next suggestion shows,
+    /// when any teardown hides the overlay, or via a backstop timer. See `armPostExhaustionAcceptance`.
+    var isPostExhaustionAcceptanceArmed = false
+    /// Set when a Tab is swallowed during that window. The next continuation that lands accepts its
+    /// first word, so rapid Tabbing keeps inserting words across the exhaustion boundary instead of
+    /// stalling. Bounded to a single queued accept so mashing Tab cannot run away.
+    var hasQueuedPostExhaustionAccept = false
+
     init(
         permissionManager: any SuggestionPermissionProviding,
         focusModel: any SuggestionFocusProviding,
@@ -166,7 +182,11 @@ final class SuggestionCoordinator: ObservableObject {
         // before the tap passes the original key through.
         inputMonitor.shouldConsumeAcceptKeyProvider = { [weak self] in
             guard let self else { return false }
-            guard self.overlayState.isVisible else { return false }
+            // Keep owning the accept key through the brief post-acceptance regeneration window too,
+            // even though the overlay is hidden then. Otherwise a fast follow-up Tab in that gap
+            // falls through to the host app as a real Tab and focus jumps out of the field — the
+            // "rapid Tab breaks, slow Tab is fine" report. See `armPostExhaustionAcceptance`.
+            guard self.overlayState.isVisible || self.isPostExhaustionAcceptanceArmed else { return false }
             return true
         }
 
@@ -181,6 +201,13 @@ final class SuggestionCoordinator: ObservableObject {
                 self.inputMonitor.setAcceptInterceptionActive(true)
             case .hidden:
                 self.inputMonitor.setAcceptInterceptionActive(false)
+                // A hidden overlay ends any post-exhaustion Tab-ownership window. Every teardown and
+                // abort path hides the overlay, so clearing the flags here is the single catch-all
+                // that returns the accept key to the host once the window is genuinely over. The
+                // `.exhausted` accept re-arms *after* its own `hideOverlay` call, so this never
+                // cancels a window that was just opened.
+                self.isPostExhaustionAcceptanceArmed = false
+                self.hasQueuedPostExhaustionAccept = false
             }
         }
 

--- a/Cotabby/App/Coordinators/SuggestionCoordinator.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator.swift
@@ -202,12 +202,11 @@ final class SuggestionCoordinator: ObservableObject {
             case .hidden:
                 self.inputMonitor.setAcceptInterceptionActive(false)
                 // A hidden overlay ends any post-exhaustion Tab-ownership window. Every teardown and
-                // abort path hides the overlay, so clearing the flags here is the single catch-all
-                // that returns the accept key to the host once the window is genuinely over. The
-                // `.exhausted` accept re-arms *after* its own `hideOverlay` call, so this never
-                // cancels a window that was just opened.
-                self.isPostExhaustionAcceptanceArmed = false
-                self.hasQueuedPostExhaustionAccept = false
+                // abort path hides the overlay, so ending the window here is the single catch-all
+                // that returns the accept key to the host (and cancels the backstop timer) once the
+                // window is genuinely over. The `.exhausted` accept re-arms *after* its own
+                // `hideOverlay` call, so this never cancels a window that was just opened.
+                self.clearPostExhaustionAcceptanceWindow()
             }
         }
 

--- a/CotabbyTests/SuggestionCoordinatorAcceptanceTests.swift
+++ b/CotabbyTests/SuggestionCoordinatorAcceptanceTests.swift
@@ -132,6 +132,144 @@ final class SuggestionCoordinatorAcceptanceTests: XCTestCase {
         }
     }
 
+    func test_rapidSecondAcceptDuringRegenerationIsConsumedNotPassedThrough() {
+        runOnMainActor {
+            let snapshot = CotabbyTestFixtures.focusedInputSnapshot(precedingText: "what's on your mind")
+            let context = FocusedInputContext(snapshot: snapshot, generation: 7)
+            let interactionState = SuggestionInteractionState()
+            _ = interactionState.startSession(
+                fullText: " today",
+                liveContext: context,
+                latency: 0.1
+            )
+            let overlayState = OverlayState.visible(
+                text: " today",
+                geometry: CotabbyTestFixtures.overlayGeometry(caretRect: context.caretRect),
+                mode: .inline
+            )
+            let inputMonitor = StubSuggestionInputMonitor()
+            let inserter = StubSuggestionInserter()
+            let coordinator = makeCoordinator(
+                snapshot: snapshot,
+                overlayState: overlayState,
+                inputMonitor: inputMonitor,
+                inserter: inserter,
+                interactionState: interactionState
+            )
+
+            // First Tab accepts the only remaining chunk, exhausts the session, and arms the window.
+            XCTAssertTrue(coordinator.acceptCurrentSuggestion())
+            XCTAssertEqual(inserter.insertedChunks, [" today"])
+            XCTAssertTrue(coordinator.isPostExhaustionAcceptanceArmed)
+            XCTAssertFalse(coordinator.overlayState.isVisible)
+            // Ownership of Tab was re-asserted even though the overlay is now hidden.
+            XCTAssertEqual(inputMonitor.acceptInterceptionRequests.last, true)
+            XCTAssertTrue(
+                inputMonitor.shouldConsumeAcceptKeyProvider(),
+                "The accept tap must keep owning Tab while the continuation regenerates."
+            )
+
+            // The rapid second Tab lands before the continuation regenerates. It must be swallowed
+            // (consumed) and queued — never forwarded to the host as a real Tab that moves focus.
+            XCTAssertTrue(
+                coordinator.acceptCurrentSuggestion(),
+                "A fast follow-up Tab during regeneration must be consumed, not passed through to the host."
+            )
+            XCTAssertEqual(
+                inserter.insertedChunks,
+                [" today"],
+                "The second Tab has nothing to insert yet; it is queued, not inserted."
+            )
+            XCTAssertTrue(coordinator.hasQueuedPostExhaustionAccept)
+        }
+    }
+
+    func test_postExhaustionWindowReleasesAcceptKeyWhenOverlayHides() {
+        runOnMainActor {
+            let snapshot = CotabbyTestFixtures.focusedInputSnapshot(precedingText: "what's on your mind")
+            let context = FocusedInputContext(snapshot: snapshot, generation: 7)
+            let interactionState = SuggestionInteractionState()
+            _ = interactionState.startSession(
+                fullText: " today",
+                liveContext: context,
+                latency: 0.1
+            )
+            let overlayState = OverlayState.visible(
+                text: " today",
+                geometry: CotabbyTestFixtures.overlayGeometry(caretRect: context.caretRect),
+                mode: .inline
+            )
+            let inputMonitor = StubSuggestionInputMonitor()
+            let inserter = StubSuggestionInserter()
+            let coordinator = makeCoordinator(
+                snapshot: snapshot,
+                overlayState: overlayState,
+                inputMonitor: inputMonitor,
+                inserter: inserter,
+                interactionState: interactionState
+            )
+
+            XCTAssertTrue(coordinator.acceptCurrentSuggestion())
+            XCTAssertTrue(coordinator.isPostExhaustionAcceptanceArmed)
+
+            // Any teardown that hides the overlay (focus change, typing, dismissal, an empty
+            // regeneration) must end the window so the user can Tab out of the field normally again.
+            coordinator.invalidateActiveSuggestion(reason: "Focus moved to another field.")
+
+            XCTAssertFalse(coordinator.isPostExhaustionAcceptanceArmed)
+            XCTAssertFalse(coordinator.hasQueuedPostExhaustionAccept)
+            XCTAssertFalse(
+                inputMonitor.shouldConsumeAcceptKeyProvider(),
+                "Once the window is released the accept tap should stop owning Tab."
+            )
+            XCTAssertFalse(
+                coordinator.acceptCurrentSuggestion(),
+                "With the window released and no suggestion, Tab must pass through to the host."
+            )
+        }
+    }
+
+    func test_queuedPostExhaustionAcceptInsertsNextWordWhenContinuationArrives() {
+        runOnMainActor {
+            let snapshot = CotabbyTestFixtures.focusedInputSnapshot(precedingText: "Hello")
+            let context = FocusedInputContext(snapshot: snapshot, generation: 7)
+            let interactionState = SuggestionInteractionState()
+            let session = interactionState.startSession(
+                fullText: " world again",
+                liveContext: context,
+                latency: 0.1
+            )
+            let overlayState = OverlayState.visible(
+                text: session.remainingText,
+                geometry: CotabbyTestFixtures.overlayGeometry(caretRect: context.caretRect),
+                mode: .inline
+            )
+            let inputMonitor = StubSuggestionInputMonitor()
+            let inserter = StubSuggestionInserter()
+            let coordinator = makeCoordinator(
+                snapshot: snapshot,
+                overlayState: overlayState,
+                inputMonitor: inputMonitor,
+                inserter: inserter,
+                interactionState: interactionState
+            )
+            // Simulate a Tab that was swallowed and queued while this continuation was still loading;
+            // `apply` calls `flushQueuedPostExhaustionAcceptIfNeeded` once the suggestion is on screen.
+            coordinator.isPostExhaustionAcceptanceArmed = true
+            coordinator.hasQueuedPostExhaustionAccept = true
+
+            coordinator.flushQueuedPostExhaustionAcceptIfNeeded()
+
+            XCTAssertEqual(
+                inserter.insertedChunks,
+                [" world"],
+                "The queued Tab should accept the continuation's first word."
+            )
+            XCTAssertFalse(coordinator.isPostExhaustionAcceptanceArmed)
+            XCTAssertFalse(coordinator.hasQueuedPostExhaustionAccept)
+        }
+    }
+
     @MainActor
     private func makeCoordinator(
         snapshot: FocusedInputSnapshot,


### PR DESCRIPTION
## Summary

Rapid `Tab` presses leaked into the focused app and moved focus out of the field. Accepting the last word of a suggestion exhausts the buffer, which synchronously clears the session and hides the overlay and then regenerates the continuation asynchronously. A fast second `Tab` landing in that gap found no active session and no visible overlay, so the accept-tap preflight (which keys on overlay visibility) declined and the tap forwarded the original `Tab` to the host as a real key. Slow tabbing was always fine because regeneration finished and re-showed ghost text before the next press. Short completions (`maxPredictionTokens: 8`) make the exhausting boundary common, so the second quick `Tab` was routinely the one that leaked.

This keeps the accept tap owning `Tab` across the regeneration window: a fast follow-up press is swallowed (never forwarded to the host) and queued, and the next continuation that lands accepts its first word, so rapid Tabbing keeps inserting words across the exhaustion boundary instead of jumping focus away.

## Validation

```
# build
xcodebuild build -project Cotabby.xcodeproj -scheme Cotabby \
  -destination 'platform=macOS' -derivedDataPath build/DerivedData
# ** BUILD SUCCEEDED **

# lint (changed files)
swiftlint lint Cotabby/App/Coordinators/SuggestionCoordinator*.swift \
  CotabbyTests/SuggestionCoordinatorAcceptanceTests.swift
# Done linting! Found 0 violations, 0 serious in 4 files.

# tests
xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby \
  -destination 'platform=macOS' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO
# ** TEST SUCCEEDED **  Executed 578 tests, with 4 tests skipped and 0 failures
```

Three new tests in `SuggestionCoordinatorAcceptanceTests` lock down the fix:

- `test_rapidSecondAcceptDuringRegenerationIsConsumedNotPassedThrough`: a fast second `Tab` during regeneration is consumed (returns `true`) and queued, never forwarded to the host.
- `test_postExhaustionWindowReleasesAcceptKeyWhenOverlayHides`: any teardown that hides the overlay releases the window, so `Tab` can never be trapped in the field.
- `test_queuedPostExhaustionAcceptInsertsNextWordWhenContinuationArrives`: the queued `Tab` accepts the continuation's first word once it lands.

Not verified end to end in this environment (no live rapid-`Tab` reproduction against a real text field); the behavior is covered at the coordinator boundary by the unit tests above.

## Linked issues

Refs #478 (addresses item 2, "tabs jump off" on fast double-`Tab`; the optional-cat-image and suggestion-quality items in that issue are out of scope here).

## Risk / rollout notes

- Behavior change to the existing accept flow: after a final-word accept, the accept tap keeps owning `Tab` during the brief regeneration window instead of releasing it immediately.
- This re-enters the "active tap while the overlay is hidden" territory that issue #328 cares about, but only while the user is actively tabbing in the field. The window self-releases at the regeneration terminal (suggestion shown, or overlay hidden by any teardown) and is hard-bounded by a token-keyed `0.8s` backstop, so it cannot trap `Tab` or persist when idle.
- A queued `Tab` accepts the next continuation's first word as soon as it generates, so the second word appears slightly after the keypress (it does not exist until the model produces it). Bounded to one queued accept per regeneration so mashing `Tab` cannot run away.
- No schema, settings, or `project.yml`/pbxproj changes. New source and test files are auto-discovered by folder.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the \"rapid Tab jumps focus out of the field\" bug: accepting the last buffered word tears down the session and regenerates asynchronously, leaving a gap where a fast follow-up Tab found no active session and no visible overlay, so the accept tap forwarded it to the host as a real key. The fix keeps the coordinator owning Tab across that regeneration gap, queues any Tab that arrives in it, and flushes the queued accept as the continuation's first word once the new suggestion is on screen.

- Three new instance flags (`isPostExhaustionAcceptanceArmed`, `hasQueuedPostExhaustionAccept`, `postExhaustionAcceptanceGeneration`) drive the window; a generation-keyed 0.8 s backstop timer guarantees Tab can never be permanently trapped even if regen stalls.
- `armPostExhaustionAcceptance()` is called in the `.exhausted` branch *after* `hideOverlay()` so it always follows the `.hidden` state callback that clears the previous window; `clearPostExhaustionAcceptanceWindow()` is wired into every teardown path through the single `onStateChange(.hidden)` catch-all.
- Three new unit tests lock down the fix boundary: rapid Tab is consumed not forwarded, any overlay-hide teardown releases the window, and a queued Tab correctly inserts the continuation's first word on arrival.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The change is well-scoped to the coordinator boundary, has a hard-bounded backstop that prevents any Tab-trapping regression, and the new state is cleaned up through a single, authoritative teardown path.

The fix is mechanically sound: the ordering invariant (arm always follows a clear from the `.hidden` callback) is preserved and documented, the generation token correctly invalidates stale backstop timers, and all known teardown paths reach `clearPostExhaustionAcceptanceWindow` through `onStateChange(.hidden)`. The only observation is a missing log when an in-flight queued Tab is silently dropped by an early-return path in `apply()` (stale echo, empty result, etc.), which affects debuggability but not correctness.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift | Core of the fix: adds post-exhaustion acceptance window arm/clear/release/flush methods; swallows rapid Tab presses during regen and queues them for the next continuation; integrates `armPostExhaustionAcceptance()` call after the `.exhausted` branch's `hideOverlay`, correctly ordering it after the `.hidden` state change so re-arming always follows a clean clear. |
| Cotabby/App/Coordinators/SuggestionCoordinator.swift | Adds three new state variables for the post-exhaustion window; extends `shouldConsumeAcceptKeyProvider` to also return `true` while `isPostExhaustionAcceptanceArmed`; clears the window on every `.hidden` overlay state transition as the single catch-all teardown path. |
| Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift | Single four-line change: calls `flushQueuedPostExhaustionAcceptIfNeeded()` at the very end of `apply()`'s success path, after the new session and overlay are live — correct placement since any earlier call would race with `startSession`. |
| CotabbyTests/SuggestionCoordinatorAcceptanceTests.swift | Adds three focused tests covering the main fix contract: rapid Tab consumed and queued, window releases Tab on any overlay-hide teardown, and queued Tab inserts the next word when the continuation arrives. Happy path of the flush is well-covered. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant InputMonitor
    participant Coordinator
    participant OverlayController
    participant Engine

    Note over User,Engine: Slow Tab (no issue — regen finishes before next press)
    User->>InputMonitor: Tab (final word)
    InputMonitor->>Coordinator: acceptCurrentSuggestion()
    Coordinator->>OverlayController: hideOverlay → onStateChange(.hidden)
    OverlayController-->>Coordinator: clearPostExhaustionAcceptanceWindow()
    Coordinator->>Coordinator: armPostExhaustionAcceptance() [re-asserts interception]
    Coordinator->>Engine: schedulePredictionAfterHostPublishDelay()
    Engine-->>Coordinator: apply(result) → presentOverlay → flushQueuedPostExhaustionAcceptIfNeeded()
    Note over Coordinator: No queued Tab → window cleared, normal flow resumes
    User->>InputMonitor: Tab (next word, overlay visible)
    InputMonitor->>Coordinator: acceptCurrentSuggestion() → inserts next word

    Note over User,Engine: Rapid Tab (the bug this PR fixes)
    User->>InputMonitor: Tab (final word)
    InputMonitor->>Coordinator: acceptCurrentSuggestion()
    Coordinator->>OverlayController: hideOverlay → onStateChange(.hidden)
    OverlayController-->>Coordinator: clearPostExhaustionAcceptanceWindow()
    Coordinator->>Coordinator: "armPostExhaustionAcceptance() [isPostExhaustionAcceptanceArmed=true]"
    Coordinator->>Engine: schedulePredictionAfterHostPublishDelay()
    User->>InputMonitor: Tab (rapid, regen in flight)
    InputMonitor->>Coordinator: shouldConsumeAcceptKeyProvider() → true (armed)
    InputMonitor->>Coordinator: acceptCurrentSuggestion()
    Note over Coordinator: No active session, but isPostExhaustionAcceptanceArmed=true
    Coordinator->>Coordinator: "hasQueuedPostExhaustionAccept=true, return true (swallowed)"
    Engine-->>Coordinator: apply(result) → presentOverlay
    Coordinator->>Coordinator: flushQueuedPostExhaustionAcceptIfNeeded()
    Coordinator->>Coordinator: clearPostExhaustionAcceptanceWindow()
    Coordinator->>Coordinator: acceptCurrentSuggestion() → inserts first word of continuation
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Frapid-tab-next-word%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Frapid-tab-next-word%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BPrediction.swift%3A191-204%0A**Queued%20Tab%20silently%20dropped%20on%20early-return%20paths%20in%20%60apply%28%29%60**%0A%0A%60flushQueuedPostExhaustionAcceptIfNeeded%28%29%60%20is%20only%20reachable%20via%20the%20success%20path%20at%20the%20bottom%20of%20%60apply%28%29%60.%20When%20%60apply%28%29%60%20exits%20early%20%E2%80%94%20%60stale-drop%60%2C%20%60empty-result%60%2C%20%60selected-text%60%2C%20%60stale-accept-echo%60%2C%20or%20%60applyFailure%60%20%E2%80%94%20each%20of%20those%20paths%20calls%20%60hideOverlay%28%29%60%2C%20which%20routes%20through%20%60onStateChange%28.hidden%29%60%20and%20calls%20%60clearPostExhaustionAcceptanceWindow%28%29%60.%20That%20clears%20%60hasQueuedPostExhaustionAccept%60%20without%20any%20log%20entry%2C%20so%20a%20Tab%20that%20was%20swallowed%20and%20queued%20during%20the%20regen%20window%20disappears%20without%20a%20trace.%0A%0AThe%20failure-inside-flush%20case%20%28%60acceptCurrentSuggestion%28%29%60%20returns%20%60false%60%20from%20%60flushQueuedPostExhaustionAcceptIfNeeded%60%29%20does%20log%20%60flush-queued-accept-failed%60%2C%20so%20that%20path%20is%20diagnosed.%20The%20earlier-exit%20paths%20are%20not.%20Adding%20a%20%60logStage%60%20inside%20%60clearPostExhaustionAcceptanceWindow%28%29%60%20%28or%20at%20least%20inside%20the%20%60.hidden%60%20callback%29%20when%20both%20flags%20are%20true%20at%20clear%20time%20would%20make%20this%20edge%20case%20debuggable%20without%20any%20behavior%20change.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BPrediction.swift%3A191-204%0A**Queued%20Tab%20silently%20dropped%20on%20early-return%20paths%20in%20%60apply%28%29%60**%0A%0A%60flushQueuedPostExhaustionAcceptIfNeeded%28%29%60%20is%20only%20reachable%20via%20the%20success%20path%20at%20the%20bottom%20of%20%60apply%28%29%60.%20When%20%60apply%28%29%60%20exits%20early%20%E2%80%94%20%60stale-drop%60%2C%20%60empty-result%60%2C%20%60selected-text%60%2C%20%60stale-accept-echo%60%2C%20or%20%60applyFailure%60%20%E2%80%94%20each%20of%20those%20paths%20calls%20%60hideOverlay%28%29%60%2C%20which%20routes%20through%20%60onStateChange%28.hidden%29%60%20and%20calls%20%60clearPostExhaustionAcceptanceWindow%28%29%60.%20That%20clears%20%60hasQueuedPostExhaustionAccept%60%20without%20any%20log%20entry%2C%20so%20a%20Tab%20that%20was%20swallowed%20and%20queued%20during%20the%20regen%20window%20disappears%20without%20a%20trace.%0A%0AThe%20failure-inside-flush%20case%20%28%60acceptCurrentSuggestion%28%29%60%20returns%20%60false%60%20from%20%60flushQueuedPostExhaustionAcceptIfNeeded%60%29%20does%20log%20%60flush-queued-accept-failed%60%2C%20so%20that%20path%20is%20diagnosed.%20The%20earlier-exit%20paths%20are%20not.%20Adding%20a%20%60logStage%60%20inside%20%60clearPostExhaustionAcceptanceWindow%28%29%60%20%28or%20at%20least%20inside%20the%20%60.hidden%60%20callback%29%20when%20both%20flags%20are%20true%20at%20clear%20time%20would%20make%20this%20edge%20case%20debuggable%20without%20any%20behavior%20change.%0A%0A&repo=fujacob%2Fcotabby&pr=484&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Cancel post-exhaustion backstop on relea..."](https://github.com/fujacob/cotabby/commit/ef247f1b15d27804e3bd88d79ae434bb63870f18) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34811253)</sub>

<!-- /greptile_comment -->