### PR TITLE
Collapse the Open Source catalog to four named tiers

### DIFF
--- a/Cotabby/Models/LlamaRuntimeModels.swift
+++ b/Cotabby/Models/LlamaRuntimeModels.swift
@@ -96,15 +96,13 @@ enum RuntimeModelCatalog {
     static func displayName(for filename: String) -> String {
         switch filename {
         case "Qwen3.5-0.8B-Base.i1-Q6_K.gguf":
-            return "tabby-2-mini"
+            return "tabby-2-nano"
         case "Qwen3.5-2B-Base.i1-Q4_K_M.gguf":
-            return "tabby-2-base"
-        case "Qwen3.5-4B-Base.i1-Q4_K_M.gguf":
-            return "tabby-2-pro"
+            return "tabby-2-mini"
         case "gemma-4-E2B.i1-Q6_K.gguf":
-            return "tabby-2-gemma-mini"
+            return "tabby-2-base"
         case "gemma-4-E4B.i1-Q4_K_M.gguf":
-            return "tabby-2-gemma-pro"
+            return "tabby-2-pro"
         default:
             return filename
         }
@@ -132,12 +130,6 @@ enum RuntimeModelCatalog {
             displayName: displayName(for: "Qwen3.5-2B-Base.i1-Q4_K_M.gguf"),
             downloadURL: hfURL("mradermacher/Qwen3.5-2B-Base-i1-GGUF", "Qwen3.5-2B-Base.i1-Q4_K_M.gguf"),
             approximateSizeInGigabytes: 1.4
-        ),
-        DownloadableRuntimeModel(
-            filename: "Qwen3.5-4B-Base.i1-Q4_K_M.gguf",
-            displayName: displayName(for: "Qwen3.5-4B-Base.i1-Q4_K_M.gguf"),
-            downloadURL: hfURL("mradermacher/Qwen3.5-4B-Base-i1-GGUF", "Qwen3.5-4B-Base.i1-Q4_K_M.gguf"),
-            approximateSizeInGigabytes: 2.6
         ),
         DownloadableRuntimeModel(
             filename: "gemma-4-E2B.i1-Q6_K.gguf",
@@ -169,7 +161,6 @@ struct LlamaRuntimeConfiguration: Equatable, Sendable {
         preferredModelNames: [
             "Qwen3.5-2B-Base.i1-Q4_K_M.gguf",
             "Qwen3.5-0.8B-Base.i1-Q6_K.gguf",
-            "Qwen3.5-4B-Base.i1-Q4_K_M.gguf",
             "gemma-4-E2B.i1-Q6_K.gguf",
             "gemma-4-E4B.i1-Q4_K_M.gguf"
         ],

--- a/Cotabby/Models/LlamaRuntimeModels.swift
+++ b/Cotabby/Models/LlamaRuntimeModels.swift
@@ -159,9 +159,9 @@ struct LlamaRuntimeConfiguration: Equatable, Sendable {
     static let `default` = LlamaRuntimeConfiguration(
         runtimeDirectoryPath: nil,
         preferredModelNames: [
+            "gemma-4-E2B.i1-Q6_K.gguf",
             "Qwen3.5-2B-Base.i1-Q4_K_M.gguf",
             "Qwen3.5-0.8B-Base.i1-Q6_K.gguf",
-            "gemma-4-E2B.i1-Q6_K.gguf",
             "gemma-4-E4B.i1-Q4_K_M.gguf"
         ],
         contextWindowTokens: 2048,

--- a/Cotabby/Models/OnboardingTemplate.swift
+++ b/Cotabby/Models/OnboardingTemplate.swift
@@ -101,7 +101,7 @@ enum OnboardingTemplate: String, CaseIterable, Identifiable, Equatable, Sendable
         case .everyday:
             return "Qwen3.5-2B-Base.i1-Q4_K_M.gguf"
         case .powerful:
-            return "Qwen3.5-4B-Base.i1-Q4_K_M.gguf"
+            return "gemma-4-E4B.i1-Q4_K_M.gguf"
         }
     }
 }

--- a/Cotabby/Models/OnboardingTemplate.swift
+++ b/Cotabby/Models/OnboardingTemplate.swift
@@ -99,7 +99,7 @@ enum OnboardingTemplate: String, CaseIterable, Identifiable, Equatable, Sendable
         case .quick:
             return "Qwen3.5-0.8B-Base.i1-Q6_K.gguf"
         case .everyday:
-            return "Qwen3.5-2B-Base.i1-Q4_K_M.gguf"
+            return "gemma-4-E2B.i1-Q6_K.gguf"
         case .powerful:
             return "gemma-4-E4B.i1-Q4_K_M.gguf"
         }

--- a/CotabbyTests/ModelAndPresentationValueTests.swift
+++ b/CotabbyTests/ModelAndPresentationValueTests.swift
@@ -147,14 +147,27 @@ final class RuntimeAndInputModelValueTests: XCTestCase {
 
     func test_runtimeModelCatalogMapsKnownNamesAndLeavesCustomNamesAlone() {
         XCTAssertEqual(
+            RuntimeModelCatalog.displayName(for: "Qwen3.5-0.8B-Base.i1-Q6_K.gguf"),
+            "tabby-2-nano"
+        )
+        XCTAssertEqual(
             RuntimeModelCatalog.displayName(for: "Qwen3.5-2B-Base.i1-Q4_K_M.gguf"),
+            "tabby-2-mini"
+        )
+        XCTAssertEqual(
+            RuntimeModelCatalog.displayName(for: "gemma-4-E2B.i1-Q6_K.gguf"),
             "tabby-2-base"
         )
         XCTAssertEqual(
-            RuntimeModelCatalog.displayName(for: "Qwen3.5-0.8B-Base.i1-Q6_K.gguf"),
-            "tabby-2-mini"
+            RuntimeModelCatalog.displayName(for: "gemma-4-E4B.i1-Q4_K_M.gguf"),
+            "tabby-2-pro"
         )
-        // Retired models fall back to their raw filename like any unknown local GGUF.
+        // Retired models fall back to their raw filename like any unknown local GGUF. The 4B Qwen
+        // base was dropped when the catalog moved to the nano/mini/base/pro four-tier lineup.
+        XCTAssertEqual(
+            RuntimeModelCatalog.displayName(for: "Qwen3.5-4B-Base.i1-Q4_K_M.gguf"),
+            "Qwen3.5-4B-Base.i1-Q4_K_M.gguf"
+        )
         XCTAssertEqual(
             RuntimeModelCatalog.displayName(for: "Qwen3.5-0.8B-Q4_K_M.gguf"),
             "Qwen3.5-0.8B-Q4_K_M.gguf"

--- a/CotabbyTests/OnboardingTemplateRecommenderTests.swift
+++ b/CotabbyTests/OnboardingTemplateRecommenderTests.swift
@@ -47,7 +47,7 @@ final class OnboardingTemplateRecommenderTests: XCTestCase {
     func testOpenSourceTiersMapToTheirLocalModels() {
         let expected: [OnboardingTemplate: String] = [
             .quick: "Qwen3.5-0.8B-Base.i1-Q6_K.gguf",
-            .everyday: "Qwen3.5-2B-Base.i1-Q4_K_M.gguf",
+            .everyday: "gemma-4-E2B.i1-Q6_K.gguf",
             .powerful: "gemma-4-E4B.i1-Q4_K_M.gguf"
         ]
         for (template, filename) in expected {

--- a/CotabbyTests/OnboardingTemplateRecommenderTests.swift
+++ b/CotabbyTests/OnboardingTemplateRecommenderTests.swift
@@ -48,7 +48,7 @@ final class OnboardingTemplateRecommenderTests: XCTestCase {
         let expected: [OnboardingTemplate: String] = [
             .quick: "Qwen3.5-0.8B-Base.i1-Q6_K.gguf",
             .everyday: "Qwen3.5-2B-Base.i1-Q4_K_M.gguf",
-            .powerful: "Qwen3.5-4B-Base.i1-Q4_K_M.gguf"
+            .powerful: "gemma-4-E4B.i1-Q4_K_M.gguf"
         ]
         for (template, filename) in expected {
             let plan = OnboardingTemplateRecommender.resolvePlan(for: template, engine: .llamaOpenSource)

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Everything runs on-device. No hosted API, no cloud round-trip.
 | `tabby-2-base` | `gemma-4-E2B.i1-Q6_K.gguf`       | ~4.5 GB | [mradermacher/gemma-4-E2B-i1-GGUF](https://huggingface.co/mradermacher/gemma-4-E2B-i1-GGUF)             |
 | `tabby-2-pro`  | `gemma-4-E4B.i1-Q4_K_M.gguf`     | ~5.0 GB | [mradermacher/gemma-4-E4B-i1-GGUF](https://huggingface.co/mradermacher/gemma-4-E4B-i1-GGUF)             |
 
-`tabby-2-mini` (Qwen 2B) is the default; `tabby-2-nano` suits low-memory Macs, and `tabby-2-base` / `tabby-2-pro` (Gemma) are larger opt-in downloads. Apple Intelligence remains instruction-tuned and is unaffected by the base-model path.
+`tabby-2-base` (Gemma E2B) is the default and the recommended onboarding tier; `tabby-2-nano` is the lightweight option for low-memory Macs, `tabby-2-mini` is a smaller alternative, and `tabby-2-pro` is the largest. Apple Intelligence remains instruction-tuned and is unaffected by the base-model path.
 
 ### Bring your own model
 

--- a/README.md
+++ b/README.md
@@ -85,17 +85,16 @@ Everything runs on-device. No hosted API, no cloud round-trip.
 
 **Apple Intelligence**: uses Apple's on-device `FoundationModels` runtime on macOS 26 or later, no download required.
 
-**Open Source**: runs local GGUF *base* models in-process through llama.cpp via `CotabbyInference`. Rather than instructing an instruction-tuned model, Cotabby treats the model as a pure text continuer and conditions it on your persona, style, language, and on-screen context. Cotabby ships with five built-in downloadable models:
+**Open Source**: runs local GGUF *base* models in-process through llama.cpp via `CotabbyInference`. Rather than instructing an instruction-tuned model, Cotabby treats the model as a pure text continuer and conditions it on your persona, style, language, and on-screen context. Cotabby ships with four built-in downloadable models:
 
-| Model                | File                                 | Size    | Source                                                                                                          |
-| -------------------- | ------------------------------------ | ------- | --------------------------------------------------------------------------------------------------------------- |
-| `tabby-2-mini`       | `Qwen3.5-0.8B-Base.i1-Q6_K.gguf`     | ~0.8 GB | [mradermacher/Qwen3.5-0.8B-Base-i1-GGUF](https://huggingface.co/mradermacher/Qwen3.5-0.8B-Base-i1-GGUF)         |
-| `tabby-2-base`       | `Qwen3.5-2B-Base.i1-Q4_K_M.gguf`     | ~1.4 GB | [mradermacher/Qwen3.5-2B-Base-i1-GGUF](https://huggingface.co/mradermacher/Qwen3.5-2B-Base-i1-GGUF)             |
-| `tabby-2-pro`        | `Qwen3.5-4B-Base.i1-Q4_K_M.gguf`     | ~2.6 GB | [mradermacher/Qwen3.5-4B-Base-i1-GGUF](https://huggingface.co/mradermacher/Qwen3.5-4B-Base-i1-GGUF)             |
-| `tabby-2-gemma-mini` | `gemma-4-E2B.i1-Q6_K.gguf`           | ~4.5 GB | [mradermacher/gemma-4-E2B-i1-GGUF](https://huggingface.co/mradermacher/gemma-4-E2B-i1-GGUF)                     |
-| `tabby-2-gemma-pro`  | `gemma-4-E4B.i1-Q4_K_M.gguf`         | ~5.0 GB | [mradermacher/gemma-4-E4B-i1-GGUF](https://huggingface.co/mradermacher/gemma-4-E4B-i1-GGUF)                     |
+| Model          | File                             | Size    | Source                                                                                                  |
+| -------------- | -------------------------------- | ------- | ------------------------------------------------------------------------------------------------------- |
+| `tabby-2-nano` | `Qwen3.5-0.8B-Base.i1-Q6_K.gguf` | ~0.8 GB | [mradermacher/Qwen3.5-0.8B-Base-i1-GGUF](https://huggingface.co/mradermacher/Qwen3.5-0.8B-Base-i1-GGUF) |
+| `tabby-2-mini` | `Qwen3.5-2B-Base.i1-Q4_K_M.gguf` | ~1.4 GB | [mradermacher/Qwen3.5-2B-Base-i1-GGUF](https://huggingface.co/mradermacher/Qwen3.5-2B-Base-i1-GGUF)     |
+| `tabby-2-base` | `gemma-4-E2B.i1-Q6_K.gguf`       | ~4.5 GB | [mradermacher/gemma-4-E2B-i1-GGUF](https://huggingface.co/mradermacher/gemma-4-E2B-i1-GGUF)             |
+| `tabby-2-pro`  | `gemma-4-E4B.i1-Q4_K_M.gguf`     | ~5.0 GB | [mradermacher/gemma-4-E4B-i1-GGUF](https://huggingface.co/mradermacher/gemma-4-E4B-i1-GGUF)             |
 
-`tabby-2-base` is the default. Apple Intelligence remains instruction-tuned and is unaffected by the base-model path.
+`tabby-2-mini` (Qwen 2B) is the default; `tabby-2-nano` suits low-memory Macs, and `tabby-2-base` / `tabby-2-pro` (Gemma) are larger opt-in downloads. Apple Intelligence remains instruction-tuned and is unaffected by the base-model path.
 
 ### Bring your own model
 


### PR DESCRIPTION
## Summary

Collapses the Open Source model catalog to a single, coherent four-tier ladder so users stop
seeing five names spread across two families (`tabby-2-mini/base/pro` plus a parallel
`tabby-2-gemma-mini/-pro` sub-brand). The new lineup is `nano / mini / base / pro`:

| New label | File | Was |
| --- | --- | --- |
| `tabby-2-nano` | `Qwen3.5-0.8B-Base.i1-Q6_K.gguf` | `tabby-2-mini` |
| `tabby-2-mini` | `Qwen3.5-2B-Base.i1-Q4_K_M.gguf` | `tabby-2-base` |
| `tabby-2-base` | `gemma-4-E2B.i1-Q6_K.gguf` | `tabby-2-gemma-mini` (now the default) |
| `tabby-2-pro` | `gemma-4-E4B.i1-Q4_K_M.gguf` | `tabby-2-gemma-pro` |
| dropped | `Qwen3.5-4B-Base.i1-Q4_K_M.gguf` | `tabby-2-pro` |

Display names are derived from the GGUF filename (the persisted state is the filename), so the
relabel needs no re-download and changes no one's selected model. All four download URLs were
verified to resolve (HTTP 200) before committing.

Onboarding now reads `nano` (Quick) / `base` (Everyday, Recommended) / `pro` (Powerful), and
`tabby-2-base` (gemma-4-E2B) is the default load.

## Validation

```
xcodebuild ... test ... CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO \
  -only-testing:CotabbyTests/RuntimeAndInputModelValueTests \
  -only-testing:CotabbyTests/OnboardingTemplateRecommenderTests
# ** TEST SUCCEEDED **  Executed 17 tests, 0 failures
#   RuntimeAndInputModelValueTests        4/4  (catalog displayName mappings)
#   OnboardingTemplateRecommenderTests   13/13 (tier -> GGUF: nano / base / pro)

swiftlint lint --quiet   # exit 0 (clean)
```

App-hosted tests run unsigned (the default-signed bundle hits a Team ID mismatch on this machine).

## Linked issues

None filed. Follow-up to the base-model migration; addresses recurring confusion from the
five-names-two-families catalog.

## Risk / rollout notes

- **Relabel, not a re-download.** `displayName` is derived from the filename and the persisted state
  is the filename, so an existing user's installed model keeps working and just shows its new label.
- **`Qwen3.5-4B-Base` retired.** Removed from the download list and preferred-load order. An
  already-installed copy still loads and falls back to its raw filename (existing retired-model
  behavior, covered by a test).
- **Default + Everyday are now `tabby-2-base` (gemma-4-E2B, ~4.5 GB).** This makes the recommended
  onboarding download larger than before (~1.4 GB Qwen 2B previously). Intentional per the requested
  lineup. Quick stays nano (~0.8 GB); Powerful is pro (gemma-4-E4B, ~5.0 GB).
- **Naming caveat carried over:** `base` is both a tier name and the technical term for these
  non-instruct models. Kept per the requested lineup.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR collapses the five-model Open Source catalog into a clean four-tier ladder (`nano / mini / base / pro`), retiring the `tabby-2-gemma-*` sub-brand and the dropped Qwen 4B, and rewires onboarding templates to the new filenames.

- **Catalog relabeling**: `displayName` switch in `LlamaRuntimeModels.swift` updated to the new four-tier names; Qwen 4B removed from `downloadableModels`; display-name and retired-model fallback tests extended to cover all four active tiers.
- **Onboarding rewiring**: `.everyday` now installs `gemma-4-E2B` (4.5 GB, up from 1.4 GB) and `.powerful` now installs `gemma-4-E4B` (5.0 GB, previously the broken dropped-4B path); test assertions updated accordingly.
- **preferredModelNames reordered**: `gemma-4-E2B.i1-Q6_K.gguf` moved to position 0, making it the auto-loaded model for any user who has it installed — despite the PR description's explicit note that this change was intentionally deferred.

<h3>Confidence Score: 4/5</h3>

Safe to merge for new users and single-model installs; users with both Qwen 2B and Gemma E2B installed will silently switch to the larger model on next launch.

The PR description explicitly deferred promoting Gemma E2B to the default load due to the 1.4 GB to 4.5 GB size jump, yet preferredModelNames and the README both implement that promotion. Any user who had the old tabby-2-gemma-mini installed alongside the old tabby-2-base will experience a silent auto-load change.

Cotabby/Models/LlamaRuntimeModels.swift and README.md need to be reconciled — either the preferredModelNames order should revert to keep Qwen 2B first, or the PR description should be updated to acknowledge this as an intentional change.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Models/LlamaRuntimeModels.swift | Relabels displayName mappings (nano/mini/base/pro), removes 4B Qwen entry from catalog, and moves gemma-4-E2B to first position in preferredModelNames — contradicting the PR description's explicit statement that changing the default load was intentionally excluded. |
| Cotabby/Models/OnboardingTemplate.swift | Rewires .everyday to gemma-4-E2B (4.5 GB) and .powerful to gemma-4-E4B (5.0 GB); .quick is unchanged. The everyday tier now triggers a 3x larger download during onboarding, though this is intentional per the new tier lineup. |
| CotabbyTests/ModelAndPresentationValueTests.swift | Extends displayName test coverage to all four active tiers and adds a retired-model fallback assertion for the dropped Qwen 4B; tests are aligned with the new catalog. |
| CotabbyTests/OnboardingTemplateRecommenderTests.swift | Updates tier-to-GGUF assertions to the new filenames; availability-gating tests remain structurally unchanged, keeping the 8 GB disable floor whose governing comment is now stale (previously flagged). |
| README.md | Collapses the five-row model table to four rows with new tier names; the updated default description contradicts the PR description's claim that making Gemma E2B the default was intentionally left out. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Old["Old catalog (5 models)"]
        O1["tabby-2-mini\nQwen3.5-0.8B (~0.8 GB)"]
        O2["tabby-2-base\nQwen3.5-2B (~1.4 GB)"]
        O3["tabby-2-pro\nQwen3.5-4B (~2.6 GB) - DROPPED"]
        O4["tabby-2-gemma-mini\ngemma-4-E2B (~4.5 GB)"]
        O5["tabby-2-gemma-pro\ngemma-4-E4B (~5.0 GB)"]
    end
    subgraph New["New catalog (4 models)"]
        N1["tabby-2-nano\nQwen3.5-0.8B (~0.8 GB)"]
        N2["tabby-2-mini\nQwen3.5-2B (~1.4 GB)"]
        N3["tabby-2-base\ngemma-4-E2B (~4.5 GB)"]
        N4["tabby-2-pro\ngemma-4-E4B (~5.0 GB)"]
    end
    subgraph Onboarding["Onboarding tiers to GGUF"]
        QK["Quick"] --> N1
        EV["Everyday 1.4GB to 4.5GB"] --> N3
        PW["Powerful"] --> N4
    end
    O1 --> N1
    O2 --> N2
    O3 -. dropped .-> N3
    O4 --> N3
    O5 --> N4
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22chore%2Fbase-model-catalog-four-tiers%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2Fbase-model-catalog-four-tiers%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FModels%2FLlamaRuntimeModels.swift%3A159-166%0A**preferredModelNames%20promotes%20Gemma%20E2B%20to%20first%20despite%20PR%20description%20explicitly%20deferring%20that**%0A%0AThe%20PR%20description's%20%22Risk%20%2F%20rollout%20notes%22%20says%20%22Making%20%60base%60%20the%20default%20is%20a%20one-line%20change%20but%20raises%20the%20default%20download%20from%20~1.4%20GB%20to%20~4.5%20GB%2C%20so%20it%20is%20intentionally%20left%20out%20of%20this%20PR.%22%20Yet%20this%20diff%20moves%20%60gemma-4-E2B.i1-Q6_K.gguf%60%20to%20position%200%20in%20%60preferredModelNames%60%2C%20and%20the%20README%20now%20says%20%22tabby-2-base%20%28Gemma%20E2B%29%20is%20the%20default.%22%20The%20locator%20picks%20the%20first%20GGUF%20that%20exists%2C%20so%20any%20user%20who%20has%20both%20Qwen%202B%20and%20Gemma%20E2B%20installed%20will%20silently%20auto-load%20Gemma%20E2B%20%284.5%20GB%29%20instead%20of%20Qwen%202B%20%281.4%20GB%29%20after%20this%20update%20%E2%80%94%20a%20direct%20contradiction%20of%20%22no%20change%20to%20anyone's%20selected%20model.%22%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FModels%2FLlamaRuntimeModels.swift%3A159-166%0A**preferredModelNames%20promotes%20Gemma%20E2B%20to%20first%20despite%20PR%20description%20explicitly%20deferring%20that**%0A%0AThe%20PR%20description's%20%22Risk%20%2F%20rollout%20notes%22%20says%20%22Making%20%60base%60%20the%20default%20is%20a%20one-line%20change%20but%20raises%20the%20default%20download%20from%20~1.4%20GB%20to%20~4.5%20GB%2C%20so%20it%20is%20intentionally%20left%20out%20of%20this%20PR.%22%20Yet%20this%20diff%20moves%20%60gemma-4-E2B.i1-Q6_K.gguf%60%20to%20position%200%20in%20%60preferredModelNames%60%2C%20and%20the%20README%20now%20says%20%22tabby-2-base%20%28Gemma%20E2B%29%20is%20the%20default.%22%20The%20locator%20picks%20the%20first%20GGUF%20that%20exists%2C%20so%20any%20user%20who%20has%20both%20Qwen%202B%20and%20Gemma%20E2B%20installed%20will%20silently%20auto-load%20Gemma%20E2B%20%284.5%20GB%29%20instead%20of%20Qwen%202B%20%281.4%20GB%29%20after%20this%20update%20%E2%80%94%20a%20direct%20contradiction%20of%20%22no%20change%20to%20anyone's%20selected%20model.%22%0A%0A&repo=fujacob%2Fcotabby&pr=514&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Make tabby-2-base the default and the Ev..."](https://github.com/fujacob/cotabby/commit/5346fe3e715826962c5efdc3c372e7318610456e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35034340)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->