### PR TITLE
Bump suggestion token budgets down to track word presets

### DIFF
--- a/Cotabby/Models/SuggestionModels.swift
+++ b/Cotabby/Models/SuggestionModels.swift
@@ -43,20 +43,22 @@ enum SuggestionWordCountPreset: String, CaseIterable, Equatable, Hashable, Senda
     }
 
     /// Token budget is the sole governor of completion length on the local model (the in-prompt
-    /// word-range cue was removed), so it must track the upper word bound closely. Sized at
-    /// ~1.5x the upper word count to leave headroom for multi-token words (contractions, proper
-    /// nouns, punctuation) without overrunning the preset. The earlier 50% bump (17/27/45) let
-    /// completions blow past the setting, e.g. ~12 words on the shortest preset (#271).
+    /// word-range cue was removed), so it must track the upper word bound closely. English BPE
+    /// averages ~1.3 tokens per word, so these are sized at ~1.25x the upper word count: the cap
+    /// lands at or just under the upper bound instead of past it. History: a ~1.5x sizing
+    /// (6/11/18/30) still overran because real prose uses fewer tokens per word than that assumed,
+    /// and an earlier 50% bump overran further, e.g. ~12 words on the shortest preset (#271). When
+    /// unsure, bias shorter; a clipped suggestion is cheaper than one that blows past the setting.
     var suggestedPredictionTokenBudget: Int {
         switch self {
         case .twoToFour:
-            return 6
+            return 5
         case .fourToSeven:
-            return 11
+            return 9
         case .sevenToTwelve:
-            return 18
+            return 15
         case .twelveToTwenty:
-            return 30
+            return 25
         }
     }
 }
@@ -101,8 +103,10 @@ struct SuggestionConfiguration: Equatable, Sendable {
     /// The configuration shipped by the app today.
     /// These are product defaults, not temporary debug overrides.
     static let standard = SuggestionConfiguration(
-        // Keep completions short so ghost text stays fast and easy to accept.
-        maxPredictionTokens: 8,
+        // Floor for the per-request token budget (see SuggestionRequestFactory.activeMaxPredictionTokens).
+        // Held at the smallest word-count preset (2-4 words) so that preset's budget governs instead
+        // of being silently raised; keeps ghost text short, fast, and easy to accept.
+        maxPredictionTokens: 5,
         // Aggressive debounce: 20ms keeps time-to-first-suggestion low while still collapsing
         // bursts (superseded generations are cancelled; the host-publish poll absorbs AX lag).
         debounceMilliseconds: 20,

--- a/CotabbyTests/ModelAndPresentationValueTests.swift
+++ b/CotabbyTests/ModelAndPresentationValueTests.swift
@@ -40,16 +40,16 @@ final class SuggestionTextColorCodecTests: XCTestCase {
 final class SuggestionModelValueTests: XCTestCase {
     func test_wordCountPresetsExposeMatchingPromptInstructionsAndTokenBudgets() {
         XCTAssertEqual(SuggestionWordCountPreset.twoToFour.promptInstruction, "Return only the next 2 to 4 words.")
-        XCTAssertEqual(SuggestionWordCountPreset.twoToFour.suggestedPredictionTokenBudget, 6)
+        XCTAssertEqual(SuggestionWordCountPreset.twoToFour.suggestedPredictionTokenBudget, 5)
 
         XCTAssertEqual(SuggestionWordCountPreset.fourToSeven.promptInstruction, "Return only the next 4 to 7 words.")
-        XCTAssertEqual(SuggestionWordCountPreset.fourToSeven.suggestedPredictionTokenBudget, 11)
+        XCTAssertEqual(SuggestionWordCountPreset.fourToSeven.suggestedPredictionTokenBudget, 9)
 
         XCTAssertEqual(SuggestionWordCountPreset.sevenToTwelve.promptInstruction, "Return only the next 7 to 12 words.")
-        XCTAssertEqual(SuggestionWordCountPreset.sevenToTwelve.suggestedPredictionTokenBudget, 18)
+        XCTAssertEqual(SuggestionWordCountPreset.sevenToTwelve.suggestedPredictionTokenBudget, 15)
 
         XCTAssertEqual(SuggestionWordCountPreset.twelveToTwenty.promptInstruction, "Return only the next 12 to 20 words.")
-        XCTAssertEqual(SuggestionWordCountPreset.twelveToTwenty.suggestedPredictionTokenBudget, 30)
+        XCTAssertEqual(SuggestionWordCountPreset.twelveToTwenty.suggestedPredictionTokenBudget, 25)
     }
 
     func test_activeSuggestionSession_clampsConsumedCountAndSlicesByCharacters() {

--- a/CotabbyTests/SuggestionRequestFactoryTests.swift
+++ b/CotabbyTests/SuggestionRequestFactoryTests.swift
@@ -167,7 +167,7 @@ final class SuggestionRequestFactoryTests: XCTestCase {
             result.request.completionLengthInstruction,
             "Return only the next 12 to 20 words."
         )
-        XCTAssertEqual(result.request.maxPredictionTokens, 30)
+        XCTAssertEqual(result.request.maxPredictionTokens, 25)
         XCTAssertEqual(result.promptPreview, result.request.prompt)
     }
 


### PR DESCRIPTION
## Summary

The per-preset token budget is the sole governor of completion length on the local model (the in-prompt word-range cue was removed). It was sized at ~1.5x the upper word bound, but English BPE averages ~1.3 tokens/word, so every preset could overrun its stated word range. The shortest preset was worst: the `2-4 words` budget of 6 was floored up to 8 by `SuggestionConfiguration.standard.maxPredictionTokens`, allowing roughly 6 words for a "2-4 words" setting.

This resizes budgets to ~1.25x the upper bound so the cap lands at or just under the upper word bound, and lowers the config floor so the smallest preset can actually deliver its length:

| Preset | Upper bound | Budget (before → after) | Effective before* | Effective after |
|--------|-------------|--------------------------|-------------------|-----------------|
| 2-4    | 4           | 6 → 5                    | 8 (floored)       | 5               |
| 4-7    | 7           | 11 → 9                   | 11                | 9               |
| 7-12   | 12          | 18 → 15                  | 18                | 15              |
| 12-20  | 20          | 30 → 25                  | 30                | 25              |

\* Effective = `max(SuggestionConfiguration.standard.maxPredictionTokens, presetBudget)`. The floor (read only in `SuggestionRequestFactory.activeMaxPredictionTokens`) is lowered from 8 to 5 so it never silently raises the smallest preset above its budget.

## Validation

```
swiftlint lint --strict --quiet        # exit 0 (lints Cotabby/, per included: in .swiftlint.yml)

xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby \
  -destination 'platform=macOS' \
  -skip-testing:CotabbyTests/FoundationModelDriftEvalTests CODE_SIGNING_ALLOWED=NO
# ** TEST SUCCEEDED **  Executed 607 tests, 3 skipped, 0 failures
```

Local Team ID caveat: app-hosted suites run with `CODE_SIGNING_ALLOWED=NO`.

Updated the two tests that pin these numbers: `SuggestionModelValueTests.test_wordCountPresetsExposeMatchingPromptInstructionsAndTokenBudgets` and `SuggestionRequestFactoryTests.test_buildRequest_usesWordCountPresetForInstructionAndTokenBudget`.

## Linked issues

Refs #271 (the earlier completion-overrun work this continues).

## Risk / rollout notes

- Behavior change: inline suggestions get shorter across all four length presets. This is intentional and conservative; a clipped suggestion is cheaper than one that blows past the chosen length.
- Product default change: `SuggestionConfiguration.standard.maxPredictionTokens` 8 → 5. It is read only as the per-request lower bound, so the only behavioral effect is that the `2-4` preset is no longer floored up to 8.
- No settings, schema, or pbxproj migration (existing files only; no new sources).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reduces per-preset token budgets from a ~1.5x to a ~1.25x multiplier of each preset's upper word bound, and lowers the `SuggestionConfiguration.standard` floor from 8 to 5 so it no longer silently overrides the smallest (`2-4 words`) preset. The math checks out in all four cases (4×1.25=5, 7×1.25≈9, 12×1.25=15, 20×1.25=25), the BPE-based rationale in the comment is sound, and the `activeMaxPredictionTokens` floor logic (`max(config.maxPredictionTokens, presetBudget)`) now correctly resolves to 5 for the smallest preset instead of being raised to 8.

- All four `suggestedPredictionTokenBudget` values are reduced, and both affected test files are updated to match — no stale assertions remain.
- The product default `maxPredictionTokens` drop (8 → 5) is scoped exclusively to the per-request floor; it does not affect the larger presets, and the multi-line path (`base × 2`, capped at 60) is untouched.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted numeric adjustment with clear rationale, consistent test coverage, and no structural modifications.

All four budget values match their stated 1.25x multiplier, the floor value now equals the smallest preset budget (so max(5, 5) no longer raises it), and both test files are updated in lockstep. The activeMaxPredictionTokens logic in SuggestionRequestFactory is untouched and behaves correctly with the new floor.

No files require special attention. The only file with non-trivial logic (SuggestionRequestFactory.swift) was read to verify the floor behavior and is not modified by this PR.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Models/SuggestionModels.swift | Token budgets reduced to ~1.25x the upper word bound (5/9/15/25) and the config floor lowered from 8 to 5; comment updated to explain the BPE-based rationale. |
| CotabbyTests/ModelAndPresentationValueTests.swift | Four token-budget assertions updated to match the new preset values (6→5, 11→9, 18→15, 30→25); all other test logic unchanged. |
| CotabbyTests/SuggestionRequestFactoryTests.swift | Single assertion updated for the twelveToTwenty preset (30→25); the configuration fixture in this test uses maxPredictionTokens: 1 as the floor, correctly exercising max(1, 25) = 25. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User selects word-count preset] --> B{selectedWordCountPreset}
    B --> |twoToFour| C[budget = 5]
    B --> |fourToSeven| D[budget = 9]
    B --> |sevenToTwelve| E[budget = 15]
    B --> |twelveToTwenty| F[budget = 25]
    C & D & E & F --> G["activeMaxPredictionTokens()\nbase = max(config.maxPredictionTokens=5, presetBudget)"]
    G --> H{isMultiLineEnabled?}
    H --> |No| I[maxPredictionTokens = base]
    H --> |Yes| J["maxPredictionTokens = min(base × 2, 60)"]
    I & J --> K[SuggestionRequest.maxPredictionTokens]
    K --> L[Local model hard-stops generation at this token count]
```

<sub>Reviews (1): Last reviewed commit: ["Bump suggestion token budgets down to tr..."](https://github.com/fujacob/cotabby/commit/c75c431a16e57a53b00f7c36ab425db04bf74f2a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34849500)</sub>

<!-- /greptile_comment -->