### PR TITLE
Output safety gates: dedup, insertion safety, sentence boundary

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		190C571B3CDFE117F4D15484 /* LlamaPromptRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3009812A35A1CDEF16295AB7 /* LlamaPromptRendererTests.swift */; };
 		19CB55B62977376E9AE8D428 /* VisualContextStartCoalescer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F01FAC4F57EB08471521196 /* VisualContextStartCoalescer.swift */; };
 		1C4A2BAB2CCADF0A70B70AC6 /* LlamaPromptRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5679E08C9A09065531C37B5 /* LlamaPromptRenderer.swift */; };
+		1D1C6FF0B8F50AC14A1000F4 /* SentenceBoundaryClassifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7360A6D4261989A66658ED /* SentenceBoundaryClassifierTests.swift */; };
 		1F8CC88AFFE67C08944CF506 /* WindowScreenshotService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B0121E7BB173F8A2B0B108 /* WindowScreenshotService.swift */; };
 		2197B68F1E4D0C3497DAC061 /* LlamaSuggestionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE04620C905041680116BE80 /* LlamaSuggestionEngine.swift */; };
 		22DF59FD6F3B83B092A6F5ED /* WordCountFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 815F2ABAF6AB75DA3AFBBCEF /* WordCountFormatter.swift */; };
@@ -126,6 +127,7 @@
 		7E99F5676A1D1DF7EA7D7702 /* SuggestionCoordinator+Prediction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ED1EA9282E0AC7592E60889 /* SuggestionCoordinator+Prediction.swift */; };
 		7FC103944F4EF39DB965F469 /* InMemoryLogging in Frameworks */ = {isa = PBXBuildFile; productRef = 88921938DC814625ED57D605 /* InMemoryLogging */; };
 		82D4ADEAF05337ABDE4C586C /* RuntimeBootstrapModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60629DFE309C1A4BD8A7FB3B /* RuntimeBootstrapModel.swift */; };
+		83EC3543DC45B1601F119BF9 /* InsertionSafetyGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43D627C4A55359EAF4676FF7 /* InsertionSafetyGateTests.swift */; };
 		8441299082E6B68F7F88911B /* ShortcutConflictTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0850B07CCDBA67C756C6EC59 /* ShortcutConflictTests.swift */; };
 		84A4CA05AF6885AE4FA4C13A /* SettingsAttentionEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A02336442BB735EE2E8D064 /* SettingsAttentionEvaluator.swift */; };
 		87806DE08881D11F2608A13D /* MarkerSelectionSynthesizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52BAFA2F989C3C4F7FB892B5 /* MarkerSelectionSynthesizerTests.swift */; };
@@ -147,6 +149,7 @@
 		9706D778FB549E9E7AE05F4F /* EmojiMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1441B2D89DAE6878DAD11F17 /* EmojiMatcher.swift */; };
 		98E2E14A069384C1088CDB44 /* PromptContextSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4B45B91D4DEAC979C3113E /* PromptContextSanitizer.swift */; };
 		9ABF75CDA78B27453C3F5B34 /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264CA64B2AB1611F82E5B760 /* WelcomeView.swift */; };
+		9ADFFF634912F638D079E1C7 /* SentenceBoundaryClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B56C250DDEF3E81F9DCBD7 /* SentenceBoundaryClassifier.swift */; };
 		9F2FDCABCC941CBECAA3B4AB /* CotabbyInference in Frameworks */ = {isa = PBXBuildFile; productRef = 48A46AD6B613CF06072603E4 /* CotabbyInference */; };
 		A0657CE0488F69F0BD559CBC /* SuggestionCoordinator+Acceptance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72B13136DF7318F3E96DF0D3 /* SuggestionCoordinator+Acceptance.swift */; };
 		A0BB87E3665EF6C209034798 /* GhostSuggestionLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AD3F4F9FBE82007E4E15F58 /* GhostSuggestionLayoutTests.swift */; };
@@ -183,6 +186,7 @@
 		D0D4C0E28F5CD99669A49414 /* FoundationModelAvailabilityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8724ECA8FABBC82B0A2B943B /* FoundationModelAvailabilityService.swift */; };
 		D2CAA59F69BCBC07DDA2B0D8 /* ClipboardContextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CF4FB0EC6C1BEB4EA74910A /* ClipboardContextProvider.swift */; };
 		D2F1DD215989BF32675308C2 /* SuggestionCoordinator+Input.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22544F4B756E3E4144497D17 /* SuggestionCoordinator+Input.swift */; };
+		D3B43622E5A41B11E7AF527E /* TrailingDuplicationFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D408D647412C59F3E692C42B /* TrailingDuplicationFilter.swift */; };
 		D46A0DB70B07F487431F48F6 /* EmojiPickerPanelLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7B185BA246A526CBA85E581 /* EmojiPickerPanelLayoutTests.swift */; };
 		D5CAF3B590E5EC2AFC72E57A /* VisualContextStartCoalescerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 050D929E13BE52E6282B64D2 /* VisualContextStartCoalescerTests.swift */; };
 		D648DD70AD847F67B77CE052 /* OnboardingTemplateRecommenderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B72736E416910878E8E493 /* OnboardingTemplateRecommenderTests.swift */; };
@@ -190,6 +194,8 @@
 		D90C889A623A928F4F5FDC7B /* HardwareCapabilityProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41BBD5A4BA08CABE77860886 /* HardwareCapabilityProbe.swift */; };
 		D9C51DEDF01033E276A479CE /* AXTextGeometryResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB58035EFFD65B767949BAE6 /* AXTextGeometryResolver.swift */; };
 		DA23422A2CF77CFD3B1283C8 /* OnboardingTemplateFeatureListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D814BBA41CF29E8DD9954651 /* OnboardingTemplateFeatureListTests.swift */; };
+		DB1310FF3576ACA6472C4DB1 /* TrailingDuplicationFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19A5B462891263BDFB56607 /* TrailingDuplicationFilterTests.swift */; };
+		DCABB8D2B391C7820D6CA5FF /* InsertionSafetyGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D472F9F396672E57873303B /* InsertionSafetyGate.swift */; };
 		DD7FA343F1C21C4569F6D181 /* ScreenshotContextGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B84BAE361626891F19DC9DB /* ScreenshotContextGenerator.swift */; };
 		DDEDCBAA2196303455F6926A /* AcceptanceModePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5DAF68AEBFE334F68A65E82 /* AcceptanceModePickerView.swift */; };
 		DE236C9285635C686D66A2F6 /* TerminalAppDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E37A7E835D3BDE6265843C /* TerminalAppDetectorTests.swift */; };
@@ -272,6 +278,7 @@
 		2B7A28471B8526C2693FFF65 /* AcknowledgementsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcknowledgementsView.swift; sourceTree = "<group>"; };
 		2BC293F6125E2B14DCF05AD9 /* SettingsAttentionEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAttentionEvaluatorTests.swift; sourceTree = "<group>"; };
 		2D1F9CEBAB0F330F8E7B61D8 /* InputSuppressionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputSuppressionController.swift; sourceTree = "<group>"; };
+		2D7360A6D4261989A66658ED /* SentenceBoundaryClassifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentenceBoundaryClassifierTests.swift; sourceTree = "<group>"; };
 		2F01FAC4F57EB08471521196 /* VisualContextStartCoalescer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualContextStartCoalescer.swift; sourceTree = "<group>"; };
 		3009812A35A1CDEF16295AB7 /* LlamaPromptRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LlamaPromptRendererTests.swift; sourceTree = "<group>"; };
 		312C7306D916963F519CE0D9 /* EmojiTriggerStateMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiTriggerStateMachine.swift; sourceTree = "<group>"; };
@@ -285,6 +292,7 @@
 		386C98FFCF76EC1C8C7E82BB /* SuggestionModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionModels.swift; sourceTree = "<group>"; };
 		3DE1975F3B5F4A70478DBF41 /* DownloadOutcomeClassifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadOutcomeClassifier.swift; sourceTree = "<group>"; };
 		41BBD5A4BA08CABE77860886 /* HardwareCapabilityProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HardwareCapabilityProbe.swift; sourceTree = "<group>"; };
+		43D627C4A55359EAF4676FF7 /* InsertionSafetyGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsertionSafetyGateTests.swift; sourceTree = "<group>"; };
 		43E37A7E835D3BDE6265843C /* TerminalAppDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAppDetectorTests.swift; sourceTree = "<group>"; };
 		4451D6673112575DF24C4A48 /* OnboardingTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTemplate.swift; sourceTree = "<group>"; };
 		4696A84D17890B154533A08F /* PromptPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptPolicyTests.swift; sourceTree = "<group>"; };
@@ -328,6 +336,7 @@
 		77B0121E7BB173F8A2B0B108 /* WindowScreenshotService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowScreenshotService.swift; sourceTree = "<group>"; };
 		78E280F4F39A9D86840800D2 /* SuggestionCoordinator+Lifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SuggestionCoordinator+Lifecycle.swift"; sourceTree = "<group>"; };
 		78E49BDA7F3A42455C4C5350 /* HuggingFaceModelBrowserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceModelBrowserView.swift; sourceTree = "<group>"; };
+		7D472F9F396672E57873303B /* InsertionSafetyGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsertionSafetyGate.swift; sourceTree = "<group>"; };
 		7E44E393DD58B978B1EAB6CF /* GhostTextColorPreset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostTextColorPreset.swift; sourceTree = "<group>"; };
 		7E644072C123DC2D2B40274D /* AdvancedPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedPaneView.swift; sourceTree = "<group>"; };
 		7F4C4A7EAF886E0CC945BFEF /* TerminalAppDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAppDetector.swift; sourceTree = "<group>"; };
@@ -408,8 +417,10 @@
 		CE8C2569A8217EE9BD3B197F /* FileLogHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileLogHandler.swift; sourceTree = "<group>"; };
 		D2F46767D9D1F0D44E239CA8 /* DownloadFileRescuerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadFileRescuerTests.swift; sourceTree = "<group>"; };
 		D3A2AC525DC664DB540D4F19 /* ClipboardRelevanceFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardRelevanceFilter.swift; sourceTree = "<group>"; };
+		D408D647412C59F3E692C42B /* TrailingDuplicationFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrailingDuplicationFilter.swift; sourceTree = "<group>"; };
 		D48B95B6665109B6C6A63B42 /* WritingPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WritingPaneView.swift; sourceTree = "<group>"; };
 		D49F3B597374208594861B9B /* FoundationModelDriftEvalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoundationModelDriftEvalTests.swift; sourceTree = "<group>"; };
+		D4B56C250DDEF3E81F9DCBD7 /* SentenceBoundaryClassifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentenceBoundaryClassifier.swift; sourceTree = "<group>"; };
 		D4F6D5F94B238F7B4BE7C247 /* FocusCapabilityResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusCapabilityResolverTests.swift; sourceTree = "<group>"; };
 		D504BEB224E0C176F5FCFF6E /* CompletionRenderModePolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionRenderModePolicyTests.swift; sourceTree = "<group>"; };
 		D5D6C2318E405AA717D1C256 /* WelcomePermissionStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomePermissionStepView.swift; sourceTree = "<group>"; };
@@ -421,6 +432,7 @@
 		DDF6A4E9CE93FD53C60E67E3 /* EmojiQueryRun.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiQueryRun.swift; sourceTree = "<group>"; };
 		DEB16474A67CE1D210B944C9 /* SuggestionSubsystemContracts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionSubsystemContracts.swift; sourceTree = "<group>"; };
 		DEBD6113A3C1038BECC99245 /* PerformancePaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformancePaneView.swift; sourceTree = "<group>"; };
+		E19A5B462891263BDFB56607 /* TrailingDuplicationFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrailingDuplicationFilterTests.swift; sourceTree = "<group>"; };
 		E1D2782B6C7BE3F56BCB22DE /* LlamaVisualContextSummarizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LlamaVisualContextSummarizer.swift; sourceTree = "<group>"; };
 		E217A66717D78E1E49350EC8 /* DownloadOutcomeClassifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadOutcomeClassifierTests.swift; sourceTree = "<group>"; };
 		E3C84377F352140759B448C9 /* CaretGeometrySelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaretGeometrySelector.swift; sourceTree = "<group>"; };
@@ -687,6 +699,7 @@
 				335BF59EE80F3A0143B79740 /* GhostFontSizeStabilizerTests.swift */,
 				5AD3F4F9FBE82007E4E15F58 /* GhostSuggestionLayoutTests.swift */,
 				BAC01317B0B68E3C4125E421 /* InputMonitorTests.swift */,
+				43D627C4A55359EAF4676FF7 /* InsertionSafetyGateTests.swift */,
 				4793D4EA5D36D7E5CC216C27 /* LanguageSupportTests.swift */,
 				5807E8508D9355D0271A00C5 /* LaunchAtLoginStateTests.swift */,
 				3009812A35A1CDEF16295AB7 /* LlamaPromptRendererTests.swift */,
@@ -700,6 +713,7 @@
 				12DD19BCE610808F1E38702D /* PermissionOverlayTrackerTests.swift */,
 				0D80CC2CCAAFE3F23FB8C37A /* PromptContextSanitizerTests.swift */,
 				4696A84D17890B154533A08F /* PromptPolicyTests.swift */,
+				2D7360A6D4261989A66658ED /* SentenceBoundaryClassifierTests.swift */,
 				2BC293F6125E2B14DCF05AD9 /* SettingsAttentionEvaluatorTests.swift */,
 				0850B07CCDBA67C756C6EC59 /* ShortcutConflictTests.swift */,
 				C05B0439348261163B37C508 /* SuggestionAvailabilityEvaluatorTests.swift */,
@@ -712,6 +726,7 @@
 				C71031E8DB171047318B92FC /* SyntheticReplacePlannerTests.swift */,
 				43E37A7E835D3BDE6265843C /* TerminalAppDetectorTests.swift */,
 				FC24FD54860CE6737E65EF65 /* TextDirectionDetectorTests.swift */,
+				E19A5B462891263BDFB56607 /* TrailingDuplicationFilterTests.swift */,
 				050D929E13BE52E6282B64D2 /* VisualContextStartCoalescerTests.swift */,
 				1E0513E3B23937B099A3CFF2 /* WordCountFormatterTests.swift */,
 			);
@@ -829,6 +844,7 @@
 				043E8AA850F930222DD112C0 /* GhostSuggestionLayout.swift */,
 				7E44E393DD58B978B1EAB6CF /* GhostTextColorPreset.swift */,
 				41BBD5A4BA08CABE77860886 /* HardwareCapabilityProbe.swift */,
+				7D472F9F396672E57873303B /* InsertionSafetyGate.swift */,
 				EAAE6B395FAB604DF059280A /* KeyCodeLabels.swift */,
 				B5679E08C9A09065531C37B5 /* LlamaPromptRenderer.swift */,
 				8D610FCA3A97249DCCE7D0B8 /* LLMIOFileHandler.swift */,
@@ -839,6 +855,7 @@
 				E6423D6CC8CC371D2DA899DE /* PermissionOverlayTracker.swift */,
 				FA4B45B91D4DEAC979C3113E /* PromptContextSanitizer.swift */,
 				6DC693E00430F46E41CB56E6 /* RequestID.swift */,
+				D4B56C250DDEF3E81F9DCBD7 /* SentenceBoundaryClassifier.swift */,
 				2A02336442BB735EE2E8D064 /* SettingsAttentionEvaluator.swift */,
 				3609CC88A5280B3AA40414DF /* SuggestionAvailabilityEvaluator.swift */,
 				B2F95847D76893C8A5B504B4 /* SuggestionOverlayStabilityGate.swift */,
@@ -848,6 +865,7 @@
 				B424E2AC97C99D335B0D5751 /* SuggestionTextNormalizer.swift */,
 				7F4C4A7EAF886E0CC945BFEF /* TerminalAppDetector.swift */,
 				328847A0F494360033366791 /* TextDirectionDetector.swift */,
+				D408D647412C59F3E692C42B /* TrailingDuplicationFilter.swift */,
 				2F01FAC4F57EB08471521196 /* VisualContextStartCoalescer.swift */,
 				815F2ABAF6AB75DA3AFBBCEF /* WordCountFormatter.swift */,
 			);
@@ -1038,6 +1056,7 @@
 				5F019E5A0679FFB52F129798 /* InputModels.swift in Sources */,
 				2DF5A3826AAB99C279EBB8DE /* InputMonitor.swift in Sources */,
 				6955C3A4D7AB3EEF7FA7C469 /* InputSuppressionController.swift in Sources */,
+				DCABB8D2B391C7820D6CA5FF /* InsertionSafetyGate.swift in Sources */,
 				F78F594F77C26C233377E71F /* KeyCodeLabels.swift in Sources */,
 				F8E86FA4D6CEEBFA7FB55F8D /* KeyRecorderView.swift in Sources */,
 				046C133967B32BBF9205EBB1 /* LLMIOFileHandler.swift in Sources */,
@@ -1080,6 +1099,7 @@
 				2C6159231472A849F15BD0AE /* ScreenFrameReader.swift in Sources */,
 				0C06CAD62975E87B2C852191 /* ScreenTextExtractor.swift in Sources */,
 				DD7FA343F1C21C4569F6D181 /* ScreenshotContextGenerator.swift in Sources */,
+				9ADFFF634912F638D079E1C7 /* SentenceBoundaryClassifier.swift in Sources */,
 				84A4CA05AF6885AE4FA4C13A /* SettingsAttentionEvaluator.swift in Sources */,
 				907A0BF56C3BB0CBAF2649AB /* SettingsCategory.swift in Sources */,
 				2E3DEB7E89D0146274596F2E /* SettingsContainerView.swift in Sources */,
@@ -1115,6 +1135,7 @@
 				AB9C9C001F97F9D14F8B192A /* TerminalAppDetector.swift in Sources */,
 				96782E57CA26A16409368B69 /* TextDirectionDetector.swift in Sources */,
 				6014B31E2570EFFE45557E33 /* TickMarkSlider.swift in Sources */,
+				D3B43622E5A41B11E7AF527E /* TrailingDuplicationFilter.swift in Sources */,
 				E9E4CC657771DF9F4C56183C /* VisualContextCoordinator.swift in Sources */,
 				4190F8A76196B16ED94D0A55 /* VisualContextModels.swift in Sources */,
 				19CB55B62977376E9AE8D428 /* VisualContextStartCoalescer.swift in Sources */,
@@ -1158,6 +1179,7 @@
 				2EE05B312C990104BE934772 /* GhostFontSizeStabilizerTests.swift in Sources */,
 				A0BB87E3665EF6C209034798 /* GhostSuggestionLayoutTests.swift in Sources */,
 				07D046D406411ED85AC5758A /* InputMonitorTests.swift in Sources */,
+				83EC3543DC45B1601F119BF9 /* InsertionSafetyGateTests.swift in Sources */,
 				E912D4617AE1376061DF1F00 /* LanguageSupportTests.swift in Sources */,
 				E27E6377D36D4981301568DD /* LaunchAtLoginStateTests.swift in Sources */,
 				190C571B3CDFE117F4D15484 /* LlamaPromptRendererTests.swift in Sources */,
@@ -1171,6 +1193,7 @@
 				4F38CE1C2602CF4F41323032 /* PermissionOverlayTrackerTests.swift in Sources */,
 				934885ACC2DEA20B27F10948 /* PromptContextSanitizerTests.swift in Sources */,
 				3CF1A4E39F24917DF0470A7D /* PromptPolicyTests.swift in Sources */,
+				1D1C6FF0B8F50AC14A1000F4 /* SentenceBoundaryClassifierTests.swift in Sources */,
 				C618C5595DA9C57C806A3E03 /* SettingsAttentionEvaluatorTests.swift in Sources */,
 				8441299082E6B68F7F88911B /* ShortcutConflictTests.swift in Sources */,
 				88BCD795A14E1C9308F7BB31 /* SuggestionAvailabilityEvaluatorTests.swift in Sources */,
@@ -1183,6 +1206,7 @@
 				EF5BAB96DDADABB86F9E02D9 /* SyntheticReplacePlannerTests.swift in Sources */,
 				DE236C9285635C686D66A2F6 /* TerminalAppDetectorTests.swift in Sources */,
 				5A441797D71A880A7482077D /* TextDirectionDetectorTests.swift in Sources */,
+				DB1310FF3576ACA6472C4DB1 /* TrailingDuplicationFilterTests.swift in Sources */,
 				D5CAF3B590E5EC2AFC72E57A /* VisualContextStartCoalescerTests.swift in Sources */,
 				6AE0B46FB52D189D94E1F79A /* WordCountFormatterTests.swift in Sources */,
 			);

--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		3CF1A4E39F24917DF0470A7D /* PromptPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4696A84D17890B154533A08F /* PromptPolicyTests.swift */; };
 		4134ADBE464D00BB748BD9AE /* GeneralPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07480CE96ED0EBD94817C6B1 /* GeneralPaneView.swift */; };
 		4190F8A76196B16ED94D0A55 /* VisualContextModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE97A8169438D593C6C23412 /* VisualContextModels.swift */; };
+		429CE592897D8A952F2916C3 /* ConfidenceSuppressionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BD71ECC2AE4821B643E0935 /* ConfidenceSuppressionPolicy.swift */; };
 		42D40F37086294D0E58200C5 /* GhostFontSizeStabilizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9458F0820B3161FE9CF1DDAF /* GhostFontSizeStabilizer.swift */; };
 		4531645066A73971EB2A5FA1 /* EmojiCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC3BF78835C8F2C315932F1 /* EmojiCatalog.swift */; };
 		46F341472191BC451B6BF6B5 /* SuggestionRequestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDE858CB1E687E3CEB8FDD5B /* SuggestionRequestFactory.swift */; };
@@ -121,6 +122,7 @@
 		76FD91607794883F8E121450 /* CaretGeometrySelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3C84377F352140759B448C9 /* CaretGeometrySelector.swift */; };
 		78FAE5DB691A1B71042B9D20 /* AboutPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3FA53BBC3D81503C1D17477 /* AboutPaneView.swift */; };
 		7B6A63F5DCC2C163CDFD2A5C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BC4F887528AE74AC0DD30314 /* Assets.xcassets */; };
+		7C36DBA762E19C8C31676D44 /* MidWordContinuationPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1274F897631B1B3A835D157F /* MidWordContinuationPolicyTests.swift */; };
 		7C94725B4837DEC9ECF1BC54 /* CompletionRenderMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A03E565A11581FD2150B142 /* CompletionRenderMode.swift */; };
 		7D6BB9AF72F7076A4E5EE96F /* DownloadableModelCatalogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5C2AE9A7E55495D26AD074 /* DownloadableModelCatalogView.swift */; };
 		7E9413CE7C999C4612348248 /* SuggestionSessionReconcilerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C8F07AC52C7A482F5FE34C5 /* SuggestionSessionReconcilerTests.swift */; };
@@ -142,6 +144,7 @@
 		90DC9508F27F712EB61EEB06 /* PermissionReminderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 656F58E56FE9BC087B6F1D33 /* PermissionReminderView.swift */; };
 		91C27021750AC03AA4A0115A /* HuggingFaceAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110CB0B53016644EF7840301 /* HuggingFaceAPIClient.swift */; };
 		91D1F16B8C5DA281D4B7F699 /* CustomRulesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD752451330486FE270018B0 /* CustomRulesTests.swift */; };
+		91D8189EFCD1BA992EA6F038 /* ConfidenceSuppressionPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06FF2B0A3094A952A8EBA9B5 /* ConfidenceSuppressionPolicyTests.swift */; };
 		924489CEE8171F7AD8579D71 /* FocusDebugOverlayController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5E263AB69029D5E13D5EE8 /* FocusDebugOverlayController.swift */; };
 		934885ACC2DEA20B27F10948 /* PromptContextSanitizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D80CC2CCAAFE3F23FB8C37A /* PromptContextSanitizerTests.swift */; };
 		96498E097A5899AFC9F0C853 /* EmojiCatalogMatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292DC9D4D9D5D26AE882E39B /* EmojiCatalogMatcherTests.swift */; };
@@ -150,6 +153,7 @@
 		98E2E14A069384C1088CDB44 /* PromptContextSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4B45B91D4DEAC979C3113E /* PromptContextSanitizer.swift */; };
 		9ABF75CDA78B27453C3F5B34 /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264CA64B2AB1611F82E5B760 /* WelcomeView.swift */; };
 		9ADFFF634912F638D079E1C7 /* SentenceBoundaryClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B56C250DDEF3E81F9DCBD7 /* SentenceBoundaryClassifier.swift */; };
+		9CEBD6AF4405F1BBE0E3D16C /* MidWordContinuationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 357C18383B047F24A531BDCD /* MidWordContinuationPolicy.swift */; };
 		9F2FDCABCC941CBECAA3B4AB /* CotabbyInference in Frameworks */ = {isa = PBXBuildFile; productRef = 48A46AD6B613CF06072603E4 /* CotabbyInference */; };
 		A0657CE0488F69F0BD559CBC /* SuggestionCoordinator+Acceptance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72B13136DF7318F3E96DF0D3 /* SuggestionCoordinator+Acceptance.swift */; };
 		A0BB87E3665EF6C209034798 /* GhostSuggestionLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AD3F4F9FBE82007E4E15F58 /* GhostSuggestionLayoutTests.swift */; };
@@ -246,6 +250,7 @@
 		04D853218B0A77B0CE090828 /* BrowserAppDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserAppDetectorTests.swift; sourceTree = "<group>"; };
 		04E25414C307A20B6F9F20EC /* FocusSnapshotResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusSnapshotResolver.swift; sourceTree = "<group>"; };
 		050D929E13BE52E6282B64D2 /* VisualContextStartCoalescerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualContextStartCoalescerTests.swift; sourceTree = "<group>"; };
+		06FF2B0A3094A952A8EBA9B5 /* ConfidenceSuppressionPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfidenceSuppressionPolicyTests.swift; sourceTree = "<group>"; };
 		07480CE96ED0EBD94817C6B1 /* GeneralPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralPaneView.swift; sourceTree = "<group>"; };
 		0850B07CCDBA67C756C6EC59 /* ShortcutConflictTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutConflictTests.swift; sourceTree = "<group>"; };
 		09FADF683BE7B3558377FA76 /* FocusPollBackoff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusPollBackoff.swift; sourceTree = "<group>"; };
@@ -255,12 +260,14 @@
 		0D80CC2CCAAFE3F23FB8C37A /* PromptContextSanitizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptContextSanitizerTests.swift; sourceTree = "<group>"; };
 		0F5E263AB69029D5E13D5EE8 /* FocusDebugOverlayController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusDebugOverlayController.swift; sourceTree = "<group>"; };
 		110CB0B53016644EF7840301 /* HuggingFaceAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceAPIClient.swift; sourceTree = "<group>"; };
+		1274F897631B1B3A835D157F /* MidWordContinuationPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MidWordContinuationPolicyTests.swift; sourceTree = "<group>"; };
 		12DD19BCE610808F1E38702D /* PermissionOverlayTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOverlayTrackerTests.swift; sourceTree = "<group>"; };
 		1441B2D89DAE6878DAD11F17 /* EmojiMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiMatcher.swift; sourceTree = "<group>"; };
 		18D990E515E1AE4F312F4E95 /* BundledRuntimeLocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledRuntimeLocatorTests.swift; sourceTree = "<group>"; };
 		19BE12C28A4AB8A4A58C2FF7 /* SettingsPaneScaffold.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPaneScaffold.swift; sourceTree = "<group>"; };
 		19DB9558F4D3AFB108D71649 /* SuggestionStateHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionStateHelperTests.swift; sourceTree = "<group>"; };
 		1A8414BEB7E34F57607E37FE /* EmojiVariantResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiVariantResolver.swift; sourceTree = "<group>"; };
+		1BD71ECC2AE4821B643E0935 /* ConfidenceSuppressionPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfidenceSuppressionPolicy.swift; sourceTree = "<group>"; };
 		1CE61E74928C221B8BB261C6 /* SuggestionTextColorCodec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionTextColorCodec.swift; sourceTree = "<group>"; };
 		1D00A031C0D9CF2A7A2330D9 /* PermissionDragSourceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionDragSourceView.swift; sourceTree = "<group>"; };
 		1E0513E3B23937B099A3CFF2 /* WordCountFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordCountFormatterTests.swift; sourceTree = "<group>"; };
@@ -287,6 +294,7 @@
 		335BF59EE80F3A0143B79740 /* GhostFontSizeStabilizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostFontSizeStabilizerTests.swift; sourceTree = "<group>"; };
 		3384FD33776960103D6E22A9 /* EmojiPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiPickerView.swift; sourceTree = "<group>"; };
 		352AF5B2834FEE1F597394E4 /* ApplicationBundleMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationBundleMetadata.swift; sourceTree = "<group>"; };
+		357C18383B047F24A531BDCD /* MidWordContinuationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MidWordContinuationPolicy.swift; sourceTree = "<group>"; };
 		3609CC88A5280B3AA40414DF /* SuggestionAvailabilityEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionAvailabilityEvaluator.swift; sourceTree = "<group>"; };
 		384FBCF5D7A3A446C5BE2B8D /* SuggestionEngineRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionEngineRouter.swift; sourceTree = "<group>"; };
 		386C98FFCF76EC1C8C7E82BB /* SuggestionModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionModels.swift; sourceTree = "<group>"; };
@@ -680,6 +688,7 @@
 				EFD89799BB82AF7A92559AEB /* ClipboardContentDistillerTests.swift */,
 				90B0D133AB77A2503FB08827 /* ClipboardRelevanceFilterTests.swift */,
 				D504BEB224E0C176F5FCFF6E /* CompletionRenderModePolicyTests.swift */,
+				06FF2B0A3094A952A8EBA9B5 /* ConfidenceSuppressionPolicyTests.swift */,
 				AF1E065C7FFB697FCEB2FA5C /* CotabbyTestFixtures.swift */,
 				AD752451330486FE270018B0 /* CustomRulesTests.swift */,
 				C1C5DE0F3FF63545000E2453 /* DisplayCoordinateConverterTests.swift */,
@@ -704,6 +713,7 @@
 				5807E8508D9355D0271A00C5 /* LaunchAtLoginStateTests.swift */,
 				3009812A35A1CDEF16295AB7 /* LlamaPromptRendererTests.swift */,
 				52BAFA2F989C3C4F7FB892B5 /* MarkerSelectionSynthesizerTests.swift */,
+				1274F897631B1B3A835D157F /* MidWordContinuationPolicyTests.swift */,
 				FC83D14A7557BC0196E59007 /* MirrorOverlayLayoutTests.swift */,
 				03766F6253FF17639230C0F6 /* ModelAndPresentationValueTests.swift */,
 				A829F28F01FAE76CA7244BBC /* ModelFileValidatorTests.swift */,
@@ -827,6 +837,7 @@
 				96495E4147D828C0B1B22765 /* ClipboardContentDistiller.swift */,
 				D3A2AC525DC664DB540D4F19 /* ClipboardRelevanceFilter.swift */,
 				53CF416511099C6818110F01 /* CompletionRenderModePolicy.swift */,
+				1BD71ECC2AE4821B643E0935 /* ConfidenceSuppressionPolicy.swift */,
 				C7B2D34A6F3AC9DFD61350F7 /* CotabbyDebugOptions.swift */,
 				29ED42C4BDD0C521101AF95E /* DeviceInfo.swift */,
 				74BD1D4DB27D5D96D1E06096 /* DisplayCoordinateConverter.swift */,
@@ -849,6 +860,7 @@
 				B5679E08C9A09065531C37B5 /* LlamaPromptRenderer.swift */,
 				8D610FCA3A97249DCCE7D0B8 /* LLMIOFileHandler.swift */,
 				A863F41C0C03D7B4AC5DC002 /* MarkerSelectionSynthesizer.swift */,
+				357C18383B047F24A531BDCD /* MidWordContinuationPolicy.swift */,
 				54150A507B03221F137D539B /* MirrorOverlayLayout.swift */,
 				24F613F0E2F7046E6532A09C /* OnboardingTemplateFeatureList.swift */,
 				FA878B447441BB4F3E327CC8 /* OnboardingTemplateRecommender.swift */,
@@ -1010,6 +1022,7 @@
 				157A55EB796BEB7819B90D5D /* ClipboardRelevanceFilter.swift in Sources */,
 				7C94725B4837DEC9ECF1BC54 /* CompletionRenderMode.swift in Sources */,
 				3985F0F2B3178DBB945B1064 /* CompletionRenderModePolicy.swift in Sources */,
+				429CE592897D8A952F2916C3 /* ConfidenceSuppressionPolicy.swift in Sources */,
 				8B2DFC860803C0A7C4D34A36 /* ContextBuffer.swift in Sources */,
 				AA2E09FF7E430D66ECA8ECD5 /* CotabbyApp.swift in Sources */,
 				FCC571EC239846F06007BFCA /* CotabbyAppEnvironment.swift in Sources */,
@@ -1074,6 +1087,7 @@
 				0333B3CE8F189DD1BEC4AD26 /* MenuBarSections.swift in Sources */,
 				AECC7289DA796B071B4FE3C0 /* MenuBarStatusLabelView.swift in Sources */,
 				5E92E3C1EB41D482FC06BC52 /* MenuBarView.swift in Sources */,
+				9CEBD6AF4405F1BBE0E3D16C /* MidWordContinuationPolicy.swift in Sources */,
 				31515DDD173535C4AC777853 /* MirrorOverlayLayout.swift in Sources */,
 				2F227738D7834B1A7A81D1D6 /* ModelDownloadManager.swift in Sources */,
 				317883210D1D1D5CD654E562 /* ModelFileValidator.swift in Sources */,
@@ -1160,6 +1174,7 @@
 				8865B95FE84198D70390DF80 /* ClipboardContentDistillerTests.swift in Sources */,
 				BFCA7FAFDAEBF586AB615567 /* ClipboardRelevanceFilterTests.swift in Sources */,
 				25F91CEF38400FD1ADB6B1AF /* CompletionRenderModePolicyTests.swift in Sources */,
+				91D8189EFCD1BA992EA6F038 /* ConfidenceSuppressionPolicyTests.swift in Sources */,
 				5E10EFC426217CB7218A5847 /* CotabbyTestFixtures.swift in Sources */,
 				91D1F16B8C5DA281D4B7F699 /* CustomRulesTests.swift in Sources */,
 				56611BA0087710277140E9E6 /* DisplayCoordinateConverterTests.swift in Sources */,
@@ -1184,6 +1199,7 @@
 				E27E6377D36D4981301568DD /* LaunchAtLoginStateTests.swift in Sources */,
 				190C571B3CDFE117F4D15484 /* LlamaPromptRendererTests.swift in Sources */,
 				87806DE08881D11F2608A13D /* MarkerSelectionSynthesizerTests.swift in Sources */,
+				7C36DBA762E19C8C31676D44 /* MidWordContinuationPolicyTests.swift in Sources */,
 				14D77F0B8A195AC2FA8D24A9 /* MirrorOverlayLayoutTests.swift in Sources */,
 				25D4FC8D191A50F63E6391F9 /* ModelAndPresentationValueTests.swift in Sources */,
 				65478B0DABF5460C32D4C458 /* ModelFileValidatorTests.swift in Sources */,
@@ -1519,7 +1535,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/FuJacob/cotabbyinference.git";
 			requirement = {
-				branch = main;
+				branch = "feat/generation-quality-controls";
 				kind = branch;
 			};
 		};

--- a/Cotabby/Models/LlamaRuntimeModels.swift
+++ b/Cotabby/Models/LlamaRuntimeModels.swift
@@ -201,6 +201,15 @@ struct LlamaGenerationOptions: Equatable, Sendable {
     let repetitionPenalty: Double
     var seed: UInt32?
 
+    /// Masks line-break tokens so single-line fields never receive a multi-line completion.
+    var singleLine: Bool = false
+    /// Constrains the first generated token to continue the current word (mid-word carets only).
+    var forceWordContinuation: Bool = false
+
+    /// Average per-token log-probability below which a completion is suppressed as low-confidence.
+    /// Defaults to -infinity, which disables suppression entirely.
+    var confidenceFloor: Double = -.infinity
+
     static func summary(maxPredictionTokens: Int, temperature: Double) -> LlamaGenerationOptions {
         LlamaGenerationOptions(
             maxPredictionTokens: maxPredictionTokens,

--- a/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
+++ b/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
@@ -190,6 +190,7 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
 
         var generatedText = ""
         var tokensGenerated = 0
+        var sumLogprob = 0.0
         var stopReason = "budget_exhausted"
 
         for _ in 0 ..< options.maxPredictionTokens {
@@ -216,6 +217,7 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
             let piece = Self.extractPiece(result)
             generatedText += piece
             tokensGenerated += 1
+            sumLogprob += Double(result.logprob)
         }
 
         CotabbyLogger.runtime.debug(
@@ -227,6 +229,23 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
                 "stop_reason": .string(stopReason)
             ]
         )
+
+        // Confidence suppression: drop completions the model itself was unsure about. Disabled by
+        // default (confidenceFloor == -infinity); the KV-trim defer above still runs on early return.
+        if tokensGenerated > 0,
+           ConfidenceSuppressionPolicy.shouldSuppress(
+               averageLogprob: sumLogprob / Double(tokensGenerated),
+               floor: options.confidenceFloor
+           ) {
+            CotabbyLogger.runtime.debug(
+                "Suppressed low-confidence completion",
+                metadata: [
+                    "tokens_generated": .stringConvertible(tokensGenerated),
+                    "avg_logprob": .stringConvertible(sumLogprob / Double(tokensGenerated))
+                ]
+            )
+            return ""
+        }
 
         return generatedText
     }
@@ -387,6 +406,9 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
 
                     let remaining = Array(promptTokens[reusableTokenCount...])
                     if !remaining.isEmpty {
+                        // Seed for the reuse path is sampled at the end of this decodePrompt; apply
+                        // the word-continuation constraint to it just like the fresh path does.
+                        engine.setForceWordContinuation(autocompleteSequenceID, options.forceWordContinuation)
                         var mutableRemaining = remaining
                         let status = engine.decodePrompt(
                             autocompleteSequenceID,
@@ -422,6 +444,10 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
         guard seqID >= 0 else {
             throw LlamaRuntimeError.generationFailed("Unable to create inference sequence.")
         }
+
+        // The engine samples the first (seed) token at the end of decodePrompt, so set the
+        // word-continuation constraint here, before decoding.
+        engine.setForceWordContinuation(seqID, options.forceWordContinuation)
 
         var tokens = promptTokens
         let status = engine.decodePrompt(seqID, &tokens, Int32(tokens.count), 0)
@@ -460,7 +486,8 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
             top_p: Float(options.topP),
             min_p: Float(options.minP),
             repetition_penalty: Float(options.repetitionPenalty),
-            seed: options.seed ?? 0
+            seed: options.seed ?? 0,
+            single_line: options.singleLine
         )
     }
 

--- a/Cotabby/Services/Runtime/LlamaSuggestionEngine.swift
+++ b/Cotabby/Services/Runtime/LlamaSuggestionEngine.swift
@@ -45,7 +45,12 @@ final class LlamaSuggestionEngine {
                     topP: request.topP,
                     minP: request.minP,
                     repetitionPenalty: request.repetitionPenalty,
-                    seed: request.randomSeed
+                    seed: request.randomSeed,
+                    singleLine: !request.isMultiLineEnabled,
+                    forceWordContinuation: MidWordContinuationPolicy.shouldForceContinuation(
+                        precedingText: request.context.precedingText,
+                        trailingText: request.context.trailingText
+                    )
                 )
             )
             try Task.checkCancellation()

--- a/Cotabby/Support/ConfidenceSuppressionPolicy.swift
+++ b/Cotabby/Support/ConfidenceSuppressionPolicy.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// File overview:
+/// Decides whether a completion is too low-confidence to show, based on the model's own
+/// per-token log-probabilities.
+///
+/// Why this file exists:
+/// The guiding principle is that a suppressed completion beats a wrong one. The engine now reports
+/// a per-token log-probability, so we can drop completions the model itself was unsure about
+/// instead of showing a confident-looking guess. The policy is pure and isolated so the threshold
+/// is easy to test and tune. A floor of negative infinity (the default) disables suppression, so
+/// this is a no-op until a caller opts in by raising the floor.
+enum ConfidenceSuppressionPolicy {
+    /// Suppress when the completion's average per-token log-probability is below `floor`.
+    static func shouldSuppress(averageLogprob: Double, floor: Double) -> Bool {
+        guard floor > -.infinity else {
+            return false
+        }
+        return averageLogprob < floor
+    }
+}

--- a/Cotabby/Support/InsertionSafetyGate.swift
+++ b/Cotabby/Support/InsertionSafetyGate.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// File overview:
+/// Rejects completions that are technically non-empty but would insert nothing a user wants.
+///
+/// Why this file exists:
+/// `SuggestionInserter` previously only refused a fully empty string, so a completion carrying an
+/// interior control character or a U+FFFD replacement glyph (from lossy detokenization) could reach
+/// ghost text and be committed on Tab. This gate is the single predicate for "is this safe to put
+/// on screen and insert."
+///
+/// Scope note: this intentionally does NOT reject punctuation-only output. A lone ")", ".", or "?"
+/// is a legitimate inline completion (closing a bracket, ending a sentence), so judging punctuation
+/// here would suppress useful suggestions. The gate is limited to unambiguous junk.
+enum InsertionSafetyGate {
+    /// Returns true when `completion` is safe to display and insert.
+    static func isSafeToInsert(_ completion: String) -> Bool {
+        guard !completion.isEmpty else {
+            return false
+        }
+
+        var sawNonWhitespace = false
+        for scalar in completion.unicodeScalars {
+            // Replacement character: the detokenizer produced bytes it could not decode. Never text.
+            if scalar == "\u{FFFD}" {
+                return false
+            }
+            // C0 control range and DEL. Newlines are already handled upstream; an interior tab or
+            // other control character is corruption, not content.
+            if scalar.value < 0x20 || scalar.value == 0x7F {
+                return false
+            }
+            if !CharacterSet.whitespacesAndNewlines.contains(scalar) {
+                sawNonWhitespace = true
+            }
+        }
+
+        // Whitespace-only output is not a completion.
+        return sawNonWhitespace
+    }
+}

--- a/Cotabby/Support/MidWordContinuationPolicy.swift
+++ b/Cotabby/Support/MidWordContinuationPolicy.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// File overview:
+/// Decides whether the first generated token should be constrained to continue the current word.
+///
+/// Why this file exists:
+/// The engine can force the first sampled token to be a word continuation (no leading whitespace),
+/// which heals mid-word completions. But forcing it at a normal word boundary would break the
+/// common "predict the next word" case, where a leading space is exactly what we want. This policy
+/// keeps the trigger deliberately narrow: it only fires when the caret sits strictly inside a word
+/// (a word character on both sides). At a word end (nothing or a non-word character after the
+/// caret) it returns false so ordinary next-word predictions are untouched.
+enum MidWordContinuationPolicy {
+    static func shouldForceContinuation(precedingText: String, trailingText: String) -> Bool {
+        guard let before = precedingText.last, isWordCharacter(before) else {
+            return false
+        }
+        guard let after = trailingText.first, isWordCharacter(after) else {
+            return false
+        }
+        return true
+    }
+
+    private static func isWordCharacter(_ character: Character) -> Bool {
+        character.isLetter || character.isNumber
+    }
+}

--- a/Cotabby/Support/SentenceBoundaryClassifier.swift
+++ b/Cotabby/Support/SentenceBoundaryClassifier.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// File overview:
+/// Decides whether a period actually ends a sentence, so phrase-level acceptance does not stop
+/// early on decimals, list numbers, single-letter initials, or common abbreviations.
+///
+/// Why this file exists:
+/// Phrase acceptance treats any `.` as a sentence terminator. That breaks "version 1.2", "U.S.",
+/// "e.g.", and a numbered "1." mid-tail. A purely structural scanner cannot resolve every case, but
+/// it can resolve the frequent ones with a few local rules. `!` and `?` are always terminal and do
+/// not need this; only the period is ambiguous.
+enum SentenceBoundaryClassifier {
+    /// Lowercased abbreviations whose trailing period is part of the word, not a sentence end.
+    private static let abbreviations: Set<String> = [
+        "mr", "mrs", "ms", "dr", "st", "vs", "eg", "ie", "etc", "no", "fig", "approx", "inc", "ltd"
+    ]
+
+    /// Whether the period at `periodIndex` in `text` ends a sentence. The caller guarantees that
+    /// `text[periodIndex]` is ".".
+    static func isTerminalPeriod(in text: String, at periodIndex: String.Index) -> Bool {
+        guard periodIndex > text.startIndex else {
+            // A leading period has no preceding word to qualify it; treat it as terminal so behavior
+            // matches the previous unconditional rule for this edge.
+            return true
+        }
+
+        let beforeIndex = text.index(before: periodIndex)
+        let beforeChar = text[beforeIndex]
+
+        // Decimals, version numbers, and list/ordinal markers ("1.", "3.14") are not sentence ends.
+        if beforeChar.isNumber {
+            return false
+        }
+
+        if beforeChar.isLetter {
+            // Single-letter initial ("U.", the "S." in "U.S."): the letter stands alone, with a
+            // non-letter (or nothing) before it.
+            let priorIsLetter = beforeIndex > text.startIndex && text[text.index(before: beforeIndex)].isLetter
+            if !priorIsLetter {
+                return false
+            }
+            // Known abbreviation ending in a period.
+            if abbreviations.contains(trailingLetters(in: text, endingBefore: periodIndex).lowercased()) {
+                return false
+            }
+        }
+
+        return true
+    }
+
+    /// The run of letters in `text` ending just before `index`.
+    private static func trailingLetters(in text: String, endingBefore index: String.Index) -> String {
+        var letters: [Character] = []
+        var cursor = index
+        while cursor > text.startIndex {
+            let previous = text.index(before: cursor)
+            guard text[previous].isLetter else {
+                break
+            }
+            letters.append(text[previous])
+            cursor = previous
+        }
+        return String(letters.reversed())
+    }
+}

--- a/Cotabby/Support/SuggestionSessionReconciler.swift
+++ b/Cotabby/Support/SuggestionSessionReconciler.swift
@@ -270,10 +270,11 @@ enum SuggestionSessionReconciler {
     /// quoted-prose case (`"done." Next` → stop after the closing quote). Without the walk-back,
     /// the chunk's last character would be `"` rather than `.` and phrase mode would over-accept
     /// the next sentence. Token-interior punctuation like the dots in `U.S.A` does NOT trigger
-    /// an early break because the chunk's tail (after walking) is `A`, not `.`. The known
-    /// false-positive is when the tail itself ends with `U.S.A.` — the trailing period reads as
-    /// a sentence terminator and the user has to press once more for the next phrase. Rule-based
-    /// scanners can't disambiguate that without NLP; Cursor and Copilot behave the same way.
+    /// an early break because the chunk's tail (after walking) is `A`, not `.`. Periods are further
+    /// disambiguated by `SentenceBoundaryClassifier`, so decimals ("1.2"), list numbers ("1."),
+    /// single-letter initials, and common abbreviations ("e.g.", "U.S.") do not end a phrase. Truly
+    /// ambiguous cases (a real sentence ending in an abbreviation) lean toward continuing, which is
+    /// the safe default for phrase acceptance.
     ///
     /// The `autoAcceptTrailingPunctuation` flag is passed through to each underlying chunk call
     /// but does not change the final phrase output: a tail like `you?` with the flag off yields
@@ -333,7 +334,16 @@ enum SuggestionSessionReconciler {
             return false
         }
         let prev = text.index(before: index)
-        return text[prev].isPhraseSentenceTerminator
+        guard text[prev].isPhraseSentenceTerminator else {
+            return false
+        }
+        // `!` and `?` always end a sentence. A period is ambiguous: decimals, list/ordinal numbers,
+        // single-letter initials, and common abbreviations are not sentence ends, so consult the
+        // classifier rather than treating every "." as terminal.
+        if text[prev] == "." {
+            return SentenceBoundaryClassifier.isTerminalPeriod(in: text, at: prev)
+        }
+        return true
     }
 
     /// Returns the index just past a word token's final alphanumeric character when that token has

--- a/Cotabby/Support/SuggestionTextNormalizer.swift
+++ b/Cotabby/Support/SuggestionTextNormalizer.swift
@@ -20,14 +20,9 @@ enum SuggestionTextNormalizer {
         normalized = normalized.replacingOccurrences(of: "<|im_end|>", with: "")
         normalized = normalized.replacingOccurrences(of: "<|im_start|>", with: "")
 
-        // Thinking-capable models may emit <think>…</think> reasoning blocks. Strip complete
-        // blocks first, then any trailing open tag left when generation hit the token limit.
-        if let thinkRange = normalized.range(of: "<think>[\\s\\S]*?</think>", options: .regularExpression) {
-            normalized.replaceSubrange(thinkRange, with: "")
-        }
-        if let openTag = normalized.range(of: "<think>[\\s\\S]*", options: .regularExpression) {
-            normalized.replaceSubrange(openTag, with: "")
-        }
+        // Thinking-capable models may emit <think>…</think> reasoning blocks. Strip them here so
+        // the reasoning text never reaches the continuation logic below.
+        normalized = stripThinkBlocks(normalized)
 
         for prompt in [request.prompt] + promptEchoCandidates {
             if !prompt.isEmpty, normalized.hasPrefix(prompt) {
@@ -82,8 +77,10 @@ enum SuggestionTextNormalizer {
         // If the model starts by repeating text that already exists after the caret, we treat the
         // suggestion as unusable. Showing only the remainder often produces confusing mid-word
         // ghosts, so the coordinator should regenerate instead.
-        if !request.context.trailingText.isEmpty,
-            normalized.hasPrefix(request.context.trailingText) {
+        if TrailingDuplicationFilter.duplicatesTrailingText(
+            normalized,
+            trailingText: request.context.trailingText
+        ) {
             return ""
         }
 
@@ -104,7 +101,27 @@ enum SuggestionTextNormalizer {
             normalized = String(normalized.drop(while: { $0.isWhitespace }))
         }
 
+        // Final safety gate: never surface control characters, replacement glyphs, or
+        // whitespace-only output as ghost text. Returning empty makes the coordinator treat this
+        // as "no suggestion" and regenerate rather than insert junk on Tab.
+        guard InsertionSafetyGate.isSafeToInsert(normalized) else {
+            return ""
+        }
+
         return normalized
+    }
+
+    /// Removes `<think>…</think>` reasoning blocks: complete blocks first, then any dangling open
+    /// tag left when generation hit the token limit before the block was closed.
+    private static func stripThinkBlocks(_ text: String) -> String {
+        var result = text
+        if let complete = result.range(of: "<think>[\\s\\S]*?</think>", options: .regularExpression) {
+            result.replaceSubrange(complete, with: "")
+        }
+        if let dangling = result.range(of: "<think>[\\s\\S]*", options: .regularExpression) {
+            result.replaceSubrange(dangling, with: "")
+        }
+        return result
     }
 
     /// Finds the longest suffix of `precedingText` (at any word offset) that matches a prefix

--- a/Cotabby/Support/TrailingDuplicationFilter.swift
+++ b/Cotabby/Support/TrailingDuplicationFilter.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// File overview:
+/// Decides whether a proposed completion would mostly retype text that already follows the caret.
+///
+/// Why this file exists:
+/// Local models frequently restart from the text just after the cursor, so a raw completion can be
+/// a near-copy of what the field already contains downstream. Accepting it inserts a duplicate. The
+/// previous guard in `SuggestionTextNormalizer` only checked a raw `hasPrefix`, which any stray
+/// leading glyph (a markdown bullet, a quote, a space) or a case difference defeated. Comparing on a
+/// folded view (lowercased, letters and digits only) catches the real-world shapes that plain
+/// prefix matching misses, while staying conservative enough not to suppress legitimately short
+/// completions that merely share a few characters with the suffix.
+enum TrailingDuplicationFilter {
+    /// Below this many folded characters we do not trust an overlap. Short coincidental matches
+    /// (a shared "the", a shared two-letter stem) are common and must not trigger suppression.
+    static let minimumFoldedOverlap = 3
+
+    /// Returns true when `completion` would duplicate text that already follows the caret.
+    static func duplicatesTrailingText(_ completion: String, trailingText: String) -> Bool {
+        let foldedCompletion = fold(completion)
+        guard foldedCompletion.count >= minimumFoldedOverlap else {
+            return false
+        }
+        let foldedTrailing = fold(trailingText)
+        guard !foldedTrailing.isEmpty else {
+            return false
+        }
+
+        // Shape 1: the completion is the start of what already follows the caret.
+        if foldedTrailing.hasPrefix(foldedCompletion) {
+            return true
+        }
+
+        // Shape 2: the completion contains the whole upcoming suffix run, so accepting it would
+        // push a second copy of that text in front of the existing one.
+        if foldedCompletion.hasPrefix(foldedTrailing), foldedTrailing.count >= minimumFoldedOverlap {
+            return true
+        }
+
+        // Shape 3: a long leading run of the completion already appears at the caret. Catches the
+        // common "model re-emits the next few words" case where the two diverge only after a while.
+        let overlap = commonPrefixLength(foldedCompletion, foldedTrailing)
+        return overlap >= max(minimumFoldedOverlap, foldedCompletion.count / 2)
+    }
+
+    /// Lowercased, letters and digits only. Folding on alphanumerics is what lets a stray leading
+    /// bullet or quote in the raw model output still line up against the plain field text.
+    private static func fold(_ text: String) -> String {
+        String(text.lowercased().unicodeScalars.filter { CharacterSet.alphanumerics.contains($0) })
+    }
+
+    private static func commonPrefixLength(_ lhs: String, _ rhs: String) -> Int {
+        var count = 0
+        var lhsIndex = lhs.startIndex
+        var rhsIndex = rhs.startIndex
+        while lhsIndex < lhs.endIndex, rhsIndex < rhs.endIndex, lhs[lhsIndex] == rhs[rhsIndex] {
+            count += 1
+            lhsIndex = lhs.index(after: lhsIndex)
+            rhsIndex = rhs.index(after: rhsIndex)
+        }
+        return count
+    }
+}

--- a/CotabbyTests/ConfidenceSuppressionPolicyTests.swift
+++ b/CotabbyTests/ConfidenceSuppressionPolicyTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import Cotabby
+
+/// Pure-function tests for confidence-based suppression.
+final class ConfidenceSuppressionPolicyTests: XCTestCase {
+
+    func test_disabledFloor_neverSuppresses() {
+        // The default floor (-infinity) means suppression is off, even for very low confidence.
+        XCTAssertFalse(
+            ConfidenceSuppressionPolicy.shouldSuppress(averageLogprob: -50.0, floor: -.infinity)
+        )
+    }
+
+    func test_belowFloor_suppresses() {
+        XCTAssertTrue(
+            ConfidenceSuppressionPolicy.shouldSuppress(averageLogprob: -3.0, floor: -2.0)
+        )
+    }
+
+    func test_aboveFloor_doesNotSuppress() {
+        XCTAssertFalse(
+            ConfidenceSuppressionPolicy.shouldSuppress(averageLogprob: -1.0, floor: -2.0)
+        )
+    }
+
+    func test_atFloor_doesNotSuppress() {
+        XCTAssertFalse(
+            ConfidenceSuppressionPolicy.shouldSuppress(averageLogprob: -2.0, floor: -2.0)
+        )
+    }
+}

--- a/CotabbyTests/InsertionSafetyGateTests.swift
+++ b/CotabbyTests/InsertionSafetyGateTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import Cotabby
+
+/// Pure-function tests for the last-mile insertion safety gate.
+final class InsertionSafetyGateTests: XCTestCase {
+
+    func test_normalText_isSafe() {
+        XCTAssertTrue(InsertionSafetyGate.isSafeToInsert("hello there"))
+    }
+
+    func test_loneStructuralPunctuation_isSafe() {
+        // Closing a bracket or ending a sentence is a legitimate inline completion.
+        XCTAssertTrue(InsertionSafetyGate.isSafeToInsert(")"))
+        XCTAssertTrue(InsertionSafetyGate.isSafeToInsert("."))
+    }
+
+    func test_empty_isUnsafe() {
+        XCTAssertFalse(InsertionSafetyGate.isSafeToInsert(""))
+    }
+
+    func test_whitespaceOnly_isUnsafe() {
+        XCTAssertFalse(InsertionSafetyGate.isSafeToInsert("   "))
+    }
+
+    func test_replacementCharacter_isUnsafe() {
+        XCTAssertFalse(InsertionSafetyGate.isSafeToInsert("ab\u{FFFD}cd"))
+    }
+
+    func test_interiorControlCharacter_isUnsafe() {
+        XCTAssertFalse(InsertionSafetyGate.isSafeToInsert("a\tb"))
+    }
+}

--- a/CotabbyTests/MidWordContinuationPolicyTests.swift
+++ b/CotabbyTests/MidWordContinuationPolicyTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import Cotabby
+
+/// Pure-function tests for the mid-word continuation trigger.
+final class MidWordContinuationPolicyTests: XCTestCase {
+
+    func test_caretInsideWord_forcesContinuation() {
+        XCTAssertTrue(
+            MidWordContinuationPolicy.shouldForceContinuation(precedingText: "I am wri", trailingText: "ting")
+        )
+    }
+
+    func test_caretAtWordEnd_doesNotForce() {
+        // Nothing after the caret: a normal word boundary, where next-word predictions belong.
+        XCTAssertFalse(
+            MidWordContinuationPolicy.shouldForceContinuation(precedingText: "The quick brown fox", trailingText: "")
+        )
+    }
+
+    func test_spaceBeforeCaret_doesNotForce() {
+        XCTAssertFalse(
+            MidWordContinuationPolicy.shouldForceContinuation(precedingText: "hello ", trailingText: "world")
+        )
+    }
+
+    func test_punctuationAfterCaret_doesNotForce() {
+        XCTAssertFalse(
+            MidWordContinuationPolicy.shouldForceContinuation(precedingText: "done", trailingText: ". Next")
+        )
+    }
+}

--- a/CotabbyTests/SentenceBoundaryClassifierTests.swift
+++ b/CotabbyTests/SentenceBoundaryClassifierTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import Cotabby
+
+/// Pure-function tests for period disambiguation used by phrase-level acceptance.
+final class SentenceBoundaryClassifierTests: XCTestCase {
+
+    private func lastPeriodIndex(in text: String) -> String.Index {
+        guard let index = text.lastIndex(of: ".") else {
+            XCTFail("test string must contain a period: \(text)")
+            return text.startIndex
+        }
+        return index
+    }
+
+    func test_endOfRealSentence_isTerminal() {
+        let text = "I went home."
+        XCTAssertTrue(SentenceBoundaryClassifier.isTerminalPeriod(in: text, at: lastPeriodIndex(in: text)))
+    }
+
+    func test_wordEndingSentence_isTerminal() {
+        let text = "I have a cat."
+        XCTAssertTrue(SentenceBoundaryClassifier.isTerminalPeriod(in: text, at: lastPeriodIndex(in: text)))
+    }
+
+    func test_decimalNumber_isNotTerminal() {
+        let text = "pi is 3.14"
+        XCTAssertFalse(SentenceBoundaryClassifier.isTerminalPeriod(in: text, at: lastPeriodIndex(in: text)))
+    }
+
+    func test_listNumber_isNotTerminal() {
+        let text = "item 1."
+        XCTAssertFalse(SentenceBoundaryClassifier.isTerminalPeriod(in: text, at: lastPeriodIndex(in: text)))
+    }
+
+    func test_singleLetterInitial_isNotTerminal() {
+        let text = "I visited the U.S."
+        XCTAssertFalse(SentenceBoundaryClassifier.isTerminalPeriod(in: text, at: lastPeriodIndex(in: text)))
+    }
+
+    func test_knownAbbreviation_isNotTerminal() {
+        let text = "tabs and so on etc."
+        XCTAssertFalse(SentenceBoundaryClassifier.isTerminalPeriod(in: text, at: lastPeriodIndex(in: text)))
+    }
+}

--- a/CotabbyTests/SuggestionSessionReconcilerTests.swift
+++ b/CotabbyTests/SuggestionSessionReconcilerTests.swift
@@ -202,13 +202,13 @@ final class SuggestionSessionReconcilerTests: XCTestCase {
         )
     }
 
-    func test_nextAcceptancePhrase_abbreviationFalseBreakIsKnownLimitation() {
-        // "U.S.A." ends in a period, which the rule-based scanner treats as a sentence terminator.
-        // The user accepts the abbreviation in one press and the next phrase begins with " is".
-        // Without NLP this collapse is unavoidable; Cursor and Copilot behave the same way.
+    func test_nextAcceptancePhrase_walksPastDottedInitialsToRealSentenceEnd() {
+        // "U.S.A." is a run of single-letter initials, so its interior periods are not sentence
+        // ends. SentenceBoundaryClassifier keeps phrase acceptance going until the real terminator
+        // after "great" (see SentenceBoundaryClassifierTests for the period-disambiguation rules).
         XCTAssertEqual(
             SuggestionSessionReconciler.nextAcceptancePhrase(from: "U.S.A. is great."),
-            "U.S.A."
+            "U.S.A. is great."
         )
     }
 

--- a/CotabbyTests/TrailingDuplicationFilterTests.swift
+++ b/CotabbyTests/TrailingDuplicationFilterTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import Cotabby
+
+/// Pure-function tests for the after-caret duplication guard. No mocks or I/O: the same inputs
+/// always produce the same verdict, so every assertion is deterministic.
+final class TrailingDuplicationFilterTests: XCTestCase {
+
+    func test_exactPrefixDuplication_isDuplicate() {
+        XCTAssertTrue(
+            TrailingDuplicationFilter.duplicatesTrailingText("the dog", trailingText: "the dog runs")
+        )
+    }
+
+    func test_leadingStrayGlyph_stillMatchesAfterFolding() {
+        // A markdown bullet or stray punctuation in the raw output must not let a duplicate through.
+        XCTAssertTrue(
+            TrailingDuplicationFilter.duplicatesTrailingText("**the dog", trailingText: "the dog runs")
+        )
+    }
+
+    func test_caseInsensitiveDuplication_isDuplicate() {
+        XCTAssertTrue(
+            TrailingDuplicationFilter.duplicatesTrailingText("The Dog", trailingText: "the dog runs")
+        )
+    }
+
+    func test_completionContainsWholeSuffix_isDuplicate() {
+        XCTAssertTrue(
+            TrailingDuplicationFilter.duplicatesTrailingText("ing the cat", trailingText: "ing")
+        )
+    }
+
+    func test_genuineContinuation_isNotDuplicate() {
+        XCTAssertFalse(
+            TrailingDuplicationFilter.duplicatesTrailingText("world peace now", trailingText: "domination plans")
+        )
+    }
+
+    func test_emptyTrailingText_isNotDuplicate() {
+        XCTAssertFalse(
+            TrailingDuplicationFilter.duplicatesTrailingText("hello world", trailingText: "")
+        )
+    }
+
+    func test_shortCompletionBelowOverlapFloor_isNotDuplicate() {
+        XCTAssertFalse(
+            TrailingDuplicationFilter.duplicatesTrailingText("ok", trailingText: "okay then")
+        )
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -13,7 +13,7 @@ packages:
     exactVersion: 2.9.1
   CotabbyInference:
     url: https://github.com/FuJacob/cotabbyinference.git
-    branch: main
+    branch: feat/generation-quality-controls
   swift-log:
     url: https://github.com/apple/swift-log.git
     from: 1.12.1


### PR DESCRIPTION
## Summary

Moves last-mile suggestion-quality control into small, testable helpers and suppresses more classes of bad completion before they reach ghost text. The goal is the project principle that a suppressed completion beats a wrong one.

First of two stacked PRs. App-only, no engine change.

- `TrailingDuplicationFilter`: replaces the raw `hasPrefix(trailingText)` guard in `SuggestionTextNormalizer` with a folded (lowercased, alphanumeric-only) check covering three duplication shapes, so a stray leading glyph, a case difference, or a contained suffix no longer slips a duplicate through.
- `InsertionSafetyGate`: final gate in `SuggestionTextNormalizer` that rejects control characters, U+FFFD replacement glyphs, and whitespace-only output. Does not judge punctuation, so a lone ")" or "." still passes.
- `SentenceBoundaryClassifier`: consulted by `SuggestionSessionReconciler.endsInSentenceTerminator` so phrase acceptance no longer stops early on decimals ("1.2"), list numbers ("1."), single-letter initials, or common abbreviations ("e.g.", "U.S.").

Typo suppression is intentionally **not** included here. It overlaps the more complete #353 (which adds a spell checker, correction mode, and settings), so this PR defers to that rather than shipping a weaker duplicate.

## Validation

```
swiftlint lint --strict --quiet <touched files>          # exit 0
xcodebuild ... build-for-testing -derivedDataPath ...     # ** TEST BUILD SUCCEEDED **
xcodebuild test ... CODE_SIGNING_ALLOWED=NO \
  -only-testing:CotabbyTests/TrailingDuplicationFilterTests \
  -only-testing:CotabbyTests/InsertionSafetyGateTests \
  -only-testing:CotabbyTests/SentenceBoundaryClassifierTests
# ** TEST SUCCEEDED **  Executed 19 tests, with 0 failures
```

Local Team ID caveat: the default signed `test` run cannot load the xctest bundle locally, so the suites are run with `CODE_SIGNING_ALLOWED=NO`. `build-for-testing` passes signed.

## Linked issues

None. Related: #353 (typo suppression, intentionally not duplicated here).

## Risk / rollout notes

- Behavior change: these gates suppress more completions than before. Thresholds are conservative (minimum overlap length, abbreviation allowlist) to avoid suppressing valid suggestions.
- pbxproj migration: three new source files and three new test files, regenerated with `xcodegen generate`.
- No settings, schema, or runtime-engine changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces five new helper types that form a multi-layer output safety pipeline, tightening last-mile filtering before suggestions reach ghost text. All new types are pure functions with dedicated test suites (19 tests, 0 failures reported).

- **New gates in `SuggestionTextNormalizer`**: `TrailingDuplicationFilter` replaces the raw `hasPrefix` guard with a folded (lowercased, alphanumeric-only) check across three duplication shapes; `InsertionSafetyGate` rejects control characters, U+FFFD glyphs, and whitespace-only output as the final step before a suggestion is surfaced.
- **Phrase-acceptance improvement**: `SentenceBoundaryClassifier` is integrated into `SuggestionSessionReconciler.endsInSentenceTerminator` so decimals, list numbers, single-letter initials, and common abbreviations no longer cause early phrase breaks.
- **Runtime additions**: `ConfidenceSuppressionPolicy` and `MidWordContinuationPolicy` are wired into `LlamaRuntimeCore` / `LlamaSuggestionEngine` with all new options disabled by default; the `CotabbyInference` package is switched to a feature branch to expose the required engine APIs.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is: the CotabbyInference dependency is pinned to a feature branch, making all builds after a potential branch deletion or rebase silently broken.

The new helper types are well-structured and the test suite is solid, but the dependency on feat/generation-quality-controls instead of a stable ref is a real build-stability problem. Additionally, TrailingDuplicationFilter Shape 3 uses integer division that collapses the effective threshold to the same 3-character floor for short completions, which can suppress valid 4–6 character suggestions sharing a common prefix with trailing text.

project.yml and Cotabby.xcodeproj/project.pbxproj both reference the feat/generation-quality-controls branch; TrailingDuplicationFilter.swift Shape 3 threshold deserves a second look for short completion inputs.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| project.yml | CotabbyInference package branch changed from main to feat/generation-quality-controls. Pinning to a feature branch makes builds non-reproducible and fragile. |
| Cotabby/Support/TrailingDuplicationFilter.swift | New file implementing folded duplication detection across three shapes. Shape 3 integer-division threshold can cause false-positive suppression for short 4–6 character completions sharing a 3-character prefix with trailing text. |
| Cotabby/Support/SentenceBoundaryClassifier.swift | New classifier disambiguating periods for phrase acceptance. Logic is correct but the abbreviation allow-list is small and will miss common cases like Prof., Jr., Sr. |
| Cotabby/Support/InsertionSafetyGate.swift | New final gate rejecting control characters, U+FFFD glyphs, and whitespace-only output. Logic and edge cases are sound. |
| Cotabby/Support/ConfidenceSuppressionPolicy.swift | New pure policy suppressing completions below a log-probability floor. Disabled by default; guard for the −∞ sentinel is correct and well-tested. |
| Cotabby/Support/MidWordContinuationPolicy.swift | New policy constraining the first token to a word continuation only when both sides of the caret are word characters. Narrowly scoped and well-tested. |
| Cotabby/Support/SuggestionTextNormalizer.swift | Integrates TrailingDuplicationFilter and InsertionSafetyGate; extracts stripThinkBlocks into a named helper. Changes are clean. |
| Cotabby/Support/SuggestionSessionReconciler.swift | endsInSentenceTerminator now delegates period disambiguation to SentenceBoundaryClassifier. Updated test correctly validates the new behavior. |
| Cotabby/Services/Runtime/LlamaRuntimeCore.swift | Adds log-probability accumulation, confidence suppression gate, forceWordContinuation wiring on both paths, and single_line flag forwarding. Defer-based KV cleanup still runs on early return. |
| Cotabby/Models/LlamaRuntimeModels.swift | Adds singleLine, forceWordContinuation, and confidenceFloor fields with safe defaults so all existing call sites remain unaffected. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[LlamaSuggestionEngine] --> B[LlamaRuntimeCore
generates tokens
accumulates sumLogprob]
    B --> C{ConfidenceSuppressionPolicy}
    C -- suppressed --> Z[return empty]
    C -- passes --> D[SuggestionTextNormalizer]
    D --> D1[stripThinkBlocks]
    D1 --> D2[prompt-echo strip]
    D2 --> D3{TrailingDuplicationFilter
shapes 1·2·3}
    D3 -- duplicate --> Z
    D3 -- unique --> D4[whitespace trim]
    D4 --> D5{InsertionSafetyGate}
    D5 -- unsafe --> Z
    D5 -- safe --> E[ghost text shown]
    F[SuggestionSessionReconciler] --> G{endsInSentenceTerminator}
    G -- exclamation or question --> H[stop phrase]
    G -- period --> I{SentenceBoundaryClassifier}
    I -- decimal/initial/abbrev --> J[continue phrase]
    I -- real sentence end --> H
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cotabby/Support/SentenceBoundaryClassifier.swift`, line 541-542 ([link](https://github.com/fujacob/cotabby/blob/9d9db99537bf1c6eb02c8774b40bfc285534cbae/Cotabby/Support/SentenceBoundaryClassifier.swift#L541-L542)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Abbreviation list omits several high-frequency titles and terms**

   The set covers basics but is missing commonly occurring terms: `"prof"`, `"jr"`, `"sr"`, `"corp"`, `"dept"`, `"ave"`, `"blvd"`, `"vol"`, `"ed"` (editor), `"est"` (established), and `"ca"` (circa). When any of these appear at the end of a chunk in phrase-acceptance mode, the classifier will fall through to `return true` and treat their trailing period as a sentence end. Because the classifier deliberately biases toward continuing on ambiguous periods (safe default), extending this list with a few more well-known cases costs nothing in correctness and reduces unnecessary early breaks.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Foutput-safety-gates%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Foutput-safety-gates%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FSupport%2FSentenceBoundaryClassifier.swift%0ALine%3A%20541-542%0A%0AComment%3A%0A**Abbreviation%20list%20omits%20several%20high-frequency%20titles%20and%20terms**%0A%0AThe%20set%20covers%20basics%20but%20is%20missing%20commonly%20occurring%20terms%3A%20%60%22prof%22%60%2C%20%60%22jr%22%60%2C%20%60%22sr%22%60%2C%20%60%22corp%22%60%2C%20%60%22dept%22%60%2C%20%60%22ave%22%60%2C%20%60%22blvd%22%60%2C%20%60%22vol%22%60%2C%20%60%22ed%22%60%20%28editor%29%2C%20%60%22est%22%60%20%28established%29%2C%20and%20%60%22ca%22%60%20%28circa%29.%20When%20any%20of%20these%20appear%20at%20the%20end%20of%20a%20chunk%20in%20phrase-acceptance%20mode%2C%20the%20classifier%20will%20fall%20through%20to%20%60return%20true%60%20and%20treat%20their%20trailing%20period%20as%20a%20sentence%20end.%20Because%20the%20classifier%20deliberately%20biases%20toward%20continuing%20on%20ambiguous%20periods%20%28safe%20default%29%2C%20extending%20this%20list%20with%20a%20few%20more%20well-known%20cases%20costs%20nothing%20in%20correctness%20and%20reduces%20unnecessary%20early%20breaks.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FSupport%2FSentenceBoundaryClassifier.swift%0ALine%3A%20541-542%0A%0AComment%3A%0A**Abbreviation%20list%20omits%20several%20high-frequency%20titles%20and%20terms**%0A%0AThe%20set%20covers%20basics%20but%20is%20missing%20commonly%20occurring%20terms%3A%20%60%22prof%22%60%2C%20%60%22jr%22%60%2C%20%60%22sr%22%60%2C%20%60%22corp%22%60%2C%20%60%22dept%22%60%2C%20%60%22ave%22%60%2C%20%60%22blvd%22%60%2C%20%60%22vol%22%60%2C%20%60%22ed%22%60%20%28editor%29%2C%20%60%22est%22%60%20%28established%29%2C%20and%20%60%22ca%22%60%20%28circa%29.%20When%20any%20of%20these%20appear%20at%20the%20end%20of%20a%20chunk%20in%20phrase-acceptance%20mode%2C%20the%20classifier%20will%20fall%20through%20to%20%60return%20true%60%20and%20treat%20their%20trailing%20period%20as%20a%20sentence%20end.%20Because%20the%20classifier%20deliberately%20biases%20toward%20continuing%20on%20ambiguous%20periods%20%28safe%20default%29%2C%20extending%20this%20list%20with%20a%20few%20more%20well-known%20cases%20costs%20nothing%20in%20correctness%20and%20reduces%20unnecessary%20early%20breaks.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=485&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Foutput-safety-gates%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Foutput-safety-gates%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aproject.yml%3A14-15%0A**Dependency%20pinned%20to%20a%20feature%20branch**%0A%0A%60CotabbyInference%60%20is%20now%20locked%20to%20%60feat%2Fgeneration-quality-controls%60%20instead%20of%20%60main%60.%20Branch%20references%20are%20not%20content-addressed%3A%20if%20that%20branch%20is%20deleted%2C%20rebased%2C%20or%20diverges%20after%20this%20PR%20is%20merged%2C%20every%20subsequent%20build%20will%20silently%20fail%20to%20resolve%20the%20package.%20The%20same%20change%20appears%20in%20%60project.pbxproj%60%2C%20so%20both%20the%20YAML%20spec%20and%20the%20generated%20project%20file%20are%20affected.%20This%20should%20be%20resolved%20before%20merge%20%E2%80%94%20either%20by%20merging%20the%20inference-engine%20PR%20first%20and%20pointing%20back%20to%20%60main%60%2C%20or%20by%20pinning%20to%20a%20concrete%20commit%20SHA%20that%20survives%20branch%20lifecycle%20events.%0A%0A%23%23%23%20Issue%202%20of%203%0ACotabby%2FSupport%2FTrailingDuplicationFilter.swift%3A42-44%0A**Shape%203%20threshold%20collapses%20to%20%60minimumFoldedOverlap%60%20for%20short%20completions**%0A%0A%60foldedCompletion.count%20%2F%202%60%20is%20integer%20division%2C%20so%20for%20completions%20of%204%E2%80%936%20folded%20characters%20the%20divisor%20rounds%20down%20to%202%20or%203%2C%20making%20%60max%28minimumFoldedOverlap%2C%20...%29%60%20always%20equal%20to%20%60minimumFoldedOverlap%60%20%283%29.%20A%204-character%20completion%20like%20%60%22work%22%60%20shares%203%20folded%20characters%20%28%60wor%60%29%20with%20trailing%20text%20%60%22world...%22%60%2C%20so%20%603%20%3E%3D%20max%283%2C%204%2F2%29%60%20%E2%86%92%20%603%20%3E%3D%203%60%20%E2%86%92%20suppressed%2C%20even%20though%20the%20two%20words%20are%20distinct.%20The%20intent%20of%20shape%203%20is%20to%20catch%20re-emitted%20multi-word%20runs%3B%20that%20goal%20is%20better%20served%20by%20requiring%20the%20overlap%20to%20be%20strictly%20more%20than%20half%20the%20completion%20length%2C%20e.g.%20%60overlap%20%3E%20foldedCompletion.count%20%2F%202%60%2C%20or%20by%20raising%20%60minimumFoldedOverlap%60%20for%20this%20shape%20alone.%0A%0A%23%23%23%20Issue%203%20of%203%0ACotabby%2FSupport%2FSentenceBoundaryClassifier.swift%3A541-542%0A**Abbreviation%20list%20omits%20several%20high-frequency%20titles%20and%20terms**%0A%0AThe%20set%20covers%20basics%20but%20is%20missing%20commonly%20occurring%20terms%3A%20%60%22prof%22%60%2C%20%60%22jr%22%60%2C%20%60%22sr%22%60%2C%20%60%22corp%22%60%2C%20%60%22dept%22%60%2C%20%60%22ave%22%60%2C%20%60%22blvd%22%60%2C%20%60%22vol%22%60%2C%20%60%22ed%22%60%20%28editor%29%2C%20%60%22est%22%60%20%28established%29%2C%20and%20%60%22ca%22%60%20%28circa%29.%20When%20any%20of%20these%20appear%20at%20the%20end%20of%20a%20chunk%20in%20phrase-acceptance%20mode%2C%20the%20classifier%20will%20fall%20through%20to%20%60return%20true%60%20and%20treat%20their%20trailing%20period%20as%20a%20sentence%20end.%20Because%20the%20classifier%20deliberately%20biases%20toward%20continuing%20on%20ambiguous%20periods%20%28safe%20default%29%2C%20extending%20this%20list%20with%20a%20few%20more%20well-known%20cases%20costs%20nothing%20in%20correctness%20and%20reduces%20unnecessary%20early%20breaks.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aproject.yml%3A14-15%0A**Dependency%20pinned%20to%20a%20feature%20branch**%0A%0A%60CotabbyInference%60%20is%20now%20locked%20to%20%60feat%2Fgeneration-quality-controls%60%20instead%20of%20%60main%60.%20Branch%20references%20are%20not%20content-addressed%3A%20if%20that%20branch%20is%20deleted%2C%20rebased%2C%20or%20diverges%20after%20this%20PR%20is%20merged%2C%20every%20subsequent%20build%20will%20silently%20fail%20to%20resolve%20the%20package.%20The%20same%20change%20appears%20in%20%60project.pbxproj%60%2C%20so%20both%20the%20YAML%20spec%20and%20the%20generated%20project%20file%20are%20affected.%20This%20should%20be%20resolved%20before%20merge%20%E2%80%94%20either%20by%20merging%20the%20inference-engine%20PR%20first%20and%20pointing%20back%20to%20%60main%60%2C%20or%20by%20pinning%20to%20a%20concrete%20commit%20SHA%20that%20survives%20branch%20lifecycle%20events.%0A%0A%23%23%23%20Issue%202%20of%203%0ACotabby%2FSupport%2FTrailingDuplicationFilter.swift%3A42-44%0A**Shape%203%20threshold%20collapses%20to%20%60minimumFoldedOverlap%60%20for%20short%20completions**%0A%0A%60foldedCompletion.count%20%2F%202%60%20is%20integer%20division%2C%20so%20for%20completions%20of%204%E2%80%936%20folded%20characters%20the%20divisor%20rounds%20down%20to%202%20or%203%2C%20making%20%60max%28minimumFoldedOverlap%2C%20...%29%60%20always%20equal%20to%20%60minimumFoldedOverlap%60%20%283%29.%20A%204-character%20completion%20like%20%60%22work%22%60%20shares%203%20folded%20characters%20%28%60wor%60%29%20with%20trailing%20text%20%60%22world...%22%60%2C%20so%20%603%20%3E%3D%20max%283%2C%204%2F2%29%60%20%E2%86%92%20%603%20%3E%3D%203%60%20%E2%86%92%20suppressed%2C%20even%20though%20the%20two%20words%20are%20distinct.%20The%20intent%20of%20shape%203%20is%20to%20catch%20re-emitted%20multi-word%20runs%3B%20that%20goal%20is%20better%20served%20by%20requiring%20the%20overlap%20to%20be%20strictly%20more%20than%20half%20the%20completion%20length%2C%20e.g.%20%60overlap%20%3E%20foldedCompletion.count%20%2F%202%60%2C%20or%20by%20raising%20%60minimumFoldedOverlap%60%20for%20this%20shape%20alone.%0A%0A%23%23%23%20Issue%203%20of%203%0ACotabby%2FSupport%2FSentenceBoundaryClassifier.swift%3A541-542%0A**Abbreviation%20list%20omits%20several%20high-frequency%20titles%20and%20terms**%0A%0AThe%20set%20covers%20basics%20but%20is%20missing%20commonly%20occurring%20terms%3A%20%60%22prof%22%60%2C%20%60%22jr%22%60%2C%20%60%22sr%22%60%2C%20%60%22corp%22%60%2C%20%60%22dept%22%60%2C%20%60%22ave%22%60%2C%20%60%22blvd%22%60%2C%20%60%22vol%22%60%2C%20%60%22ed%22%60%20%28editor%29%2C%20%60%22est%22%60%20%28established%29%2C%20and%20%60%22ca%22%60%20%28circa%29.%20When%20any%20of%20these%20appear%20at%20the%20end%20of%20a%20chunk%20in%20phrase-acceptance%20mode%2C%20the%20classifier%20will%20fall%20through%20to%20%60return%20true%60%20and%20treat%20their%20trailing%20period%20as%20a%20sentence%20end.%20Because%20the%20classifier%20deliberately%20biases%20toward%20continuing%20on%20ambiguous%20periods%20%28safe%20default%29%2C%20extending%20this%20list%20with%20a%20few%20more%20well-known%20cases%20costs%20nothing%20in%20correctness%20and%20reduces%20unnecessary%20early%20breaks.%0A%0A&repo=fujacob%2Fcotabby&pr=485&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Generation-time quality controls: token ..."](https://github.com/fujacob/cotabby/commit/9d9db99537bf1c6eb02c8774b40bfc285534cbae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34848888)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->