### PR TITLE
Fix CotabbyTests build broken by #499 (summarizer test scaffolding)

### DIFF
--- a/CotabbyTests/ScreenshotContextGeneratorTests.swift
+++ b/CotabbyTests/ScreenshotContextGeneratorTests.swift
@@ -4,43 +4,7 @@ import XCTest
 
 @MainActor
 final class ScreenshotContextGeneratorTests: XCTestCase {
-    func test_generateContext_usesGoodSummaryWhenAvailable() async throws {
-        let generator = makeGenerator(
-            extractedText: "Issue 471 asks Cotabby to improve suggestions in GeneralPaneView.swift",
-            summaryResult: .success("Surface Xcode task update Screen Recording permission copy")
-        )
-
-        let excerpt = try await generator.generateContext(for: makeSnapshot())
-
-        XCTAssertTrue(excerpt.text.contains("Surface Xcode task"))
-        XCTAssertFalse(excerpt.text.contains("Issue 471"))
-    }
-
-    func test_generateContext_emptySummaryFallsBackToSanitizedOCR() async throws {
-        let generator = makeGenerator(
-            extractedText: "Issue 471 asks Cotabby to improve suggestions in GeneralPaneView.swift",
-            summaryResult: .success("   ")
-        )
-
-        let excerpt = try await generator.generateContext(for: makeSnapshot())
-
-        XCTAssertTrue(excerpt.text.contains("Issue"))
-        XCTAssertTrue(excerpt.text.contains("GeneralPaneView.swift"))
-    }
-
-    func test_generateContext_thrownSummarizerErrorFallsBackToSanitizedOCR() async throws {
-        let generator = makeGenerator(
-            extractedText: "GitHub PR needs exact context about ScreenshotContextGenerator.swift",
-            summaryResult: .failure
-        )
-
-        let excerpt = try await generator.generateContext(for: makeSnapshot())
-
-        XCTAssertTrue(excerpt.text.contains("GitHub PR"))
-        XCTAssertTrue(excerpt.text.contains("ScreenshotContextGenerator.swift"))
-    }
-
-    func test_generateContext_ocrOnlyFallbackIsCappedAndSanitized() async throws {
+    func test_generateContext_ocrTextIsCappedAndSanitized() async throws {
         let configuration = VisualContextConfiguration(
             snapshotDimension: 700,
             maxImageDimension: 1600,
@@ -53,7 +17,6 @@ final class ScreenshotContextGeneratorTests: XCTestCase {
             gLVWrt bDokE 54tbdbDX
             GeneralPaneView.swift should say Screen Recording is required for autocomplete context
             """,
-            summaryResult: nil,
             configuration: configuration
         )
 
@@ -66,10 +29,7 @@ final class ScreenshotContextGeneratorTests: XCTestCase {
     }
 
     func test_generateContext_allNoiseOCRReturnsUnavailable() async throws {
-        let generator = makeGenerator(
-            extractedText: "gLVWrt bDokE 54tbdbDX\n50 424 102 99",
-            summaryResult: nil
-        )
+        let generator = makeGenerator(extractedText: "gLVWrt bDokE 54tbdbDX\n50 424 102 99")
 
         do {
             _ = try await generator.generateContext(for: makeSnapshot())
@@ -83,7 +43,6 @@ final class ScreenshotContextGeneratorTests: XCTestCase {
 
     private func makeGenerator(
         extractedText: String,
-        summaryResult: StubSummarizer.Result?,
         configuration: VisualContextConfiguration = .default
     ) -> ScreenshotContextGenerator {
         ScreenshotContextGenerator(
@@ -93,7 +52,6 @@ final class ScreenshotContextGeneratorTests: XCTestCase {
             textExtractor: StubTextExtractor(
                 result: .success(ExtractedScreenText(text: extractedText, lineCount: 1))
             ),
-            summarizer: summaryResult.map(StubSummarizer.init(result:)),
             configuration: configuration
         )
     }
@@ -162,30 +120,4 @@ private struct StubTextExtractor: ScreenTextExtracting {
             throw error
         }
     }
-}
-
-private final class StubSummarizer: VisualContextSummarizing {
-    enum Result {
-        case success(String)
-        case failure
-    }
-
-    let result: Result
-
-    init(result: Result) {
-        self.result = result
-    }
-
-    func summarize(text: String, applicationName: String) async throws -> String {
-        switch result {
-        case let .success(summary):
-            return summary
-        case .failure:
-            throw StubSummarizerError.failed
-        }
-    }
-}
-
-private enum StubSummarizerError: Error {
-    case failed
 }


### PR DESCRIPTION
#499 deleted `VisualContextSummarizing` but `ScreenshotContextGeneratorTests` still referenced it via `StubSummarizer`, breaking the test-target compile (`Cannot find type 'VisualContextSummarizing'`). A local *incremental* build-for-testing falsely passed by not recompiling the unchanged test file; CI's clean build caught it. This removes the summarizer stubs + the three summary-path tests and keeps the OCR cap/sanitize + all-noise-unavailable tests (still satisfied by the `normalizeRecognizedText` pass after `OCRTextHygiene`). Un-breaks `main`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes dead test scaffolding left over after PR #499 deleted `VisualContextSummarizing` — specifically the `StubSummarizer` class, `StubSummarizerError`, and three tests that exercised the summarizer code path, all of which would cause a compile error on a clean build.

- `StubSummarizer: VisualContextSummarizing` and its `Result` enum are deleted; `makeGenerator` loses its `summaryResult` parameter to match the updated `ScreenshotContextGenerator.init`.
- The three summarizer-path tests are removed (good summary wins, empty-summary fallback, thrown-error fallback); the two remaining tests — OCR cap/sanitize and all-noise-unavailable — continue to exercise the live pipeline and are unaffected.

<h3>Confidence Score: 5/5</h3>

Test-only deletion that removes code referencing a type that no longer exists; no production logic is touched.

The change is purely subtractive in the test target: dead stubs and the tests that relied on them are gone, and the two surviving tests still build against and exercise the current production initializer. Nothing is added that could introduce a regression.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CotabbyTests/ScreenshotContextGeneratorTests.swift | Removes StubSummarizer, StubSummarizerError, and three summarizer-path tests; trims makeGenerator signature to match the updated ScreenshotContextGenerator initializer. Two OCR tests remain intact. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[generateContext] --> B[captureScreenshot]
    B --> C[textExtractor.extractText]
    C -->|noRecognizedText| D{windowTitle?}
    D -->|nil| E[throw .unavailable]
    D -->|exists| F[normalizeRecognizedText]
    F --> G{hasMeaningfulSignal?}
    G -->|no| E
    G -->|yes| H[boundedSummaryText → VisualContextExcerpt]
    C -->|success| I[OCRTextHygiene.clean]
    I --> J[normalizeRecognizedText]
    J --> K[boundedSummaryText]
    K --> L{hasMeaningfulSignal?}
    L -->|no| E
    L -->|yes| M[return VisualContextExcerpt]

    subgraph Tests["Remaining Tests (PR #500)"]
        T1[test_ocrTextIsCappedAndSanitized]
        T2[test_allNoiseOCRReturnsUnavailable]
    end

    subgraph Removed["Removed Tests (PR #500)"]
        R1[test_usesGoodSummaryWhenAvailable]
        R2[test_emptySummaryFallsBack]
        R3[test_thrownSummarizerErrorFallsBack]
    end
```

<sub>Reviews (1): Last reviewed commit: ["Fix CotabbyTests build: drop summarizer ..."](https://github.com/fujacob/cotabby/commit/0e6e2216edfb6101d15ed154caa6e822c956fd1a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34869053)</sub>

<!-- /greptile_comment -->