### PR TITLE
Cache the constrained-decode vocabulary profile on disk

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -217,8 +217,10 @@
 		D46A0DB70B07F487431F48F6 /* EmojiPickerPanelLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7B185BA246A526CBA85E581 /* EmojiPickerPanelLayoutTests.swift */; };
 		D5CAF3B590E5EC2AFC72E57A /* VisualContextStartCoalescerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 050D929E13BE52E6282B64D2 /* VisualContextStartCoalescerTests.swift */; };
 		D648DD70AD847F67B77CE052 /* OnboardingTemplateRecommenderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B72736E416910878E8E493 /* OnboardingTemplateRecommenderTests.swift */; };
+		D747A2C2B49450D26C6179A7 /* TokenProfileCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73C04A71D85B25998144F11 /* TokenProfileCache.swift */; };
 		D800277BE3296DE2FB8198A8 /* ChromiumAccessibilityEnabler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8896D976C7F116EBA0F3969F /* ChromiumAccessibilityEnabler.swift */; };
 		D90C889A623A928F4F5FDC7B /* HardwareCapabilityProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41BBD5A4BA08CABE77860886 /* HardwareCapabilityProbe.swift */; };
+		D9B992A608F7FC9924D13271 /* TokenProfileCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F394B8A6E30CC47015772089 /* TokenProfileCacheTests.swift */; };
 		D9C51DEDF01033E276A479CE /* AXTextGeometryResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB58035EFFD65B767949BAE6 /* AXTextGeometryResolver.swift */; };
 		DA23422A2CF77CFD3B1283C8 /* OnboardingTemplateFeatureListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D814BBA41CF29E8DD9954651 /* OnboardingTemplateFeatureListTests.swift */; };
 		DB1310FF3576ACA6472C4DB1 /* TrailingDuplicationFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19A5B462891263BDFB56607 /* TrailingDuplicationFilterTests.swift */; };
@@ -497,6 +499,7 @@
 		E43E587E421AF544A8300CE4 /* CustomRulesCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomRulesCatalog.swift; sourceTree = "<group>"; };
 		E5DAF68AEBFE334F68A65E82 /* AcceptanceModePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcceptanceModePickerView.swift; sourceTree = "<group>"; };
 		E6423D6CC8CC371D2DA899DE /* PermissionOverlayTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOverlayTracker.swift; sourceTree = "<group>"; };
+		E73C04A71D85B25998144F11 /* TokenProfileCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenProfileCache.swift; sourceTree = "<group>"; };
 		E7D0BF193110927BEB865748 /* TokenProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenProfileTests.swift; sourceTree = "<group>"; };
 		E7F42112F14026E6253BB865 /* PermissionAndContextModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionAndContextModelTests.swift; sourceTree = "<group>"; };
 		EAAE6B395FAB604DF059280A /* KeyCodeLabels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyCodeLabels.swift; sourceTree = "<group>"; };
@@ -506,6 +509,7 @@
 		EE94342B888A5A2CCF66BC93 /* SuggestionRequestFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionRequestFactoryTests.swift; sourceTree = "<group>"; };
 		EFD89799BB82AF7A92559AEB /* ClipboardContentDistillerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardContentDistillerTests.swift; sourceTree = "<group>"; };
 		F308F6E274CC645E27CB651F /* OverlayController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayController.swift; sourceTree = "<group>"; };
+		F394B8A6E30CC47015772089 /* TokenProfileCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenProfileCacheTests.swift; sourceTree = "<group>"; };
 		F3CEFE8C321E17BB3873C893 /* TokenProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenProfile.swift; sourceTree = "<group>"; };
 		FA4B45B91D4DEAC979C3113E /* PromptContextSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptContextSanitizer.swift; sourceTree = "<group>"; };
 		FA878B447441BB4F3E327CC8 /* OnboardingTemplateRecommender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTemplateRecommender.swift; sourceTree = "<group>"; };
@@ -805,6 +809,7 @@
 				C71031E8DB171047318B92FC /* SyntheticReplacePlannerTests.swift */,
 				43E37A7E835D3BDE6265843C /* TerminalAppDetectorTests.swift */,
 				FC24FD54860CE6737E65EF65 /* TextDirectionDetectorTests.swift */,
+				F394B8A6E30CC47015772089 /* TokenProfileCacheTests.swift */,
 				E7D0BF193110927BEB865748 /* TokenProfileTests.swift */,
 				E19A5B462891263BDFB56607 /* TrailingDuplicationFilterTests.swift */,
 				050D929E13BE52E6282B64D2 /* VisualContextStartCoalescerTests.swift */,
@@ -958,6 +963,7 @@
 				7F4C4A7EAF886E0CC945BFEF /* TerminalAppDetector.swift */,
 				328847A0F494360033366791 /* TextDirectionDetector.swift */,
 				F3CEFE8C321E17BB3873C893 /* TokenProfile.swift */,
+				E73C04A71D85B25998144F11 /* TokenProfileCache.swift */,
 				D408D647412C59F3E692C42B /* TrailingDuplicationFilter.swift */,
 				2F01FAC4F57EB08471521196 /* VisualContextStartCoalescer.swift */,
 				815F2ABAF6AB75DA3AFBBCEF /* WordCountFormatter.swift */,
@@ -1242,6 +1248,7 @@
 				96782E57CA26A16409368B69 /* TextDirectionDetector.swift in Sources */,
 				6014B31E2570EFFE45557E33 /* TickMarkSlider.swift in Sources */,
 				8EED2B55999A119AE3B67359 /* TokenProfile.swift in Sources */,
+				D747A2C2B49450D26C6179A7 /* TokenProfileCache.swift in Sources */,
 				D3B43622E5A41B11E7AF527E /* TrailingDuplicationFilter.swift in Sources */,
 				E9E4CC657771DF9F4C56183C /* VisualContextCoordinator.swift in Sources */,
 				4190F8A76196B16ED94D0A55 /* VisualContextModels.swift in Sources */,
@@ -1329,6 +1336,7 @@
 				EF5BAB96DDADABB86F9E02D9 /* SyntheticReplacePlannerTests.swift in Sources */,
 				DE236C9285635C686D66A2F6 /* TerminalAppDetectorTests.swift in Sources */,
 				5A441797D71A880A7482077D /* TextDirectionDetectorTests.swift in Sources */,
+				D9B992A608F7FC9924D13271 /* TokenProfileCacheTests.swift in Sources */,
 				CA8F453AA4AD02FAA8C961F7 /* TokenProfileTests.swift in Sources */,
 				DB1310FF3576ACA6472C4DB1 /* TrailingDuplicationFilterTests.swift in Sources */,
 				D5CAF3B590E5EC2AFC72E57A /* VisualContextStartCoalescerTests.swift in Sources */,

--- a/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
+++ b/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
@@ -734,6 +734,18 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
             throw LlamaRuntimeError.generationFailed("Vocabulary unavailable for constrained decoding.")
         }
 
+        let fingerprint = Self.tokenProfileFingerprint(modelURL: modelURL, vocabSize: vocabSize)
+        let cacheURL = Self.tokenProfileCacheURL(for: modelURL)
+        if let cached = loadCachedTokenProfile(from: cacheURL, fingerprint: fingerprint) {
+            cachedTokenProfile = cached
+            cachedTokenProfileModelURL = modelURL
+            CotabbyLogger.runtime.debug(
+                "Loaded constrained-decode token profile from disk cache",
+                metadata: ["vocab_size": .stringConvertible(vocabSize)]
+            )
+            return cached
+        }
+
         // Detokenize every token once up front; the build closures index this snapshot so each
         // token's bytes are computed a single time and its control flag derives from the same bytes.
         var tokenBytes: [[UInt8]] = []
@@ -752,11 +764,65 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
         )
         cachedTokenProfile = profile
         cachedTokenProfileModelURL = modelURL
+        if let cacheURL {
+            Self.writeTokenProfileCache(profile, fingerprint: fingerprint, to: cacheURL)
+        }
         CotabbyLogger.runtime.debug(
             "Built constrained-decode token profile",
             metadata: ["vocab_size": .stringConvertible(vocabSize)]
         )
         return profile
+    }
+
+    /// Reads a cached profile for the current model, or nil when there is no usable cache file. Any
+    /// read or decode failure (missing file, fingerprint mismatch, corruption) returns nil so the
+    /// caller rebuilds; the cache can never produce a wrong profile, only a rebuild.
+    private func loadCachedTokenProfile(from cacheURL: URL?, fingerprint: UInt64) -> TokenProfile? {
+        guard let cacheURL, let data = try? Data(contentsOf: cacheURL) else {
+            return nil
+        }
+        return TokenProfileCache.decode(data, expectedFingerprint: fingerprint)
+    }
+
+    /// Best-effort write of a freshly built profile to the cache. Failures are swallowed: the cache is
+    /// an optimization, and the in-memory profile is already returned regardless.
+    private static func writeTokenProfileCache(_ profile: TokenProfile, fingerprint: UInt64, to url: URL) {
+        let data = TokenProfileCache.encode(profile, fingerprint: fingerprint)
+        try? data.write(to: url, options: .atomic)
+    }
+
+    /// Cache file location: `<Application Support>/Cotabby/TokenProfiles/<model>.ctkp`. Returns nil
+    /// when the support directory is unavailable (the cache is then simply skipped).
+    private static func tokenProfileCacheURL(for modelURL: URL?) -> URL? {
+        guard let modelURL,
+              let support = try? FileManager.default.url(
+                for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+        else {
+            return nil
+        }
+        let directory = support.appendingPathComponent("Cotabby/TokenProfiles", isDirectory: true)
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let safeName = modelURL.lastPathComponent.replacingOccurrences(of: "/", with: "_")
+        return directory.appendingPathComponent(safeName).appendingPathExtension("ctkp")
+    }
+
+    /// Stable (non-randomized) fingerprint tying a cache file to one model: FNV-1a over the model path,
+    /// file size, and vocabulary size, so replacing the model file or loading a different one
+    /// invalidates the cache. Swift's `hashValue` is per-process randomized and unusable here.
+    private static func tokenProfileFingerprint(modelURL: URL?, vocabSize: Int) -> UInt64 {
+        var hash: UInt64 = 0xcbf2_9ce4_8422_2325
+        func mix(_ bytes: [UInt8]) {
+            for byte in bytes {
+                hash = (hash ^ UInt64(byte)) &* 0x0000_0100_0000_01b3
+            }
+        }
+        mix(Array((modelURL?.path ?? "").utf8))
+        let fileSize = modelURL.flatMap { url in
+            (try? FileManager.default.attributesOfItem(atPath: url.path))?[.size] as? Int
+        } ?? 0
+        mix(withUnsafeBytes(of: Int64(fileSize).littleEndian) { Array($0) })
+        mix(withUnsafeBytes(of: Int64(vocabSize).littleEndian) { Array($0) })
+        return hash
     }
 
     /// The raw UTF-8 bytes a token detokenizes to, or empty for a structural token that renders to

--- a/Cotabby/Support/TokenProfileCache.swift
+++ b/Cotabby/Support/TokenProfileCache.swift
@@ -1,0 +1,123 @@
+import Foundation
+
+/// File overview:
+/// A compact on-disk encoding of a constrained-decode `TokenProfile`, so the expensive full-vocabulary
+/// detokenize scan that builds it runs once per model and is reloaded from disk on later launches
+/// instead of rebuilt every time the constrained decoder first runs.
+///
+/// Why this file exists:
+/// Building a `TokenProfile` calls the engine's detokenizer once per vocabulary token (often 100k+),
+/// which delays the first constrained completion after launch. The profile is a pure function of the
+/// model's vocabulary, so it can be cached. Only the per-token raw bytes and the end-of-generation bit
+/// need storing; every other flag (`isControl`, whitespace-only, newline) is derived from the bytes by
+/// `TokenProfile.build`, so decoding reconstructs an identical profile. A fingerprint in the header
+/// ties a cache file to one model + vocabulary, and a mismatch (or any malformed/truncated data)
+/// decodes to nil so the caller rebuilds. The cache is therefore strictly an optimization: a wrong or
+/// corrupt file can never produce a wrong profile, only a rebuild.
+enum TokenProfileCache {
+    private static let magic: [UInt8] = Array("CTKP".utf8)   // CoTabby Token Profile
+    private static let version: UInt8 = 1
+    /// Defensive cap so a corrupt vocab-size field cannot drive a giant allocation; real vocabularies
+    /// are well under this.
+    private static let maxVocabSize = 5_000_000
+
+    /// Serializes `profile` with a `fingerprint` (model + vocabulary identity) in the header.
+    static func encode(_ profile: TokenProfile, fingerprint: UInt64) -> Data {
+        var data = Data()
+        data.append(contentsOf: magic)
+        data.append(version)
+        appendUInt64(fingerprint, to: &data)
+        appendUInt32(UInt32(clamping: profile.entries.count), to: &data)
+        for entry in profile.entries {
+            appendUInt32(UInt32(clamping: entry.bytes.count), to: &data)
+            data.append(contentsOf: entry.bytes)
+            data.append(entry.isEndOfGeneration ? 1 : 0)
+        }
+        return data
+    }
+
+    /// Reconstructs a `TokenProfile` from `data`, or nil when the magic / version / fingerprint do not
+    /// match or the data is malformed. Reconstruction goes through `TokenProfile.build`, so the derived
+    /// flags are recomputed from the stored bytes and exactly match a freshly-built profile.
+    static func decode(_ data: Data, expectedFingerprint: UInt64) -> TokenProfile? {
+        var reader = Reader(data)
+        guard reader.readBytes(magic.count) == magic,
+              reader.readUInt8() == version,
+              reader.readUInt64() == expectedFingerprint,
+              let vocabSize = reader.readUInt32().map(Int.init),
+              vocabSize <= maxVocabSize else {
+            return nil
+        }
+        var tokenBytes: [[UInt8]] = []
+        var endOfGeneration: [Bool] = []
+        tokenBytes.reserveCapacity(vocabSize)
+        endOfGeneration.reserveCapacity(vocabSize)
+        for _ in 0 ..< vocabSize {
+            guard let byteCount = reader.readUInt32().map(Int.init),
+                  let bytes = reader.readBytes(byteCount),
+                  let flag = reader.readUInt8() else {
+                return nil
+            }
+            tokenBytes.append(bytes)
+            endOfGeneration.append(flag & 1 == 1)
+        }
+        guard reader.isAtEnd else {
+            return nil
+        }
+        return TokenProfile.build(
+            vocabSize: vocabSize,
+            bytesFor: { tokenBytes[$0] },
+            isControl: { tokenBytes[$0].isEmpty },
+            isEndOfGeneration: { endOfGeneration[$0] }
+        )
+    }
+
+    private static func appendUInt32(_ value: UInt32, to data: inout Data) {
+        var little = value.littleEndian
+        withUnsafeBytes(of: &little) { data.append(contentsOf: $0) }
+    }
+
+    private static func appendUInt64(_ value: UInt64, to data: inout Data) {
+        var little = value.littleEndian
+        withUnsafeBytes(of: &little) { data.append(contentsOf: $0) }
+    }
+
+    /// Forward-only byte reader that returns nil rather than trapping when asked for more than remains,
+    /// so a truncated cache file decodes to nil instead of crashing.
+    private struct Reader {
+        private let bytes: [UInt8]
+        private var offset = 0
+
+        init(_ data: Data) {
+            bytes = [UInt8](data)
+        }
+
+        var isAtEnd: Bool { offset == bytes.count }
+
+        mutating func readBytes(_ count: Int) -> [UInt8]? {
+            guard count >= 0, offset + count <= bytes.count else {
+                return nil
+            }
+            defer { offset += count }
+            return Array(bytes[offset ..< offset + count])
+        }
+
+        mutating func readUInt8() -> UInt8? {
+            readBytes(1)?.first
+        }
+
+        mutating func readUInt32() -> UInt32? {
+            guard let slice = readBytes(4) else { return nil }
+            return UInt32(slice[0]) | UInt32(slice[1]) << 8 | UInt32(slice[2]) << 16 | UInt32(slice[3]) << 24
+        }
+
+        mutating func readUInt64() -> UInt64? {
+            guard let slice = readBytes(8) else { return nil }
+            var value: UInt64 = 0
+            for index in 0 ..< 8 {
+                value |= UInt64(slice[index]) << (8 * index)
+            }
+            return value
+        }
+    }
+}

--- a/CotabbyTests/TokenProfileCacheTests.swift
+++ b/CotabbyTests/TokenProfileCacheTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+@testable import Cotabby
+
+/// Round-trip and robustness tests for the on-disk token-profile codec. The cache must reconstruct an
+/// identical profile, and must reject any mismatched or malformed data with nil so the runtime rebuilds
+/// rather than trusting a bad file.
+final class TokenProfileCacheTests: XCTestCase {
+    private func makeProfile(byteStrings: [String], eog: Set<Int> = []) -> TokenProfile {
+        let bytes = byteStrings.map { Array($0.utf8) }
+        return TokenProfile.build(
+            vocabSize: bytes.count,
+            bytesFor: { bytes[$0] },
+            isControl: { bytes[$0].isEmpty },
+            isEndOfGeneration: { eog.contains($0) })
+    }
+
+    func test_roundTrip_reconstructsIdenticalProfile() {
+        // Mix of leading-space, empty (control), multi-byte, and punctuation tokens.
+        let profile = makeProfile(byteStrings: ["a", " the", "", "héllo", ".", "\n"], eog: [2])
+        let data = TokenProfileCache.encode(profile, fingerprint: 0xABCD_1234)
+        let decoded = TokenProfileCache.decode(data, expectedFingerprint: 0xABCD_1234)
+
+        XCTAssertNotNil(decoded)
+        XCTAssertEqual(decoded?.vocabSize, profile.vocabSize)
+        for id in 0 ..< profile.vocabSize {
+            XCTAssertEqual(decoded?.bytes(for: id), profile.bytes(for: id))
+            XCTAssertEqual(decoded?.isEndOfGeneration(id), profile.isEndOfGeneration(id))
+            XCTAssertEqual(decoded?.isExcluded(id), profile.isExcluded(id), "derived control flag must match")
+            XCTAssertEqual(decoded?.isNewline(id), profile.isNewline(id), "derived newline flag must match")
+        }
+    }
+
+    func test_decode_returnsNilOnFingerprintMismatch() {
+        let data = TokenProfileCache.encode(makeProfile(byteStrings: ["a", "b"]), fingerprint: 1)
+        XCTAssertNil(TokenProfileCache.decode(data, expectedFingerprint: 2))
+    }
+
+    func test_decode_returnsNilOnTruncatedData() {
+        let data = TokenProfileCache.encode(makeProfile(byteStrings: ["hello", "world"]), fingerprint: 7)
+        XCTAssertNil(TokenProfileCache.decode(data.dropLast(3), expectedFingerprint: 7))
+    }
+
+    func test_decode_returnsNilOnEmptyOrGarbageData() {
+        XCTAssertNil(TokenProfileCache.decode(Data(), expectedFingerprint: 0))
+        XCTAssertNil(TokenProfileCache.decode(Data([0, 1, 2, 3, 4, 5, 6, 7, 8]), expectedFingerprint: 0))
+    }
+
+    func test_roundTrip_emptyProfile() {
+        let profile = TokenProfile.build(
+            vocabSize: 0, bytesFor: { _ in [] }, isControl: { _ in true }, isEndOfGeneration: { _ in false })
+        let data = TokenProfileCache.encode(profile, fingerprint: 99)
+        XCTAssertEqual(TokenProfileCache.decode(data, expectedFingerprint: 99)?.vocabSize, 0)
+    }
+}


### PR DESCRIPTION
## Summary

The constrained decoder builds a per-model token profile (each vocabulary token's bytes plus an
end-of-generation bit) by calling the engine's detokenizer once per token — often 100k+ calls, slow
enough to delay the first constrained completion after each launch. This adds a small on-disk cache so
that scan runs once per model and is reloaded from `<Application Support>/Cotabby/TokenProfiles/` on
later launches.

The codec (`TokenProfileCache`) is pure and stores only the per-token bytes and EOG bit; every other
flag (control, whitespace-only, newline) is re-derived from the bytes by `TokenProfile.build`, so a
decoded profile is byte-identical to a freshly built one. A stable FNV-1a fingerprint over the model
path, file size, and vocab size is written in the header; on load, a mismatch — or any malformed,
truncated, or missing file — decodes to nil and the runtime rebuilds. The cache is therefore strictly
an optimization: it can never produce a wrong profile, only a rebuild.

## Validation

```
xcodebuild ... test ... CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO \
  -only-testing:CotabbyTests/TokenProfileCacheTests \
  -only-testing:CotabbyTests/LlamaSuggestionEngineCancellationTests \
  -only-testing:CotabbyTests/ConstrainedBeamSearchTests
# ** TEST SUCCEEDED **
#   TokenProfileCacheTests: round-trip reconstructs an identical profile (incl. derived flags),
#     and nil on fingerprint mismatch / truncation / empty / garbage / empty-profile

swiftlint --strict --quiet   # exit 0 (clean)
xcodegen generate            # registered the two new files (CI drift guard passes)
```

## Linked issues

None. Phase-1 foundation: a persisted, validated per-model token profile (the "built once" property of
the planned profile format).

## Risk / rollout notes

- **Only exercised when the constrained decoder runs** (the `cotabbyConstrainedDecoderEnabled`
  developer flag, default off), so there is no change to shipped behavior. The fail-safe design means a
  stale or corrupt cache file just triggers a rebuild.
- All file I/O is best-effort (`try?`): if the support directory is unavailable or a write fails, the
  in-memory profile is still returned and the decoder runs normally.
- Cache files live under Application Support and are keyed by model; replacing a model file changes the
  fingerprint and invalidates the old entry.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an on-disk cache for the constrained decoder's per-model token profile, avoiding the expensive full-vocabulary detokenize scan (100k+ calls) on every launch after the first. The codec stores only per-token raw bytes and the end-of-generation bit; all derived flags (`isControl`, `isWhitespaceOnly`, `isNewline`) are recomputed via `TokenProfile.build` on load, so a decoded profile is byte-identical to a freshly built one.

- **`TokenProfileCache.swift`** — New binary codec (magic + version + FNV-1a fingerprint header, little-endian fields, nil-returning safe reader) that serializes and deserializes a `TokenProfile`; any mismatch or corruption returns `nil` so the runtime rebuilds.
- **`LlamaRuntimeCore.swift`** — Integrates the cache into `autocompleteTokenProfile()`: fingerprint is derived from model path + file size + vocab size; cache is read before building and written (best-effort, `.atomic`) after; all I/O failures are swallowed so the in-memory profile is always returned.
- **`TokenProfileCacheTests.swift`** — Round-trip, fingerprint-mismatch, truncation, garbage, and empty-profile tests verify codec correctness and robustness.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the cache is purely additive, gated behind the existing developer flag, and falls back to a full rebuild on any I/O or fingerprint failure, so it cannot produce an incorrect profile or regress existing behavior.

The codec, fingerprint, and fail-safe design are solid. Two quality concerns exist: models with identical filenames in different directories will share a cache file and perpetually invalidate each other, and the first-build write is synchronous on the return path adding disk I/O latency on top of the already-slow detokenize scan.

LlamaRuntimeCore.swift — the cache filename derivation and synchronous write path are the areas worth a second look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/TokenProfileCache.swift | New codec for on-disk token profile; magic/version/fingerprint header, little-endian binary encoding, and a safe nil-returning reader — well-structured with no correctness issues found. |
| Cotabby/Services/Runtime/LlamaRuntimeCore.swift | Cache load/write integration is sound and fail-safe; two P2 concerns: same-named models in different directories share a cache filename (causing perpetual invalidation), and the first-build write is synchronous on the return path. |
| CotabbyTests/TokenProfileCacheTests.swift | Covers round-trip, fingerprint mismatch, truncation, empty data, garbage, and empty-profile edge cases; good coverage for the codec. |
| Cotabby.xcodeproj/project.pbxproj | Registers TokenProfileCache.swift and TokenProfileCacheTests.swift in both the main target and the test target; no issues found. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant LlamaRuntimeCore
    participant FileManager
    participant TokenProfileCache
    participant LlamaEngine

    Caller->>LlamaRuntimeCore: autocompleteTokenProfile()
    LlamaRuntimeCore->>LlamaRuntimeCore: check in-memory cachedTokenProfile
    alt in-memory hit
        LlamaRuntimeCore-->>Caller: return cached profile
    else in-memory miss
        LlamaRuntimeCore->>LlamaRuntimeCore: compute fingerprint (FNV-1a: path + size + vocabSize)
        LlamaRuntimeCore->>FileManager: tokenProfileCacheURL(for: modelURL)
        FileManager-->>LlamaRuntimeCore: cacheURL (or nil)
        LlamaRuntimeCore->>FileManager: Data(contentsOf: cacheURL)
        FileManager-->>LlamaRuntimeCore: data (or nil)
        alt disk cache hit and fingerprint matches
            LlamaRuntimeCore->>TokenProfileCache: decode(data, expectedFingerprint)
            TokenProfileCache-->>LlamaRuntimeCore: TokenProfile
            LlamaRuntimeCore->>LlamaRuntimeCore: store in cachedTokenProfile
            LlamaRuntimeCore-->>Caller: return profile
        else disk miss / mismatch / corrupt
            loop "for each token id 0..<vocabSize"
                LlamaRuntimeCore->>LlamaEngine: detokenize(id)
                LlamaEngine-->>LlamaRuntimeCore: bytes
            end
            LlamaRuntimeCore->>LlamaRuntimeCore: TokenProfile.build(...)
            LlamaRuntimeCore->>LlamaRuntimeCore: store in cachedTokenProfile
            LlamaRuntimeCore->>TokenProfileCache: encode(profile, fingerprint)
            TokenProfileCache-->>LlamaRuntimeCore: data
            LlamaRuntimeCore->>FileManager: data.write(to: cacheURL, .atomic)
            LlamaRuntimeCore-->>Caller: return profile
        end
    end
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Ftoken-profile-cache%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Ftoken-profile-cache%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%3A805-806%0A**Cache-file%20naming%20collision%20for%20same-named%20models%20in%20different%20directories**%0A%0AThe%20cache%20filename%20is%20derived%20solely%20from%20%60modelURL.lastPathComponent%60%2C%20so%20two%20models%20with%20the%20same%20filename%20but%20different%20parent%20paths%20%28e.g.%20%60%2Fmodels%2Ffast%2Fggml-model-q4.gguf%60%20and%20%60%2Fmodels%2Fslow%2Fggml-model-q4.gguf%60%29%20share%20one%20%60.ctkp%60%20file.%20The%20fingerprint%20includes%20the%20full%20path%2C%20so%20correctness%20is%20preserved%20%E2%80%94%20every%20load%20is%20a%20cache%20miss%20and%20the%20file%20is%20overwritten%20%E2%80%94%20but%20neither%20model%20ever%20benefits%20from%20the%20cache.%20A%20user%20who%20alternates%20between%20such%20models%20will%20rebuild%20the%20profile%20every%20launch.%20Consider%20keying%20the%20filename%20on%20a%20compact%20hash%20of%20the%20full%20path%20%28e.g.%20the%20first%208%20hex%20digits%20of%20the%20FNV-1a%20result%20over%20the%20path%29%20to%20make%20the%20mapping%20injective%2C%20or%20appending%20a%20truncated%20path%20fragment%20for%20human%20readability.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%3A767-769%0A**Synchronous%20disk%20write%20prolongs%20the%20first%20constrained%20completion**%0A%0A%60writeTokenProfileCache%60%20is%20called%20on%20the%20same%20thread%20and%20before%20%60return%20profile%60%2C%20so%20the%20first%20build%20incurs%20both%20the%20detokenize%20scan%20%28already%20slow%20at%20100k%2B%20calls%29%20and%20a%20potentially%20multi-MB%20synchronous%20write%20before%20the%20caller%20receives%20the%20profile.%20Moving%20the%20write%20to%20a%20detached%20%60Task%60%20or%20a%20background%20queue%20would%20let%20the%20caller%20proceed%20immediately%20while%20the%20cache%20is%20persisted%20in%20the%20background%2C%20without%20affecting%20correctness%20%28failures%20are%20already%20swallowed%20and%20the%20in-memory%20profile%20is%20available%29.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%3A805-806%0A**Cache-file%20naming%20collision%20for%20same-named%20models%20in%20different%20directories**%0A%0AThe%20cache%20filename%20is%20derived%20solely%20from%20%60modelURL.lastPathComponent%60%2C%20so%20two%20models%20with%20the%20same%20filename%20but%20different%20parent%20paths%20%28e.g.%20%60%2Fmodels%2Ffast%2Fggml-model-q4.gguf%60%20and%20%60%2Fmodels%2Fslow%2Fggml-model-q4.gguf%60%29%20share%20one%20%60.ctkp%60%20file.%20The%20fingerprint%20includes%20the%20full%20path%2C%20so%20correctness%20is%20preserved%20%E2%80%94%20every%20load%20is%20a%20cache%20miss%20and%20the%20file%20is%20overwritten%20%E2%80%94%20but%20neither%20model%20ever%20benefits%20from%20the%20cache.%20A%20user%20who%20alternates%20between%20such%20models%20will%20rebuild%20the%20profile%20every%20launch.%20Consider%20keying%20the%20filename%20on%20a%20compact%20hash%20of%20the%20full%20path%20%28e.g.%20the%20first%208%20hex%20digits%20of%20the%20FNV-1a%20result%20over%20the%20path%29%20to%20make%20the%20mapping%20injective%2C%20or%20appending%20a%20truncated%20path%20fragment%20for%20human%20readability.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%3A767-769%0A**Synchronous%20disk%20write%20prolongs%20the%20first%20constrained%20completion**%0A%0A%60writeTokenProfileCache%60%20is%20called%20on%20the%20same%20thread%20and%20before%20%60return%20profile%60%2C%20so%20the%20first%20build%20incurs%20both%20the%20detokenize%20scan%20%28already%20slow%20at%20100k%2B%20calls%29%20and%20a%20potentially%20multi-MB%20synchronous%20write%20before%20the%20caller%20receives%20the%20profile.%20Moving%20the%20write%20to%20a%20detached%20%60Task%60%20or%20a%20background%20queue%20would%20let%20the%20caller%20proceed%20immediately%20while%20the%20cache%20is%20persisted%20in%20the%20background%2C%20without%20affecting%20correctness%20%28failures%20are%20already%20swallowed%20and%20the%20in-memory%20profile%20is%20available%29.%0A%0A&repo=fujacob%2Fcotabby&pr=519&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Cache the constrained-decode vocabulary ..."](https://github.com/fujacob/cotabby/commit/e699e573571da90d6f6a01f0e11debf160811ba3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35046973)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->