### PR TITLE
Add per-site disable rules to the availability gate

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -141,6 +141,7 @@
 		7C36DBA762E19C8C31676D44 /* MidWordContinuationPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1274F897631B1B3A835D157F /* MidWordContinuationPolicyTests.swift */; };
 		7C94725B4837DEC9ECF1BC54 /* CompletionRenderMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A03E565A11581FD2150B142 /* CompletionRenderMode.swift */; };
 		7D6BB9AF72F7076A4E5EE96F /* DownloadableModelCatalogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5C2AE9A7E55495D26AD074 /* DownloadableModelCatalogView.swift */; };
+		7D9C3D733CE7633FB12A35BE /* BrowserDomain.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD8025E4A296845FC53E660D /* BrowserDomain.swift */; };
 		7E9413CE7C999C4612348248 /* SuggestionSessionReconcilerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C8F07AC52C7A482F5FE34C5 /* SuggestionSessionReconcilerTests.swift */; };
 		7E99F5676A1D1DF7EA7D7702 /* SuggestionCoordinator+Prediction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ED1EA9282E0AC7592E60889 /* SuggestionCoordinator+Prediction.swift */; };
 		7EB20783E0D36715D1230A5C /* PromptSectionBudgetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E260C4D08C786CDBD527B329 /* PromptSectionBudgetTests.swift */; };
@@ -203,6 +204,7 @@
 		C0B833234748E82D3382631A /* emoji.json in Resources */ = {isa = PBXBuildFile; fileRef = C379D77029D6E88C8C1B9AF7 /* emoji.json */; };
 		C0FE11D76BDF01A5470C554D /* FocusCapabilityFlickerGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A44BEC8C23FF227731DD0CD /* FocusCapabilityFlickerGate.swift */; };
 		C2C958D6E5F5FE1CCC414BCE /* SuggestionSubsystemContracts.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB16474A67CE1D210B944C9 /* SuggestionSubsystemContracts.swift */; };
+		C3B6C8B9DE20A71C65D390DA /* BrowserDomainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F761083EA5465023D82B5F4 /* BrowserDomainTests.swift */; };
 		C4C6734678797669055988E0 /* AppUpdateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD9573F3504CAE6891DF9B7D /* AppUpdateManager.swift */; };
 		C618C5595DA9C57C806A3E03 /* SettingsAttentionEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BC293F6125E2B14DCF05AD9 /* SettingsAttentionEvaluatorTests.swift */; };
 		C638466A2F373BABA6F60A6D /* ConstrainedBeamSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83264218423B61E59109EB3 /* ConstrainedBeamSearch.swift */; };
@@ -313,6 +315,7 @@
 		1D00A031C0D9CF2A7A2330D9 /* PermissionDragSourceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionDragSourceView.swift; sourceTree = "<group>"; };
 		1E0513E3B23937B099A3CFF2 /* WordCountFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordCountFormatterTests.swift; sourceTree = "<group>"; };
 		1ED1EA9282E0AC7592E60889 /* SuggestionCoordinator+Prediction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SuggestionCoordinator+Prediction.swift"; sourceTree = "<group>"; };
+		1F761083EA5465023D82B5F4 /* BrowserDomainTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDomainTests.swift; sourceTree = "<group>"; };
 		21CB3008986BE7FD2A4D9132 /* WelcomeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeCoordinator.swift; sourceTree = "<group>"; };
 		220CD4AFA1E96A37BC4514AD /* LaunchAtLoginService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchAtLoginService.swift; sourceTree = "<group>"; };
 		224438039A86E5619294EAF7 /* EmojiUsageStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiUsageStoreTests.swift; sourceTree = "<group>"; };
@@ -444,6 +447,7 @@
 		AC70775535A3428991025AB8 /* AXHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AXHelper.swift; sourceTree = "<group>"; };
 		AD0D15AE00F01D327F708DFC /* FillInMiddlePolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FillInMiddlePolicyTests.swift; sourceTree = "<group>"; };
 		AD752451330486FE270018B0 /* CustomRulesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomRulesTests.swift; sourceTree = "<group>"; };
+		AD8025E4A296845FC53E660D /* BrowserDomain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDomain.swift; sourceTree = "<group>"; };
 		AD9573F3504CAE6891DF9B7D /* AppUpdateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdateManager.swift; sourceTree = "<group>"; };
 		ADBE3E6CC585C1683787C877 /* SuggestionEngineModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionEngineModels.swift; sourceTree = "<group>"; };
 		AF1E065C7FFB697FCEB2FA5C /* CotabbyTestFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CotabbyTestFixtures.swift; sourceTree = "<group>"; };
@@ -756,6 +760,7 @@
 				C046CB4F3CB4BFE9391DB5DE /* AXTextGeometryResolverTests.swift */,
 				9966D09D8D80F54BF2734E00 /* BaseCompletionPromptRendererTests.swift */,
 				04D853218B0A77B0CE090828 /* BrowserAppDetectorTests.swift */,
+				1F761083EA5465023D82B5F4 /* BrowserDomainTests.swift */,
 				18D990E515E1AE4F312F4E95 /* BundledRuntimeLocatorTests.swift */,
 				8EA827D6A2A54DF4BAD56405 /* CaretLinePositionTests.swift */,
 				EFD89799BB82AF7A92559AEB /* ClipboardContentDistillerTests.swift */,
@@ -923,6 +928,7 @@
 				AC70775535A3428991025AB8 /* AXHelper.swift */,
 				85EF79E6144D6C6AD062B569 /* BaseCompletionPromptRenderer.swift */,
 				B997EC69E1C65B1E18234221 /* BrowserAppDetector.swift */,
+				AD8025E4A296845FC53E660D /* BrowserDomain.swift */,
 				AA33F5FFAC5B99384E15CE3E /* BundledRuntimeLocator.swift */,
 				E3C84377F352140759B448C9 /* CaretGeometrySelector.swift */,
 				D77364C1AF183EF1C0A4074D /* CaretLinePosition.swift */,
@@ -1120,6 +1126,7 @@
 				EF0DE5E045F328F1E912A02A /* AppsPaneView.swift in Sources */,
 				E4382BEA8A8551612E5966B9 /* BaseCompletionPromptRenderer.swift in Sources */,
 				49C91DE326A590708D76102A /* BrowserAppDetector.swift in Sources */,
+				7D9C3D733CE7633FB12A35BE /* BrowserDomain.swift in Sources */,
 				3CBBC3BFAC0DC8952EE24EF7 /* BundledRuntimeLocator.swift in Sources */,
 				76FD91607794883F8E121450 /* CaretGeometrySelector.swift in Sources */,
 				543D71217CA218426E9638BF /* CaretLinePosition.swift in Sources */,
@@ -1292,6 +1299,7 @@
 				A36481222BB5B2A67349D389 /* ApplicationBundleMetadataTests.swift in Sources */,
 				F4A01E4F12F0183449BCCBB9 /* BaseCompletionPromptRendererTests.swift in Sources */,
 				5C0D3B6012C7412001BE3773 /* BrowserAppDetectorTests.swift in Sources */,
+				C3B6C8B9DE20A71C65D390DA /* BrowserDomainTests.swift in Sources */,
 				58AC3193D846FDE88513377D /* BundledRuntimeLocatorTests.swift in Sources */,
 				62FADA407797998742502DD9 /* CaretLinePositionTests.swift in Sources */,
 				8865B95FE84198D70390DF80 /* ClipboardContentDistillerTests.swift in Sources */,

--- a/Cotabby/Support/BrowserDomain.swift
+++ b/Cotabby/Support/BrowserDomain.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// File overview:
+/// Pure helpers for turning a focused browser tab's URL into a comparable host and deciding whether
+/// that host falls under a user-configured disable list. Kept separate from focus capture (where the
+/// raw URL is read over Accessibility) so the parsing and matching rules stay trivially testable and
+/// reusable, independent of how the URL was obtained.
+enum BrowserDomain {
+    /// Extracts the lowercased host from a URL string, dropping a leading "www." so "www.bank.com" and
+    /// "bank.com" compare equal. Returns nil for URLs without a network host (file://, about:, data:,
+    /// empty, unparseable), so non-web focus never matches a domain rule.
+    static func host(fromURLString urlString: String) -> String? {
+        let trimmed = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              let components = URLComponents(string: trimmed),
+              let host = components.host,
+              !host.isEmpty
+        else {
+            return nil
+        }
+        return stripLeadingWWW(host.lowercased())
+    }
+
+    /// Whether `host` is covered by `disabledDomains`: an exact match, or a subdomain of a listed
+    /// domain ("mail.bank.com" is disabled by "bank.com"). Comparison is case-insensitive and
+    /// "www."-insensitive on both sides, and tolerates list entries pasted as full URLs. An empty/nil
+    /// host or empty list never matches.
+    static func isHostDisabled(_ host: String?, disabledDomains: Set<String>) -> Bool {
+        guard let host, !host.isEmpty, !disabledDomains.isEmpty else {
+            return false
+        }
+        for entry in disabledDomains {
+            guard let domain = normalize(entry) else { continue }
+            if host == domain || host.hasSuffix("." + domain) {
+                return true
+            }
+        }
+        return false
+    }
+
+    /// Normalizes a configured list entry the same way a parsed host is normalized, tolerating a user
+    /// pasting either a full URL ("https://bank.com/login") or a bare host ("bank.com").
+    private static func normalize(_ entry: String) -> String? {
+        let trimmed = entry.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        if let parsed = host(fromURLString: trimmed) {
+            return parsed
+        }
+        return stripLeadingWWW(trimmed.lowercased())
+    }
+
+    private static func stripLeadingWWW(_ host: String) -> String {
+        guard host.hasPrefix("www."), host.count > 4 else { return host }
+        return String(host.dropFirst(4))
+    }
+}

--- a/Cotabby/Support/SuggestionAvailabilityEvaluator.swift
+++ b/Cotabby/Support/SuggestionAvailabilityEvaluator.swift
@@ -10,6 +10,8 @@ enum SuggestionAvailabilityEvaluator {
     static func disabledReason(
         globallyEnabled: Bool = true,
         disabledAppBundleIdentifiers: Set<String> = [],
+        disabledDomains: Set<String> = [],
+        focusedURLString: String? = nil,
         inputMonitoringGranted: Bool,
         screenRecordingGranted: Bool,
         focusSnapshot: FocusSnapshot,
@@ -22,6 +24,15 @@ enum SuggestionAvailabilityEvaluator {
         if let bundleIdentifier = focusSnapshot.bundleIdentifier,
            disabledAppBundleIdentifiers.contains(bundleIdentifier) {
             return "Cotabby is disabled in \(focusSnapshot.applicationName)."
+        }
+
+        // Per-site disable: when the focused element carries a web URL, a host on the user's disabled
+        // list (exact or parent domain) suppresses autocomplete the same way a disabled app does.
+        // Defaults make this inert (no URL / empty list) so non-browser focus is unaffected.
+        if let focusedURLString,
+           let host = BrowserDomain.host(fromURLString: focusedURLString),
+           BrowserDomain.isHostDisabled(host, disabledDomains: disabledDomains) {
+            return "Cotabby is disabled on \(host)."
         }
 
         if TerminalAppDetector.isTerminal(bundleIdentifier: focusSnapshot.bundleIdentifier) {

--- a/CotabbyTests/BrowserDomainTests.swift
+++ b/CotabbyTests/BrowserDomainTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import Cotabby
+
+/// Tests for the pure browser-domain parsing and matching used by per-site disable.
+///
+/// Two invariants matter: a focused URL reduces to a normalized host (lowercased, "www."-stripped,
+/// nil when there is no web host), and matching covers a domain and its subdomains without ever
+/// matching a lookalike ("evilbank.com" is not disabled by "bank.com").
+final class BrowserDomainTests: XCTestCase {
+
+    // MARK: - host(fromURLString:)
+
+    func test_host_extractsAndLowercasesHost() {
+        XCTAssertEqual(BrowserDomain.host(fromURLString: "https://Mail.Example.COM/inbox"), "mail.example.com")
+    }
+
+    func test_host_stripsLeadingWWW() {
+        XCTAssertEqual(BrowserDomain.host(fromURLString: "https://www.bank.com/login"), "bank.com")
+    }
+
+    func test_host_ignoresPortAndPathAndQuery() {
+        XCTAssertEqual(BrowserDomain.host(fromURLString: "http://bank.com:8443/a/b?c=d#e"), "bank.com")
+    }
+
+    func test_host_nilForNonWebSchemes() {
+        XCTAssertNil(BrowserDomain.host(fromURLString: "about:blank"))
+        XCTAssertNil(BrowserDomain.host(fromURLString: "file:///Users/x/notes.txt"))
+        XCTAssertNil(BrowserDomain.host(fromURLString: "data:text/plain,hello"))
+    }
+
+    func test_host_nilForEmptyOrHostlessStrings() {
+        XCTAssertNil(BrowserDomain.host(fromURLString: ""))
+        XCTAssertNil(BrowserDomain.host(fromURLString: "   "))
+        // No scheme: the string parses as a path, not a host.
+        XCTAssertNil(BrowserDomain.host(fromURLString: "bank.com"))
+    }
+
+    // MARK: - isHostDisabled
+
+    func test_isHostDisabled_exactMatch() {
+        XCTAssertTrue(BrowserDomain.isHostDisabled("bank.com", disabledDomains: ["bank.com"]))
+    }
+
+    func test_isHostDisabled_subdomainMatch() {
+        XCTAssertTrue(BrowserDomain.isHostDisabled("mail.bank.com", disabledDomains: ["bank.com"]))
+    }
+
+    func test_isHostDisabled_doesNotMatchLookalike() {
+        XCTAssertFalse(BrowserDomain.isHostDisabled("evilbank.com", disabledDomains: ["bank.com"]))
+    }
+
+    func test_isHostDisabled_normalizesListEntries() {
+        // Entries pasted as a full URL or with "www." still match a bare host.
+        XCTAssertTrue(BrowserDomain.isHostDisabled("bank.com", disabledDomains: ["https://bank.com/x"]))
+        XCTAssertTrue(BrowserDomain.isHostDisabled("bank.com", disabledDomains: ["www.bank.com"]))
+    }
+
+    func test_isHostDisabled_falseForEmptyInputs() {
+        XCTAssertFalse(BrowserDomain.isHostDisabled(nil, disabledDomains: ["bank.com"]))
+        XCTAssertFalse(BrowserDomain.isHostDisabled("bank.com", disabledDomains: []))
+        XCTAssertFalse(BrowserDomain.isHostDisabled("other.com", disabledDomains: ["bank.com"]))
+    }
+}

--- a/CotabbyTests/SuggestionAvailabilityEvaluatorTests.swift
+++ b/CotabbyTests/SuggestionAvailabilityEvaluatorTests.swift
@@ -74,6 +74,33 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
         XCTAssertEqual(reason, "Cotabby is turned off.")
     }
 
+    func test_disabledReason_whenFocusedDomainIsDisabled_returnsSiteReason() {
+        let reason = SuggestionAvailabilityEvaluator.disabledReason(
+            globallyEnabled: true,
+            disabledDomains: ["bank.com"],
+            focusedURLString: "https://www.bank.com/account",
+            inputMonitoringGranted: true,
+            screenRecordingGranted: true,
+            focusSnapshot: makeSnapshot(capability: .supported)
+        )
+
+        XCTAssertEqual(reason, "Cotabby is disabled on bank.com.")
+    }
+
+    func test_disabledReason_domainCheckIsInertByDefault() {
+        // No focused URL and no disabled domains: the per-site gate must never fire, so an otherwise
+        // healthy environment stays enabled exactly as before this gate existed.
+        let reason = SuggestionAvailabilityEvaluator.disabledReason(
+            globallyEnabled: true,
+            focusedURLString: "https://bank.com/account",
+            inputMonitoringGranted: true,
+            screenRecordingGranted: true,
+            focusSnapshot: makeSnapshot(capability: .supported)
+        )
+
+        XCTAssertNil(reason, "a focused URL with no disabled-domains list must not suppress autocomplete")
+    }
+
     func test_disabledReason_whenInputMonitoringDenied_mentionsPermission() {
         let reason = SuggestionAvailabilityEvaluator.disabledReason(
             globallyEnabled: true,


### PR DESCRIPTION
## Summary

Cotabby can be disabled per app but not per website, so autocomplete stays on across every tab of a browser the user otherwise wants it in (e.g. their bank, an internal admin tool). This lands the matching foundation for per-site disable: a focused page URL reduces to a normalized host, and a host on a user-configured disable list — exact or parent domain — suppresses autocomplete exactly like a disabled app does.

- `BrowserDomain` (new, pure): `host(fromURLString:)` normalizes a URL to a lowercased, `www.`-stripped host and returns nil for hostless schemes (`file://`, `about:`, `data:`); `isHostDisabled` matches a host against the list including subdomains, and crucially does **not** match a lookalike (`evilbank.com` is not covered by `bank.com`). List entries are tolerant of being pasted as a full URL or a bare host.
- `SuggestionAvailabilityEvaluator` gains optional `focusedURLString` / `disabledDomains` parameters and a per-site branch, slotted next to the existing per-app disable.

## Validation

```
xcodebuild ... test ... CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO \
  -only-testing:CotabbyTests/BrowserDomainTests \
  -only-testing:CotabbyTests/SuggestionAvailabilityEvaluatorTests
# ** TEST SUCCEEDED **
#   8 BrowserDomain tests: host extraction (www/port/path/case, non-web schemes -> nil),
#     exact + subdomain match, lookalike rejection, URL/www-tolerant list entries, empty inputs
#   evaluator: per-site reason fires; inert by default; all existing gate tests unchanged

swiftlint --strict   # exit 0 (CI-equivalent, lints Cotabby/)
xcodegen generate    # registered the new source + test file
```

## Linked issues

None. App/domain-compatibility parity: per-site (not just per-app) disable.

## Risk / rollout notes

- **Inert until wired.** Both new parameters default to empty, so the per-site branch never fires until a caller supplies a focused URL *and* a non-empty disabled list. Existing behavior is byte-for-byte unchanged and the evaluator's other tests pass untouched.
- This PR is the verifiable, fully unit-tested matching core. The two pieces that need on-device work are deliberately left as follow-ups: reading the focused tab's URL over Accessibility (the delicate, browser-specific capture path), and a settings surface (or `defaults`-backed list) for configuring domains.
- `project.pbxproj` regenerated by XcodeGen for the two new files.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces the matching foundation for per-site autocomplete disable: a new `BrowserDomain` helper normalizes browser tab URLs to stripped hosts and checks them against a user-configured blocklist, and `SuggestionAvailabilityEvaluator.disabledReason` gains a per-site branch slotted next to the existing per-app disable.

- `BrowserDomain` (pure, fully tested) handles `www.`-stripping, case normalization, nil returns for non-web schemes, subdomain inheritance, and lookalike rejection.
- `disabledReason` correctly gates on the new parameters with safe defaults that keep existing behavior unchanged until the feature is wired.
- `shouldSchedulePrediction` and `shouldCaptureVisualContext` are not updated to accept or forward `disabledDomains`/`focusedURLString`, so when the feature is wired, those paths will still schedule predictions and capture visual context for domain-blocked sites — only the reason string will reflect the block.

<h3>Confidence Score: 3/5</h3>

Safe to merge as a foundation layer, but the wrapper methods are incomplete and will silently allow predictions and visual context capture on domain-blocked sites when the feature is wired.

The `BrowserDomain` logic and `disabledReason` gate are correct and well-tested. However, `shouldSchedulePrediction` and `shouldCaptureVisualContext` — the methods that govern whether the prediction pipeline actually runs — do not accept or forward `disabledDomains` or `focusedURLString`. When a follow-up PR wires up the URL and domain list, those two methods will continue to green-light prediction scheduling and visual context capture for sites the user intended to block, defeating the purpose of the gate on that code path.

Cotabby/Support/SuggestionAvailabilityEvaluator.swift — specifically the `shouldSchedulePrediction` and `shouldCaptureVisualContext` method signatures and their internal `disabledReason` calls.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/Support/BrowserDomain.swift | New pure helper: normalizes URLs to stripped/lowercased hosts and checks against a disabled-domain set with correct subdomain and lookalike handling. |
| Cotabby/Support/SuggestionAvailabilityEvaluator.swift | Per-site branch added to `disabledReason`, but the two sibling wrappers (`shouldSchedulePrediction`, `shouldCaptureVisualContext`) don't expose or forward the new domain parameters, so domain blocking won't reach scheduling decisions when the feature is wired. |
| CotabbyTests/BrowserDomainTests.swift | Solid unit tests covering host extraction, www-stripping, nil returns for non-web schemes, exact/subdomain matching, lookalike rejection, and URL/www-tolerant list entries. |
| CotabbyTests/SuggestionAvailabilityEvaluatorTests.swift | Two new evaluator tests added; one has a misleading comment saying 'No focused URL' when a URL is in fact passed. Logic of the assertions themselves is correct. |
| Cotabby.xcodeproj/project.pbxproj | XcodeGen-regenerated project file registering the two new source and test files; no manual edits. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[disabledReason called] --> B{globallyEnabled?}
    B -- No --> Z1[return: turned off]
    B -- Yes --> C{bundleId in disabledApps?}
    C -- Yes --> Z2[return: disabled in App]
    C -- No --> D{focusedURLString provided?}
    D -- No --> F[skip domain check]
    D -- Yes --> E{BrowserDomain.host resolves?}
    E -- nil / non-web scheme --> F
    E -- host string --> G{isHostDisabled?}
    G -- Yes --> Z3[return: disabled on host]
    G -- No --> F
    F --> H{isTerminal?}
    H -- Yes --> Z4[return: not available in terminals]
    H -- No --> I{inputMonitoring granted?}
    I -- No --> Z5[return: permission required]
    I -- Yes --> J{screenRecording granted?}
    J -- No --> Z6[return: permission required]
    J -- Yes --> K{checkCapability?}
    K -- No --> Z7[return nil]
    K -- Yes --> L{capability}
    L -- supported --> Z7
    L -- blocked/unsupported --> Z8[return capability reason]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cotabby/Support/SuggestionAvailabilityEvaluator.swift`, line 63-77 ([link](https://github.com/fujacob/cotabby/blob/310da8475f3cb73ac89eadbe25dba29e86d13019/Cotabby/Support/SuggestionAvailabilityEvaluator.swift#L63-L77)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Per-site disable not enforced by convenience wrappers**

   `shouldSchedulePrediction` and `shouldCaptureVisualContext` both call `disabledReason` but neither exposes `disabledDomains` or `focusedURLString` in their signatures, so those parameters silently default to empty/nil in both callers. When the feature is wired up, a browser tab on a disabled domain will still have prediction scheduling triggered and visual context captured — only the `disabledReason` string will reflect the block. The per-site gate needs to be propagated through both wrapper signatures and their internal calls to `disabledReason` to enforce the disable end-to-end.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fper-domain-disable%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fper-domain-disable%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FSupport%2FSuggestionAvailabilityEvaluator.swift%0ALine%3A%2063-77%0A%0AComment%3A%0A**Per-site%20disable%20not%20enforced%20by%20convenience%20wrappers**%0A%0A%60shouldSchedulePrediction%60%20and%20%60shouldCaptureVisualContext%60%20both%20call%20%60disabledReason%60%20but%20neither%20exposes%20%60disabledDomains%60%20or%20%60focusedURLString%60%20in%20their%20signatures%2C%20so%20those%20parameters%20silently%20default%20to%20empty%2Fnil%20in%20both%20callers.%20When%20the%20feature%20is%20wired%20up%2C%20a%20browser%20tab%20on%20a%20disabled%20domain%20will%20still%20have%20prediction%20scheduling%20triggered%20and%20visual%20context%20captured%20%E2%80%94%20only%20the%20%60disabledReason%60%20string%20will%20reflect%20the%20block.%20The%20per-site%20gate%20needs%20to%20be%20propagated%20through%20both%20wrapper%20signatures%20and%20their%20internal%20calls%20to%20%60disabledReason%60%20to%20enforce%20the%20disable%20end-to-end.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FSupport%2FSuggestionAvailabilityEvaluator.swift%0ALine%3A%2063-77%0A%0AComment%3A%0A**Per-site%20disable%20not%20enforced%20by%20convenience%20wrappers**%0A%0A%60shouldSchedulePrediction%60%20and%20%60shouldCaptureVisualContext%60%20both%20call%20%60disabledReason%60%20but%20neither%20exposes%20%60disabledDomains%60%20or%20%60focusedURLString%60%20in%20their%20signatures%2C%20so%20those%20parameters%20silently%20default%20to%20empty%2Fnil%20in%20both%20callers.%20When%20the%20feature%20is%20wired%20up%2C%20a%20browser%20tab%20on%20a%20disabled%20domain%20will%20still%20have%20prediction%20scheduling%20triggered%20and%20visual%20context%20captured%20%E2%80%94%20only%20the%20%60disabledReason%60%20string%20will%20reflect%20the%20block.%20The%20per-site%20gate%20needs%20to%20be%20propagated%20through%20both%20wrapper%20signatures%20and%20their%20internal%20calls%20to%20%60disabledReason%60%20to%20enforce%20the%20disable%20end-to-end.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=527&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fper-domain-disable%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fper-domain-disable%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FSupport%2FSuggestionAvailabilityEvaluator.swift%3A63-77%0A**Per-site%20disable%20not%20enforced%20by%20convenience%20wrappers**%0A%0A%60shouldSchedulePrediction%60%20and%20%60shouldCaptureVisualContext%60%20both%20call%20%60disabledReason%60%20but%20neither%20exposes%20%60disabledDomains%60%20or%20%60focusedURLString%60%20in%20their%20signatures%2C%20so%20those%20parameters%20silently%20default%20to%20empty%2Fnil%20in%20both%20callers.%20When%20the%20feature%20is%20wired%20up%2C%20a%20browser%20tab%20on%20a%20disabled%20domain%20will%20still%20have%20prediction%20scheduling%20triggered%20and%20visual%20context%20captured%20%E2%80%94%20only%20the%20%60disabledReason%60%20string%20will%20reflect%20the%20block.%20The%20per-site%20gate%20needs%20to%20be%20propagated%20through%20both%20wrapper%20signatures%20and%20their%20internal%20calls%20to%20%60disabledReason%60%20to%20enforce%20the%20disable%20end-to-end.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabbyTests%2FSuggestionAvailabilityEvaluatorTests.swift%3A90-93%0AThe%20comment%20says%20%22No%20focused%20URL%20and%20no%20disabled%20domains%22%20but%20the%20call%20site%20does%20supply%20a%20focused%20URL%20%E2%80%94%20only%20%60disabledDomains%60%20is%20absent.%20The%20misleading%20comment%20makes%20it%20harder%20to%20understand%20what%20invariant%20the%20test%20is%20actually%20exercising%20%28URL%20present%2C%20domains%20empty%20%E2%86%92%20nil%29.%0A%0A%60%60%60suggestion%0A%20%20%20%20func%20test_disabledReason_domainCheckIsInertByDefault%28%29%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20A%20focused%20URL%20with%20an%20empty%20disabled-domains%20list%20must%20never%20suppress%20autocomplete.%0A%20%20%20%20%20%20%20%20%2F%2F%20Verifies%20that%20the%20domain%20gate%20is%20off-by-default%20even%20when%20a%20URL%20is%20present.%0A%20%20%20%20%20%20%20%20let%20reason%20%3D%20SuggestionAvailabilityEvaluator.disabledReason%28%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FSupport%2FSuggestionAvailabilityEvaluator.swift%3A63-77%0A**Per-site%20disable%20not%20enforced%20by%20convenience%20wrappers**%0A%0A%60shouldSchedulePrediction%60%20and%20%60shouldCaptureVisualContext%60%20both%20call%20%60disabledReason%60%20but%20neither%20exposes%20%60disabledDomains%60%20or%20%60focusedURLString%60%20in%20their%20signatures%2C%20so%20those%20parameters%20silently%20default%20to%20empty%2Fnil%20in%20both%20callers.%20When%20the%20feature%20is%20wired%20up%2C%20a%20browser%20tab%20on%20a%20disabled%20domain%20will%20still%20have%20prediction%20scheduling%20triggered%20and%20visual%20context%20captured%20%E2%80%94%20only%20the%20%60disabledReason%60%20string%20will%20reflect%20the%20block.%20The%20per-site%20gate%20needs%20to%20be%20propagated%20through%20both%20wrapper%20signatures%20and%20their%20internal%20calls%20to%20%60disabledReason%60%20to%20enforce%20the%20disable%20end-to-end.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabbyTests%2FSuggestionAvailabilityEvaluatorTests.swift%3A90-93%0AThe%20comment%20says%20%22No%20focused%20URL%20and%20no%20disabled%20domains%22%20but%20the%20call%20site%20does%20supply%20a%20focused%20URL%20%E2%80%94%20only%20%60disabledDomains%60%20is%20absent.%20The%20misleading%20comment%20makes%20it%20harder%20to%20understand%20what%20invariant%20the%20test%20is%20actually%20exercising%20%28URL%20present%2C%20domains%20empty%20%E2%86%92%20nil%29.%0A%0A%60%60%60suggestion%0A%20%20%20%20func%20test_disabledReason_domainCheckIsInertByDefault%28%29%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20A%20focused%20URL%20with%20an%20empty%20disabled-domains%20list%20must%20never%20suppress%20autocomplete.%0A%20%20%20%20%20%20%20%20%2F%2F%20Verifies%20that%20the%20domain%20gate%20is%20off-by-default%20even%20when%20a%20URL%20is%20present.%0A%20%20%20%20%20%20%20%20let%20reason%20%3D%20SuggestionAvailabilityEvaluator.disabledReason%28%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=527&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add per-site disable rules to the availa..."](https://github.com/fujacob/cotabby/commit/310da8475f3cb73ac89eadbe25dba29e86d13019) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35056927)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->