### PR TITLE
Stop the constrained decoder at sentence boundaries

### DIFF
--- a/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
+++ b/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
@@ -210,6 +210,42 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
     /// single-token runs after a few repeats, without blocking ordinary short repeats like "very very".
     private static let noRepeatNgramSize = 3
 
+    /// ASCII sentence terminators (`.` `!` `?`), used as a cheap pre-filter: the constrained decoder
+    /// only decodes the accumulated bytes to test for a sentence boundary when a token carried one of
+    /// these, keeping the steady path on raw byte accumulation.
+    private static func isSentenceTerminatorByte(_ byte: UInt8) -> Bool {
+        byte == 0x2E || byte == 0x21 || byte == 0x3F
+    }
+
+    /// The stop reason for a token that must end the loop *before* it is committed to the output: an
+    /// end-of-generation token, or a line break in a single-line field. Returns nil to commit the
+    /// token. Folding both checks into one helper keeps the decode loop under the complexity budget.
+    private static func preCommitStopReason(
+        tokenID: Int,
+        options: LlamaGenerationOptions,
+        profile: TokenProfile
+    ) -> String? {
+        if profile.isEndOfGeneration(tokenID) {
+            return "eos"
+        }
+        if options.singleLine, profile.isNewline(tokenID) {
+            return "single_line"
+        }
+        return nil
+    }
+
+    /// Whether the accumulated completion bytes now end a sentence. Decodes only when the last token
+    /// carried an ASCII sentence terminator, so the steady decode path avoids per-token String work.
+    /// Kept as a helper so the decode loop stays under the cyclomatic-complexity budget.
+    private static func completesSentence(_ generatedBytes: [UInt8], lastTokenBytes: [UInt8]) -> Bool {
+        guard lastTokenBytes.contains(where: isSentenceTerminatorByte) else {
+            return false
+        }
+        // swiftlint:disable:next optional_data_string_conversion
+        let decoded = String(decoding: generatedBytes, as: UTF8.self)
+        return SentenceBoundaryClassifier.endsSentence(decoded)
+    }
+
     /// The shipping decoder: delegates token selection to the engine's built-in sampler
     /// (`sampleNext`), which applies temperature / top-k / top-p / min-p and commits each token.
     private func runEngineSampledDecode(sequenceID: Int32, options: LlamaGenerationOptions) -> String {
@@ -319,28 +355,31 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
                 break
             }
 
-            if profile.isEndOfGeneration(tokenID) {
-                stopReason = "eos"
-                break
-            }
-            // Single-line fields must never receive a line break; stop before emitting one so the
-            // partial completion so far is preserved (mirrors the sampler path's single_line mask).
-            if options.singleLine, profile.isNewline(tokenID) {
-                stopReason = "single_line"
+            // A token can stop the loop before it is committed: an end-of-generation token, or a line
+            // break in a single-line field (the partial completion so far is preserved).
+            if let preCommitStop = Self.preCommitStopReason(tokenID: tokenID, options: options, profile: profile) {
+                stopReason = preCommitStop
                 break
             }
 
             // Accumulate raw bytes and decode once at the end: a single token may carry only part of
             // a multi-byte UTF-8 scalar, so per-token String decoding would corrupt CJK / emoji.
+            let tokenBytes = profile.bytes(for: tokenID)
             if let logProb = ConstrainedSampler.logProb(ofTokenAt: tokenID, in: logits) {
                 sumLogprob += logProb
             }
-            generatedBytes.append(contentsOf: profile.bytes(for: tokenID))
+            generatedBytes.append(contentsOf: tokenBytes)
             generatedTokenIDs.append(tokenID)
             tokensGenerated += 1
 
             if engine.acceptToken(sequenceID, Int32(tokenID)) != .ok {
                 stopReason = "accept_failed"
+                break
+            }
+
+            // Stop cleanly at the end of a sentence rather than running into the next one.
+            if Self.completesSentence(generatedBytes, lastTokenBytes: tokenBytes) {
+                stopReason = "sentence_boundary"
                 break
             }
         }

--- a/Cotabby/Support/SentenceBoundaryClassifier.swift
+++ b/Cotabby/Support/SentenceBoundaryClassifier.swift
@@ -15,6 +15,37 @@ enum SentenceBoundaryClassifier {
         "mr", "mrs", "ms", "dr", "st", "vs", "eg", "ie", "etc", "no", "fig", "approx", "inc", "ltd"
     ]
 
+    /// Whether `text` ends at a sentence boundary: after skipping any trailing whitespace and a run of
+    /// closing punctuation (quotes / brackets), the last visible character is `!`, `?`, or a *terminal*
+    /// period. The closing-punctuation skip lets `He said "stop."` and `(done!)` count as sentence ends
+    /// even though their final character is a quote or paren. Used to stop a constrained completion
+    /// cleanly at the end of one sentence instead of letting it run into the next.
+    static func endsSentence(_ text: String) -> Bool {
+        var index = text.endIndex
+        while index > text.startIndex {
+            let previous = text.index(before: index)
+            guard text[previous].isWhitespace else { break }
+            index = previous
+        }
+        while index > text.startIndex {
+            let previous = text.index(before: index)
+            guard text[previous].isSentenceClosingPunctuation else { break }
+            index = previous
+        }
+        guard index > text.startIndex else {
+            return false
+        }
+        let lastIndex = text.index(before: index)
+        switch text[lastIndex] {
+        case "!", "?":
+            return true
+        case ".":
+            return isTerminalPeriod(in: text, at: lastIndex)
+        default:
+            return false
+        }
+    }
+
     /// Whether the period at `periodIndex` in `text` ends a sentence. The caller guarantees that
     /// `text[periodIndex]` is ".".
     static func isTerminalPeriod(in text: String, at periodIndex: String.Index) -> Bool {
@@ -61,5 +92,15 @@ enum SentenceBoundaryClassifier {
             cursor = previous
         }
         return String(letters.reversed())
+    }
+}
+
+private extension Character {
+    /// Closing punctuation that may follow a sentence terminator: straight and curly quotes,
+    /// parentheses, square brackets, and braces. `endsSentence` walks back past a run of these to find
+    /// the real terminator underneath, so `"done."` and `(stop!)` register as sentence ends.
+    var isSentenceClosingPunctuation: Bool {
+        self == "\"" || self == "'" || self == ")" || self == "]" || self == "}"
+            || self == "\u{201D}" || self == "\u{2019}"
     }
 }

--- a/CotabbyTests/SentenceBoundaryClassifierTests.swift
+++ b/CotabbyTests/SentenceBoundaryClassifierTests.swift
@@ -41,4 +41,39 @@ final class SentenceBoundaryClassifierTests: XCTestCase {
         let text = "tabs and so on etc."
         XCTAssertFalse(SentenceBoundaryClassifier.isTerminalPeriod(in: text, at: lastPeriodIndex(in: text)))
     }
+
+    // MARK: - endsSentence
+
+    func test_endsSentence_trueForTerminalPeriod() {
+        XCTAssertTrue(SentenceBoundaryClassifier.endsSentence("Hello world."))
+    }
+
+    func test_endsSentence_falseWithoutTerminator() {
+        XCTAssertFalse(SentenceBoundaryClassifier.endsSentence("Hello world"))
+    }
+
+    func test_endsSentence_trueForExclamationAndQuestion() {
+        XCTAssertTrue(SentenceBoundaryClassifier.endsSentence("Yes!"))
+        XCTAssertTrue(SentenceBoundaryClassifier.endsSentence("Really?"))
+    }
+
+    func test_endsSentence_ignoresTrailingWhitespace() {
+        XCTAssertTrue(SentenceBoundaryClassifier.endsSentence("Done.   "))
+    }
+
+    func test_endsSentence_walksPastClosingPunctuation() {
+        XCTAssertTrue(SentenceBoundaryClassifier.endsSentence("He said \"stop.\""))
+        XCTAssertTrue(SentenceBoundaryClassifier.endsSentence("(done!)"))
+    }
+
+    func test_endsSentence_falseForNonTerminalPeriods() {
+        XCTAssertFalse(SentenceBoundaryClassifier.endsSentence("It is version 1."))
+        XCTAssertFalse(SentenceBoundaryClassifier.endsSentence("for example, e.g."))
+        XCTAssertFalse(SentenceBoundaryClassifier.endsSentence("from the U.S."))
+        XCTAssertFalse(SentenceBoundaryClassifier.endsSentence("Hello Mr."))
+    }
+
+    func test_endsSentence_falseForEmptyString() {
+        XCTAssertFalse(SentenceBoundaryClassifier.endsSentence(""))
+    }
 }


### PR DESCRIPTION
## Summary

Adds a sentence-boundary stop to the deterministic constrained decoder so a completion ends cleanly
at the end of one sentence instead of running into the next. After committing a token that carried an
ASCII sentence terminator, the decoder decodes the accumulated bytes and stops when they end a
sentence (a terminal `.`, `!`, or `?`, allowing a trailing run of closing quotes/brackets). The
period case reuses the existing `SentenceBoundaryClassifier` disambiguation, so decimals ("1.2"),
list numbers ("1."), single-letter initials ("U.S."), and abbreviations ("e.g.", "Mr.") do not stop
generation early.

This affects only the constrained decode path (the `cotabbyConstrainedDecoderEnabled` developer
flag, default off); the shipping sampler path is unchanged.

## Validation

```
xcodebuild ... test ... CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO \
  -only-testing:CotabbyTests/SentenceBoundaryClassifierTests \
  -only-testing:CotabbyTests/SuggestionSessionReconcilerTests
# ** TEST SUCCEEDED ** — incl. 8 new endsSentence cases (terminal vs abbreviation/decimal/initial,
#   closing-punctuation walk-back, trailing whitespace, empty string)

swiftlint --strict --quiet   # exit 0 (kept runConstrainedDecode under the cyclomatic-complexity
                             # budget by folding the pre-commit stop checks into one helper)
```

## Linked issues

None. Brings the constrained decoder closer to the intended "predict a short continuation, stop at a
sentence boundary" behavior.

## Risk / rollout notes

- **Constrained path only**, which is default-off, so there is no change to shipped suggestion
  behavior. It is a building block toward making that path good enough to enable by default (which
  still needs on-device evaluation).
- The boundary decode runs only when a token carried an ASCII `.`/`!`/`?`, so the steady decode path
  stays on raw byte accumulation with a single decode at the end. Non-ASCII terminators (CJK 。！？)
  are not yet handled and fall through to the existing token-budget stop.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds sentence-boundary stopping to the constrained decoder (`cotabbyConstrainedDecoderEnabled` dev flag, default off). After each committed token, if its bytes contain an ASCII terminator (`.`/`!`/`?`), the accumulated completion is decoded and `SentenceBoundaryClassifier.endsSentence` is consulted; the loop breaks with `stopReason = \"sentence_boundary\"` when a true sentence end is detected. The PR also refactors the pre-commit EOS/newline checks into a single `preCommitStopReason` helper to stay under the cyclomatic-complexity budget.

- `SentenceBoundaryClassifier.endsSentence` walks back past trailing whitespace and closing punctuation (quotes, brackets) before checking the terminal character, correctly delegating period disambiguation to the existing `isTerminalPeriod` logic so decimals, initials, and abbreviations do not trigger early stops.
- The constrained path is guarded by a developer flag and is not active in shipped builds, so there is no impact on production suggestion behaviour.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the new logic is gated behind a default-off developer flag and does not touch the shipped sampler path.

The SentenceBoundaryClassifier changes are thoroughly unit-tested and the walk-back logic is correct. The main behavioural gap is in LlamaRuntimeCore: when a tokenizer emits a sentence terminator and a closing quotation mark in consecutive separate tokens, the sentence-boundary check fires after the terminator token and the closing quote is never appended, producing an unclosed quote. This is specific to tokenizer splitting behaviour and affects only the dev-flag constrained path, but it is a real output-quality issue worth addressing before the path is enabled by default.

The token-split edge case is isolated to LlamaRuntimeCore.swift around the completesSentence call site at line 381.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Services/Runtime/LlamaRuntimeCore.swift | Adds completesSentence, preCommitStopReason, and isSentenceTerminatorByte helpers to stop the constrained decode loop at sentence boundaries; refactors pre-commit EOS/newline checks into a single helper. Logic is correct but has a token-boundary edge case when . and a trailing closing quote arrive in separate tokens. |
| Cotabby/Support/SentenceBoundaryClassifier.swift | Adds endsSentence and the isSentenceClosingPunctuation Character extension. Walk-back logic (whitespace → closing punctuation → terminator) is sound, and isTerminalPeriod delegation correctly handles decimals, initials, and abbreviations. |
| CotabbyTests/SentenceBoundaryClassifierTests.swift | Adds 8 well-chosen endsSentence unit tests covering terminal vs. non-terminal periods, !/?, trailing whitespace, closing-punctuation walk-back, and empty string. All expected behaviours are exercised. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant DecodeLoop as "Decode Loop"
    participant PreCommit as "preCommitStopReason"
    participant Accept as "engine.acceptToken"
    participant CS as "completesSentence"
    participant SBC as "SentenceBoundaryClassifier"

    DecodeLoop->>PreCommit: tokenID, options, profile
    PreCommit-->>DecodeLoop: nil or eos/single_line (break)
    DecodeLoop->>Accept: acceptToken(sequenceID, tokenID)
    Accept-->>DecodeLoop: ok or error (break)
    DecodeLoop->>CS: completesSentence(generatedBytes, lastTokenBytes)
    CS->>CS: guard lastTokenBytes contains terminator byte
    CS->>SBC: endsSentence(String decoding generatedBytes)
    SBC->>SBC: skip trailing whitespace
    SBC->>SBC: skip closing punctuation
    SBC->>SBC: inspect last visible character
    SBC-->>CS: true or false
    CS-->>DecodeLoop: true means stopReason sentence_boundary and break
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fconstrained-sentence-stop%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fconstrained-sentence-stop%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%3A381-384%0A**Token-split%20may%20produce%20unclosed%20quotation%20marks**%0A%0A%60completesSentence%60%20evaluates%20%60generatedBytes%60%20immediately%20after%20the%20token%20that%20carries%20%60.%60%2C%20%60!%60%2C%20or%20%60%3F%60%20is%20appended.%20If%20the%20tokenizer%20emits%20a%20closing%20quote%20as%20a%20separate%20subsequent%20token%20%28e.g.%20token%20N%20%3D%20%60%22stop.%22%60%2C%20token%20N%2B1%20%3D%20%60'%22'%60%29%2C%20the%20check%20fires%20after%20token%20N%20when%20%60generatedBytes%60%20ends%20with%20%60stop.%60%20%E2%80%94%20%60endsSentence%60%20returns%20%60true%60%2C%20the%20loop%20breaks%2C%20and%20the%20closing%20%60%22%60%20is%20never%20appended.%20The%20walk-back%20logic%20in%20%60endsSentence%60%20only%20helps%20when%20the%20closing%20punctuation%20is%20already%20in%20the%20buffer.%20For%20%60%22He%20said%20%5C%22Good%20morning.%5C%22%22%60%20split%20across%20two%20tokens%20this%20would%20yield%20%60He%20said%20%22Good%20morning.%60%20in%20the%20output.%20Consider%20deferring%20the%20sentence-end%20break%20by%20one%20additional%20token%20when%20the%20current%20check%20fires%2C%20to%20allow%20a%20potential%20closing-quote%20token%20to%20land%20first.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%3A240-247%0A**Full-buffer%20decode%20on%20every%20terminator%20token**%0A%0A%60String%28decoding%3A%20generatedBytes%2C%20as%3A%20UTF8.self%29%60%20re-decodes%20the%20entire%20accumulated%20byte%20array%20every%20time%20a%20token%20carries%20a%20terminator%20byte.%20For%20the%20intended%20short%20completions%20under%20a%20small%20%60maxPredictionTokens%60%20budget%20this%20is%20negligible%2C%20but%20if%20the%20budget%20grows%20or%20a%20sentence%20contains%20multiple%20terminator%20bytes%20%28e.g.%20%60U.S.%60%20followed%20by%20a%20real%20period%29%2C%20this%20is%20called%20multiple%20times%20and%20scales%20with%20total%20completion%20length.%20A%20suffix-only%20decode%20%E2%80%94%20e.g.%20keeping%20a%20rolling%20%60decodedSoFar%3A%20String%60%20updated%20incrementally%2C%20or%20only%20decoding%20the%20last%20~50%20bytes%20%E2%80%94%20would%20keep%20per-token%20cost%20constant.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%3A381-384%0A**Token-split%20may%20produce%20unclosed%20quotation%20marks**%0A%0A%60completesSentence%60%20evaluates%20%60generatedBytes%60%20immediately%20after%20the%20token%20that%20carries%20%60.%60%2C%20%60!%60%2C%20or%20%60%3F%60%20is%20appended.%20If%20the%20tokenizer%20emits%20a%20closing%20quote%20as%20a%20separate%20subsequent%20token%20%28e.g.%20token%20N%20%3D%20%60%22stop.%22%60%2C%20token%20N%2B1%20%3D%20%60'%22'%60%29%2C%20the%20check%20fires%20after%20token%20N%20when%20%60generatedBytes%60%20ends%20with%20%60stop.%60%20%E2%80%94%20%60endsSentence%60%20returns%20%60true%60%2C%20the%20loop%20breaks%2C%20and%20the%20closing%20%60%22%60%20is%20never%20appended.%20The%20walk-back%20logic%20in%20%60endsSentence%60%20only%20helps%20when%20the%20closing%20punctuation%20is%20already%20in%20the%20buffer.%20For%20%60%22He%20said%20%5C%22Good%20morning.%5C%22%22%60%20split%20across%20two%20tokens%20this%20would%20yield%20%60He%20said%20%22Good%20morning.%60%20in%20the%20output.%20Consider%20deferring%20the%20sentence-end%20break%20by%20one%20additional%20token%20when%20the%20current%20check%20fires%2C%20to%20allow%20a%20potential%20closing-quote%20token%20to%20land%20first.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%3A240-247%0A**Full-buffer%20decode%20on%20every%20terminator%20token**%0A%0A%60String%28decoding%3A%20generatedBytes%2C%20as%3A%20UTF8.self%29%60%20re-decodes%20the%20entire%20accumulated%20byte%20array%20every%20time%20a%20token%20carries%20a%20terminator%20byte.%20For%20the%20intended%20short%20completions%20under%20a%20small%20%60maxPredictionTokens%60%20budget%20this%20is%20negligible%2C%20but%20if%20the%20budget%20grows%20or%20a%20sentence%20contains%20multiple%20terminator%20bytes%20%28e.g.%20%60U.S.%60%20followed%20by%20a%20real%20period%29%2C%20this%20is%20called%20multiple%20times%20and%20scales%20with%20total%20completion%20length.%20A%20suffix-only%20decode%20%E2%80%94%20e.g.%20keeping%20a%20rolling%20%60decodedSoFar%3A%20String%60%20updated%20incrementally%2C%20or%20only%20decoding%20the%20last%20~50%20bytes%20%E2%80%94%20would%20keep%20per-token%20cost%20constant.%0A%0A&repo=fujacob%2Fcotabby&pr=517&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Stop the constrained decoder at sentence..."](https://github.com/fujacob/cotabby/commit/164c51c860a38d1059df191aafe085af3a570906) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35043427)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->