### PR TITLE
Refresh docs for the base-model migration

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -46,11 +46,13 @@ change as shipping to end users, not as an exercise.
 - Focus comes from `FocusTracker`, `FocusSnapshotResolver`, `AXTextGeometryResolver`,
   and `AXHelper`. Treat AX data as eventually consistent and app-specific.
 - Visual context flows through `VisualContextCoordinator`,
-  `ScreenshotContextGenerator`, `ScreenTextExtractor`, `WindowScreenshotService`,
-  and `LlamaVisualContextSummarizer`.
+  `ScreenshotContextGenerator`, `ScreenTextExtractor`, and `WindowScreenshotService`.
+  OCR text is cleaned by the pure `OCRTextHygiene`; there is no model summarization step.
 - Runtime generation flows through `SuggestionEngineRouter`,
   `FoundationModelSuggestionEngine`, `LlamaSuggestionEngine`,
-  `LlamaRuntimeManager`, and the serialized `LlamaRuntimeCore` actor.
+  `LlamaRuntimeManager`, and the serialized `LlamaRuntimeCore` actor. The OSS
+  (llama.cpp) path drives base models via `BaseCompletionPromptRenderer`; Apple
+  Foundation Models stays instruct via `FoundationModelPromptRenderer`.
 
 ## Comments
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,8 @@ When adding a `struct`, `class`, `enum`, actor, or protocol, explain:
   reconciliation, geometry helpers, and low-level bridging utilities.
 - `CotabbyTests/`: unit and microbench tests. Prefer testing pure `Support/` and `Models/` logic
   when possible.
-- `LlamaRuntime/`: local llama.swift / llama.cpp integration artifacts.
+- `CotabbyInference`: the llama.cpp wrapper, consumed as a SwiftPM package
+  (`github.com/FuJacob/cotabbyinference`, pinned to `main`) rather than vendored in-tree.
 
 ## App Ownership
 
@@ -112,10 +113,11 @@ native AppKit fields, and secure fields expose different AX shapes. Preserve sta
 Visual context currently flows through:
 
 - `VisualContextCoordinator`: field-scoped visual-context session lifecycle.
-- `ScreenshotContextGenerator`: screenshot -> OCR -> optional summary -> bounded excerpt.
+- `ScreenshotContextGenerator`: screenshot -> OCR -> `OCRTextHygiene` cleanup -> bounded excerpt.
 - `WindowScreenshotService`: captures the relevant window or region.
-- `ScreenTextExtractor`: Vision OCR extraction.
-- `LlamaVisualContextSummarizer`: optional local summary using the selected llama runtime.
+- `ScreenTextExtractor`: Vision OCR extraction, carrying per-line recognition confidence.
+- `OCRTextHygiene`: pure cleanup of raw OCR (drops low-confidence lines and chrome noise). There is
+  no model summarization step; a base model conditions fine on cleaned raw context.
 - `VisualContextModels`: configuration, status, and excerpt values.
 
 Do not put raw screenshots, unbounded OCR dumps, or noisy AX tree text directly into prompts.
@@ -131,8 +133,15 @@ Runtime generation is split by responsibility:
 - `LlamaSuggestionEngine`: request-to-prompt, llama result handling, and cache reset handoff.
 - `LlamaRuntimeManager`: UI-facing runtime state, model selection, warmup, and lifecycle control.
 - `LlamaRuntimeCore`: serialized actor around mutable llama.cpp pointers, prompt tokenization,
-  KV-cache reuse, sampling, and shutdown.
-- `LlamaPromptRenderer`: prompt construction.
+  KV-cache reuse, sampling, an optional deterministic constrained decoder
+  (`runConstrainedDecode`, gated behind the default-off `cotabbyConstrainedDecoderEnabled`), and
+  shutdown.
+- `BaseCompletionPromptRenderer`: prompt construction for the Open Source path. The llama models are
+  now *base* (non-instruct) GGUFs, so this renders a pure text continuation: no instruction preamble,
+  custom rules and context fold into a short conditioning preface (a base model conditions on
+  description, it does not obey commands), sections are character-budgeted via `PromptSectionBudget`,
+  and the caret prefix comes last. `FoundationModelPromptRenderer` stays instruct-shaped because
+  Apple's Foundation Models path gives us a first-class instructions channel.
 
 Keep llama.cpp pointer work serialized inside `LlamaRuntimeCore`. The manager should publish state;
 the core should own native correctness.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -63,7 +63,7 @@ The coordinator should not own pure decision rules or low-level OS logic. Those 
 - `Cotabby/Support/SuggestionRequestFactory.swift`: pure request building
 - `Cotabby/Support/SuggestionSessionReconciler.swift`: pure session and acceptance rules
 - `Cotabby/Support/SuggestionAvailabilityEvaluator.swift`: pure gating logic
-- `Cotabby/Services/Visual/VisualContextCoordinator.swift`: legacy screenshot/OCR lifecycle (deprecated during context rebuild)
+- `Cotabby/Services/Visual/VisualContextCoordinator.swift`: screenshot/OCR lifecycle; OCR text is cleaned by the pure `OCRTextHygiene` filters (no model-summarization step)
 - `Cotabby/Services/Runtime/LlamaSuggestionEngine.swift`: prompt/result normalization over the runtime
 
 ## Focus And Accessibility

--- a/README.md
+++ b/README.md
@@ -85,14 +85,17 @@ Everything runs on-device. No hosted API, no cloud round-trip.
 
 **Apple Intelligence**: uses Apple's on-device `FoundationModels` runtime on macOS 26 or later, no download required.
 
-**Open Source**: runs local GGUF models in-process through llama.cpp via `CotabbyInference`. Cotabby ships with four built-in downloadable models:
+**Open Source**: runs local GGUF *base* models in-process through llama.cpp via `CotabbyInference`. Rather than instructing an instruction-tuned model, Cotabby treats the model as a pure text continuer and conditions it on your persona, style, language, and on-screen context. Cotabby ships with five built-in downloadable models:
 
-| Model          | File                              | Size    | Source                                                                                                  |
-| -------------- | --------------------------------- | ------- | ------------------------------------------------------------------------------------------------------- |
-| `tabby-1-nano` | `SmolLM2-135M-Instruct-q8_0.gguf` | ~0.1 GB | [Mungert/SmolLM2-135M-Instruct-GGUF](https://huggingface.co/Mungert/SmolLM2-135M-Instruct-GGUF)         |
-| `tabby-1-mini` | `Qwen3-0.6B-Q4_K_M.gguf`          | ~0.4 GB | [unsloth/Qwen3-0.6B-GGUF](https://huggingface.co/unsloth/Qwen3-0.6B-GGUF)                               |
-| `tabby-1-base` | `gemma-4-E2B-it-Q4_K_M.gguf`      | ~3.1 GB | [unsloth/gemma-4-E2B-it-GGUF](https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF)                       |
-| `tabby-1-pro`  | `gemma-4-E4B-it-Q4_K_M.gguf`      | ~5.0 GB | [unsloth/gemma-4-E4B-it-GGUF](https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF)                       |
+| Model                | File                                 | Size    | Source                                                                                                          |
+| -------------------- | ------------------------------------ | ------- | --------------------------------------------------------------------------------------------------------------- |
+| `tabby-2-mini`       | `Qwen3.5-0.8B-Base.i1-Q6_K.gguf`     | ~0.8 GB | [mradermacher/Qwen3.5-0.8B-Base-i1-GGUF](https://huggingface.co/mradermacher/Qwen3.5-0.8B-Base-i1-GGUF)         |
+| `tabby-2-base`       | `Qwen3.5-2B-Base.i1-Q4_K_M.gguf`     | ~1.4 GB | [mradermacher/Qwen3.5-2B-Base-i1-GGUF](https://huggingface.co/mradermacher/Qwen3.5-2B-Base-i1-GGUF)             |
+| `tabby-2-pro`        | `Qwen3.5-4B-Base.i1-Q4_K_M.gguf`     | ~2.6 GB | [mradermacher/Qwen3.5-4B-Base-i1-GGUF](https://huggingface.co/mradermacher/Qwen3.5-4B-Base-i1-GGUF)             |
+| `tabby-2-gemma-mini` | `gemma-4-E2B.i1-Q6_K.gguf`           | ~4.5 GB | [mradermacher/gemma-4-E2B-i1-GGUF](https://huggingface.co/mradermacher/gemma-4-E2B-i1-GGUF)                     |
+| `tabby-2-gemma-pro`  | `gemma-4-E4B.i1-Q4_K_M.gguf`         | ~5.0 GB | [mradermacher/gemma-4-E4B-i1-GGUF](https://huggingface.co/mradermacher/gemma-4-E4B-i1-GGUF)                     |
+
+`tabby-2-base` is the default. Apple Intelligence remains instruction-tuned and is unaffected by the base-model path.
 
 ### Bring your own model
 

--- a/docs/POLLING_AND_DELAYS.md
+++ b/docs/POLLING_AND_DELAYS.md
@@ -37,7 +37,6 @@ Update this file whenever you add, remove, or change a timing constant.
 | Location | Value | Purpose |
 |----------|-------|---------|
 | `Cotabby/Services/Visual/VisualContextCoordinator.swift:29` | 250 ms | Session-start settle delay. Debounces visual context capture on focus change so a flapping Chromium focus doesn't retrigger screenshots and OCR. |
-| `Cotabby/Services/Visual/LlamaVisualContextSummarizer.swift:20` | 3 s | Llama visual context summarization soft timeout. Cancels generation after 3 s and returns whatever partial text was produced. |
 
 ## Permissions
 


### PR DESCRIPTION
## Summary

Markdown docs drifted after the open-source completion path moved from instruction-tuned to **base** models (+ a default-off constrained decoder) and the visual-context **summarizer was removed**. This brings them back in line with `main`. Each change was verified against the current code by a per-file audit.

- **README.md** — model table now lists the `tabby-2-*` base GGUFs (Qwen3.5 0.8B/2B/4B + Gemma E2B/E4B) with real sizes and `mradermacher` sources; the Open Source engine is reframed as base-model continuation (conditioned, not instructed).
- **ARCHITECTURE.md / AGENTS.md / .claude/CLAUDE.md** — drop the deleted `LlamaVisualContextSummarizer` and instruct `LlamaPromptRenderer`; describe the `OCRTextHygiene` cleanup (no summarization step), `BaseCompletionPromptRenderer`, and the default-off constrained decoder; point the llama integration at the `CotabbyInference` SwiftPM package instead of a nonexistent `LlamaRuntime/` dir / `llama.swift`.
- **docs/POLLING_AND_DELAYS.md** — remove the deleted summarizer timeout row.

`CONTRIBUTING.md`, `RELEASING.md`, the issue/PR templates, `CODE_OF_CONDUCT.md`, and the ship skill were audited and needed no changes.

## Validation

Docs-only change (no build). Audited by per-file subagents that cross-checked every factual claim against the current code; a repo-wide sweep confirms no residual references to the deleted `LlamaVisualContextSummarizer`, `LlamaPromptRenderer`, `VisualContextSummaryPromptRenderer`, `llama.swift`, or the old `tabby-1-*` / instruct model names.

## Linked issues

_None._

## Risk / rollout notes

- Documentation only; no code or behavior change.
- The project wiki (separate repo, no PR mechanism) was refreshed in the same pass and pushed directly: `How-Cotabby-Works`, `Debugging-Guide`, `How-To-Add-a-Feature`, `Privacy-and-Safety-Model`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a documentation-only PR that refreshes five markdown files to align with code that has already shipped: the OSS path migrated from instruction-tuned to base GGUFs, `LlamaVisualContextSummarizer` was removed, and `LlamaPromptRenderer` was replaced by `BaseCompletionPromptRenderer`.

- **README.md**: Model table updated from four `tabby-1-*` instruct entries to five `tabby-2-*` base-model entries (filenames, sizes, and mradermacher HuggingFace links); all values confirmed exact matches against `LlamaRuntimeModels.swift`.
- **AGENTS.md / ARCHITECTURE.md / .claude/CLAUDE.md**: Remove `LlamaVisualContextSummarizer`, describe `OCRTextHygiene` as the cleanup step, document `BaseCompletionPromptRenderer` and the default-off `cotabbyConstrainedDecoderEnabled`/`runConstrainedDecode` path; point the llama integration at the `CotabbyInference` SwiftPM package.
- **docs/POLLING_AND_DELAYS.md**: Drops the now-deleted `LlamaVisualContextSummarizer` 3 s timeout row.

<h3>Confidence Score: 5/5</h3>

Documentation-only change; no code or runtime behavior is modified.

Every factual claim in the updated docs was cross-checked against the live source: model filenames, sizes, and HuggingFace URLs match LlamaRuntimeModels.swift exactly; OCRTextHygiene, BaseCompletionPromptRenderer, runConstrainedDecode, and cotabbyConstrainedDecoderEnabled all exist in the codebase; LlamaVisualContextSummarizer and LlamaPromptRenderer are confirmed absent; the CotabbyInference SwiftPM package reference matches the Xcode project. No stale claims remain.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Model table replaced with five tabby-2-* base GGUFs; all filenames, sizes, and mradermacher sources verified against LlamaRuntimeModels.swift. Default model claim (tabby-2-base) confirmed by LlamaRuntimeConfiguration.default. |
| AGENTS.md | Removes LlamaVisualContextSummarizer and LlamaRuntime/ directory references; adds OCRTextHygiene, BaseCompletionPromptRenderer, and constrained-decoder details — all verified present in source. |
| ARCHITECTURE.md | Removes stale 'legacy / deprecated' label from VisualContextCoordinator (no @available deprecated annotation exists in source) and adds OCRTextHygiene description. Clean and accurate. |
| .claude/CLAUDE.md | Drops LlamaVisualContextSummarizer from the visual-context list; adds OSS/instruct renderer split note. Both changes reflect current code accurately. |
| docs/POLLING_AND_DELAYS.md | Removes the LlamaVisualContextSummarizer 3 s timeout row; the remaining VisualContextCoordinator:29 entry was verified still present in source. No other timing rows affected. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Visual Context
        VC[VisualContextCoordinator] --> SCG[ScreenshotContextGenerator]
        SCG --> WSS[WindowScreenshotService]
        SCG --> STE[ScreenTextExtractor\nVision OCR]
        STE --> OCR[OCRTextHygiene\npure cleanup]
        OCR --> EXCERPT[Bounded Excerpt]
    end

    subgraph Runtime Generation
        SER[SuggestionEngineRouter] -->|Open Source| LSE[LlamaSuggestionEngine]
        SER -->|Apple Intelligence| FMSE[FoundationModelSuggestionEngine]
        LSE --> LRM[LlamaRuntimeManager]
        LRM --> LRC[LlamaRuntimeCore\nserialised actor]
        LRC -->|default| NORM[Normal Decode]
        LRC -->|cotabbyConstrainedDecoderEnabled default-off| CD[runConstrainedDecode]
    end

    subgraph Prompt Rendering
        LSE --> BCPR[BaseCompletionPromptRenderer\nbase-model continuation]
        FMSE --> FMPR[FoundationModelPromptRenderer\ninstruct-shaped]
    end

    subgraph Models tabby-2
        M1[tabby-2-mini Qwen3.5-0.8B ~0.8 GB]
        M2[tabby-2-base default Qwen3.5-2B ~1.4 GB]
        M3[tabby-2-pro Qwen3.5-4B ~2.6 GB]
        M4[tabby-2-gemma-mini gemma-4-E2B ~4.5 GB]
        M5[tabby-2-gemma-pro gemma-4-E4B ~5.0 GB]
    end

    LRC --> M1
    LRC --> M2
    LRC --> M3
    LRC --> M4
    LRC --> M5
```

<sub>Reviews (1): Last reviewed commit: ["Refresh docs for the base-model migratio..."](https://github.com/fujacob/cotabby/commit/aa3c05d536d19fc309292c3320ca7eb9eb65ff51) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34981248)</sub>

<!-- /greptile_comment -->