### PR TITLE
Accept one word at a time in space-less scripts

### DIFF
--- a/Cotabby/Support/SuggestionSessionReconciler.swift
+++ b/Cotabby/Support/SuggestionSessionReconciler.swift
@@ -247,12 +247,43 @@ enum SuggestionSessionReconciler {
             index = remainingText.index(after: index)
         }
 
+        // Space-less scripts (CJK, Japanese, Korean, Thai, ...) put no whitespace between words, so the
+        // whitespace scan above swallows an entire run as a single "word". When the token begins with
+        // such a script, segment it with ICU word breaking and accept only the first word, so one Tab
+        // advances by a single word the way it does in space-delimited text. Space-delimited scripts
+        // never enter this branch, so Latin / Cyrillic / Arabic acceptance stays byte-for-byte unchanged.
+        if tokenStart < index,
+           remainingText[tokenStart].beginsSpacelessScriptWord,
+           let wordEnd = firstSegmentedWordEnd(in: remainingText, from: tokenStart, notPast: index) {
+            index = wordEnd
+        }
+
         if !autoAcceptTrailingPunctuation,
            let wordEnd = wordEndTrimmingTrailingPunctuation(in: remainingText, from: tokenStart, to: index) {
             index = wordEnd
         }
 
         return String(remainingText[..<index])
+    }
+
+    /// The index just past the first ICU word in `text[from..<limit]`, or nil when segmentation finds
+    /// no word there. Only the space-less-script branch of `nextAcceptanceChunk` calls this; the result
+    /// is clamped to `limit` so it can never extend past the non-whitespace token the caller already
+    /// bounded. `.substringNotRequired` skips materializing the word string we don't need.
+    private static func firstSegmentedWordEnd(
+        in text: String,
+        from start: String.Index,
+        notPast limit: String.Index
+    ) -> String.Index? {
+        var wordEnd: String.Index?
+        text.enumerateSubstrings(in: start..<limit, options: [.byWords, .substringNotRequired]) { _, range, _, stop in
+            wordEnd = range.upperBound
+            stop = true
+        }
+        guard let wordEnd, wordEnd > start else {
+            return nil
+        }
+        return min(wordEnd, limit)
     }
 
     /// Accepts a full phrase up to the next sentence terminator (`.`, `!`, `?`, `\n`) or the end
@@ -490,6 +521,34 @@ private extension String {
 }
 
 private extension Character {
+    /// True when the character begins a word of a space-less script (Han, Hiragana, Katakana, Hangul,
+    /// Thai, Lao, Khmer, Myanmar, ...). These scripts write words without separating spaces, so the
+    /// whitespace-run acceptance rule would over-accept a whole run; `nextAcceptanceChunk` switches to
+    /// ICU word segmentation when a token begins with one of them. Detection is by leading scalar so it
+    /// stays a cheap, allocation-free check on the common (space-delimited) path.
+    var beginsSpacelessScriptWord: Bool {
+        guard let scalar = unicodeScalars.first else {
+            return false
+        }
+        switch scalar.value {
+        case 0x3040...0x30FF,   // Hiragana + Katakana
+             0x3400...0x4DBF,   // CJK Unified Ideographs Extension A
+             0x4E00...0x9FFF,   // CJK Unified Ideographs
+             0xF900...0xFAFF,   // CJK Compatibility Ideographs
+             0xAC00...0xD7A3,   // Hangul syllables
+             0x1100...0x11FF,   // Hangul Jamo
+             0x0E00...0x0E7F,   // Thai
+             0x0E80...0x0EFF,   // Lao
+             0x1780...0x17FF,   // Khmer
+             0x1000...0x109F,   // Myanmar
+             0x20000...0x2A6DF, // CJK Unified Ideographs Extension B
+             0x30000...0x3134F: // CJK Unified Ideographs Extension G
+            return true
+        default:
+            return false
+        }
+    }
+
     /// Alphanumerics form the core of a "word"; everything else trailing a word is punctuation that
     /// can be peeled into its own acceptance part when auto-accept is disabled.
     var isAcceptanceWordCharacter: Bool {

--- a/CotabbyTests/SuggestionSessionReconcilerTests.swift
+++ b/CotabbyTests/SuggestionSessionReconcilerTests.swift
@@ -131,6 +131,61 @@ final class SuggestionSessionReconcilerTests: XCTestCase {
         )
     }
 
+    // MARK: - Space-less-script word acceptance
+
+    func test_nextAcceptanceChunk_latinAcceptanceIsUnchangedBySpacelessBranch() {
+        // Regression guard: the space-less branch must never alter space-delimited acceptance.
+        XCTAssertEqual(SuggestionSessionReconciler.nextAcceptanceChunk(from: "hello world"), "hello")
+        XCTAssertEqual(SuggestionSessionReconciler.nextAcceptanceChunk(from: "don't stop now"), "don't")
+        XCTAssertEqual(SuggestionSessionReconciler.nextAcceptanceChunk(from: "U.S.A today"), "U.S.A")
+        XCTAssertEqual(SuggestionSessionReconciler.nextAcceptanceChunk(from: "1.5 times"), "1.5")
+        XCTAssertEqual(SuggestionSessionReconciler.nextAcceptanceChunk(from: "café René"), "café")
+        // A space-less script appearing later in the tail must not pull the first Latin token early.
+        XCTAssertEqual(SuggestionSessionReconciler.nextAcceptanceChunk(from: "world 你好"), "world")
+    }
+
+    func test_nextAcceptanceChunk_segmentsChineseBelowWholeLength() {
+        // ICU word segmentation may be per-character or dictionary-based depending on the OS, so this
+        // asserts the robust property (accept one segment, not the whole run) rather than a pinned word.
+        let run = "你好世界"
+        let chunk = SuggestionSessionReconciler.nextAcceptanceChunk(from: run)
+        XCTAssertFalse(chunk.isEmpty)
+        XCTAssertTrue(run.hasPrefix(chunk))
+        XCTAssertLessThan(chunk.count, run.count, "a space-less Chinese run must segment, not accept the whole run")
+    }
+
+    func test_nextAcceptanceChunk_segmentsJapaneseRunBelowWholeLength() {
+        let run = "今日はいい天気です"
+        let chunk = SuggestionSessionReconciler.nextAcceptanceChunk(from: run)
+        XCTAssertFalse(chunk.isEmpty)
+        XCTAssertTrue(run.hasPrefix(chunk))
+        XCTAssertLessThan(chunk.count, run.count, "a space-less Japanese run must segment, not accept whole")
+    }
+
+    func test_nextAcceptanceChunk_segmentsThaiRunBelowWholeLength() {
+        let run = "สวัสดีครับ"
+        let chunk = SuggestionSessionReconciler.nextAcceptanceChunk(from: run)
+        XCTAssertFalse(chunk.isEmpty)
+        XCTAssertTrue(run.hasPrefix(chunk))
+        XCTAssertLessThan(chunk.count, run.count, "a space-less Thai run must segment, not accept whole")
+    }
+
+    func test_nextAcceptanceChunk_chineseAcceptanceStaysWithinRunBeforeSpace() {
+        let chunk = SuggestionSessionReconciler.nextAcceptanceChunk(from: "你好 world")
+        XCTAssertFalse(chunk.isEmpty)
+        XCTAssertTrue("你好".hasPrefix(chunk), "acceptance must stay within the CJK run and not cross the space")
+        XCTAssertFalse(chunk.contains(" "))
+    }
+
+    func test_nextAcceptanceChunk_keepsLeadingWhitespaceBeforeSpacelessWord() {
+        let chunk = SuggestionSessionReconciler.nextAcceptanceChunk(from: " 你好世界")
+        XCTAssertTrue(chunk.hasPrefix(" "), "leading whitespace is preserved before the segmented word")
+        let afterSpace = String(chunk.dropFirst())
+        XCTAssertFalse(afterSpace.isEmpty)
+        XCTAssertTrue("你好世界".hasPrefix(afterSpace))
+        XCTAssertLessThan(afterSpace.count, 4, "only the first segment is accepted, not the whole run")
+    }
+
     // MARK: - Phrase chunker
 
     func test_nextAcceptancePhrase_returnsEmptyForEmptyTail() {


### PR DESCRIPTION
## Summary

Tab acceptance scanned to the next whitespace boundary to find "a word", so in scripts written
without spaces between words (Chinese, Japanese, Thai, Lao, Khmer, ...) a single Tab swallowed the
entire suggestion run instead of advancing one word. When an acceptance token begins with such a
script, it is now segmented with ICU word breaking and only the first segment is accepted, matching
the one-word-per-Tab feel of space-delimited text. Space-delimited scripts never enter the new
branch, so Latin / Cyrillic / Arabic acceptance is byte-for-byte unchanged.

## Validation

```
xcodebuild ... test ... CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO \
  -only-testing:CotabbyTests/SuggestionSessionReconcilerTests \
  -only-testing:CotabbyTests/SuggestionCoordinatorAcceptanceTests
# ** TEST SUCCEEDED ** — 72 reconciler + 6 acceptance tests, 0 failures
#   incl. a Latin-unchanged regression guard and CJK / Japanese / Thai segmentation cases

swiftlint lint --quiet   # exit 0 (clean)
```

## Linked issues

None. Closes a confirmed gap where one Tab accepted an entire space-less-script suggestion.

## Risk / rollout notes

- **Latin/space-delimited acceptance is unchanged** — the whitespace-run path is untouched; the new
  ICU branch only runs when a token *begins* with a space-less script (detected by leading scalar).
- Segmentation granularity follows the OS ICU word breaker (per-character or dictionary-based
  depending on the script/OS); tests assert the robust property (one segment, not the whole run)
  rather than a pinned word, so they don't flake on ICU differences.
- Full-suggestion acceptance (the full-accept key) still takes everything at once.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes single-Tab over-acceptance in space-less scripts (Chinese, Japanese, Thai, Khmer, etc.) by routing the acceptance chunk through ICU's `enumerateSubstrings(.byWords)` whenever the leading character of a non-whitespace token is detected as belonging to a space-less script. Latin/Cyrillic/Arabic paths are untouched.

- `beginsSpacelessScriptWord` on `Character` performs a cheap scalar-value range check to gate the new branch, keeping the common space-delimited path allocation-free.
- `firstSegmentedWordEnd` wraps `enumerateSubstrings` with an early-exit and `min(..., limit)` clamp, correctly bounding the result to the whitespace-scanned token.
- Six new unit tests cover a Latin regression guard, CJK/Japanese/Thai run segmentation, cross-space boundary containment, and leading-whitespace preservation, with intentionally OS-agnostic \"less than whole run\" assertions.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the new ICU branch is correctly gated and cannot affect Latin/Cyrillic/Arabic acceptance paths.

The core logic is correct and well-tested. The only gap is that CJK Unified Ideograph Extensions C, D, E, and F are missing from the range table, so rare archaic Han characters starting a token would still trigger the old whole-run acceptance. The impact is narrow and the fallback is the previous behavior rather than a crash or data loss.

The `beginsSpacelessScriptWord` switch in `SuggestionSessionReconciler.swift` needs the four missing CJK extension ranges added.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/SuggestionSessionReconciler.swift | Adds ICU word-break segmentation for space-less scripts; logic is sound but the `beginsSpacelessScriptWord` switch misses CJK Extensions C–F (U+2A700–U+2EBEF) |
| CotabbyTests/SuggestionSessionReconcilerTests.swift | Good test coverage for the new branch with Latin regression guard, CJK/Japanese/Thai run tests, and leading-whitespace preservation; the "less than whole run" assertions are intentionally OS-agnostic |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[nextAcceptanceChunk called] --> B[Skip leading whitespace to tokenStart]
    B --> C[Scan forward to next whitespace to index]
    C --> D{tokenStart < index AND leading char is space-less script?}
    D -- No --> F{autoAcceptTrailingPunctuation = false?}
    D -- Yes --> E[firstSegmentedWordEnd: enumerateSubstrings byWords stop after first segment]
    E --> E2{wordEnd found and wordEnd > tokenStart?}
    E2 -- Yes --> E3[index = min wordEnd limit]
    E2 -- No --> F
    E3 --> F
    F -- Yes --> G[wordEndTrimmingTrailingPunctuation peel trailing non-word chars]
    G --> H[Return remainingText up to index]
    F -- No --> H
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Funicode-word-acceptance%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Funicode-word-acceptance%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FSupport%2FSuggestionSessionReconciler.swift%3A544-545%0ACJK%20Unified%20Ideograph%20Extensions%20C%2C%20D%2C%20E%2C%20and%20F%20%28U%2B2A700%E2%80%93U%2B2EBEF%29%20are%20absent%20from%20the%20switch.%20Any%20suggestion%20that%20starts%20with%20a%20character%20from%20those%20blocks%20%28rare%2Farchaic%20Han%20characters%20appearing%20in%20scholarly%20texts%29%20would%20pass%20%60beginsSpacelessScriptWord%60%20as%20%60false%60%20and%20fall%20through%20to%20the%20old%20whitespace-scan%20path%2C%20accepting%20the%20whole%20run%20on%20a%20single%20Tab.%20Extension%20B%20ends%20at%20U%2B2A6DF%20and%20Extension%20G%20starts%20at%20U%2B30000%2C%20so%20the%20gap%20is%20currently%20silent.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%200x20000...0x2A6DF%2C%20%2F%2F%20CJK%20Unified%20Ideographs%20Extension%20B%0A%20%20%20%20%20%20%20%20%20%20%20%20%200x2A700...0x2B73F%2C%20%2F%2F%20CJK%20Unified%20Ideographs%20Extension%20C%0A%20%20%20%20%20%20%20%20%20%20%20%20%200x2B740...0x2B81F%2C%20%2F%2F%20CJK%20Unified%20Ideographs%20Extension%20D%0A%20%20%20%20%20%20%20%20%20%20%20%20%200x2B820...0x2CEAF%2C%20%2F%2F%20CJK%20Unified%20Ideographs%20Extension%20E%0A%20%20%20%20%20%20%20%20%20%20%20%20%200x2CEB0...0x2EBEF%2C%20%2F%2F%20CJK%20Unified%20Ideographs%20Extension%20F%0A%20%20%20%20%20%20%20%20%20%20%20%20%200x30000...0x3134F%3A%20%2F%2F%20CJK%20Unified%20Ideographs%20Extension%20G%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabbyTests%2FSuggestionSessionReconcilerTests.swift%3A186%0A**Fragile%20magic-number%20bound%20in%20leading-whitespace%20test**%0A%0AThe%20assertion%20%60afterSpace.count%20%3C%204%60%20is%20tied%20to%20the%20length%20of%20the%20literal%20run%20%60%22%E4%BD%A0%E5%A5%BD%E4%B8%96%E7%95%8C%22%60%20%284%20grapheme%20clusters%29.%20If%20a%20future%20maintainer%20changes%20the%20run%20to%20something%20shorter%20%E2%80%94%20say%203%20characters%20%E2%80%94%20the%20guard%20would%20vacuously%20pass%20even%20if%20the%20entire%20run%20were%20accepted%20in%20one%20chunk.%20Expressing%20the%20bound%20relative%20to%20the%20actual%20run%20length%20%28e.g.%20%60afterSpace.count%20%3C%20%22%E4%BD%A0%E5%A5%BD%E4%B8%96%E7%95%8C%22.count%60%29%20makes%20the%20intent%20self-documenting%20and%20resilient%20to%20edits.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FSupport%2FSuggestionSessionReconciler.swift%3A544-545%0ACJK%20Unified%20Ideograph%20Extensions%20C%2C%20D%2C%20E%2C%20and%20F%20%28U%2B2A700%E2%80%93U%2B2EBEF%29%20are%20absent%20from%20the%20switch.%20Any%20suggestion%20that%20starts%20with%20a%20character%20from%20those%20blocks%20%28rare%2Farchaic%20Han%20characters%20appearing%20in%20scholarly%20texts%29%20would%20pass%20%60beginsSpacelessScriptWord%60%20as%20%60false%60%20and%20fall%20through%20to%20the%20old%20whitespace-scan%20path%2C%20accepting%20the%20whole%20run%20on%20a%20single%20Tab.%20Extension%20B%20ends%20at%20U%2B2A6DF%20and%20Extension%20G%20starts%20at%20U%2B30000%2C%20so%20the%20gap%20is%20currently%20silent.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%200x20000...0x2A6DF%2C%20%2F%2F%20CJK%20Unified%20Ideographs%20Extension%20B%0A%20%20%20%20%20%20%20%20%20%20%20%20%200x2A700...0x2B73F%2C%20%2F%2F%20CJK%20Unified%20Ideographs%20Extension%20C%0A%20%20%20%20%20%20%20%20%20%20%20%20%200x2B740...0x2B81F%2C%20%2F%2F%20CJK%20Unified%20Ideographs%20Extension%20D%0A%20%20%20%20%20%20%20%20%20%20%20%20%200x2B820...0x2CEAF%2C%20%2F%2F%20CJK%20Unified%20Ideographs%20Extension%20E%0A%20%20%20%20%20%20%20%20%20%20%20%20%200x2CEB0...0x2EBEF%2C%20%2F%2F%20CJK%20Unified%20Ideographs%20Extension%20F%0A%20%20%20%20%20%20%20%20%20%20%20%20%200x30000...0x3134F%3A%20%2F%2F%20CJK%20Unified%20Ideographs%20Extension%20G%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabbyTests%2FSuggestionSessionReconcilerTests.swift%3A186%0A**Fragile%20magic-number%20bound%20in%20leading-whitespace%20test**%0A%0AThe%20assertion%20%60afterSpace.count%20%3C%204%60%20is%20tied%20to%20the%20length%20of%20the%20literal%20run%20%60%22%E4%BD%A0%E5%A5%BD%E4%B8%96%E7%95%8C%22%60%20%284%20grapheme%20clusters%29.%20If%20a%20future%20maintainer%20changes%20the%20run%20to%20something%20shorter%20%E2%80%94%20say%203%20characters%20%E2%80%94%20the%20guard%20would%20vacuously%20pass%20even%20if%20the%20entire%20run%20were%20accepted%20in%20one%20chunk.%20Expressing%20the%20bound%20relative%20to%20the%20actual%20run%20length%20%28e.g.%20%60afterSpace.count%20%3C%20%22%E4%BD%A0%E5%A5%BD%E4%B8%96%E7%95%8C%22.count%60%29%20makes%20the%20intent%20self-documenting%20and%20resilient%20to%20edits.%0A%0A&repo=fujacob%2Fcotabby&pr=515&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Accept one word at a time in space-less ..."](https://github.com/fujacob/cotabby/commit/410faeadcd1d4e29f24ba8159518e9e86da62dee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35041206)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->