### PR TITLE
Make the constrained beam finish the current word mid-word

### DIFF
--- a/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
+++ b/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
@@ -448,7 +448,8 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
                 topK: topK,
                 noRepeatNgramSize: Self.noRepeatNgramSize
             ),
-            isSingleLine: options.singleLine
+            isSingleLine: options.singleLine,
+            isMidWord: options.forceWordContinuation
         )
         let best = candidates.first
         CotabbyLogger.runtime.debug(

--- a/Cotabby/Support/ConstrainedBeamSearch.swift
+++ b/Cotabby/Support/ConstrainedBeamSearch.swift
@@ -67,13 +67,15 @@ enum ConstrainedBeamSearch {
         nextLogits: @escaping BeamLogitsProvider,
         profile: TokenProfile,
         configuration: BeamSearchConfiguration,
-        isSingleLine: Bool
+        isSingleLine: Bool,
+        isMidWord: Bool = false
     ) -> [BeamCandidate] {
         Engine(
             nextLogits: nextLogits,
             profile: profile,
             configuration: configuration,
-            isSingleLine: isSingleLine
+            isSingleLine: isSingleLine,
+            isMidWord: isMidWord
         ).run()
     }
 }
@@ -85,6 +87,7 @@ private struct Engine {
     let profile: TokenProfile
     let configuration: BeamSearchConfiguration
     let isSingleLine: Bool
+    let isMidWord: Bool
 
     func run() -> [BeamCandidate] {
         var frontier: [BeamCandidate] = [BeamCandidate(tokenIDs: [], bytes: [], cumulativeLogprob: 0)]
@@ -121,13 +124,19 @@ private struct Engine {
             history: branch.tokenIDs,
             ngramSize: configuration.noRepeatNgramSize
         )
-        let candidates = ConstrainedSampler.rankedAdmissibleTokens(
+        var candidates = ConstrainedSampler.rankedAdmissibleTokens(
             logits: logits,
             profile: profile,
             admissibleTokenIDs: nil,
             topK: configuration.topK,
             blockedTokenIDs: blocked
         )
+        // Mid-word: the first generated token must finish the current word, not start a new token with
+        // punctuation / whitespace / a symbol. Applies only to the first step; later tokens generate
+        // freely once the word is being continued.
+        if isMidWord, branch.tokenIDs.isEmpty {
+            candidates = candidates.filter { profile.continuesWordMidStream($0) }
+        }
         for tokenID in candidates {
             if profile.isEndOfGeneration(tokenID) {
                 completed.append(branch)

--- a/Cotabby/Support/TokenProfile.swift
+++ b/Cotabby/Support/TokenProfile.swift
@@ -105,6 +105,27 @@ struct TokenProfile {
         entry(for: id)?.isWhitespaceOnly ?? false
     }
 
+    /// Whether `id` can continue the current word mid-stream: its first byte is an ASCII letter or
+    /// digit, a common within-word mark (apostrophe or hyphen), or a non-ASCII lead byte (which starts
+    /// a multi-byte letter or ideograph). Tokens that begin with whitespace, breaking punctuation, or a
+    /// symbol are rejected, so a mid-word completion finishes the word instead of starting a new token.
+    /// False for an out-of-range or empty (control) token.
+    func continuesWordMidStream(_ id: Int) -> Bool {
+        guard let bytes = entry(for: id)?.bytes, !bytes.isEmpty else {
+            return false
+        }
+        // Inspect the first character with Unicode-aware classification: letters (including CJK and
+        // other scripts) and digits continue a word, as do the two common within-word marks; whitespace,
+        // punctuation, and symbols (ASCII or not, e.g. an em dash or arrow) do not. The lossy decode is
+        // fine because only the first scalar is examined and a malformed lead decodes to U+FFFD, which
+        // is not a letter, so it is rejected.
+        // swiftlint:disable:next optional_data_string_conversion
+        guard let first = String(decoding: bytes, as: UTF8.self).first else {
+            return false
+        }
+        return first.isLetter || first.isNumber || first == "'" || first == "-"
+    }
+
     private func entry(for id: Int) -> Entry? {
         guard id >= 0, id < entries.count else {
             return nil
@@ -133,4 +154,5 @@ struct TokenProfile {
             return false
         }
     }
+
 }

--- a/CotabbyTests/ConstrainedBeamSearchTests.swift
+++ b/CotabbyTests/ConstrainedBeamSearchTests.swift
@@ -150,6 +150,24 @@ final class ConstrainedBeamSearchTests: XCTestCase {
         XCTAssertFalse(recorder.paths.contains([0, 1]), "search must stop at the sentence and not step past it")
     }
 
+    func test_search_midWord_firstTokenMustContinueTheWord() {
+        // token 0 breaks the word (leading punctuation) but has the higher logit; token 1 continues it.
+        // Mid-word, only a word-continuing token may start the completion.
+        let profile = makeProfile(byteStrings: [", and", "ing"])
+        let rows: [[Int]: [Float]] = [[]: row([0: 9, 1: 1], vocabSize: 2)]
+        let normal = ConstrainedBeamSearch.search(
+            nextLogits: provider(vocabSize: 2, rows: rows), profile: profile,
+            configuration: BeamSearchConfiguration(beamWidth: 1, maxTokens: 1, topK: 5),
+            isSingleLine: false, isMidWord: false)
+        let midWord = ConstrainedBeamSearch.search(
+            nextLogits: provider(vocabSize: 2, rows: rows), profile: profile,
+            configuration: BeamSearchConfiguration(beamWidth: 1, maxTokens: 1, topK: 5),
+            isSingleLine: false, isMidWord: true)
+
+        XCTAssertEqual(normal.first?.tokenIDs, [0], "without mid-word, the highest-logit token wins")
+        XCTAssertEqual(midWord.first?.tokenIDs, [1], "mid-word, the word-breaking token is filtered out")
+    }
+
     func test_search_respectsMaxTokenBudget() {
         // No EOG / sentence end: every token keeps generating, so the budget bounds the length.
         let profile = makeProfile(byteStrings: ["a", "b"])

--- a/CotabbyTests/TokenProfileTests.swift
+++ b/CotabbyTests/TokenProfileTests.swift
@@ -106,4 +106,26 @@ final class TokenProfileTests: XCTestCase {
         XCTAssertFalse(profile.isNewline(5))
         XCTAssertFalse(profile.isWhitespaceOnly(5))
     }
+
+    func test_continuesWordMidStream_acceptsWordCharactersAndRejectsBreakers() {
+        let profile = makeProfile([
+            Stub(bytes: bytes("rrow"), control: false, eog: false),    // 0: letters
+            Stub(bytes: bytes("3rd"), control: false, eog: false),     // 1: leading digit
+            Stub(bytes: bytes("'t"), control: false, eog: false),      // 2: apostrophe (don't)
+            Stub(bytes: bytes("-op"), control: false, eog: false),     // 3: hyphen (co-op)
+            Stub(bytes: bytes("中文"), control: false, eog: false),      // 4: CJK letter
+            Stub(bytes: bytes(" word"), control: false, eog: false),   // 5: leading space
+            Stub(bytes: bytes(".rrow"), control: false, eog: false),   // 6: leading period
+            Stub(bytes: bytes("!stop"), control: false, eog: false),   // 7: leading punctuation
+            Stub(bytes: bytes("→x"), control: false, eog: false),      // 8: non-ASCII symbol
+            Stub(bytes: [], control: true, eog: false)                 // 9: empty / control
+        ])
+        for id in [0, 1, 2, 3, 4] {
+            XCTAssertTrue(profile.continuesWordMidStream(id), "id \(id) should continue a word")
+        }
+        for id in [5, 6, 7, 8, 9] {
+            XCTAssertFalse(profile.continuesWordMidStream(id), "id \(id) should not continue a word")
+        }
+        XCTAssertFalse(profile.continuesWordMidStream(-1))
+    }
 }


### PR DESCRIPTION
## Summary

When the caret sits inside a word (a mid-word completion), the constrained beam search's first token
should finish that word, not start a new one with punctuation, whitespace, or a symbol. This adds a
`TokenProfile.continuesWordMidStream(_:)` check — Unicode-aware, so letters (including CJK), digits,
and the within-word marks `'` and `-` continue a word while breakers (an ASCII period, an em dash, an
arrow, a leading space, ...) do not — and the beam filters its first step to word-continuing tokens
when the request asks for word continuation.

This complements the engine's existing first-step word-continuation mask: it is a Swift-side guard
that holds regardless of how that mask behaves under the beam's trim-and-re-accept stepping.

Affects only the constrained beam path (the `cotabbyConstrainedDecoderEnabled` developer flag with
`cotabbyConstrainedBeamWidth` > 1, both off by default); the shipping sampler path is unchanged.

## Validation

```
xcodebuild ... test ... CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO \
  -only-testing:CotabbyTests/TokenProfileTests \
  -only-testing:CotabbyTests/ConstrainedBeamSearchTests
# ** TEST SUCCEEDED **
#   TokenProfileTests: continuesWordMidStream accepts letters/CJK/digits/'/- and rejects
#     space/period/punctuation/non-ASCII-symbol/empty
#   ConstrainedBeamSearchTests: a higher-logit word-breaking first token is filtered out mid-word,
#     so the word-continuing token starts the completion

swiftlint --strict --quiet   # exit 0 (clean)
```

## Linked issues

None. A constrained-decoder quality guard for mid-word completions.

## Risk / rollout notes

- **Constrained beam path only**, default off, so there is no change to shipped behavior. The guard
  only ever *removes* a word-breaking first token mid-word; it can never introduce one.
- Applies to the first generated token only; once the word is being continued, later tokens generate
  freely.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `continuesWordMidStream` check to `TokenProfile` and threads an `isMidWord` flag through the constrained beam search so that, when the caret sits inside a word, only word-continuing tokens (letters, digits, `'`, `-`, or non-ASCII lead bytes) are eligible for the first generated step. The shipping sampler path is entirely unaffected; the guard only fires under the two developer-facing flags that enable the constrained beam.

- **`TokenProfile.continuesWordMidStream`**: Unicode-aware first-character inspection via a lossy UTF-8 decode; partial sequences and symbols map to U+FFFD and are correctly rejected.
- **`ConstrainedBeamSearch`**: The `isMidWord` flag is plumbed through `search(…)` and `Engine` and applied inside `expand` only when `branch.tokenIDs.isEmpty`, ensuring later tokens generate freely.
- Both new code paths have targeted unit tests; the `swiftlint` suppression on the intentionally-lossy `String(decoding:as:)` call is well-motivated.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the guard is default-off, only removes candidates, and the empty-result path already degrades gracefully to an empty completion string.

The change is narrow and conservative — it can only ever remove word-breaking tokens from the first step, never introduce one. The caller already handles an empty candidate list with `guard let best else { return "" }`. Findings are documentation wording and a missing edge-case test, not behavioral defects.

No files require special attention, though a test pinning the all-candidates-filtered fallback in `ConstrainedBeamSearchTests.swift` would harden the contract.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/TokenProfile.swift | Adds `continuesWordMidStream(_:)` — a Unicode-aware classifier that decodes the first UTF-8 character and accepts letters/digits/apostrophe/hyphen. The lossy-decode approach is intentional and well-commented; one minor doc imprecision about the empty-bytes guard. |
| Cotabby/Support/ConstrainedBeamSearch.swift | Threads `isMidWord: Bool = false` through `search(…)` and `Engine`, filtering candidates to word-continuing tokens only on the first expansion step (`branch.tokenIDs.isEmpty`). Defaulting to `false` preserves backward compatibility for all existing callers. |
| Cotabby/Services/Runtime/LlamaRuntimeCore.swift | One-line change passing `options.forceWordContinuation` as `isMidWord`; the empty-candidates case is already handled gracefully by the existing `guard let best else { return "" }` below. |
| CotabbyTests/TokenProfileTests.swift | New test covers ASCII letters, digits, apostrophe, hyphen, CJK, space, period, punctuation, non-ASCII symbol, and empty/control. Missing an explicit assertion for the all-candidates-filtered scenario. |
| CotabbyTests/ConstrainedBeamSearchTests.swift | New test verifies that the higher-logit word-breaking token is filtered out mid-word and the lower-logit word-continuing token wins. Complementary `normal` assertion confirms non-mid-word behavior is unchanged. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ConstrainedBeamSearch.search called
isMidWord = options.forceWordContinuation] --> B[Engine.run
frontier = initial empty branch]
    B --> C{frontier empty?}
    C -- yes --> G
    C -- no --> D[expand each branch]
    D --> E[rankedAdmissibleTokens
filters control + blocked tokens]
    E --> F{isMidWord AND
branch.tokenIDs.isEmpty?}
    F -- yes --> F1[filter candidates via
continuesWordMidStream]
    F1 --> F2{first byte isLetter
or isNumber or apostrophe
or hyphen?}
    F2 -- yes --> H[token passes]
    F2 -- no --> I[token rejected]
    F -- no --> H
    H --> J{isEOG / newline
/ sentence end?}
    J -- yes --> K[branch → completed]
    J -- no --> L[branch → live / nextFrontier]
    L --> M[prune nextFrontier
to beamWidth]
    M --> C
    G[all completed branches
sorted by meanLogprob]
    G --> N{best == nil?}
    N -- yes --> O[return empty string]
    N -- no --> P[return best.text]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fbeam-midword-guard%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fbeam-midword-guard%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FSupport%2FTokenProfile.swift%3A108-112%0AThe%20doc%20comment%20says%20%22False%20for%20an%20out-of-range%20or%20empty%20%28control%29%20token%22%2C%20but%20%60isControl%60%20is%20never%20consulted%20%E2%80%94%20only%20%60bytes.isEmpty%60%20is%20checked.%20A%20non-control%20token%20whose%20bytes%20happen%20to%20be%20empty%20would%20also%20return%20%60false%60%2C%20and%20a%20control%20token%20with%20non-empty%20bytes%20starting%20with%20a%20letter%20would%20return%20%60true%60%20%28though%20%60rankedAdmissibleTokens%60%20would%20already%20have%20excluded%20it%29.%20The%20parenthetical%20is%20misleading%3B%20tightening%20the%20wording%20removes%20the%20ambiguity.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Whether%20%60id%60%20can%20continue%20the%20current%20word%20mid-stream%3A%20its%20first%20byte%20is%20an%20ASCII%20letter%20or%0A%20%20%20%20%2F%2F%2F%20digit%2C%20a%20common%20within-word%20mark%20%28apostrophe%20or%20hyphen%29%2C%20or%20a%20non-ASCII%20lead%20byte%20%28which%20starts%0A%20%20%20%20%2F%2F%2F%20a%20multi-byte%20letter%20or%20ideograph%29.%20Tokens%20that%20begin%20with%20whitespace%2C%20breaking%20punctuation%2C%20or%20a%0A%20%20%20%20%2F%2F%2F%20symbol%20are%20rejected%2C%20so%20a%20mid-word%20completion%20finishes%20the%20word%20instead%20of%20starting%20a%20new%20token.%0A%20%20%20%20%2F%2F%2F%20False%20for%20an%20out-of-range%20id%20or%20a%20token%20whose%20byte%20sequence%20is%20empty.%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabbyTests%2FConstrainedBeamSearchTests.swift%3A150-173%0A**No%20test%20for%20all-candidates-filtered%20path**%0A%0AThe%20new%20test%20covers%20the%20normal%20filtered%20case%2C%20but%20there's%20no%20assertion%20for%20when%20%60isMidWord%3A%20true%60%20and%20every%20admissible%20token%20is%20word-breaking%20%28e.g.%20the%20only%20tokens%20in%20the%20vocabulary%20are%20%60%22%20x%22%60%2C%20%60%22.y%22%60%29.%20In%20that%20scenario%20%60candidates%60%20is%20empty%20after%20filtering%2C%20the%20branch%20is%20silently%20dropped%20from%20both%20%60live%60%20and%20%60completed%60%2C%20and%20%60search%60%20returns%20%60%5B%5D%60.%20The%20caller%20in%20%60LlamaRuntimeCore%60%20handles%20this%20correctly%20with%20%60guard%20let%20best%20else%20%7B%20return%20%22%22%20%7D%60%2C%20but%20adding%20a%20single%20test%20case%20would%20pin%20that%20contract%20and%20prevent%20a%20future%20refactor%20from%20introducing%20a%20crash%20or%20incorrect%20fallback.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FSupport%2FTokenProfile.swift%3A108-112%0AThe%20doc%20comment%20says%20%22False%20for%20an%20out-of-range%20or%20empty%20%28control%29%20token%22%2C%20but%20%60isControl%60%20is%20never%20consulted%20%E2%80%94%20only%20%60bytes.isEmpty%60%20is%20checked.%20A%20non-control%20token%20whose%20bytes%20happen%20to%20be%20empty%20would%20also%20return%20%60false%60%2C%20and%20a%20control%20token%20with%20non-empty%20bytes%20starting%20with%20a%20letter%20would%20return%20%60true%60%20%28though%20%60rankedAdmissibleTokens%60%20would%20already%20have%20excluded%20it%29.%20The%20parenthetical%20is%20misleading%3B%20tightening%20the%20wording%20removes%20the%20ambiguity.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Whether%20%60id%60%20can%20continue%20the%20current%20word%20mid-stream%3A%20its%20first%20byte%20is%20an%20ASCII%20letter%20or%0A%20%20%20%20%2F%2F%2F%20digit%2C%20a%20common%20within-word%20mark%20%28apostrophe%20or%20hyphen%29%2C%20or%20a%20non-ASCII%20lead%20byte%20%28which%20starts%0A%20%20%20%20%2F%2F%2F%20a%20multi-byte%20letter%20or%20ideograph%29.%20Tokens%20that%20begin%20with%20whitespace%2C%20breaking%20punctuation%2C%20or%20a%0A%20%20%20%20%2F%2F%2F%20symbol%20are%20rejected%2C%20so%20a%20mid-word%20completion%20finishes%20the%20word%20instead%20of%20starting%20a%20new%20token.%0A%20%20%20%20%2F%2F%2F%20False%20for%20an%20out-of-range%20id%20or%20a%20token%20whose%20byte%20sequence%20is%20empty.%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabbyTests%2FConstrainedBeamSearchTests.swift%3A150-173%0A**No%20test%20for%20all-candidates-filtered%20path**%0A%0AThe%20new%20test%20covers%20the%20normal%20filtered%20case%2C%20but%20there's%20no%20assertion%20for%20when%20%60isMidWord%3A%20true%60%20and%20every%20admissible%20token%20is%20word-breaking%20%28e.g.%20the%20only%20tokens%20in%20the%20vocabulary%20are%20%60%22%20x%22%60%2C%20%60%22.y%22%60%29.%20In%20that%20scenario%20%60candidates%60%20is%20empty%20after%20filtering%2C%20the%20branch%20is%20silently%20dropped%20from%20both%20%60live%60%20and%20%60completed%60%2C%20and%20%60search%60%20returns%20%60%5B%5D%60.%20The%20caller%20in%20%60LlamaRuntimeCore%60%20handles%20this%20correctly%20with%20%60guard%20let%20best%20else%20%7B%20return%20%22%22%20%7D%60%2C%20but%20adding%20a%20single%20test%20case%20would%20pin%20that%20contract%20and%20prevent%20a%20future%20refactor%20from%20introducing%20a%20crash%20or%20incorrect%20fallback.%0A%0A&repo=fujacob%2Fcotabby&pr=520&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Make the constrained beam finish the cur..."](https://github.com/fujacob/cotabby/commit/381884ce58bb27be022fdbd2d88fb44e0767c0d1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35048081)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->