### PR TITLE
Surface per-line OCR confidence so the low-confidence filter runs

### DIFF
--- a/Cotabby/Services/Visual/ScreenTextExtractor.swift
+++ b/Cotabby/Services/Visual/ScreenTextExtractor.swift
@@ -14,6 +14,17 @@ import Logging
 struct ExtractedScreenText: Sendable {
     let text: String
     let lineCount: Int
+    /// Per-line OCR text paired with Vision's recognition confidence, in reading order. Carries the
+    /// confidence that the joined `text` discards, so `OCRTextHygiene.dropLowConfidence` can filter on
+    /// real values instead of a synthesized constant. Defaults to empty for callers (and tests) that
+    /// only supply joined text.
+    let lines: [OCRTextHygiene.OCRLine]
+
+    init(text: String, lineCount: Int, lines: [OCRTextHygiene.OCRLine] = []) {
+        self.text = text
+        self.lineCount = lineCount
+        self.lines = lines
+    }
 }
 
 /// Test seam for screenshot OCR.
@@ -72,7 +83,10 @@ struct ScreenTextExtractor: ScreenTextExtracting {
                     }
 
                     let observations = (request.results as? [VNRecognizedTextObservation]) ?? []
-                    let orderedLines = observations
+                    // Keep each line's confidence (from its top candidate) so the hygiene pass can drop
+                    // the recognizer's weakest guesses; the joined `text` below is for logging and the
+                    // window-title fallback only.
+                    let recognizedLines: [OCRTextHygiene.OCRLine] = observations
                         .sorted {
                             if Swift.abs($0.boundingBox.minY - $1.boundingBox.minY) > 0.02 {
                                 return $0.boundingBox.minY > $1.boundingBox.minY
@@ -80,27 +94,36 @@ struct ScreenTextExtractor: ScreenTextExtracting {
 
                             return $0.boundingBox.minX < $1.boundingBox.minX
                         }
-                        .compactMap { $0.topCandidates(1).first?.string }
-                        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-                        .filter { !$0.isEmpty }
+                        .compactMap { observation -> OCRTextHygiene.OCRLine? in
+                            guard let candidate = observation.topCandidates(1).first else { return nil }
+                            let trimmed = candidate.string.trimmingCharacters(in: .whitespacesAndNewlines)
+                            guard !trimmed.isEmpty else { return nil }
+                            return OCRTextHygiene.OCRLine(text: trimmed, confidence: candidate.confidence)
+                        }
 
-                    let joinedText = orderedLines.joined(separator: "\n")
+                    let joinedText = recognizedLines.map(\.text).joined(separator: "\n")
                     let cappedText = String(joinedText.prefix(maxRecognizedCharacters))
 
                     guard !cappedText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
                         let elapsedMilliseconds = Int(Date().timeIntervalSince(startedAt) * 1000)
-                        self.log("ocr-empty elapsed_ms=\(elapsedMilliseconds) lines=\(orderedLines.count)")
+                        self.log("ocr-empty elapsed_ms=\(elapsedMilliseconds) lines=\(recognizedLines.count)")
                         continuation.resume(throwing: ScreenTextExtractionError.noRecognizedText)
                         return
                     }
 
                     let elapsedMilliseconds = Int(Date().timeIntervalSince(startedAt) * 1000)
                     self.log(
-                        "ocr-success elapsed_ms=\(elapsedMilliseconds) lines=\(orderedLines.count) chars=\(cappedText.count) " +
+                        "ocr-success elapsed_ms=\(elapsedMilliseconds) lines=\(recognizedLines.count) chars=\(cappedText.count) " +
                             "preview=\(self.preview(cappedText))"
                     )
 
-                    continuation.resume(returning: ExtractedScreenText(text: cappedText, lineCount: orderedLines.count))
+                    continuation.resume(
+                        returning: ExtractedScreenText(
+                            text: cappedText,
+                            lineCount: recognizedLines.count,
+                            lines: recognizedLines
+                        )
+                    )
                 }
 
                 // Accurate OCR is slower, but visual context is only captured once per focused

--- a/Cotabby/Services/Visual/ScreenshotContextGenerator.swift
+++ b/Cotabby/Services/Visual/ScreenshotContextGenerator.swift
@@ -60,9 +60,9 @@ final class ScreenshotContextGenerator {
 
         await onStatusChange?(.extractingText)
 
-        let extractedText: String
+        let extracted: ExtractedScreenText
         do {
-            extractedText = try await textExtractor.extractText(from: screenshot.image).text
+            extracted = try await textExtractor.extractText(from: screenshot.image)
         } catch ScreenTextExtractionError.noRecognizedText {
             guard let windowTitle = screenshot.windowTitle else {
                 throw ScreenshotContextGenerationError.unavailable(
@@ -94,9 +94,7 @@ final class ScreenshotContextGenerator {
         // safety. No model summarization: a base model conditions fine on cleaned raw context, and
         // the old summary step cost an extra generation per refresh and could hallucinate.
         let cleanedOCR = OCRTextHygiene.clean(
-            lines: extractedText
-                .split(separator: "\n", omittingEmptySubsequences: true)
-                .map { OCRTextHygiene.OCRLine(text: String($0), confidence: 1.0) },
+            lines: extracted.lines,
             fieldText: context.precedingText + " " + context.trailingText,
             maxChars: configuration.maxRecognizedCharacters
         )
@@ -105,7 +103,7 @@ final class ScreenshotContextGenerator {
         if CotabbyDebugOptions.isEnabled {
             saveDebugScreenshot(
                 screenshot.image,
-                text: extractedText,
+                text: extracted.text,
                 name: sanitizedDebugName(from: context.applicationName)
             )
         }

--- a/Cotabby/Support/OCRTextHygiene.swift
+++ b/Cotabby/Support/OCRTextHygiene.swift
@@ -21,7 +21,7 @@ enum OCRTextHygiene {
     /// Confidence is carried alongside the text because the cheapest, highest-signal filter
     /// (`dropLowConfidence`) needs it. The orchestrating extractor currently discards Vision's
     /// per-candidate confidence; surfacing it into this value type is what lets filter #1 run.
-    struct OCRLine: Equatable {
+    struct OCRLine: Equatable, Sendable {
         let text: String
         let confidence: Float
 

--- a/CotabbyTests/ScreenshotContextGeneratorTests.swift
+++ b/CotabbyTests/ScreenshotContextGeneratorTests.swift
@@ -45,15 +45,63 @@ final class ScreenshotContextGeneratorTests: XCTestCase {
         extractedText: String,
         configuration: VisualContextConfiguration = .default
     ) -> ScreenshotContextGenerator {
+        // Mirror the real extractor: split into per-line OCR with a confidence above the hygiene
+        // threshold, so these cases keep exercising the non-confidence filters exactly as before.
+        let lines = extractedText
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .map { OCRTextHygiene.OCRLine(text: String($0), confidence: 0.9) }
+        return makeGenerator(
+            extracted: ExtractedScreenText(text: extractedText, lineCount: lines.count, lines: lines),
+            configuration: configuration
+        )
+    }
+
+    private func makeGenerator(
+        lines: [OCRTextHygiene.OCRLine],
+        configuration: VisualContextConfiguration = .default
+    ) -> ScreenshotContextGenerator {
+        let joined = lines.map(\.text).joined(separator: "\n")
+        return makeGenerator(
+            extracted: ExtractedScreenText(text: joined, lineCount: lines.count, lines: lines),
+            configuration: configuration
+        )
+    }
+
+    private func makeGenerator(
+        extracted: ExtractedScreenText,
+        configuration: VisualContextConfiguration
+    ) -> ScreenshotContextGenerator {
         ScreenshotContextGenerator(
             screenshotService: StubScreenshotCapture(
                 screenshot: CapturedWindowScreenshot(image: makeImage(), windowTitle: nil)
             ),
-            textExtractor: StubTextExtractor(
-                result: .success(ExtractedScreenText(text: extractedText, lineCount: 1))
-            ),
+            textExtractor: StubTextExtractor(result: .success(extracted)),
             configuration: configuration
         )
+    }
+
+    func test_generateContext_dropsLowConfidenceOCRLines() async throws {
+        // A clean, plausible sentence at low confidence must be dropped even though no other hygiene
+        // filter would catch it, proving real per-line Vision confidence now reaches the hygiene pass.
+        let configuration = VisualContextConfiguration(
+            snapshotDimension: 700,
+            maxImageDimension: 1600,
+            minRecognizedCharacterCount: 12,
+            maxRecognizedCharacters: 500,
+            maxSummaryCharacters: 200
+        )
+        let generator = makeGenerator(
+            lines: [
+                OCRTextHygiene.OCRLine(text: "The quarterly report is due on Friday afternoon.", confidence: 0.2),
+                OCRTextHygiene.OCRLine(text: "Please review the attached budget spreadsheet carefully.", confidence: 0.95)
+            ],
+            configuration: configuration
+        )
+
+        let excerpt = try await generator.generateContext(for: makeSnapshot())
+
+        XCTAssertFalse(excerpt.text.contains("quarterly report"))
+        XCTAssertTrue(excerpt.text.contains("budget spreadsheet"))
     }
 
     private func makeSnapshot() -> FocusedInputSnapshot {


### PR DESCRIPTION
## Summary

`ScreenTextExtractor` discarded Vision's per-observation confidence, so `OCRTextHygiene.dropLowConfidence` — the cheapest, highest-signal hygiene filter — only ever saw a synthesized `1.0` and dropped nothing. This carries each recognized line's real confidence through a new `ExtractedScreenText.lines` field and feeds those lines to `OCRTextHygiene.clean`, so the recognizer's weakest guesses are dropped before they reach the completion prompt.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  build-for-testing -derivedDataPath build/DerivedData
# ** TEST BUILD SUCCEEDED **

swiftlint lint --quiet
# 0 violations
```

- New test `test_generateContext_dropsLowConfidenceOCRLines` proves the wiring end-to-end: a clean, plausible sentence at 0.2 confidence is dropped while a 0.95-confidence line survives, even though no other hygiene filter would catch the former.
- The existing generator tests are updated to populate `lines` (at a confidence above the threshold), so they keep exercising the symbol/digit/sanitizer filters unchanged.

## Linked issues

_None._

## Risk / rollout notes

- **Behavior change (visual context only).** Real OCR confidence now gates lines via the existing `dropLowConfidence` threshold (0.4). Lines Vision is unsure about no longer enter the prompt; this only affects the screen-context excerpt, not completion generation.
- `ExtractedScreenText.lines` defaults to empty for any caller that supplies only joined text, so the type stays backward compatible.
- `OCRTextHygiene.OCRLine` gains `Sendable` (pure value type) to cross the OCR continuation boundary inside the `Sendable` `ExtractedScreenText`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR threads Vision's per-observation confidence through `ExtractedScreenText.lines` so `OCRTextHygiene.dropLowConfidence` — previously neutralized by a synthesized `1.0` — now filters on real recognizer scores before lines reach the completion prompt.

- `ExtractedScreenText` gains a `lines: [OCRTextHygiene.OCRLine]` field (default-empty, backward compatible), and `ScreenTextExtractor` populates it with each top candidate's actual `confidence` value.
- `ScreenshotContextGenerator` replaces the old re-split-with-fake-confidence pattern with a direct pass of `extracted.lines` to `OCRTextHygiene.clean`.
- `OCRLine` picks up `Sendable` conformance, and a new end-to-end test confirms the wiring: a 0.2-confidence line is dropped while a 0.95-confidence line survives.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the core wiring is correct and the new test provides solid end-to-end coverage of the confidence gate.

The only finding is a one-sentence doc-comment in OCRTextHygiene.swift that still says the extractor currently discards confidence, directly contradicting what this PR accomplishes. It does not affect runtime behavior.

Cotabby/Support/OCRTextHygiene.swift — the OCRLine doc-comment contains a now-false claim about confidence being discarded.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Services/Visual/ScreenTextExtractor.swift | Adds `lines: [OCRTextHygiene.OCRLine]` to `ExtractedScreenText` (default-empty for backward compatibility) and rewires the Vision callback to capture `candidate.confidence` per observation instead of discarding it. |
| Cotabby/Services/Visual/ScreenshotContextGenerator.swift | Switches from extracting only `.text` (then re-splitting with synthetic confidence 1.0) to storing the full `ExtractedScreenText` and passing `extracted.lines` directly to `OCRTextHygiene.clean`, enabling real confidence gating. |
| Cotabby/Support/OCRTextHygiene.swift | Adds `Sendable` conformance to `OCRLine` (correct). The doc-comment on `OCRLine.confidence` contains a stale sentence claiming the extractor currently discards confidence, which this PR directly contradicts. |
| CotabbyTests/ScreenshotContextGeneratorTests.swift | Existing helpers updated to supply `OCRLine` objects at confidence 0.9 to preserve prior test coverage. New test proves end-to-end wiring: 0.2-confidence line is dropped, 0.95-confidence line survives. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant SCG as ScreenshotContextGenerator
    participant STE as ScreenTextExtractor
    participant Vision as Vision OCR
    participant Hyg as OCRTextHygiene.clean

    SCG->>STE: extractText(from: image)
    STE->>Vision: VNRecognizeTextRequest
    Vision-->>STE: [VNRecognizedTextObservation]
    Note over STE: Build OCRLine(text, confidence)<br/>for each top candidate
    STE-->>SCG: ExtractedScreenText(text, lineCount, lines)
    Note over SCG: lines carry real Vision confidence<br/>(was: re-split text with confidence=1.0)
    SCG->>Hyg: clean(lines: extracted.lines, maxChars:)
    Note over Hyg: 1. dropLowConfidence (threshold 0.4) now effective<br/>2. dropReplacementCharacter<br/>3. dropHighSymbolDensity<br/>4. dropDigitSubstitution<br/>5. dropLowWordCharacterRatio<br/>6. strip fieldText echoes
    Hyg-->>SCG: cleaned OCR string
    SCG-->>SCG: return VisualContextExcerpt
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Focr-line-confidence%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Focr-line-confidence%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FSupport%2FOCRTextHygiene.swift%3A21-24%0AThe%20doc-comment%20on%20%60OCRLine.confidence%60%20says%20%22The%20orchestrating%20extractor%20currently%20discards%20Vision's%20per-candidate%20confidence%22%20%E2%80%94%20but%20that%20statement%20is%20precisely%20what%20this%20PR%20fixes.%20Leaving%20it%20in%20place%20makes%20the%20comment%20actively%20misleading%20for%20anyone%20reading%20the%20type%20definition%20after%20the%20change%20lands.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Confidence%20is%20carried%20alongside%20the%20text%20because%20the%20cheapest%2C%20highest-signal%20filter%0A%20%20%20%20%2F%2F%2F%20%28%60dropLowConfidence%60%29%20needs%20it.%20%60ScreenTextExtractor%60%20surfaces%20Vision's%20per-candidate%0A%20%20%20%20%2F%2F%2F%20confidence%20here%20so%20filter%20%231%20operates%20on%20real%20recognizer%20scores%20instead%20of%20a%20constant.%0A%20%20%20%20struct%20OCRLine%3A%20Equatable%2C%20Sendable%20%7B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FSupport%2FOCRTextHygiene.swift%3A21-24%0AThe%20doc-comment%20on%20%60OCRLine.confidence%60%20says%20%22The%20orchestrating%20extractor%20currently%20discards%20Vision's%20per-candidate%20confidence%22%20%E2%80%94%20but%20that%20statement%20is%20precisely%20what%20this%20PR%20fixes.%20Leaving%20it%20in%20place%20makes%20the%20comment%20actively%20misleading%20for%20anyone%20reading%20the%20type%20definition%20after%20the%20change%20lands.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Confidence%20is%20carried%20alongside%20the%20text%20because%20the%20cheapest%2C%20highest-signal%20filter%0A%20%20%20%20%2F%2F%2F%20%28%60dropLowConfidence%60%29%20needs%20it.%20%60ScreenTextExtractor%60%20surfaces%20Vision's%20per-candidate%0A%20%20%20%20%2F%2F%2F%20confidence%20here%20so%20filter%20%231%20operates%20on%20real%20recognizer%20scores%20instead%20of%20a%20constant.%0A%20%20%20%20struct%20OCRLine%3A%20Equatable%2C%20Sendable%20%7B%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=506&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Surface per-line OCR confidence so the l..."](https://github.com/fujacob/cotabby/commit/dcdd22020c77cf2420ec3fa7ea5cc4dc768adcf1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34934509)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->