### PR TITLE
Add multi-branch (beam) search to the constrained decoder

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		279F017530A86AF62EB17918 /* EmojiSynonymCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0846DE4E0293AF13890620D3 /* EmojiSynonymCatalog.swift */; };
 		27D4F5CACADE171F142178B4 /* SettingsSidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BADB38D0160B47637572FC5E /* SettingsSidebarView.swift */; };
 		286B7022E2A2774275004447 /* WelcomeTemplateStepView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9199B9CEAB320982CA333B8 /* WelcomeTemplateStepView.swift */; };
+		29EC35D67D9B4C3C50222619 /* ConstrainedBeamSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D891397DAFCEF9DDD612A771 /* ConstrainedBeamSearchTests.swift */; };
 		2C6159231472A849F15BD0AE /* ScreenFrameReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5484C8A04B9C00CF79D589EB /* ScreenFrameReader.swift */; };
 		2DF5A3826AAB99C279EBB8DE /* InputMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B81DD30EB657368AACE9625A /* InputMonitor.swift */; };
 		2E3DEB7E89D0146274596F2E /* SettingsContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB0CE9AB1286367BA2E82392 /* SettingsContainerView.swift */; };
@@ -200,6 +201,7 @@
 		C2C958D6E5F5FE1CCC414BCE /* SuggestionSubsystemContracts.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB16474A67CE1D210B944C9 /* SuggestionSubsystemContracts.swift */; };
 		C4C6734678797669055988E0 /* AppUpdateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD9573F3504CAE6891DF9B7D /* AppUpdateManager.swift */; };
 		C618C5595DA9C57C806A3E03 /* SettingsAttentionEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BC293F6125E2B14DCF05AD9 /* SettingsAttentionEvaluatorTests.swift */; };
+		C638466A2F373BABA6F60A6D /* ConstrainedBeamSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83264218423B61E59109EB3 /* ConstrainedBeamSearch.swift */; };
 		C71B594433F3B411CAE5DE7E /* FocusCapabilityResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F6D5F94B238F7B4BE7C247 /* FocusCapabilityResolverTests.swift */; };
 		C9B815652CED38966C53A5E8 /* EmojiVariantResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8BB19D8EC9A75CD3458A6B /* EmojiVariantResolverTests.swift */; };
 		CA5B2D226FBAA5419E78F14F /* SuggestionSessionReconciler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0AA0503128B0FC3951D700 /* SuggestionSessionReconciler.swift */; };
@@ -423,6 +425,7 @@
 		A52D0B550E00EF173A5D157E /* LlamaRuntimeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LlamaRuntimeManager.swift; sourceTree = "<group>"; };
 		A804F4DB6FD9BC8C27B2B65F /* LlamaRuntimeModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LlamaRuntimeModels.swift; sourceTree = "<group>"; };
 		A829F28F01FAE76CA7244BBC /* ModelFileValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelFileValidatorTests.swift; sourceTree = "<group>"; };
+		A83264218423B61E59109EB3 /* ConstrainedBeamSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstrainedBeamSearch.swift; sourceTree = "<group>"; };
 		A854CAFB1F557BC4CAED8819 /* VisualContextCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualContextCoordinator.swift; sourceTree = "<group>"; };
 		A863F41C0C03D7B4AC5DC002 /* MarkerSelectionSynthesizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkerSelectionSynthesizer.swift; sourceTree = "<group>"; };
 		A9199B9CEAB320982CA333B8 /* WelcomeTemplateStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeTemplateStepView.swift; sourceTree = "<group>"; };
@@ -479,6 +482,7 @@
 		D5D6C2318E405AA717D1C256 /* WelcomePermissionStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomePermissionStepView.swift; sourceTree = "<group>"; };
 		D814BBA41CF29E8DD9954651 /* OnboardingTemplateFeatureListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTemplateFeatureListTests.swift; sourceTree = "<group>"; };
 		D84D4528EEC9EFEB8AE8E318 /* ActivationIndicatorController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivationIndicatorController.swift; sourceTree = "<group>"; };
+		D891397DAFCEF9DDD612A771 /* ConstrainedBeamSearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstrainedBeamSearchTests.swift; sourceTree = "<group>"; };
 		D9C1C921A1CDA2ADFC39EA01 /* AppsPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppsPaneView.swift; sourceTree = "<group>"; };
 		DB0CE9AB1286367BA2E82392 /* SettingsContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsContainerView.swift; sourceTree = "<group>"; };
 		DDE858CB1E687E3CEB8FDD5B /* SuggestionRequestFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionRequestFactory.swift; sourceTree = "<group>"; };
@@ -741,6 +745,7 @@
 				90B0D133AB77A2503FB08827 /* ClipboardRelevanceFilterTests.swift */,
 				D504BEB224E0C176F5FCFF6E /* CompletionRenderModePolicyTests.swift */,
 				06FF2B0A3094A952A8EBA9B5 /* ConfidenceSuppressionPolicyTests.swift */,
+				D891397DAFCEF9DDD612A771 /* ConstrainedBeamSearchTests.swift */,
 				6B0200AA5C4A644A3B52A3EC /* ConstrainedSamplerTests.swift */,
 				AF1E065C7FFB697FCEB2FA5C /* CotabbyTestFixtures.swift */,
 				AD752451330486FE270018B0 /* CustomRulesTests.swift */,
@@ -904,6 +909,7 @@
 				D3A2AC525DC664DB540D4F19 /* ClipboardRelevanceFilter.swift */,
 				53CF416511099C6818110F01 /* CompletionRenderModePolicy.swift */,
 				1BD71ECC2AE4821B643E0935 /* ConfidenceSuppressionPolicy.swift */,
+				A83264218423B61E59109EB3 /* ConstrainedBeamSearch.swift */,
 				47CF010A66DA31989524FCD0 /* ConstrainedSampler.swift */,
 				C7B2D34A6F3AC9DFD61350F7 /* CotabbyDebugOptions.swift */,
 				29ED42C4BDD0C521101AF95E /* DeviceInfo.swift */,
@@ -1099,6 +1105,7 @@
 				7C94725B4837DEC9ECF1BC54 /* CompletionRenderMode.swift in Sources */,
 				3985F0F2B3178DBB945B1064 /* CompletionRenderModePolicy.swift in Sources */,
 				429CE592897D8A952F2916C3 /* ConfidenceSuppressionPolicy.swift in Sources */,
+				C638466A2F373BABA6F60A6D /* ConstrainedBeamSearch.swift in Sources */,
 				81FC391E375B7EEFF965FF1B /* ConstrainedSampler.swift in Sources */,
 				8B2DFC860803C0A7C4D34A36 /* ContextBuffer.swift in Sources */,
 				AA2E09FF7E430D66ECA8ECD5 /* CotabbyApp.swift in Sources */,
@@ -1262,6 +1269,7 @@
 				BFCA7FAFDAEBF586AB615567 /* ClipboardRelevanceFilterTests.swift in Sources */,
 				25F91CEF38400FD1ADB6B1AF /* CompletionRenderModePolicyTests.swift in Sources */,
 				91D8189EFCD1BA992EA6F038 /* ConfidenceSuppressionPolicyTests.swift in Sources */,
+				29EC35D67D9B4C3C50222619 /* ConstrainedBeamSearchTests.swift in Sources */,
 				1C00CE3D553B58723EAE5F92 /* ConstrainedSamplerTests.swift in Sources */,
 				5E10EFC426217CB7218A5847 /* CotabbyTestFixtures.swift in Sources */,
 				91D1F16B8C5DA281D4B7F699 /* CustomRulesTests.swift in Sources */,

--- a/Cotabby/Models/LlamaRuntimeModels.swift
+++ b/Cotabby/Models/LlamaRuntimeModels.swift
@@ -199,6 +199,12 @@ struct LlamaGenerationOptions: Equatable, Sendable {
     /// validated on device. Changing it does not affect KV reuse, so it is intentionally excluded
     /// from `SamplingFingerprint`.
     var useConstrainedDecoder: Bool = false
+
+    /// Beam width for the constrained decoder. 1 keeps the single-path greedy decode; values > 1 run a
+    /// multi-branch beam search that explores several short continuations and keeps the highest-scoring
+    /// one. Only consulted when `useConstrainedDecoder` is true. Like `useConstrainedDecoder`, it does
+    /// not affect KV reuse, so it is excluded from `SamplingFingerprint`.
+    var beamWidth: Int = 1
 }
 
 /// The concrete runtime assets selected during bootstrap after checking available model files.

--- a/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
+++ b/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
@@ -198,9 +198,16 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
         // The KV-trim defer above runs after whichever decoder returns. Both decoders share the
         // prepared sequence and the same confidence-suppression contract; they differ only in how
         // they pick each token (engine sampler vs. deterministic constrained selection).
-        return options.useConstrainedDecoder
-            ? try runConstrainedDecode(sequenceID: sequenceID, options: options)
-            : runEngineSampledDecode(sequenceID: sequenceID, options: options)
+        guard options.useConstrainedDecoder else {
+            return runEngineSampledDecode(sequenceID: sequenceID, options: options)
+        }
+        return options.beamWidth > 1
+            ? try runConstrainedBeamDecode(
+                sequenceID: sequenceID,
+                promptTokenCount: promptTokens.count,
+                options: options
+            )
+            : try runConstrainedDecode(sequenceID: sequenceID, options: options)
     }
 
     // MARK: - Decoders
@@ -404,6 +411,128 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
             return ""
         }
         return generatedText
+    }
+
+    /// Multi-branch (beam) variant of the constrained decoder. Explores several short continuations
+    /// over the shared sequence — `EngineBeamStepper` syncs the KV cache to each branch's token path —
+    /// and returns the highest-scoring one. Reuses the same token profile, no-repeat-ngram guard,
+    /// sentence-boundary stop, and confidence suppression as the greedy path. The caller's KV-trim
+    /// defer restores the prompt-only state afterward.
+    private func runConstrainedBeamDecode(
+        sequenceID: Int32,
+        promptTokenCount: Int,
+        options: LlamaGenerationOptions
+    ) throws -> String {
+        let profile = try autocompleteTokenProfile()
+        let vocabSize = profile.vocabSize
+        guard vocabSize > 0 else {
+            throw LlamaRuntimeError.generationFailed("Vocabulary unavailable for constrained decoding.")
+        }
+        let topK = options.topK > 0 ? options.topK : vocabSize
+        var currentPath: [Int] = []
+        var logitsBuffer = [Float](repeating: 0, count: vocabSize)
+        let candidates = ConstrainedBeamSearch.search(
+            nextLogits: { generatedTokens in
+                self.beamLogits(
+                    forGeneratedTokens: generatedTokens,
+                    sequenceID: sequenceID,
+                    promptTokenCount: promptTokenCount,
+                    currentPath: &currentPath,
+                    logitsBuffer: &logitsBuffer
+                )
+            },
+            profile: profile,
+            configuration: BeamSearchConfiguration(
+                beamWidth: options.beamWidth,
+                maxTokens: options.maxPredictionTokens,
+                topK: topK,
+                noRepeatNgramSize: Self.noRepeatNgramSize
+            ),
+            isSingleLine: options.singleLine
+        )
+        let best = candidates.first
+        CotabbyLogger.runtime.debug(
+            "Decode end",
+            metadata: [
+                "kind": .string("generate_beam"),
+                "beam_width": .stringConvertible(options.beamWidth),
+                "candidates": .stringConvertible(candidates.count),
+                "tokens_generated": .stringConvertible(best?.tokenIDs.count ?? 0)
+            ]
+        )
+        guard let best else {
+            return ""
+        }
+        if Self.shouldSuppress(
+            sumLogprob: best.cumulativeLogprob,
+            tokensGenerated: best.tokenIDs.count,
+            options: options
+        ) {
+            return ""
+        }
+        return best.text
+    }
+
+    /// Beam-search logits provider: syncs the shared sequence's KV to `generatedTokens`, then reads
+    /// the next-token logits. `currentPath` / `logitsBuffer` are owned by one beam run (the caller),
+    /// so this stays a plain method on the runtime where `engine` (a noncopyable C++ value) is mutable.
+    private func beamLogits(
+        forGeneratedTokens generatedTokens: [Int],
+        sequenceID: Int32,
+        promptTokenCount: Int,
+        currentPath: inout [Int],
+        logitsBuffer: inout [Float]
+    ) -> [Float]? {
+        guard syncBeamSequence(
+            to: generatedTokens,
+            sequenceID: sequenceID,
+            promptTokenCount: promptTokenCount,
+            currentPath: &currentPath
+        ) else {
+            return nil
+        }
+        let vocabSize = logitsBuffer.count
+        let written = logitsBuffer.withUnsafeMutableBufferPointer { buffer in
+            Int(engine.getNextTokenLogits(sequenceID, buffer.baseAddress, Int32(buffer.count)))
+        }
+        guard written == vocabSize else {
+            return nil
+        }
+        return logitsBuffer
+    }
+
+    /// Brings the sequence KV to exactly `target` tokens beyond the prompt: trim back to the longest
+    /// shared prefix with the current path, then accept the remaining target tokens. `currentPath` is
+    /// updated as tokens are accepted so it always reflects the real KV length, even on a mid-accept
+    /// failure (the caller treats a false return as "this branch cannot be extended").
+    private func syncBeamSequence(
+        to target: [Int],
+        sequenceID: Int32,
+        promptTokenCount: Int,
+        currentPath: inout [Int]
+    ) -> Bool {
+        let shared = Self.commonPrefixLength(currentPath, target)
+        if currentPath.count > shared, !engine.trimKV(sequenceID, Int32(promptTokenCount + shared)) {
+            currentPath = []
+            return false
+        }
+        currentPath = Array(target[..<shared])
+        for index in shared ..< target.count {
+            guard engine.acceptToken(sequenceID, Int32(target[index])) == .ok else {
+                return false
+            }
+            currentPath.append(target[index])
+        }
+        return true
+    }
+
+    private static func commonPrefixLength(_ lhs: [Int], _ rhs: [Int]) -> Int {
+        var count = 0
+        let limit = min(lhs.count, rhs.count)
+        while count < limit, lhs[count] == rhs[count] {
+            count += 1
+        }
+        return count
     }
 
     /// Shared low-confidence gate for both decoders: drop completions the model itself was unsure

--- a/Cotabby/Services/Runtime/LlamaSuggestionEngine.swift
+++ b/Cotabby/Services/Runtime/LlamaSuggestionEngine.swift
@@ -22,6 +22,15 @@ final class LlamaSuggestionEngine {
         UserDefaults.standard.bool(forKey: constrainedDecoderDefaultsKey)
     }
 
+    /// UserDefaults key (no UI) for the constrained decoder's beam width. Default 1 keeps the existing
+    /// single-path greedy decode; a value > 1 runs a multi-branch beam search. Paired with the
+    /// constrained-decoder flag as a hidden developer/dogfood knob until validated on device.
+    private static let constrainedBeamWidthDefaultsKey = "cotabbyConstrainedBeamWidth"
+    private static var constrainedBeamWidth: Int {
+        let stored = UserDefaults.standard.integer(forKey: constrainedBeamWidthDefaultsKey)
+        return stored > 0 ? stored : 1
+    }
+
     init(runtimeManager: LlamaRuntimeGenerating) {
         self.runtimeManager = runtimeManager
     }
@@ -60,7 +69,8 @@ final class LlamaSuggestionEngine {
                         precedingText: request.context.precedingText,
                         trailingText: request.context.trailingText
                     ),
-                    useConstrainedDecoder: Self.isConstrainedDecoderEnabled
+                    useConstrainedDecoder: Self.isConstrainedDecoderEnabled,
+                    beamWidth: Self.constrainedBeamWidth
                 )
             )
             try Task.checkCancellation()

--- a/Cotabby/Support/ConstrainedBeamSearch.swift
+++ b/Cotabby/Support/ConstrainedBeamSearch.swift
@@ -1,0 +1,181 @@
+import Foundation
+
+/// File overview:
+/// A deterministic multi-branch (beam) search over a model's next-token logits, used by the
+/// constrained decoder to explore several short continuations at once and keep the highest-scoring
+/// one instead of committing to a single greedy token at each step.
+///
+/// Why this file exists:
+/// Greedy argmax can paint a completion into a corner: a locally-best token that leads nowhere good.
+/// A small beam keeps the best few branches per step and scores whole continuations by cumulative
+/// log-probability, which yields steadier short completions. The algorithm is written against the
+/// `BeamDecodeStepping` protocol so the search can be unit-tested against an in-memory fake that
+/// returns fixed logits per token path; the live llama adapter is a thin KV-sync wrapper supplied by
+/// the runtime. Everything here is pure and deterministic given the stepping inputs.
+
+/// The single operation a beam search needs from the model: the next-token logits for a branch's
+/// token path (the tokens generated so far, beyond the prompt). The provider syncs its own KV state
+/// to `generatedTokens` before reading and returns nil when logits are unavailable. Modeled as a
+/// closure rather than a protocol so the live adapter can be an instance method on the runtime — the
+/// inference engine is a noncopyable C++ type that cannot be stored in a separate object — while
+/// tests pass a scripted closure.
+typealias BeamLogitsProvider = (_ generatedTokens: [Int]) -> [Float]?
+
+/// Tuning for one beam search. `beamWidth` is the number of live branches kept per step; `topK` bounds
+/// the per-branch expansion pool; `noRepeatNgramSize` forbids re-emitting an n-gram already in a
+/// branch (the same anti-loop guard the greedy decoder uses).
+struct BeamSearchConfiguration: Equatable {
+    let beamWidth: Int
+    let maxTokens: Int
+    let topK: Int
+    let noRepeatNgramSize: Int
+
+    init(beamWidth: Int, maxTokens: Int, topK: Int, noRepeatNgramSize: Int = 3) {
+        self.beamWidth = max(1, beamWidth)
+        self.maxTokens = max(0, maxTokens)
+        self.topK = topK
+        self.noRepeatNgramSize = noRepeatNgramSize
+    }
+}
+
+/// One explored continuation: the committed token ids (beyond the prompt), their accumulated raw
+/// UTF-8 bytes, and the cumulative log-probability of the path.
+struct BeamCandidate: Equatable {
+    let tokenIDs: [Int]
+    let bytes: [UInt8]
+    let cumulativeLogprob: Double
+
+    /// Mean per-token log-probability; ranks completed branches so a short confident continuation is
+    /// not unfairly beaten by a longer, lower-average one. An empty branch ranks last.
+    var meanLogprob: Double {
+        tokenIDs.isEmpty ? -.infinity : cumulativeLogprob / Double(tokenIDs.count)
+    }
+
+    /// The decoded text of the branch. Lossy on a partial trailing scalar (a final token may carry
+    /// only part of a multi-byte character), which renders as U+FFFD rather than dropping the branch.
+    var text: String {
+        // swiftlint:disable:next optional_data_string_conversion
+        String(decoding: bytes, as: UTF8.self)
+    }
+}
+
+enum ConstrainedBeamSearch {
+    /// Runs a best-first beam search and returns completed branches, best mean-logprob first. A branch
+    /// completes on an end-of-generation token, a single-line newline (not emitted), a sentence
+    /// boundary, the token budget, or when no admissible token remains. Pure given `stepping`.
+    static func search(
+        nextLogits: @escaping BeamLogitsProvider,
+        profile: TokenProfile,
+        configuration: BeamSearchConfiguration,
+        isSingleLine: Bool
+    ) -> [BeamCandidate] {
+        Engine(
+            nextLogits: nextLogits,
+            profile: profile,
+            configuration: configuration,
+            isSingleLine: isSingleLine
+        ).run()
+    }
+}
+
+/// The mutable-free search context, holding the inputs so the per-step helpers stay small. A struct
+/// rather than passing the same four values through every call.
+private struct Engine {
+    let nextLogits: BeamLogitsProvider
+    let profile: TokenProfile
+    let configuration: BeamSearchConfiguration
+    let isSingleLine: Bool
+
+    func run() -> [BeamCandidate] {
+        var frontier: [BeamCandidate] = [BeamCandidate(tokenIDs: [], bytes: [], cumulativeLogprob: 0)]
+        var completed: [BeamCandidate] = []
+
+        for _ in 0 ..< configuration.maxTokens {
+            guard !frontier.isEmpty else { break }
+            var nextFrontier: [BeamCandidate] = []
+            for branch in frontier {
+                guard let logits = nextLogits(branch.tokenIDs) else {
+                    completed.append(branch)
+                    continue
+                }
+                expand(branch: branch, logits: logits, live: &nextFrontier, completed: &completed)
+            }
+            frontier = Self.prune(nextFrontier, to: configuration.beamWidth)
+        }
+        // Budget exhausted: surviving branches are valid completions too.
+        completed.append(contentsOf: frontier)
+        return completed
+            .filter { !$0.tokenIDs.isEmpty }
+            .sorted { $0.meanLogprob > $1.meanLogprob }
+    }
+
+    /// Expands one branch across its admissible tokens, routing branch-ending tokens (end-of-
+    /// generation, single-line newline, sentence boundary) into `completed` and the rest into `live`.
+    private func expand(
+        branch: BeamCandidate,
+        logits: [Float],
+        live: inout [BeamCandidate],
+        completed: inout [BeamCandidate]
+    ) {
+        let blocked = RepetitionGuard.blockedTokens(
+            history: branch.tokenIDs,
+            ngramSize: configuration.noRepeatNgramSize
+        )
+        let candidates = ConstrainedSampler.rankedAdmissibleTokens(
+            logits: logits,
+            profile: profile,
+            admissibleTokenIDs: nil,
+            topK: configuration.topK,
+            blockedTokenIDs: blocked
+        )
+        for tokenID in candidates {
+            if profile.isEndOfGeneration(tokenID) {
+                completed.append(branch)
+                continue
+            }
+            if isSingleLine, profile.isNewline(tokenID) {
+                completed.append(branch)
+                continue
+            }
+            let tokenBytes = profile.bytes(for: tokenID)
+            let child = extend(branch, by: tokenID, tokenBytes: tokenBytes, logits: logits)
+            if Self.completesSentence(child.bytes, lastTokenBytes: tokenBytes) {
+                completed.append(child)
+            } else {
+                live.append(child)
+            }
+        }
+    }
+
+    private func extend(
+        _ branch: BeamCandidate,
+        by tokenID: Int,
+        tokenBytes: [UInt8],
+        logits: [Float]
+    ) -> BeamCandidate {
+        var bytes = branch.bytes
+        bytes.append(contentsOf: tokenBytes)
+        let logprob = ConstrainedSampler.logProb(ofTokenAt: tokenID, in: logits) ?? 0
+        return BeamCandidate(
+            tokenIDs: branch.tokenIDs + [tokenID],
+            bytes: bytes,
+            cumulativeLogprob: branch.cumulativeLogprob + logprob
+        )
+    }
+
+    /// Keeps the best `width` live branches by cumulative log-probability.
+    private static func prune(_ branches: [BeamCandidate], to width: Int) -> [BeamCandidate] {
+        guard branches.count > width else {
+            return branches
+        }
+        return Array(branches.sorted { $0.cumulativeLogprob > $1.cumulativeLogprob }.prefix(width))
+    }
+
+    private static func completesSentence(_ bytes: [UInt8], lastTokenBytes: [UInt8]) -> Bool {
+        guard lastTokenBytes.contains(where: { $0 == 0x2E || $0 == 0x21 || $0 == 0x3F }) else {
+            return false
+        }
+        // swiftlint:disable:next optional_data_string_conversion
+        return SentenceBoundaryClassifier.endsSentence(String(decoding: bytes, as: UTF8.self))
+    }
+}

--- a/Cotabby/Support/ConstrainedSampler.swift
+++ b/Cotabby/Support/ConstrainedSampler.swift
@@ -72,6 +72,38 @@ enum ConstrainedSampler {
         return best
     }
 
+    /// The admissible token ids for a step, ranked highest-logit first. Survivors are the same set
+    /// `selectToken` would consider — in-range, not `profile.isExcluded`, not in `blockedTokenIDs`,
+    /// and, when `admissibleTokenIDs` is non-nil, members of that set — and at most `topK` are
+    /// returned. This is the multi-candidate form of `selectToken`: the beam search expands a branch
+    /// across these instead of committing to the single best. Ties break by lower id for determinism.
+    static func rankedAdmissibleTokens(
+        logits: [Float],
+        profile: TokenProfile,
+        admissibleTokenIDs: Set<Int>?,
+        topK: Int,
+        blockedTokenIDs: Set<Int> = []
+    ) -> [Int] {
+        guard topK > 0, !logits.isEmpty else {
+            return []
+        }
+        if let admissible = admissibleTokenIDs, admissible.isEmpty {
+            return []
+        }
+        let survivors = (0 ..< logits.count).filter { id in
+            !profile.isExcluded(id)
+                && !blockedTokenIDs.contains(id)
+                && (admissibleTokenIDs?.contains(id) ?? true)
+        }
+        let ranked = survivors.sorted { lhs, rhs in
+            if logits[lhs] != logits[rhs] {
+                return logits[lhs] > logits[rhs]
+            }
+            return lhs < rhs
+        }
+        return Array(ranked.prefix(topK))
+    }
+
     /// Average per-step log-probability of a sequence of chosen tokens, a confidence summary suitable
     /// for the existing low-confidence suppression policy.
     ///

--- a/CotabbyTests/ConstrainedBeamSearchTests.swift
+++ b/CotabbyTests/ConstrainedBeamSearchTests.swift
@@ -1,0 +1,164 @@
+import XCTest
+@testable import Cotabby
+
+/// Tests for the constrained beam search, exercised against a scripted `BeamLogitsProvider` that maps
+/// a generated-token path to a logits row. This validates the whole search algorithm deterministically
+/// without loading a model; the live llama adapter is a thin KV-sync method on the runtime.
+final class ConstrainedBeamSearchTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    /// Records the token paths the search queried, so a test can assert it stopped where expected.
+    private final class PathRecorder {
+        private(set) var paths: [[Int]] = []
+        func record(_ path: [Int]) { paths.append(path) }
+    }
+
+    /// A scripted logits provider: returns the row mapped for a path, or a uniform low row otherwise.
+    private func provider(
+        vocabSize: Int,
+        rows: [[Int]: [Float]],
+        recorder: PathRecorder? = nil
+    ) -> BeamLogitsProvider {
+        { path in
+            recorder?.record(path)
+            return rows[path] ?? [Float](repeating: -20, count: vocabSize)
+        }
+    }
+
+    private func makeProfile(byteStrings: [String], eog: Set<Int> = []) -> TokenProfile {
+        let bytes = byteStrings.map { Array($0.utf8) }
+        return TokenProfile.build(
+            vocabSize: bytes.count,
+            bytesFor: { bytes[$0] },
+            isControl: { bytes[$0].isEmpty },
+            isEndOfGeneration: { eog.contains($0) }
+        )
+    }
+
+    private func row(_ values: [Int: Float], vocabSize: Int) -> [Float] {
+        var logits = [Float](repeating: -20, count: vocabSize)
+        for (id, value) in values {
+            logits[id] = value
+        }
+        return logits
+    }
+
+    // MARK: - rankedAdmissibleTokens
+
+    func test_rankedAdmissibleTokens_ordersByLogitAndDropsExcludedAndBlocked() {
+        // token 2 is control (empty bytes) -> excluded; token 0 is blocked by the caller.
+        let profile = makeProfile(byteStrings: ["a", "b", "", "d"])
+        let logits: [Float] = [9, 8, 7, 6]
+
+        let ranked = ConstrainedSampler.rankedAdmissibleTokens(
+            logits: logits, profile: profile, admissibleTokenIDs: nil, topK: 10, blockedTokenIDs: [0])
+
+        XCTAssertEqual(ranked, [1, 3], "drops blocked 0 and control 2; orders the rest by logit")
+    }
+
+    func test_rankedAdmissibleTokens_capsAtTopK() {
+        let profile = makeProfile(byteStrings: ["a", "b", "c", "d"])
+        let ranked = ConstrainedSampler.rankedAdmissibleTokens(
+            logits: [1, 4, 3, 2], profile: profile, admissibleTokenIDs: nil, topK: 2)
+        XCTAssertEqual(ranked, [1, 2])
+    }
+
+    // MARK: - search
+
+    func test_search_widthOne_takesTheHighestLogitToken() {
+        let profile = makeProfile(byteStrings: ["a", "b"])
+        let result = ConstrainedBeamSearch.search(
+            nextLogits: provider(vocabSize: 2, rows: [[]: row([0: 2, 1: 1], vocabSize: 2)]),
+            profile: profile,
+            configuration: BeamSearchConfiguration(beamWidth: 1, maxTokens: 1, topK: 5),
+            isSingleLine: false)
+
+        XCTAssertEqual(result.first?.text, "a")
+        XCTAssertEqual(result.first?.tokenIDs, [0])
+    }
+
+    func test_search_stopsOnEndOfGenerationToken() {
+        // Token 2 is EOG with non-empty bytes (so it is not masked as a control token). When it is the
+        // chosen next token, the branch completes without emitting it. (Real EOG tokens render empty
+        // and are excluded like any control token; this drives the EOG branch directly.)
+        let profile = makeProfile(byteStrings: ["a", "b", "Z"], eog: [2])
+        let result = ConstrainedBeamSearch.search(
+            nextLogits: provider(vocabSize: 3, rows: [
+                []: row([0: 5], vocabSize: 3),
+                [0]: row([2: 9], vocabSize: 3)
+            ]),
+            profile: profile,
+            configuration: BeamSearchConfiguration(beamWidth: 1, maxTokens: 4, topK: 2),
+            isSingleLine: false)
+
+        XCTAssertEqual(result.first?.text, "a")
+        XCTAssertEqual(result.first?.tokenIDs, [0])
+    }
+
+    func test_search_widerBeamExploresASecondBestFirstTokenThatGreedyMisses() {
+        // 0="A" (best first), 1="B" (second). Each leads to a continuation that ends a sentence, so the
+        // branches complete cleanly. Greedy only follows "A"; a width-2 beam also reaches "By.".
+        let profile = makeProfile(byteStrings: ["A", "B", "x.", "y."])
+        let rows: [[Int]: [Float]] = [
+            []: row([0: 5, 1: 4], vocabSize: 4),
+            [0]: row([2: 9], vocabSize: 4),
+            [1]: row([3: 9], vocabSize: 4)
+        ]
+        let greedy = ConstrainedBeamSearch.search(
+            nextLogits: provider(vocabSize: 4, rows: rows), profile: profile,
+            configuration: BeamSearchConfiguration(beamWidth: 1, maxTokens: 4, topK: 2),
+            isSingleLine: false)
+        let beam = ConstrainedBeamSearch.search(
+            nextLogits: provider(vocabSize: 4, rows: rows), profile: profile,
+            configuration: BeamSearchConfiguration(beamWidth: 2, maxTokens: 4, topK: 2),
+            isSingleLine: false)
+
+        XCTAssertFalse(greedy.map(\.text).contains("By."), "greedy only explores the best first token")
+        XCTAssertTrue(beam.map(\.text).contains("By."), "a width-2 beam also explores the second-best first token")
+    }
+
+    func test_search_doesNotEmitNewlineInSingleLineField() {
+        // token 0 is a newline, token 1 is "a". In a single-line field the newline ends a branch
+        // without being emitted.
+        let profile = makeProfile(byteStrings: ["\n", "a"])
+        let result = ConstrainedBeamSearch.search(
+            nextLogits: provider(vocabSize: 2, rows: [[]: row([0: 5, 1: 4], vocabSize: 2)]),
+            profile: profile,
+            configuration: BeamSearchConfiguration(beamWidth: 2, maxTokens: 1, topK: 5),
+            isSingleLine: true)
+
+        XCTAssertEqual(result.first?.text, "a")
+        XCTAssertFalse(result.contains { $0.text.contains("\n") })
+    }
+
+    func test_search_stopsAtSentenceBoundaryAndDoesNotGenerateFurther() {
+        // 0="Done", 1=".", 2="More". The completion should stop after the period and never step past.
+        let profile = makeProfile(byteStrings: ["Done", ".", "More"])
+        let recorder = PathRecorder()
+        let result = ConstrainedBeamSearch.search(
+            nextLogits: provider(vocabSize: 3, rows: [
+                []: row([0: 5], vocabSize: 3),
+                [0]: row([1: 5], vocabSize: 3),
+                [0, 1]: row([2: 5], vocabSize: 3)
+            ], recorder: recorder),
+            profile: profile,
+            configuration: BeamSearchConfiguration(beamWidth: 1, maxTokens: 6, topK: 5),
+            isSingleLine: false)
+
+        XCTAssertEqual(result.first?.text, "Done.")
+        XCTAssertFalse(recorder.paths.contains([0, 1]), "search must stop at the sentence and not step past it")
+    }
+
+    func test_search_respectsMaxTokenBudget() {
+        // No EOG / sentence end: every token keeps generating, so the budget bounds the length.
+        let profile = makeProfile(byteStrings: ["a", "b"])
+        let result = ConstrainedBeamSearch.search(
+            nextLogits: provider(vocabSize: 2, rows: [:]),  // unmapped -> uniform low logits
+            profile: profile,
+            configuration: BeamSearchConfiguration(beamWidth: 1, maxTokens: 2, topK: 2),
+            isSingleLine: false)
+
+        XCTAssertEqual(result.first?.tokenIDs.count, 2)
+    }
+}


### PR DESCRIPTION
## Summary

Adds a multi-branch (beam) search to the constrained decoder so it can explore several short
continuations at once and keep the highest-scoring one, instead of committing to a single greedy
token at each step (greedy argmax can pick a locally-best token that leads nowhere good).

The search is written against a small `BeamLogitsProvider` closure — "give me the next-token logits
for this branch's token path" — so the whole algorithm is unit-tested against a scripted closure that
returns fixed logits, with **no model required**. The live llama adapter is a thin KV-sync method on
the runtime (`beamLogits` / `syncBeamSequence`): before reading a branch's logits it trims the shared
sequence's KV cache back to the longest shared prefix and re-accepts the remainder, all under the
existing `autocompleteLock`, and the existing KV-trim defer restores prompt-only state afterward. (A
closure rather than a protocol object because the inference engine is a noncopyable C++ type that
cannot be stored in a separate adapter object.)

Each branch reuses the same machinery as the greedy path: the token profile, the no-repeat-ngram
guard, the sentence-boundary stop, single-line newline masking, and the confidence-suppression gate.
Branches are scored by cumulative log-probability and the result is ranked by mean log-probability.

Gated behind the existing developer flags: `cotabbyConstrainedDecoderEnabled` (default off) plus a new
`cotabbyConstrainedBeamWidth` (default 1 = the existing single-path greedy decode). The shipping
sampler path is untouched.

## Validation

```
xcodebuild ... test ... CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO \
  -only-testing:CotabbyTests/ConstrainedBeamSearchTests \
  -only-testing:CotabbyTests/ConstrainedSamplerTests \
  -only-testing:CotabbyTests/LlamaSuggestionEngineCancellationTests
# ** TEST SUCCEEDED **
#   ConstrainedBeamSearchTests: 8/8 — greedy width-1, beam exploring a second-best first token that
#     greedy misses, EOG stop, single-line newline not emitted, sentence-boundary stop, max-token
#     budget, plus rankedAdmissibleTokens ordering/cap
#   ConstrainedSamplerTests + cancellation tests: unchanged, green

swiftlint --strict --quiet   # exit 0 (clean)
xcodegen generate            # registered the two new files (CI drift guard passes)
```

## Linked issues

None. Brings the constrained decoder up to a real multi-branch search.

## Risk / rollout notes

- **Default-off, twice over.** Beam only runs when the constrained decoder flag is on AND
  `cotabbyConstrainedBeamWidth > 1`. With the defaults, behavior is byte-for-byte the existing
  greedy/sampler path. No change to shipped suggestion behavior.
- **The algorithm is fully unit-tested; the engine adapter is intentionally thin.** The only part not
  exercised by tests is the ~25-line `EngineBeamStepper` KV-sync (it uses the same `trimKV` /
  `acceptToken` / `getNextTokenLogits` calls the greedy decoder already relies on). Enabling beam by
  default still needs on-device evaluation of completion quality and per-keystroke latency (beam width
  W decodes up to ~W× the greedy token count) — that is the next step before promoting the flag.
- A future optimization could add KV snapshot/restore to the inference engine to avoid the
  trim-and-re-accept on each branch switch; not required for correctness.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a multi-branch (beam) search mode to the constrained decoder, letting it explore several continuations per step and return the highest mean-log-probability one instead of committing greedily to each token. The new path is double-gated (`cotabbyConstrainedDecoderEnabled` AND `cotabbyConstrainedBeamWidth > 1`), so shipped behavior is unchanged.

- `ConstrainedBeamSearch.swift` implements the search engine as a pure closure-based algorithm (`BeamLogitsProvider`), reusing the same token profile, no-repeat-ngram guard, single-line newline masking, and sentence-boundary stop as the greedy path; 8 unit tests exercise all core stop conditions against a scripted logits closure.
- `LlamaRuntimeCore` adds `runConstrainedBeamDecode` and a `syncBeamSequence` KV-cache sync helper that trims the shared sequence to the longest common prefix of the current and target paths before re-accepting branch tokens, all under the existing `autocompleteLock`.
- `ConstrainedSampler` gains `rankedAdmissibleTokens` (the multi-candidate analogue of `selectToken`) and `LlamaGenerationOptions` gains `beamWidth: Int = 1`, intentionally excluded from `SamplingFingerprint` to preserve KV reuse.

<h3>Confidence Score: 3/5</h3>

Safe to merge as-shipped since the beam path is double-gated and off by default, but the decode loop holds autocompleteLock without any cancellation check, which will degrade responsiveness noticeably during dogfood testing with the flags enabled.

The new beam decode path does not check Task.isCancelled between steps, unlike both the sampled and greedy decoders that break early on cancel. Under fast typing, each new keystroke supersedes the previous request; for greedy/sampled the lock is freed after 1-2 tokens, but for beam the lock is held for the full W x N step search, making every subsequent request wait. A secondary gap is that branches with no remaining admissible tokens are silently discarded rather than collected as partial completions, inconsistent with the greedy decoder behavior.

Cotabby/Services/Runtime/LlamaRuntimeCore.swift (missing cancellation in runConstrainedBeamDecode) and Cotabby/Support/ConstrainedBeamSearch.swift (silent branch loss on empty candidate list).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/Support/ConstrainedBeamSearch.swift | New file implementing the beam search engine; algorithmically sound for the happy path, but branches that exhaust all admissible tokens are silently dropped rather than completed, inconsistent with the greedy decoder behavior. |
| Cotabby/Services/Runtime/LlamaRuntimeCore.swift | Adds runConstrainedBeamDecode and KV-sync helpers; logic is correct but lacks the Task.isCancelled cooperative cancellation present in both other decode paths, causing the lock to be held for the full beam budget even when the request is superseded. |
| Cotabby/Support/ConstrainedSampler.swift | Adds rankedAdmissibleTokens; implementation is correct and deterministic, but the docstring incorrectly claims it produces the same candidate set as selectToken when topK < vocabSize. |
| Cotabby/Services/Runtime/LlamaSuggestionEngine.swift | Adds constrainedBeamWidth UserDefaults knob with a safe default and threads it into LlamaGenerationOptions; clean and low-risk. |
| Cotabby/Models/LlamaRuntimeModels.swift | Adds beamWidth: Int = 1 to LlamaGenerationOptions with correct exclusion from SamplingFingerprint matching the existing useConstrainedDecoder approach. |
| CotabbyTests/ConstrainedBeamSearchTests.swift | Good unit test coverage of the main beam-search behaviors with a scripted logits provider; no test for the empty-candidates case. |
| Cotabby.xcodeproj/project.pbxproj | Registers ConstrainedBeamSearch.swift in the main target and ConstrainedBeamSearchTests.swift in the test target; straightforward Xcode project file update. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant SE as LlamaSuggestionEngine
    participant RC as LlamaRuntimeCore
    participant BS as ConstrainedBeamSearch
    participant KV as Engine (KV cache)

    SE->>RC: "generate(options beamWidth>1)"
    RC->>RC: obtain sequence, hold autocompleteLock
    RC->>BS: search(nextLogits closure, profile, config)
    loop each beam step
        loop each live branch
            BS->>RC: nextLogits(branch.tokenIDs)
            RC->>KV: trimKV to common prefix
            RC->>KV: acceptToken for remainder
            KV-->>RC: logits[vocabSize]
            RC-->>BS: [Float]
            BS->>BS: expand across topK candidates
            BS->>BS: route stops to completed, rest to live
        end
        BS->>BS: prune live to beamWidth
    end
    BS-->>RC: [BeamCandidate] sorted by meanLogprob
    RC->>RC: shouldSuppress check
    RC->>KV: trimKV to prompt only
    RC-->>SE: best.text
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cotabby/Services/Runtime/LlamaRuntimeCore.swift`, line 419-542 ([link](https://github.com/fujacob/cotabby/blob/63ea566add821f9e9f3f733b0ba2e2e998e742b7/Cotabby/Services/Runtime/LlamaRuntimeCore.swift#L419-L542)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Missing cooperative cancellation in beam decode**

   Both the sampled decoder (`runEngineSampledDecode`) and the greedy constrained decoder (`runConstrainedDecode`) check `Task.isCancelled` at each token step and break early, releasing `autocompleteLock` promptly. `runConstrainedBeamDecode` holds the lock for the entire `ConstrainedBeamSearch.search` call with no cancellation hook anywhere in the search loop. During fast typing, every new keystroke supersedes the in-flight generation — for greedy/sampled this means only ~1–2 tokens are decoded before the lock is freed; for beam with width W and budget N, the next request waits up to W×N KV syncs before it can proceed.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fconstrained-beam-search%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fconstrained-beam-search%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%0ALine%3A%20419-542%0A%0AComment%3A%0A**Missing%20cooperative%20cancellation%20in%20beam%20decode**%0A%0ABoth%20the%20sampled%20decoder%20%28%60runEngineSampledDecode%60%29%20and%20the%20greedy%20constrained%20decoder%20%28%60runConstrainedDecode%60%29%20check%20%60Task.isCancelled%60%20at%20each%20token%20step%20and%20break%20early%2C%20releasing%20%60autocompleteLock%60%20promptly.%20%60runConstrainedBeamDecode%60%20holds%20the%20lock%20for%20the%20entire%20%60ConstrainedBeamSearch.search%60%20call%20with%20no%20cancellation%20hook%20anywhere%20in%20the%20search%20loop.%20During%20fast%20typing%2C%20every%20new%20keystroke%20supersedes%20the%20in-flight%20generation%20%E2%80%94%20for%20greedy%2Fsampled%20this%20means%20only%20~1%E2%80%932%20tokens%20are%20decoded%20before%20the%20lock%20is%20freed%3B%20for%20beam%20with%20width%20W%20and%20budget%20N%2C%20the%20next%20request%20waits%20up%20to%20W%C3%97N%20KV%20syncs%20before%20it%20can%20proceed.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%0ALine%3A%20419-542%0A%0AComment%3A%0A**Missing%20cooperative%20cancellation%20in%20beam%20decode**%0A%0ABoth%20the%20sampled%20decoder%20%28%60runEngineSampledDecode%60%29%20and%20the%20greedy%20constrained%20decoder%20%28%60runConstrainedDecode%60%29%20check%20%60Task.isCancelled%60%20at%20each%20token%20step%20and%20break%20early%2C%20releasing%20%60autocompleteLock%60%20promptly.%20%60runConstrainedBeamDecode%60%20holds%20the%20lock%20for%20the%20entire%20%60ConstrainedBeamSearch.search%60%20call%20with%20no%20cancellation%20hook%20anywhere%20in%20the%20search%20loop.%20During%20fast%20typing%2C%20every%20new%20keystroke%20supersedes%20the%20in-flight%20generation%20%E2%80%94%20for%20greedy%2Fsampled%20this%20means%20only%20~1%E2%80%932%20tokens%20are%20decoded%20before%20the%20lock%20is%20freed%3B%20for%20beam%20with%20width%20W%20and%20budget%20N%2C%20the%20next%20request%20waits%20up%20to%20W%C3%97N%20KV%20syncs%20before%20it%20can%20proceed.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=518&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fconstrained-beam-search%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fconstrained-beam-search%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0ACotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%3A419-542%0A**Missing%20cooperative%20cancellation%20in%20beam%20decode**%0A%0ABoth%20the%20sampled%20decoder%20%28%60runEngineSampledDecode%60%29%20and%20the%20greedy%20constrained%20decoder%20%28%60runConstrainedDecode%60%29%20check%20%60Task.isCancelled%60%20at%20each%20token%20step%20and%20break%20early%2C%20releasing%20%60autocompleteLock%60%20promptly.%20%60runConstrainedBeamDecode%60%20holds%20the%20lock%20for%20the%20entire%20%60ConstrainedBeamSearch.search%60%20call%20with%20no%20cancellation%20hook%20anywhere%20in%20the%20search%20loop.%20During%20fast%20typing%2C%20every%20new%20keystroke%20supersedes%20the%20in-flight%20generation%20%E2%80%94%20for%20greedy%2Fsampled%20this%20means%20only%20~1%E2%80%932%20tokens%20are%20decoded%20before%20the%20lock%20is%20freed%3B%20for%20beam%20with%20width%20W%20and%20budget%20N%2C%20the%20next%20request%20waits%20up%20to%20W%C3%97N%20KV%20syncs%20before%20it%20can%20proceed.%0A%0A%23%23%23%20Issue%202%20of%203%0ACotabby%2FSupport%2FConstrainedBeamSearch.swift%3A120-148%0A**Branch%20silently%20dropped%20when%20no%20admissible%20tokens%20remain**%0A%0AWhen%20%60rankedAdmissibleTokens%60%20returns%20an%20empty%20list%20%28all%20tokens%20excluded%20or%20blocked%20by%20the%20no-repeat-ngram%20guard%29%2C%20the%20%60for%20tokenID%20in%20candidates%60%20loop%20body%20never%20executes.%20The%20branch%20is%20appended%20to%20neither%20%60live%60%20nor%20%60completed%60%2C%20so%20it%20disappears%20silently.%20In%20contrast%2C%20the%20greedy%20constrained%20decoder%20breaks%20with%20%60stopReason%20%3D%20%22no_admissible_token%22%60%20and%20returns%20whatever%20it%20has%20generated%20so%20far.%20A%20branch%20with%20partial%20output%20that%20cannot%20be%20extended%20should%20be%20treated%20as%20a%20completion%20%28%60completed.append%28branch%29%60%29%20rather%20than%20discarded%2C%20to%20stay%20consistent%20with%20the%20greedy%20behavior.%0A%0A%23%23%23%20Issue%203%20of%203%0ACotabby%2FSupport%2FConstrainedSampler.swift%3A75-79%0A**Docstring%20overstates%20equivalence%20with%20%60selectToken%60's%20topK%20semantics**%0A%0AThe%20comment%20says%20%22Survivors%20are%20the%20same%20set%20%60selectToken%60%20would%20consider%22%2C%20but%20the%20two%20functions%20handle%20%60topK%60%20differently.%20%60selectToken%60%20pre-filters%20to%20the%20top-K%20tokens%20by%20raw%20logit%20%28via%20%60candidatePool%60%29%20and%20then%20applies%20constraints%20%E2%80%94%20so%20a%20token%20at%20raw-logit%20rank%20K%2B1%20is%20never%20seen%20even%20if%20it%20would%20pass%20all%20filters.%20%60rankedAdmissibleTokens%60%20filters%20the%20full%20vocabulary%20first%20and%20then%20takes%20the%20top-K%20survivors%2C%20so%20a%20token%20at%20raw-logit%20rank%20K%2B1%20that%20passes%20all%20filters%20does%20appear.%20The%20beam%20search%20therefore%20explores%20a%20strictly%20broader%20set%20than%20greedy%20for%20any%20%60topK%20%3C%20vocabSize%60%2C%20which%20is%20intentional%2C%20but%20the%20%22same%20set%22%20claim%20is%20inaccurate%20and%20may%20confuse%20future%20maintainers%20comparing%20the%20two%20code%20paths.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0ACotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%3A419-542%0A**Missing%20cooperative%20cancellation%20in%20beam%20decode**%0A%0ABoth%20the%20sampled%20decoder%20%28%60runEngineSampledDecode%60%29%20and%20the%20greedy%20constrained%20decoder%20%28%60runConstrainedDecode%60%29%20check%20%60Task.isCancelled%60%20at%20each%20token%20step%20and%20break%20early%2C%20releasing%20%60autocompleteLock%60%20promptly.%20%60runConstrainedBeamDecode%60%20holds%20the%20lock%20for%20the%20entire%20%60ConstrainedBeamSearch.search%60%20call%20with%20no%20cancellation%20hook%20anywhere%20in%20the%20search%20loop.%20During%20fast%20typing%2C%20every%20new%20keystroke%20supersedes%20the%20in-flight%20generation%20%E2%80%94%20for%20greedy%2Fsampled%20this%20means%20only%20~1%E2%80%932%20tokens%20are%20decoded%20before%20the%20lock%20is%20freed%3B%20for%20beam%20with%20width%20W%20and%20budget%20N%2C%20the%20next%20request%20waits%20up%20to%20W%C3%97N%20KV%20syncs%20before%20it%20can%20proceed.%0A%0A%23%23%23%20Issue%202%20of%203%0ACotabby%2FSupport%2FConstrainedBeamSearch.swift%3A120-148%0A**Branch%20silently%20dropped%20when%20no%20admissible%20tokens%20remain**%0A%0AWhen%20%60rankedAdmissibleTokens%60%20returns%20an%20empty%20list%20%28all%20tokens%20excluded%20or%20blocked%20by%20the%20no-repeat-ngram%20guard%29%2C%20the%20%60for%20tokenID%20in%20candidates%60%20loop%20body%20never%20executes.%20The%20branch%20is%20appended%20to%20neither%20%60live%60%20nor%20%60completed%60%2C%20so%20it%20disappears%20silently.%20In%20contrast%2C%20the%20greedy%20constrained%20decoder%20breaks%20with%20%60stopReason%20%3D%20%22no_admissible_token%22%60%20and%20returns%20whatever%20it%20has%20generated%20so%20far.%20A%20branch%20with%20partial%20output%20that%20cannot%20be%20extended%20should%20be%20treated%20as%20a%20completion%20%28%60completed.append%28branch%29%60%29%20rather%20than%20discarded%2C%20to%20stay%20consistent%20with%20the%20greedy%20behavior.%0A%0A%23%23%23%20Issue%203%20of%203%0ACotabby%2FSupport%2FConstrainedSampler.swift%3A75-79%0A**Docstring%20overstates%20equivalence%20with%20%60selectToken%60's%20topK%20semantics**%0A%0AThe%20comment%20says%20%22Survivors%20are%20the%20same%20set%20%60selectToken%60%20would%20consider%22%2C%20but%20the%20two%20functions%20handle%20%60topK%60%20differently.%20%60selectToken%60%20pre-filters%20to%20the%20top-K%20tokens%20by%20raw%20logit%20%28via%20%60candidatePool%60%29%20and%20then%20applies%20constraints%20%E2%80%94%20so%20a%20token%20at%20raw-logit%20rank%20K%2B1%20is%20never%20seen%20even%20if%20it%20would%20pass%20all%20filters.%20%60rankedAdmissibleTokens%60%20filters%20the%20full%20vocabulary%20first%20and%20then%20takes%20the%20top-K%20survivors%2C%20so%20a%20token%20at%20raw-logit%20rank%20K%2B1%20that%20passes%20all%20filters%20does%20appear.%20The%20beam%20search%20therefore%20explores%20a%20strictly%20broader%20set%20than%20greedy%20for%20any%20%60topK%20%3C%20vocabSize%60%2C%20which%20is%20intentional%2C%20but%20the%20%22same%20set%22%20claim%20is%20inaccurate%20and%20may%20confuse%20future%20maintainers%20comparing%20the%20two%20code%20paths.%0A%0A&repo=fujacob%2Fcotabby&pr=518&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add multi-branch (beam) search to the co..."](https://github.com/fujacob/cotabby/commit/63ea566add821f9e9f3f733b0ba2e2e998e742b7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35045885)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->