### PR TITLE
Keep the KV cache on cancelled llama generations

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -191,6 +191,7 @@
 		B93AB7E845086F6FBB068369 /* SuggestionRequestFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE94342B888A5A2CCF66BC93 /* SuggestionRequestFactoryTests.swift */; };
 		BB6325CA50F97B18B9725918 /* SuggestionTextNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B424E2AC97C99D335B0D5751 /* SuggestionTextNormalizer.swift */; };
 		BBE22CE4EF43247F8775B25D /* FocusPollBackoff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09FADF683BE7B3558377FA76 /* FocusPollBackoff.swift */; };
+		BE3CB85508055D159C35020A /* LlamaSuggestionEngineCancellationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABCC3FD99B1824A81E665F3 /* LlamaSuggestionEngineCancellationTests.swift */; };
 		BFCA7FAFDAEBF586AB615567 /* ClipboardRelevanceFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90B0D133AB77A2503FB08827 /* ClipboardRelevanceFilterTests.swift */; };
 		C0B833234748E82D3382631A /* emoji.json in Resources */ = {isa = PBXBuildFile; fileRef = C379D77029D6E88C8C1B9AF7 /* emoji.json */; };
 		C0FE11D76BDF01A5470C554D /* FocusCapabilityFlickerGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A44BEC8C23FF227731DD0CD /* FocusCapabilityFlickerGate.swift */; };
@@ -422,6 +423,7 @@
 		A863F41C0C03D7B4AC5DC002 /* MarkerSelectionSynthesizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkerSelectionSynthesizer.swift; sourceTree = "<group>"; };
 		A9199B9CEAB320982CA333B8 /* WelcomeTemplateStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeTemplateStepView.swift; sourceTree = "<group>"; };
 		AA33F5FFAC5B99384E15CE3E /* BundledRuntimeLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledRuntimeLocator.swift; sourceTree = "<group>"; };
+		AABCC3FD99B1824A81E665F3 /* LlamaSuggestionEngineCancellationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LlamaSuggestionEngineCancellationTests.swift; sourceTree = "<group>"; };
 		AC70775535A3428991025AB8 /* AXHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AXHelper.swift; sourceTree = "<group>"; };
 		AD752451330486FE270018B0 /* CustomRulesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomRulesTests.swift; sourceTree = "<group>"; };
 		AD9573F3504CAE6891DF9B7D /* AppUpdateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdateManager.swift; sourceTree = "<group>"; };
@@ -764,6 +766,7 @@
 				4793D4EA5D36D7E5CC216C27 /* LanguageSupportTests.swift */,
 				5807E8508D9355D0271A00C5 /* LaunchAtLoginStateTests.swift */,
 				0CA88BB29BC8727878C99E95 /* LlamaPromptCacheHintTrackerTests.swift */,
+				AABCC3FD99B1824A81E665F3 /* LlamaSuggestionEngineCancellationTests.swift */,
 				52BAFA2F989C3C4F7FB892B5 /* MarkerSelectionSynthesizerTests.swift */,
 				1274F897631B1B3A835D157F /* MidWordContinuationPolicyTests.swift */,
 				FC83D14A7557BC0196E59007 /* MirrorOverlayLayoutTests.swift */,
@@ -1281,6 +1284,7 @@
 				E912D4617AE1376061DF1F00 /* LanguageSupportTests.swift in Sources */,
 				E27E6377D36D4981301568DD /* LaunchAtLoginStateTests.swift in Sources */,
 				E38801433B99E65BD7E45A0E /* LlamaPromptCacheHintTrackerTests.swift in Sources */,
+				BE3CB85508055D159C35020A /* LlamaSuggestionEngineCancellationTests.swift in Sources */,
 				87806DE08881D11F2608A13D /* MarkerSelectionSynthesizerTests.swift in Sources */,
 				7C36DBA762E19C8C31676D44 /* MidWordContinuationPolicyTests.swift in Sources */,
 				14D77F0B8A195AC2FA8D24A9 /* MirrorOverlayLayoutTests.swift in Sources */,

--- a/Cotabby/Models/SuggestionSubsystemContracts.swift
+++ b/Cotabby/Models/SuggestionSubsystemContracts.swift
@@ -82,6 +82,17 @@ extension SuggestionGenerating {
     func prewarm(for request: SuggestionRequest) async {}
 }
 
+/// Behavior-shaped view of the llama runtime that `LlamaSuggestionEngine` depends on: run one
+/// generation and drop the native KV cache. Extracted so the engine's failure handling — in
+/// particular the invariant that a *cancelled* generation must NOT reset the cache (resetting it on
+/// every superseded keystroke was the base-model input-lag regression) — can be unit-tested against
+/// a fake runtime instead of loading a real model. `LlamaRuntimeManager` is the production conformer.
+@MainActor
+protocol LlamaRuntimeGenerating: AnyObject {
+    func generate(prompt: String, cachedPrefixBytes: Int?, options: LlamaGenerationOptions) async throws -> String
+    func resetPromptCache()
+}
+
 @MainActor
 protocol SuggestionSettingsProviding: AnyObject {
     var snapshot: SuggestionSettingsSnapshot { get }

--- a/Cotabby/Services/Runtime/LlamaRuntimeManager.swift
+++ b/Cotabby/Services/Runtime/LlamaRuntimeManager.swift
@@ -325,3 +325,5 @@ final class LlamaRuntimeManager: ObservableObject {
         state = .ready("Loaded \(preparedRuntime.resolvedRuntime.modelDisplayName) in-process.")
     }
 }
+
+extension LlamaRuntimeManager: LlamaRuntimeGenerating {}

--- a/Cotabby/Services/Runtime/LlamaSuggestionEngine.swift
+++ b/Cotabby/Services/Runtime/LlamaSuggestionEngine.swift
@@ -10,7 +10,7 @@ import Logging
 /// That separation matters because prompt strategy changes far more often than model lifecycle code.
 @MainActor
 final class LlamaSuggestionEngine {
-    private let runtimeManager: LlamaRuntimeManager
+    private let runtimeManager: LlamaRuntimeGenerating
     private var promptCacheHintTracker = LlamaPromptCacheHintTracker()
 
     /// UserDefaults key (no UI) that routes llama generation through the deterministic constrained
@@ -22,7 +22,7 @@ final class LlamaSuggestionEngine {
         UserDefaults.standard.bool(forKey: constrainedDecoderDefaultsKey)
     }
 
-    init(runtimeManager: LlamaRuntimeManager) {
+    init(runtimeManager: LlamaRuntimeGenerating) {
         self.runtimeManager = runtimeManager
     }
 
@@ -101,6 +101,22 @@ final class LlamaSuggestionEngine {
             )
         } catch is CancellationError {
             CotabbyLogger.suggestion.debug("Llama generation cancelled", metadata: baseMetadata)
+            throw SuggestionClientError.cancelled
+        } catch LlamaRuntimeError.cancelled {
+            // A cancelled generation is NOT a runtime failure, so it must not reset the KV cache.
+            // `LlamaRuntimeManager.generate` surfaces an outer-Task cancellation as
+            // `LlamaRuntimeError.cancelled` (its `catch is CancellationError` rethrows it so callers
+            // share one error vocabulary). Without this branch that case falls through to the generic
+            // `LlamaRuntimeError` handler below and wipes the native KV sequence on every cancel.
+            //
+            // During fast typing nearly every keystroke supersedes the previous in-flight generation,
+            // so that path fired ~twice a second — each time synchronously destroying the prompt KV on
+            // the main actor (contending with the keystroke-delivery run loop) and forcing the next
+            // keystroke to re-decode the whole prompt from scratch. The cooperative cancel inside
+            // `LlamaRuntimeCore.generate` already unwound cleanly (its KV-trim defer restored
+            // prompt-only state), so the cache is still valid and reusable. Route this to the same
+            // quiet path as `CancellationError` and leave the cache intact.
+            CotabbyLogger.suggestion.debug("Llama generation cancelled (runtime task)", metadata: baseMetadata)
             throw SuggestionClientError.cancelled
         } catch let error as LlamaRuntimeError {
             CotabbyLogger.suggestion.error(

--- a/CotabbyTests/LlamaSuggestionEngineCancellationTests.swift
+++ b/CotabbyTests/LlamaSuggestionEngineCancellationTests.swift
@@ -1,0 +1,144 @@
+import CoreGraphics
+import Foundation
+import XCTest
+@testable import Cotabby
+
+/// Regression tests for `LlamaSuggestionEngine`'s failure handling, guarding the input-lag fix:
+/// a *cancelled* generation must be treated as a quiet cancellation, NOT as a runtime error that
+/// wipes the native KV cache. During fast typing nearly every keystroke supersedes the in-flight
+/// generation, so resetting the cache on each cancel (the base-model regression) fired ~twice a
+/// second — synchronously destroying the prompt KV on the main actor and forcing a full prompt
+/// re-decode on the next keystroke. These tests pin the routing for both cancellation shapes the
+/// runtime can surface (`CancellationError` and `LlamaRuntimeError.cancelled`) and confirm genuine
+/// runtime errors still reset.
+@MainActor
+final class LlamaSuggestionEngineCancellationTests: XCTestCase {
+
+    func test_runtimeCancelledError_doesNotResetCache_andThrowsCancelled() async {
+        // `LlamaRuntimeManager.generate` surfaces an outer-Task cancellation as
+        // `LlamaRuntimeError.cancelled`. The engine must route that to the quiet cancel path.
+        let runtime = FakeLlamaRuntime()
+        runtime.generateResult = .failure(LlamaRuntimeError.cancelled)
+        let engine = LlamaSuggestionEngine(runtimeManager: runtime)
+
+        await assertThrowsCancelled(engine)
+        XCTAssertEqual(runtime.resetCount, 0, "A cancelled generation must not reset the KV cache")
+    }
+
+    func test_pureCancellationError_doesNotResetCache_andThrowsCancelled() async {
+        // Guards the pre-existing clean path so a future refactor cannot regress it either.
+        let runtime = FakeLlamaRuntime()
+        runtime.generateResult = .failure(CancellationError())
+        let engine = LlamaSuggestionEngine(runtimeManager: runtime)
+
+        await assertThrowsCancelled(engine)
+        XCTAssertEqual(runtime.resetCount, 0)
+    }
+
+    func test_genuineRuntimeError_resetsCache_andThrowsUnavailable() async {
+        let runtime = FakeLlamaRuntime()
+        runtime.generateResult = .failure(LlamaRuntimeError.generationFailed("boom"))
+        let engine = LlamaSuggestionEngine(runtimeManager: runtime)
+
+        do {
+            _ = try await engine.generateSuggestion(for: makeRequest(prompt: "hello"))
+            XCTFail("Expected a thrown error")
+        } catch SuggestionClientError.unavailable {
+            // Expected: a real runtime failure does reset and surfaces as unavailable.
+        } catch {
+            XCTFail("Expected SuggestionClientError.unavailable, got \(error)")
+        }
+        XCTAssertEqual(runtime.resetCount, 1, "A genuine runtime error should reset the KV cache exactly once")
+    }
+
+    func test_successfulGeneration_doesNotResetCache() async throws {
+        let runtime = FakeLlamaRuntime()
+        runtime.generateResult = .success("world")
+        let engine = LlamaSuggestionEngine(runtimeManager: runtime)
+
+        let result = try await engine.generateSuggestion(for: makeRequest(prompt: "hello "))
+
+        XCTAssertEqual(result.generation, 1)
+        XCTAssertEqual(runtime.resetCount, 0)
+    }
+
+    // MARK: - Helpers
+
+    private func assertThrowsCancelled(
+        _ engine: LlamaSuggestionEngine,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        do {
+            _ = try await engine.generateSuggestion(for: makeRequest(prompt: "hello"))
+            XCTFail("Expected a thrown error", file: file, line: line)
+        } catch SuggestionClientError.cancelled {
+            // Expected quiet cancellation.
+        } catch {
+            XCTFail("Expected SuggestionClientError.cancelled, got \(error)", file: file, line: line)
+        }
+    }
+
+    private func makeRequest(prompt: String) -> SuggestionRequest {
+        let snapshot = FocusedInputSnapshot(
+            applicationName: "TestApp",
+            bundleIdentifier: "com.example.TestApp",
+            processIdentifier: 123,
+            elementIdentifier: "field",
+            role: "AXTextField",
+            subrole: nil,
+            caretRect: .zero,
+            inputFrameRect: nil,
+            caretSource: "test",
+            caretQuality: .exact,
+            observedCharWidth: nil,
+            precedingText: prompt,
+            trailingText: "",
+            selection: NSRange(location: prompt.count, length: 0),
+            isSecure: false
+        )
+        let context = FocusedInputContext(snapshot: snapshot, generation: 1)
+
+        return SuggestionRequest(
+            context: context,
+            prefixText: prompt,
+            prompt: prompt,
+            generation: context.generation,
+            maxPredictionTokens: 8,
+            temperature: 0.1,
+            topK: 20,
+            topP: 0.7,
+            minP: 0.08,
+            repetitionPenalty: 1.05,
+            randomSeed: 42,
+            maxSuffixCharacters: 192,
+            completionLengthInstruction: "Return only the next few words.",
+            userName: nil,
+            customRules: [],
+            languageInstruction: nil,
+            clipboardContext: nil,
+            visualContextSummary: nil,
+            isMultiLineEnabled: false
+        )
+    }
+}
+
+/// Minimal `LlamaRuntimeGenerating` fake that returns a staged result and counts cache resets,
+/// so the engine's failure routing can be exercised without loading a real model.
+@MainActor
+private final class FakeLlamaRuntime: LlamaRuntimeGenerating {
+    var generateResult: Result<String, Error> = .success("")
+    private(set) var resetCount = 0
+
+    func generate(
+        prompt: String,
+        cachedPrefixBytes: Int?,
+        options: LlamaGenerationOptions
+    ) async throws -> String {
+        try generateResult.get()
+    }
+
+    func resetPromptCache() {
+        resetCount += 1
+    }
+}


### PR DESCRIPTION
## Summary

Typing became laggy after the base-model migration. Root cause: a *cancelled* llama
generation was misrouted as a runtime error and synchronously wiped the native KV cache on the
main actor, then forced a full prompt re-decode on the next keystroke. `LlamaRuntimeManager`
surfaces an outer-Task cancellation as `LlamaRuntimeError.cancelled`, which fell through to the
cache-resetting `LlamaRuntimeError` handler instead of the quiet `CancellationError` path.

On the slower base models nearly every keystroke supersedes the in-flight generation, so the wipe
fired ~twice a second while typing; because the active accept event tap shares the main run loop the
reset was stalling, it surfaced as input lag. The cooperative cancel inside `LlamaRuntimeCore.generate`
already unwinds cleanly (its KV-trim `defer` restores prompt-only state), so the cache is still valid —
this adds a dedicated `catch LlamaRuntimeError.cancelled` that throws `SuggestionClientError.cancelled`
without resetting. A narrow `LlamaRuntimeGenerating` seam makes the failure routing unit-testable.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  build-for-testing -derivedDataPath build/DerivedData
# ** BUILD SUCCEEDED **

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' test \
  -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO \
  -only-testing:CotabbyTests/LlamaSuggestionEngineCancellationTests \
  -only-testing:CotabbyTests/LlamaPromptCacheHintTrackerTests
# ** TEST SUCCEEDED ** — Executed 9 tests, with 0 failures
#   LlamaSuggestionEngineCancellationTests 4/4:
#     - runtime cancel (LlamaRuntimeError.cancelled) => no cache reset, throws .cancelled
#     - pure CancellationError                       => no cache reset, throws .cancelled
#     - genuine runtime error                        => resets cache exactly once, throws .unavailable
#     - successful generation                        => no cache reset

swiftlint lint --quiet
# exit 0 (clean)
```

App-hosted tests are run unsigned: the default-signed test bundle hits a Team ID mismatch on this
machine (`...different Team IDs`), so signing is disabled for the local run. `build-for-testing`
(default signing) still succeeds.

## Linked issues

No tracking issue was filed; this was surfaced from on-device input-lag logs after the base-model
migration. Refs the OSS base-model cutover (#497) that exposed the latent misclassification.

## Risk / rollout notes

- **Behavior change:** a cancelled generation no longer resets the llama KV cache or the prompt-cache
  hint. This is the intended fix — the cache is valid after a cooperative cancel — and it restores
  prompt-prefix reuse across keystrokes (far fewer full re-decodes). Genuine runtime errors still
  reset exactly once (covered by a test).
- **Performance:** removes ~2 synchronous main-actor KV-cache wipes per second during fast typing on
  the OSS/base-model path. No effect on the Apple Foundation Models path.
- **Project file:** regenerated `Cotabby.xcodeproj` with `xcodegen generate` to register the new test
  file; the pbxproj diff is only that file reference.
- **Out of scope:** pre-existing amplifiers found during the investigation — the active accept tap
  still living on the main run loop, per-keystroke Chrome AX-walk cost, and the caret-geometry cache
  removed in #321 — predate this regression and are tracked separately as follow-ups.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes an input-lag regression introduced with the base-model migration: a cancelled llama generation was falling through to the generic `LlamaRuntimeError` catch handler, which synchronously wiped the native KV cache on the main actor — firing roughly twice per second during fast typing and forcing a full prompt re-decode on every subsequent keystroke. The fix adds a dedicated `catch LlamaRuntimeError.cancelled` branch that routes cancelled generations to the quiet `SuggestionClientError.cancelled` path without touching the cache.

- **Engine fix (`LlamaSuggestionEngine.swift`):** inserts a specific catch clause for `LlamaRuntimeError.cancelled` before the generic `LlamaRuntimeError` handler; narrowing `runtimeManager` to the new `LlamaRuntimeGenerating` protocol enables unit-testing the routing without loading a real model.
- **Protocol seam (`SuggestionSubsystemContracts.swift` + `LlamaRuntimeManager.swift`):** adds `LlamaRuntimeGenerating` (wrapping `generate` and `resetPromptCache`) and satisfies it with an empty extension on `LlamaRuntimeManager`.
- **Regression tests (`LlamaSuggestionEngineCancellationTests.swift`):** four tests using a `FakeLlamaRuntime` double pin all four routing outcomes — runtime cancel (no reset), `CancellationError` (no reset), genuine runtime error (reset exactly once), and success (no reset).

<h3>Confidence Score: 4/5</h3>

Safe to merge; the cancellation routing change is narrow, the catch-clause order is correct, and four targeted regression tests guard the fix.

The core change is a single added catch clause in a well-understood error chain. Catch ordering is correct, the `LlamaRuntimeGenerating` protocol extraction is clean, and four regression tests cover all relevant routing outcomes. Two style-level observations were noted but neither affects runtime behaviour.

No files require special attention; `LlamaSuggestionEngine.swift` is the only file with runtime-behaviour impact and the change there is minimal and well-covered by the new tests.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Services/Runtime/LlamaSuggestionEngine.swift | Adds a dedicated `catch LlamaRuntimeError.cancelled` clause before the generic `LlamaRuntimeError` handler so cancellations skip the KV-cache reset; also narrows `runtimeManager` to the new `LlamaRuntimeGenerating` protocol. |
| Cotabby/Models/SuggestionSubsystemContracts.swift | Adds `LlamaRuntimeGenerating` protocol (generate + resetPromptCache) as the test seam between `LlamaSuggestionEngine` and the real runtime; placement in this file is a minor organizational choice since the protocol serves `LlamaSuggestionEngine`, not `SuggestionCoordinator` directly. |
| Cotabby/Services/Runtime/LlamaRuntimeManager.swift | Empty conformance extension to `LlamaRuntimeGenerating`; existing `generate` and `resetPromptCache` methods already satisfy the protocol requirements exactly. |
| CotabbyTests/LlamaSuggestionEngineCancellationTests.swift | Four focused regression tests using a `FakeLlamaRuntime` double covering the fixed path (`LlamaRuntimeError.cancelled` → no reset), the `CancellationError` path, genuine runtime errors (reset exactly once), and success (no reset). |
| Cotabby.xcodeproj/project.pbxproj | Mechanical xcodegen output registering the new test file; no manual edits or unexpected changes. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant KS as Keystroke
    participant SE as LlamaSuggestionEngine
    participant RM as LlamaRuntimeManager
    participant RC as LlamaRuntimeCore

    KS->>SE: generateSuggestion(request)
    SE->>RM: generate(prompt, cachedPrefixBytes, options)
    RM->>RC: core.generate(...) [detached Task]
    Note over KS,RC: Next keystroke supersedes request
    RC-->>RM: partial buffer (cooperative cancel)
    RM->>RM: Task.checkCancellation() throws CancellationError
    RM->>RM: catch CancellationError, throw LlamaRuntimeError.cancelled
    RM-->>SE: throws LlamaRuntimeError.cancelled

    alt BEFORE this PR (bug)
        SE->>SE: catch LlamaRuntimeError (generic)
        SE->>RM: resetPromptCache() wipes KV cache
        SE-->>KS: throws SuggestionClientError.unavailable
    else AFTER this PR (fix)
        SE->>SE: catch LlamaRuntimeError.cancelled (new specific branch)
        Note over SE: No resetPromptCache() call, KV cache preserved
        SE-->>KS: throws SuggestionClientError.cancelled
    end
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fcancelled-generation-keeps-kv-cache%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fcancelled-generation-keeps-kv-cache%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FModels%2FSuggestionSubsystemContracts.swift%3A85-94%0A**Protocol%20lives%20outside%20its%20natural%20file%20scope**%0A%0A%60SuggestionSubsystemContracts.swift%60%20declares%20itself%20in%20its%20file%20header%20as%20defining%20contracts%20that%20%60SuggestionCoordinator%60%20depends%20on%2C%20but%20%60LlamaRuntimeGenerating%60%20is%20consumed%20exclusively%20by%20%60LlamaSuggestionEngine%60.%20In%20isolation%20this%20isn't%20a%20bug%2C%20but%20as%20this%20file%20grows%20it%20becomes%20less%20clear%20which%20protocols%20belong%20to%20the%20coordinator%20boundary%20and%20which%20are%20internal%20seams%20elsewhere.%20A%20dedicated%20%60LlamaRuntimeContracts.swift%60%20%28alongside%20the%20existing%20%60Runtime%2F%60%20files%29%20or%20a%20comment%20noting%20this%20protocol%20is%20for%20the%20engine%20layer%20would%20keep%20the%20boundary%20explicit%20for%20future%20readers.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabbyTests%2FLlamaSuggestionEngineCancellationTests.swift%3A28-36%0A**%60CancellationError%60%20test%20exercises%20a%20path%20the%20real%20runtime%20cannot%20produce**%0A%0A%60LlamaRuntimeManager.generate%60%20always%20wraps%20any%20%60CancellationError%60%20it%20sees%20into%20%60LlamaRuntimeError.cancelled%60%20before%20rethrowing%2C%20so%20the%20engine%20will%20never%20receive%20a%20raw%20%60CancellationError%60%20from%20%60generate%60.%20The%20only%20source%20of%20a%20raw%20%60CancellationError%60%20to%20the%20engine%20is%20the%20%60try%20Task.checkCancellation%28%29%60%20call%20on%20line%2066%20of%20%60LlamaSuggestionEngine.swift%60%20%28the%20post-generation%20check%29.%20The%20test%20is%20still%20useful%20as%20a%20guard%20that%20%60CancellationError%60%20is%20not%20accidentally%20routed%20to%20the%20cache-resetting%20handler%20if%20the%20runtime%20contract%20changes%2C%20but%20the%20comment%20%28%22Guards%20the%20pre-existing%20clean%20path%22%29%20could%20mention%20that%20this%20exercises%20the%20post-generation%20check%20rather%20than%20the%20generation%20call%20itself%2C%20to%20prevent%20future%20maintainers%20from%20misreading%20the%20intent.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FModels%2FSuggestionSubsystemContracts.swift%3A85-94%0A**Protocol%20lives%20outside%20its%20natural%20file%20scope**%0A%0A%60SuggestionSubsystemContracts.swift%60%20declares%20itself%20in%20its%20file%20header%20as%20defining%20contracts%20that%20%60SuggestionCoordinator%60%20depends%20on%2C%20but%20%60LlamaRuntimeGenerating%60%20is%20consumed%20exclusively%20by%20%60LlamaSuggestionEngine%60.%20In%20isolation%20this%20isn't%20a%20bug%2C%20but%20as%20this%20file%20grows%20it%20becomes%20less%20clear%20which%20protocols%20belong%20to%20the%20coordinator%20boundary%20and%20which%20are%20internal%20seams%20elsewhere.%20A%20dedicated%20%60LlamaRuntimeContracts.swift%60%20%28alongside%20the%20existing%20%60Runtime%2F%60%20files%29%20or%20a%20comment%20noting%20this%20protocol%20is%20for%20the%20engine%20layer%20would%20keep%20the%20boundary%20explicit%20for%20future%20readers.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabbyTests%2FLlamaSuggestionEngineCancellationTests.swift%3A28-36%0A**%60CancellationError%60%20test%20exercises%20a%20path%20the%20real%20runtime%20cannot%20produce**%0A%0A%60LlamaRuntimeManager.generate%60%20always%20wraps%20any%20%60CancellationError%60%20it%20sees%20into%20%60LlamaRuntimeError.cancelled%60%20before%20rethrowing%2C%20so%20the%20engine%20will%20never%20receive%20a%20raw%20%60CancellationError%60%20from%20%60generate%60.%20The%20only%20source%20of%20a%20raw%20%60CancellationError%60%20to%20the%20engine%20is%20the%20%60try%20Task.checkCancellation%28%29%60%20call%20on%20line%2066%20of%20%60LlamaSuggestionEngine.swift%60%20%28the%20post-generation%20check%29.%20The%20test%20is%20still%20useful%20as%20a%20guard%20that%20%60CancellationError%60%20is%20not%20accidentally%20routed%20to%20the%20cache-resetting%20handler%20if%20the%20runtime%20contract%20changes%2C%20but%20the%20comment%20%28%22Guards%20the%20pre-existing%20clean%20path%22%29%20could%20mention%20that%20this%20exercises%20the%20post-generation%20check%20rather%20than%20the%20generation%20call%20itself%2C%20to%20prevent%20future%20maintainers%20from%20misreading%20the%20intent.%0A%0A&repo=fujacob%2Fcotabby&pr=513&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Keep the KV cache on cancelled llama gen..."](https://github.com/fujacob/cotabby/commit/a8ddacb210a8066f0cb570d618a379316d05da46) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35029908)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->