### PR TITLE
Add fill-in-middle prompting for mid-line completions

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -223,6 +223,7 @@
 		D9B992A608F7FC9924D13271 /* TokenProfileCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F394B8A6E30CC47015772089 /* TokenProfileCacheTests.swift */; };
 		D9C51DEDF01033E276A479CE /* AXTextGeometryResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB58035EFFD65B767949BAE6 /* AXTextGeometryResolver.swift */; };
 		DA23422A2CF77CFD3B1283C8 /* OnboardingTemplateFeatureListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D814BBA41CF29E8DD9954651 /* OnboardingTemplateFeatureListTests.swift */; };
+		DA2A22F5386CC25420E98E6C /* FillInMiddlePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 276FA037D0F8DF51AABF4292 /* FillInMiddlePolicy.swift */; };
 		DB1310FF3576ACA6472C4DB1 /* TrailingDuplicationFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19A5B462891263BDFB56607 /* TrailingDuplicationFilterTests.swift */; };
 		DCABB8D2B391C7820D6CA5FF /* InsertionSafetyGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D472F9F396672E57873303B /* InsertionSafetyGate.swift */; };
 		DD7FA343F1C21C4569F6D181 /* ScreenshotContextGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B84BAE361626891F19DC9DB /* ScreenshotContextGenerator.swift */; };
@@ -230,6 +231,7 @@
 		DE236C9285635C686D66A2F6 /* TerminalAppDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E37A7E835D3BDE6265843C /* TerminalAppDetectorTests.swift */; };
 		DF8794793110A8ED234CBA96 /* OnboardingTemplateRecommender.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA878B447441BB4F3E327CC8 /* OnboardingTemplateRecommender.swift */; };
 		E17CAA453B1F534D284F0D89 /* PermissionHostApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6ACCB12E4DB32D2F2BEA567 /* PermissionHostApp.swift */; };
+		E277627C1EFE2A7B7BC5DD80 /* FillInMiddlePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0D15AE00F01D327F708DFC /* FillInMiddlePolicyTests.swift */; };
 		E27E6377D36D4981301568DD /* LaunchAtLoginStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5807E8508D9355D0271A00C5 /* LaunchAtLoginStateTests.swift */; };
 		E313639E71AE1374D2B9A956 /* SuggestionWorkController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B2D97BAA3618A7D0357AC44 /* SuggestionWorkController.swift */; };
 		E38801433B99E65BD7E45A0E /* LlamaPromptCacheHintTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA88BB29BC8727878C99E95 /* LlamaPromptCacheHintTrackerTests.swift */; };
@@ -315,6 +317,7 @@
 		262BE2F1E97389FE8D7A5FB9 /* Cotabby.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Cotabby.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		264CA64B2AB1611F82E5B760 /* WelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
 		273B4DC844F79B4BE2C8910F /* FocusPollBackoffTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusPollBackoffTests.swift; sourceTree = "<group>"; };
+		276FA037D0F8DF51AABF4292 /* FillInMiddlePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FillInMiddlePolicy.swift; sourceTree = "<group>"; };
 		292DC9D4D9D5D26AE882E39B /* EmojiCatalogMatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiCatalogMatcherTests.swift; sourceTree = "<group>"; };
 		29ED42C4BDD0C521101AF95E /* DeviceInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceInfo.swift; sourceTree = "<group>"; };
 		2A02336442BB735EE2E8D064 /* SettingsAttentionEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAttentionEvaluator.swift; sourceTree = "<group>"; };
@@ -434,6 +437,7 @@
 		AA33F5FFAC5B99384E15CE3E /* BundledRuntimeLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledRuntimeLocator.swift; sourceTree = "<group>"; };
 		AABCC3FD99B1824A81E665F3 /* LlamaSuggestionEngineCancellationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LlamaSuggestionEngineCancellationTests.swift; sourceTree = "<group>"; };
 		AC70775535A3428991025AB8 /* AXHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AXHelper.swift; sourceTree = "<group>"; };
+		AD0D15AE00F01D327F708DFC /* FillInMiddlePolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FillInMiddlePolicyTests.swift; sourceTree = "<group>"; };
 		AD752451330486FE270018B0 /* CustomRulesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomRulesTests.swift; sourceTree = "<group>"; };
 		AD9573F3504CAE6891DF9B7D /* AppUpdateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdateManager.swift; sourceTree = "<group>"; };
 		ADBE3E6CC585C1683787C877 /* SuggestionEngineModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionEngineModels.swift; sourceTree = "<group>"; };
@@ -767,6 +771,7 @@
 				224438039A86E5619294EAF7 /* EmojiUsageStoreTests.swift */,
 				EE8BB19D8EC9A75CD3458A6B /* EmojiVariantResolverTests.swift */,
 				54BC85605541E913EE57B258 /* ExtendedContextTests.swift */,
+				AD0D15AE00F01D327F708DFC /* FillInMiddlePolicyTests.swift */,
 				1972BD2C5254D8266618781F /* FocusCapabilityFlickerGateTests.swift */,
 				D4F6D5F94B238F7B4BE7C247 /* FocusCapabilityResolverTests.swift */,
 				273B4DC844F79B4BE2C8910F /* FocusPollBackoffTests.swift */,
@@ -929,6 +934,7 @@
 				312C7306D916963F519CE0D9 /* EmojiTriggerStateMachine.swift */,
 				1A8414BEB7E34F57607E37FE /* EmojiVariantResolver.swift */,
 				CE8C2569A8217EE9BD3B197F /* FileLogHandler.swift */,
+				276FA037D0F8DF51AABF4292 /* FillInMiddlePolicy.swift */,
 				6A44BEC8C23FF227731DD0CD /* FocusCapabilityFlickerGate.swift */,
 				70367FCC1E0F08EE3B8EB26F /* FocusCapabilityResolver.swift */,
 				09FADF683BE7B3558377FA76 /* FocusPollBackoff.swift */,
@@ -1142,6 +1148,7 @@
 				5DF31F465A3A1233260BD3A4 /* EngineAndModelPaneView.swift in Sources */,
 				5BE53CE921664582F593B7B0 /* FieldEdgeIconIndicatorView.swift in Sources */,
 				6E49ADEB31D04DC77A47DEB0 /* FileLogHandler.swift in Sources */,
+				DA2A22F5386CC25420E98E6C /* FillInMiddlePolicy.swift in Sources */,
 				C0FE11D76BDF01A5470C554D /* FocusCapabilityFlickerGate.swift in Sources */,
 				CC98B842D10574C5206BEFA7 /* FocusCapabilityResolver.swift in Sources */,
 				924489CEE8171F7AD8579D71 /* FocusDebugOverlayController.swift in Sources */,
@@ -1294,6 +1301,7 @@
 				26C5604C3CEF43FC755FD24E /* EmojiUsageStoreTests.swift in Sources */,
 				C9B815652CED38966C53A5E8 /* EmojiVariantResolverTests.swift in Sources */,
 				63054CBDCA87560130BF5ADC /* ExtendedContextTests.swift in Sources */,
+				E277627C1EFE2A7B7BC5DD80 /* FillInMiddlePolicyTests.swift in Sources */,
 				78A8713A0E5B4C89E2D715BC /* FocusCapabilityFlickerGateTests.swift in Sources */,
 				C71B594433F3B411CAE5DE7E /* FocusCapabilityResolverTests.swift in Sources */,
 				A147C5EC3F2214A670F7556E /* FocusPollBackoffTests.swift in Sources */,

--- a/Cotabby/Models/LlamaRuntimeModels.swift
+++ b/Cotabby/Models/LlamaRuntimeModels.swift
@@ -205,6 +205,19 @@ struct LlamaGenerationOptions: Equatable, Sendable {
     /// one. Only consulted when `useConstrainedDecoder` is true. Like `useConstrainedDecoder`, it does
     /// not affect KV reuse, so it is excluded from `SamplingFingerprint`.
     var beamWidth: Int = 1
+
+    /// When set (and the model is FIM-capable), the runtime builds a fill-in-middle prompt from the
+    /// text before and after the caret instead of using `prompt`, so the completion is conditioned on
+    /// what follows the cursor. Nil uses the ordinary forward base prompt. Does not affect KV reuse
+    /// (the FIM path decodes fresh), so it is excluded from `SamplingFingerprint`.
+    var fillInMiddle: FillInMiddleRequest?
+}
+
+/// The text around the caret used to build a fill-in-middle prompt: everything before the cursor and
+/// everything after it. The runtime tokenizes each side and wraps them in the model's FIM markers.
+struct FillInMiddleRequest: Equatable, Sendable {
+    let prefix: String
+    let suffix: String
 }
 
 /// The concrete runtime assets selected during bootstrap after checking available model files.

--- a/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
+++ b/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
@@ -41,6 +41,12 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
     private var cachedTokenProfile: TokenProfile?
     private var cachedTokenProfileModelURL: URL?
 
+    /// Per-model fill-in-middle marker token ids (nil means the model is not FIM-capable). Detected
+    /// once by scanning the vocabulary and keyed by model URL like the token profile; the URL tracker
+    /// distinguishes "not yet detected" from a cached nil result. Accessed only under `autocompleteLock`.
+    private var cachedFIMMarkers: FIMMarkers?
+    private var cachedFIMMarkersModelURL: URL?
+
     /// Coordinates model lifecycle with in-flight operations. `generate()` and `summarize()`
     /// increment the active count on entry and decrement on exit. `shutdown()` sets the
     /// shutting-down flag and blocks until all active operations finish before unloading.
@@ -144,7 +150,7 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
             lifecycleCondition.unlock()
         }
 
-        let promptBytes = Array(prompt.utf8)
+        var promptBytes = Array(prompt.utf8)
         let allPromptTokens = tokenize(prompt)
         guard !allPromptTokens.isEmpty else {
             CotabbyLogger.runtime.error(
@@ -164,8 +170,8 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
         )
 
         let maxPromptTokens = max(1, preparedRuntime.contextWindowTokens - options.maxPredictionTokens)
-        let promptTokens: [Int32]
-        let adjustedCachedPrefixBytes: Int?
+        var promptTokens: [Int32]
+        var adjustedCachedPrefixBytes: Int?
         if allPromptTokens.count > maxPromptTokens {
             promptTokens = Array(allPromptTokens.suffix(maxPromptTokens))
             adjustedCachedPrefixBytes = nil
@@ -178,6 +184,17 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
 
         autocompleteLock.lock()
         defer { autocompleteLock.unlock() }
+
+        // Replace the forward prompt with a fill-in-middle prompt when requested and the model is
+        // FIM-capable. Built under the lock so the marker-detection cache is serialized with the rest of
+        // the autocomplete state. FIM bypasses prompt-byte reuse (its structure differs from the forward
+        // prompt), so it clears the reuse hint; the assembled tokens are already budgeted to
+        // maxPromptTokens with the mandatory markers, so they are used as-is.
+        if let fimTokens = fillInMiddlePromptTokens(options.fillInMiddle, maxPromptTokens: maxPromptTokens) {
+            promptTokens = fimTokens
+            promptBytes = []
+            adjustedCachedPrefixBytes = nil
+        }
 
         let sequenceID = try obtainAutocompleteSequence(
             promptTokens: promptTokens,
@@ -616,6 +633,8 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
         preparedRuntime = nil
         cachedTokenProfile = nil
         cachedTokenProfileModelURL = nil
+        cachedFIMMarkers = nil
+        cachedFIMMarkersModelURL = nil
         CotabbyLogger.runtime.info("Runtime shutdown complete")
 
         lifecycleCondition.lock()
@@ -824,6 +843,39 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
         mix(withUnsafeBytes(of: Int64(fileSize).littleEndian) { Array($0) })
         mix(withUnsafeBytes(of: Int64(vocabSize).littleEndian) { Array($0) })
         return hash
+    }
+
+    /// The model's fill-in-middle marker token ids, detected once by scanning the vocabulary and cached
+    /// per model (nil when the model is not FIM-capable). The URL tracker distinguishes "not yet
+    /// detected" from a cached nil result. Must be called while holding `autocompleteLock`.
+    private func fimMarkers() -> FIMMarkers? {
+        let modelURL = preparedRuntime?.resolvedRuntime.modelFileURL
+        if cachedFIMMarkersModelURL == modelURL {
+            return cachedFIMMarkers
+        }
+        let vocabSize = Int(engine.getVocabSize())
+        let markers = vocabSize > 0
+            ? FillInMiddlePolicy.detectMarkers(vocabSize: vocabSize) { self.detokenizeBytes(Int32($0)) }
+            : nil
+        cachedFIMMarkers = markers
+        cachedFIMMarkersModelURL = modelURL
+        return markers
+    }
+
+    /// Builds a fill-in-middle prompt token sequence from `request`, or nil when there is no request or
+    /// the model lacks FIM markers (the caller then falls back to the forward base prompt). Must be
+    /// called while holding `autocompleteLock`.
+    private func fillInMiddlePromptTokens(_ request: FillInMiddleRequest?, maxPromptTokens: Int) -> [Int32]? {
+        guard let request, let markers = fimMarkers() else {
+            return nil
+        }
+        let tokens = FillInMiddlePolicy.assemblePromptTokens(
+            prefixTokens: tokenize(request.prefix),
+            suffixTokens: tokenize(request.suffix),
+            markers: markers,
+            maxTokens: maxPromptTokens
+        )
+        return tokens.isEmpty ? nil : tokens
     }
 
     /// The raw UTF-8 bytes a token detokenizes to, or empty for a structural token that renders to

--- a/Cotabby/Services/Runtime/LlamaSuggestionEngine.swift
+++ b/Cotabby/Services/Runtime/LlamaSuggestionEngine.swift
@@ -31,6 +31,28 @@ final class LlamaSuggestionEngine {
         return stored > 0 ? stored : 1
     }
 
+    /// UserDefaults key (no UI) for fill-in-middle prompting. Default off: FIM only helps models that
+    /// ship the FIM marker tokens, and it changes the prompt structure, so it stays a developer toggle
+    /// until validated on device.
+    private static let fillInMiddleDefaultsKey = "cotabbyFillInMiddleEnabled"
+    private static var isFillInMiddleEnabled: Bool {
+        UserDefaults.standard.bool(forKey: fillInMiddleDefaultsKey)
+    }
+
+    /// The fill-in-middle request for a generation, or nil to use the forward base prompt. Built only
+    /// when the flag is on and the caret has text after it (a mid-line completion); the runtime still
+    /// falls back to the base prompt when the model lacks FIM markers.
+    private static func fillInMiddleRequest(for request: SuggestionRequest) -> FillInMiddleRequest? {
+        guard isFillInMiddleEnabled else {
+            return nil
+        }
+        let suffix = request.context.trailingText
+        guard !suffix.isEmpty else {
+            return nil
+        }
+        return FillInMiddleRequest(prefix: request.context.precedingText, suffix: suffix)
+    }
+
     init(runtimeManager: LlamaRuntimeGenerating) {
         self.runtimeManager = runtimeManager
     }
@@ -70,7 +92,8 @@ final class LlamaSuggestionEngine {
                         trailingText: request.context.trailingText
                     ),
                     useConstrainedDecoder: Self.isConstrainedDecoderEnabled,
-                    beamWidth: Self.constrainedBeamWidth
+                    beamWidth: Self.constrainedBeamWidth,
+                    fillInMiddle: Self.fillInMiddleRequest(for: request)
                 )
             )
             try Task.checkCancellation()

--- a/Cotabby/Support/FillInMiddlePolicy.swift
+++ b/Cotabby/Support/FillInMiddlePolicy.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// File overview:
+/// Pure rules for fill-in-middle (FIM) prompting: detecting whether a model's vocabulary carries the
+/// FIM marker tokens, and assembling a FIM prompt token sequence from the text before and after the
+/// caret. FIM lets a base model infill at the cursor conditioned on what comes *after* it, not just
+/// before, which is what a correct mid-line completion needs.
+///
+/// Why this file exists:
+/// FIM is a prompt-construction concern, not a decoding one, and it is model-specific (only models
+/// trained with FIM markers can do it). Keeping detection and assembly pure makes both unit-testable
+/// without a runtime, and leaves the runtime only "tokenize and decode". Detection is an exact match
+/// against the well-known marker strings, so a model that lacks them simply falls back to the ordinary
+/// base prompt.
+
+/// The three FIM marker token ids a model needs for prefix / suffix / middle infilling.
+struct FIMMarkers: Equatable {
+    let prefix: Int
+    let suffix: Int
+    let middle: Int
+}
+
+enum FillInMiddlePolicy {
+    /// The marker strings this detector recognizes (the llama.cpp / Qwen convention). A model is
+    /// FIM-capable here only if all three decode to a single vocabulary token.
+    static let prefixMarker = "<|fim_prefix|>"
+    static let suffixMarker = "<|fim_suffix|>"
+    static let middleMarker = "<|fim_middle|>"
+
+    /// Finds the FIM marker token ids by scanning the vocabulary for tokens whose decoded bytes equal a
+    /// marker string. Returns nil unless all three are present (the model is then not FIM-capable, and
+    /// the caller falls back to the base prompt). `bytesFor` is the same per-token detokenize the token
+    /// profile uses, so a runtime can reuse its vocabulary snapshot.
+    static func detectMarkers(vocabSize: Int, bytesFor: (Int) -> [UInt8]) -> FIMMarkers? {
+        let prefixBytes = Array(prefixMarker.utf8)
+        let suffixBytes = Array(suffixMarker.utf8)
+        let middleBytes = Array(middleMarker.utf8)
+        var prefix: Int?
+        var suffix: Int?
+        var middle: Int?
+        for id in 0 ..< vocabSize {
+            let bytes = bytesFor(id)
+            if bytes == prefixBytes {
+                prefix = id
+            } else if bytes == suffixBytes {
+                suffix = id
+            } else if bytes == middleBytes {
+                middle = id
+            }
+            if let prefix, let suffix, let middle {
+                return FIMMarkers(prefix: prefix, suffix: suffix, middle: middle)
+            }
+        }
+        return nil
+    }
+
+    /// Assembles a FIM prompt in prefix-suffix-middle order: `[prefix] prefixTokens [suffix]
+    /// suffixTokens [middle]`. The model then generates the text that belongs at the caret. When the
+    /// prefix and suffix together exceed `maxTokens`, each is trimmed toward the caret (the prefix keeps
+    /// its tail, the suffix keeps its head), so the marker structure and the text nearest the cursor are
+    /// preserved. The three marker tokens are always included (they are the prompt's structure), so the
+    /// prefix and suffix together are bounded by `maxTokens - 3`.
+    static func assemblePromptTokens(
+        prefixTokens: [Int32],
+        suffixTokens: [Int32],
+        markers: FIMMarkers,
+        maxTokens: Int
+    ) -> [Int32] {
+        let budget = max(0, maxTokens - 3)
+        // Suffix gets up to half the budget (its head, nearest the caret); the prefix gets the rest of
+        // the budget from its tail, so the words right before the caret are always kept.
+        let suffixKept = Array(suffixTokens.prefix(min(suffixTokens.count, budget / 2)))
+        let prefixKept = Array(prefixTokens.suffix(max(0, budget - suffixKept.count)))
+
+        var tokens: [Int32] = [Int32(markers.prefix)]
+        tokens.append(contentsOf: prefixKept)
+        tokens.append(Int32(markers.suffix))
+        tokens.append(contentsOf: suffixKept)
+        tokens.append(Int32(markers.middle))
+        return tokens
+    }
+}

--- a/CotabbyTests/FillInMiddlePolicyTests.swift
+++ b/CotabbyTests/FillInMiddlePolicyTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import Cotabby
+
+/// Pure tests for FIM marker detection and prompt assembly. No runtime is involved: the vocabulary is
+/// supplied as a stub, so detection and the prefix-suffix-middle ordering and trimming are deterministic.
+final class FillInMiddlePolicyTests: XCTestCase {
+    private func vocab(_ strings: [String]) -> (Int, (Int) -> [UInt8]) {
+        let bytes = strings.map { Array($0.utf8) }
+        return (bytes.count, { bytes[$0] })
+    }
+
+    func test_detectMarkers_findsAllThree() {
+        let (size, bytesFor) = vocab([
+            "hello",
+            FillInMiddlePolicy.prefixMarker,
+            "x",
+            FillInMiddlePolicy.middleMarker,
+            FillInMiddlePolicy.suffixMarker
+        ])
+        XCTAssertEqual(
+            FillInMiddlePolicy.detectMarkers(vocabSize: size, bytesFor: bytesFor),
+            FIMMarkers(prefix: 1, suffix: 4, middle: 3))
+    }
+
+    func test_detectMarkers_nilWhenAnyMarkerMissing() {
+        // No middle marker -> not FIM-capable.
+        let (size, bytesFor) = vocab(["hi", FillInMiddlePolicy.prefixMarker, FillInMiddlePolicy.suffixMarker])
+        XCTAssertNil(FillInMiddlePolicy.detectMarkers(vocabSize: size, bytesFor: bytesFor))
+    }
+
+    func test_assemble_ordersPrefixSuffixMiddle() {
+        let markers = FIMMarkers(prefix: 100, suffix: 101, middle: 102)
+        let tokens = FillInMiddlePolicy.assemblePromptTokens(
+            prefixTokens: [1, 2, 3], suffixTokens: [7, 8], markers: markers, maxTokens: 50)
+        XCTAssertEqual(tokens, [100, 1, 2, 3, 101, 7, 8, 102])
+    }
+
+    func test_assemble_trimsTowardCaretWhenOverBudget() {
+        let markers = FIMMarkers(prefix: 100, suffix: 101, middle: 102)
+        // budget = 8 - 3 = 5; suffix keeps its head (up to 2), prefix keeps its tail (the rest).
+        let tokens = FillInMiddlePolicy.assemblePromptTokens(
+            prefixTokens: [1, 2, 3, 4, 5, 6], suffixTokens: [7, 8, 9, 10], markers: markers, maxTokens: 8)
+        XCTAssertEqual(tokens, [100, 4, 5, 6, 101, 7, 8, 102])
+        XCTAssertLessThanOrEqual(tokens.count, 8)
+    }
+
+    func test_assemble_keepsMarkersEvenWithTinyBudget() {
+        let markers = FIMMarkers(prefix: 1, suffix: 2, middle: 3)
+        let tokens = FillInMiddlePolicy.assemblePromptTokens(
+            prefixTokens: [9], suffixTokens: [9], markers: markers, maxTokens: 2)
+        XCTAssertEqual(tokens, [1, 2, 3], "the three markers are mandatory even when the budget is exhausted")
+    }
+}


### PR DESCRIPTION
## Summary

Adds fill-in-middle (FIM) prompting so a base model can infill at the caret conditioned on the text
that comes *after* it, not just before. Today the Open Source path always builds a forward base prompt
(prefix last), so a mid-line completion has no idea what follows the cursor and tends to duplicate or
ignore it. FIM wraps the before- and after-cursor text in the model's FIM marker tokens
(`[prefix] <before> [suffix] <after> [middle]`) and lets the model generate the missing middle.

- `FillInMiddlePolicy` (pure, tested): detects the FIM marker token ids by scanning the vocabulary
  for the `<|fim_prefix|>` / `<|fim_suffix|>` / `<|fim_middle|>` strings, and assembles the
  prefix-suffix-middle token sequence, trimming each side toward the caret to fit a token budget.
- The runtime detects and caches the markers per model (under `autocompleteLock`), and when a FIM
  request is present builds the FIM prompt in place of the forward prompt; FIM bypasses KV-prefix
  reuse and is never suffix-trimmed (which would drop the trailing `[middle]` marker). If the model
  lacks the markers, it transparently falls back to the base prompt.
- The suggestion engine supplies a FIM request only when the caret has text after it (a real mid-line
  completion).

Gated behind a new `cotabbyFillInMiddleEnabled` developer flag (default off), and additionally
capability-gated: it only activates on models that actually ship the FIM markers (e.g. the Qwen
tiers). The forward base prompt is unchanged otherwise.

## Validation

```
xcodebuild ... test ... CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO \
  -only-testing:CotabbyTests/FillInMiddlePolicyTests \
  -only-testing:CotabbyTests/LlamaSuggestionEngineCancellationTests \
  -only-testing:CotabbyTests/ConstrainedBeamSearchTests
# ** TEST SUCCEEDED **
#   FillInMiddlePolicyTests: marker detection (all-present vs missing), prefix-suffix-middle ordering,
#     trim-toward-caret over budget, markers kept under a tiny budget
#   runtime tests unchanged / green (generate() restructure compiles and behaves)

swiftlint --strict --quiet   # exit 0 (clean)
xcodegen generate            # registered the two new files (CI drift guard passes)
```

## Linked issues

None. Phase-3 parity: native FIM for mid-line completions.

## Risk / rollout notes

- **Default off and capability-gated.** With the flag off (or on a model without FIM markers), behavior
  is byte-for-byte the existing forward base prompt. No change to shipped behavior.
- FIM uses the raw before/after-cursor text (it is document-structure infilling), so it does not carry
  the persona/custom-rules conditioning the forward prompt adds; that is the standard FIM trade-off and
  can be revisited.
- Detecting markers scans the vocabulary once per model (cached, under the lock) the first time a FIM
  completion is requested. Enabling FIM by default still needs on-device quality evaluation on a
  FIM-capable model.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds fill-in-middle (FIM) prompting for mid-line completions so the model can condition on text after the cursor, not just before it. The feature is default-off and capability-gated (falls back silently to the existing forward prompt on models without FIM marker tokens).

- `FillInMiddlePolicy` (new, pure, tested) scans the vocabulary once per model to detect the three FIM marker token IDs and assembles a prefix-suffix-middle token sequence trimmed to fit the token budget.
- `LlamaRuntimeCore` caches the detected markers per model under `autocompleteLock`, replaces the forward prompt tokens with the FIM sequence when requested, and clears the KV-reuse hint accordingly.
- `LlamaSuggestionEngine` builds a `FillInMiddleRequest` only when the developer flag is on and the caret has non-empty trailing text.

<h3>Confidence Score: 4/5</h3>

Safe to merge: the feature is default-off and the existing forward-prompt path is untouched, so there is no change in shipped behavior.

The implementation is well-structured and the fallback path is robust. One functional limitation stands out in assemblePromptTokens: suffix context is hard-capped at half the token budget even when the prefix is short or empty, meaning the model sees less post-cursor content than the window allows in those cases. This would matter most for mid-line completions near the top of a document. There is also minor wasted work tokenizing the forward prompt before the FIM override, which is harmless now but worth cleaning up before the flag is enabled by default.

Cotabby/Support/FillInMiddlePolicy.swift — the budget-split logic in assemblePromptTokens; Cotabby/Services/Runtime/LlamaRuntimeCore.swift — the forward tokenize happens unconditionally before the FIM override.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/Support/FillInMiddlePolicy.swift | New pure FIM policy: marker detection (early-exit scan) and prompt assembly. Budget allocation gives suffix a hard cap of budget/2 even when prefix is empty, leaving slots unused. |
| Cotabby/Services/Runtime/LlamaRuntimeCore.swift | Integrates FIM prompt building under autocompleteLock with per-model marker cache; forward prompt is still fully tokenized before being discarded when FIM overrides it. |
| Cotabby/Services/Runtime/LlamaSuggestionEngine.swift | Correctly gates FIM on the developer flag and non-empty trailing text; passes FillInMiddleRequest to generation options. |
| Cotabby/Models/LlamaRuntimeModels.swift | Adds FillInMiddleRequest struct and fillInMiddle option to LlamaGenerationOptions; well-isolated, excluded from SamplingFingerprint as documented. |
| CotabbyTests/FillInMiddlePolicyTests.swift | Covers marker detection, ordering, trim-toward-caret, and tiny-budget behaviour; all cases are deterministic and runtime-free. |
| Cotabby.xcodeproj/project.pbxproj | Registers FillInMiddlePolicy.swift and FillInMiddlePolicyTests.swift in both the app and test targets; no issues. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant SE as LlamaSuggestionEngine
    participant RC as LlamaRuntimeCore
    participant FP as FillInMiddlePolicy

    SE->>SE: "fillInMiddleRequest(for:)<br/>(flag on & trailingText non-empty)"
    SE->>RC: "generate(prompt:options:)<br/>options.fillInMiddle = FillInMiddleRequest"

    RC->>RC: "tokenize(forwardPrompt)<br/>(always runs, discarded if FIM active)"
    RC->>RC: autocompleteLock.lock()

    RC->>RC: "fimMarkers()<br/>(check per-model URL cache)"
    alt markers not yet cached
        RC->>FP: detectMarkers(vocabSize, bytesFor:)
        FP-->>RC: FIMMarkers? (nil if model lacks them)
        RC->>RC: cache markers + modelURL
    end

    alt "FIM active (request non-nil & markers found)"
        RC->>FP: assemblePromptTokens(prefix, suffix, markers, maxTokens)
        FP-->>RC: [Int32] token sequence
        RC->>RC: "promptTokens = fimTokens"
    else FIM inactive (flag off, no request, or model lacks markers)
        RC->>RC: use forward prompt tokens as-is
    end

    RC->>RC: obtainAutocompleteSequence(promptTokens, ...)
    RC-->>SE: generated text
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cotabby/Services/Runtime/LlamaRuntimeCore.swift`, line 150-162 ([link](https://github.com/fujacob/cotabby/blob/39f842d5734ee25e8c704899494772e02d250ea1/Cotabby/Services/Runtime/LlamaRuntimeCore.swift#L150-L162)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Wasted forward-prompt tokenization when FIM overrides it. `tokenize(prompt)` (the full forward base prompt) is called unconditionally before the FIM override under the lock. When FIM is active the resulting `allPromptTokens` and all the trimming work are discarded. Since `options.fillInMiddle` is known before the lock, a `guard options.fillInMiddle == nil || …` early-path could skip the forward tokenize when FIM will definitely take over. Minor for now with the flag off, but worth addressing before enabling FIM by default.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Ffill-in-middle%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Ffill-in-middle%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%0ALine%3A%20150-162%0A%0AComment%3A%0AWasted%20forward-prompt%20tokenization%20when%20FIM%20overrides%20it.%20%60tokenize%28prompt%29%60%20%28the%20full%20forward%20base%20prompt%29%20is%20called%20unconditionally%20before%20the%20FIM%20override%20under%20the%20lock.%20When%20FIM%20is%20active%20the%20resulting%20%60allPromptTokens%60%20and%20all%20the%20trimming%20work%20are%20discarded.%20Since%20%60options.fillInMiddle%60%20is%20known%20before%20the%20lock%2C%20a%20%60guard%20options.fillInMiddle%20%3D%3D%20nil%20%7C%7C%20%E2%80%A6%60%20early-path%20could%20skip%20the%20forward%20tokenize%20when%20FIM%20will%20definitely%20take%20over.%20Minor%20for%20now%20with%20the%20flag%20off%2C%20but%20worth%20addressing%20before%20enabling%20FIM%20by%20default.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%0ALine%3A%20150-162%0A%0AComment%3A%0AWasted%20forward-prompt%20tokenization%20when%20FIM%20overrides%20it.%20%60tokenize%28prompt%29%60%20%28the%20full%20forward%20base%20prompt%29%20is%20called%20unconditionally%20before%20the%20FIM%20override%20under%20the%20lock.%20When%20FIM%20is%20active%20the%20resulting%20%60allPromptTokens%60%20and%20all%20the%20trimming%20work%20are%20discarded.%20Since%20%60options.fillInMiddle%60%20is%20known%20before%20the%20lock%2C%20a%20%60guard%20options.fillInMiddle%20%3D%3D%20nil%20%7C%7C%20%E2%80%A6%60%20early-path%20could%20skip%20the%20forward%20tokenize%20when%20FIM%20will%20definitely%20take%20over.%20Minor%20for%20now%20with%20the%20flag%20off%2C%20but%20worth%20addressing%20before%20enabling%20FIM%20by%20default.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=521&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Ffill-in-middle%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Ffill-in-middle%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FSupport%2FFillInMiddlePolicy.swift%3A72-73%0AUnused%20prefix%20budget%20is%20not%20reclaimed%20by%20the%20suffix.%20%60suffixKept%60%20is%20hard-capped%20at%20%60budget%20%2F%202%60%20regardless%20of%20how%20few%20prefix%20tokens%20are%20actually%20available.%20When%20the%20cursor%20is%20near%20the%20start%20of%20a%20document%20%28short%20or%20empty%20prefix%29%2C%20the%20suffix%20can%20only%20fill%20half%20the%20budget%20even%20though%20the%20other%20half%20goes%20unused%20%E2%80%94%20so%20the%20model%20sees%20far%20less%20post-cursor%20context%20than%20the%20window%20allows.%20The%20fix%20is%20to%20compute%20each%20side's%20actual%20allocation%20and%20let%20the%20other%20side%20claim%20the%20slack.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20prefixAvail%20%3D%20min%28prefixTokens.count%2C%20budget%20-%20min%28suffixTokens.count%2C%20budget%20%2F%202%29%29%0A%20%20%20%20%20%20%20%20let%20prefixKept%20%3D%20Array%28prefixTokens.suffix%28prefixAvail%29%29%0A%20%20%20%20%20%20%20%20let%20suffixKept%20%3D%20Array%28suffixTokens.prefix%28min%28suffixTokens.count%2C%20budget%20-%20prefixKept.count%29%29%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%3A150-162%0AWasted%20forward-prompt%20tokenization%20when%20FIM%20overrides%20it.%20%60tokenize%28prompt%29%60%20%28the%20full%20forward%20base%20prompt%29%20is%20called%20unconditionally%20before%20the%20FIM%20override%20under%20the%20lock.%20When%20FIM%20is%20active%20the%20resulting%20%60allPromptTokens%60%20and%20all%20the%20trimming%20work%20are%20discarded.%20Since%20%60options.fillInMiddle%60%20is%20known%20before%20the%20lock%2C%20a%20%60guard%20options.fillInMiddle%20%3D%3D%20nil%20%7C%7C%20%E2%80%A6%60%20early-path%20could%20skip%20the%20forward%20tokenize%20when%20FIM%20will%20definitely%20take%20over.%20Minor%20for%20now%20with%20the%20flag%20off%2C%20but%20worth%20addressing%20before%20enabling%20FIM%20by%20default.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FSupport%2FFillInMiddlePolicy.swift%3A72-73%0AUnused%20prefix%20budget%20is%20not%20reclaimed%20by%20the%20suffix.%20%60suffixKept%60%20is%20hard-capped%20at%20%60budget%20%2F%202%60%20regardless%20of%20how%20few%20prefix%20tokens%20are%20actually%20available.%20When%20the%20cursor%20is%20near%20the%20start%20of%20a%20document%20%28short%20or%20empty%20prefix%29%2C%20the%20suffix%20can%20only%20fill%20half%20the%20budget%20even%20though%20the%20other%20half%20goes%20unused%20%E2%80%94%20so%20the%20model%20sees%20far%20less%20post-cursor%20context%20than%20the%20window%20allows.%20The%20fix%20is%20to%20compute%20each%20side's%20actual%20allocation%20and%20let%20the%20other%20side%20claim%20the%20slack.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20prefixAvail%20%3D%20min%28prefixTokens.count%2C%20budget%20-%20min%28suffixTokens.count%2C%20budget%20%2F%202%29%29%0A%20%20%20%20%20%20%20%20let%20prefixKept%20%3D%20Array%28prefixTokens.suffix%28prefixAvail%29%29%0A%20%20%20%20%20%20%20%20let%20suffixKept%20%3D%20Array%28suffixTokens.prefix%28min%28suffixTokens.count%2C%20budget%20-%20prefixKept.count%29%29%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%3A150-162%0AWasted%20forward-prompt%20tokenization%20when%20FIM%20overrides%20it.%20%60tokenize%28prompt%29%60%20%28the%20full%20forward%20base%20prompt%29%20is%20called%20unconditionally%20before%20the%20FIM%20override%20under%20the%20lock.%20When%20FIM%20is%20active%20the%20resulting%20%60allPromptTokens%60%20and%20all%20the%20trimming%20work%20are%20discarded.%20Since%20%60options.fillInMiddle%60%20is%20known%20before%20the%20lock%2C%20a%20%60guard%20options.fillInMiddle%20%3D%3D%20nil%20%7C%7C%20%E2%80%A6%60%20early-path%20could%20skip%20the%20forward%20tokenize%20when%20FIM%20will%20definitely%20take%20over.%20Minor%20for%20now%20with%20the%20flag%20off%2C%20but%20worth%20addressing%20before%20enabling%20FIM%20by%20default.%0A%0A&repo=fujacob%2Fcotabby&pr=521&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add fill-in-middle prompting for mid-lin..."](https://github.com/fujacob/cotabby/commit/39f842d5734ee25e8c704899494772e02d250ea1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35049400)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->