### PR TITLE
Document how to evaluate the experimental decoder on device

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -87,6 +87,8 @@ The local model runtime is intentionally split:
 
 That split matters because runtime lifecycle concerns change at a different rate than prompt strategy or output cleanup.
 
+The constrained decoder, beam search, and fill-in-middle prompting ship behind default-off developer flags. See [docs/EVALUATING_THE_DECODER.md](docs/EVALUATING_THE_DECODER.md) for how to enable each path on device and read acceptance rate and suppression reasons from the logs before promoting one to the default.
+
 ## Safe Change Order
 
 If you need to change behavior, prefer this order:

--- a/docs/EVALUATING_THE_DECODER.md
+++ b/docs/EVALUATING_THE_DECODER.md
@@ -1,0 +1,101 @@
+# Evaluating the Experimental Constrained Decoder
+
+The constrained decoder, multi-branch (beam) search, and fill-in-middle (FIM)
+prompting ship **behind default-off developer flags**. Decode quality can only be
+judged with a real model in a real text field, so none of them is promoted to the
+default until it has been dogfooded on device. This doc is the recipe for that:
+how to turn each path on, and how to read the logs to decide whether it earns the
+default.
+
+The flags live in `LlamaSuggestionEngine` and `LlamaGenerationOptions`; they do
+not affect KV reuse, so toggling them mid-session is safe.
+
+## Flags
+
+Set these against the app's `UserDefaults` domain (`com.jacobfu.tabby`), then
+restart the app:
+
+| Key | Type | Effect |
+| --- | --- | --- |
+| `cotabbyConstrainedDecoderEnabled` | Bool | Routes generation through the deterministic constrained decoder (logit read + admissibility mask + manual token commit) instead of the engine's stochastic sampler. |
+| `cotabbyConstrainedBeamWidth` | Int (default `1`) | Beam width when the constrained decoder is on. `1` is greedy; `>1` enables multi-branch search. |
+| `cotabbyFillInMiddleEnabled` | Bool | Uses FIM prompting for genuine mid-line carets (text after the caret on the same line) on models that ship FIM markers. |
+
+```bash
+# Greedy constrained decode
+defaults write com.jacobfu.tabby cotabbyConstrainedDecoderEnabled -bool YES
+
+# Constrained decode with a 3-wide beam
+defaults write com.jacobfu.tabby cotabbyConstrainedBeamWidth -int 3
+
+# Mid-line fill-in-middle (only engages on a FIM-capable model, e.g. the Qwen tiers)
+defaults write com.jacobfu.tabby cotabbyFillInMiddleEnabled -bool YES
+
+# Back to the shipping sampler
+defaults delete com.jacobfu.tabby cotabbyConstrainedDecoderEnabled
+```
+
+Run the app with `-cotabby-debug` so the on-disk JSONL sinks are populated (see
+the main README / CLAUDE notes). All recipes below read those files.
+
+## Reading the results
+
+Every suggestion carries a `request_id` that joins the engine logs
+(`llm-io.jsonl`) to the coordinator stage logs (`cotabby.jsonl`). The two signals
+that matter for a quality call are **acceptance rate** and the
+**suppression-reason breakdown**.
+
+### Acceptance rate
+
+A suggestion is *shown* when the coordinator logs `stage == "ready"`, and
+*accepted* when it logs an `…-accepted-chunk` / `…-accepted-final-chunk` stage.
+Approximate the rate by deduping on `request_id`:
+
+```bash
+L=~/Library/Logs/Cotabby/cotabby.jsonl
+shown=$(jq -r 'select(.stage=="ready") | .request_id' "$L" | sort -u | wc -l)
+accepted=$(jq -r 'select(.stage|test("accepted")) | .request_id' "$L" | sort -u | wc -l)
+echo "accepted $accepted / shown $shown"
+```
+
+Compare a session with the flag on against one with it off. A decode change earns
+the default only if acceptance does not regress.
+
+### Why suggestions were suppressed
+
+When ghost text comes back empty, `suppression_reason` says why — the join key
+for telling "the model produced nothing usable" apart from "a filter dropped a
+real completion":
+
+```bash
+jq -r 'select(.suppression_reason and .suppression_reason != "none") | .suppression_reason' \
+  ~/Library/Logs/Cotabby/cotabby.jsonl | sort | uniq -c | sort -rn
+```
+
+- `emptyGeneration` / `normalizedToEmpty` dominating → the **model/decode** is
+  producing nothing usable. Look at the prompt and the decode path, not the
+  filters.
+- `duplicatesTrailingText` / `echoesPrecedingText` / `unsafeToInsert` dominating
+  → the model *is* producing text but a **filter** is dropping it. Decide whether
+  the filter is too aggressive or the model genuinely needs the guard.
+
+### Latency
+
+The constrained/beam paths do more per token than the sampler. Confirm latency
+stays acceptable before promoting, especially at beam width `> 1`:
+
+```bash
+jq 'select(.engine=="llama") | .latency_ms' ~/Library/Logs/Cotabby/llm-io.jsonl \
+  | jq -s 'sort | {p50: .[length/2|floor], p95: .[length*95/100|floor], max: max}'
+```
+
+## Promotion checklist
+
+Flip a flag's default (in `LlamaSuggestionEngine`) only when, on device:
+
+1. Acceptance rate is at least on par with the shipping sampler.
+2. The suppression breakdown is not dominated by `emptyGeneration` /
+   `normalizedToEmpty` (the model is actually completing, not stalling).
+3. p95 latency is within the typing-latency budget the app already targets.
+
+Until then, the flags stay off and the shipping sampler is untouched.


### PR DESCRIPTION
## Summary

The constrained decoder, beam search, and fill-in-middle prompting (PRs #517–#523) all ship behind default-off developer flags because decode quality can only be judged with a real model in a real field. This documents the handoff so the maintainer can actually run that evaluation: the exact `UserDefaults` keys to flip, and `jq` recipes to read acceptance rate, the `suppression_reason` breakdown, and latency from the `-cotabby-debug` logs — plus a promotion checklist for when a flag earns the default.

- New `docs/EVALUATING_THE_DECODER.md`.
- Linked from `ARCHITECTURE.md`'s "Runtime And Models" section.

## Validation

Docs-only change — no source, project, or build impact.

```
# the recipes were written against the real log fields:
#   suppression_reason (engine logs, added in #522)
#   stage=="ready" (shown) and *-accepted-* (accepted), joined by request_id
#   latency_ms (llm-io.jsonl)
```

## Linked issues

None. Operationalizes the on-device evaluation that gates promoting the constrained decoder to the default.

## Risk / rollout notes

- Documentation only. No behavior, schema, or build change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This docs-only PR adds `docs/EVALUATING_THE_DECODER.md` — a hands-on guide for running the experimental constrained decoder, beam search, and FIM prompting on device — and links it from `ARCHITECTURE.md`'s "Runtime And Models" section. No source, build, or schema changes are included.

- **New evaluation guide**: covers the three `UserDefaults` keys to flip, `jq` recipes for acceptance rate and suppression-reason breakdowns from `cotabby.jsonl`, a latency-percentile recipe against `llm-io.jsonl`, and a promotion checklist.
- **`ARCHITECTURE.md` update**: a two-sentence paragraph under "Runtime And Models" describes the flags and links to the new guide.

<h3>Confidence Score: 4/5</h3>

Safe to merge — documentation only, no source or build changes.

Both changed files are pure documentation. The ARCHITECTURE.md addition and the link are correct. Two small issues in the jq recipes: the reset block only deletes one of the three keys it set, and the latency snippet does not filter null values before computing percentiles. Neither breaks anything in the app, but an evaluator following the guide could end up with lingering flags or misleading latency numbers.

docs/EVALUATING_THE_DECODER.md — the reset commands block and the latency jq recipe.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/EVALUATING_THE_DECODER.md | New evaluation guide covering UserDefaults flags, acceptance-rate/suppression-reason/latency jq recipes, and a promotion checklist; two minor recipe issues: incomplete reset commands and unfiltered nulls in the latency percentile snippet. |
| ARCHITECTURE.md | Adds a two-sentence paragraph under 'Runtime And Models' that links to the new evaluation guide; content and relative link path are correct. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Enable flag via defaults write] --> B{Which flag?}
    B --> |cotabbyConstrainedDecoderEnabled| C[Constrained decoder active]
    B --> |cotabbyConstrainedBeamWidth > 1| D[Multi-branch beam search active]
    B --> |cotabbyFillInMiddleEnabled| E[FIM prompting active]
    C & D & E --> F[Run app with -cotabby-debug]
    F --> G[JSONL logs written to ~/Library/Logs/Cotabby/]
    G --> H[cotabby.jsonl — stage & suppression_reason]
    G --> I[llm-io.jsonl — latency_ms]
    H --> J{Check acceptance rate}
    H --> K{Check suppression breakdown}
    I --> L{Check p95 latency}
    J & K & L --> M{All criteria met?}
    M --> |Yes| N[Promote flag default in LlamaSuggestionEngine]
    M --> |No| O[Keep flag off, iterate]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22docs%2Fevaluate-constrained-decoder%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Fevaluate-constrained-decoder%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Adocs%2FEVALUATING_THE_DECODER.md%3A33-36%0A**Incomplete%20reset%20%E2%80%94%20two%20flags%20are%20left%20set%20after%20%22Back%20to%20the%20shipping%20sampler%22**%0A%0AThe%20%60defaults%20delete%60%20line%20only%20removes%20%60cotabbyConstrainedDecoderEnabled%60.%20If%20an%20evaluator%20previously%20ran%20all%20three%20%60write%60%20commands%2C%20%60cotabbyConstrainedBeamWidth%60%20%28still%20%603%60%29%20and%20%60cotabbyFillInMiddleEnabled%60%20%28still%20%60YES%60%29%20remain%20in%20the%20domain%20after%20the%20delete.%20The%20next%20session%20would%20pick%20those%20up%20silently%2C%20making%20it%20look%20like%20the%20default%20sampler%20is%20active%20when%20it%20isn't.%20Two%20more%20%60defaults%20delete%60%20lines%20%28or%20a%20%60defaults%20delete%20com.jacobfu.tabby%60%20to%20wipe%20the%20whole%20domain%2C%20with%20a%20note%20to%20re-add%20any%20desired%20keys%29%20would%20make%20the%20reset%20unambiguous.%0A%0A%23%23%23%20Issue%202%20of%202%0Adocs%2FEVALUATING_THE_DECODER.md%3A88-89%0AThe%20%60jq%60%20pipeline%20doesn't%20filter%20out%20%60null%60%20values%20before%20sorting.%20If%20any%20log%20entry%20matches%20%60.engine%3D%3D%22llama%22%60%20but%20has%20no%20%60latency_ms%60%20field%20%28e.g.%20error%20records%20or%20entries%20logged%20before%20the%20field%20was%20added%29%2C%20%60jq%60%20emits%20%60null%60%20for%20each%20one%2C%20and%20those%20nulls%20sort%20to%20the%20front%20of%20the%20array%20in%20jq's%20ordering%20rules.%20The%20resulting%20p50%2Fp95%20indices%20then%20count%20from%20a%20base%20that%20includes%20the%20nulls%2C%20silently%20skewing%20every%20percentile.%20Adding%20a%20%60select%28.%20!%3D%20null%29%60%20after%20the%20field%20extraction%20keeps%20only%20real%20numbers.%0A%0A%60%60%60suggestion%0Ajq%20'select%28.engine%3D%3D%22llama%22%29%20%7C%20.latency_ms%20%7C%20select%28.%20!%3D%20null%29'%20~%2FLibrary%2FLogs%2FCotabby%2Fllm-io.jsonl%20%5C%0A%20%20%7C%20jq%20-s%20'sort%20%7C%20%7Bp50%3A%20.%5Blength%2F2%7Cfloor%5D%2C%20p95%3A%20.%5Blength*95%2F100%7Cfloor%5D%2C%20max%3A%20max%7D'%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Adocs%2FEVALUATING_THE_DECODER.md%3A33-36%0A**Incomplete%20reset%20%E2%80%94%20two%20flags%20are%20left%20set%20after%20%22Back%20to%20the%20shipping%20sampler%22**%0A%0AThe%20%60defaults%20delete%60%20line%20only%20removes%20%60cotabbyConstrainedDecoderEnabled%60.%20If%20an%20evaluator%20previously%20ran%20all%20three%20%60write%60%20commands%2C%20%60cotabbyConstrainedBeamWidth%60%20%28still%20%603%60%29%20and%20%60cotabbyFillInMiddleEnabled%60%20%28still%20%60YES%60%29%20remain%20in%20the%20domain%20after%20the%20delete.%20The%20next%20session%20would%20pick%20those%20up%20silently%2C%20making%20it%20look%20like%20the%20default%20sampler%20is%20active%20when%20it%20isn't.%20Two%20more%20%60defaults%20delete%60%20lines%20%28or%20a%20%60defaults%20delete%20com.jacobfu.tabby%60%20to%20wipe%20the%20whole%20domain%2C%20with%20a%20note%20to%20re-add%20any%20desired%20keys%29%20would%20make%20the%20reset%20unambiguous.%0A%0A%23%23%23%20Issue%202%20of%202%0Adocs%2FEVALUATING_THE_DECODER.md%3A88-89%0AThe%20%60jq%60%20pipeline%20doesn't%20filter%20out%20%60null%60%20values%20before%20sorting.%20If%20any%20log%20entry%20matches%20%60.engine%3D%3D%22llama%22%60%20but%20has%20no%20%60latency_ms%60%20field%20%28e.g.%20error%20records%20or%20entries%20logged%20before%20the%20field%20was%20added%29%2C%20%60jq%60%20emits%20%60null%60%20for%20each%20one%2C%20and%20those%20nulls%20sort%20to%20the%20front%20of%20the%20array%20in%20jq's%20ordering%20rules.%20The%20resulting%20p50%2Fp95%20indices%20then%20count%20from%20a%20base%20that%20includes%20the%20nulls%2C%20silently%20skewing%20every%20percentile.%20Adding%20a%20%60select%28.%20!%3D%20null%29%60%20after%20the%20field%20extraction%20keeps%20only%20real%20numbers.%0A%0A%60%60%60suggestion%0Ajq%20'select%28.engine%3D%3D%22llama%22%29%20%7C%20.latency_ms%20%7C%20select%28.%20!%3D%20null%29'%20~%2FLibrary%2FLogs%2FCotabby%2Fllm-io.jsonl%20%5C%0A%20%20%7C%20jq%20-s%20'sort%20%7C%20%7Bp50%3A%20.%5Blength%2F2%7Cfloor%5D%2C%20p95%3A%20.%5Blength*95%2F100%7Cfloor%5D%2C%20max%3A%20max%7D'%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=524&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Document how to evaluate the experimenta..."](https://github.com/fujacob/cotabby/commit/fd6725c05d2c8311af1562eb84c1b19071489256) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35053952)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->