### PR TITLE
Remove the dead summarizing-text visual-context state

### DIFF
--- a/Cotabby/Models/VisualContextModels.swift
+++ b/Cotabby/Models/VisualContextModels.swift
@@ -37,7 +37,6 @@ nonisolated enum VisualContextStatus: Equatable, Sendable {
     case idle
     case capturing
     case extractingText
-    case summarizingText
     case ready
     case unavailable(String)
     case failed(String)
@@ -50,8 +49,6 @@ nonisolated enum VisualContextStatus: Equatable, Sendable {
             return "Capturing nearby screen content."
         case .extractingText:
             return "Extracting visible text from the screenshot."
-        case .summarizingText:
-            return "Summarizing visible text for context."
         case .ready:
             return "Nearby visible text is ready."
         case let .unavailable(reason), let .failed(reason):

--- a/Cotabby/Services/UI/FocusDebugOverlayController.swift
+++ b/Cotabby/Services/UI/FocusDebugOverlayController.swift
@@ -336,8 +336,6 @@ private struct BottomDebugStatusView: View {
             return "capturing screenshot"
         case .extractingText:
             return "running OCR"
-        case .summarizingText:
-            return "summarizing OCR"
         case .ready:
             return "ready"
         case .unavailable:
@@ -355,7 +353,7 @@ private struct BottomDebugStatusView: View {
             return .red
         case .idle:
             return .white.opacity(0.5)
-        case .capturing, .extractingText, .summarizingText:
+        case .capturing, .extractingText:
             return .yellow
         }
     }
@@ -368,7 +366,7 @@ private struct BottomDebugStatusView: View {
             return "All stages complete."
         case .unavailable(let reason), .failed(let reason):
             return reason
-        case .capturing, .extractingText, .summarizingText:
+        case .capturing, .extractingText:
             let remaining = stages
                 .filter { stageState(for: $0) == .pending }
                 .map(\.title)
@@ -385,9 +383,6 @@ private struct BottomDebugStatusView: View {
         case .extractingText:
             if stage == .capture { return .completed }
             return stage == .ocr ? .active : .pending
-        case .summarizingText:
-            if stage == .capture || stage == .ocr { return .completed }
-            return stage == .summarize ? .active : .pending
         case .ready:
             return .completed
         case .unavailable, .failed:
@@ -423,7 +418,6 @@ private struct VisualContextStagePill: View {
 private enum VisualContextDebugStage: CaseIterable, Identifiable {
     case capture
     case ocr
-    case summarize
     case inject
 
     var id: Self { self }
@@ -434,8 +428,6 @@ private enum VisualContextDebugStage: CaseIterable, Identifiable {
             return "Capture"
         case .ocr:
             return "OCR"
-        case .summarize:
-            return "Summarize"
         case .inject:
             return "Inject"
         }

--- a/CotabbyTests/PermissionAndContextModelTests.swift
+++ b/CotabbyTests/PermissionAndContextModelTests.swift
@@ -76,7 +76,7 @@ final class VisualContextModelTests: XCTestCase {
 
     func test_status_detail_returnsNonEmptyStringForEachCase() {
         let cases: [VisualContextStatus] = [
-            .idle, .capturing, .extractingText, .summarizingText, .ready,
+            .idle, .capturing, .extractingText, .ready,
             .unavailable("no permission"), .failed("timeout")
         ]
         let details = cases.map(\.detail)


### PR DESCRIPTION
## Summary

The visual-context summarizer was deleted in #499, so `VisualContextStatus.summarizingText` and the matching "Summarize" debug stage are now unreachable — nothing ever produces them. This removes the status case, the debug stage, and their switch arms so the visual-context state machine and the focus debug overlay only model the stages that can actually occur (capture → OCR → inject).

## Validation

```
rm -rf build/DerivedData
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  build-for-testing -derivedDataPath build/DerivedData
# ** TEST BUILD SUCCEEDED **  (clean build, so the removed enum case can't hide behind stale objects)

swiftlint lint --quiet
# 0 violations
```

- `rg 'summarizingText'` and `rg '\.summarize'` across the app and tests return no remaining references.
- `VisualContextModelTests.test_status_detail_returnsNonEmptyStringForEachCase` updated to drop the removed case from its enumeration; it still asserts every remaining status has a unique, non-empty detail.

## Linked issues

_Refs #499._

## Risk / rollout notes

- Pure dead-code removal of an unreachable state; no behavior change. The only surfaces touched are the visual-context status enum and the developer-only focus debug overlay, which now shows three stages (Capture, OCR, Inject) instead of a never-active Summarize pill.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the `VisualContextStatus.summarizingText` enum case and the matching `VisualContextDebugStage.summarize` case from the developer-only focus debug overlay, following the deletion of the visual-context summarizer service in #499.

- `VisualContextStatus` is trimmed from 7 to 6 cases; all switch statements across both changed files remain exhaustive.
- `VisualContextDebugStage` shrinks from 4 to 3 pills (Capture → OCR → Inject) in the debug overlay, and `stageState(for:)` correctly reflects the simplified pipeline.
- The test in `PermissionAndContextModelTests` is updated to drop the removed case from its enumeration, and still asserts every remaining status has a unique, non-empty detail string.

<h3>Confidence Score: 5/5</h3>

Pure dead-code removal with no behaviour change; safe to merge.

Every switch that touched `summarizingText` is now exhaustive over the six remaining cases, and the compiler would have rejected the build otherwise. The test update correctly mirrors the enum change and the uniqueness assertion still exercises every live case. No production logic was altered — only an unreachable state and its developer-debug rendering were deleted.

No files require special attention. The stale summarizer-related doc comments in `VisualContextModels.swift` (lines 61–62) are pre-existing and out of scope for this PR.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Models/VisualContextModels.swift | Removes `summarizingText` enum case and its `detail` switch arm; remaining switch is exhaustive. Stale doc comments referencing the summarizer exist but are outside this PR's scope and `maxSummaryCharacters` is still actively used by `ScreenshotContextGenerator`. |
| Cotabby/Services/UI/FocusDebugOverlayController.swift | Removes `summarizingText` arms from all four switch statements and drops `VisualContextDebugStage.summarize`; all switches remain exhaustive and the stage pill set correctly reflects the three-step capture→OCR→inject pipeline. |
| CotabbyTests/PermissionAndContextModelTests.swift | Drops `.summarizingText` from the manual case list in `test_status_detail_returnsNonEmptyStringForEachCase`; all remaining cases are still covered and the uniqueness assertion still holds. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([idle]) --> B([capturing])
    B --> C([extractingText])
    C --> D([ready])
    B --> E([unavailable / failed])
    C --> E

    style A fill:#555,color:#fff
    style B fill:#b8860b,color:#fff
    style C fill:#b8860b,color:#fff
    style D fill:#2d6a2d,color:#fff
    style E fill:#8b0000,color:#fff
```

<sub>Reviews (1): Last reviewed commit: ["Remove the dead summarizing-text visual-..."](https://github.com/fujacob/cotabby/commit/1e12e55729f89b112e45712075055e2eea605cd4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34955032)</sub>

<!-- /greptile_comment -->