### PR TITLE
Add an execution-ready plan for the remaining parity work

### DIFF
--- a/docs/REMAINING_PARITY_PLAN.md
+++ b/docs/REMAINING_PARITY_PLAN.md
@@ -1,0 +1,90 @@
+# Remaining Parity Work: Implementation Plan
+
+The constrained-decoder and prompting parity work shipped over a run of PRs (see
+the constrained decoder, beam search, FIM, required-prefix admissibility, and the
+per-site matching core). This file is the execution-ready design for the items
+that remain, all of which live in delicate, system-interacting paths (Accessibility
+capture, the clipboard, input timing). Per the repo's working rules, those are
+built narrowly and verified on device rather than guessed at — so each item below
+separates the part that is pure and already provable from the part that needs the
+app running.
+
+Already done, for the record: cross-keystroke completion **reuse** is not a gap.
+`SuggestionCoordinator+Input.handleInputEvent(_:with:)` calls
+`advanceActiveSessionIfTypedCharactersMatch`, which on a matching keystroke
+advances the shown ghost locally and returns *without* scheduling a regeneration.
+The only unbuilt increment is multi-branch promotion on the (off-by-default) beam —
+a niche, high-risk hot-path change for marginal gain.
+
+## 1. Per-site disable (matching shipped; capture + wiring remain)
+
+`BrowserDomain` already turns a URL into a normalized host and matches it against a
+disabled list (exact + subdomain, lookalike-safe), and `SuggestionAvailabilityEvaluator`
+already has the per-site branch behind inert-by-default parameters. Three pieces
+remain, behind a `cotabbyPerDomainDisableEnabled` flag (default off):
+
+- **Settings list.** Add `disabledDomainRules` to `SuggestionSettingsModel`,
+  mirroring `disabledAppRules`, and derive `settingsSnapshot.disabledDomains:
+  Set<String>` (see `SuggestionSettingsModel.swift:400`). A bare `defaults`-backed
+  array (`cotabbyDisabledDomains`) is the zero-UI dogfood version; a settings pane
+  mirroring per-app disable is the productized version.
+- **URL capture (the delicate part).** Add `focusedURLString: String?` to
+  `FocusedInputSnapshot` (`FocusModels.swift:110`; only two construction sites) and
+  populate it in `FocusSnapshotResolver` next to the existing context build
+  (`:203`) via a new fail-safe `AXHelper.webURL(near:)` that walks up from the
+  focused element reading `kAXURLAttribute`. Gate it behind the flag and restrict
+  to browser bundles, and cache per focus-change so it adds no AX round-trips to
+  the non-browser hot path.
+- **Wire-up.** Have `disabledReason` read `focusSnapshot.context?.focusedURLString`
+  (it already receives the snapshot), and pass `disabledDomains:
+  settingsSnapshot.disabledDomains` at the ~6 `disabledReason` call sites, exactly
+  alongside the existing `disabledAppBundleIdentifiers`.
+
+Fail-safe: a nil URL (read failed, non-browser, or flag off) leaves the gate inert,
+so there is no regression path. **Needs on device:** that the URL read actually
+resolves in Chrome (OOPIF), Safari, and Arc, and that the walk-up + caching add no
+measurable focus-capture latency.
+
+## 2. Paste / match-style insertion
+
+`SuggestionInserter.insert(_:)` already posts a whole chunk in one Unicode keydown,
+so this is about *reliability* in apps that mishandle synthetic Unicode strings, and
+match-style paste into rich-text fields — not raw speed.
+
+- **Pure, provable now:** an `InsertionStrategy` enum and a pure
+  `InsertionStrategySelector.strategy(forChunk:)` (decide keystroke vs. paste from
+  length / newline content), fully unit-tested.
+- **Behind `cotabbyPasteInsertionEnabled` (default off):** a paste path in
+  `SuggestionInserter` that snapshots `NSPasteboard` items, writes the chunk, marks
+  the synthetic `Cmd-V` through `InputSuppressionController`, posts it, and restores
+  the pasteboard after the host publishes.
+
+**Needs on device:** `InputSuppressionController` counts synthetic *keydowns*; a
+paste inserts N characters from one `Cmd-V`, so the suppression/observation
+accounting must be verified not to re-observe the pasted text as user typing (a
+regeneration loop), and the clipboard save/restore timing must be validated so it
+never loses the user's clipboard. On any failure the path falls back to the existing
+keystroke insert.
+
+## 3. Token-accurate prompt budgeting
+
+The runtime already tokenizes every prompt, logs the true `prompt_tokens`, and
+truncates to the context window. The gap is only that the *section* budgets in the
+prompt factory are counted in characters.
+
+- **Measure first.** Before building anything, read the already-logged
+  `prompt_tokens` against the context window to confirm char-budgeting actually
+  overflows in practice. It may not be worth changing.
+- **Option A (accurate, costly):** tokenize sections via the runtime tokenizer on
+  the main-actor prompt path — a real per-keystroke latency cost to measure against
+  the typing-latency budget, right after the lag fix.
+- **Option B (cheap, approximate):** a pure, tested `TokenCountEstimator` heuristic
+  for section budgeting, with the quality delta validated on device.
+
+## Sequencing
+
+Per-site disable is the most advanced (matching shipped) and the safest to finish
+(fail-safe, flag-gated). Paste is self-contained but its risk is the clipboard and
+suppression interaction. Token budgeting should not start until the measurement
+step shows it is needed. Each lands behind a default-off flag so it can be dogfooded
+without touching shipped behavior, the same way the constrained decoder did.


### PR DESCRIPTION
## Summary

The pure, provable slices of the remaining parity items have shipped (the constrained decoder end to end; the per-site matching core in #527). What remains — finishing per-site disable, paste/match-style insertion, and token-accurate budgeting — lives in delicate Accessibility-capture, clipboard, and input-timing paths. Per the repo's own working rules (don't guess at AX, keep changes narrow, talk through architecture before delicate/lifecycle changes), those are designed up front and verified on device rather than blind-shipped.

This adds `docs/REMAINING_PARITY_PLAN.md`: for each remaining item, the part that is pure and provable now, the part that needs the app running, and the default-off flag it lands behind. It also records — with the call site — that cross-keystroke reuse is **already implemented** (`advanceActiveSessionIfTypedCharactersMatch`), so it is not an open gap.

## Validation

Documentation only. No source, project, or build impact.

## Linked issues

None. Captures the execution plan for the remaining app/domain, insertion, and prompting parity items.

## Risk / rollout notes

- Documentation only. No behavior, schema, or build change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `docs/REMAINING_PARITY_PLAN.md`, an execution-ready design document for the three parity items that require on-device verification: per-site domain disable, paste/match-style insertion, and token-accurate prompt budgeting. Each item is decomposed into a pure/provable slice (implementable now) and a device-dependent slice (needing the app running), all landing behind default-off feature flags.

- **Per-site disable** — `BrowserDomain` matching and `SuggestionAvailabilityEvaluator` already accept `disabledDomains`/`focusedURLString` with inert defaults; the plan scopes the remaining work to settings persistence, AX URL capture, and wiring at the ~6 call sites.
- **Paste insertion** — describes an `InsertionStrategy` enum (pure/testable) plus a `cotabbyPasteInsertionEnabled`-gated path in `SuggestionInserter` with explicit clipboard save/restore and suppression-accounting validation.
- **Token budgeting** — correctly gates implementation on a measurement step first, offering two options (accurate tokenizer vs. heuristic estimator) with quality-delta validation.

<h3>Confidence Score: 5/5</h3>

Documentation-only addition with no source, build, or behavior changes — safe to merge as-is.

The file added is a pure Markdown planning document. All code references were checked against the current codebase: function names, struct names, and the referenced line numbers are accurate. The document correctly identifies what is already implemented versus what remains. No Swift source, project file, or build artifact is touched.

No files require special attention — `docs/REMAINING_PARITY_PLAN.md` is the only changed file and it contains no executable code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/REMAINING_PARITY_PLAN.md | New planning document describing the three remaining parity items; references to source files, line numbers, and function names verified accurate against the current codebase. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Remaining Parity Items] --> B[1. Per-site disable]
    A --> C[2. Paste/match-style insertion]
    A --> D[3. Token-accurate budgeting]

    B --> B1["Pure now: BrowserDomain matching ✅\nSuggestionAvailabilityEvaluator branch ✅"]
    B --> B2["Needs device: AX URL read via\nkAXURLAttribute walk-up\n(Chrome OOPIF, Safari, Arc)"]
    B1 --> B3["Flag: cotabbyPerDomainDisableEnabled\n(default off)"]

    C --> C1["Pure now: InsertionStrategy enum\n+ InsertionStrategySelector (unit-tested)"]
    C --> C2["Needs device: clipboard save/restore timing\n+ InputSuppressionController accounting"]
    C1 --> C3["Flag: cotabbyPasteInsertionEnabled\n(default off)"]

    D --> D1["Measure first: compare logged\nprompt_tokens vs context window"]
    D1 --> D2{Overflow\nobserved?}
    D2 -- Yes --> D3["Option A: runtime tokenizer\nOR Option B: heuristic estimator"]
    D2 -- No --> D4["Skip — not worth changing"]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22docs%2Fremaining-parity-plan%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Fremaining-parity-plan%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2FREMAINING_PARITY_PLAN.md%3A34-36%0A**Hardcoded%20line%20numbers%20will%20drift**%20%E2%80%94%20the%20document%20pins%20three%20specific%20line%20numbers%20%28%60SuggestionSettingsModel.swift%3A400%60%2C%20%60FocusModels.swift%3A110%60%2C%20%60FocusSnapshotResolver.swift%3A203%60%29%20that%20are%20currently%20accurate%20but%20will%20silently%20become%20wrong%20whenever%20surrounding%20code%20is%20inserted%20or%20removed.%20Consider%20referencing%20by%20symbol%20name%20or%20grep%20anchor%20instead%20%28e.g.%2C%20%22the%20%60settingsSnapshot%60%20construction%20in%20%60SuggestionSettingsModel%60%22%20rather%20than%20%60%3A400%60%29%2C%20which%20would%20survive%20refactors%20without%20becoming%20misleading.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2FREMAINING_PARITY_PLAN.md%3A34-36%0A**Hardcoded%20line%20numbers%20will%20drift**%20%E2%80%94%20the%20document%20pins%20three%20specific%20line%20numbers%20%28%60SuggestionSettingsModel.swift%3A400%60%2C%20%60FocusModels.swift%3A110%60%2C%20%60FocusSnapshotResolver.swift%3A203%60%29%20that%20are%20currently%20accurate%20but%20will%20silently%20become%20wrong%20whenever%20surrounding%20code%20is%20inserted%20or%20removed.%20Consider%20referencing%20by%20symbol%20name%20or%20grep%20anchor%20instead%20%28e.g.%2C%20%22the%20%60settingsSnapshot%60%20construction%20in%20%60SuggestionSettingsModel%60%22%20rather%20than%20%60%3A400%60%29%2C%20which%20would%20survive%20refactors%20without%20becoming%20misleading.%0A%0A&repo=fujacob%2Fcotabby&pr=528&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add an execution-ready plan for the rema..."](https://github.com/fujacob/cotabby/commit/60066728053e3cca6ee338ccfc568187d18151d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35058340)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->