### PR TITLE
Catch more secure fields: role description and non-password secrets

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		4CAFD8F3444FEDC9ACAFF529 /* LlamaRuntimeModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A804F4DB6FD9BC8C27B2B65F /* LlamaRuntimeModels.swift */; };
 		4F369F5284DDCEABF082E59B /* SuggestionAvailabilityEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3609CC88A5280B3AA40414DF /* SuggestionAvailabilityEvaluator.swift */; };
 		4F38CE1C2602CF4F41323032 /* PermissionOverlayTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12DD19BCE610808F1E38702D /* PermissionOverlayTrackerTests.swift */; };
+		4FC52FB28AFC013F000D8FF9 /* SecureFieldDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 474560E524C1D74BAB1570DA /* SecureFieldDetectorTests.swift */; };
 		51C069603DA16830868F1628 /* LanguageTagsEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7CDA90E128350BFF1A9D66 /* LanguageTagsEditor.swift */; };
 		52518CF0760DFEE9AF7C786C /* SuggestionEngineRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384FBCF5D7A3A446C5BE2B8D /* SuggestionEngineRouter.swift */; };
 		53FB56A095BCF0389DAC0A56 /* SuggestionTextColorCodec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CE61E74928C221B8BB261C6 /* SuggestionTextColorCodec.swift */; };
@@ -172,6 +173,7 @@
 		9ADFFF634912F638D079E1C7 /* SentenceBoundaryClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B56C250DDEF3E81F9DCBD7 /* SentenceBoundaryClassifier.swift */; };
 		9CEBD6AF4405F1BBE0E3D16C /* MidWordContinuationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 357C18383B047F24A531BDCD /* MidWordContinuationPolicy.swift */; };
 		9F2FDCABCC941CBECAA3B4AB /* CotabbyInference in Frameworks */ = {isa = PBXBuildFile; productRef = 48A46AD6B613CF06072603E4 /* CotabbyInference */; };
+		9F6F88ED74ECA3E23A8E3CC0 /* SecureFieldDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1827565F4FAD3E4E61CA65C3 /* SecureFieldDetector.swift */; };
 		A0657CE0488F69F0BD559CBC /* SuggestionCoordinator+Acceptance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72B13136DF7318F3E96DF0D3 /* SuggestionCoordinator+Acceptance.swift */; };
 		A0BB87E3665EF6C209034798 /* GhostSuggestionLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AD3F4F9FBE82007E4E15F58 /* GhostSuggestionLayoutTests.swift */; };
 		A147C5EC3F2214A670F7556E /* FocusPollBackoffTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 273B4DC844F79B4BE2C8910F /* FocusPollBackoffTests.swift */; };
@@ -290,6 +292,7 @@
 		1274F897631B1B3A835D157F /* MidWordContinuationPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MidWordContinuationPolicyTests.swift; sourceTree = "<group>"; };
 		12DD19BCE610808F1E38702D /* PermissionOverlayTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOverlayTrackerTests.swift; sourceTree = "<group>"; };
 		1441B2D89DAE6878DAD11F17 /* EmojiMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiMatcher.swift; sourceTree = "<group>"; };
+		1827565F4FAD3E4E61CA65C3 /* SecureFieldDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureFieldDetector.swift; sourceTree = "<group>"; };
 		18D990E515E1AE4F312F4E95 /* BundledRuntimeLocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledRuntimeLocatorTests.swift; sourceTree = "<group>"; };
 		1972BD2C5254D8266618781F /* FocusCapabilityFlickerGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusCapabilityFlickerGateTests.swift; sourceTree = "<group>"; };
 		19BE12C28A4AB8A4A58C2FF7 /* SettingsPaneScaffold.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPaneScaffold.swift; sourceTree = "<group>"; };
@@ -333,6 +336,7 @@
 		4451D6673112575DF24C4A48 /* OnboardingTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTemplate.swift; sourceTree = "<group>"; };
 		44595B534DD7323F0AD60825 /* MenuBarPopoverDismisser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarPopoverDismisser.swift; sourceTree = "<group>"; };
 		4696A84D17890B154533A08F /* PromptPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptPolicyTests.swift; sourceTree = "<group>"; };
+		474560E524C1D74BAB1570DA /* SecureFieldDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureFieldDetectorTests.swift; sourceTree = "<group>"; };
 		4793D4EA5D36D7E5CC216C27 /* LanguageSupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageSupportTests.swift; sourceTree = "<group>"; };
 		47CF010A66DA31989524FCD0 /* ConstrainedSampler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstrainedSampler.swift; sourceTree = "<group>"; };
 		51020F8CD58338BD643FBF63 /* ModelDownloadManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelDownloadManager.swift; sourceTree = "<group>"; };
@@ -782,6 +786,7 @@
 				E260C4D08C786CDBD527B329 /* PromptSectionBudgetTests.swift */,
 				5D957E76B6EA508DE3510F98 /* RepetitionGuardTests.swift */,
 				B2BFD19A159680A495EE02FD /* ScreenshotContextGeneratorTests.swift */,
+				474560E524C1D74BAB1570DA /* SecureFieldDetectorTests.swift */,
 				2D7360A6D4261989A66658ED /* SentenceBoundaryClassifierTests.swift */,
 				2BC293F6125E2B14DCF05AD9 /* SettingsAttentionEvaluatorTests.swift */,
 				0850B07CCDBA67C756C6EC59 /* ShortcutConflictTests.swift */,
@@ -935,6 +940,7 @@
 				AFCFCCCB69C29A86E726B10A /* PromptSectionBudget.swift */,
 				04FAB8DC9CC29F7A3EB8C91F /* RepetitionGuard.swift */,
 				6DC693E00430F46E41CB56E6 /* RequestID.swift */,
+				1827565F4FAD3E4E61CA65C3 /* SecureFieldDetector.swift */,
 				D4B56C250DDEF3E81F9DCBD7 /* SentenceBoundaryClassifier.swift */,
 				2A02336442BB735EE2E8D064 /* SettingsAttentionEvaluator.swift */,
 				3609CC88A5280B3AA40414DF /* SuggestionAvailabilityEvaluator.swift */,
@@ -1192,6 +1198,7 @@
 				2C6159231472A849F15BD0AE /* ScreenFrameReader.swift in Sources */,
 				0C06CAD62975E87B2C852191 /* ScreenTextExtractor.swift in Sources */,
 				DD7FA343F1C21C4569F6D181 /* ScreenshotContextGenerator.swift in Sources */,
+				9F6F88ED74ECA3E23A8E3CC0 /* SecureFieldDetector.swift in Sources */,
 				9ADFFF634912F638D079E1C7 /* SentenceBoundaryClassifier.swift in Sources */,
 				84A4CA05AF6885AE4FA4C13A /* SettingsAttentionEvaluator.swift in Sources */,
 				907A0BF56C3BB0CBAF2649AB /* SettingsCategory.swift in Sources */,
@@ -1300,6 +1307,7 @@
 				7EB20783E0D36715D1230A5C /* PromptSectionBudgetTests.swift in Sources */,
 				ED642B8D6D0EAF52E3907DE5 /* RepetitionGuardTests.swift in Sources */,
 				1B3FFCB9A979F49BF86EAAD4 /* ScreenshotContextGeneratorTests.swift in Sources */,
+				4FC52FB28AFC013F000D8FF9 /* SecureFieldDetectorTests.swift in Sources */,
 				1D1C6FF0B8F50AC14A1000F4 /* SentenceBoundaryClassifierTests.swift in Sources */,
 				C618C5595DA9C57C806A3E03 /* SettingsAttentionEvaluatorTests.swift in Sources */,
 				8441299082E6B68F7F88911B /* ShortcutConflictTests.swift in Sources */,

--- a/Cotabby/Services/Focus/FocusSnapshotResolver.swift
+++ b/Cotabby/Services/Focus/FocusSnapshotResolver.swift
@@ -798,18 +798,16 @@ struct FocusSnapshotResolver {
 
     /// Detects secure inputs so Cotabby can intentionally refuse to operate in sensitive fields.
     private func isSecureElement(element: AXUIElement, role: String, subrole: String?) -> Bool {
-        let secureMarkers = [
-            role.lowercased(),
-            subrole?.lowercased() ?? "",
-            AXHelper.stringValue(for: kAXDescriptionAttribute as CFString, on: element)?
-                .lowercased() ?? "",
-            AXHelper.stringValue(for: kAXTitleAttribute as CFString, on: element)?.lowercased()
-                ?? ""
-        ]
-
-        return secureMarkers.contains { marker in
-            marker.contains("secure") || marker.contains("password")
-        }
+        // Read the role description too: a native NSSecureTextField announces its sensitivity there
+        // ("secure text field") rather than through AXDescription, so the previous role/desc/title-only
+        // check missed it. SecureFieldDetector owns the (pure, testable) marker policy.
+        SecureFieldDetector.isSecure(
+            role: role,
+            subrole: subrole,
+            roleDescription: AXHelper.stringValue(for: kAXRoleDescriptionAttribute as CFString, on: element),
+            title: AXHelper.stringValue(for: kAXTitleAttribute as CFString, on: element),
+            descriptionLabel: AXHelper.stringValue(for: kAXDescriptionAttribute as CFString, on: element)
+        )
     }
 
     // MARK: - Debug AX tree dump

--- a/Cotabby/Support/SecureFieldDetector.swift
+++ b/Cotabby/Support/SecureFieldDetector.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// File overview:
+/// Pure classification of whether a focused field is sensitive enough that Cotabby must never
+/// generate a suggestion for it (passwords, card numbers, security/verification codes, ...). Kept
+/// pure and string-only so the policy is unit-testable without a live Accessibility element: the
+/// resolver reads a few AX markers and hands the strings here.
+///
+/// Why this exists:
+/// The previous inline check looked only at the role, subrole, `AXDescription`, and `AXTitle` for the
+/// substrings "secure" / "password". That missed two common cases: a native `NSSecureTextField`,
+/// which announces its sensitivity through the *role description* ("secure text field") rather than
+/// the description; and fields labelled for other secrets (CVV, security code, one-time code) that
+/// never contain the literal word "password". Suppressing in a non-sensitive field only costs a
+/// missed suggestion, so the marker set deliberately errs toward caution.
+enum SecureFieldDetector {
+    /// True when any supplied Accessibility marker indicates a sensitive field. Every marker is
+    /// optional so the caller can pass whatever it managed to read; nil and empty markers are ignored.
+    /// Matching is case-insensitive substring containment, which is why a role description of
+    /// "secure text field" trips the "secure" marker.
+    static func isSecure(
+        role: String?,
+        subrole: String?,
+        roleDescription: String?,
+        title: String?,
+        descriptionLabel: String?
+    ) -> Bool {
+        let markers = [role, subrole, roleDescription, title, descriptionLabel]
+            .compactMap { $0?.lowercased() }
+            .filter { !$0.isEmpty }
+        return markers.contains { marker in
+            sensitiveMarkers.contains { marker.contains($0) }
+        }
+    }
+
+    /// Substrings that mark a field sensitive when they appear in any of its markers. Lowercased for
+    /// case-insensitive containment. Intentionally broad: a false positive only suppresses a
+    /// suggestion, while a false negative could surface a secret as ghost text. "secure" is kept from
+    /// the original check (it also catches the `NSSecureTextField` role description); the rest cover
+    /// the common non-password secrets that never contain the word "password".
+    static let sensitiveMarkers: [String] = [
+        "secure",
+        "password",
+        "passcode",
+        "passphrase",
+        "cvv",
+        "cvc",
+        "security code",
+        "verification code",
+        "one-time code",
+        "one time code",
+        "social security",
+        "card number",
+        "credit card"
+    ]
+}

--- a/CotabbyTests/SecureFieldDetectorTests.swift
+++ b/CotabbyTests/SecureFieldDetectorTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import Cotabby
+
+/// Tests for the pure sensitive-field policy. Suppression is the safe default, so the cases lean
+/// toward confirming that secrets are caught (including the role-description-only NSSecureTextField
+/// case the previous inline check missed) without over-matching obviously benign fields.
+final class SecureFieldDetectorTests: XCTestCase {
+    func test_isSecure_falseForPlainTextField() {
+        XCTAssertFalse(SecureFieldDetector.isSecure(
+            role: "AXTextField", subrole: nil, roleDescription: "text field",
+            title: "Email", descriptionLabel: nil))
+    }
+
+    func test_isSecure_detectsSecureTextFieldViaRoleDescriptionOnly() {
+        XCTAssertTrue(SecureFieldDetector.isSecure(
+            role: "AXTextField", subrole: nil, roleDescription: "secure text field",
+            title: nil, descriptionLabel: nil))
+    }
+
+    func test_isSecure_detectsPasswordByDescription() {
+        XCTAssertTrue(SecureFieldDetector.isSecure(
+            role: "AXTextField", subrole: nil, roleDescription: "text field",
+            title: nil, descriptionLabel: "Password"))
+    }
+
+    func test_isSecure_detectsNonPasswordSecretsByLabel() {
+        for label in ["CVV", "Security code", "Verification code", "One-time code", "Card number"] {
+            XCTAssertTrue(
+                SecureFieldDetector.isSecure(
+                    role: "AXTextField", subrole: nil, roleDescription: nil,
+                    title: label, descriptionLabel: nil),
+                "Expected \(label) to be treated as sensitive")
+        }
+    }
+
+    func test_isSecure_isCaseInsensitive() {
+        XCTAssertTrue(SecureFieldDetector.isSecure(
+            role: nil, subrole: nil, roleDescription: nil, title: "PASSWORD", descriptionLabel: nil))
+    }
+
+    func test_isSecure_ignoresNilAndEmptyMarkers() {
+        XCTAssertFalse(SecureFieldDetector.isSecure(
+            role: "", subrole: nil, roleDescription: "", title: nil, descriptionLabel: ""))
+    }
+
+    func test_isSecure_falseForUnrelatedSearchField() {
+        XCTAssertFalse(SecureFieldDetector.isSecure(
+            role: "AXTextField", subrole: nil, roleDescription: "text field",
+            title: "Search", descriptionLabel: "Type to search"))
+    }
+}


### PR DESCRIPTION
## Summary

Strengthens the secure-field gate so Cotabby suppresses suggestions in more sensitive fields. The
previous inline check read only role / subrole / `AXDescription` / `AXTitle` for the substrings
"secure" or "password", which missed (1) a native `NSSecureTextField`, whose sensitivity is announced
through the **role description** ("secure text field") rather than the description, and (2) non-password
secrets (CVV, security/verification code, one-time code, card number) that never contain the word
"password". The policy is extracted into a pure, unit-tested `SecureFieldDetector` and the resolver
now also reads `AXRoleDescription`.

## Validation

```
xcodebuild ... test ... CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO \
  -only-testing:CotabbyTests/SecureFieldDetectorTests
# ** TEST SUCCEEDED ** — 7 tests, 0 failures
#   incl. NSSecureTextField-via-role-description, non-password secrets, benign-field negatives

swiftlint lint --quiet   # exit 0 (clean)
xcodegen generate        # registered the two new files (CI drift guard passes)
```

## Linked issues

None. Closes a confirmed gap where the secure-field check missed role-description-only secure fields
and non-password secrets.

## Risk / rollout notes

- **Suppression-only change.** This can only ever cause Cotabby to *decline* to suggest in a field it
  previously acted on; it never surfaces a suggestion it previously withheld. The marker set is
  deliberately broad for that reason (a false positive costs a missed suggestion; a false negative
  could surface a secret).
- One extra `AXRoleDescription` read per secure-field check on the focus-resolve path; bounded by the
  existing 50 ms AX-messaging timeout in `AXHelper`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts the inline secure-field detection into a dedicated `SecureFieldDetector` enum and extends its coverage to include the `AXRoleDescription` attribute (catching `NSSecureTextField` that announces sensitivity only through its role description) and a broader set of sensitive-field keywords beyond "secure"/"password".

- `SecureFieldDetector.isSecure()` is a pure, string-only function with 7 unit tests; the resolver now reads one additional AX attribute (`kAXRoleDescriptionAttribute`) per focus-resolve call.
- The `sensitiveMarkers` list covers card numbers, CVV/CVC, OTC, passcodes, and social security phrases, but is missing several common abbreviated labels (`"pin"`, `"ssn"`, `"otp"`, `"secret"`) that would silently pass a field through as non-sensitive.

<h3>Confidence Score: 4/5</h3>

Safe to merge as a net security improvement; the only risk is that a few common abbreviated labels remain unblocked, which was also the case before this PR.

The refactoring is clean and suppression-only — it can never cause a previously-hidden secret to surface. The gap in the marker list (missing pin, ssn, otp, secret) means some real sensitive fields still won't be blocked, but this is not a regression introduced by the PR.

Cotabby/Support/SecureFieldDetector.swift — the sensitiveMarkers list is the authoritative policy; any gaps there silently pass sensitive fields through to the suggestion engine.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/SecureFieldDetector.swift | New pure enum encapsulating secure-field detection policy; well-structured, but the sensitiveMarkers list is missing several common sensitive-field identifiers (PIN, SSN abbreviation, secret) that could silently allow suggestions in sensitive inputs. |
| Cotabby/Services/Focus/FocusSnapshotResolver.swift | isSecureElement refactored to delegate to SecureFieldDetector; correctly adds kAXRoleDescriptionAttribute read to catch NSSecureTextField, functional behavior is equivalent for all previously-covered markers. |
| CotabbyTests/SecureFieldDetectorTests.swift | 7 focused unit tests covering the new role-description path, non-password secrets, case-insensitivity, and benign-field negatives; missing coverage for common abbreviated labels (PIN, SSN, OTP) and the all-nil input edge case. |
| Cotabby.xcodeproj/project.pbxproj | Standard project file update registering SecureFieldDetector.swift in the app target and SecureFieldDetectorTests.swift in the test target; no issues found. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as FocusSnapshotResolver
    participant AX as AXHelper
    participant Det as SecureFieldDetector

    App->>AX: stringValue(kAXRoleDescriptionAttribute)
    AX-->>App: roleDescription
    App->>AX: stringValue(kAXTitleAttribute)
    AX-->>App: title
    App->>AX: stringValue(kAXDescriptionAttribute)
    AX-->>App: descriptionLabel

    App->>Det: isSecure(role, subrole, roleDescription, title, descriptionLabel)
    Det->>Det: compactMap + filter empty markers
    Det->>Det: check each marker against sensitiveMarkers substrings
    Det-->>App: Bool

    alt "isSecure == true"
        App-->>App: skip suggestion
    else "isSecure == false"
        App-->>App: proceed with suggestion
    end
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fsecure-field-detection%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fsecure-field-detection%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FSupport%2FSecureFieldDetector.swift%3A41-55%0ASeveral%20common%20sensitive-field%20identifiers%20are%20missing%20from%20%60sensitiveMarkers%60.%20A%20field%20whose%20label%20or%20title%20is%20exactly%20%60%22PIN%22%60%2C%20%60%22SSN%22%60%2C%20or%20%60%22OTP%22%60%20would%20produce%20%60false%60%20from%20%60isSecure%28%29%60%2C%20allowing%20Cotabby%20to%20suggest%20into%20those%20fields.%20%60%22pin%22%60%20in%20particular%20is%20ubiquitous%20in%20banking%20and%20device-auth%20flows%3B%20%60%22ssn%22%60%20covers%20the%20abbreviation%20for%20Social%20Security%20Number%20that%20%60%22social%20security%22%60%20does%20not%20catch%3B%20%60%22otp%22%60%20and%20%60%22secret%22%60%20are%20common%20in%20API-credential%20and%202FA%20flows.%0A%0A%60%60%60suggestion%0A%20%20%20%20static%20let%20sensitiveMarkers%3A%20%5BString%5D%20%3D%20%5B%0A%20%20%20%20%20%20%20%20%22secure%22%2C%0A%20%20%20%20%20%20%20%20%22password%22%2C%0A%20%20%20%20%20%20%20%20%22passcode%22%2C%0A%20%20%20%20%20%20%20%20%22passphrase%22%2C%0A%20%20%20%20%20%20%20%20%22pin%22%2C%0A%20%20%20%20%20%20%20%20%22cvv%22%2C%0A%20%20%20%20%20%20%20%20%22cvc%22%2C%0A%20%20%20%20%20%20%20%20%22otp%22%2C%0A%20%20%20%20%20%20%20%20%22secret%22%2C%0A%20%20%20%20%20%20%20%20%22security%20code%22%2C%0A%20%20%20%20%20%20%20%20%22verification%20code%22%2C%0A%20%20%20%20%20%20%20%20%22one-time%20code%22%2C%0A%20%20%20%20%20%20%20%20%22one%20time%20code%22%2C%0A%20%20%20%20%20%20%20%20%22social%20security%22%2C%0A%20%20%20%20%20%20%20%20%22ssn%22%2C%0A%20%20%20%20%20%20%20%20%22card%20number%22%2C%0A%20%20%20%20%20%20%20%20%22credit%20card%22%2C%0A%20%20%20%20%20%20%20%20%22account%20number%22%0A%20%20%20%20%5D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabbyTests%2FSecureFieldDetectorTests.swift%3A26-27%0AThe%20test%20for%20non-password%20secrets%20doesn't%20include%20abbreviated%20labels%20like%20%60%22PIN%22%60%20or%20%60%22SSN%22%60%2C%20which%20are%20present%20in%20real%20banking%20UIs%20and%20absent%20from%20the%20current%20%60sensitiveMarkers%60%20list.%20Adding%20them%20here%20would%20also%20serve%20as%20a%20regression%20guard%20if%20the%20marker%20list%20is%20ever%20pruned.%0A%0A%60%60%60suggestion%0A%20%20%20%20func%20test_isSecure_detectsNonPasswordSecretsByLabel%28%29%20%7B%0A%20%20%20%20%20%20%20%20for%20label%20in%20%5B%22CVV%22%2C%20%22Security%20code%22%2C%20%22Verification%20code%22%2C%20%22One-time%20code%22%2C%20%22Card%20number%22%2C%20%22PIN%22%2C%20%22SSN%22%2C%20%22OTP%22%5D%20%7B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FSupport%2FSecureFieldDetector.swift%3A41-55%0ASeveral%20common%20sensitive-field%20identifiers%20are%20missing%20from%20%60sensitiveMarkers%60.%20A%20field%20whose%20label%20or%20title%20is%20exactly%20%60%22PIN%22%60%2C%20%60%22SSN%22%60%2C%20or%20%60%22OTP%22%60%20would%20produce%20%60false%60%20from%20%60isSecure%28%29%60%2C%20allowing%20Cotabby%20to%20suggest%20into%20those%20fields.%20%60%22pin%22%60%20in%20particular%20is%20ubiquitous%20in%20banking%20and%20device-auth%20flows%3B%20%60%22ssn%22%60%20covers%20the%20abbreviation%20for%20Social%20Security%20Number%20that%20%60%22social%20security%22%60%20does%20not%20catch%3B%20%60%22otp%22%60%20and%20%60%22secret%22%60%20are%20common%20in%20API-credential%20and%202FA%20flows.%0A%0A%60%60%60suggestion%0A%20%20%20%20static%20let%20sensitiveMarkers%3A%20%5BString%5D%20%3D%20%5B%0A%20%20%20%20%20%20%20%20%22secure%22%2C%0A%20%20%20%20%20%20%20%20%22password%22%2C%0A%20%20%20%20%20%20%20%20%22passcode%22%2C%0A%20%20%20%20%20%20%20%20%22passphrase%22%2C%0A%20%20%20%20%20%20%20%20%22pin%22%2C%0A%20%20%20%20%20%20%20%20%22cvv%22%2C%0A%20%20%20%20%20%20%20%20%22cvc%22%2C%0A%20%20%20%20%20%20%20%20%22otp%22%2C%0A%20%20%20%20%20%20%20%20%22secret%22%2C%0A%20%20%20%20%20%20%20%20%22security%20code%22%2C%0A%20%20%20%20%20%20%20%20%22verification%20code%22%2C%0A%20%20%20%20%20%20%20%20%22one-time%20code%22%2C%0A%20%20%20%20%20%20%20%20%22one%20time%20code%22%2C%0A%20%20%20%20%20%20%20%20%22social%20security%22%2C%0A%20%20%20%20%20%20%20%20%22ssn%22%2C%0A%20%20%20%20%20%20%20%20%22card%20number%22%2C%0A%20%20%20%20%20%20%20%20%22credit%20card%22%2C%0A%20%20%20%20%20%20%20%20%22account%20number%22%0A%20%20%20%20%5D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabbyTests%2FSecureFieldDetectorTests.swift%3A26-27%0AThe%20test%20for%20non-password%20secrets%20doesn't%20include%20abbreviated%20labels%20like%20%60%22PIN%22%60%20or%20%60%22SSN%22%60%2C%20which%20are%20present%20in%20real%20banking%20UIs%20and%20absent%20from%20the%20current%20%60sensitiveMarkers%60%20list.%20Adding%20them%20here%20would%20also%20serve%20as%20a%20regression%20guard%20if%20the%20marker%20list%20is%20ever%20pruned.%0A%0A%60%60%60suggestion%0A%20%20%20%20func%20test_isSecure_detectsNonPasswordSecretsByLabel%28%29%20%7B%0A%20%20%20%20%20%20%20%20for%20label%20in%20%5B%22CVV%22%2C%20%22Security%20code%22%2C%20%22Verification%20code%22%2C%20%22One-time%20code%22%2C%20%22Card%20number%22%2C%20%22PIN%22%2C%20%22SSN%22%2C%20%22OTP%22%5D%20%7B%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=516&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Catch more secure fields: role descripti..."](https://github.com/fujacob/cotabby/commit/4d22001ab4c02e82b38599cc61ae4314cb410c07) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35042014)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->