### PR TITLE
Add required-prefix admissibility to the constrained beam decoder

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		27D4F5CACADE171F142178B4 /* SettingsSidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BADB38D0160B47637572FC5E /* SettingsSidebarView.swift */; };
 		286B7022E2A2774275004447 /* WelcomeTemplateStepView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9199B9CEAB320982CA333B8 /* WelcomeTemplateStepView.swift */; };
 		29EC35D67D9B4C3C50222619 /* ConstrainedBeamSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D891397DAFCEF9DDD612A771 /* ConstrainedBeamSearchTests.swift */; };
+		2A1ED4231B6EAD2640AE1568 /* RequiredPrefixConstraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8D1BE91149614EE5D888672 /* RequiredPrefixConstraint.swift */; };
 		2C6159231472A849F15BD0AE /* ScreenFrameReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5484C8A04B9C00CF79D589EB /* ScreenFrameReader.swift */; };
 		2DF5A3826AAB99C279EBB8DE /* InputMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B81DD30EB657368AACE9625A /* InputMonitor.swift */; };
 		2E3DEB7E89D0146274596F2E /* SettingsContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB0CE9AB1286367BA2E82392 /* SettingsContainerView.swift */; };
@@ -161,6 +162,7 @@
 		909EBE545CE644C6C57F1B5D /* SuggestionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F961F5DF2A392F6F5F94F8A /* SuggestionCoordinator.swift */; };
 		90CD3F7238E223DEBA2B4D92 /* TagChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB317C82CE2CBC69056BA4B8 /* TagChip.swift */; };
 		90DC9508F27F712EB61EEB06 /* PermissionReminderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 656F58E56FE9BC087B6F1D33 /* PermissionReminderView.swift */; };
+		912EE366AD8107CDAE0FBC6E /* RequiredPrefixConstraintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E498506C46AC3AB19D8AE6EC /* RequiredPrefixConstraintTests.swift */; };
 		91C27021750AC03AA4A0115A /* HuggingFaceAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110CB0B53016644EF7840301 /* HuggingFaceAPIClient.swift */; };
 		91D1F16B8C5DA281D4B7F699 /* CustomRulesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD752451330486FE270018B0 /* CustomRulesTests.swift */; };
 		91D8189EFCD1BA992EA6F038 /* ConfidenceSuppressionPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06FF2B0A3094A952A8EBA9B5 /* ConfidenceSuppressionPolicyTests.swift */; };
@@ -505,6 +507,7 @@
 		E27B962C66727776D00069DE /* EmojiPopularity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiPopularity.swift; sourceTree = "<group>"; };
 		E3C84377F352140759B448C9 /* CaretGeometrySelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaretGeometrySelector.swift; sourceTree = "<group>"; };
 		E43E587E421AF544A8300CE4 /* CustomRulesCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomRulesCatalog.swift; sourceTree = "<group>"; };
+		E498506C46AC3AB19D8AE6EC /* RequiredPrefixConstraintTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequiredPrefixConstraintTests.swift; sourceTree = "<group>"; };
 		E5DAF68AEBFE334F68A65E82 /* AcceptanceModePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcceptanceModePickerView.swift; sourceTree = "<group>"; };
 		E6423D6CC8CC371D2DA899DE /* PermissionOverlayTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionOverlayTracker.swift; sourceTree = "<group>"; };
 		E73C04A71D85B25998144F11 /* TokenProfileCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenProfileCache.swift; sourceTree = "<group>"; };
@@ -519,6 +522,7 @@
 		F308F6E274CC645E27CB651F /* OverlayController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayController.swift; sourceTree = "<group>"; };
 		F394B8A6E30CC47015772089 /* TokenProfileCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenProfileCacheTests.swift; sourceTree = "<group>"; };
 		F3CEFE8C321E17BB3873C893 /* TokenProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenProfile.swift; sourceTree = "<group>"; };
+		F8D1BE91149614EE5D888672 /* RequiredPrefixConstraint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequiredPrefixConstraint.swift; sourceTree = "<group>"; };
 		FA4B45B91D4DEAC979C3113E /* PromptContextSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptContextSanitizer.swift; sourceTree = "<group>"; };
 		FA878B447441BB4F3E327CC8 /* OnboardingTemplateRecommender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTemplateRecommender.swift; sourceTree = "<group>"; };
 		FB317C82CE2CBC69056BA4B8 /* TagChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagChip.swift; sourceTree = "<group>"; };
@@ -804,6 +808,7 @@
 				4696A84D17890B154533A08F /* PromptPolicyTests.swift */,
 				E260C4D08C786CDBD527B329 /* PromptSectionBudgetTests.swift */,
 				5D957E76B6EA508DE3510F98 /* RepetitionGuardTests.swift */,
+				E498506C46AC3AB19D8AE6EC /* RequiredPrefixConstraintTests.swift */,
 				B2BFD19A159680A495EE02FD /* ScreenshotContextGeneratorTests.swift */,
 				474560E524C1D74BAB1570DA /* SecureFieldDetectorTests.swift */,
 				2D7360A6D4261989A66658ED /* SentenceBoundaryClassifierTests.swift */,
@@ -963,6 +968,7 @@
 				AFCFCCCB69C29A86E726B10A /* PromptSectionBudget.swift */,
 				04FAB8DC9CC29F7A3EB8C91F /* RepetitionGuard.swift */,
 				6DC693E00430F46E41CB56E6 /* RequestID.swift */,
+				F8D1BE91149614EE5D888672 /* RequiredPrefixConstraint.swift */,
 				1827565F4FAD3E4E61CA65C3 /* SecureFieldDetector.swift */,
 				D4B56C250DDEF3E81F9DCBD7 /* SentenceBoundaryClassifier.swift */,
 				2A02336442BB735EE2E8D064 /* SettingsAttentionEvaluator.swift */,
@@ -1221,6 +1227,7 @@
 				3C561CD717064F9250200667 /* PromptSectionBudget.swift in Sources */,
 				097B59F01FEC03651D5732A3 /* RepetitionGuard.swift in Sources */,
 				A5A6CE0EF01CA6A9AFA7A400 /* RequestID.swift in Sources */,
+				2A1ED4231B6EAD2640AE1568 /* RequiredPrefixConstraint.swift in Sources */,
 				82D4ADEAF05337ABDE4C586C /* RuntimeBootstrapModel.swift in Sources */,
 				2C6159231472A849F15BD0AE /* ScreenFrameReader.swift in Sources */,
 				0C06CAD62975E87B2C852191 /* ScreenTextExtractor.swift in Sources */,
@@ -1337,6 +1344,7 @@
 				3CF1A4E39F24917DF0470A7D /* PromptPolicyTests.swift in Sources */,
 				7EB20783E0D36715D1230A5C /* PromptSectionBudgetTests.swift in Sources */,
 				ED642B8D6D0EAF52E3907DE5 /* RepetitionGuardTests.swift in Sources */,
+				912EE366AD8107CDAE0FBC6E /* RequiredPrefixConstraintTests.swift in Sources */,
 				1B3FFCB9A979F49BF86EAAD4 /* ScreenshotContextGeneratorTests.swift in Sources */,
 				4FC52FB28AFC013F000D8FF9 /* SecureFieldDetectorTests.swift in Sources */,
 				1D1C6FF0B8F50AC14A1000F4 /* SentenceBoundaryClassifierTests.swift in Sources */,

--- a/Cotabby/Support/ConstrainedBeamSearch.swift
+++ b/Cotabby/Support/ConstrainedBeamSearch.swift
@@ -44,6 +44,17 @@ struct BeamCandidate: Equatable {
     let tokenIDs: [Int]
     let bytes: [UInt8]
     let cumulativeLogprob: Double
+    /// Required-prefix bytes this branch must still emit before it may complete. Empty in the common
+    /// unconstrained case (so behavior is unchanged); non-empty only while steering the branch toward
+    /// a required continuation. A branch may finish only once this is empty.
+    let remainingPrefix: [UInt8]
+
+    init(tokenIDs: [Int], bytes: [UInt8], cumulativeLogprob: Double, remainingPrefix: [UInt8] = []) {
+        self.tokenIDs = tokenIDs
+        self.bytes = bytes
+        self.cumulativeLogprob = cumulativeLogprob
+        self.remainingPrefix = remainingPrefix
+    }
 
     /// Mean per-token log-probability; ranks completed branches so a short confident continuation is
     /// not unfairly beaten by a longer, lower-average one. An empty branch ranks last.
@@ -68,29 +79,35 @@ enum ConstrainedBeamSearch {
         profile: TokenProfile,
         configuration: BeamSearchConfiguration,
         isSingleLine: Bool,
-        isMidWord: Bool = false
+        isMidWord: Bool = false,
+        requiredPrefix: [UInt8] = []
     ) -> [BeamCandidate] {
         Engine(
             nextLogits: nextLogits,
             profile: profile,
             configuration: configuration,
             isSingleLine: isSingleLine,
-            isMidWord: isMidWord
+            isMidWord: isMidWord,
+            requiredPrefix: requiredPrefix
         ).run()
     }
 }
 
 /// The mutable-free search context, holding the inputs so the per-step helpers stay small. A struct
-/// rather than passing the same four values through every call.
+/// rather than passing the same values through every call.
 private struct Engine {
     let nextLogits: BeamLogitsProvider
     let profile: TokenProfile
     let configuration: BeamSearchConfiguration
     let isSingleLine: Bool
     let isMidWord: Bool
+    /// Bytes every branch must emit before it may complete. Empty for an unconstrained search.
+    let requiredPrefix: [UInt8]
 
     func run() -> [BeamCandidate] {
-        var frontier: [BeamCandidate] = [BeamCandidate(tokenIDs: [], bytes: [], cumulativeLogprob: 0)]
+        var frontier: [BeamCandidate] = [
+            BeamCandidate(tokenIDs: [], bytes: [], cumulativeLogprob: 0, remainingPrefix: requiredPrefix)
+        ]
         var completed: [BeamCandidate] = []
 
         for _ in 0 ..< configuration.maxTokens {
@@ -98,17 +115,20 @@ private struct Engine {
             var nextFrontier: [BeamCandidate] = []
             for branch in frontier {
                 guard let logits = nextLogits(branch.tokenIDs) else {
-                    completed.append(branch)
+                    // A stalled branch is only a valid completion if it has satisfied its requirement.
+                    if branch.remainingPrefix.isEmpty {
+                        completed.append(branch)
+                    }
                     continue
                 }
                 expand(branch: branch, logits: logits, live: &nextFrontier, completed: &completed)
             }
             frontier = Self.prune(nextFrontier, to: configuration.beamWidth)
         }
-        // Budget exhausted: surviving branches are valid completions too.
-        completed.append(contentsOf: frontier)
+        // Budget exhausted: surviving branches complete too, but only if their required prefix is met.
+        completed.append(contentsOf: frontier.filter { $0.remainingPrefix.isEmpty })
         return completed
-            .filter { !$0.tokenIDs.isEmpty }
+            .filter { !$0.tokenIDs.isEmpty && $0.remainingPrefix.isEmpty }
             .sorted { $0.meanLogprob > $1.meanLogprob }
     }
 
@@ -124,11 +144,16 @@ private struct Engine {
             history: branch.tokenIDs,
             ngramSize: configuration.noRepeatNgramSize
         )
+        // While a required prefix is unmet, the admissible token can rank far below the model's
+        // top-K (a forced continuation the model finds locally unlikely), so the pool must not be
+        // capped by raw logit — scan the full vocabulary and let the prefix rule below select. The
+        // unconstrained common case keeps the cheap top-K bound.
+        let effectiveTopK = branch.remainingPrefix.isEmpty ? configuration.topK : logits.count
         var candidates = ConstrainedSampler.rankedAdmissibleTokens(
             logits: logits,
             profile: profile,
             admissibleTokenIDs: nil,
-            topK: configuration.topK,
+            topK: effectiveTopK,
             blockedTokenIDs: blocked
         )
         // Mid-word: the first generated token must finish the current word, not start a new token with
@@ -138,17 +163,40 @@ private struct Engine {
             candidates = candidates.filter { profile.continuesWordMidStream($0) }
         }
         for tokenID in candidates {
+            // A branch may only stop (end-of-generation or single-line newline) once it has emitted
+            // its full required prefix; otherwise the would-be completion omits required bytes.
             if profile.isEndOfGeneration(tokenID) {
-                completed.append(branch)
+                if branch.remainingPrefix.isEmpty {
+                    completed.append(branch)
+                }
                 continue
             }
             if isSingleLine, profile.isNewline(tokenID) {
-                completed.append(branch)
+                if branch.remainingPrefix.isEmpty {
+                    completed.append(branch)
+                }
                 continue
             }
             let tokenBytes = profile.bytes(for: tokenID)
-            let child = extend(branch, by: tokenID, tokenBytes: tokenBytes, logits: logits)
-            if Self.completesSentence(child.bytes, lastTokenBytes: tokenBytes) {
+            // Required-prefix admissibility: drop tokens that diverge, and carry the unconsumed tail.
+            let remainingAfterToken: [UInt8]
+            switch RequiredPrefixConstraint.step(remainingPrefix: branch.remainingPrefix, tokenBytes: tokenBytes) {
+            case .rejected:
+                continue
+            case .satisfied:
+                remainingAfterToken = []
+            case .advanced(let remaining):
+                remainingAfterToken = remaining
+            }
+            let child = extend(
+                branch,
+                by: tokenID,
+                tokenBytes: tokenBytes,
+                logits: logits,
+                remainingPrefix: remainingAfterToken
+            )
+            // A sentence boundary only finishes a branch that has also satisfied its required prefix.
+            if remainingAfterToken.isEmpty, Self.completesSentence(child.bytes, lastTokenBytes: tokenBytes) {
                 completed.append(child)
             } else {
                 live.append(child)
@@ -160,7 +208,8 @@ private struct Engine {
         _ branch: BeamCandidate,
         by tokenID: Int,
         tokenBytes: [UInt8],
-        logits: [Float]
+        logits: [Float],
+        remainingPrefix: [UInt8]
     ) -> BeamCandidate {
         var bytes = branch.bytes
         bytes.append(contentsOf: tokenBytes)
@@ -168,7 +217,8 @@ private struct Engine {
         return BeamCandidate(
             tokenIDs: branch.tokenIDs + [tokenID],
             bytes: bytes,
-            cumulativeLogprob: branch.cumulativeLogprob + logprob
+            cumulativeLogprob: branch.cumulativeLogprob + logprob,
+            remainingPrefix: remainingPrefix
         )
     }
 

--- a/Cotabby/Support/RequiredPrefixConstraint.swift
+++ b/Cotabby/Support/RequiredPrefixConstraint.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// File overview:
+/// The required-prefix admissibility rule for constrained decoding. Given a byte prefix the
+/// completion must still produce, it decides whether a candidate token may be emitted and what
+/// prefix remains afterward. This is the foundation for steering generation onto a known
+/// continuation — finishing a specific partially-formed word, for example — without ever letting the
+/// model emit bytes that diverge from the requirement.
+///
+/// The rule is byte-exact and deliberately trie-free: correctness needs only the two-way prefix
+/// check below (the token completes the requirement, or is itself a step toward it). A trie over the
+/// vocabulary would only speed the per-step lookup, never change the result, so it can be layered in
+/// later as a pure optimization without touching this contract. Working in bytes (not Characters)
+/// keeps the rule correct across token boundaries that split a multi-byte UTF-8 scalar.
+enum RequiredPrefixConstraint {
+    /// The outcome of testing one token against the remaining required prefix.
+    enum Step: Equatable {
+        /// The token satisfies the requirement: it either completes the remaining prefix, or the
+        /// prefix was already empty. Nothing is required of later tokens in this branch.
+        case satisfied
+        /// The token is a strict prefix of the requirement; `remaining` is what later tokens must
+        /// still produce.
+        case advanced(remaining: [UInt8])
+        /// The token diverges from the requirement and is inadmissible.
+        case rejected
+    }
+
+    /// Tests `tokenBytes` against `remainingPrefix` and reports whether the token may be emitted and
+    /// what prefix would remain afterward.
+    ///
+    /// - An empty `remainingPrefix` means the requirement is already met: every token is `satisfied`.
+    /// - A token at least as long as the remaining prefix is admissible only if it *starts with* the
+    ///   whole remaining prefix (it completes, and may extend past, the requirement).
+    /// - A shorter token is admissible only if the remaining prefix *starts with* the token's bytes
+    ///   (it is a step toward the requirement); the unconsumed tail is what remains.
+    static func step(remainingPrefix: [UInt8], tokenBytes: [UInt8]) -> Step {
+        guard !remainingPrefix.isEmpty else {
+            return .satisfied
+        }
+        if tokenBytes.count >= remainingPrefix.count {
+            return tokenBytes.starts(with: remainingPrefix) ? .satisfied : .rejected
+        }
+        guard remainingPrefix.starts(with: tokenBytes) else {
+            return .rejected
+        }
+        return .advanced(remaining: Array(remainingPrefix.dropFirst(tokenBytes.count)))
+    }
+
+    /// Whether `tokenBytes` may be emitted next given `remainingPrefix`, ignoring the leftover. A thin
+    /// predicate over `step` for callers (e.g. a greedy admissibility mask) that do not track the
+    /// remainder themselves.
+    static func admits(remainingPrefix: [UInt8], tokenBytes: [UInt8]) -> Bool {
+        step(remainingPrefix: remainingPrefix, tokenBytes: tokenBytes) != .rejected
+    }
+}

--- a/CotabbyTests/ConstrainedBeamSearchTests.swift
+++ b/CotabbyTests/ConstrainedBeamSearchTests.swift
@@ -179,4 +179,62 @@ final class ConstrainedBeamSearchTests: XCTestCase {
 
         XCTAssertEqual(result.first?.tokenIDs.count, 2)
     }
+
+    // MARK: - Required prefix
+
+    func test_search_requiredPrefix_steersOntoLowLogitRequiredToken() {
+        // 0="a", 1="b", 2="z". The model strongly prefers "z" at every step, but a required prefix of
+        // "ab" must force "a" then "b" even though both rank far below "z".
+        let profile = makeProfile(byteStrings: ["a", "b", "z"])
+        let rows: [[Int]: [Float]] = [
+            []: row([2: 9, 0: 1], vocabSize: 3),
+            [0]: row([2: 9, 1: 1], vocabSize: 3)
+        ]
+        let unconstrained = ConstrainedBeamSearch.search(
+            nextLogits: provider(vocabSize: 3, rows: rows), profile: profile,
+            configuration: BeamSearchConfiguration(beamWidth: 1, maxTokens: 2, topK: 5),
+            isSingleLine: false)
+        let constrained = ConstrainedBeamSearch.search(
+            nextLogits: provider(vocabSize: 3, rows: rows), profile: profile,
+            configuration: BeamSearchConfiguration(beamWidth: 1, maxTokens: 2, topK: 5),
+            isSingleLine: false, requiredPrefix: Array("ab".utf8))
+
+        XCTAssertEqual(unconstrained.first?.text.hasPrefix("z"), true, "unconstrained follows the model's preference")
+        XCTAssertEqual(constrained.first?.text, "ab", "the required prefix overrides the model's preference")
+    }
+
+    func test_search_requiredPrefix_doesNotStopBeforePrefixIsSatisfied() {
+        // 0="a", 1="." (EOG, non-empty bytes), 2="b". The model wants to stop immediately, but with a
+        // required prefix of "ab" no returned completion may omit the prefix.
+        let profile = makeProfile(byteStrings: ["a", ".", "b"], eog: [1])
+        let rows: [[Int]: [Float]] = [
+            []: row([1: 9, 0: 1], vocabSize: 3),
+            [0]: row([1: 9, 2: 1], vocabSize: 3)
+        ]
+        let result = ConstrainedBeamSearch.search(
+            nextLogits: provider(vocabSize: 3, rows: rows), profile: profile,
+            configuration: BeamSearchConfiguration(beamWidth: 1, maxTokens: 3, topK: 5),
+            isSingleLine: false, requiredPrefix: Array("ab".utf8))
+
+        XCTAssertFalse(result.isEmpty, "the search still produces a completion")
+        XCTAssertTrue(result.allSatisfy { $0.text.hasPrefix("ab") }, "no completion stopped before the prefix was met")
+    }
+
+    func test_search_requiredPrefix_spansTokensOfDifferingLengths() {
+        // 0="a", 1="bc", 2="ab", 3="c", 4="z". A required prefix of "abc" can be reached either as
+        // "ab"+"c" or "a"+"bc"; both must yield exactly "abc".
+        let profile = makeProfile(byteStrings: ["a", "bc", "ab", "c", "z"])
+        let rows: [[Int]: [Float]] = [
+            []: row([4: 9, 2: 5, 0: 1], vocabSize: 5),
+            [2]: row([3: 5], vocabSize: 5),
+            [0]: row([1: 5], vocabSize: 5)
+        ]
+        let result = ConstrainedBeamSearch.search(
+            nextLogits: provider(vocabSize: 5, rows: rows), profile: profile,
+            configuration: BeamSearchConfiguration(beamWidth: 2, maxTokens: 2, topK: 5),
+            isSingleLine: false, requiredPrefix: Array("abc".utf8))
+
+        XCTAssertFalse(result.isEmpty)
+        XCTAssertTrue(result.allSatisfy { $0.text == "abc" }, "every surviving branch reproduces the required prefix exactly")
+    }
 }

--- a/CotabbyTests/RequiredPrefixConstraintTests.swift
+++ b/CotabbyTests/RequiredPrefixConstraintTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import Cotabby
+
+/// Tests for the byte-exact required-prefix admissibility rule used by the constrained decoder.
+///
+/// The invariant: a token is admissible iff it completes the remaining prefix (token starts with the
+/// prefix) or is a step toward it (prefix starts with the token); anything else diverges and is
+/// rejected. The rule operates on raw bytes so it stays correct when a token splits a multi-byte
+/// UTF-8 scalar.
+final class RequiredPrefixConstraintTests: XCTestCase {
+    private func bytes(_ string: String) -> [UInt8] { Array(string.utf8) }
+
+    func test_emptyRemainingPrefix_admitsAnyToken() {
+        XCTAssertEqual(
+            RequiredPrefixConstraint.step(remainingPrefix: [], tokenBytes: bytes("anything")),
+            .satisfied
+        )
+    }
+
+    func test_tokenExactlyCompletesPrefix() {
+        XCTAssertEqual(
+            RequiredPrefixConstraint.step(remainingPrefix: bytes("ation"), tokenBytes: bytes("ation")),
+            .satisfied
+        )
+    }
+
+    func test_tokenCompletesAndOvershootsPrefix() {
+        // A token longer than the requirement is fine as long as it starts with the whole prefix.
+        XCTAssertEqual(
+            RequiredPrefixConstraint.step(remainingPrefix: bytes("at"), tokenBytes: bytes("ation")),
+            .satisfied
+        )
+    }
+
+    func test_shorterTokenAdvancesPrefix() {
+        XCTAssertEqual(
+            RequiredPrefixConstraint.step(remainingPrefix: bytes("ation"), tokenBytes: bytes("at")),
+            .advanced(remaining: bytes("ion"))
+        )
+    }
+
+    func test_singleByteTokenAdvancesPrefix() {
+        XCTAssertEqual(
+            RequiredPrefixConstraint.step(remainingPrefix: bytes("ation"), tokenBytes: bytes("a")),
+            .advanced(remaining: bytes("tion"))
+        )
+    }
+
+    func test_divergingLongerTokenIsRejected() {
+        XCTAssertEqual(
+            RequiredPrefixConstraint.step(remainingPrefix: bytes("at"), tokenBytes: bytes("be")),
+            .rejected
+        )
+    }
+
+    func test_divergingShorterTokenIsRejected() {
+        XCTAssertEqual(
+            RequiredPrefixConstraint.step(remainingPrefix: bytes("ation"), tokenBytes: bytes("x")),
+            .rejected
+        )
+    }
+
+    func test_multiByteScalarSplitAcrossTokens() {
+        // "é" is two UTF-8 bytes (0xC3 0xA9). A token carrying only the lead byte must advance by it,
+        // and only the correct continuation byte may follow.
+        let prefix = bytes("é")
+        XCTAssertEqual(prefix, [0xC3, 0xA9])
+
+        XCTAssertEqual(
+            RequiredPrefixConstraint.step(remainingPrefix: prefix, tokenBytes: [0xC3]),
+            .advanced(remaining: [0xA9])
+        )
+        XCTAssertEqual(
+            RequiredPrefixConstraint.step(remainingPrefix: [0xA9], tokenBytes: [0xC3]),
+            .rejected
+        )
+        XCTAssertEqual(
+            RequiredPrefixConstraint.step(remainingPrefix: prefix, tokenBytes: prefix),
+            .satisfied
+        )
+    }
+
+    func test_admitsPredicateMatchesStep() {
+        XCTAssertTrue(RequiredPrefixConstraint.admits(remainingPrefix: bytes("ation"), tokenBytes: bytes("a")))
+        XCTAssertTrue(RequiredPrefixConstraint.admits(remainingPrefix: bytes("at"), tokenBytes: bytes("ation")))
+        XCTAssertFalse(RequiredPrefixConstraint.admits(remainingPrefix: bytes("ation"), tokenBytes: bytes("x")))
+        XCTAssertTrue(RequiredPrefixConstraint.admits(remainingPrefix: [], tokenBytes: bytes("x")))
+    }
+}


### PR DESCRIPTION
## Summary

Adds the lowest-parity decode-core capability: a byte-exact **required-prefix admissibility** rule that steers the constrained decoder onto a known continuation without ever letting it emit bytes that diverge. Given a prefix the completion must still produce, a token is admissible only if it completes the prefix (token starts with prefix) or is a step toward it (prefix starts with token); the consumed bytes advance and the remainder carries forward. This is the foundation for constraining a completion to a required string — for example, finishing a specific partially-formed word.

- `RequiredPrefixConstraint.step` (new, pure): the two-way prefix rule, in raw bytes so it stays correct when a token splits a multi-byte UTF-8 scalar. Deliberately trie-free — a vocabulary trie would only speed the per-step lookup, never change the result, so it can be layered in later.
- `ConstrainedBeamSearch` now tracks a per-branch `remainingPrefix`: a branch may complete (EOG, single-line newline, sentence boundary, budget) only once it is empty, and while it is non-empty the search scans the full admissible vocabulary rather than the logit-capped top-K, because the required token can rank far below the model's local preference.

## Validation

```
xcodebuild ... test ... CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO \
  -only-testing:CotabbyTests/RequiredPrefixConstraintTests \
  -only-testing:CotabbyTests/ConstrainedBeamSearchTests
# ** TEST SUCCEEDED **
#   10 pure rule tests (complete / overshoot / advance / single-byte / divergence both ways /
#     multi-byte scalar split across tokens / empty prefix / admits predicate)
#   3 new beam tests: steers onto a low-logit required token against the model's preference;
#     refuses to stop (EOG) before the prefix is satisfied; spans tokens of differing lengths
#   9 existing beam tests unchanged and green (empty prefix = identical behavior)

swiftlint lint --strict --quiet <changed files>   # exit 0
xcodegen generate                                  # registered the two new files (drift guard passes)
```

## Linked issues

None. Decode-core parity: the required-prefix / ACPF constraint foundation.

## Risk / rollout notes

- **No behavior change to the shipping decoder.** `requiredPrefix` defaults to empty everywhere, which makes every token immediately `satisfied` and every code path identical to before. The existing beam tests pass untouched.
- No runtime or engine change in this PR — this lands the pure, tested capability. The per-request trigger that supplies a required prefix needs on-device design (Cotabby's append-only ghost text differs from a word-replacement healing model), so it is intentionally a separate step rather than guessed here.
- `project.pbxproj` regenerated by XcodeGen for the two new files.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds required-prefix admissibility to the constrained beam decoder, letting the search steer generation onto a specific byte-exact continuation without ever emitting diverging bytes. The `RequiredPrefixConstraint.step` pure function implements the two-way prefix rule; `ConstrainedBeamSearch` carries a per-branch `remainingPrefix` and expands to the full vocabulary (instead of the logit-capped top-K) while any prefix bytes remain unmet.

- **`RequiredPrefixConstraint`** (new): pure, trie-free, byte-level admissibility rule; three cases \u2014 `satisfied`, `advanced(remaining:)`, and `rejected` \u2014 handled correctly for all documented scenarios including multi-byte UTF-8 splits.
- **`ConstrainedBeamSearch`**: `remainingPrefix` added to `BeamCandidate` with a default of `[]` so every existing call site is unaffected; all five completion gates (EOG, newline, sentence boundary, stalled branch, budget exhaustion) guard on an empty remaining prefix.
- **Tests**: 10 unit tests for the constraint rule and 3 new beam-level integration tests covering low-logit steering, early-stop prevention, and multi-token spanning.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is additive, the empty-prefix default preserves all existing behaviour, and every completion gate was updated consistently.

The core constraint logic and its beam integration are correct and well-tested. The empty `tokenBytes` edge case in `step` is admitted with no forward progress, harmless today but a real rough edge for external callers of `admits`. The undocumented interaction between `isMidWord` and a non-empty `requiredPrefix` can silently return empty results when the two constraints are incompatible.

`RequiredPrefixConstraint.swift` (empty-token edge case in `step`/`admits`) and `ConstrainedBeamSearch.swift` (undocumented `isMidWord` + `requiredPrefix` interaction).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/Support/RequiredPrefixConstraint.swift | New pure constraint module implementing byte-exact prefix admissibility; logic is correct for all documented cases but the empty-tokenBytes edge case can silently admit a token that makes zero progress toward the prefix |
| Cotabby/Support/ConstrainedBeamSearch.swift | Required-prefix integration is correct; adds per-branch `remainingPrefix`, expands to full vocabulary while prefix is unmet, and guards every completion gate — minor redundant filter in the final return and an undocumented isMidWord + requiredPrefix interaction |
| CotabbyTests/RequiredPrefixConstraintTests.swift | 10 focused unit tests cover the key cases: empty prefix, exact match, overshoot, advance, single-byte step, both divergence directions, multi-byte UTF-8 split, and the admits predicate |
| CotabbyTests/ConstrainedBeamSearchTests.swift | 3 new beam tests cover low-logit steering, EOG suppression, and multi-token spanning; all 9 existing tests unaffected due to the default empty prefix |
| Cotabby.xcodeproj/project.pbxproj | XcodeGen-regenerated project file correctly registers RequiredPrefixConstraint.swift in Sources and RequiredPrefixConstraintTests.swift in the test target |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ConstrainedBeamSearch.search
requiredPrefix: UInt8] --> B[Engine.run
frontier = BeamCandidate
remainingPrefix = requiredPrefix]
    B --> C{frontier empty
or budget exhausted?}
    C -- No --> D[expand each branch]
    D --> E{remainingPrefix
empty?}
    E -- Yes --> F[effectiveTopK = config.topK]
    E -- No --> G[effectiveTopK = logits.count
full vocab scan]
    F & G --> H[rankedAdmissibleTokens]
    H --> I{Token type?}
    I -- EOG or Newline --> J{remainingPrefix
empty?}
    J -- Yes --> K[completed.append branch]
    J -- No --> L[skip token]
    I -- Normal token --> M[RequiredPrefixConstraint.step]
    M --> N{Step result?}
    N -- rejected --> O[continue / skip]
    N -- satisfied --> P[remainingAfterToken = empty]
    N -- advanced --> Q[remainingAfterToken = tail]
    P & Q --> R{remainingAfterToken
empty AND
sentence complete?}
    R -- Yes --> K
    R -- No --> S[live.append child
with new remainingPrefix]
    S --> C
    C -- Yes --> T[completed += frontier
where remainingPrefix empty]
    T --> U[return sorted by meanLogprob]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cotabby/Support/ConstrainedBeamSearch.swift`, line 162-163 ([link](https://github.com/fujacob/cotabby/blob/4a259828d1972f85a72b4816ed10f0681d6ba749/Cotabby/Support/ConstrainedBeamSearch.swift#L162-L163)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Silent empty result when `isMidWord` and `requiredPrefix` are both active**

   `isMidWord` filters the first-step candidates to tokens where `profile.continuesWordMidStream` is true, and this filter runs *before* the prefix-admissibility check. If the first byte(s) of `requiredPrefix` can only be satisfied by a token that doesn't pass `continuesWordMidStream` (e.g., the required continuation starts with a space or punctuation), every candidate is rejected and the search returns nothing — with no indication of why. Neither the parameter documentation nor the call sites warn about this incompatibility. At minimum a precondition or a doc-comment on `search` should note that callers are responsible for ensuring the two constraints are compatible.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Frequired-prefix-constraint%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Frequired-prefix-constraint%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FSupport%2FConstrainedBeamSearch.swift%0ALine%3A%20162-163%0A%0AComment%3A%0A**Silent%20empty%20result%20when%20%60isMidWord%60%20and%20%60requiredPrefix%60%20are%20both%20active**%0A%0A%60isMidWord%60%20filters%20the%20first-step%20candidates%20to%20tokens%20where%20%60profile.continuesWordMidStream%60%20is%20true%2C%20and%20this%20filter%20runs%20*before*%20the%20prefix-admissibility%20check.%20If%20the%20first%20byte%28s%29%20of%20%60requiredPrefix%60%20can%20only%20be%20satisfied%20by%20a%20token%20that%20doesn't%20pass%20%60continuesWordMidStream%60%20%28e.g.%2C%20the%20required%20continuation%20starts%20with%20a%20space%20or%20punctuation%29%2C%20every%20candidate%20is%20rejected%20and%20the%20search%20returns%20nothing%20%E2%80%94%20with%20no%20indication%20of%20why.%20Neither%20the%20parameter%20documentation%20nor%20the%20call%20sites%20warn%20about%20this%20incompatibility.%20At%20minimum%20a%20precondition%20or%20a%20doc-comment%20on%20%60search%60%20should%20note%20that%20callers%20are%20responsible%20for%20ensuring%20the%20two%20constraints%20are%20compatible.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FSupport%2FConstrainedBeamSearch.swift%0ALine%3A%20162-163%0A%0AComment%3A%0A**Silent%20empty%20result%20when%20%60isMidWord%60%20and%20%60requiredPrefix%60%20are%20both%20active**%0A%0A%60isMidWord%60%20filters%20the%20first-step%20candidates%20to%20tokens%20where%20%60profile.continuesWordMidStream%60%20is%20true%2C%20and%20this%20filter%20runs%20*before*%20the%20prefix-admissibility%20check.%20If%20the%20first%20byte%28s%29%20of%20%60requiredPrefix%60%20can%20only%20be%20satisfied%20by%20a%20token%20that%20doesn't%20pass%20%60continuesWordMidStream%60%20%28e.g.%2C%20the%20required%20continuation%20starts%20with%20a%20space%20or%20punctuation%29%2C%20every%20candidate%20is%20rejected%20and%20the%20search%20returns%20nothing%20%E2%80%94%20with%20no%20indication%20of%20why.%20Neither%20the%20parameter%20documentation%20nor%20the%20call%20sites%20warn%20about%20this%20incompatibility.%20At%20minimum%20a%20precondition%20or%20a%20doc-comment%20on%20%60search%60%20should%20note%20that%20callers%20are%20responsible%20for%20ensuring%20the%20two%20constraints%20are%20compatible.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=526&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Frequired-prefix-constraint%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Frequired-prefix-constraint%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0ACotabby%2FSupport%2FRequiredPrefixConstraint.swift%3A36-39%0AEmpty%20%60tokenBytes%60%20is%20silently%20admitted%20and%20makes%20no%20forward%20progress.%20When%20%60tokenBytes%60%20is%20%60%5B%5D%60%2C%20%60remainingPrefix.starts%28with%3A%20%5B%5D%29%60%20is%20always%20%60true%60%2C%20so%20%60step%60%20returns%20%60.advanced%28remaining%3A%20remainingPrefix%29%60%20%E2%80%94%20the%20token%20is%20considered%20admissible%20but%20the%20remaining%20prefix%20is%20unchanged.%20Within%20the%20beam%20search%20this%20is%20harmless%20because%20%60rankedAdmissibleTokens%60%20already%20filters%20control%2Fempty%20tokens%2C%20but%20the%20docstring%20explicitly%20advertises%20%60admits%60%20for%20external%20greedy-mask%20callers%20who%20might%20not%20share%20that%20invariant.%20An%20empty%20token%20in%20their%20vocabulary%20would%20be%20wrongly%20admitted.%20Adding%20an%20early%20guard%20removes%20the%20ambiguity.%0A%0A%60%60%60suggestion%0A%20%20%20%20static%20func%20step%28remainingPrefix%3A%20%5BUInt8%5D%2C%20tokenBytes%3A%20%5BUInt8%5D%29%20-%3E%20Step%20%7B%0A%20%20%20%20%20%20%20%20guard%20!remainingPrefix.isEmpty%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20.satisfied%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20guard%20!tokenBytes.isEmpty%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20.rejected%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0ACotabby%2FSupport%2FConstrainedBeamSearch.swift%3A162-163%0A**Silent%20empty%20result%20when%20%60isMidWord%60%20and%20%60requiredPrefix%60%20are%20both%20active**%0A%0A%60isMidWord%60%20filters%20the%20first-step%20candidates%20to%20tokens%20where%20%60profile.continuesWordMidStream%60%20is%20true%2C%20and%20this%20filter%20runs%20*before*%20the%20prefix-admissibility%20check.%20If%20the%20first%20byte%28s%29%20of%20%60requiredPrefix%60%20can%20only%20be%20satisfied%20by%20a%20token%20that%20doesn't%20pass%20%60continuesWordMidStream%60%20%28e.g.%2C%20the%20required%20continuation%20starts%20with%20a%20space%20or%20punctuation%29%2C%20every%20candidate%20is%20rejected%20and%20the%20search%20returns%20nothing%20%E2%80%94%20with%20no%20indication%20of%20why.%20Neither%20the%20parameter%20documentation%20nor%20the%20call%20sites%20warn%20about%20this%20incompatibility.%20At%20minimum%20a%20precondition%20or%20a%20doc-comment%20on%20%60search%60%20should%20note%20that%20callers%20are%20responsible%20for%20ensuring%20the%20two%20constraints%20are%20compatible.%0A%0A%23%23%23%20Issue%203%20of%203%0ACotabby%2FSupport%2FConstrainedBeamSearch.swift%3A130-132%0AThe%20%60.remainingPrefix.isEmpty%60%20predicate%20in%20the%20%60return%60%20filter%20is%20redundant.%20Every%20code%20path%20that%20adds%20a%20candidate%20to%20%60completed%60%20already%20enforces%20an%20empty%20remaining%20prefix%20%E2%80%94%20via%20explicit%20%60if%20branch.remainingPrefix.isEmpty%60%20guards%20on%20EOG%2Fnewline%2Fstalled%20branches%2C%20via%20the%20%60if%20remainingAfterToken.isEmpty%60%20guard%20on%20sentence%20boundaries%2C%20and%20via%20the%20%60.filter%20%7B%20%240.remainingPrefix.isEmpty%20%7D%60%20applied%20to%20the%20frontier%20at%20budget%20exhaustion.%20The%20second%20filter%20in%20the%20return%20statement%20can%20never%20catch%20anything%20the%20earlier%20guards%20missed%2C%20so%20removing%20it%20reduces%20noise%20without%20changing%20behaviour.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20return%20completed%0A%20%20%20%20%20%20%20%20%20%20%20%20.filter%20%7B%20!%240.tokenIDs.isEmpty%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20.sorted%20%7B%20%240.meanLogprob%20%3E%20%241.meanLogprob%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0ACotabby%2FSupport%2FRequiredPrefixConstraint.swift%3A36-39%0AEmpty%20%60tokenBytes%60%20is%20silently%20admitted%20and%20makes%20no%20forward%20progress.%20When%20%60tokenBytes%60%20is%20%60%5B%5D%60%2C%20%60remainingPrefix.starts%28with%3A%20%5B%5D%29%60%20is%20always%20%60true%60%2C%20so%20%60step%60%20returns%20%60.advanced%28remaining%3A%20remainingPrefix%29%60%20%E2%80%94%20the%20token%20is%20considered%20admissible%20but%20the%20remaining%20prefix%20is%20unchanged.%20Within%20the%20beam%20search%20this%20is%20harmless%20because%20%60rankedAdmissibleTokens%60%20already%20filters%20control%2Fempty%20tokens%2C%20but%20the%20docstring%20explicitly%20advertises%20%60admits%60%20for%20external%20greedy-mask%20callers%20who%20might%20not%20share%20that%20invariant.%20An%20empty%20token%20in%20their%20vocabulary%20would%20be%20wrongly%20admitted.%20Adding%20an%20early%20guard%20removes%20the%20ambiguity.%0A%0A%60%60%60suggestion%0A%20%20%20%20static%20func%20step%28remainingPrefix%3A%20%5BUInt8%5D%2C%20tokenBytes%3A%20%5BUInt8%5D%29%20-%3E%20Step%20%7B%0A%20%20%20%20%20%20%20%20guard%20!remainingPrefix.isEmpty%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20.satisfied%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20guard%20!tokenBytes.isEmpty%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20.rejected%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0ACotabby%2FSupport%2FConstrainedBeamSearch.swift%3A162-163%0A**Silent%20empty%20result%20when%20%60isMidWord%60%20and%20%60requiredPrefix%60%20are%20both%20active**%0A%0A%60isMidWord%60%20filters%20the%20first-step%20candidates%20to%20tokens%20where%20%60profile.continuesWordMidStream%60%20is%20true%2C%20and%20this%20filter%20runs%20*before*%20the%20prefix-admissibility%20check.%20If%20the%20first%20byte%28s%29%20of%20%60requiredPrefix%60%20can%20only%20be%20satisfied%20by%20a%20token%20that%20doesn't%20pass%20%60continuesWordMidStream%60%20%28e.g.%2C%20the%20required%20continuation%20starts%20with%20a%20space%20or%20punctuation%29%2C%20every%20candidate%20is%20rejected%20and%20the%20search%20returns%20nothing%20%E2%80%94%20with%20no%20indication%20of%20why.%20Neither%20the%20parameter%20documentation%20nor%20the%20call%20sites%20warn%20about%20this%20incompatibility.%20At%20minimum%20a%20precondition%20or%20a%20doc-comment%20on%20%60search%60%20should%20note%20that%20callers%20are%20responsible%20for%20ensuring%20the%20two%20constraints%20are%20compatible.%0A%0A%23%23%23%20Issue%203%20of%203%0ACotabby%2FSupport%2FConstrainedBeamSearch.swift%3A130-132%0AThe%20%60.remainingPrefix.isEmpty%60%20predicate%20in%20the%20%60return%60%20filter%20is%20redundant.%20Every%20code%20path%20that%20adds%20a%20candidate%20to%20%60completed%60%20already%20enforces%20an%20empty%20remaining%20prefix%20%E2%80%94%20via%20explicit%20%60if%20branch.remainingPrefix.isEmpty%60%20guards%20on%20EOG%2Fnewline%2Fstalled%20branches%2C%20via%20the%20%60if%20remainingAfterToken.isEmpty%60%20guard%20on%20sentence%20boundaries%2C%20and%20via%20the%20%60.filter%20%7B%20%240.remainingPrefix.isEmpty%20%7D%60%20applied%20to%20the%20frontier%20at%20budget%20exhaustion.%20The%20second%20filter%20in%20the%20return%20statement%20can%20never%20catch%20anything%20the%20earlier%20guards%20missed%2C%20so%20removing%20it%20reduces%20noise%20without%20changing%20behaviour.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20return%20completed%0A%20%20%20%20%20%20%20%20%20%20%20%20.filter%20%7B%20!%240.tokenIDs.isEmpty%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20.sorted%20%7B%20%240.meanLogprob%20%3E%20%241.meanLogprob%20%7D%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=526&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add required-prefix admissibility to the..."](https://github.com/fujacob/cotabby/commit/4a259828d1972f85a72b4816ed10f0681d6ba749) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35055386)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->