### PR TITLE
Generation-time quality controls: token masks, single-line, mid-word continuation

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		3CF1A4E39F24917DF0470A7D /* PromptPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4696A84D17890B154533A08F /* PromptPolicyTests.swift */; };
 		4134ADBE464D00BB748BD9AE /* GeneralPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07480CE96ED0EBD94817C6B1 /* GeneralPaneView.swift */; };
 		4190F8A76196B16ED94D0A55 /* VisualContextModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE97A8169438D593C6C23412 /* VisualContextModels.swift */; };
+		429CE592897D8A952F2916C3 /* ConfidenceSuppressionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BD71ECC2AE4821B643E0935 /* ConfidenceSuppressionPolicy.swift */; };
 		42D40F37086294D0E58200C5 /* GhostFontSizeStabilizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9458F0820B3161FE9CF1DDAF /* GhostFontSizeStabilizer.swift */; };
 		4531645066A73971EB2A5FA1 /* EmojiCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC3BF78835C8F2C315932F1 /* EmojiCatalog.swift */; };
 		46F341472191BC451B6BF6B5 /* SuggestionRequestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDE858CB1E687E3CEB8FDD5B /* SuggestionRequestFactory.swift */; };
@@ -143,6 +144,7 @@
 		90DC9508F27F712EB61EEB06 /* PermissionReminderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 656F58E56FE9BC087B6F1D33 /* PermissionReminderView.swift */; };
 		91C27021750AC03AA4A0115A /* HuggingFaceAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110CB0B53016644EF7840301 /* HuggingFaceAPIClient.swift */; };
 		91D1F16B8C5DA281D4B7F699 /* CustomRulesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD752451330486FE270018B0 /* CustomRulesTests.swift */; };
+		91D8189EFCD1BA992EA6F038 /* ConfidenceSuppressionPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06FF2B0A3094A952A8EBA9B5 /* ConfidenceSuppressionPolicyTests.swift */; };
 		924489CEE8171F7AD8579D71 /* FocusDebugOverlayController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5E263AB69029D5E13D5EE8 /* FocusDebugOverlayController.swift */; };
 		934885ACC2DEA20B27F10948 /* PromptContextSanitizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D80CC2CCAAFE3F23FB8C37A /* PromptContextSanitizerTests.swift */; };
 		96498E097A5899AFC9F0C853 /* EmojiCatalogMatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292DC9D4D9D5D26AE882E39B /* EmojiCatalogMatcherTests.swift */; };
@@ -248,6 +250,7 @@
 		04D853218B0A77B0CE090828 /* BrowserAppDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserAppDetectorTests.swift; sourceTree = "<group>"; };
 		04E25414C307A20B6F9F20EC /* FocusSnapshotResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusSnapshotResolver.swift; sourceTree = "<group>"; };
 		050D929E13BE52E6282B64D2 /* VisualContextStartCoalescerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualContextStartCoalescerTests.swift; sourceTree = "<group>"; };
+		06FF2B0A3094A952A8EBA9B5 /* ConfidenceSuppressionPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfidenceSuppressionPolicyTests.swift; sourceTree = "<group>"; };
 		07480CE96ED0EBD94817C6B1 /* GeneralPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralPaneView.swift; sourceTree = "<group>"; };
 		0850B07CCDBA67C756C6EC59 /* ShortcutConflictTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutConflictTests.swift; sourceTree = "<group>"; };
 		09FADF683BE7B3558377FA76 /* FocusPollBackoff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusPollBackoff.swift; sourceTree = "<group>"; };
@@ -264,6 +267,7 @@
 		19BE12C28A4AB8A4A58C2FF7 /* SettingsPaneScaffold.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPaneScaffold.swift; sourceTree = "<group>"; };
 		19DB9558F4D3AFB108D71649 /* SuggestionStateHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionStateHelperTests.swift; sourceTree = "<group>"; };
 		1A8414BEB7E34F57607E37FE /* EmojiVariantResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiVariantResolver.swift; sourceTree = "<group>"; };
+		1BD71ECC2AE4821B643E0935 /* ConfidenceSuppressionPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfidenceSuppressionPolicy.swift; sourceTree = "<group>"; };
 		1CE61E74928C221B8BB261C6 /* SuggestionTextColorCodec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionTextColorCodec.swift; sourceTree = "<group>"; };
 		1D00A031C0D9CF2A7A2330D9 /* PermissionDragSourceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionDragSourceView.swift; sourceTree = "<group>"; };
 		1E0513E3B23937B099A3CFF2 /* WordCountFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordCountFormatterTests.swift; sourceTree = "<group>"; };
@@ -684,6 +688,7 @@
 				EFD89799BB82AF7A92559AEB /* ClipboardContentDistillerTests.swift */,
 				90B0D133AB77A2503FB08827 /* ClipboardRelevanceFilterTests.swift */,
 				D504BEB224E0C176F5FCFF6E /* CompletionRenderModePolicyTests.swift */,
+				06FF2B0A3094A952A8EBA9B5 /* ConfidenceSuppressionPolicyTests.swift */,
 				AF1E065C7FFB697FCEB2FA5C /* CotabbyTestFixtures.swift */,
 				AD752451330486FE270018B0 /* CustomRulesTests.swift */,
 				C1C5DE0F3FF63545000E2453 /* DisplayCoordinateConverterTests.swift */,
@@ -832,6 +837,7 @@
 				96495E4147D828C0B1B22765 /* ClipboardContentDistiller.swift */,
 				D3A2AC525DC664DB540D4F19 /* ClipboardRelevanceFilter.swift */,
 				53CF416511099C6818110F01 /* CompletionRenderModePolicy.swift */,
+				1BD71ECC2AE4821B643E0935 /* ConfidenceSuppressionPolicy.swift */,
 				C7B2D34A6F3AC9DFD61350F7 /* CotabbyDebugOptions.swift */,
 				29ED42C4BDD0C521101AF95E /* DeviceInfo.swift */,
 				74BD1D4DB27D5D96D1E06096 /* DisplayCoordinateConverter.swift */,
@@ -1016,6 +1022,7 @@
 				157A55EB796BEB7819B90D5D /* ClipboardRelevanceFilter.swift in Sources */,
 				7C94725B4837DEC9ECF1BC54 /* CompletionRenderMode.swift in Sources */,
 				3985F0F2B3178DBB945B1064 /* CompletionRenderModePolicy.swift in Sources */,
+				429CE592897D8A952F2916C3 /* ConfidenceSuppressionPolicy.swift in Sources */,
 				8B2DFC860803C0A7C4D34A36 /* ContextBuffer.swift in Sources */,
 				AA2E09FF7E430D66ECA8ECD5 /* CotabbyApp.swift in Sources */,
 				FCC571EC239846F06007BFCA /* CotabbyAppEnvironment.swift in Sources */,
@@ -1167,6 +1174,7 @@
 				8865B95FE84198D70390DF80 /* ClipboardContentDistillerTests.swift in Sources */,
 				BFCA7FAFDAEBF586AB615567 /* ClipboardRelevanceFilterTests.swift in Sources */,
 				25F91CEF38400FD1ADB6B1AF /* CompletionRenderModePolicyTests.swift in Sources */,
+				91D8189EFCD1BA992EA6F038 /* ConfidenceSuppressionPolicyTests.swift in Sources */,
 				5E10EFC426217CB7218A5847 /* CotabbyTestFixtures.swift in Sources */,
 				91D1F16B8C5DA281D4B7F699 /* CustomRulesTests.swift in Sources */,
 				56611BA0087710277140E9E6 /* DisplayCoordinateConverterTests.swift in Sources */,

--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 		76FD91607794883F8E121450 /* CaretGeometrySelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3C84377F352140759B448C9 /* CaretGeometrySelector.swift */; };
 		78FAE5DB691A1B71042B9D20 /* AboutPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3FA53BBC3D81503C1D17477 /* AboutPaneView.swift */; };
 		7B6A63F5DCC2C163CDFD2A5C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BC4F887528AE74AC0DD30314 /* Assets.xcassets */; };
+		7C36DBA762E19C8C31676D44 /* MidWordContinuationPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1274F897631B1B3A835D157F /* MidWordContinuationPolicyTests.swift */; };
 		7C94725B4837DEC9ECF1BC54 /* CompletionRenderMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A03E565A11581FD2150B142 /* CompletionRenderMode.swift */; };
 		7D6BB9AF72F7076A4E5EE96F /* DownloadableModelCatalogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5C2AE9A7E55495D26AD074 /* DownloadableModelCatalogView.swift */; };
 		7E9413CE7C999C4612348248 /* SuggestionSessionReconcilerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C8F07AC52C7A482F5FE34C5 /* SuggestionSessionReconcilerTests.swift */; };
@@ -150,6 +151,7 @@
 		98E2E14A069384C1088CDB44 /* PromptContextSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4B45B91D4DEAC979C3113E /* PromptContextSanitizer.swift */; };
 		9ABF75CDA78B27453C3F5B34 /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264CA64B2AB1611F82E5B760 /* WelcomeView.swift */; };
 		9ADFFF634912F638D079E1C7 /* SentenceBoundaryClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B56C250DDEF3E81F9DCBD7 /* SentenceBoundaryClassifier.swift */; };
+		9CEBD6AF4405F1BBE0E3D16C /* MidWordContinuationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 357C18383B047F24A531BDCD /* MidWordContinuationPolicy.swift */; };
 		9F2FDCABCC941CBECAA3B4AB /* CotabbyInference in Frameworks */ = {isa = PBXBuildFile; productRef = 48A46AD6B613CF06072603E4 /* CotabbyInference */; };
 		A0657CE0488F69F0BD559CBC /* SuggestionCoordinator+Acceptance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72B13136DF7318F3E96DF0D3 /* SuggestionCoordinator+Acceptance.swift */; };
 		A0BB87E3665EF6C209034798 /* GhostSuggestionLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AD3F4F9FBE82007E4E15F58 /* GhostSuggestionLayoutTests.swift */; };
@@ -255,6 +257,7 @@
 		0D80CC2CCAAFE3F23FB8C37A /* PromptContextSanitizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptContextSanitizerTests.swift; sourceTree = "<group>"; };
 		0F5E263AB69029D5E13D5EE8 /* FocusDebugOverlayController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusDebugOverlayController.swift; sourceTree = "<group>"; };
 		110CB0B53016644EF7840301 /* HuggingFaceAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceAPIClient.swift; sourceTree = "<group>"; };
+		1274F897631B1B3A835D157F /* MidWordContinuationPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MidWordContinuationPolicyTests.swift; sourceTree = "<group>"; };
 		12DD19BCE610808F1E38702D /* PermissionOverlayTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOverlayTrackerTests.swift; sourceTree = "<group>"; };
 		1441B2D89DAE6878DAD11F17 /* EmojiMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiMatcher.swift; sourceTree = "<group>"; };
 		18D990E515E1AE4F312F4E95 /* BundledRuntimeLocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledRuntimeLocatorTests.swift; sourceTree = "<group>"; };
@@ -287,6 +290,7 @@
 		335BF59EE80F3A0143B79740 /* GhostFontSizeStabilizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostFontSizeStabilizerTests.swift; sourceTree = "<group>"; };
 		3384FD33776960103D6E22A9 /* EmojiPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiPickerView.swift; sourceTree = "<group>"; };
 		352AF5B2834FEE1F597394E4 /* ApplicationBundleMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationBundleMetadata.swift; sourceTree = "<group>"; };
+		357C18383B047F24A531BDCD /* MidWordContinuationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MidWordContinuationPolicy.swift; sourceTree = "<group>"; };
 		3609CC88A5280B3AA40414DF /* SuggestionAvailabilityEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionAvailabilityEvaluator.swift; sourceTree = "<group>"; };
 		384FBCF5D7A3A446C5BE2B8D /* SuggestionEngineRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionEngineRouter.swift; sourceTree = "<group>"; };
 		386C98FFCF76EC1C8C7E82BB /* SuggestionModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionModels.swift; sourceTree = "<group>"; };
@@ -704,6 +708,7 @@
 				5807E8508D9355D0271A00C5 /* LaunchAtLoginStateTests.swift */,
 				3009812A35A1CDEF16295AB7 /* LlamaPromptRendererTests.swift */,
 				52BAFA2F989C3C4F7FB892B5 /* MarkerSelectionSynthesizerTests.swift */,
+				1274F897631B1B3A835D157F /* MidWordContinuationPolicyTests.swift */,
 				FC83D14A7557BC0196E59007 /* MirrorOverlayLayoutTests.swift */,
 				03766F6253FF17639230C0F6 /* ModelAndPresentationValueTests.swift */,
 				A829F28F01FAE76CA7244BBC /* ModelFileValidatorTests.swift */,
@@ -849,6 +854,7 @@
 				B5679E08C9A09065531C37B5 /* LlamaPromptRenderer.swift */,
 				8D610FCA3A97249DCCE7D0B8 /* LLMIOFileHandler.swift */,
 				A863F41C0C03D7B4AC5DC002 /* MarkerSelectionSynthesizer.swift */,
+				357C18383B047F24A531BDCD /* MidWordContinuationPolicy.swift */,
 				54150A507B03221F137D539B /* MirrorOverlayLayout.swift */,
 				24F613F0E2F7046E6532A09C /* OnboardingTemplateFeatureList.swift */,
 				FA878B447441BB4F3E327CC8 /* OnboardingTemplateRecommender.swift */,
@@ -1074,6 +1080,7 @@
 				0333B3CE8F189DD1BEC4AD26 /* MenuBarSections.swift in Sources */,
 				AECC7289DA796B071B4FE3C0 /* MenuBarStatusLabelView.swift in Sources */,
 				5E92E3C1EB41D482FC06BC52 /* MenuBarView.swift in Sources */,
+				9CEBD6AF4405F1BBE0E3D16C /* MidWordContinuationPolicy.swift in Sources */,
 				31515DDD173535C4AC777853 /* MirrorOverlayLayout.swift in Sources */,
 				2F227738D7834B1A7A81D1D6 /* ModelDownloadManager.swift in Sources */,
 				317883210D1D1D5CD654E562 /* ModelFileValidator.swift in Sources */,
@@ -1184,6 +1191,7 @@
 				E27E6377D36D4981301568DD /* LaunchAtLoginStateTests.swift in Sources */,
 				190C571B3CDFE117F4D15484 /* LlamaPromptRendererTests.swift in Sources */,
 				87806DE08881D11F2608A13D /* MarkerSelectionSynthesizerTests.swift in Sources */,
+				7C36DBA762E19C8C31676D44 /* MidWordContinuationPolicyTests.swift in Sources */,
 				14D77F0B8A195AC2FA8D24A9 /* MirrorOverlayLayoutTests.swift in Sources */,
 				25D4FC8D191A50F63E6391F9 /* ModelAndPresentationValueTests.swift in Sources */,
 				65478B0DABF5460C32D4C458 /* ModelFileValidatorTests.swift in Sources */,
@@ -1519,7 +1527,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/FuJacob/cotabbyinference.git";
 			requirement = {
-				branch = main;
+				branch = "feat/generation-quality-controls";
 				kind = branch;
 			};
 		};

--- a/Cotabby/Models/LlamaRuntimeModels.swift
+++ b/Cotabby/Models/LlamaRuntimeModels.swift
@@ -206,6 +206,10 @@ struct LlamaGenerationOptions: Equatable, Sendable {
     /// Constrains the first generated token to continue the current word (mid-word carets only).
     var forceWordContinuation: Bool = false
 
+    /// Average per-token log-probability below which a completion is suppressed as low-confidence.
+    /// Defaults to -infinity, which disables suppression entirely.
+    var confidenceFloor: Double = -.infinity
+
     static func summary(maxPredictionTokens: Int, temperature: Double) -> LlamaGenerationOptions {
         LlamaGenerationOptions(
             maxPredictionTokens: maxPredictionTokens,

--- a/Cotabby/Models/LlamaRuntimeModels.swift
+++ b/Cotabby/Models/LlamaRuntimeModels.swift
@@ -201,6 +201,11 @@ struct LlamaGenerationOptions: Equatable, Sendable {
     let repetitionPenalty: Double
     var seed: UInt32?
 
+    /// Masks line-break tokens so single-line fields never receive a multi-line completion.
+    var singleLine: Bool = false
+    /// Constrains the first generated token to continue the current word (mid-word carets only).
+    var forceWordContinuation: Bool = false
+
     static func summary(maxPredictionTokens: Int, temperature: Double) -> LlamaGenerationOptions {
         LlamaGenerationOptions(
             maxPredictionTokens: maxPredictionTokens,

--- a/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
+++ b/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
@@ -190,6 +190,7 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
 
         var generatedText = ""
         var tokensGenerated = 0
+        var sumLogprob = 0.0
         var stopReason = "budget_exhausted"
 
         for _ in 0 ..< options.maxPredictionTokens {
@@ -216,6 +217,7 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
             let piece = Self.extractPiece(result)
             generatedText += piece
             tokensGenerated += 1
+            sumLogprob += Double(result.logprob)
         }
 
         CotabbyLogger.runtime.debug(
@@ -227,6 +229,23 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
                 "stop_reason": .string(stopReason)
             ]
         )
+
+        // Confidence suppression: drop completions the model itself was unsure about. Disabled by
+        // default (confidenceFloor == -infinity); the KV-trim defer above still runs on early return.
+        if tokensGenerated > 0,
+           ConfidenceSuppressionPolicy.shouldSuppress(
+               averageLogprob: sumLogprob / Double(tokensGenerated),
+               floor: options.confidenceFloor
+           ) {
+            CotabbyLogger.runtime.debug(
+                "Suppressed low-confidence completion",
+                metadata: [
+                    "tokens_generated": .stringConvertible(tokensGenerated),
+                    "avg_logprob": .stringConvertible(sumLogprob / Double(tokensGenerated))
+                ]
+            )
+            return ""
+        }
 
         return generatedText
     }

--- a/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
+++ b/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
@@ -387,6 +387,9 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
 
                     let remaining = Array(promptTokens[reusableTokenCount...])
                     if !remaining.isEmpty {
+                        // Seed for the reuse path is sampled at the end of this decodePrompt; apply
+                        // the word-continuation constraint to it just like the fresh path does.
+                        engine.setForceWordContinuation(autocompleteSequenceID, options.forceWordContinuation)
                         var mutableRemaining = remaining
                         let status = engine.decodePrompt(
                             autocompleteSequenceID,
@@ -422,6 +425,10 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
         guard seqID >= 0 else {
             throw LlamaRuntimeError.generationFailed("Unable to create inference sequence.")
         }
+
+        // The engine samples the first (seed) token at the end of decodePrompt, so set the
+        // word-continuation constraint here, before decoding.
+        engine.setForceWordContinuation(seqID, options.forceWordContinuation)
 
         var tokens = promptTokens
         let status = engine.decodePrompt(seqID, &tokens, Int32(tokens.count), 0)
@@ -460,7 +467,8 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
             top_p: Float(options.topP),
             min_p: Float(options.minP),
             repetition_penalty: Float(options.repetitionPenalty),
-            seed: options.seed ?? 0
+            seed: options.seed ?? 0,
+            single_line: options.singleLine
         )
     }
 

--- a/Cotabby/Services/Runtime/LlamaSuggestionEngine.swift
+++ b/Cotabby/Services/Runtime/LlamaSuggestionEngine.swift
@@ -45,7 +45,12 @@ final class LlamaSuggestionEngine {
                     topP: request.topP,
                     minP: request.minP,
                     repetitionPenalty: request.repetitionPenalty,
-                    seed: request.randomSeed
+                    seed: request.randomSeed,
+                    singleLine: !request.isMultiLineEnabled,
+                    forceWordContinuation: MidWordContinuationPolicy.shouldForceContinuation(
+                        precedingText: request.context.precedingText,
+                        trailingText: request.context.trailingText
+                    )
                 )
             )
             try Task.checkCancellation()

--- a/Cotabby/Support/ConfidenceSuppressionPolicy.swift
+++ b/Cotabby/Support/ConfidenceSuppressionPolicy.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// File overview:
+/// Decides whether a completion is too low-confidence to show, based on the model's own
+/// per-token log-probabilities.
+///
+/// Why this file exists:
+/// The guiding principle is that a suppressed completion beats a wrong one. The engine now reports
+/// a per-token log-probability, so we can drop completions the model itself was unsure about
+/// instead of showing a confident-looking guess. The policy is pure and isolated so the threshold
+/// is easy to test and tune. A floor of negative infinity (the default) disables suppression, so
+/// this is a no-op until a caller opts in by raising the floor.
+enum ConfidenceSuppressionPolicy {
+    /// Suppress when the completion's average per-token log-probability is below `floor`.
+    static func shouldSuppress(averageLogprob: Double, floor: Double) -> Bool {
+        guard floor > -.infinity else {
+            return false
+        }
+        return averageLogprob < floor
+    }
+}

--- a/Cotabby/Support/MidWordContinuationPolicy.swift
+++ b/Cotabby/Support/MidWordContinuationPolicy.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// File overview:
+/// Decides whether the first generated token should be constrained to continue the current word.
+///
+/// Why this file exists:
+/// The engine can force the first sampled token to be a word continuation (no leading whitespace),
+/// which heals mid-word completions. But forcing it at a normal word boundary would break the
+/// common "predict the next word" case, where a leading space is exactly what we want. This policy
+/// keeps the trigger deliberately narrow: it only fires when the caret sits strictly inside a word
+/// (a word character on both sides). At a word end (nothing or a non-word character after the
+/// caret) it returns false so ordinary next-word predictions are untouched.
+enum MidWordContinuationPolicy {
+    static func shouldForceContinuation(precedingText: String, trailingText: String) -> Bool {
+        guard let before = precedingText.last, isWordCharacter(before) else {
+            return false
+        }
+        guard let after = trailingText.first, isWordCharacter(after) else {
+            return false
+        }
+        return true
+    }
+
+    private static func isWordCharacter(_ character: Character) -> Bool {
+        character.isLetter || character.isNumber
+    }
+}

--- a/CotabbyTests/ConfidenceSuppressionPolicyTests.swift
+++ b/CotabbyTests/ConfidenceSuppressionPolicyTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import Cotabby
+
+/// Pure-function tests for confidence-based suppression.
+final class ConfidenceSuppressionPolicyTests: XCTestCase {
+
+    func test_disabledFloor_neverSuppresses() {
+        // The default floor (-infinity) means suppression is off, even for very low confidence.
+        XCTAssertFalse(
+            ConfidenceSuppressionPolicy.shouldSuppress(averageLogprob: -50.0, floor: -.infinity)
+        )
+    }
+
+    func test_belowFloor_suppresses() {
+        XCTAssertTrue(
+            ConfidenceSuppressionPolicy.shouldSuppress(averageLogprob: -3.0, floor: -2.0)
+        )
+    }
+
+    func test_aboveFloor_doesNotSuppress() {
+        XCTAssertFalse(
+            ConfidenceSuppressionPolicy.shouldSuppress(averageLogprob: -1.0, floor: -2.0)
+        )
+    }
+
+    func test_atFloor_doesNotSuppress() {
+        XCTAssertFalse(
+            ConfidenceSuppressionPolicy.shouldSuppress(averageLogprob: -2.0, floor: -2.0)
+        )
+    }
+}

--- a/CotabbyTests/MidWordContinuationPolicyTests.swift
+++ b/CotabbyTests/MidWordContinuationPolicyTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import Cotabby
+
+/// Pure-function tests for the mid-word continuation trigger.
+final class MidWordContinuationPolicyTests: XCTestCase {
+
+    func test_caretInsideWord_forcesContinuation() {
+        XCTAssertTrue(
+            MidWordContinuationPolicy.shouldForceContinuation(precedingText: "I am wri", trailingText: "ting")
+        )
+    }
+
+    func test_caretAtWordEnd_doesNotForce() {
+        // Nothing after the caret: a normal word boundary, where next-word predictions belong.
+        XCTAssertFalse(
+            MidWordContinuationPolicy.shouldForceContinuation(precedingText: "The quick brown fox", trailingText: "")
+        )
+    }
+
+    func test_spaceBeforeCaret_doesNotForce() {
+        XCTAssertFalse(
+            MidWordContinuationPolicy.shouldForceContinuation(precedingText: "hello ", trailingText: "world")
+        )
+    }
+
+    func test_punctuationAfterCaret_doesNotForce() {
+        XCTAssertFalse(
+            MidWordContinuationPolicy.shouldForceContinuation(precedingText: "done", trailingText: ". Next")
+        )
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -13,7 +13,7 @@ packages:
     exactVersion: 2.9.1
   CotabbyInference:
     url: https://github.com/FuJacob/cotabbyinference.git
-    branch: main
+    branch: feat/generation-quality-controls
   swift-log:
     url: https://github.com/apple/swift-log.git
     from: 1.12.1


### PR DESCRIPTION
## Summary

Wires generation-time quality controls into the app so unwanted tokens are stopped at the sampler instead of cleaned up after the fact. Builds on the engine changes in FuJacob/cotabbyinference#8. Second of two stacked PRs, based on the `feat/output-safety-gates` branch (#485).

- **Nonprintable token mask (free on the pin bump):** the engine masks control, chat-template, and unused tokens from sampling (EOG stays sampleable so natural stopping still works), so they can never appear as ghost text. No app code beyond the dependency bump.
- **`single_line`:** set from the focused field (`LlamaGenerationOptions.singleLine = !request.isMultiLineEnabled`). Single-line fields never receive a multi-line completion at the source.
- **`forceWordContinuation`:** `MidWordContinuationPolicy` fires only when the caret sits strictly inside a word, so the engine constrains the first sampled token to continue the current word. At a normal word end it does not fire, so ordinary next-word predictions are unchanged.
- **Confidence suppression (off by default):** the engine now reports a per-token log-probability. `LlamaRuntimeCore` averages it and, when `LlamaGenerationOptions.confidenceFloor` is raised above its default of -infinity, suppresses low-confidence completions via the pure `ConfidenceSuppressionPolicy`. Disabled by default, so no behavior change until a caller opts in.

Threading: `singleLine` / `forceWordContinuation` / `confidenceFloor` flow through `LlamaGenerationOptions` into `LlamaRuntimeCore` (sampling config, `setForceWordContinuation` before each `decodePrompt`, and the logprob accumulation in the sample loop).

## Validation

```
swiftlint lint --strict --quiet <touched files>          # exit 0
xcodebuild ... build         -derivedDataPath ...         # ** BUILD SUCCEEDED **
xcodebuild ... build-for-testing -derivedDataPath ...     # ** TEST BUILD SUCCEEDED **
xcodebuild test ... CODE_SIGNING_ALLOWED=NO \
  -only-testing:CotabbyTests/ConfidenceSuppressionPolicyTests \
  -only-testing:CotabbyTests/MidWordContinuationPolicyTests \
  -only-testing:CotabbyTests/TrailingDuplicationFilterTests \
  -only-testing:CotabbyTests/InsertionSafetyGateTests \
  -only-testing:CotabbyTests/SentenceBoundaryClassifierTests
# ** TEST SUCCEEDED **  Executed 27 tests, with 0 failures
```

Package pin resolves to `cotabbyinference @ feat/generation-quality-controls (be64365)`. The engine side was separately validated with `swift test` against a local gemma-3-1b model: 20 tests, 0 failures (see the engine PR).

## Linked issues

Depends on FuJacob/cotabbyinference#8 (engine).

## Risk / rollout notes

- **Merge order:** `project.yml` pins the engine feature branch. Merge the engine PR to `cotabbyinference` `main` first, then flip this PR's `project.yml` back to `branch: main`, re-resolve, and merge. Kept as a draft until then.
- **Behavior:** the nonprintable mask changes sampling for all local models but only removes never-visible tokens (greedy determinism preserved, verified by the engine's interleaved test). `single_line` only affects single-line fields. `forceWordContinuation` uses a narrow trigger. Confidence suppression is off by default.
- **Follow-ups (deliberate):** wiring a Settings control for `confidenceFloor`, full multi-candidate N-best ranking, and the base-model prompt path (covered by the in-flight #438). These need on-device tuning that green CI cannot stand in for.
- Typo suppression is handled by #353, not here.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires three generation-time quality controls into the app: `single_line` token masking (derived from the focused field's multi-line capability), `forceWordContinuation` (applied only when the caret sits strictly inside a word), and an opt-in confidence suppression layer that averages per-token log-probabilities and discards low-confidence completions. All three flow through a new `LlamaGenerationOptions` extension into `LlamaRuntimeCore`.

- **`singleLine`** is passed as part of `SamplingConfig` on sequence creation and correctly flips from field metadata; however, `LlamaRuntimeCore.SamplingFingerprint` does not capture it, so switching between a single-line and multi-line field that share a prompt prefix can silently reuse a sequence built with the wrong `single_line` value.
- **`forceWordContinuation`** is applied via `setForceWordContinuation` before each `decodePrompt` on both the fresh and reuse paths; when the reuse path has no remaining tokens to decode (`remaining.isEmpty`), the call is skipped and a stale seed token from the prior decode may carry the wrong constraint.
- **Confidence suppression** (`ConfidenceSuppressionPolicy`) and **mid-word policy** (`MidWordContinuationPolicy`) are clean pure functions with good test coverage and safe defaults.

<h3>Confidence Score: 3/5</h3>

Merging now introduces a silent correctness gap: users switching between single-line and multi-line fields that share a prompt prefix can receive completions constrained by the wrong field type, with no visible error or log warning beyond the wrong output.

The `singleLine` flag is baked into a sequence at creation time but is absent from the fingerprint that gates KV-cache reuse. After the sequence is created correctly for a single-line field, a subsequent request from a multi-line field with the same prompt prefix will silently reuse it, masking newline tokens in a context where they should be allowed. This is an observable behavioral regression on a path users hit naturally by tabbing between fields. The rest of the feature is well-structured and tested.

`LlamaRuntimeCore.swift` (the `SamplingFingerprint` struct near the bottom of the file) and `LlamaSuggestionEngine.swift` (the parallel `SamplingFingerprint` in the hint tracker) both need `singleLine` added before this is safe to merge.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/Services/Runtime/LlamaRuntimeCore.swift | Adds sumLogprob accumulation and confidence suppression after generation, plus setForceWordContinuation on both the fresh and reuse paths. SamplingFingerprint does not capture singleLine, allowing KV cache to be reused with the wrong single_line sampling config when switching field types. |
| Cotabby/Services/Runtime/LlamaSuggestionEngine.swift | Wires singleLine and forceWordContinuation into LlamaGenerationOptions; the hint-tracker SamplingFingerprint does not include singleLine, which can feed a stale cache hint to the runtime when the user switches between field types. |
| Cotabby/Support/MidWordContinuationPolicy.swift | New pure policy that fires only when both the preceding and trailing characters are letters or digits; correctly avoids triggering at word boundaries and is well-tested. |
| Cotabby/Support/ConfidenceSuppressionPolicy.swift | New pure policy that suppresses completions below an average log-probability floor; disabled by default via -infinity sentinel and correctly tested for boundary conditions. |
| Cotabby/Models/LlamaRuntimeModels.swift | Adds singleLine, forceWordContinuation, and confidenceFloor to LlamaGenerationOptions with safe defaults; no issues. |
| CotabbyTests/MidWordContinuationPolicyTests.swift | Covers the four key boundary cases (mid-word, word end, space before caret, non-word character after caret); clean and focused. |
| CotabbyTests/ConfidenceSuppressionPolicyTests.swift | Tests all four relevant cases including the at-floor boundary (should not suppress) and the disabled floor sentinel; correct and complete. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant SE as LlamaSuggestionEngine
    participant RC as LlamaRuntimeCore
    participant ENG as CotabbyInference Engine

    SE->>SE: MidWordContinuationPolicy.shouldForceContinuation(preceding, trailing)
    SE->>RC: generate(prompt, options)
    RC->>RC: SamplingFingerprint(options) — singleLine NOT captured
    RC->>RC: obtainAutocompleteSequence()
    alt KV cache reusable
        RC->>ENG: setForceWordContinuation [only if remaining non-empty]
        RC->>ENG: decodePrompt(seqID, remaining)
    else Fresh sequence
        RC->>ENG: createSequence(SamplingConfig incl. single_line)
        RC->>ENG: setForceWordContinuation(seqID, flag)
        RC->>ENG: decodePrompt(seqID, tokens)
    end
    loop up to maxPredictionTokens
        RC->>ENG: sampleNext(seqID)
        ENG-->>RC: SampleResult with logprob
        RC->>RC: "sumLogprob += logprob"
    end
    RC->>RC: ConfidenceSuppressionPolicy.shouldSuppress(avg, floor)
    RC-->>SE: generatedText or empty string
    SE->>SE: SuggestionTextNormalizer.normalize(raw, request)
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `Cotabby/Services/Runtime/LlamaRuntimeCore.swift`, line 509-527 ([link](https://github.com/fujacob/cotabby/blob/ca104196ff9bf38943ba3c50d94b8220543db9d2/Cotabby/Services/Runtime/LlamaRuntimeCore.swift#L509-L527)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`singleLine` missing from `LlamaRuntimeCore.SamplingFingerprint`**

   `singleLine` is encoded into `SamplingConfig` at sequence-creation time (`createSequence(config)`) and cannot be updated on an existing sequence. However, `SamplingFingerprint` — which gates KV-cache reuse — doesn't capture it. This means that if a user alternates between a multi-line field and a single-line field that share the same prompt prefix, the runtime may reuse a sequence created with the wrong `single_line` value. Concretely: after visiting a single-line field (sequence created with `single_line: true`), returning to a multi-line field with the same preceding text causes the cached sequence (with line-break tokens masked) to be reused, silently suppressing newline completions in the multi-line context.

   `singleLine` should be added alongside the other sampling knobs in this struct.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fgeneration-quality-controls%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fgeneration-quality-controls%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%0ALine%3A%20509-527%0A%0AComment%3A%0A**%60singleLine%60%20missing%20from%20%60LlamaRuntimeCore.SamplingFingerprint%60**%0A%0A%60singleLine%60%20is%20encoded%20into%20%60SamplingConfig%60%20at%20sequence-creation%20time%20%28%60createSequence%28config%29%60%29%20and%20cannot%20be%20updated%20on%20an%20existing%20sequence.%20However%2C%20%60SamplingFingerprint%60%20%E2%80%94%20which%20gates%20KV-cache%20reuse%20%E2%80%94%20doesn't%20capture%20it.%20This%20means%20that%20if%20a%20user%20alternates%20between%20a%20multi-line%20field%20and%20a%20single-line%20field%20that%20share%20the%20same%20prompt%20prefix%2C%20the%20runtime%20may%20reuse%20a%20sequence%20created%20with%20the%20wrong%20%60single_line%60%20value.%20Concretely%3A%20after%20visiting%20a%20single-line%20field%20%28sequence%20created%20with%20%60single_line%3A%20true%60%29%2C%20returning%20to%20a%20multi-line%20field%20with%20the%20same%20preceding%20text%20causes%20the%20cached%20sequence%20%28with%20line-break%20tokens%20masked%29%20to%20be%20reused%2C%20silently%20suppressing%20newline%20completions%20in%20the%20multi-line%20context.%0A%0A%60singleLine%60%20should%20be%20added%20alongside%20the%20other%20sampling%20knobs%20in%20this%20struct.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%0ALine%3A%20509-527%0A%0AComment%3A%0A**%60singleLine%60%20missing%20from%20%60LlamaRuntimeCore.SamplingFingerprint%60**%0A%0A%60singleLine%60%20is%20encoded%20into%20%60SamplingConfig%60%20at%20sequence-creation%20time%20%28%60createSequence%28config%29%60%29%20and%20cannot%20be%20updated%20on%20an%20existing%20sequence.%20However%2C%20%60SamplingFingerprint%60%20%E2%80%94%20which%20gates%20KV-cache%20reuse%20%E2%80%94%20doesn't%20capture%20it.%20This%20means%20that%20if%20a%20user%20alternates%20between%20a%20multi-line%20field%20and%20a%20single-line%20field%20that%20share%20the%20same%20prompt%20prefix%2C%20the%20runtime%20may%20reuse%20a%20sequence%20created%20with%20the%20wrong%20%60single_line%60%20value.%20Concretely%3A%20after%20visiting%20a%20single-line%20field%20%28sequence%20created%20with%20%60single_line%3A%20true%60%29%2C%20returning%20to%20a%20multi-line%20field%20with%20the%20same%20preceding%20text%20causes%20the%20cached%20sequence%20%28with%20line-break%20tokens%20masked%29%20to%20be%20reused%2C%20silently%20suppressing%20newline%20completions%20in%20the%20multi-line%20context.%0A%0A%60singleLine%60%20should%20be%20added%20alongside%20the%20other%20sampling%20knobs%20in%20this%20struct.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=488&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>


2. `Cotabby/Services/Runtime/LlamaSuggestionEngine.swift`, line 229-247 ([link](https://github.com/fujacob/cotabby/blob/ca104196ff9bf38943ba3c50d94b8220543db9d2/Cotabby/Services/Runtime/LlamaSuggestionEngine.swift#L229-L247)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`singleLine` absent from the hint-tracker `SamplingFingerprint`**

   This fingerprint controls when `cachedPrefixBytes` is reset to `nil` before being passed to the runtime. Without `singleLine`, switching between field types with the same prompt prefix passes a non-nil hint to the runtime even though the `SamplingConfig` changed. The runtime's own fingerprint check (also currently missing `singleLine`) then allows cache reuse. Adding `singleLine` here closes the hint-tracker's side of the gap in concert with fixing the runtime's fingerprint.

   

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fgeneration-quality-controls%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fgeneration-quality-controls%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FServices%2FRuntime%2FLlamaSuggestionEngine.swift%0ALine%3A%20229-247%0A%0AComment%3A%0A**%60singleLine%60%20absent%20from%20the%20hint-tracker%20%60SamplingFingerprint%60**%0A%0AThis%20fingerprint%20controls%20when%20%60cachedPrefixBytes%60%20is%20reset%20to%20%60nil%60%20before%20being%20passed%20to%20the%20runtime.%20Without%20%60singleLine%60%2C%20switching%20between%20field%20types%20with%20the%20same%20prompt%20prefix%20passes%20a%20non-nil%20hint%20to%20the%20runtime%20even%20though%20the%20%60SamplingConfig%60%20changed.%20The%20runtime's%20own%20fingerprint%20check%20%28also%20currently%20missing%20%60singleLine%60%29%20then%20allows%20cache%20reuse.%20Adding%20%60singleLine%60%20here%20closes%20the%20hint-tracker's%20side%20of%20the%20gap%20in%20concert%20with%20fixing%20the%20runtime's%20fingerprint.%0A%0A%60%60%60suggestion%0A%20%20%20%20struct%20SamplingFingerprint%3A%20Equatable%20%7B%0A%20%20%20%20%20%20%20%20let%20maxPredictionTokens%3A%20Int%0A%20%20%20%20%20%20%20%20let%20temperature%3A%20Double%0A%20%20%20%20%20%20%20%20let%20topK%3A%20Int%0A%20%20%20%20%20%20%20%20let%20topP%3A%20Double%0A%20%20%20%20%20%20%20%20let%20minP%3A%20Double%0A%20%20%20%20%20%20%20%20let%20repetitionPenalty%3A%20Double%0A%20%20%20%20%20%20%20%20let%20randomSeed%3A%20UInt32%3F%0A%20%20%20%20%20%20%20%20let%20isMultiLineEnabled%3A%20Bool%0A%0A%20%20%20%20%20%20%20%20init%28request%3A%20SuggestionRequest%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20maxPredictionTokens%20%3D%20request.maxPredictionTokens%0A%20%20%20%20%20%20%20%20%20%20%20%20temperature%20%3D%20request.temperature%0A%20%20%20%20%20%20%20%20%20%20%20%20topK%20%3D%20request.topK%0A%20%20%20%20%20%20%20%20%20%20%20%20topP%20%3D%20request.topP%0A%20%20%20%20%20%20%20%20%20%20%20%20minP%20%3D%20request.minP%0A%20%20%20%20%20%20%20%20%20%20%20%20repetitionPenalty%20%3D%20request.repetitionPenalty%0A%20%20%20%20%20%20%20%20%20%20%20%20randomSeed%20%3D%20request.randomSeed%0A%20%20%20%20%20%20%20%20%20%20%20%20isMultiLineEnabled%20%3D%20request.isMultiLineEnabled%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FServices%2FRuntime%2FLlamaSuggestionEngine.swift%0ALine%3A%20229-247%0A%0AComment%3A%0A**%60singleLine%60%20absent%20from%20the%20hint-tracker%20%60SamplingFingerprint%60**%0A%0AThis%20fingerprint%20controls%20when%20%60cachedPrefixBytes%60%20is%20reset%20to%20%60nil%60%20before%20being%20passed%20to%20the%20runtime.%20Without%20%60singleLine%60%2C%20switching%20between%20field%20types%20with%20the%20same%20prompt%20prefix%20passes%20a%20non-nil%20hint%20to%20the%20runtime%20even%20though%20the%20%60SamplingConfig%60%20changed.%20The%20runtime's%20own%20fingerprint%20check%20%28also%20currently%20missing%20%60singleLine%60%29%20then%20allows%20cache%20reuse.%20Adding%20%60singleLine%60%20here%20closes%20the%20hint-tracker's%20side%20of%20the%20gap%20in%20concert%20with%20fixing%20the%20runtime's%20fingerprint.%0A%0A%60%60%60suggestion%0A%20%20%20%20struct%20SamplingFingerprint%3A%20Equatable%20%7B%0A%20%20%20%20%20%20%20%20let%20maxPredictionTokens%3A%20Int%0A%20%20%20%20%20%20%20%20let%20temperature%3A%20Double%0A%20%20%20%20%20%20%20%20let%20topK%3A%20Int%0A%20%20%20%20%20%20%20%20let%20topP%3A%20Double%0A%20%20%20%20%20%20%20%20let%20minP%3A%20Double%0A%20%20%20%20%20%20%20%20let%20repetitionPenalty%3A%20Double%0A%20%20%20%20%20%20%20%20let%20randomSeed%3A%20UInt32%3F%0A%20%20%20%20%20%20%20%20let%20isMultiLineEnabled%3A%20Bool%0A%0A%20%20%20%20%20%20%20%20init%28request%3A%20SuggestionRequest%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20maxPredictionTokens%20%3D%20request.maxPredictionTokens%0A%20%20%20%20%20%20%20%20%20%20%20%20temperature%20%3D%20request.temperature%0A%20%20%20%20%20%20%20%20%20%20%20%20topK%20%3D%20request.topK%0A%20%20%20%20%20%20%20%20%20%20%20%20topP%20%3D%20request.topP%0A%20%20%20%20%20%20%20%20%20%20%20%20minP%20%3D%20request.minP%0A%20%20%20%20%20%20%20%20%20%20%20%20repetitionPenalty%20%3D%20request.repetitionPenalty%0A%20%20%20%20%20%20%20%20%20%20%20%20randomSeed%20%3D%20request.randomSeed%0A%20%20%20%20%20%20%20%20%20%20%20%20isMultiLineEnabled%20%3D%20request.isMultiLineEnabled%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=488&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>


3. `Cotabby/Services/Runtime/LlamaRuntimeCore.swift`, line 404-426 ([link](https://github.com/fujacob/cotabby/blob/ca104196ff9bf38943ba3c50d94b8220543db9d2/Cotabby/Services/Runtime/LlamaRuntimeCore.swift#L404-L426)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Stale `forceWordContinuation` seed when `remaining.isEmpty`**

   `setForceWordContinuation` is guarded inside `if !remaining.isEmpty`, so it is only called when there are new tokens to decode. When `remaining.isEmpty` (the full prompt is already in the KV cache), no new `decodePrompt` is issued, and the seed token — sampled at the end of the previous `decodePrompt` — is reused unchanged. Because `forceWordContinuation` depends on `trailingText` (which is not part of the prompt), a user can reach this state with a different trailing-text boundary: for example, they were mid-word when the first decode happened, then deleted the trailing letters so the caret is now at a word end. In that request `remaining.isEmpty` is true (same preceding text = same prompt), but the stale seed token may carry the word-continuation constraint from the prior decode, causing the first generated token to be joined to the word even though prediction should start fresh.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fgeneration-quality-controls%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fgeneration-quality-controls%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%0ALine%3A%20404-426%0A%0AComment%3A%0A**Stale%20%60forceWordContinuation%60%20seed%20when%20%60remaining.isEmpty%60**%0A%0A%60setForceWordContinuation%60%20is%20guarded%20inside%20%60if%20!remaining.isEmpty%60%2C%20so%20it%20is%20only%20called%20when%20there%20are%20new%20tokens%20to%20decode.%20When%20%60remaining.isEmpty%60%20%28the%20full%20prompt%20is%20already%20in%20the%20KV%20cache%29%2C%20no%20new%20%60decodePrompt%60%20is%20issued%2C%20and%20the%20seed%20token%20%E2%80%94%20sampled%20at%20the%20end%20of%20the%20previous%20%60decodePrompt%60%20%E2%80%94%20is%20reused%20unchanged.%20Because%20%60forceWordContinuation%60%20depends%20on%20%60trailingText%60%20%28which%20is%20not%20part%20of%20the%20prompt%29%2C%20a%20user%20can%20reach%20this%20state%20with%20a%20different%20trailing-text%20boundary%3A%20for%20example%2C%20they%20were%20mid-word%20when%20the%20first%20decode%20happened%2C%20then%20deleted%20the%20trailing%20letters%20so%20the%20caret%20is%20now%20at%20a%20word%20end.%20In%20that%20request%20%60remaining.isEmpty%60%20is%20true%20%28same%20preceding%20text%20%3D%20same%20prompt%29%2C%20but%20the%20stale%20seed%20token%20may%20carry%20the%20word-continuation%20constraint%20from%20the%20prior%20decode%2C%20causing%20the%20first%20generated%20token%20to%20be%20joined%20to%20the%20word%20even%20though%20prediction%20should%20start%20fresh.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%0ALine%3A%20404-426%0A%0AComment%3A%0A**Stale%20%60forceWordContinuation%60%20seed%20when%20%60remaining.isEmpty%60**%0A%0A%60setForceWordContinuation%60%20is%20guarded%20inside%20%60if%20!remaining.isEmpty%60%2C%20so%20it%20is%20only%20called%20when%20there%20are%20new%20tokens%20to%20decode.%20When%20%60remaining.isEmpty%60%20%28the%20full%20prompt%20is%20already%20in%20the%20KV%20cache%29%2C%20no%20new%20%60decodePrompt%60%20is%20issued%2C%20and%20the%20seed%20token%20%E2%80%94%20sampled%20at%20the%20end%20of%20the%20previous%20%60decodePrompt%60%20%E2%80%94%20is%20reused%20unchanged.%20Because%20%60forceWordContinuation%60%20depends%20on%20%60trailingText%60%20%28which%20is%20not%20part%20of%20the%20prompt%29%2C%20a%20user%20can%20reach%20this%20state%20with%20a%20different%20trailing-text%20boundary%3A%20for%20example%2C%20they%20were%20mid-word%20when%20the%20first%20decode%20happened%2C%20then%20deleted%20the%20trailing%20letters%20so%20the%20caret%20is%20now%20at%20a%20word%20end.%20In%20that%20request%20%60remaining.isEmpty%60%20is%20true%20%28same%20preceding%20text%20%3D%20same%20prompt%29%2C%20but%20the%20stale%20seed%20token%20may%20carry%20the%20word-continuation%20constraint%20from%20the%20prior%20decode%2C%20causing%20the%20first%20generated%20token%20to%20be%20joined%20to%20the%20word%20even%20though%20prediction%20should%20start%20fresh.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=488&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fgeneration-quality-controls%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fgeneration-quality-controls%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0ACotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%3A509-527%0A**%60singleLine%60%20missing%20from%20%60LlamaRuntimeCore.SamplingFingerprint%60**%0A%0A%60singleLine%60%20is%20encoded%20into%20%60SamplingConfig%60%20at%20sequence-creation%20time%20%28%60createSequence%28config%29%60%29%20and%20cannot%20be%20updated%20on%20an%20existing%20sequence.%20However%2C%20%60SamplingFingerprint%60%20%E2%80%94%20which%20gates%20KV-cache%20reuse%20%E2%80%94%20doesn't%20capture%20it.%20This%20means%20that%20if%20a%20user%20alternates%20between%20a%20multi-line%20field%20and%20a%20single-line%20field%20that%20share%20the%20same%20prompt%20prefix%2C%20the%20runtime%20may%20reuse%20a%20sequence%20created%20with%20the%20wrong%20%60single_line%60%20value.%20Concretely%3A%20after%20visiting%20a%20single-line%20field%20%28sequence%20created%20with%20%60single_line%3A%20true%60%29%2C%20returning%20to%20a%20multi-line%20field%20with%20the%20same%20preceding%20text%20causes%20the%20cached%20sequence%20%28with%20line-break%20tokens%20masked%29%20to%20be%20reused%2C%20silently%20suppressing%20newline%20completions%20in%20the%20multi-line%20context.%0A%0A%60singleLine%60%20should%20be%20added%20alongside%20the%20other%20sampling%20knobs%20in%20this%20struct.%0A%0A%23%23%23%20Issue%202%20of%203%0ACotabby%2FServices%2FRuntime%2FLlamaSuggestionEngine.swift%3A229-247%0A**%60singleLine%60%20absent%20from%20the%20hint-tracker%20%60SamplingFingerprint%60**%0A%0AThis%20fingerprint%20controls%20when%20%60cachedPrefixBytes%60%20is%20reset%20to%20%60nil%60%20before%20being%20passed%20to%20the%20runtime.%20Without%20%60singleLine%60%2C%20switching%20between%20field%20types%20with%20the%20same%20prompt%20prefix%20passes%20a%20non-nil%20hint%20to%20the%20runtime%20even%20though%20the%20%60SamplingConfig%60%20changed.%20The%20runtime's%20own%20fingerprint%20check%20%28also%20currently%20missing%20%60singleLine%60%29%20then%20allows%20cache%20reuse.%20Adding%20%60singleLine%60%20here%20closes%20the%20hint-tracker's%20side%20of%20the%20gap%20in%20concert%20with%20fixing%20the%20runtime's%20fingerprint.%0A%0A%60%60%60suggestion%0A%20%20%20%20struct%20SamplingFingerprint%3A%20Equatable%20%7B%0A%20%20%20%20%20%20%20%20let%20maxPredictionTokens%3A%20Int%0A%20%20%20%20%20%20%20%20let%20temperature%3A%20Double%0A%20%20%20%20%20%20%20%20let%20topK%3A%20Int%0A%20%20%20%20%20%20%20%20let%20topP%3A%20Double%0A%20%20%20%20%20%20%20%20let%20minP%3A%20Double%0A%20%20%20%20%20%20%20%20let%20repetitionPenalty%3A%20Double%0A%20%20%20%20%20%20%20%20let%20randomSeed%3A%20UInt32%3F%0A%20%20%20%20%20%20%20%20let%20isMultiLineEnabled%3A%20Bool%0A%0A%20%20%20%20%20%20%20%20init%28request%3A%20SuggestionRequest%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20maxPredictionTokens%20%3D%20request.maxPredictionTokens%0A%20%20%20%20%20%20%20%20%20%20%20%20temperature%20%3D%20request.temperature%0A%20%20%20%20%20%20%20%20%20%20%20%20topK%20%3D%20request.topK%0A%20%20%20%20%20%20%20%20%20%20%20%20topP%20%3D%20request.topP%0A%20%20%20%20%20%20%20%20%20%20%20%20minP%20%3D%20request.minP%0A%20%20%20%20%20%20%20%20%20%20%20%20repetitionPenalty%20%3D%20request.repetitionPenalty%0A%20%20%20%20%20%20%20%20%20%20%20%20randomSeed%20%3D%20request.randomSeed%0A%20%20%20%20%20%20%20%20%20%20%20%20isMultiLineEnabled%20%3D%20request.isMultiLineEnabled%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0ACotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%3A404-426%0A**Stale%20%60forceWordContinuation%60%20seed%20when%20%60remaining.isEmpty%60**%0A%0A%60setForceWordContinuation%60%20is%20guarded%20inside%20%60if%20!remaining.isEmpty%60%2C%20so%20it%20is%20only%20called%20when%20there%20are%20new%20tokens%20to%20decode.%20When%20%60remaining.isEmpty%60%20%28the%20full%20prompt%20is%20already%20in%20the%20KV%20cache%29%2C%20no%20new%20%60decodePrompt%60%20is%20issued%2C%20and%20the%20seed%20token%20%E2%80%94%20sampled%20at%20the%20end%20of%20the%20previous%20%60decodePrompt%60%20%E2%80%94%20is%20reused%20unchanged.%20Because%20%60forceWordContinuation%60%20depends%20on%20%60trailingText%60%20%28which%20is%20not%20part%20of%20the%20prompt%29%2C%20a%20user%20can%20reach%20this%20state%20with%20a%20different%20trailing-text%20boundary%3A%20for%20example%2C%20they%20were%20mid-word%20when%20the%20first%20decode%20happened%2C%20then%20deleted%20the%20trailing%20letters%20so%20the%20caret%20is%20now%20at%20a%20word%20end.%20In%20that%20request%20%60remaining.isEmpty%60%20is%20true%20%28same%20preceding%20text%20%3D%20same%20prompt%29%2C%20but%20the%20stale%20seed%20token%20may%20carry%20the%20word-continuation%20constraint%20from%20the%20prior%20decode%2C%20causing%20the%20first%20generated%20token%20to%20be%20joined%20to%20the%20word%20even%20though%20prediction%20should%20start%20fresh.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0ACotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%3A509-527%0A**%60singleLine%60%20missing%20from%20%60LlamaRuntimeCore.SamplingFingerprint%60**%0A%0A%60singleLine%60%20is%20encoded%20into%20%60SamplingConfig%60%20at%20sequence-creation%20time%20%28%60createSequence%28config%29%60%29%20and%20cannot%20be%20updated%20on%20an%20existing%20sequence.%20However%2C%20%60SamplingFingerprint%60%20%E2%80%94%20which%20gates%20KV-cache%20reuse%20%E2%80%94%20doesn't%20capture%20it.%20This%20means%20that%20if%20a%20user%20alternates%20between%20a%20multi-line%20field%20and%20a%20single-line%20field%20that%20share%20the%20same%20prompt%20prefix%2C%20the%20runtime%20may%20reuse%20a%20sequence%20created%20with%20the%20wrong%20%60single_line%60%20value.%20Concretely%3A%20after%20visiting%20a%20single-line%20field%20%28sequence%20created%20with%20%60single_line%3A%20true%60%29%2C%20returning%20to%20a%20multi-line%20field%20with%20the%20same%20preceding%20text%20causes%20the%20cached%20sequence%20%28with%20line-break%20tokens%20masked%29%20to%20be%20reused%2C%20silently%20suppressing%20newline%20completions%20in%20the%20multi-line%20context.%0A%0A%60singleLine%60%20should%20be%20added%20alongside%20the%20other%20sampling%20knobs%20in%20this%20struct.%0A%0A%23%23%23%20Issue%202%20of%203%0ACotabby%2FServices%2FRuntime%2FLlamaSuggestionEngine.swift%3A229-247%0A**%60singleLine%60%20absent%20from%20the%20hint-tracker%20%60SamplingFingerprint%60**%0A%0AThis%20fingerprint%20controls%20when%20%60cachedPrefixBytes%60%20is%20reset%20to%20%60nil%60%20before%20being%20passed%20to%20the%20runtime.%20Without%20%60singleLine%60%2C%20switching%20between%20field%20types%20with%20the%20same%20prompt%20prefix%20passes%20a%20non-nil%20hint%20to%20the%20runtime%20even%20though%20the%20%60SamplingConfig%60%20changed.%20The%20runtime's%20own%20fingerprint%20check%20%28also%20currently%20missing%20%60singleLine%60%29%20then%20allows%20cache%20reuse.%20Adding%20%60singleLine%60%20here%20closes%20the%20hint-tracker's%20side%20of%20the%20gap%20in%20concert%20with%20fixing%20the%20runtime's%20fingerprint.%0A%0A%60%60%60suggestion%0A%20%20%20%20struct%20SamplingFingerprint%3A%20Equatable%20%7B%0A%20%20%20%20%20%20%20%20let%20maxPredictionTokens%3A%20Int%0A%20%20%20%20%20%20%20%20let%20temperature%3A%20Double%0A%20%20%20%20%20%20%20%20let%20topK%3A%20Int%0A%20%20%20%20%20%20%20%20let%20topP%3A%20Double%0A%20%20%20%20%20%20%20%20let%20minP%3A%20Double%0A%20%20%20%20%20%20%20%20let%20repetitionPenalty%3A%20Double%0A%20%20%20%20%20%20%20%20let%20randomSeed%3A%20UInt32%3F%0A%20%20%20%20%20%20%20%20let%20isMultiLineEnabled%3A%20Bool%0A%0A%20%20%20%20%20%20%20%20init%28request%3A%20SuggestionRequest%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20maxPredictionTokens%20%3D%20request.maxPredictionTokens%0A%20%20%20%20%20%20%20%20%20%20%20%20temperature%20%3D%20request.temperature%0A%20%20%20%20%20%20%20%20%20%20%20%20topK%20%3D%20request.topK%0A%20%20%20%20%20%20%20%20%20%20%20%20topP%20%3D%20request.topP%0A%20%20%20%20%20%20%20%20%20%20%20%20minP%20%3D%20request.minP%0A%20%20%20%20%20%20%20%20%20%20%20%20repetitionPenalty%20%3D%20request.repetitionPenalty%0A%20%20%20%20%20%20%20%20%20%20%20%20randomSeed%20%3D%20request.randomSeed%0A%20%20%20%20%20%20%20%20%20%20%20%20isMultiLineEnabled%20%3D%20request.isMultiLineEnabled%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%281%20more%20issue%20omitted%20due%20to%20length%20limits.%20Use%20individual%20%22Fix%20in%20Claude%20Code%22%20links%20for%20remaining%20issues.%29%0A&repo=fujacob%2Fcotabby&pr=488&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add confidence-based suppression (off by..."](https://github.com/fujacob/cotabby/commit/ca104196ff9bf38943ba3c50d94b8220543db9d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34848875)</sub>

<!-- /greptile_comment -->