### PR TITLE
Gate fill-in-middle on a precise end-of-line signal

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		51C069603DA16830868F1628 /* LanguageTagsEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7CDA90E128350BFF1A9D66 /* LanguageTagsEditor.swift */; };
 		52518CF0760DFEE9AF7C786C /* SuggestionEngineRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384FBCF5D7A3A446C5BE2B8D /* SuggestionEngineRouter.swift */; };
 		53FB56A095BCF0389DAC0A56 /* SuggestionTextColorCodec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CE61E74928C221B8BB261C6 /* SuggestionTextColorCodec.swift */; };
+		543D71217CA218426E9638BF /* CaretLinePosition.swift in Sources */ = {isa = PBXBuildFile; fileRef = D77364C1AF183EF1C0A4074D /* CaretLinePosition.swift */; };
 		54BDF0D9C3DC7175555BD0F6 /* LlamaRuntimeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A52D0B550E00EF173A5D157E /* LlamaRuntimeManager.swift */; };
 		54E515A0E75B3902E6497A71 /* EmojiPopularity.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27B962C66727776D00069DE /* EmojiPopularity.swift */; };
 		56611BA0087710277140E9E6 /* DisplayCoordinateConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1C5DE0F3FF63545000E2453 /* DisplayCoordinateConverterTests.swift */; };
@@ -117,6 +118,7 @@
 		6106B16C0DBA94EBF838D93E /* PermissionOverlayTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6423D6CC8CC371D2DA899DE /* PermissionOverlayTracker.swift */; };
 		61EC9D635D416115E7C96E0F /* PermissionOverlayWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C6EB9FDA48ADF425A116A9 /* PermissionOverlayWindowController.swift */; };
 		62DBCF429B7F464A6B467725 /* OnboardingFeatureShowcase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 926B332E7B4CFEE42C4CAA75 /* OnboardingFeatureShowcase.swift */; };
+		62FADA407797998742502DD9 /* CaretLinePositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EA827D6A2A54DF4BAD56405 /* CaretLinePositionTests.swift */; };
 		63054CBDCA87560130BF5ADC /* ExtendedContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54BC85605541E913EE57B258 /* ExtendedContextTests.swift */; };
 		644EEF959D07D54CC779BBF6 /* SettingsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3350EDE01ED5125520C79D53 /* SettingsCoordinator.swift */; };
 		64DA031AEAC20AC6C852A24A /* OnboardingTemplateFeatureList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F613F0E2F7046E6532A09C /* OnboardingTemplateFeatureList.swift */; };
@@ -402,6 +404,7 @@
 		8724ECA8FABBC82B0A2B943B /* FoundationModelAvailabilityService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoundationModelAvailabilityService.swift; sourceTree = "<group>"; };
 		8896D976C7F116EBA0F3969F /* ChromiumAccessibilityEnabler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromiumAccessibilityEnabler.swift; sourceTree = "<group>"; };
 		8D610FCA3A97249DCCE7D0B8 /* LLMIOFileHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMIOFileHandler.swift; sourceTree = "<group>"; };
+		8EA827D6A2A54DF4BAD56405 /* CaretLinePositionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaretLinePositionTests.swift; sourceTree = "<group>"; };
 		8F426127917FCB1096134732 /* HuggingFaceSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceSearchService.swift; sourceTree = "<group>"; };
 		8F961F5DF2A392F6F5F94F8A /* SuggestionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionCoordinator.swift; sourceTree = "<group>"; };
 		907549CB913B40C28B953A5D /* SettingsRowLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRowLabel.swift; sourceTree = "<group>"; };
@@ -486,6 +489,7 @@
 		D4F6D5F94B238F7B4BE7C247 /* FocusCapabilityResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusCapabilityResolverTests.swift; sourceTree = "<group>"; };
 		D504BEB224E0C176F5FCFF6E /* CompletionRenderModePolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionRenderModePolicyTests.swift; sourceTree = "<group>"; };
 		D5D6C2318E405AA717D1C256 /* WelcomePermissionStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomePermissionStepView.swift; sourceTree = "<group>"; };
+		D77364C1AF183EF1C0A4074D /* CaretLinePosition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaretLinePosition.swift; sourceTree = "<group>"; };
 		D814BBA41CF29E8DD9954651 /* OnboardingTemplateFeatureListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTemplateFeatureListTests.swift; sourceTree = "<group>"; };
 		D84D4528EEC9EFEB8AE8E318 /* ActivationIndicatorController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivationIndicatorController.swift; sourceTree = "<group>"; };
 		D891397DAFCEF9DDD612A771 /* ConstrainedBeamSearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstrainedBeamSearchTests.swift; sourceTree = "<group>"; };
@@ -749,6 +753,7 @@
 				9966D09D8D80F54BF2734E00 /* BaseCompletionPromptRendererTests.swift */,
 				04D853218B0A77B0CE090828 /* BrowserAppDetectorTests.swift */,
 				18D990E515E1AE4F312F4E95 /* BundledRuntimeLocatorTests.swift */,
+				8EA827D6A2A54DF4BAD56405 /* CaretLinePositionTests.swift */,
 				EFD89799BB82AF7A92559AEB /* ClipboardContentDistillerTests.swift */,
 				90B0D133AB77A2503FB08827 /* ClipboardRelevanceFilterTests.swift */,
 				D504BEB224E0C176F5FCFF6E /* CompletionRenderModePolicyTests.swift */,
@@ -915,6 +920,7 @@
 				B997EC69E1C65B1E18234221 /* BrowserAppDetector.swift */,
 				AA33F5FFAC5B99384E15CE3E /* BundledRuntimeLocator.swift */,
 				E3C84377F352140759B448C9 /* CaretGeometrySelector.swift */,
+				D77364C1AF183EF1C0A4074D /* CaretLinePosition.swift */,
 				96495E4147D828C0B1B22765 /* ClipboardContentDistiller.swift */,
 				D3A2AC525DC664DB540D4F19 /* ClipboardRelevanceFilter.swift */,
 				53CF416511099C6818110F01 /* CompletionRenderModePolicy.swift */,
@@ -1110,6 +1116,7 @@
 				49C91DE326A590708D76102A /* BrowserAppDetector.swift in Sources */,
 				3CBBC3BFAC0DC8952EE24EF7 /* BundledRuntimeLocator.swift in Sources */,
 				76FD91607794883F8E121450 /* CaretGeometrySelector.swift in Sources */,
+				543D71217CA218426E9638BF /* CaretLinePosition.swift in Sources */,
 				D800277BE3296DE2FB8198A8 /* ChromiumAccessibilityEnabler.swift in Sources */,
 				6E01052209B73D7361C12CEF /* ClipboardContentDistiller.swift in Sources */,
 				D2CAA59F69BCBC07DDA2B0D8 /* ClipboardContextProvider.swift in Sources */,
@@ -1279,6 +1286,7 @@
 				F4A01E4F12F0183449BCCBB9 /* BaseCompletionPromptRendererTests.swift in Sources */,
 				5C0D3B6012C7412001BE3773 /* BrowserAppDetectorTests.swift in Sources */,
 				58AC3193D846FDE88513377D /* BundledRuntimeLocatorTests.swift in Sources */,
+				62FADA407797998742502DD9 /* CaretLinePositionTests.swift in Sources */,
 				8865B95FE84198D70390DF80 /* ClipboardContentDistillerTests.swift in Sources */,
 				BFCA7FAFDAEBF586AB615567 /* ClipboardRelevanceFilterTests.swift in Sources */,
 				25F91CEF38400FD1ADB6B1AF /* CompletionRenderModePolicyTests.swift in Sources */,

--- a/Cotabby/Models/SuggestionModels.swift
+++ b/Cotabby/Models/SuggestionModels.swift
@@ -186,6 +186,13 @@ struct FocusedInputContext: Equatable, Sendable {
         )
     }
 
+    /// True when the caret is at the end of its line (only whitespace, if anything, before the next
+    /// line break). Derived from `trailingText` via `CaretLinePosition`; used to decide when a
+    /// mid-line completion strategy like fill-in-middle applies versus a plain forward continuation.
+    var isCaretAtEndOfLine: Bool {
+        CaretLinePosition.isAtEndOfLine(trailingText: trailingText)
+    }
+
     /// Stable per-process key for the focused field, intentionally NOT including the input frame
     /// rect. The polling signature in `FocusTracker` bumps `focusChangeSequence` whenever the
     /// field's frame changes (e.g., a chat composer growing taller as the user types wraps onto a

--- a/Cotabby/Services/Runtime/LlamaSuggestionEngine.swift
+++ b/Cotabby/Services/Runtime/LlamaSuggestionEngine.swift
@@ -40,17 +40,22 @@ final class LlamaSuggestionEngine {
     }
 
     /// The fill-in-middle request for a generation, or nil to use the forward base prompt. Built only
-    /// when the flag is on and the caret has text after it (a mid-line completion); the runtime still
-    /// falls back to the base prompt when the model lacks FIM markers.
+    /// when the flag is on and the caret is genuinely mid-line (real text follows it on the same line);
+    /// the runtime still falls back to the base prompt when the model lacks FIM markers.
     private static func fillInMiddleRequest(for request: SuggestionRequest) -> FillInMiddleRequest? {
         guard isFillInMiddleEnabled else {
             return nil
         }
-        let suffix = request.context.trailingText
-        guard !suffix.isEmpty else {
+        // A caret at end of line wants a forward continuation, not infilling — even if `trailingText`
+        // is non-empty because a line break and later paragraphs follow it. Gating on end-of-line
+        // (rather than `trailingText.isEmpty`) keeps FIM to the case it is actually meant for.
+        guard !request.context.isCaretAtEndOfLine else {
             return nil
         }
-        return FillInMiddleRequest(prefix: request.context.precedingText, suffix: suffix)
+        return FillInMiddleRequest(
+            prefix: request.context.precedingText,
+            suffix: request.context.trailingText
+        )
     }
 
     init(runtimeManager: LlamaRuntimeGenerating) {

--- a/Cotabby/Support/CaretLinePosition.swift
+++ b/Cotabby/Support/CaretLinePosition.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// File overview:
+/// Pure caret-position rules derived from the text immediately around the caret. Kept out of the
+/// focus-capture layer so these signals stay trivially testable and reusable across the suggestion
+/// pipeline (gating, prompting, diagnostics) without dragging in AX or runtime state.
+enum CaretLinePosition {
+    /// Whether the caret sits at the end of its line: only whitespace (if anything) separates it from
+    /// the next line break, or it is at the very end of the field.
+    ///
+    /// This is the precise distinction between "a forward continuation is appropriate" and "the caret
+    /// is mid-line, so any completion has to fit between existing text." The latter is exactly the
+    /// case fill-in-middle exists for; a bare `trailingText.isEmpty` check misses a caret parked at
+    /// the end of a line that still has later paragraphs after the line break.
+    static func isAtEndOfLine(trailingText: String) -> Bool {
+        for character in trailingText {
+            if character.isNewline {
+                // Hit the line break with only whitespace seen so far: this line ends at the caret.
+                return true
+            }
+            if !character.isWhitespace {
+                return false
+            }
+        }
+        // No line break and nothing but whitespace after the caret: end of the final line.
+        return true
+    }
+}

--- a/CotabbyTests/CaretLinePositionTests.swift
+++ b/CotabbyTests/CaretLinePositionTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+@testable import Cotabby
+
+/// Tests for the pure end-of-line classifier that gates mid-line completion strategies.
+///
+/// The key distinction these lock down: a caret can have non-empty `trailingText` (a line break and
+/// later paragraphs) while still being at the end of its own line. Fill-in-middle must treat that as
+/// end-of-line, not as mid-line infilling.
+final class CaretLinePositionTests: XCTestCase {
+    func test_emptyTrailingTextIsEndOfLine() {
+        XCTAssertTrue(CaretLinePosition.isAtEndOfLine(trailingText: ""))
+    }
+
+    func test_leadingNewlineIsEndOfLine() {
+        // Caret sits at line end; the next paragraph follows after the break.
+        XCTAssertTrue(CaretLinePosition.isAtEndOfLine(trailingText: "\nnext paragraph"))
+    }
+
+    func test_whitespaceThenNewlineIsEndOfLine() {
+        XCTAssertTrue(CaretLinePosition.isAtEndOfLine(trailingText: "   \nmore"))
+    }
+
+    func test_trailingWhitespaceOnlyIsEndOfLine() {
+        XCTAssertTrue(CaretLinePosition.isAtEndOfLine(trailingText: "   "))
+    }
+
+    func test_sameLineTextIsNotEndOfLine() {
+        XCTAssertFalse(CaretLinePosition.isAtEndOfLine(trailingText: " world"))
+    }
+
+    func test_singleNonWhitespaceCharacterIsNotEndOfLine() {
+        XCTAssertFalse(CaretLinePosition.isAtEndOfLine(trailingText: ")"))
+    }
+
+    func test_whitespaceThenSameLineTextIsNotEndOfLine() {
+        // Whitespace before real same-line text still means the caret is mid-line.
+        XCTAssertFalse(CaretLinePosition.isAtEndOfLine(trailingText: "  rest of line\n"))
+    }
+
+    func test_focusedInputContextExposesSignal() {
+        let midLine = CotabbyTestFixtures.suggestionRequest(trailingText: " rest of line")
+        XCTAssertFalse(midLine.context.isCaretAtEndOfLine)
+
+        let endOfLine = CotabbyTestFixtures.suggestionRequest(trailingText: "\nnext paragraph")
+        XCTAssertTrue(endOfLine.context.isCaretAtEndOfLine)
+    }
+}


### PR DESCRIPTION
## Summary

Fill-in-middle was gated on `trailingText.isEmpty`, which fires for a caret parked at the *end of its line* whenever later paragraphs follow the line break — precisely the case that wants a forward continuation, not infilling. This adds a precise end-of-line signal and gates FIM on it, so infilling only engages when there is real text after the caret on the same line.

- `CaretLinePosition.isAtEndOfLine(trailingText:)` — a pure classifier: only whitespace (if anything) between the caret and the next line break, or the end of the field, counts as end-of-line.
- Exposed on `FocusedInputContext` as the computed `isCaretAtEndOfLine` (a reusable capture signal derived from already-captured text; no new stored state, no capture-site changes).
- `LlamaSuggestionEngine.fillInMiddleRequest` now returns nil at end-of-line instead of on empty trailing text.

## Validation

```
xcodebuild ... test ... CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO \
  -only-testing:CotabbyTests/CaretLinePositionTests \
  -only-testing:CotabbyTests/FillInMiddlePolicyTests \
  -only-testing:CotabbyTests/LlamaSuggestionEngineCancellationTests
# ** TEST SUCCEEDED **
#   8 new CaretLinePosition tests (empty / leading-newline / whitespace-then-newline /
#     trailing-whitespace-only = end-of-line; same-line text / single glyph / whitespace-then-text
#     = mid-line; plus the FocusedInputContext computed property)
#   5 FIM policy tests + 4 engine cancellation tests still green

swiftlint lint --strict --quiet <changed files>   # exit 0
xcodegen generate                                  # registered the two new files (drift guard passes)
```

## Linked issues

None. Context-capture parity: a precise end-of-line signal, and tighter FIM triggering.

## Risk / rollout notes

- **No shipped behavior change.** FIM remains behind `cotabbyFillInMiddleEnabled` (default off) and capability-gated; this only refines when that path engages. The new `isCaretAtEndOfLine` is a pure function of existing `trailingText`.
- `project.pbxproj` regenerated by XcodeGen to register `CaretLinePosition.swift` and `CaretLinePositionTests.swift`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a FIM (fill-in-middle) over-triggering bug where a caret parked at the end of a line — with only a newline and subsequent paragraphs in `trailingText` — was incorrectly treated as a mid-line insertion point because `trailingText.isEmpty` was false.

- Introduces `CaretLinePosition.isAtEndOfLine(trailingText:)`, a pure classifier that returns `true` when only whitespace (if anything) precedes the next line break, or when the field ends. The check order (`isNewline` before `!isWhitespace`) is critical since Swift's `isWhitespace` returns `true` for newline characters.
- Exposes `isCaretAtEndOfLine` as a computed property on `FocusedInputContext` derived entirely from the already-captured `trailingText`, with no new stored state or capture-site changes.
- Gates `fillInMiddleRequest` on `!isCaretAtEndOfLine` instead of `!trailingText.isEmpty`, so FIM only engages when real same-line text follows the caret — exactly the case infilling is designed for.

<h3>Confidence Score: 5/5</h3>

Safe to merge; FIM remains feature-flagged off by default and this change only tightens when it engages.

The classifier logic is correct — the ordering of `isNewline` before `!isWhitespace` is the key subtlety, and it is handled properly. The behavior change is strictly a restriction: cases that previously triggered FIM incorrectly (end-of-line with following paragraphs) now correctly skip it. The only gap is that the test suite exercises space-based whitespace but not tab or CRLF line endings, which the implementation handles correctly but leaves untested.

The test file `CotabbyTests/CaretLinePositionTests.swift` could benefit from tab and CRLF test cases, though all existing tests pass and the implementation is correct.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/CaretLinePosition.swift | New pure classifier file; logic correctly gates on `isNewline` before `!isWhitespace`, which is critical because Swift's `isWhitespace` returns true for newlines. |
| Cotabby/Models/SuggestionModels.swift | Adds `isCaretAtEndOfLine` computed property to `FocusedInputContext`; correctly delegates to `CaretLinePosition`, adds no stored state, and does not affect `Equatable` conformance. |
| Cotabby/Services/Runtime/LlamaSuggestionEngine.swift | Replaces the `!trailingText.isEmpty` FIM guard with `!isCaretAtEndOfLine`; the suffix passed to `FillInMiddleRequest` is unchanged (still `trailingText`), only the gating condition is tightened. |
| CotabbyTests/CaretLinePositionTests.swift | Eight focused tests covering the key end-of-line / mid-line cases with spaces; CRLF (`\r\n`) and tab-only trailing text are not tested, leaving minor whitespace-variant coverage gaps. |
| Cotabby.xcodeproj/project.pbxproj | XcodeGen-regenerated to register `CaretLinePosition.swift` in the app target and `CaretLinePositionTests.swift` in the test target; changes are mechanical and correct. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[fillInMiddleRequest called] --> B{isFillInMiddleEnabled?}
    B -- No --> C[return nil\nuse forward base prompt]
    B -- Yes --> D{isCaretAtEndOfLine?}
    D -- Yes\nonly whitespace or newline after caret --> C
    D -- No\nnon-whitespace text on same line --> E[return FillInMiddleRequest\nprefix + trailingText suffix]
    
    subgraph CaretLinePosition.isAtEndOfLine
        F[Iterate trailingText chars] --> G{char.isNewline?}
        G -- Yes --> H[return true\nend-of-line]
        G -- No --> I{char.isWhitespace?}
        I -- No --> J[return false\nmid-line]
        I -- Yes --> F
        F -- exhausted --> K[return true\nend of field]
    end

    D -.->|calls| CaretLinePosition.isAtEndOfLine
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fcaret-end-of-line%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fcaret-end-of-line%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabbyTests%2FCaretLinePositionTests.swift%3A23-25%0AThe%20test%20suite%20exercises%20space-based%20whitespace%20only.%20Two%20variants%20worth%20adding%3A%20a%20tab-only%20trailing%20string%20%28e.g.%2C%20%60%22%09%22%60%29%20and%20a%20CRLF%20sequence%20%28e.g.%2C%20%60%22%0Anext%20paragraph%22%60%29.%20In%20Swift%2C%20%60Character%28%22%0A%22%29%60%20is%20a%20single%20extended%20grapheme%20cluster%20with%20%60isNewline%20%3D%20true%60%2C%20so%20it%20takes%20a%20different%20code%20path%20through%20the%20loop%20than%20%60%22%0A%22%60%20alone.%20Both%20cases%20are%20handled%20correctly%20by%20the%20implementation%2C%20but%20an%20explicit%20test%20would%20lock%20down%20the%20behavior%20against%20future%20edits%20to%20the%20classifier.%0A%0A%60%60%60suggestion%0A%20%20%20%20func%20test_trailingWhitespaceOnlyIsEndOfLine%28%29%20%7B%0A%20%20%20%20%20%20%20%20XCTAssertTrue%28CaretLinePosition.isAtEndOfLine%28trailingText%3A%20%22%20%20%20%22%29%29%0A%20%20%20%20%7D%0A%0A%20%20%20%20func%20test_trailingTabOnlyIsEndOfLine%28%29%20%7B%0A%20%20%20%20%20%20%20%20XCTAssertTrue%28CaretLinePosition.isAtEndOfLine%28trailingText%3A%20%22%5Ct%22%29%29%0A%20%20%20%20%7D%0A%0A%20%20%20%20func%20test_crlfLeadingNewlineIsEndOfLine%28%29%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20CRLF%20is%20a%20single%20Swift%20Character%20%28extended%20grapheme%20cluster%29%20with%20isNewline%20%3D%3D%20true.%0A%20%20%20%20%20%20%20%20XCTAssertTrue%28CaretLinePosition.isAtEndOfLine%28trailingText%3A%20%22%5Cr%5Cnnext%20paragraph%22%29%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabbyTests%2FCaretLinePositionTests.swift%3A23-25%0AThe%20test%20suite%20exercises%20space-based%20whitespace%20only.%20Two%20variants%20worth%20adding%3A%20a%20tab-only%20trailing%20string%20%28e.g.%2C%20%60%22%09%22%60%29%20and%20a%20CRLF%20sequence%20%28e.g.%2C%20%60%22%0Anext%20paragraph%22%60%29.%20In%20Swift%2C%20%60Character%28%22%0A%22%29%60%20is%20a%20single%20extended%20grapheme%20cluster%20with%20%60isNewline%20%3D%20true%60%2C%20so%20it%20takes%20a%20different%20code%20path%20through%20the%20loop%20than%20%60%22%0A%22%60%20alone.%20Both%20cases%20are%20handled%20correctly%20by%20the%20implementation%2C%20but%20an%20explicit%20test%20would%20lock%20down%20the%20behavior%20against%20future%20edits%20to%20the%20classifier.%0A%0A%60%60%60suggestion%0A%20%20%20%20func%20test_trailingWhitespaceOnlyIsEndOfLine%28%29%20%7B%0A%20%20%20%20%20%20%20%20XCTAssertTrue%28CaretLinePosition.isAtEndOfLine%28trailingText%3A%20%22%20%20%20%22%29%29%0A%20%20%20%20%7D%0A%0A%20%20%20%20func%20test_trailingTabOnlyIsEndOfLine%28%29%20%7B%0A%20%20%20%20%20%20%20%20XCTAssertTrue%28CaretLinePosition.isAtEndOfLine%28trailingText%3A%20%22%5Ct%22%29%29%0A%20%20%20%20%7D%0A%0A%20%20%20%20func%20test_crlfLeadingNewlineIsEndOfLine%28%29%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20CRLF%20is%20a%20single%20Swift%20Character%20%28extended%20grapheme%20cluster%29%20with%20isNewline%20%3D%3D%20true.%0A%20%20%20%20%20%20%20%20XCTAssertTrue%28CaretLinePosition.isAtEndOfLine%28trailingText%3A%20%22%5Cr%5Cnnext%20paragraph%22%29%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=523&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Gate fill-in-middle on a precise end-of-..."](https://github.com/fujacob/cotabby/commit/13620ee8e3a802d7a2e76684fdaf1638c2adba7d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35052177)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->