### PR TITLE
Add deterministic constrained decoder behind a default-off flag

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		15FA56CEF6FB5FF54C2FBA6F /* PermissionAndContextModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F42112F14026E6253BB865 /* PermissionAndContextModelTests.swift */; };
 		19CB55B62977376E9AE8D428 /* VisualContextStartCoalescer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F01FAC4F57EB08471521196 /* VisualContextStartCoalescer.swift */; };
 		1B3FFCB9A979F49BF86EAAD4 /* ScreenshotContextGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2BFD19A159680A495EE02FD /* ScreenshotContextGeneratorTests.swift */; };
+		1C00CE3D553B58723EAE5F92 /* ConstrainedSamplerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B0200AA5C4A644A3B52A3EC /* ConstrainedSamplerTests.swift */; };
 		1D1C6FF0B8F50AC14A1000F4 /* SentenceBoundaryClassifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7360A6D4261989A66658ED /* SentenceBoundaryClassifierTests.swift */; };
 		1F8CC88AFFE67C08944CF506 /* WindowScreenshotService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B0121E7BB173F8A2B0B108 /* WindowScreenshotService.swift */; };
 		2197B68F1E4D0C3497DAC061 /* LlamaSuggestionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE04620C905041680116BE80 /* LlamaSuggestionEngine.swift */; };
@@ -139,6 +140,7 @@
 		7EB20783E0D36715D1230A5C /* PromptSectionBudgetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E260C4D08C786CDBD527B329 /* PromptSectionBudgetTests.swift */; };
 		7FC103944F4EF39DB965F469 /* InMemoryLogging in Frameworks */ = {isa = PBXBuildFile; productRef = 88921938DC814625ED57D605 /* InMemoryLogging */; };
 		814E348C663B697537594F0C /* EmojiRecentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 671689F289D45A124639C9C6 /* EmojiRecentsTests.swift */; };
+		81FC391E375B7EEFF965FF1B /* ConstrainedSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CF010A66DA31989524FCD0 /* ConstrainedSampler.swift */; };
 		82D4ADEAF05337ABDE4C586C /* RuntimeBootstrapModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60629DFE309C1A4BD8A7FB3B /* RuntimeBootstrapModel.swift */; };
 		83EC3543DC45B1601F119BF9 /* InsertionSafetyGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43D627C4A55359EAF4676FF7 /* InsertionSafetyGateTests.swift */; };
 		8441299082E6B68F7F88911B /* ShortcutConflictTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0850B07CCDBA67C756C6EC59 /* ShortcutConflictTests.swift */; };
@@ -148,6 +150,7 @@
 		88BCD795A14E1C9308F7BB31 /* SuggestionAvailabilityEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05B0439348261163B37C508 /* SuggestionAvailabilityEvaluatorTests.swift */; };
 		8B2DFC860803C0A7C4D34A36 /* ContextBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54EF3C7F5D9D6F3FA50FD51C /* ContextBuffer.swift */; };
 		8DA36F1521B6A59D8C20AC59 /* Logging in Frameworks */ = {isa = PBXBuildFile; productRef = 5A60D1467BBFECB3DFEB39C2 /* Logging */; };
+		8EED2B55999A119AE3B67359 /* TokenProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3CEFE8C321E17BB3873C893 /* TokenProfile.swift */; };
 		902B83CCB82E286FBEB9DAAD /* EmojiPickerPanelLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62EDF1199CC5E18BD7651661 /* EmojiPickerPanelLayout.swift */; };
 		907A0BF56C3BB0CBAF2649AB /* SettingsCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D0AEFF86F8210CBE7CFCBAD /* SettingsCategory.swift */; };
 		909EBE545CE644C6C57F1B5D /* SuggestionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F961F5DF2A392F6F5F94F8A /* SuggestionCoordinator.swift */; };
@@ -197,6 +200,7 @@
 		C71B594433F3B411CAE5DE7E /* FocusCapabilityResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F6D5F94B238F7B4BE7C247 /* FocusCapabilityResolverTests.swift */; };
 		C9B815652CED38966C53A5E8 /* EmojiVariantResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8BB19D8EC9A75CD3458A6B /* EmojiVariantResolverTests.swift */; };
 		CA5B2D226FBAA5419E78F14F /* SuggestionSessionReconciler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0AA0503128B0FC3951D700 /* SuggestionSessionReconciler.swift */; };
+		CA8F453AA4AD02FAA8C961F7 /* TokenProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7D0BF193110927BEB865748 /* TokenProfileTests.swift */; };
 		CB65A79F164269991FABC32E /* SuggestionStateHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19DB9558F4D3AFB108D71649 /* SuggestionStateHelperTests.swift */; };
 		CC98B842D10574C5206BEFA7 /* FocusCapabilityResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70367FCC1E0F08EE3B8EB26F /* FocusCapabilityResolver.swift */; };
 		CCC83DC5AE51C17F153D5A6A /* PermissionModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D82FFC568527700EC17C07D /* PermissionModels.swift */; };
@@ -327,6 +331,7 @@
 		44595B534DD7323F0AD60825 /* MenuBarPopoverDismisser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarPopoverDismisser.swift; sourceTree = "<group>"; };
 		4696A84D17890B154533A08F /* PromptPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptPolicyTests.swift; sourceTree = "<group>"; };
 		4793D4EA5D36D7E5CC216C27 /* LanguageSupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageSupportTests.swift; sourceTree = "<group>"; };
+		47CF010A66DA31989524FCD0 /* ConstrainedSampler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstrainedSampler.swift; sourceTree = "<group>"; };
 		51020F8CD58338BD643FBF63 /* ModelDownloadManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelDownloadManager.swift; sourceTree = "<group>"; };
 		52BAFA2F989C3C4F7FB892B5 /* MarkerSelectionSynthesizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkerSelectionSynthesizerTests.swift; sourceTree = "<group>"; };
 		53CF416511099C6818110F01 /* CompletionRenderModePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionRenderModePolicy.swift; sourceTree = "<group>"; };
@@ -356,6 +361,7 @@
 		671689F289D45A124639C9C6 /* EmojiRecentsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiRecentsTests.swift; sourceTree = "<group>"; };
 		67586807ACE8EB13C9014535 /* TickMarkSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TickMarkSlider.swift; sourceTree = "<group>"; };
 		6A44BEC8C23FF227731DD0CD /* FocusCapabilityFlickerGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusCapabilityFlickerGate.swift; sourceTree = "<group>"; };
+		6B0200AA5C4A644A3B52A3EC /* ConstrainedSamplerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstrainedSamplerTests.swift; sourceTree = "<group>"; };
 		6B2D97BAA3618A7D0357AC44 /* SuggestionWorkController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionWorkController.swift; sourceTree = "<group>"; };
 		6DC693E00430F46E41CB56E6 /* RequestID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestID.swift; sourceTree = "<group>"; };
 		70367FCC1E0F08EE3B8EB26F /* FocusCapabilityResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusCapabilityResolver.swift; sourceTree = "<group>"; };
@@ -479,6 +485,7 @@
 		E43E587E421AF544A8300CE4 /* CustomRulesCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomRulesCatalog.swift; sourceTree = "<group>"; };
 		E5DAF68AEBFE334F68A65E82 /* AcceptanceModePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcceptanceModePickerView.swift; sourceTree = "<group>"; };
 		E6423D6CC8CC371D2DA899DE /* PermissionOverlayTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOverlayTracker.swift; sourceTree = "<group>"; };
+		E7D0BF193110927BEB865748 /* TokenProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenProfileTests.swift; sourceTree = "<group>"; };
 		E7F42112F14026E6253BB865 /* PermissionAndContextModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionAndContextModelTests.swift; sourceTree = "<group>"; };
 		EAAE6B395FAB604DF059280A /* KeyCodeLabels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyCodeLabels.swift; sourceTree = "<group>"; };
 		EB630F9814388203DD1CA2EC /* ShortcutsPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsPaneView.swift; sourceTree = "<group>"; };
@@ -487,6 +494,7 @@
 		EE94342B888A5A2CCF66BC93 /* SuggestionRequestFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionRequestFactoryTests.swift; sourceTree = "<group>"; };
 		EFD89799BB82AF7A92559AEB /* ClipboardContentDistillerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardContentDistillerTests.swift; sourceTree = "<group>"; };
 		F308F6E274CC645E27CB651F /* OverlayController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayController.swift; sourceTree = "<group>"; };
+		F3CEFE8C321E17BB3873C893 /* TokenProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenProfile.swift; sourceTree = "<group>"; };
 		FA4B45B91D4DEAC979C3113E /* PromptContextSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptContextSanitizer.swift; sourceTree = "<group>"; };
 		FA878B447441BB4F3E327CC8 /* OnboardingTemplateRecommender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTemplateRecommender.swift; sourceTree = "<group>"; };
 		FB317C82CE2CBC69056BA4B8 /* TagChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagChip.swift; sourceTree = "<group>"; };
@@ -725,6 +733,7 @@
 				90B0D133AB77A2503FB08827 /* ClipboardRelevanceFilterTests.swift */,
 				D504BEB224E0C176F5FCFF6E /* CompletionRenderModePolicyTests.swift */,
 				06FF2B0A3094A952A8EBA9B5 /* ConfidenceSuppressionPolicyTests.swift */,
+				6B0200AA5C4A644A3B52A3EC /* ConstrainedSamplerTests.swift */,
 				AF1E065C7FFB697FCEB2FA5C /* CotabbyTestFixtures.swift */,
 				AD752451330486FE270018B0 /* CustomRulesTests.swift */,
 				C1C5DE0F3FF63545000E2453 /* DisplayCoordinateConverterTests.swift */,
@@ -780,6 +789,7 @@
 				C71031E8DB171047318B92FC /* SyntheticReplacePlannerTests.swift */,
 				43E37A7E835D3BDE6265843C /* TerminalAppDetectorTests.swift */,
 				FC24FD54860CE6737E65EF65 /* TextDirectionDetectorTests.swift */,
+				E7D0BF193110927BEB865748 /* TokenProfileTests.swift */,
 				E19A5B462891263BDFB56607 /* TrailingDuplicationFilterTests.swift */,
 				050D929E13BE52E6282B64D2 /* VisualContextStartCoalescerTests.swift */,
 				1E0513E3B23937B099A3CFF2 /* WordCountFormatterTests.swift */,
@@ -884,6 +894,7 @@
 				D3A2AC525DC664DB540D4F19 /* ClipboardRelevanceFilter.swift */,
 				53CF416511099C6818110F01 /* CompletionRenderModePolicy.swift */,
 				1BD71ECC2AE4821B643E0935 /* ConfidenceSuppressionPolicy.swift */,
+				47CF010A66DA31989524FCD0 /* ConstrainedSampler.swift */,
 				C7B2D34A6F3AC9DFD61350F7 /* CotabbyDebugOptions.swift */,
 				29ED42C4BDD0C521101AF95E /* DeviceInfo.swift */,
 				74BD1D4DB27D5D96D1E06096 /* DisplayCoordinateConverter.swift */,
@@ -928,6 +939,7 @@
 				B424E2AC97C99D335B0D5751 /* SuggestionTextNormalizer.swift */,
 				7F4C4A7EAF886E0CC945BFEF /* TerminalAppDetector.swift */,
 				328847A0F494360033366791 /* TextDirectionDetector.swift */,
+				F3CEFE8C321E17BB3873C893 /* TokenProfile.swift */,
 				D408D647412C59F3E692C42B /* TrailingDuplicationFilter.swift */,
 				2F01FAC4F57EB08471521196 /* VisualContextStartCoalescer.swift */,
 				815F2ABAF6AB75DA3AFBBCEF /* WordCountFormatter.swift */,
@@ -1075,6 +1087,7 @@
 				7C94725B4837DEC9ECF1BC54 /* CompletionRenderMode.swift in Sources */,
 				3985F0F2B3178DBB945B1064 /* CompletionRenderModePolicy.swift in Sources */,
 				429CE592897D8A952F2916C3 /* ConfidenceSuppressionPolicy.swift in Sources */,
+				81FC391E375B7EEFF965FF1B /* ConstrainedSampler.swift in Sources */,
 				8B2DFC860803C0A7C4D34A36 /* ContextBuffer.swift in Sources */,
 				AA2E09FF7E430D66ECA8ECD5 /* CotabbyApp.swift in Sources */,
 				FCC571EC239846F06007BFCA /* CotabbyAppEnvironment.swift in Sources */,
@@ -1208,6 +1221,7 @@
 				AB9C9C001F97F9D14F8B192A /* TerminalAppDetector.swift in Sources */,
 				96782E57CA26A16409368B69 /* TextDirectionDetector.swift in Sources */,
 				6014B31E2570EFFE45557E33 /* TickMarkSlider.swift in Sources */,
+				8EED2B55999A119AE3B67359 /* TokenProfile.swift in Sources */,
 				D3B43622E5A41B11E7AF527E /* TrailingDuplicationFilter.swift in Sources */,
 				E9E4CC657771DF9F4C56183C /* VisualContextCoordinator.swift in Sources */,
 				4190F8A76196B16ED94D0A55 /* VisualContextModels.swift in Sources */,
@@ -1235,6 +1249,7 @@
 				BFCA7FAFDAEBF586AB615567 /* ClipboardRelevanceFilterTests.swift in Sources */,
 				25F91CEF38400FD1ADB6B1AF /* CompletionRenderModePolicyTests.swift in Sources */,
 				91D8189EFCD1BA992EA6F038 /* ConfidenceSuppressionPolicyTests.swift in Sources */,
+				1C00CE3D553B58723EAE5F92 /* ConstrainedSamplerTests.swift in Sources */,
 				5E10EFC426217CB7218A5847 /* CotabbyTestFixtures.swift in Sources */,
 				91D1F16B8C5DA281D4B7F699 /* CustomRulesTests.swift in Sources */,
 				56611BA0087710277140E9E6 /* DisplayCoordinateConverterTests.swift in Sources */,
@@ -1290,6 +1305,7 @@
 				EF5BAB96DDADABB86F9E02D9 /* SyntheticReplacePlannerTests.swift in Sources */,
 				DE236C9285635C686D66A2F6 /* TerminalAppDetectorTests.swift in Sources */,
 				5A441797D71A880A7482077D /* TextDirectionDetectorTests.swift in Sources */,
+				CA8F453AA4AD02FAA8C961F7 /* TokenProfileTests.swift in Sources */,
 				DB1310FF3576ACA6472C4DB1 /* TrailingDuplicationFilterTests.swift in Sources */,
 				D5CAF3B590E5EC2AFC72E57A /* VisualContextStartCoalescerTests.swift in Sources */,
 				6AE0B46FB52D189D94E1F79A /* WordCountFormatterTests.swift in Sources */,
@@ -1603,7 +1619,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/FuJacob/cotabbyinference.git";
 			requirement = {
-				branch = "feat/generation-quality-controls";
+				branch = main;
 				kind = branch;
 			};
 		};

--- a/Cotabby/Models/LlamaRuntimeModels.swift
+++ b/Cotabby/Models/LlamaRuntimeModels.swift
@@ -201,6 +201,13 @@ struct LlamaGenerationOptions: Equatable, Sendable {
     /// Average per-token log-probability below which a completion is suppressed as low-confidence.
     /// Defaults to -infinity, which disables suppression entirely.
     var confidenceFloor: Double = -.infinity
+
+    /// Routes generation through the deterministic constrained decoder (logit read + admissibility
+    /// mask + argmax + manual token commit) instead of the engine's built-in stochastic sampler.
+    /// Default off so the shipping sampleNext path is unaffected until the constrained decoder is
+    /// validated on device. Changing it does not affect KV reuse, so it is intentionally excluded
+    /// from `SamplingFingerprint`.
+    var useConstrainedDecoder: Bool = false
 }
 
 /// The concrete runtime assets selected during bootstrap after checking available model files.

--- a/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
+++ b/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
@@ -34,6 +34,13 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
     private var autocompletePromptTokens: [Int32] = []
     private var autocompleteSamplingFingerprint: SamplingFingerprint?
 
+    /// Per-model constrained-decoding token table, built lazily on the first constrained request and
+    /// reused across requests. Keyed by model URL so loading a different model rebuilds it. Read and
+    /// written only inside `runConstrainedDecode`, which runs under `autocompleteLock`, so it needs
+    /// no extra synchronization. Cleared on `shutdown()` to release the table when the model unloads.
+    private var cachedTokenProfile: TokenProfile?
+    private var cachedTokenProfileModelURL: URL?
+
     /// Coordinates model lifecycle with in-flight operations. `generate()` and `summarize()`
     /// increment the active count on entry and decrement on exit. `shutdown()` sets the
     /// shutting-down flag and blocks until all active operations finish before unloading.
@@ -188,6 +195,19 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
             autocompleteSamplingFingerprint = fingerprint
         }
 
+        // The KV-trim defer above runs after whichever decoder returns. Both decoders share the
+        // prepared sequence and the same confidence-suppression contract; they differ only in how
+        // they pick each token (engine sampler vs. deterministic constrained selection).
+        return options.useConstrainedDecoder
+            ? try runConstrainedDecode(sequenceID: sequenceID, options: options)
+            : runEngineSampledDecode(sequenceID: sequenceID, options: options)
+    }
+
+    // MARK: - Decoders
+
+    /// The shipping decoder: delegates token selection to the engine's built-in sampler
+    /// (`sampleNext`), which applies temperature / top-k / top-p / min-p and commits each token.
+    private func runEngineSampledDecode(sequenceID: Int32, options: LlamaGenerationOptions) -> String {
         var generatedText = ""
         var tokensGenerated = 0
         var sumLogprob = 0.0
@@ -230,24 +250,131 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
             ]
         )
 
-        // Confidence suppression: drop completions the model itself was unsure about. Disabled by
-        // default (confidenceFloor == -infinity); the KV-trim defer above still runs on early return.
-        if tokensGenerated > 0,
-           ConfidenceSuppressionPolicy.shouldSuppress(
-               averageLogprob: sumLogprob / Double(tokensGenerated),
-               floor: options.confidenceFloor
-           ) {
+        if Self.shouldSuppress(sumLogprob: sumLogprob, tokensGenerated: tokensGenerated, options: options) {
+            return ""
+        }
+        return generatedText
+    }
+
+    /// The constrained decoder: reads the raw next-token logits, masks structural / excluded tokens
+    /// via the token profile, deterministically selects the highest-logit admissible token, and
+    /// commits it manually with `acceptToken`. This trades the sampler's randomness for reproducible,
+    /// leak-free continuations (no chat/control markers can surface as visible text). It honors the
+    /// same cancellation, single-line, and confidence-suppression contracts as the sampled path.
+    /// Mid-word word-continuation is already applied to the seed logits by `decodePrompt` (the engine
+    /// masks new-word-start tokens for the first step), so the first `getNextTokenLogits` row this
+    /// reads is already constrained when `forceWordContinuation` was set.
+    private func runConstrainedDecode(sequenceID: Int32, options: LlamaGenerationOptions) throws -> String {
+        let profile = try autocompleteTokenProfile()
+        let vocabSize = profile.vocabSize
+        guard vocabSize > 0 else {
+            throw LlamaRuntimeError.generationFailed("Vocabulary unavailable for constrained decoding.")
+        }
+        // `topK` bounds the candidate pool the selector ranks; clamp to a sane positive value so a
+        // zero/negative request still yields a full-vocab argmax rather than an empty pool.
+        let topK = options.topK > 0 ? options.topK : vocabSize
+
+        var generatedBytes: [UInt8] = []
+        var tokensGenerated = 0
+        var sumLogprob = 0.0
+        var stopReason = "budget_exhausted"
+        var logits = [Float](repeating: 0, count: vocabSize)
+
+        for _ in 0 ..< options.maxPredictionTokens {
+            if Task.isCancelled {
+                stopReason = "cancelled"
+                break
+            }
+
+            let written = logits.withUnsafeMutableBufferPointer { buffer in
+                Int(engine.getNextTokenLogits(sequenceID, buffer.baseAddress, Int32(buffer.count)))
+            }
+            guard written == vocabSize else {
+                stopReason = "no_logits"
+                break
+            }
+
+            guard let tokenID = ConstrainedSampler.selectToken(
+                logits: logits,
+                profile: profile,
+                admissibleTokenIDs: nil,
+                topK: topK
+            ) else {
+                stopReason = "no_admissible_token"
+                break
+            }
+
+            if profile.isEndOfGeneration(tokenID) {
+                stopReason = "eos"
+                break
+            }
+            // Single-line fields must never receive a line break; stop before emitting one so the
+            // partial completion so far is preserved (mirrors the sampler path's single_line mask).
+            if options.singleLine, profile.isNewline(tokenID) {
+                stopReason = "single_line"
+                break
+            }
+
+            // Accumulate raw bytes and decode once at the end: a single token may carry only part of
+            // a multi-byte UTF-8 scalar, so per-token String decoding would corrupt CJK / emoji.
+            if let logProb = ConstrainedSampler.logProb(ofTokenAt: tokenID, in: logits) {
+                sumLogprob += logProb
+            }
+            generatedBytes.append(contentsOf: profile.bytes(for: tokenID))
+            tokensGenerated += 1
+
+            if engine.acceptToken(sequenceID, Int32(tokenID)) != .ok {
+                stopReason = "accept_failed"
+                break
+            }
+        }
+
+        // Lossy decode is deliberate: the accumulated bytes are valid UTF-8 except for a possible
+        // partial trailing scalar (the final token may carry only part of a multi-byte character).
+        // The failable `String(bytes:encoding:)` would discard the entire completion in that case;
+        // `String(decoding:)` keeps every complete scalar and renders only the fragment as U+FFFD.
+        // swiftlint:disable:next optional_data_string_conversion
+        let generatedText = String(decoding: generatedBytes, as: UTF8.self)
+        CotabbyLogger.runtime.debug(
+            "Decode end",
+            metadata: [
+                "kind": .string("generate_constrained"),
+                "tokens_generated": .stringConvertible(tokensGenerated),
+                "chars_generated": .stringConvertible(generatedText.count),
+                "stop_reason": .string(stopReason)
+            ]
+        )
+
+        if Self.shouldSuppress(sumLogprob: sumLogprob, tokensGenerated: tokensGenerated, options: options) {
+            return ""
+        }
+        return generatedText
+    }
+
+    /// Shared low-confidence gate for both decoders: drop completions the model itself was unsure
+    /// about. Disabled by default (confidenceFloor == -infinity). The KV-trim defer in `generate`
+    /// still runs because the caller returns "" rather than throwing.
+    private static func shouldSuppress(
+        sumLogprob: Double,
+        tokensGenerated: Int,
+        options: LlamaGenerationOptions
+    ) -> Bool {
+        guard tokensGenerated > 0 else { return false }
+        let averageLogprob = sumLogprob / Double(tokensGenerated)
+        let suppress = ConfidenceSuppressionPolicy.shouldSuppress(
+            averageLogprob: averageLogprob,
+            floor: options.confidenceFloor
+        )
+        if suppress {
             CotabbyLogger.runtime.debug(
                 "Suppressed low-confidence completion",
                 metadata: [
                     "tokens_generated": .stringConvertible(tokensGenerated),
-                    "avg_logprob": .stringConvertible(sumLogprob / Double(tokensGenerated))
+                    "avg_logprob": .stringConvertible(averageLogprob)
                 ]
             )
-            return ""
         }
-
-        return generatedText
+        return suppress
     }
 
     // MARK: - Cache and lifecycle
@@ -302,6 +429,8 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
         resetPromptCache()
         engine.unloadModel()
         preparedRuntime = nil
+        cachedTokenProfile = nil
+        cachedTokenProfileModelURL = nil
         CotabbyLogger.runtime.info("Runtime shutdown complete")
 
         lifecycleCondition.lock()
@@ -403,6 +532,68 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
         guard utf8Count > 0 else { return [] }
         let vec = engine.tokenize(text, Int32(utf8Count))
         return Array(vec)
+    }
+
+    /// Lazily builds and caches the constrained-decoding token profile for the loaded model. The
+    /// profile records each token's bytes and structural flags so the constrained decoder can mask
+    /// excluded tokens and detect stops without calling back into the engine per step. Building scans
+    /// the whole vocabulary once (one detokenize per token), so the result is cached and reused until
+    /// the model changes. Must be called while holding `autocompleteLock`.
+    private func autocompleteTokenProfile() throws -> TokenProfile {
+        let modelURL = preparedRuntime?.resolvedRuntime.modelFileURL
+        if let cachedTokenProfile, cachedTokenProfileModelURL == modelURL {
+            return cachedTokenProfile
+        }
+
+        let vocabSize = Int(engine.getVocabSize())
+        guard vocabSize > 0 else {
+            throw LlamaRuntimeError.generationFailed("Vocabulary unavailable for constrained decoding.")
+        }
+
+        // Detokenize every token once up front; the build closures index this snapshot so each
+        // token's bytes are computed a single time and its control flag derives from the same bytes.
+        var tokenBytes: [[UInt8]] = []
+        tokenBytes.reserveCapacity(vocabSize)
+        for id in 0 ..< vocabSize {
+            tokenBytes.append(detokenizeBytes(Int32(id)))
+        }
+
+        let profile = TokenProfile.build(
+            vocabSize: vocabSize,
+            bytesFor: { tokenBytes[$0] },
+            // A token that detokenizes to no visible bytes is a structural / special / control token
+            // (llama renders those empty when special rendering is off); never emit it as text.
+            isControl: { tokenBytes[$0].isEmpty },
+            isEndOfGeneration: { self.engine.isEndOfGenerationToken(Int32($0)) }
+        )
+        cachedTokenProfile = profile
+        cachedTokenProfileModelURL = modelURL
+        CotabbyLogger.runtime.debug(
+            "Built constrained-decode token profile",
+            metadata: ["vocab_size": .stringConvertible(vocabSize)]
+        )
+        return profile
+    }
+
+    /// The raw UTF-8 bytes a token detokenizes to, or empty for a structural token that renders to
+    /// nothing. `detokenize` returns the byte count, or a negative `-(required)` when the fixed
+    /// buffer is too small; the rare large-piece case retries once at the requested size.
+    private func detokenizeBytes(_ token: Int32) -> [UInt8] {
+        var buffer = [CChar](repeating: 0, count: 256)
+        let written = buffer.withUnsafeMutableBufferPointer { ptr in
+            Int(engine.detokenize(token, ptr.baseAddress, Int32(ptr.count)))
+        }
+        if written > 0 {
+            return buffer.prefix(written).map { UInt8(bitPattern: $0) }
+        }
+        if written < 0 {
+            var large = [CChar](repeating: 0, count: -written)
+            let writtenLarge = large.withUnsafeMutableBufferPointer { ptr in
+                Int(engine.detokenize(token, ptr.baseAddress, Int32(ptr.count)))
+            }
+            return writtenLarge > 0 ? large.prefix(writtenLarge).map { UInt8(bitPattern: $0) } : []
+        }
+        return []
     }
 
     private static func extractPiece(_ result: SampleResult) -> String {

--- a/Cotabby/Services/Runtime/LlamaSuggestionEngine.swift
+++ b/Cotabby/Services/Runtime/LlamaSuggestionEngine.swift
@@ -13,6 +13,15 @@ final class LlamaSuggestionEngine {
     private let runtimeManager: LlamaRuntimeManager
     private var promptCacheHintTracker = LlamaPromptCacheHintTracker()
 
+    /// UserDefaults key (no UI) that routes llama generation through the deterministic constrained
+    /// decoder instead of the engine's stochastic sampler. Default-off: decode quality can only be
+    /// judged with a real model in a real field, so this stays a hidden developer/dogfood toggle
+    /// until it is validated on device and promoted to the default.
+    private static let constrainedDecoderDefaultsKey = "cotabbyConstrainedDecoderEnabled"
+    private static var isConstrainedDecoderEnabled: Bool {
+        UserDefaults.standard.bool(forKey: constrainedDecoderDefaultsKey)
+    }
+
     init(runtimeManager: LlamaRuntimeManager) {
         self.runtimeManager = runtimeManager
     }
@@ -50,7 +59,8 @@ final class LlamaSuggestionEngine {
                     forceWordContinuation: MidWordContinuationPolicy.shouldForceContinuation(
                         precedingText: request.context.precedingText,
                         trailingText: request.context.trailingText
-                    )
+                    ),
+                    useConstrainedDecoder: Self.isConstrainedDecoderEnabled
                 )
             )
             try Task.checkCancellation()

--- a/Cotabby/Support/ConstrainedSampler.swift
+++ b/Cotabby/Support/ConstrainedSampler.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+/// File overview:
+/// Pure, deterministic token selection over a single step's logits, plus a confidence helper that
+/// averages per-step log-probabilities. Selection skips excluded (control) tokens, optionally
+/// restricts to a set of admissible ids, and returns the surviving token with the highest logit.
+///
+/// Why this file exists:
+/// Constrained decoding needs a selection step that is fully reproducible: the same logits and the
+/// same constraints must always yield the same token, so behavior is testable and a suggestion can
+/// be explained after the fact. This sampler is therefore deterministic argmax with no RNG and no
+/// temperature. `topK` only bounds how large the candidate pool is before the argmax — it is a cost
+/// guard, not a source of randomness, so a smaller `topK` can only ever change the result by
+/// excluding lower-logit tokens that would not have won anyway among the unexcluded candidates. The
+/// admissibility set (when present) is the byte-prefix constraint computed elsewhere; passing nil
+/// means "no prefix constraint". Keeping this logic pure keeps the engine integration thin: the
+/// runtime supplies logits and the precomputed constraints, and this returns an id (or nil when
+/// nothing survives).
+enum ConstrainedSampler {
+    /// Selects the highest-logit token that survives the constraints, or nil when none survive.
+    ///
+    /// Survivors are tokens that are in-range, not `profile.isExcluded`, and — when
+    /// `admissibleTokenIDs` is non-nil — members of that set. `topK` bounds the candidate pool by
+    /// pre-ranking on logit before filtering: only the `topK` highest-logit token ids are considered.
+    /// Because selection is a plain argmax, bounding the pool cannot change which token wins unless
+    /// the winner sat outside the top `topK` by raw logit, so callers trade recall for cost by
+    /// lowering `topK`. A `topK` of zero or negative considers no candidates and returns nil.
+    ///
+    /// Determinism note: ties on logit are broken by the lower token id, so equal-logit inputs still
+    /// produce a single stable result.
+    static func selectToken(
+        logits: [Float],
+        profile: TokenProfile,
+        admissibleTokenIDs: Set<Int>?,
+        topK: Int
+    ) -> Int? {
+        guard topK > 0, !logits.isEmpty else {
+            return nil
+        }
+        if let admissible = admissibleTokenIDs, admissible.isEmpty {
+            // An explicit empty admissible set means the prefix constraint admits nothing this step.
+            return nil
+        }
+
+        let candidates = candidatePool(count: logits.count, logits: logits, limit: topK)
+
+        var best: Int?
+        var bestLogit: Float = -.infinity
+        for id in candidates {
+            if profile.isExcluded(id) {
+                continue
+            }
+            if let admissible = admissibleTokenIDs, !admissible.contains(id) {
+                continue
+            }
+            let logit = logits[id]
+            // Strict greater-than keeps the first-seen (lower-id, because the pool is id-ordered after
+            // the top-k cut) token on ties, which makes the result independent of iteration quirks.
+            if best == nil || logit > bestLogit {
+                best = id
+                bestLogit = logit
+            }
+        }
+        return best
+    }
+
+    /// Average per-step log-probability of a sequence of chosen tokens, a confidence summary suitable
+    /// for the existing low-confidence suppression policy.
+    ///
+    /// `fullRows[i]` is the full logits vector at step `i` and `chosenLogits[i]` is the logit of the
+    /// token actually committed at step `i` (the caller already knows which id it picked, so it passes
+    /// the scalar rather than the id). For each step this computes the softmax log-probability of the
+    /// chosen token, `chosenLogit - logSumExp(row)`, and returns the mean across steps. Returns nil
+    /// when there are no steps or the two inputs disagree in length, since an average is undefined
+    /// then. Pure and deterministic: a numerically stable log-sum-exp (shifted by the row maximum)
+    /// makes the result independent of constant offsets in the logits.
+    static func averageLogProb(of chosenLogits: [Float], over fullRows: [[Float]]) -> Double? {
+        guard !chosenLogits.isEmpty, chosenLogits.count == fullRows.count else {
+            return nil
+        }
+        var total = 0.0
+        for (chosen, row) in zip(chosenLogits, fullRows) {
+            guard !row.isEmpty else {
+                return nil
+            }
+            total += Double(chosen) - logSumExp(row)
+        }
+        return total / Double(chosenLogits.count)
+    }
+
+    /// The softmax log-probability of the token at `index` in `row`: `row[index] - logSumExp(row)`.
+    /// This is the single-step form of `averageLogProb`, for decoders that score each chosen token as
+    /// they go instead of retaining every logits row (retaining full rows for a whole completion would
+    /// cost vocab-size floats per step). Returns nil for an empty row or an out-of-range index.
+    static func logProb(ofTokenAt index: Int, in row: [Float]) -> Double? {
+        guard !row.isEmpty, index >= 0, index < row.count else {
+            return nil
+        }
+        return Double(row[index]) - logSumExp(row)
+    }
+
+    /// The token ids to consider this step, ordered by id. When `limit` is at least `count` every id
+    /// is returned (still id-ordered). Otherwise the ids are ranked by descending logit, the top
+    /// `limit` are kept, and that subset is re-sorted by id so downstream tie-breaking stays stable.
+    private static func candidatePool(count: Int, logits: [Float], limit: Int) -> [Int] {
+        guard limit < count else {
+            return Array(0..<count)
+        }
+        let ranked = (0..<count).sorted { lhs, rhs in
+            if logits[lhs] != logits[rhs] {
+                return logits[lhs] > logits[rhs]
+            }
+            // Stable id ordering for equal logits so the kept set is deterministic at the cut line.
+            return lhs < rhs
+        }
+        return ranked.prefix(limit).sorted()
+    }
+
+    /// Numerically stable log(sum(exp(row))): subtract the max before exponentiating so large logits
+    /// do not overflow. The caller guarantees `row` is non-empty.
+    private static func logSumExp(_ row: [Float]) -> Double {
+        let maxLogit = Double(row.max() ?? 0)
+        var sumExp = 0.0
+        for value in row {
+            sumExp += exp(Double(value) - maxLogit)
+        }
+        return maxLogit + log(sumExp)
+    }
+}

--- a/Cotabby/Support/TokenProfile.swift
+++ b/Cotabby/Support/TokenProfile.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+/// File overview:
+/// Per-token metadata used by constrained decoding: for every token id in a model's vocabulary it
+/// records the token's raw UTF-8 bytes plus a few classification flags (control, end-of-generation,
+/// whitespace-only, newline). Constrained sampling and prefix admissibility both read from this
+/// table instead of querying a live engine.
+///
+/// Why this file exists:
+/// Constrained decoding needs the *byte* shape of every candidate token (to test whether it can
+/// continue a required prefix) and a way to drop tokens that should never be sampled as visible text
+/// (control / structural tokens). A live tokenizer cannot be called from pure decision code without
+/// dragging the runtime in, and it would not be deterministically testable. Building this profile
+/// once from injected vocabulary data keeps the decoding rules pure: tests supply stub closures for
+/// the bytes and flags, and the same inputs always yield the same verdicts. The builder takes
+/// closures rather than concrete engine objects precisely so no runtime dependency leaks in.
+struct TokenProfile {
+    /// Classification flags for a single token, kept compact so the per-token table stays small even
+    /// for large vocabularies.
+    struct Entry {
+        /// The token's raw UTF-8 bytes. Byte-level (not String) because admissibility against a
+        /// partial-word prefix is a byte-prefix relationship: a token may encode only part of a
+        /// multi-byte scalar, and Strings cannot represent that fragment.
+        let bytes: [UInt8]
+        /// A structural / control token (for example a chat or special marker) that must never be
+        /// emitted as visible completion text.
+        let isControl: Bool
+        /// A token the engine treats as a stop / end-of-generation signal.
+        let isEndOfGeneration: Bool
+        /// The decoded bytes are non-empty and contain only whitespace.
+        let isWhitespaceOnly: Bool
+        /// The decoded bytes contain a line feed (`\n`).
+        let isNewline: Bool
+    }
+
+    /// Indexed by token id; `entries[id]` is the metadata for token `id`.
+    let entries: [Entry]
+
+    /// The number of tokens described by this profile.
+    var vocabSize: Int { entries.count }
+
+    /// Builds a profile for `vocabSize` tokens by pulling each token's bytes and flags from the
+    /// supplied closures. The closures are the only source of engine data, which is what keeps the
+    /// type pure and testable: a runtime passes detokenize / control / EOG lookups, and a test passes
+    /// stubs. Whitespace-only and newline are derived from the bytes here so callers cannot supply an
+    /// inconsistent classification.
+    static func build(
+        vocabSize: Int,
+        bytesFor: (Int) -> [UInt8],
+        isControl: (Int) -> Bool,
+        isEndOfGeneration: (Int) -> Bool
+    ) -> TokenProfile {
+        guard vocabSize > 0 else {
+            return TokenProfile(entries: [])
+        }
+        var entries: [Entry] = []
+        entries.reserveCapacity(vocabSize)
+        for id in 0..<vocabSize {
+            let bytes = bytesFor(id)
+            entries.append(
+                Entry(
+                    bytes: bytes,
+                    isControl: isControl(id),
+                    isEndOfGeneration: isEndOfGeneration(id),
+                    isWhitespaceOnly: Self.isWhitespaceOnly(bytes),
+                    isNewline: bytes.contains(Self.lineFeed)
+                )
+            )
+        }
+        return TokenProfile(entries: entries)
+    }
+
+    /// The token's raw UTF-8 bytes, or an empty array for an out-of-range id. Returning empty rather
+    /// than trapping keeps the decoding loop defensive against a stray id without a separate bounds
+    /// dance at every call site.
+    func bytes(for id: Int) -> [UInt8] {
+        guard let entry = entry(for: id) else {
+            return []
+        }
+        return entry.bytes
+    }
+
+    /// Whether `id` must be excluded from ordinary sampling. Control tokens are excluded so structural
+    /// markers never surface as visible completion text. An out-of-range id is treated as excluded so
+    /// it can never be selected by accident.
+    func isExcluded(_ id: Int) -> Bool {
+        guard let entry = entry(for: id) else {
+            return true
+        }
+        return entry.isControl
+    }
+
+    /// Whether `id` is an end-of-generation token. False for an out-of-range id.
+    func isEndOfGeneration(_ id: Int) -> Bool {
+        entry(for: id)?.isEndOfGeneration ?? false
+    }
+
+    /// Whether `id` decodes to bytes containing a newline. False for an out-of-range id.
+    func isNewline(_ id: Int) -> Bool {
+        entry(for: id)?.isNewline ?? false
+    }
+
+    /// Whether `id` decodes to non-empty, whitespace-only bytes. False for an out-of-range id.
+    func isWhitespaceOnly(_ id: Int) -> Bool {
+        entry(for: id)?.isWhitespaceOnly ?? false
+    }
+
+    private func entry(for id: Int) -> Entry? {
+        guard id >= 0, id < entries.count else {
+            return nil
+        }
+        return entries[id]
+    }
+
+    private static let lineFeed: UInt8 = 0x0A
+
+    /// Non-empty and every byte is an ASCII whitespace character. Constrained to ASCII whitespace on
+    /// purpose: classifying arbitrary multi-byte Unicode whitespace would require decoding partial
+    /// scalars, which a single token's bytes may not form. Empty bytes are not whitespace-only.
+    private static func isWhitespaceOnly(_ bytes: [UInt8]) -> Bool {
+        guard !bytes.isEmpty else {
+            return false
+        }
+        return bytes.allSatisfy(Self.isASCIIWhitespace)
+    }
+
+    private static func isASCIIWhitespace(_ byte: UInt8) -> Bool {
+        switch byte {
+        case 0x20, 0x09, 0x0A, 0x0B, 0x0C, 0x0D:
+            // space, tab, line feed, vertical tab, form feed, carriage return
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/CotabbyTests/ConstrainedSamplerTests.swift
+++ b/CotabbyTests/ConstrainedSamplerTests.swift
@@ -1,0 +1,242 @@
+import XCTest
+@testable import Cotabby
+
+/// Pure-function tests for deterministic constrained selection and the confidence helper. No RNG is
+/// involved, so every selection is an exact, repeatable argmax under the given constraints.
+final class ConstrainedSamplerTests: XCTestCase {
+
+    /// Profile of plain non-control, non-EOG tokens with single-letter bytes, one per logit slot.
+    private func plainProfile(count: Int, control: Set<Int> = []) -> TokenProfile {
+        TokenProfile.build(
+            vocabSize: count,
+            bytesFor: { [UInt8(65 + ($0 % 26))] },
+            isControl: { control.contains($0) },
+            isEndOfGeneration: { _ in false }
+        )
+    }
+
+    // MARK: - selectToken
+
+    func test_select_returnsHighestLogit() {
+        let logits: [Float] = [0.1, 2.5, 1.0, -3.0]
+        let id = ConstrainedSampler.selectToken(
+            logits: logits,
+            profile: plainProfile(count: 4),
+            admissibleTokenIDs: nil,
+            topK: 4
+        )
+        XCTAssertEqual(id, 1)
+    }
+
+    func test_select_skipsExcludedControlTokens() {
+        // Token 1 has the highest logit but is control, so it must be skipped in favor of token 2.
+        let logits: [Float] = [0.1, 5.0, 2.0, 1.0]
+        let id = ConstrainedSampler.selectToken(
+            logits: logits,
+            profile: plainProfile(count: 4, control: [1]),
+            admissibleTokenIDs: nil,
+            topK: 4
+        )
+        XCTAssertEqual(id, 2)
+    }
+
+    func test_select_honorsAdmissibleSet() {
+        // Highest logit is token 0, but only {2, 3} are admissible, so token 2 (higher of the two) wins.
+        let logits: [Float] = [9.0, 8.0, 3.0, 2.0]
+        let id = ConstrainedSampler.selectToken(
+            logits: logits,
+            profile: plainProfile(count: 4),
+            admissibleTokenIDs: [2, 3],
+            topK: 4
+        )
+        XCTAssertEqual(id, 2)
+    }
+
+    func test_select_emptyAdmissibleSet_returnsNil() {
+        // An explicit empty constraint admits nothing this step.
+        let logits: [Float] = [1.0, 2.0, 3.0]
+        let id = ConstrainedSampler.selectToken(
+            logits: logits,
+            profile: plainProfile(count: 3),
+            admissibleTokenIDs: [],
+            topK: 3
+        )
+        XCTAssertNil(id)
+    }
+
+    func test_select_allExcluded_returnsNil() {
+        let logits: [Float] = [1.0, 2.0, 3.0]
+        let id = ConstrainedSampler.selectToken(
+            logits: logits,
+            profile: plainProfile(count: 3, control: [0, 1, 2]),
+            admissibleTokenIDs: nil,
+            topK: 3
+        )
+        XCTAssertNil(id)
+    }
+
+    func test_select_admissibleIDOutOfRange_isIgnored() {
+        // An admissible id with no logit slot must not crash or be selected; the in-range admissible
+        // token wins instead.
+        let logits: [Float] = [1.0, 4.0]
+        let id = ConstrainedSampler.selectToken(
+            logits: logits,
+            profile: plainProfile(count: 2),
+            admissibleTokenIDs: [1, 99],
+            topK: 2
+        )
+        XCTAssertEqual(id, 1)
+    }
+
+    func test_select_tieBrokenByLowerID() {
+        // Equal logits must resolve to the lower id so the result is stable.
+        let logits: [Float] = [5.0, 5.0, 5.0]
+        let id = ConstrainedSampler.selectToken(
+            logits: logits,
+            profile: plainProfile(count: 3),
+            admissibleTokenIDs: nil,
+            topK: 3
+        )
+        XCTAssertEqual(id, 0)
+    }
+
+    func test_select_topKBoundsCandidatePool() {
+        // topK=2 keeps only the two highest-logit ids {0, 3}; the lower-logit ids 1 and 2 are never
+        // considered. Token 0 is excluded (control), so token 3 wins from within the bounded pool.
+        let logits: [Float] = [9.0, 1.0, 2.0, 8.0]
+        let id = ConstrainedSampler.selectToken(
+            logits: logits,
+            profile: plainProfile(count: 4, control: [0]),
+            admissibleTokenIDs: nil,
+            topK: 2
+        )
+        XCTAssertEqual(id, 3)
+    }
+
+    func test_select_topKTooSmallToReachAdmissible_returnsNil() {
+        // Admissible token 2 has a low logit; topK=1 keeps only the global max (token 0), which is not
+        // admissible, so nothing survives. Demonstrates that topK trades recall for cost.
+        let logits: [Float] = [9.0, 8.0, 0.5]
+        let id = ConstrainedSampler.selectToken(
+            logits: logits,
+            profile: plainProfile(count: 3),
+            admissibleTokenIDs: [2],
+            topK: 1
+        )
+        XCTAssertNil(id)
+    }
+
+    func test_select_topKZero_returnsNil() {
+        let id = ConstrainedSampler.selectToken(
+            logits: [1.0, 2.0],
+            profile: plainProfile(count: 2),
+            admissibleTokenIDs: nil,
+            topK: 0
+        )
+        XCTAssertNil(id)
+    }
+
+    func test_select_emptyLogits_returnsNil() {
+        let id = ConstrainedSampler.selectToken(
+            logits: [],
+            profile: plainProfile(count: 0),
+            admissibleTokenIDs: nil,
+            topK: 4
+        )
+        XCTAssertNil(id)
+    }
+
+    func test_select_isDeterministicAcrossRepeatedCalls() {
+        let logits: [Float] = [0.3, 0.31, 0.305, 0.31]
+        let profile = plainProfile(count: 4)
+        let first = ConstrainedSampler.selectToken(
+            logits: logits, profile: profile, admissibleTokenIDs: nil, topK: 4
+        )
+        for _ in 0..<20 {
+            let again = ConstrainedSampler.selectToken(
+                logits: logits, profile: profile, admissibleTokenIDs: nil, topK: 4
+            )
+            XCTAssertEqual(again, first)
+        }
+        // Tie between ids 1 and 3 resolves to the lower id.
+        XCTAssertEqual(first, 1)
+    }
+
+    // MARK: - averageLogProb
+
+    func test_averageLogProb_uniformRow_matchesNegativeLogVocab() {
+        // Every logit equal -> each token's probability is 1/N, so log-prob is -ln(N) every step.
+        let row: [Float] = [0, 0, 0, 0]
+        let value = ConstrainedSampler.averageLogProb(of: [0, 0], over: [row, row])
+        XCTAssertNotNil(value)
+        XCTAssertEqual(value ?? .nan, -log(4.0), accuracy: 1e-9)
+    }
+
+    func test_averageLogProb_isInvariantToConstantOffset() {
+        // Adding a constant to every logit in a row leaves softmax (and thus the log-prob) unchanged.
+        let base: [Float] = [1.0, 2.0, 0.5]
+        let shifted: [Float] = base.map { $0 + 100.0 }
+        let plain = ConstrainedSampler.averageLogProb(of: [2.0], over: [base])
+        let offset = ConstrainedSampler.averageLogProb(of: [102.0], over: [shifted])
+        XCTAssertNotNil(plain)
+        XCTAssertNotNil(offset)
+        XCTAssertEqual(plain ?? .nan, offset ?? .nan, accuracy: 1e-6)
+    }
+
+    func test_averageLogProb_averagesAcrossSteps() {
+        // Two steps with known per-step log-probs; the result is their mean.
+        let rowA: [Float] = [0, 0] // chosen logit 0 -> log(0.5)
+        let rowB: [Float] = [0, 0, 0, 0] // chosen logit 0 -> log(0.25)
+        let value = ConstrainedSampler.averageLogProb(of: [0, 0], over: [rowA, rowB])
+        let expected = (log(0.5) + log(0.25)) / 2.0
+        XCTAssertEqual(value ?? .nan, expected, accuracy: 1e-9)
+    }
+
+    func test_averageLogProb_emptyInput_returnsNil() {
+        XCTAssertNil(ConstrainedSampler.averageLogProb(of: [], over: []))
+    }
+
+    func test_averageLogProb_lengthMismatch_returnsNil() {
+        XCTAssertNil(ConstrainedSampler.averageLogProb(of: [1.0], over: [[1.0], [2.0]]))
+    }
+
+    func test_averageLogProb_emptyRow_returnsNil() {
+        XCTAssertNil(ConstrainedSampler.averageLogProb(of: [1.0], over: [[]]))
+    }
+
+    // MARK: - logProb (single-step)
+
+    func test_logProb_uniformRow_matchesNegativeLogVocab() {
+        // Uniform logits -> every token has probability 1/N -> log-prob is -ln(N).
+        let row: [Float] = [0, 0, 0, 0]
+        let value = ConstrainedSampler.logProb(ofTokenAt: 2, in: row)
+        XCTAssertEqual(value ?? .nan, -log(4.0), accuracy: 1e-9)
+    }
+
+    func test_logProb_matchesAverageLogProbForSingleStep() {
+        // The single-step helper must agree with averaging one row, since the decoder accumulates the
+        // former where the offline confidence helper uses the latter.
+        let row: [Float] = [1.0, 2.0, 0.5, -1.0]
+        let single = ConstrainedSampler.logProb(ofTokenAt: 1, in: row)
+        let averaged = ConstrainedSampler.averageLogProb(of: [row[1]], over: [row])
+        XCTAssertNotNil(single)
+        XCTAssertEqual(single ?? .nan, averaged ?? .nan, accuracy: 1e-9)
+    }
+
+    func test_logProb_isInvariantToConstantOffset() {
+        let base: [Float] = [1.0, 2.0, 0.5]
+        let shifted: [Float] = base.map { $0 + 50.0 }
+        let plain = ConstrainedSampler.logProb(ofTokenAt: 0, in: base)
+        let offset = ConstrainedSampler.logProb(ofTokenAt: 0, in: shifted)
+        XCTAssertEqual(plain ?? .nan, offset ?? .nan, accuracy: 1e-6)
+    }
+
+    func test_logProb_outOfRangeIndex_returnsNil() {
+        XCTAssertNil(ConstrainedSampler.logProb(ofTokenAt: 5, in: [1.0, 2.0]))
+        XCTAssertNil(ConstrainedSampler.logProb(ofTokenAt: -1, in: [1.0, 2.0]))
+    }
+
+    func test_logProb_emptyRow_returnsNil() {
+        XCTAssertNil(ConstrainedSampler.logProb(ofTokenAt: 0, in: []))
+    }
+}

--- a/CotabbyTests/TokenProfileTests.swift
+++ b/CotabbyTests/TokenProfileTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+@testable import Cotabby
+
+/// Pure-function tests for per-token constrained-decoding metadata. Engine data is supplied through
+/// stub closures, so every assertion is deterministic and no runtime is involved.
+final class TokenProfileTests: XCTestCase {
+
+    /// One token's stub data; a small struct rather than a tuple keeps the table readable and avoids
+    /// a large-tuple lint warning.
+    private struct Stub {
+        let bytes: [UInt8]
+        let control: Bool
+        let eog: Bool
+    }
+
+    /// Builds a profile from a literal table of stub entries indexed by token id.
+    private func makeProfile(_ table: [Stub]) -> TokenProfile {
+        TokenProfile.build(
+            vocabSize: table.count,
+            bytesFor: { table[$0].bytes },
+            isControl: { table[$0].control },
+            isEndOfGeneration: { table[$0].eog }
+        )
+    }
+
+    private func bytes(_ string: String) -> [UInt8] {
+        Array(string.utf8)
+    }
+
+    func test_build_recordsVocabSizeAndBytes() {
+        let profile = makeProfile([
+            Stub(bytes: bytes("the"), control: false, eog: false),
+            Stub(bytes: bytes(" dog"), control: false, eog: false)
+        ])
+        XCTAssertEqual(profile.vocabSize, 2)
+        XCTAssertEqual(profile.bytes(for: 0), bytes("the"))
+        XCTAssertEqual(profile.bytes(for: 1), bytes(" dog"))
+    }
+
+    func test_build_emptyVocab_producesEmptyProfile() {
+        let profile = TokenProfile.build(
+            vocabSize: 0,
+            bytesFor: { _ in [] },
+            isControl: { _ in false },
+            isEndOfGeneration: { _ in false }
+        )
+        XCTAssertEqual(profile.vocabSize, 0)
+    }
+
+    func test_controlToken_isExcluded() {
+        let profile = makeProfile([
+            Stub(bytes: bytes("hi"), control: false, eog: false),
+            Stub(bytes: bytes("<|end|>"), control: true, eog: false)
+        ])
+        XCTAssertFalse(profile.isExcluded(0))
+        XCTAssertTrue(profile.isExcluded(1))
+    }
+
+    func test_endOfGenerationFlag_isReported() {
+        let profile = makeProfile([
+            Stub(bytes: bytes("word"), control: false, eog: false),
+            Stub(bytes: bytes("</s>"), control: true, eog: true)
+        ])
+        XCTAssertFalse(profile.isEndOfGeneration(0))
+        XCTAssertTrue(profile.isEndOfGeneration(1))
+    }
+
+    func test_whitespaceOnly_classification() {
+        let profile = makeProfile([
+            Stub(bytes: bytes(" "), control: false, eog: false),
+            Stub(bytes: bytes("\t \n"), control: false, eog: false),
+            Stub(bytes: bytes(" x"), control: false, eog: false),
+            Stub(bytes: [], control: false, eog: false)
+        ])
+        XCTAssertTrue(profile.isWhitespaceOnly(0))
+        XCTAssertTrue(profile.isWhitespaceOnly(1))
+        // A space followed by a letter is not whitespace-only.
+        XCTAssertFalse(profile.isWhitespaceOnly(2))
+        // Empty bytes are not whitespace-only.
+        XCTAssertFalse(profile.isWhitespaceOnly(3))
+    }
+
+    func test_newline_classification() {
+        let profile = makeProfile([
+            Stub(bytes: bytes("\n"), control: false, eog: false),
+            Stub(bytes: bytes("a\nb"), control: false, eog: false),
+            Stub(bytes: bytes("plain"), control: false, eog: false)
+        ])
+        XCTAssertTrue(profile.isNewline(0))
+        // Newline embedded among other bytes still counts.
+        XCTAssertTrue(profile.isNewline(1))
+        XCTAssertFalse(profile.isNewline(2))
+    }
+
+    func test_outOfRangeID_isDefensive() {
+        let profile = makeProfile([
+            Stub(bytes: bytes("only"), control: false, eog: false)
+        ])
+        // Out-of-range queries must never crash and must be treated as excluded / negative so a stray
+        // id can never be selected or misclassified.
+        XCTAssertEqual(profile.bytes(for: 5), [])
+        XCTAssertEqual(profile.bytes(for: -1), [])
+        XCTAssertTrue(profile.isExcluded(5))
+        XCTAssertTrue(profile.isExcluded(-1))
+        XCTAssertFalse(profile.isEndOfGeneration(5))
+        XCTAssertFalse(profile.isNewline(5))
+        XCTAssertFalse(profile.isWhitespaceOnly(5))
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -13,7 +13,7 @@ packages:
     exactVersion: 2.9.1
   CotabbyInference:
     url: https://github.com/FuJacob/cotabbyinference.git
-    branch: feat/generation-quality-controls
+    branch: main
   swift-log:
     url: https://github.com/apple/swift-log.git
     from: 1.12.1


### PR DESCRIPTION
## Summary

Adds a deterministic, logit-level constrained decoding path for the open-source llama runtime, gated behind a hidden default-off flag. Instead of the engine's stochastic sampler, it reads the raw next-token logits, masks structural / control tokens via a per-model token profile, argmax-selects the highest admissible token, and commits it manually with `acceptToken`. This produces reproducible, leak-free completions — no chat or control markers can surface as visible text, and the same prompt always yields the same suggestion. Default behavior is unchanged.

## Validation

```
rm -rf build/DerivedData
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  build-for-testing -derivedDataPath build/DerivedData
# ** TEST BUILD SUCCEEDED **  (app + test targets, clean)

swiftlint lint --quiet
# 0 violations
```

- New pure logic is unit-tested: `ConstrainedSamplerTests` (selection, control exclusion, admissibility, top-k pool bounds, tie-breaking, determinism, single-step + averaged log-prob) and `TokenProfileTests`.
- **Not** validated end-to-end: decode quality can only be judged with a real model in a real text field, which cannot run headlessly. That on-device check is exactly what flipping the flag is for; the path stays default-off until then.
- App-hosted unit tests execute on CI's `xcodebuild test (macOS)` job (local Team-ID signing prevents the xctest host from loading here).

## Linked issues

_None._

## Risk / rollout notes

- **Default-off.** Generation is routed through the constrained decoder only when the `cotabbyConstrainedDecoderEnabled` UserDefaults flag (no UI) is true. The shipping `sampleNext` path is byte-for-byte unchanged; `generate()` only branches its inner decode loop, and the flag is excluded from the KV-reuse fingerprint.
- **Dependency pin.** `project.yml` + the generated pbxproj move the CotabbyInference pin from the `feat/generation-quality-controls` branch to `main` to consume the constrained-generation primitives (logits read, token accept, vocab introspection). `Package.resolved` is gitignored; CI resolves `branch: main` to latest.
- **Performance.** On the first constrained request per model, a token profile is built once (one detokenize per vocab token) and cached, then freed on model unload. No effect when the flag is off.
- **Follow-up.** Prefix-admissibility and best-of-N / multi-branch decode are intentionally out of scope here (they need multi-sequence engine support) and will land separately; this PR is the single-sequence deterministic path.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a deterministic, logit-level constrained decode path to the llama runtime, gated behind the `cotabbyConstrainedDecoderEnabled` UserDefaults flag (default off). The existing `sampleNext` path is byte-for-byte unchanged; the new path reads raw logits each step, masks control/structural tokens via a lazily-built, per-model `TokenProfile`, and commits the highest-admissible-logit token with `acceptToken`.

- `LlamaRuntimeCore` splits `generate()` into `runEngineSampledDecode` and `runConstrainedDecode`, sharing a single `shouldSuppress` helper; `TokenProfile` is built once on the first constrained request and cached until the model changes or `shutdown()` is called.
- `ConstrainedSampler` is a pure, RNG-free utility (argmax + optional admissibility set + top-K bounding) covered by a comprehensive unit-test suite; `CotabbyInference` dependency is re-pinned from a feature branch to `main` to consume the new logit/accept primitives.

<h3>Confidence Score: 4/5</h3>

Safe to merge as-is; the constrained decoder is default-off and the shipping sampleNext path is unchanged.

The default-off flag means no user-visible behaviour changes on merge. The new constrained path has a minor confidence-score miscalibration risk when logProb is nil, a redundant vocabSize guard, a bare-CR gap in the single-line stop check, and a per-step O(N log N) full-vocabulary sort. None of these affect the shipping path or block enabling the feature, but they are worth addressing before the flag is promoted to default-on.

LlamaRuntimeCore.swift (constrained decode loop and token-profile caching) and TokenProfile.swift (isNewline CR handling) deserve a second look before the flag is turned on by default.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/Services/Runtime/LlamaRuntimeCore.swift | Core change: splits generate() into engine-sampled and constrained decode paths, extracts shouldSuppress as a shared static, adds lazy token-profile caching cleared on shutdown. Minor: sumLogprob/tokensGenerated mismatch under nil logProb and redundant vocabSize guard. |
| Cotabby/Support/ConstrainedSampler.swift | New pure-logic file: deterministic argmax selection with control-token exclusion, admissibility filtering, and top-K bounding. Well-tested; per-step full-vocab sort is O(N log N) rather than optimal O(N log K). |
| Cotabby/Support/TokenProfile.swift | New pure-logic file: per-token metadata table (bytes, control, EOG, whitespace, newline flags). Defensive out-of-range handling is solid; isNewline only checks LF (0x0A), missing bare CR stop for single-line mode. |
| Cotabby/Services/Runtime/LlamaSuggestionEngine.swift | Reads cotabbyConstrainedDecoderEnabled UserDefaults key and plumbs it into LlamaGenerationOptions; change is minimal and default-off. |
| project.yml | Moves CotabbyInference pin from feat/generation-quality-controls to branch: main; deliberate per PR description but a floating branch reference means CI resolves to latest HEAD on every clean build. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[LlamaSuggestionEngine.suggest] -->|reads UserDefaults| B{cotabbyConstrainedDecoderEnabled?}
    B -->|false - default| C[LlamaRuntimeCore.generate]
    B -->|true| C

    C --> D[Prepare KV sequence / prompt tokens]
    D --> E{options.useConstrainedDecoder?}

    E -->|false| F[runEngineSampledDecode]
    F --> G[engine.sampleNext loop]
    G --> H[extractPiece / accumulate text]
    H --> I{EOS or budget?}
    I -->|no| G
    I -->|yes| J[shouldSuppress check]

    E -->|true| K[runConstrainedDecode]
    K --> L[autocompleteTokenProfile - lazy build + cache]
    L --> M[engine.getNextTokenLogits]
    M --> N[ConstrainedSampler.selectToken - argmax with exclusions]
    N --> O{EOS / singleLine / nil?}
    O -->|stop| P[shouldSuppress check]
    O -->|continue| Q[engine.acceptToken]
    Q --> R[accumulate bytes + logProb]
    R --> M

    J --> S[return generated text or empty]
    P --> S
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `Cotabby/Support/TokenProfile.swift`, line 704-724 ([link](https://github.com/fujacob/cotabby/blob/fe69fbb432e746be2941e01e3cc536b2478ec1b6/Cotabby/Support/TokenProfile.swift#L704-L724)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Bare `\r` token won't stop single-line decoding**

   `isNewline` only tests for LF (`0x0A`). A token whose bytes are solely `[0x0D]` (carriage return) or that ends with `\r` without a following `\n` would pass the single-line stop check undetected, allowing a partial carriage return to be appended to the completion before the next `\n`-carrying token eventually terminates the loop. `isASCIIWhitespace` already includes `0x0D`, so the byte-level knowledge is present; `isNewline` could simply union the CR check: `bytes.contains(0x0A) || bytes.contains(0x0D)`.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22experimental%2Fconstrained-engine%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22experimental%2Fconstrained-engine%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FSupport%2FTokenProfile.swift%0ALine%3A%20704-724%0A%0AComment%3A%0A**Bare%20%60%5Cr%60%20token%20won't%20stop%20single-line%20decoding**%0A%0A%60isNewline%60%20only%20tests%20for%20LF%20%28%600x0A%60%29.%20A%20token%20whose%20bytes%20are%20solely%20%60%5B0x0D%5D%60%20%28carriage%20return%29%20or%20that%20ends%20with%20%60%5Cr%60%20without%20a%20following%20%60%5Cn%60%20would%20pass%20the%20single-line%20stop%20check%20undetected%2C%20allowing%20a%20partial%20carriage%20return%20to%20be%20appended%20to%20the%20completion%20before%20the%20next%20%60%5Cn%60-carrying%20token%20eventually%20terminates%20the%20loop.%20%60isASCIIWhitespace%60%20already%20includes%20%600x0D%60%2C%20so%20the%20byte-level%20knowledge%20is%20present%3B%20%60isNewline%60%20could%20simply%20union%20the%20CR%20check%3A%20%60bytes.contains%280x0A%29%20%7C%7C%20bytes.contains%280x0D%29%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FSupport%2FTokenProfile.swift%0ALine%3A%20704-724%0A%0AComment%3A%0A**Bare%20%60%5Cr%60%20token%20won't%20stop%20single-line%20decoding**%0A%0A%60isNewline%60%20only%20tests%20for%20LF%20%28%600x0A%60%29.%20A%20token%20whose%20bytes%20are%20solely%20%60%5B0x0D%5D%60%20%28carriage%20return%29%20or%20that%20ends%20with%20%60%5Cr%60%20without%20a%20following%20%60%5Cn%60%20would%20pass%20the%20single-line%20stop%20check%20undetected%2C%20allowing%20a%20partial%20carriage%20return%20to%20be%20appended%20to%20the%20completion%20before%20the%20next%20%60%5Cn%60-carrying%20token%20eventually%20terminates%20the%20loop.%20%60isASCIIWhitespace%60%20already%20includes%20%600x0D%60%2C%20so%20the%20byte-level%20knowledge%20is%20present%3B%20%60isNewline%60%20could%20simply%20union%20the%20CR%20check%3A%20%60bytes.contains%280x0A%29%20%7C%7C%20bytes.contains%280x0D%29%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=503&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>


2. `Cotabby/Support/ConstrainedSampler.swift`, line 559-571 ([link](https://github.com/fujacob/cotabby/blob/fe69fbb432e746be2941e01e3cc536b2478ec1b6/Cotabby/Support/ConstrainedSampler.swift#L559-L571)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Per-step full-vocabulary sort is O(N log N) when O(N log K) would suffice**

   When `limit < count`, the entire range `0..<count` is sorted descending by logit before taking the `prefix(limit)`. For a 32 K–128 K vocabulary with typical `topK` values of 40–100, that is ~480 K–2.2 M comparisons per decode step just for the candidate pool. A min-heap of size `limit` (or `Array.partialSort`) would reduce that to O(N log K) — roughly 5–6× less work at K=40. On device the per-step wall time is dominated by `getNextTokenLogits` and `acceptToken`, so this is not a blocker, but the sort overhead compounds across all constrained-decode steps and is worth revisiting before the flag is turned on by default.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22experimental%2Fconstrained-engine%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22experimental%2Fconstrained-engine%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FSupport%2FConstrainedSampler.swift%0ALine%3A%20559-571%0A%0AComment%3A%0A**Per-step%20full-vocabulary%20sort%20is%20O%28N%20log%20N%29%20when%20O%28N%20log%20K%29%20would%20suffice**%0A%0AWhen%20%60limit%20%3C%20count%60%2C%20the%20entire%20range%20%600..%3Ccount%60%20is%20sorted%20descending%20by%20logit%20before%20taking%20the%20%60prefix%28limit%29%60.%20For%20a%2032%20K%E2%80%93128%20K%20vocabulary%20with%20typical%20%60topK%60%20values%20of%2040%E2%80%93100%2C%20that%20is%20~480%20K%E2%80%932.2%20M%20comparisons%20per%20decode%20step%20just%20for%20the%20candidate%20pool.%20A%20min-heap%20of%20size%20%60limit%60%20%28or%20%60Array.partialSort%60%29%20would%20reduce%20that%20to%20O%28N%20log%20K%29%20%E2%80%94%20roughly%205%E2%80%936%C3%97%20less%20work%20at%20K%3D40.%20On%20device%20the%20per-step%20wall%20time%20is%20dominated%20by%20%60getNextTokenLogits%60%20and%20%60acceptToken%60%2C%20so%20this%20is%20not%20a%20blocker%2C%20but%20the%20sort%20overhead%20compounds%20across%20all%20constrained-decode%20steps%20and%20is%20worth%20revisiting%20before%20the%20flag%20is%20turned%20on%20by%20default.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FSupport%2FConstrainedSampler.swift%0ALine%3A%20559-571%0A%0AComment%3A%0A**Per-step%20full-vocabulary%20sort%20is%20O%28N%20log%20N%29%20when%20O%28N%20log%20K%29%20would%20suffice**%0A%0AWhen%20%60limit%20%3C%20count%60%2C%20the%20entire%20range%20%600..%3Ccount%60%20is%20sorted%20descending%20by%20logit%20before%20taking%20the%20%60prefix%28limit%29%60.%20For%20a%2032%20K%E2%80%93128%20K%20vocabulary%20with%20typical%20%60topK%60%20values%20of%2040%E2%80%93100%2C%20that%20is%20~480%20K%E2%80%932.2%20M%20comparisons%20per%20decode%20step%20just%20for%20the%20candidate%20pool.%20A%20min-heap%20of%20size%20%60limit%60%20%28or%20%60Array.partialSort%60%29%20would%20reduce%20that%20to%20O%28N%20log%20K%29%20%E2%80%94%20roughly%205%E2%80%936%C3%97%20less%20work%20at%20K%3D40.%20On%20device%20the%20per-step%20wall%20time%20is%20dominated%20by%20%60getNextTokenLogits%60%20and%20%60acceptToken%60%2C%20so%20this%20is%20not%20a%20blocker%2C%20but%20the%20sort%20overhead%20compounds%20across%20all%20constrained-decode%20steps%20and%20is%20worth%20revisiting%20before%20the%20flag%20is%20turned%20on%20by%20default.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=503&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22experimental%2Fconstrained-engine%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22experimental%2Fconstrained-engine%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0ACotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%3A276-281%0A**Silent%20logprob%20gap%20silently%20inflates%20the%20confidence%20score**%0A%0AWhen%20%60ConstrainedSampler.logProb%60%20returns%20%60nil%60%2C%20%60tokensGenerated%60%20is%20still%20incremented%20but%20%60sumLogprob%60%20is%20not.%20The%20subsequent%20%60shouldSuppress%60%20call%20divides%20%60sumLogprob%60%20by%20%60tokensGenerated%60%2C%20so%20any%20skipped%20step%20makes%20the%20average%20log-probability%20closer%20to%20zero%20%28artificially%20higher%20confidence%29%2C%20risking%20a%20low-quality%20completion%20passing%20the%20floor%20check.%20In%20practice%20%60logProb%60%20cannot%20be%20nil%20here%20%28the%20token%20index%20always%20comes%20from%20%60selectToken%60%20which%20bounds%20candidates%20to%20%600..%3Clogits.count%60%29%2C%20but%20the%20defensive%20%60if%20let%60%20means%20a%20future%20refactor%20that%20breaks%20that%20invariant%20would%20silently%20miscalibrate%20suppression%20rather%20than%20surfacing%20a%20crash.%20Consider%20logging%20a%20fault%20or%20asserting%20non-nil%2C%20or%20using%20a%20known-safe%20fallback%20value%20instead%20of%20silently%20skipping%20the%20accumulation.%0A%0A%23%23%23%20Issue%202%20of%204%0ACotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%3A268-275%0A**Unreachable%20guard%3A%20%60autocompleteTokenProfile%28%29%60%20already%20guarantees%20a%20positive%20vocab%20size**%0A%0A%60autocompleteTokenProfile%28%29%60%20throws%20%60LlamaRuntimeError.generationFailed%60%20when%20%60engine.getVocabSize%28%29%60%20is%20zero%20and%20never%20stores%20a%20zero-entry%20profile%20in%20the%20cache%2C%20so%20%60profile.vocabSize%60%20can%20never%20be%20zero%20when%20the%20call%20returns%20without%20throwing.%20The%20%60guard%60%20here%20is%20dead%20code%20and%20the%20duplicated%20error%20message%20adds%20maintenance%20surface.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20profile%20%3D%20try%20autocompleteTokenProfile%28%29%0A%20%20%20%20%20%20%20%20let%20vocabSize%20%3D%20profile.vocabSize%0A%20%20%20%20%20%20%20%20%2F%2F%20%60topK%60%20bounds%20the%20candidate%20pool%20the%20selector%20ranks%3B%20clamp%20to%20a%20sane%20positive%20value%20so%20a%0A%20%20%20%20%20%20%20%20%2F%2F%20zero%2Fnegative%20request%20still%20yields%20a%20full-vocab%20argmax%20rather%20than%20an%20empty%20pool.%0A%20%20%20%20%20%20%20%20let%20topK%20%3D%20options.topK%20%3E%200%20%3F%20options.topK%20%3A%20vocabSize%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0ACotabby%2FSupport%2FTokenProfile.swift%3A704-724%0A**Bare%20%60%5Cr%60%20token%20won't%20stop%20single-line%20decoding**%0A%0A%60isNewline%60%20only%20tests%20for%20LF%20%28%600x0A%60%29.%20A%20token%20whose%20bytes%20are%20solely%20%60%5B0x0D%5D%60%20%28carriage%20return%29%20or%20that%20ends%20with%20%60%5Cr%60%20without%20a%20following%20%60%5Cn%60%20would%20pass%20the%20single-line%20stop%20check%20undetected%2C%20allowing%20a%20partial%20carriage%20return%20to%20be%20appended%20to%20the%20completion%20before%20the%20next%20%60%5Cn%60-carrying%20token%20eventually%20terminates%20the%20loop.%20%60isASCIIWhitespace%60%20already%20includes%20%600x0D%60%2C%20so%20the%20byte-level%20knowledge%20is%20present%3B%20%60isNewline%60%20could%20simply%20union%20the%20CR%20check%3A%20%60bytes.contains%280x0A%29%20%7C%7C%20bytes.contains%280x0D%29%60.%0A%0A%23%23%23%20Issue%204%20of%204%0ACotabby%2FSupport%2FConstrainedSampler.swift%3A559-571%0A**Per-step%20full-vocabulary%20sort%20is%20O%28N%20log%20N%29%20when%20O%28N%20log%20K%29%20would%20suffice**%0A%0AWhen%20%60limit%20%3C%20count%60%2C%20the%20entire%20range%20%600..%3Ccount%60%20is%20sorted%20descending%20by%20logit%20before%20taking%20the%20%60prefix%28limit%29%60.%20For%20a%2032%20K%E2%80%93128%20K%20vocabulary%20with%20typical%20%60topK%60%20values%20of%2040%E2%80%93100%2C%20that%20is%20~480%20K%E2%80%932.2%20M%20comparisons%20per%20decode%20step%20just%20for%20the%20candidate%20pool.%20A%20min-heap%20of%20size%20%60limit%60%20%28or%20%60Array.partialSort%60%29%20would%20reduce%20that%20to%20O%28N%20log%20K%29%20%E2%80%94%20roughly%205%E2%80%936%C3%97%20less%20work%20at%20K%3D40.%20On%20device%20the%20per-step%20wall%20time%20is%20dominated%20by%20%60getNextTokenLogits%60%20and%20%60acceptToken%60%2C%20so%20this%20is%20not%20a%20blocker%2C%20but%20the%20sort%20overhead%20compounds%20across%20all%20constrained-decode%20steps%20and%20is%20worth%20revisiting%20before%20the%20flag%20is%20turned%20on%20by%20default.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0ACotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%3A276-281%0A**Silent%20logprob%20gap%20silently%20inflates%20the%20confidence%20score**%0A%0AWhen%20%60ConstrainedSampler.logProb%60%20returns%20%60nil%60%2C%20%60tokensGenerated%60%20is%20still%20incremented%20but%20%60sumLogprob%60%20is%20not.%20The%20subsequent%20%60shouldSuppress%60%20call%20divides%20%60sumLogprob%60%20by%20%60tokensGenerated%60%2C%20so%20any%20skipped%20step%20makes%20the%20average%20log-probability%20closer%20to%20zero%20%28artificially%20higher%20confidence%29%2C%20risking%20a%20low-quality%20completion%20passing%20the%20floor%20check.%20In%20practice%20%60logProb%60%20cannot%20be%20nil%20here%20%28the%20token%20index%20always%20comes%20from%20%60selectToken%60%20which%20bounds%20candidates%20to%20%600..%3Clogits.count%60%29%2C%20but%20the%20defensive%20%60if%20let%60%20means%20a%20future%20refactor%20that%20breaks%20that%20invariant%20would%20silently%20miscalibrate%20suppression%20rather%20than%20surfacing%20a%20crash.%20Consider%20logging%20a%20fault%20or%20asserting%20non-nil%2C%20or%20using%20a%20known-safe%20fallback%20value%20instead%20of%20silently%20skipping%20the%20accumulation.%0A%0A%23%23%23%20Issue%202%20of%204%0ACotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%3A268-275%0A**Unreachable%20guard%3A%20%60autocompleteTokenProfile%28%29%60%20already%20guarantees%20a%20positive%20vocab%20size**%0A%0A%60autocompleteTokenProfile%28%29%60%20throws%20%60LlamaRuntimeError.generationFailed%60%20when%20%60engine.getVocabSize%28%29%60%20is%20zero%20and%20never%20stores%20a%20zero-entry%20profile%20in%20the%20cache%2C%20so%20%60profile.vocabSize%60%20can%20never%20be%20zero%20when%20the%20call%20returns%20without%20throwing.%20The%20%60guard%60%20here%20is%20dead%20code%20and%20the%20duplicated%20error%20message%20adds%20maintenance%20surface.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20profile%20%3D%20try%20autocompleteTokenProfile%28%29%0A%20%20%20%20%20%20%20%20let%20vocabSize%20%3D%20profile.vocabSize%0A%20%20%20%20%20%20%20%20%2F%2F%20%60topK%60%20bounds%20the%20candidate%20pool%20the%20selector%20ranks%3B%20clamp%20to%20a%20sane%20positive%20value%20so%20a%0A%20%20%20%20%20%20%20%20%2F%2F%20zero%2Fnegative%20request%20still%20yields%20a%20full-vocab%20argmax%20rather%20than%20an%20empty%20pool.%0A%20%20%20%20%20%20%20%20let%20topK%20%3D%20options.topK%20%3E%200%20%3F%20options.topK%20%3A%20vocabSize%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0ACotabby%2FSupport%2FTokenProfile.swift%3A704-724%0A**Bare%20%60%5Cr%60%20token%20won't%20stop%20single-line%20decoding**%0A%0A%60isNewline%60%20only%20tests%20for%20LF%20%28%600x0A%60%29.%20A%20token%20whose%20bytes%20are%20solely%20%60%5B0x0D%5D%60%20%28carriage%20return%29%20or%20that%20ends%20with%20%60%5Cr%60%20without%20a%20following%20%60%5Cn%60%20would%20pass%20the%20single-line%20stop%20check%20undetected%2C%20allowing%20a%20partial%20carriage%20return%20to%20be%20appended%20to%20the%20completion%20before%20the%20next%20%60%5Cn%60-carrying%20token%20eventually%20terminates%20the%20loop.%20%60isASCIIWhitespace%60%20already%20includes%20%600x0D%60%2C%20so%20the%20byte-level%20knowledge%20is%20present%3B%20%60isNewline%60%20could%20simply%20union%20the%20CR%20check%3A%20%60bytes.contains%280x0A%29%20%7C%7C%20bytes.contains%280x0D%29%60.%0A%0A%23%23%23%20Issue%204%20of%204%0ACotabby%2FSupport%2FConstrainedSampler.swift%3A559-571%0A**Per-step%20full-vocabulary%20sort%20is%20O%28N%20log%20N%29%20when%20O%28N%20log%20K%29%20would%20suffice**%0A%0AWhen%20%60limit%20%3C%20count%60%2C%20the%20entire%20range%20%600..%3Ccount%60%20is%20sorted%20descending%20by%20logit%20before%20taking%20the%20%60prefix%28limit%29%60.%20For%20a%2032%20K%E2%80%93128%20K%20vocabulary%20with%20typical%20%60topK%60%20values%20of%2040%E2%80%93100%2C%20that%20is%20~480%20K%E2%80%932.2%20M%20comparisons%20per%20decode%20step%20just%20for%20the%20candidate%20pool.%20A%20min-heap%20of%20size%20%60limit%60%20%28or%20%60Array.partialSort%60%29%20would%20reduce%20that%20to%20O%28N%20log%20K%29%20%E2%80%94%20roughly%205%E2%80%936%C3%97%20less%20work%20at%20K%3D40.%20On%20device%20the%20per-step%20wall%20time%20is%20dominated%20by%20%60getNextTokenLogits%60%20and%20%60acceptToken%60%2C%20so%20this%20is%20not%20a%20blocker%2C%20but%20the%20sort%20overhead%20compounds%20across%20all%20constrained-decode%20steps%20and%20is%20worth%20revisiting%20before%20the%20flag%20is%20turned%20on%20by%20default.%0A%0A&repo=fujacob%2Fcotabby&pr=503&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add deterministic constrained decoder be..."](https://github.com/fujacob/cotabby/commit/fe69fbb432e746be2941e01e3cc536b2478ec1b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34930356)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->