### PR TITLE
Re-tune onboarding model recommendations for the base-model tiers

### DIFF
--- a/Cotabby/Support/OnboardingTemplateRecommender.swift
+++ b/Cotabby/Support/OnboardingTemplateRecommender.swift
@@ -6,14 +6,17 @@ import Foundation
 /// inputs (`HardwareCapability`, Apple Intelligence availability) so the onboarding UI can stay a
 /// thin renderer and the decisions can be unit-tested without a host.
 enum OnboardingTemplateRecommender {
-    /// Below this much memory, the Powerful template's ~5 GB model leaves too little headroom (the
-    /// resident model plus OS would dominate an 8 GB machine), so it is disabled rather than offered
-    /// as a trap. Chosen above 8 so stock 8 GB Macs are excluded while any 12 GB+ config is allowed.
-    static let powerfulDisableBelowGigabytes = 10.0
-    /// Between the disable floor and this ceiling, Powerful is allowed but flagged as potentially slow.
+    /// Below this much memory, the Powerful tier's model leaves too little headroom and is disabled
+    /// rather than offered as a trap. The base-model tiers are far smaller than the old ~5 GB models,
+    /// so the floor is 8: only sub-8 GB Macs (effectively pre-Apple-Silicon) are excluded, while every
+    /// 8 GB+ machine may run it. Sizes for the copy are read from the catalog, not hardcoded here.
+    static let powerfulDisableBelowGigabytes = 8.0
+    /// Between the disable floor and this ceiling, Powerful is allowed but flagged as potentially slow
+    /// under memory pressure from other apps. 16 GB and up is treated as comfortable.
     static let powerfulWarnBelowGigabytes = 16.0
-    /// Below this, the Everyday open-source path (~3 GB model) is flagged as potentially slow. Only
-    /// relevant when Apple Intelligence is unavailable; the Apple Intelligence path has no such cost.
+    /// Below this, the Everyday open-source tier is flagged as potentially slow, and it is also the
+    /// cutoff below which Quick becomes the recommended default. Only relevant when Apple Intelligence
+    /// is unavailable; the Apple Intelligence path has no per-tier memory cost.
     static let everydayWarnBelowGigabytes = 8.0
 
     /// Resolves the model and behavior flags for a template under an explicitly chosen engine.
@@ -63,14 +66,14 @@ enum OnboardingTemplateRecommender {
                 break
             case .everyday:
                 if gigabytes < everydayWarnBelowGigabytes {
-                    warning = "Uses a ~3 GB model, which may run slowly on this Mac."
+                    warning = "Uses a \(modelSizeLabel(for: template)) model, which may run slowly on this Mac."
                 }
             case .powerful:
                 if gigabytes < powerfulDisableBelowGigabytes {
                     isDisabled = true
-                    warning = "Needs more memory than this Mac has (uses a ~5 GB model)."
+                    warning = "Needs more memory than this Mac has (uses a \(modelSizeLabel(for: template)) model)."
                 } else if gigabytes < powerfulWarnBelowGigabytes {
-                    warning = "Uses a ~5 GB model; may run slowly with less than 16 GB of memory."
+                    warning = "Uses a \(modelSizeLabel(for: template)) model; may run slowly with less than 16 GB of memory."
                 }
             }
         }
@@ -102,5 +105,12 @@ enum OnboardingTemplateRecommender {
 
     private static func downloadableModel(filename: String) -> DownloadableRuntimeModel? {
         RuntimeModelCatalog.downloadableModels.first { $0.filename == filename }
+    }
+
+    /// Human-readable size of the GGUF a template installs, read from the catalog so warning copy stays
+    /// in sync with the actual model instead of a hardcoded number. Falls back to a generic phrase if
+    /// the filename is missing from the catalog.
+    private static func modelSizeLabel(for template: OnboardingTemplate) -> String {
+        downloadableModel(filename: template.openSourceModelFilename)?.approximateSizeLabel ?? "local"
     }
 }

--- a/CotabbyTests/OnboardingTemplateRecommenderTests.swift
+++ b/CotabbyTests/OnboardingTemplateRecommenderTests.swift
@@ -60,9 +60,11 @@ final class OnboardingTemplateRecommenderTests: XCTestCase {
     // MARK: - availability gating (Open Source engine)
 
     func testPowerfulDisabledOnLowMemoryMacOpenSource() {
+        // Sub-8 GB Macs (effectively pre-Apple-Silicon) cannot comfortably hold the model, so Powerful
+        // is excluded there.
         let availability = OnboardingTemplateRecommender.availability(
             for: .powerful,
-            hardware: hardware(gigabytes: 8),
+            hardware: hardware(gigabytes: 6),
             engine: .llamaOpenSource
         )
 
@@ -71,9 +73,12 @@ final class OnboardingTemplateRecommenderTests: XCTestCase {
     }
 
     func testPowerfulWarnsBetweenDisableFloorAndComfortCeiling() {
+        // 8 GB is the disable floor: allowed, not excluded, but still flagged below the 16 GB comfort
+        // ceiling. This pins that a stock 8 GB Mac can run the Powerful base model (the smaller
+        // base-model tiers no longer need the old 10 GB floor).
         let availability = OnboardingTemplateRecommender.availability(
             for: .powerful,
-            hardware: hardware(gigabytes: 12),
+            hardware: hardware(gigabytes: 8),
             engine: .llamaOpenSource
         )
 


### PR DESCRIPTION
## Summary

The onboarding recommender's warning copy and memory thresholds were sized for the old ~3–5 GB instruct models. The base-model tiers are much smaller — quick 0.8 GB, everyday 1.4 GB, powerful 2.6 GB — so the Powerful disable floor of 10 GB wrongly excluded stock 8 GB Macs that can comfortably run a 2.6 GB model. This lowers that floor to 8 GB and derives the "~X GB" sizes in the copy from the catalog so they can't drift.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  build-for-testing -derivedDataPath build/DerivedData
# ** TEST BUILD SUCCEEDED **

swiftlint lint --quiet
# 0 violations
```

- `OnboardingTemplateRecommenderTests` updated to pin the new boundary: Powerful is disabled below 8 GB (tested at 6 GB) and allowed-but-warned at exactly 8 GB. Other cases (12/16/32 GB, Apple Intelligence, Quick, recommendation defaults) are unchanged.

## Linked issues

_None._

## Risk / rollout notes

- **Behavior change (onboarding only).** A stock 8 GB Mac now sees Powerful as available-with-a-warning instead of disabled. Apple Intelligence tiers and the Quick/Everyday recommendation logic are unchanged.
- The warning strings now read their size from `DownloadableRuntimeModel.approximateSizeLabel`, so they track the catalog automatically; no hardcoded sizes remain in the recommender.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR lowers the Powerful-tier memory disable floor from 10 GB to 8 GB (matching the new ~2.6 GB base-model GGUF vs. the old ~5 GB instruct model), and replaces hardcoded model-size strings in warning copy with a live catalog lookup via `modelSizeLabel(for:)`.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is narrowly scoped to onboarding display logic with no data-persistence or auth surface touched.

The threshold change and catalog-driven copy are both straightforward, and the updated tests correctly pin the new 8 GB boundary. The one residual hardcoded value ("16 GB" in the warn-path string) could drift from `powerfulWarnBelowGigabytes` if that constant is later adjusted, and the "local" fallback in `modelSizeLabel` produces awkward copy — neither is a functional regression on the current code path.

The warn-path string in `OnboardingTemplateRecommender.swift` line 76 still contains a literal "16 GB" that the PR description implied was removed.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/OnboardingTemplateRecommender.swift | Lowers `powerfulDisableBelowGigabytes` from 10 to 8, allowing 8 GB Macs to use the Powerful tier with a warning; replaces hardcoded model size strings with `modelSizeLabel(for:)` reading from the catalog. One hardcoded memory value ("16 GB") remains in the warn-path copy and can drift from the `powerfulWarnBelowGigabytes` constant. |
| CotabbyTests/OnboardingTemplateRecommenderTests.swift | Updates the disable-floor test probe from 8 GB to 6 GB and the warn-floor test probe from 12 GB to 8 GB, accurately pinning the new boundary decisions. All other cases unchanged. |

</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fonboarding-recommender-retune%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fonboarding-recommender-retune%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FSupport%2FOnboardingTemplateRecommender.swift%3A76%0AThe%20model%20size%20is%20now%20derived%20from%20the%20catalog%2C%20but%20the%20memory%20ceiling%20%2216%20GB%22%20is%20still%20hardcoded%20in%20this%20warning%20string.%20The%20PR%20description%20claims%20%22no%20hardcoded%20sizes%20remain%20in%20the%20recommender%2C%22%20yet%20this%20literal%20can%20drift%20if%20%60powerfulWarnBelowGigabytes%60%20is%20ever%20adjusted.%20Deriving%20it%20from%20the%20constant%20keeps%20the%20copy%20and%20the%20logic%20in%20sync.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20warning%20%3D%20%22Uses%20a%20%5C%28modelSizeLabel%28for%3A%20template%29%29%20model%3B%20may%20run%20slowly%20with%20less%20than%20%5C%28Int%28powerfulWarnBelowGigabytes%29%29%20GB%20of%20memory.%22%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FSupport%2FOnboardingTemplateRecommender.swift%3A114%0AThe%20fallback%20string%20%60%22local%22%60%20produces%20grammatically%20awkward%20warning%20copy%20%E2%80%94%20e.g.%20%22Uses%20a%20local%20model%2C%20which%20may%20run%20slowly%E2%80%A6%22%20%E2%80%94%20if%20a%20template's%20%60openSourceModelFilename%60%20is%20absent%20from%20the%20catalog.%20A%20phrase%20that%20completes%20the%20sentence%20naturally%20would%20be%20less%20confusing%20to%20users%20who%20might%20see%20this%20in%20edge%20cases.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20downloadableModel%28filename%3A%20template.openSourceModelFilename%29%3F.approximateSizeLabel%20%3F%3F%20%22large%22%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FSupport%2FOnboardingTemplateRecommender.swift%3A76%0AThe%20model%20size%20is%20now%20derived%20from%20the%20catalog%2C%20but%20the%20memory%20ceiling%20%2216%20GB%22%20is%20still%20hardcoded%20in%20this%20warning%20string.%20The%20PR%20description%20claims%20%22no%20hardcoded%20sizes%20remain%20in%20the%20recommender%2C%22%20yet%20this%20literal%20can%20drift%20if%20%60powerfulWarnBelowGigabytes%60%20is%20ever%20adjusted.%20Deriving%20it%20from%20the%20constant%20keeps%20the%20copy%20and%20the%20logic%20in%20sync.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20warning%20%3D%20%22Uses%20a%20%5C%28modelSizeLabel%28for%3A%20template%29%29%20model%3B%20may%20run%20slowly%20with%20less%20than%20%5C%28Int%28powerfulWarnBelowGigabytes%29%29%20GB%20of%20memory.%22%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FSupport%2FOnboardingTemplateRecommender.swift%3A114%0AThe%20fallback%20string%20%60%22local%22%60%20produces%20grammatically%20awkward%20warning%20copy%20%E2%80%94%20e.g.%20%22Uses%20a%20local%20model%2C%20which%20may%20run%20slowly%E2%80%A6%22%20%E2%80%94%20if%20a%20template's%20%60openSourceModelFilename%60%20is%20absent%20from%20the%20catalog.%20A%20phrase%20that%20completes%20the%20sentence%20naturally%20would%20be%20less%20confusing%20to%20users%20who%20might%20see%20this%20in%20edge%20cases.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20downloadableModel%28filename%3A%20template.openSourceModelFilename%29%3F.approximateSizeLabel%20%3F%3F%20%22large%22%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=505&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Re-tune onboarding model recommendations..."](https://github.com/fujacob/cotabby/commit/99c743fff653161edaade239844508c6aadddf45) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34933246)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->