### PR TITLE
Log why a completion normalized to empty

### DIFF
--- a/Cotabby/Services/Runtime/FoundationModelSuggestionEngine.swift
+++ b/Cotabby/Services/Runtime/FoundationModelSuggestionEngine.swift
@@ -109,21 +109,24 @@ final class FoundationModelSuggestionEngine {
                     "Apple Intelligence finished streaming without producing any content."
                 )
             }
-            let normalizedSuggestion = SuggestionTextNormalizer.normalize(
+            let normalization = SuggestionTextNormalizer.normalizeDetailed(
                 rawSuggestion,
                 for: request,
                 promptEchoCandidates: [prompt]
             )
+            let normalizedSuggestion = normalization.text
 
             let latency = Date().timeIntervalSince(startTime)
             let rawChars = rawSuggestion.count
             let normalizedChars = normalizedSuggestion.count
             let latencyMs = Int(latency * 1000)
+            let suppressionReason = normalization.suppression?.rawValue ?? "none"
             CotabbyLogger.suggestion.debug(
                 "Foundation model generated",
                 metadata: baseMetadata.merging([
                     "raw_chars": .stringConvertible(rawChars),
                     "normalized_chars": .stringConvertible(normalizedChars),
+                    "suppression_reason": .string(suppressionReason),
                     "latency_ms": .stringConvertible(latencyMs)
                 ]) { _, new in new }
             )
@@ -136,6 +139,7 @@ final class FoundationModelSuggestionEngine {
                     "prompt_bytes": .stringConvertible(prompt.utf8.count),
                     "raw_chars": .stringConvertible(rawChars),
                     "normalized_chars": .stringConvertible(normalizedChars),
+                    "suppression_reason": .string(suppressionReason),
                     "latency_ms": .stringConvertible(latencyMs),
                     "max_tokens": .stringConvertible(request.maxPredictionTokens)
                 ]) { _, new in new }

--- a/Cotabby/Services/Runtime/LlamaSuggestionEngine.swift
+++ b/Cotabby/Services/Runtime/LlamaSuggestionEngine.swift
@@ -99,16 +99,21 @@ final class LlamaSuggestionEngine {
             try Task.checkCancellation()
 
             promptCacheHintTracker.recordSuccessfulRequest(request)
-            let normalizedSuggestion = SuggestionTextNormalizer.normalize(rawSuggestion, for: request)
+            let normalization = SuggestionTextNormalizer.normalizeDetailed(rawSuggestion, for: request)
+            let normalizedSuggestion = normalization.text
             let latency = Date().timeIntervalSince(startTime)
             let rawChars = rawSuggestion.count
             let normalizedChars = normalizedSuggestion.count
             let latencyMs = Int(latency * 1000)
+            // `suppression_reason` distinguishes an empty ghost text caused by the model producing
+            // nothing from one a filter dropped — the join key for judging decode quality on device.
+            let suppressionReason = normalization.suppression?.rawValue ?? "none"
             CotabbyLogger.suggestion.debug(
                 "Llama generated",
                 metadata: baseMetadata.merging([
                     "raw_chars": .stringConvertible(rawChars),
                     "normalized_chars": .stringConvertible(normalizedChars),
+                    "suppression_reason": .string(suppressionReason),
                     "latency_ms": .stringConvertible(latencyMs)
                 ]) { _, new in new }
             )
@@ -121,6 +126,7 @@ final class LlamaSuggestionEngine {
                     "prompt_bytes": .stringConvertible(request.prompt.utf8.count),
                     "raw_chars": .stringConvertible(rawChars),
                     "normalized_chars": .stringConvertible(normalizedChars),
+                    "suppression_reason": .string(suppressionReason),
                     "latency_ms": .stringConvertible(latencyMs),
                     "cache_hint_bytes": .string(hintDesc),
                     "max_tokens": .stringConvertible(request.maxPredictionTokens)

--- a/Cotabby/Support/SuggestionTextNormalizer.swift
+++ b/Cotabby/Support/SuggestionTextNormalizer.swift
@@ -7,12 +7,54 @@ import Foundation
 ///
 /// This type is intentionally pure. Given the same request and raw output, it always returns the
 /// same normalized suggestion. That makes it safe to share across backends and easy to test later.
+
+/// Why a raw completion was reduced to empty ghost text. Logging this lets on-device evaluation
+/// separate "the model produced nothing usable" from "a safety or echo filter dropped a real
+/// completion" — the two read identically once the text is empty, but they point at opposite fixes
+/// (prompt/model tuning vs. an over-aggressive filter).
+enum CompletionSuppressionReason: String, Sendable, Equatable {
+    /// The model emitted only whitespace (or nothing) to begin with.
+    case emptyGeneration
+    /// Raw output existed but was entirely control markers, reasoning blocks, scaffolding labels,
+    /// or newlines, so nothing survived normalization.
+    case normalizedToEmpty
+    /// The completion began by repeating text that already follows the caret.
+    case duplicatesTrailingText
+    /// The completion echoed the tail of the preceding text in full, leaving nothing new to add.
+    case echoesPrecedingText
+    /// Printable characters survived but carried control/replacement glyphs the safety gate rejects.
+    case unsafeToInsert
+}
+
+/// Outcome of normalizing one raw completion: the ghost text, plus the attributable reason when that
+/// text is empty. `suppression` is always nil when `text` is non-empty.
+struct SuggestionNormalizationResult: Equatable, Sendable {
+    let text: String
+    let suppression: CompletionSuppressionReason?
+}
+
 enum SuggestionTextNormalizer {
+    /// Convenience wrapper returning only the ghost text. Callers that want to know *why* an empty
+    /// result came back (for diagnostics / on-device decode evaluation) should call
+    /// `normalizeDetailed` instead, which is the single source of truth this delegates to.
     static func normalize(
         _ rawSuggestion: String,
         for request: SuggestionRequest,
         promptEchoCandidates: [String] = []
     ) -> String {
+        normalizeDetailed(rawSuggestion, for: request, promptEchoCandidates: promptEchoCandidates).text
+    }
+
+    /// Normalizes one raw completion and, when the result is empty, attributes the suppression to a
+    /// specific cause. This is the distinction the logs need to tell "the model produced nothing
+    /// usable" apart from "a safety/echo filter dropped a real completion" — without it, every empty
+    /// outcome reads identically as a generic empty result.
+    static func normalizeDetailed(
+        _ rawSuggestion: String,
+        for request: SuggestionRequest,
+        promptEchoCandidates: [String] = []
+    ) -> SuggestionNormalizationResult {
+        let rawHadContent = !rawSuggestion.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         var normalized = rawSuggestion.replacingOccurrences(of: "\r", with: "")
 
         // Some runtimes echo the prompt or include chat-template control markers in the response.
@@ -81,14 +123,17 @@ enum SuggestionTextNormalizer {
             normalized,
             trailingText: request.context.trailingText
         ) {
-            return ""
+            return SuggestionNormalizationResult(text: "", suppression: .duplicatesTrailingText)
         }
 
         // Echo suppression: strip any leading words that repeat the tail of the preceding text.
         // Small models sometimes regurgitate the prompt suffix instead of continuing from it.
         // Word-by-word suffix–prefix overlap catches "hello world " → "world is great" and
-        // strips "world" so the ghost text shows only " is great".
+        // strips "world" so the ghost text shows only " is great". A full collapse to empty here
+        // means the model only re-emitted the preceding text, which we report distinctly below.
+        let beforeEchoStrip = normalized
         normalized = stripEchoPrefix(normalized, precedingText: request.context.precedingText)
+        let collapsedByEcho = !beforeEchoStrip.isEmpty && normalized.isEmpty
 
         // Deterministic space management runs AFTER echo suppression because stripping echoed
         // words can expose a leading space (e.g. "world is" → " is"). If the preceding text
@@ -105,10 +150,38 @@ enum SuggestionTextNormalizer {
         // whitespace-only output as ghost text. Returning empty makes the coordinator treat this
         // as "no suggestion" and regenerate rather than insert junk on Tab.
         guard InsertionSafetyGate.isSafeToInsert(normalized) else {
-            return ""
+            return SuggestionNormalizationResult(
+                text: "",
+                suppression: suppressionForEmptyResult(
+                    collapsedByEcho: collapsedByEcho,
+                    rawHadContent: rawHadContent,
+                    normalized: normalized
+                )
+            )
         }
 
-        return normalized
+        return SuggestionNormalizationResult(text: normalized, suppression: nil)
+    }
+
+    /// Names the most specific cause of an empty normalization outcome at the safety gate. The gate
+    /// rejects empty, whitespace-only, and control/replacement-glyph output alike, so we disambiguate
+    /// here: an echo collapse and a genuinely-empty generation are very different signals on device.
+    private static func suppressionForEmptyResult(
+        collapsedByEcho: Bool,
+        rawHadContent: Bool,
+        normalized: String
+    ) -> CompletionSuppressionReason {
+        if collapsedByEcho {
+            return .echoesPrecedingText
+        }
+        let survivingContent = !normalized.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        if survivingContent {
+            // Real characters made it through but carried control/replacement glyphs the gate rejects.
+            return .unsafeToInsert
+        }
+        // Nothing printable survived: either the model emitted only whitespace, or everything it
+        // produced was control markers / reasoning / scaffolding that normalization stripped away.
+        return rawHadContent ? .normalizedToEmpty : .emptyGeneration
     }
 
     /// Removes `<think>…</think>` reasoning blocks: complete blocks first, then any dangling open

--- a/CotabbyTests/SuggestionTextNormalizerTests.swift
+++ b/CotabbyTests/SuggestionTextNormalizerTests.swift
@@ -216,4 +216,77 @@ final class SuggestionTextNormalizerTests: XCTestCase {
 
         XCTAssertEqual(normalized, "first Task: review")
     }
+
+    // MARK: - Suppression-reason attribution (normalizeDetailed)
+
+    func test_normalizeDetailed_successHasNoSuppressionReason() {
+        let request = CotabbyTestFixtures.suggestionRequest(
+            prefixText: "I love ",
+            prompt: "PROMPT",
+            precedingText: "I love "
+        )
+
+        let result = SuggestionTextNormalizer.normalizeDetailed("this product", for: request)
+
+        XCTAssertEqual(result.text, "this product")
+        XCTAssertNil(result.suppression)
+    }
+
+    func test_normalizeDetailed_reportsDuplicatesTrailingText() {
+        let request = CotabbyTestFixtures.suggestionRequest(
+            precedingText: "Hello",
+            trailingText: " existing suffix"
+        )
+
+        let result = SuggestionTextNormalizer.normalizeDetailed(
+            " existing suffix and extra generated text",
+            for: request
+        )
+
+        XCTAssertEqual(result.text, "")
+        XCTAssertEqual(result.suppression, .duplicatesTrailingText)
+    }
+
+    func test_normalizeDetailed_reportsEchoesPrecedingTextWhenFullyEchoed() {
+        let request = CotabbyTestFixtures.suggestionRequest(
+            prefixText: "hello world",
+            prompt: "PROMPT",
+            precedingText: "hello world"
+        )
+
+        // The model re-emits the last word of the preceding text and nothing else.
+        let result = SuggestionTextNormalizer.normalizeDetailed("world", for: request)
+
+        XCTAssertEqual(result.text, "")
+        XCTAssertEqual(result.suppression, .echoesPrecedingText)
+    }
+
+    func test_normalizeDetailed_reportsUnsafeToInsertForReplacementGlyph() {
+        let request = CotabbyTestFixtures.suggestionRequest(precedingText: "x")
+
+        // Real characters survive normalization but carry a U+FFFD replacement glyph.
+        let result = SuggestionTextNormalizer.normalizeDetailed("abc\u{FFFD}", for: request)
+
+        XCTAssertEqual(result.text, "")
+        XCTAssertEqual(result.suppression, .unsafeToInsert)
+    }
+
+    func test_normalizeDetailed_reportsEmptyGenerationForWhitespaceOnlyRaw() {
+        let request = CotabbyTestFixtures.suggestionRequest(precedingText: "x")
+
+        let result = SuggestionTextNormalizer.normalizeDetailed("   \n  ", for: request)
+
+        XCTAssertEqual(result.text, "")
+        XCTAssertEqual(result.suppression, .emptyGeneration)
+    }
+
+    func test_normalizeDetailed_reportsNormalizedToEmptyWhenOnlyControlMarkers() {
+        let request = CotabbyTestFixtures.suggestionRequest(precedingText: "x")
+
+        // Raw had content, but it was entirely chat-template markers that normalization strips.
+        let result = SuggestionTextNormalizer.normalizeDetailed("<|im_start|><|im_end|>", for: request)
+
+        XCTAssertEqual(result.text, "")
+        XCTAssertEqual(result.suppression, .normalizedToEmpty)
+    }
 }


### PR DESCRIPTION
## Summary

Empty ghost text used to surface downstream as a single undifferentiated `empty-result`, whether the model genuinely produced nothing or a safety/echo filter dropped a perfectly good completion. Those two read identically once the text is empty but point at opposite fixes (model/prompt tuning vs. an over-aggressive filter), so this teaches the normalizer to report *why* it emptied and logs that reason. This is the observability the on-device constrained-decoder evaluation needs to tell "decode produced junk" apart from "a filter ate a real suggestion."

- `SuggestionTextNormalizer.normalizeDetailed` is the new single source of truth: it returns the normalized text plus an attributable `CompletionSuppressionReason?` (`emptyGeneration`, `normalizedToEmpty`, `duplicatesTrailingText`, `echoesPrecedingText`, `unsafeToInsert`) that is non-nil only when the text is empty. The existing `normalize` becomes a thin wrapper returning `.text`, so every other caller is untouched.
- Both `LlamaSuggestionEngine` and `FoundationModelSuggestionEngine` now emit a structured `suppression_reason` field on their existing "generated" and `llm-io` logs, joinable by `request_id`.

## Validation

```
xcodebuild ... test ... CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO \
  -only-testing:CotabbyTests/SuggestionTextNormalizerTests \
  -only-testing:CotabbyTests/LlamaSuggestionEngineCancellationTests
# ** TEST SUCCEEDED **
#   6 new normalizeDetailed tests: each reason attributed correctly (duplicate-trailing,
#     full echo, replacement glyph, whitespace-only raw, control-markers-only, success=nil)
#   16 existing normalizer tests: unchanged (behavior preserved)
#   4 engine cancellation tests: both engines still compile + behave

swiftlint lint --strict --quiet <changed files>   # exit 0
```

## Linked issues

None. Telemetry/observability parity: a named reason for every suppressed completion.

## Risk / rollout notes

- **Zero behavior change.** Same raw text in, same ghost text out; `normalize` delegates to `normalizeDetailed().text`. Only the logs gain a `suppression_reason` field. No new files (types live in the existing normalizer), so no project/pbxproj change.
- The reason is best-effort attribution at the point of emptiness: a string that is both whitespace-and-control and would-be-echo is bucketed by the first matching cause. The buckets are for diagnostics, not control flow, so coarse edges are harmless.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds structured suppression-reason attribution to the completion normalizer so empty ghost text is no longer an undifferentiated signal. `normalizeDetailed` is the new source of truth; the existing `normalize` delegates to it and every external caller is unchanged.

- Adds `CompletionSuppressionReason` (5 cases) and `SuggestionNormalizationResult`, with `normalizeDetailed` as the single path that routes each early-return into the correct attribution bucket.
- Both `LlamaSuggestionEngine` and `FoundationModelSuggestionEngine` now emit a `suppression_reason` field on their existing log events, with `"none"` for successful suggestions, making the field queryable across all completions.
- 6 new unit tests cover every suppression case plus the nil-on-success invariant; 16 existing normalizer tests and 4 cancellation tests are unchanged.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is purely additive observability with zero ghost-text behaviour change.

The normalizer refactor is correct: the `suppression` nil-iff-non-empty invariant holds across all code paths, `collapsedByEcho` is set faithfully by `stripEchoPrefix`'s word-splitting semantics, and `suppressionForEmptyResult` correctly disambiguates every gate-rejection scenario. The two findings are both observability-layer docs/test gaps with no runtime impact.

The `suppressionForEmptyResult` helper and its surrounding doc-strings in `SuggestionTextNormalizer.swift` are the only place that needs a second look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/SuggestionTextNormalizer.swift | Core change: adds `CompletionSuppressionReason` enum, `SuggestionNormalizationResult` struct, and `normalizeDetailed` as the new source of truth. `normalize` becomes a thin wrapper. Attribution logic is sound across all paths; one doc-string inaccuracy around the `normalizedToEmpty` case. |
| CotabbyTests/SuggestionTextNormalizerTests.swift | 6 new `normalizeDetailed` tests cover the happy path and all 5 suppression reasons; the `<think>`-block → `normalizedToEmpty` path is not exercised by the new tests, leaving one documented trigger untested. |
| Cotabby/Services/Runtime/LlamaSuggestionEngine.swift | Swaps `normalize` for `normalizeDetailed`, plumbs `suppression_reason` into both debug and llm-io log entries. No behaviour change; existing `promptEchoCandidates` omission (intentional, Llama never passed it) is preserved correctly. |
| Cotabby/Services/Runtime/FoundationModelSuggestionEngine.swift | Mirror of the Llama change: switches to `normalizeDetailed`, adds `suppression_reason` to both log sites. Correctly preserves `promptEchoCandidates: [prompt]` that was already passed. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[rawSuggestion] --> B{rawHadContent?}
    B -->|set flag| C[Strip CR / markers / think-blocks / prompt echo / prefix echo / scaffolding]
    C --> D{duplicatesTrailingText?}
    D -->|yes| E[Return: text='' suppression=duplicatesTrailingText]
    D -->|no| F[stripEchoPrefix]
    F --> G{normalized empty after echo strip?}
    G -->|yes| H[collapsedByEcho = true]
    G -->|no| I[collapsedByEcho = false]
    H --> J[Space management]
    I --> J
    J --> K{isSafeToInsert?}
    K -->|yes| L[Return: text=normalized suppression=nil]
    K -->|no| M{collapsedByEcho?}
    M -->|yes| N[Return: suppression=echoesPrecedingText]
    M -->|no| O{survivingContent in normalized?}
    O -->|yes| P[Return: suppression=unsafeToInsert]
    O -->|no| Q{rawHadContent?}
    Q -->|yes| R[Return: suppression=normalizedToEmpty]
    Q -->|no| S[Return: suppression=emptyGeneration]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fempty-completion-reason%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fempty-completion-reason%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FSupport%2FSuggestionTextNormalizer.swift%3A18-19%0AThe%20%60normalizedToEmpty%60%20doc-string%20lists%20%22or%20newlines%22%20as%20a%20trigger%2C%20but%20newlines%20are%20matched%20by%20%60CharacterSet.whitespacesAndNewlines%60%2C%20so%20a%20newline-only%20raw%20suggestion%20yields%20%60rawHadContent%20%3D%20false%60%20and%20is%20bucketed%20as%20%60.emptyGeneration%60%2C%20not%20%60.normalizedToEmpty%60.%20The%20%22newlines%22%20clause%20is%20misleading%20and%20could%20cause%20operators%20to%20mis-read%20the%20telemetry.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Raw%20output%20existed%20but%20was%20entirely%20control%20markers%2C%20reasoning%20blocks%2C%20or%20scaffolding%20labels%2C%0A%20%20%20%20%2F%2F%2F%20so%20nothing%20survived%20normalization.%20%28Newline-only%20raw%20is%20classified%20as%20%60emptyGeneration%60%0A%20%20%20%20%2F%2F%2F%20because%20newlines%20are%20whitespace%20for%20%60rawHadContent%60%20purposes.%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabbyTests%2FSuggestionTextNormalizerTests.swift%3A283-291%0A**Missing%20%60normalizedToEmpty%60%20path%20for%20%60%3Cthink%3E%60%20blocks**%0A%0AThe%20doc%20for%20%60normalizedToEmpty%60%20explicitly%20names%20%22reasoning%20blocks%22%20as%20a%20trigger%2C%20but%20there%20is%20no%20test%20exercising%20it.%20For%20example%2C%20%60%22%3Cthink%3Esome%20reasoning%3C%2Fthink%3E%22%60%20has%20%60rawHadContent%20%3D%20true%60%20%28non-whitespace%20chars%20exist%20before%20stripping%29%2C%20and%20%60stripThinkBlocks%60%20reduces%20it%20to%20%60%22%22%60%2C%20so%20%60suppressionForEmptyResult%60%20returns%20%60.normalizedToEmpty%60.%20Similarly%2C%20a%20raw%20suggestion%20consisting%20solely%20of%20a%20scaffolding%20label%20%28e.g.%20%60%22Task%3A%22%60%29%20takes%20the%20same%20path.%20Adding%20a%20case%20for%20each%20would%20lock%20down%20the%20full%20documented%20contract%20for%20%60normalizedToEmpty%60.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FSupport%2FSuggestionTextNormalizer.swift%3A18-19%0AThe%20%60normalizedToEmpty%60%20doc-string%20lists%20%22or%20newlines%22%20as%20a%20trigger%2C%20but%20newlines%20are%20matched%20by%20%60CharacterSet.whitespacesAndNewlines%60%2C%20so%20a%20newline-only%20raw%20suggestion%20yields%20%60rawHadContent%20%3D%20false%60%20and%20is%20bucketed%20as%20%60.emptyGeneration%60%2C%20not%20%60.normalizedToEmpty%60.%20The%20%22newlines%22%20clause%20is%20misleading%20and%20could%20cause%20operators%20to%20mis-read%20the%20telemetry.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20Raw%20output%20existed%20but%20was%20entirely%20control%20markers%2C%20reasoning%20blocks%2C%20or%20scaffolding%20labels%2C%0A%20%20%20%20%2F%2F%2F%20so%20nothing%20survived%20normalization.%20%28Newline-only%20raw%20is%20classified%20as%20%60emptyGeneration%60%0A%20%20%20%20%2F%2F%2F%20because%20newlines%20are%20whitespace%20for%20%60rawHadContent%60%20purposes.%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabbyTests%2FSuggestionTextNormalizerTests.swift%3A283-291%0A**Missing%20%60normalizedToEmpty%60%20path%20for%20%60%3Cthink%3E%60%20blocks**%0A%0AThe%20doc%20for%20%60normalizedToEmpty%60%20explicitly%20names%20%22reasoning%20blocks%22%20as%20a%20trigger%2C%20but%20there%20is%20no%20test%20exercising%20it.%20For%20example%2C%20%60%22%3Cthink%3Esome%20reasoning%3C%2Fthink%3E%22%60%20has%20%60rawHadContent%20%3D%20true%60%20%28non-whitespace%20chars%20exist%20before%20stripping%29%2C%20and%20%60stripThinkBlocks%60%20reduces%20it%20to%20%60%22%22%60%2C%20so%20%60suppressionForEmptyResult%60%20returns%20%60.normalizedToEmpty%60.%20Similarly%2C%20a%20raw%20suggestion%20consisting%20solely%20of%20a%20scaffolding%20label%20%28e.g.%20%60%22Task%3A%22%60%29%20takes%20the%20same%20path.%20Adding%20a%20case%20for%20each%20would%20lock%20down%20the%20full%20documented%20contract%20for%20%60normalizedToEmpty%60.%0A%0A&repo=fujacob%2Fcotabby&pr=522&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Log why a completion normalized to empty"](https://github.com/fujacob/cotabby/commit/e35a46d0b8dc4ba7ee95246feabec23d0d9df298) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35051735)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->