### PR TITLE
Make per-site disable live: capture the focused page URL

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -186,6 +186,7 @@
 		A2B3F4D38BCB0FED452B2A3F /* FocusTrackingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D42CD456B4B3C988B148A6 /* FocusTrackingModel.swift */; };
 		A36481222BB5B2A67349D389 /* ApplicationBundleMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A168A7B6A7AD11559B60C56B /* ApplicationBundleMetadataTests.swift */; };
 		A5A6CE0EF01CA6A9AFA7A400 /* RequestID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DC693E00430F46E41CB56E6 /* RequestID.swift */; };
+		A67B3F97DAEBEC7CA9B1215E /* PerDomainDisableSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25C3087D4A9F4DC52FD5A69 /* PerDomainDisableSettings.swift */; };
 		A87978083EBE1AC294377F7C /* HuggingFaceSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F426127917FCB1096134732 /* HuggingFaceSearchService.swift */; };
 		A93A741C8C3973687D28F0B6 /* SuggestionEngineModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADBE3E6CC585C1683787C877 /* SuggestionEngineModels.swift */; };
 		A982E243A4D8BC1BF7504B3E /* SuggestionInteractionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA942A53B7C09D1F4EC57239 /* SuggestionInteractionState.swift */; };
@@ -209,6 +210,7 @@
 		C618C5595DA9C57C806A3E03 /* SettingsAttentionEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BC293F6125E2B14DCF05AD9 /* SettingsAttentionEvaluatorTests.swift */; };
 		C638466A2F373BABA6F60A6D /* ConstrainedBeamSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83264218423B61E59109EB3 /* ConstrainedBeamSearch.swift */; };
 		C71B594433F3B411CAE5DE7E /* FocusCapabilityResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F6D5F94B238F7B4BE7C247 /* FocusCapabilityResolverTests.swift */; };
+		C9426ADFCA2EC1D11D841A2A /* PerDomainDisableSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC582636750B78D497119845 /* PerDomainDisableSettingsTests.swift */; };
 		C9B815652CED38966C53A5E8 /* EmojiVariantResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8BB19D8EC9A75CD3458A6B /* EmojiVariantResolverTests.swift */; };
 		CA5B2D226FBAA5419E78F14F /* SuggestionSessionReconciler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0AA0503128B0FC3951D700 /* SuggestionSessionReconciler.swift */; };
 		CA8F453AA4AD02FAA8C961F7 /* TokenProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7D0BF193110927BEB865748 /* TokenProfileTests.swift */; };
@@ -453,6 +455,7 @@
 		AF1E065C7FFB697FCEB2FA5C /* CotabbyTestFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CotabbyTestFixtures.swift; sourceTree = "<group>"; };
 		AFCFCCCB69C29A86E726B10A /* PromptSectionBudget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptSectionBudget.swift; sourceTree = "<group>"; };
 		B22FDEB3B1DCC9ADE906CC73 /* OCRTextHygiene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCRTextHygiene.swift; sourceTree = "<group>"; };
+		B25C3087D4A9F4DC52FD5A69 /* PerDomainDisableSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerDomainDisableSettings.swift; sourceTree = "<group>"; };
 		B2BFD19A159680A495EE02FD /* ScreenshotContextGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotContextGeneratorTests.swift; sourceTree = "<group>"; };
 		B2F95847D76893C8A5B504B4 /* SuggestionOverlayStabilityGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionOverlayStabilityGate.swift; sourceTree = "<group>"; };
 		B424E2AC97C99D335B0D5751 /* SuggestionTextNormalizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionTextNormalizer.swift; sourceTree = "<group>"; };
@@ -519,6 +522,7 @@
 		E7F42112F14026E6253BB865 /* PermissionAndContextModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionAndContextModelTests.swift; sourceTree = "<group>"; };
 		EAAE6B395FAB604DF059280A /* KeyCodeLabels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyCodeLabels.swift; sourceTree = "<group>"; };
 		EB630F9814388203DD1CA2EC /* ShortcutsPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsPaneView.swift; sourceTree = "<group>"; };
+		EC582636750B78D497119845 /* PerDomainDisableSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerDomainDisableSettingsTests.swift; sourceTree = "<group>"; };
 		ED8672B87CEC72BE3978C6BB /* CotabbyTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CotabbyTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		EE8BB19D8EC9A75CD3458A6B /* EmojiVariantResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiVariantResolverTests.swift; sourceTree = "<group>"; };
 		EE94342B888A5A2CCF66BC93 /* SuggestionRequestFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionRequestFactoryTests.swift; sourceTree = "<group>"; };
@@ -807,6 +811,7 @@
 				5EED3CD2BC7B48DF35DEE562 /* OCRTextHygieneTests.swift */,
 				D814BBA41CF29E8DD9954651 /* OnboardingTemplateFeatureListTests.swift */,
 				01B72736E416910878E8E493 /* OnboardingTemplateRecommenderTests.swift */,
+				EC582636750B78D497119845 /* PerDomainDisableSettingsTests.swift */,
 				E7F42112F14026E6253BB865 /* PermissionAndContextModelTests.swift */,
 				12DD19BCE610808F1E38702D /* PermissionOverlayTrackerTests.swift */,
 				0D80CC2CCAAFE3F23FB8C37A /* PromptContextSanitizerTests.swift */,
@@ -969,6 +974,7 @@
 				B22FDEB3B1DCC9ADE906CC73 /* OCRTextHygiene.swift */,
 				24F613F0E2F7046E6532A09C /* OnboardingTemplateFeatureList.swift */,
 				FA878B447441BB4F3E327CC8 /* OnboardingTemplateRecommender.swift */,
+				B25C3087D4A9F4DC52FD5A69 /* PerDomainDisableSettings.swift */,
 				E6423D6CC8CC371D2DA899DE /* PermissionOverlayTracker.swift */,
 				FA4B45B91D4DEAC979C3113E /* PromptContextSanitizer.swift */,
 				AFCFCCCB69C29A86E726B10A /* PromptSectionBudget.swift */,
@@ -1219,6 +1225,7 @@
 				64DA031AEAC20AC6C852A24A /* OnboardingTemplateFeatureList.swift in Sources */,
 				DF8794793110A8ED234CBA96 /* OnboardingTemplateRecommender.swift in Sources */,
 				0DDC0CFF5558A8F4355836B2 /* OverlayController.swift in Sources */,
+				A67B3F97DAEBEC7CA9B1215E /* PerDomainDisableSettings.swift in Sources */,
 				0E4009CFC86608F055909967 /* PerformanceMetricsStore.swift in Sources */,
 				60636D92D12FED132250D8D2 /* PerformancePaneView.swift in Sources */,
 				0187EAA1D37B92DD5B264016 /* PermissionDragSourceView.swift in Sources */,
@@ -1346,6 +1353,7 @@
 				3F5630CFB7BA40B900E832A1 /* OCRTextHygieneTests.swift in Sources */,
 				DA23422A2CF77CFD3B1283C8 /* OnboardingTemplateFeatureListTests.swift in Sources */,
 				D648DD70AD847F67B77CE052 /* OnboardingTemplateRecommenderTests.swift in Sources */,
+				C9426ADFCA2EC1D11D841A2A /* PerDomainDisableSettingsTests.swift in Sources */,
 				15FA56CEF6FB5FF54C2FBA6F /* PermissionAndContextModelTests.swift in Sources */,
 				4F38CE1C2602CF4F41323032 /* PermissionOverlayTrackerTests.swift in Sources */,
 				934885ACC2DEA20B27F10948 /* PromptContextSanitizerTests.swift in Sources */,

--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
@@ -14,6 +14,7 @@ extension SuggestionCoordinator {
         if SuggestionAvailabilityEvaluator.shouldSchedulePrediction(
             globallyEnabled: settingsSnapshot.isGloballyEnabled,
             disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
+            disabledDomains: PerDomainDisableSettings.disabledDomains(),
             inputMonitoringGranted: permissionManager.inputMonitoringGranted,
             screenRecordingGranted: permissionManager.screenRecordingGranted,
             focusSnapshot: focusModel.snapshot
@@ -49,6 +50,7 @@ extension SuggestionCoordinator {
            SuggestionAvailabilityEvaluator.shouldCaptureVisualContext(
                globallyEnabled: settingsSnapshot.isGloballyEnabled,
                disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
+               disabledDomains: PerDomainDisableSettings.disabledDomains(),
                inputMonitoringGranted: permissionManager.inputMonitoringGranted,
                screenRecordingGranted: permissionManager.screenRecordingGranted,
                focusSnapshot: snapshot,
@@ -60,6 +62,7 @@ extension SuggestionCoordinator {
         if let disabledReason = SuggestionAvailabilityEvaluator.disabledReason(
             globallyEnabled: settingsSnapshot.isGloballyEnabled,
             disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
+            disabledDomains: PerDomainDisableSettings.disabledDomains(),
             inputMonitoringGranted: permissionManager.inputMonitoringGranted,
             screenRecordingGranted: permissionManager.screenRecordingGranted,
             focusSnapshot: snapshot
@@ -82,6 +85,7 @@ extension SuggestionCoordinator {
         if SuggestionAvailabilityEvaluator.shouldCaptureVisualContext(
             globallyEnabled: settingsSnapshot.isGloballyEnabled,
             disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
+            disabledDomains: PerDomainDisableSettings.disabledDomains(),
             inputMonitoringGranted: permissionManager.inputMonitoringGranted,
             screenRecordingGranted: permissionManager.screenRecordingGranted,
             focusSnapshot: snapshot,
@@ -160,6 +164,7 @@ extension SuggestionCoordinator {
         if let disabledReason = SuggestionAvailabilityEvaluator.disabledReason(
             globallyEnabled: settingsSnapshot.isGloballyEnabled,
             disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
+            disabledDomains: PerDomainDisableSettings.disabledDomains(),
             inputMonitoringGranted: permissionManager.inputMonitoringGranted,
             screenRecordingGranted: permissionManager.screenRecordingGranted,
             focusSnapshot: focusModel.snapshot

--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Lifecycle.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Lifecycle.swift
@@ -73,6 +73,7 @@ extension SuggestionCoordinator {
            SuggestionAvailabilityEvaluator.shouldCaptureVisualContext(
                globallyEnabled: settingsSnapshot.isGloballyEnabled,
                disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
+               disabledDomains: PerDomainDisableSettings.disabledDomains(),
                inputMonitoringGranted: permissionManager.inputMonitoringGranted,
                screenRecordingGranted: permissionManager.screenRecordingGranted,
                focusSnapshot: focusModel.snapshot,
@@ -84,6 +85,7 @@ extension SuggestionCoordinator {
         if SuggestionAvailabilityEvaluator.shouldSchedulePrediction(
             globallyEnabled: settingsSnapshot.isGloballyEnabled,
             disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
+            disabledDomains: PerDomainDisableSettings.disabledDomains(),
             inputMonitoringGranted: permissionManager.inputMonitoringGranted,
             screenRecordingGranted: permissionManager.screenRecordingGranted,
             focusSnapshot: focusModel.snapshot

--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
@@ -11,6 +11,7 @@ extension SuggestionCoordinator {
         if let disabledReason = SuggestionAvailabilityEvaluator.disabledReason(
             globallyEnabled: settingsSnapshot.isGloballyEnabled,
             disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
+            disabledDomains: PerDomainDisableSettings.disabledDomains(),
             inputMonitoringGranted: permissionManager.inputMonitoringGranted,
             screenRecordingGranted: permissionManager.screenRecordingGranted,
             focusSnapshot: focusModel.snapshot
@@ -50,6 +51,7 @@ extension SuggestionCoordinator {
         if let disabledReason = SuggestionAvailabilityEvaluator.disabledReason(
             globallyEnabled: settingsSnapshot.isGloballyEnabled,
             disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
+            disabledDomains: PerDomainDisableSettings.disabledDomains(),
             inputMonitoringGranted: permissionManager.inputMonitoringGranted,
             screenRecordingGranted: permissionManager.screenRecordingGranted,
             focusSnapshot: snapshot
@@ -147,6 +149,7 @@ extension SuggestionCoordinator {
         if let disabledReason = SuggestionAvailabilityEvaluator.disabledReason(
             globallyEnabled: settingsSnapshot.isGloballyEnabled,
             disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
+            disabledDomains: PerDomainDisableSettings.disabledDomains(),
             inputMonitoringGranted: permissionManager.inputMonitoringGranted,
             screenRecordingGranted: permissionManager.screenRecordingGranted,
             focusSnapshot: snapshot
@@ -292,6 +295,7 @@ extension SuggestionCoordinator {
         let disabledReason = SuggestionAvailabilityEvaluator.disabledReason(
             globallyEnabled: settingsSnapshot.isGloballyEnabled,
             disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
+            disabledDomains: PerDomainDisableSettings.disabledDomains(),
             inputMonitoringGranted: permissionManager.inputMonitoringGranted,
             screenRecordingGranted: permissionManager.screenRecordingGranted,
             focusSnapshot: focusModel.snapshot

--- a/Cotabby/Models/FocusModels.swift
+++ b/Cotabby/Models/FocusModels.swift
@@ -138,6 +138,11 @@ struct FocusedInputSnapshot: Equatable {
     /// The initializer default of 0 keeps test and legacy call sites compiling without changes.
     let focusChangeSequence: UInt64
 
+    /// The focused web page URL, when capture resolved one over Accessibility (browsers only, and only
+    /// while per-site disable is enabled). Nil otherwise. Used solely by the per-site disable gate; the
+    /// initializer default keeps every existing call site compiling unchanged.
+    let focusedURLString: String?
+
     /// Explicit initializer keeps `focusChangeSequence` immutable while preserving the old
     /// memberwise-call ergonomics for tests that do not care about focus identity.
     ///
@@ -160,7 +165,8 @@ struct FocusedInputSnapshot: Equatable {
         trailingText: String,
         selection: NSRange,
         isSecure: Bool,
-        focusChangeSequence: UInt64 = 0
+        focusChangeSequence: UInt64 = 0,
+        focusedURLString: String? = nil
     ) {
         self.applicationName = applicationName
         self.bundleIdentifier = bundleIdentifier
@@ -178,6 +184,7 @@ struct FocusedInputSnapshot: Equatable {
         self.selection = selection
         self.isSecure = isSecure
         self.focusChangeSequence = focusChangeSequence
+        self.focusedURLString = focusedURLString
     }
 
     var identity: FocusedInputIdentity {

--- a/Cotabby/Services/Focus/FocusSnapshotResolver.swift
+++ b/Cotabby/Services/Focus/FocusSnapshotResolver.swift
@@ -200,6 +200,12 @@ struct FocusSnapshotResolver {
         let nsValue = contextWindow.text as NSString
         let safeSelectionLocation = min(contextWindow.selection.location, nsValue.length)
         let trailingStart = min(contextWindow.selection.location + contextWindow.selection.length, nsValue.length)
+        // Per-site disable: read the page URL only when the feature is enabled, so the default
+        // focus-capture path performs no extra Accessibility round-trips. The read is fail-safe (nil on
+        // any miss), so the worst case is the per-site gate staying inert.
+        let focusedURLString = PerDomainDisableSettings.isEnabled()
+            ? AXHelper.webURL(near: focusedElement)
+            : nil
         let context = FocusedInputSnapshot(
             applicationName: applicationName,
             bundleIdentifier: bundleIdentifier,
@@ -216,7 +222,8 @@ struct FocusSnapshotResolver {
             trailingText: nsValue.substring(from: trailingStart),
             selection: contextWindow.selection,
             isSecure: resolvedCandidate.isSecure,
-            focusChangeSequence: focusChangeSequence
+            focusChangeSequence: focusChangeSequence,
+            focusedURLString: focusedURLString
         )
 
         if resolvedCandidate.isSecure {

--- a/Cotabby/Support/AXHelper.swift
+++ b/Cotabby/Support/AXHelper.swift
@@ -494,6 +494,38 @@ enum AXHelper {
         return unsafeBitCast(value, to: AXUIElement.self)
     }
 
+    /// Best-effort, fail-safe read of the web page URL near `element`, used only for per-site rules.
+    /// Browsers expose `kAXURLAttribute` on the web area or window rather than the focused field, so
+    /// this walks up a bounded number of ancestors. It returns nil on any miss (non-browser focus, an
+    /// app that does not expose the attribute, or the climb running out), so a failed read degrades to
+    /// "no per-site rule applies" rather than misbehaving. It never mutates AX state.
+    static func webURL(near element: AXUIElement, maxClimb: Int = 6) -> String? {
+        var current = element
+        for _ in 0...maxClimb {
+            if let url = urlString(on: current) {
+                return url
+            }
+            guard let parent = parentElement(of: current) else { break }
+            current = parent
+        }
+        return nil
+    }
+
+    /// Reads `kAXURLAttribute` as a string, tolerating the value arriving as a `URL`/`NSURL` (the
+    /// usual case) or already as a string.
+    private static func urlString(on element: AXUIElement) -> String? {
+        guard let value = copyAttributeValue(kAXURLAttribute as CFString, on: element) else {
+            return nil
+        }
+        if let url = value as? URL {
+            return url.absoluteString
+        }
+        if let url = value as? NSURL {
+            return url.absoluteString
+        }
+        return value as? String
+    }
+
     /// Returns the immediate AX children for the current element.
     /// The result may be empty either because the node has no children or because the host app
     /// simply does not expose them through Accessibility.

--- a/Cotabby/Support/PerDomainDisableSettings.swift
+++ b/Cotabby/Support/PerDomainDisableSettings.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// File overview:
+/// Reads the per-site disable configuration from UserDefaults: a default-off feature flag and the
+/// user's list of disabled domains. Kept as a thin, injectable reader so the matching logic
+/// (`BrowserDomain`) and the gate (`SuggestionAvailabilityEvaluator`) stay pure, and so the feature
+/// is configurable via `defaults write` while it has no settings UI yet — the same hidden-flag
+/// pattern the experimental decoder paths use.
+enum PerDomainDisableSettings {
+    /// Turns on per-site disable, *including* the Accessibility URL read in focus capture. Default-off
+    /// so the focus-capture hot path is untouched until a dogfooder opts in and validates the URL read
+    /// on device.
+    static let enabledKey = "cotabbyPerDomainDisableEnabled"
+    /// Holds the disabled-domain entries (an array of strings; bare hosts or full URLs both work).
+    static let disabledDomainsKey = "cotabbyDisabledDomains"
+
+    static func isEnabled(_ defaults: UserDefaults = .standard) -> Bool {
+        defaults.bool(forKey: enabledKey)
+    }
+
+    /// The configured disabled-domain entries, or an empty set when unset. An empty set leaves the
+    /// per-site gate inert regardless of the flag.
+    static func disabledDomains(_ defaults: UserDefaults = .standard) -> Set<String> {
+        guard let entries = defaults.stringArray(forKey: disabledDomainsKey) else {
+            return []
+        }
+        return Set(entries)
+    }
+}

--- a/Cotabby/Support/SuggestionAvailabilityEvaluator.swift
+++ b/Cotabby/Support/SuggestionAvailabilityEvaluator.swift
@@ -11,7 +11,6 @@ enum SuggestionAvailabilityEvaluator {
         globallyEnabled: Bool = true,
         disabledAppBundleIdentifiers: Set<String> = [],
         disabledDomains: Set<String> = [],
-        focusedURLString: String? = nil,
         inputMonitoringGranted: Bool,
         screenRecordingGranted: Bool,
         focusSnapshot: FocusSnapshot,
@@ -26,11 +25,12 @@ enum SuggestionAvailabilityEvaluator {
             return "Cotabby is disabled in \(focusSnapshot.applicationName)."
         }
 
-        // Per-site disable: when the focused element carries a web URL, a host on the user's disabled
-        // list (exact or parent domain) suppresses autocomplete the same way a disabled app does.
-        // Defaults make this inert (no URL / empty list) so non-browser focus is unaffected.
-        if let focusedURLString,
-           let host = BrowserDomain.host(fromURLString: focusedURLString),
+        // Per-site disable: when focus capture resolved a page URL, a host on the user's disabled list
+        // (exact or parent domain) suppresses autocomplete the same way a disabled app does. The URL is
+        // nil unless the feature is enabled and a browser exposed it, and the list is empty by default,
+        // so non-browser focus is unaffected.
+        if let urlString = focusSnapshot.context?.focusedURLString,
+           let host = BrowserDomain.host(fromURLString: urlString),
            BrowserDomain.isHostDisabled(host, disabledDomains: disabledDomains) {
             return "Cotabby is disabled on \(host)."
         }
@@ -63,6 +63,7 @@ enum SuggestionAvailabilityEvaluator {
     static func shouldSchedulePrediction(
         globallyEnabled: Bool = true,
         disabledAppBundleIdentifiers: Set<String> = [],
+        disabledDomains: Set<String> = [],
         inputMonitoringGranted: Bool,
         screenRecordingGranted: Bool,
         focusSnapshot: FocusSnapshot
@@ -70,6 +71,7 @@ enum SuggestionAvailabilityEvaluator {
         disabledReason(
             globallyEnabled: globallyEnabled,
             disabledAppBundleIdentifiers: disabledAppBundleIdentifiers,
+            disabledDomains: disabledDomains,
             inputMonitoringGranted: inputMonitoringGranted,
             screenRecordingGranted: screenRecordingGranted,
             focusSnapshot: focusSnapshot
@@ -88,6 +90,7 @@ enum SuggestionAvailabilityEvaluator {
     static func shouldCaptureVisualContext(
         globallyEnabled: Bool = true,
         disabledAppBundleIdentifiers: Set<String> = [],
+        disabledDomains: Set<String> = [],
         inputMonitoringGranted: Bool,
         screenRecordingGranted: Bool,
         focusSnapshot: FocusSnapshot,
@@ -100,6 +103,7 @@ enum SuggestionAvailabilityEvaluator {
         return disabledReason(
             globallyEnabled: globallyEnabled,
             disabledAppBundleIdentifiers: disabledAppBundleIdentifiers,
+            disabledDomains: disabledDomains,
             inputMonitoringGranted: inputMonitoringGranted,
             screenRecordingGranted: screenRecordingGranted,
             focusSnapshot: focusSnapshot,

--- a/CotabbyTests/PerDomainDisableSettingsTests.swift
+++ b/CotabbyTests/PerDomainDisableSettingsTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import Cotabby
+
+/// Tests for the UserDefaults-backed per-site disable configuration reader.
+///
+/// The contract that matters: the feature is off and the list empty unless explicitly configured, so
+/// the focus-capture URL read and the per-site gate stay inert by default.
+final class PerDomainDisableSettingsTests: XCTestCase {
+    private let suiteName = "PerDomainDisableSettingsTests"
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        super.tearDown()
+    }
+
+    func test_isEnabled_defaultsToFalse() {
+        XCTAssertFalse(PerDomainDisableSettings.isEnabled(defaults))
+    }
+
+    func test_isEnabled_readsStoredFlag() {
+        defaults.set(true, forKey: PerDomainDisableSettings.enabledKey)
+        XCTAssertTrue(PerDomainDisableSettings.isEnabled(defaults))
+    }
+
+    func test_disabledDomains_emptyByDefault() {
+        XCTAssertEqual(PerDomainDisableSettings.disabledDomains(defaults), [])
+    }
+
+    func test_disabledDomains_readsStoredArrayAsSet() {
+        defaults.set(["bank.com", "example.org", "bank.com"], forKey: PerDomainDisableSettings.disabledDomainsKey)
+        XCTAssertEqual(PerDomainDisableSettings.disabledDomains(defaults), ["bank.com", "example.org"])
+    }
+}

--- a/CotabbyTests/SuggestionAvailabilityEvaluatorTests.swift
+++ b/CotabbyTests/SuggestionAvailabilityEvaluatorTests.swift
@@ -29,7 +29,8 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
     private func makeSupportedSnapshotWithContext(
         elementIdentifier: String = "field",
         focusChangeSequence: UInt64 = 1,
-        precedingText: String = "hello"
+        precedingText: String = "hello",
+        focusedURLString: String? = nil
     ) -> FocusSnapshot {
         let context = FocusedInputSnapshot(
             applicationName: "TestApp",
@@ -47,7 +48,8 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
             trailingText: "",
             selection: NSRange(location: precedingText.count, length: 0),
             isSecure: false,
-            focusChangeSequence: focusChangeSequence
+            focusChangeSequence: focusChangeSequence,
+            focusedURLString: focusedURLString
         )
 
         return FocusSnapshot(
@@ -78,24 +80,22 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
         let reason = SuggestionAvailabilityEvaluator.disabledReason(
             globallyEnabled: true,
             disabledDomains: ["bank.com"],
-            focusedURLString: "https://www.bank.com/account",
             inputMonitoringGranted: true,
             screenRecordingGranted: true,
-            focusSnapshot: makeSnapshot(capability: .supported)
+            focusSnapshot: makeSupportedSnapshotWithContext(focusedURLString: "https://www.bank.com/account")
         )
 
         XCTAssertEqual(reason, "Cotabby is disabled on bank.com.")
     }
 
     func test_disabledReason_domainCheckIsInertByDefault() {
-        // No focused URL and no disabled domains: the per-site gate must never fire, so an otherwise
-        // healthy environment stays enabled exactly as before this gate existed.
+        // A focused URL but no disabled-domains list: the per-site gate must never fire, so an
+        // otherwise healthy environment stays enabled exactly as before this gate existed.
         let reason = SuggestionAvailabilityEvaluator.disabledReason(
             globallyEnabled: true,
-            focusedURLString: "https://bank.com/account",
             inputMonitoringGranted: true,
             screenRecordingGranted: true,
-            focusSnapshot: makeSnapshot(capability: .supported)
+            focusSnapshot: makeSupportedSnapshotWithContext(focusedURLString: "https://bank.com/account")
         )
 
         XCTAssertNil(reason, "a focused URL with no disabled-domains list must not suppress autocomplete")


### PR DESCRIPTION
## Summary

#527 landed the pure matching core for per-site disable but left it inert. This wires it end to end behind a default-off `cotabbyPerDomainDisableEnabled` flag, so a domain on the user's list actually suppresses autocomplete the way a disabled app does.

- **`AXHelper.webURL(near:)`** — a fail-safe, read-only walk up a bounded number of ancestors reading `kAXURLAttribute` (browsers expose it on the web area / window, not the focused field). Returns nil on any miss, tolerates the value arriving as `URL`/`NSURL`/`String`, and never mutates AX state.
- **`FocusedInputSnapshot.focusedURLString`** — a new optional field, populated by `FocusSnapshotResolver` *only when the feature is enabled*, so the default focus-capture path performs zero extra Accessibility round-trips.
- **`SuggestionAvailabilityEvaluator`** reads the URL straight off the snapshot it already receives; the disabled-domains list comes from `PerDomainDisableSettings` (a `defaults`-backed array, hidden-flag pattern, no UI yet), threaded through all availability call sites alongside the existing per-app list.

## Validation

```
xcodebuild ... test ... CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO \
  -only-testing:CotabbyTests/PerDomainDisableSettingsTests \
  -only-testing:CotabbyTests/BrowserDomainTests \
  -only-testing:CotabbyTests/SuggestionAvailabilityEvaluatorTests
# ** TEST SUCCEEDED **  (full build of the app target compiles the resolver, AX, and
#   coordinator wiring; every existing availability test passes unchanged)
#   PerDomainDisableSettings: flag + list default off/empty, read stored values
#   evaluator: per-site reason fires from the snapshot URL; inert with no list

swiftlint --strict   # exit 0 (CI-equivalent, lints Cotabby/)
xcodegen generate    # registered the new source + test file
```

To exercise on device: `defaults write com.jacobfu.tabby cotabbyPerDomainDisableEnabled -bool YES` and `defaults write com.jacobfu.tabby cotabbyDisabledDomains -array bank.com`.

## Linked issues

None. Completes the per-site disable feature started in #527.

## Risk / rollout notes

- **Default-off and inert by construction.** With the flag off (or an empty list, or non-browser focus) the URL is never read and the gate never fires, so behavior is byte-for-byte unchanged — the existing availability tests confirm this. The `focusedURLString` field defaults to nil, so the two `FocusedInputSnapshot` construction sites are unaffected.
- The AX read is fail-safe (nil on any miss), so even an imperfect read cannot cause a regression — at worst the feature stays inert.
- **Needs on device before promoting:** that the URL read resolves across Chrome (OOPIF), Safari, and Arc, and adds no measurable focus-capture latency when enabled; plus a settings UI for the domain list (the `defaults`-backed array is the dogfood surface).
- `project.pbxproj` regenerated by XcodeGen for the two new files.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires the per-site disable feature end-to-end: a new `AXHelper.webURL(near:)` walks the AX ancestor tree to find the browser's page URL, which is stored in a new `focusedURLString` field on `FocusedInputSnapshot` and checked by `SuggestionAvailabilityEvaluator` against a `UserDefaults`-backed domain list. The entire path is gated behind a default-off `cotabbyPerDomainDisableEnabled` flag, leaving existing behavior byte-for-byte unchanged.

- `AXHelper.webURL(near:)` climbs up to `maxClimb` ancestors using `kAXURLAttribute`, returning nil on any miss; `FocusSnapshotResolver` only invokes it when the feature flag is on.
- `PerDomainDisableSettings` is a thin, injectable `UserDefaults` reader for the flag and domain list; `SuggestionAvailabilityEvaluator` adds a `disabledDomains` parameter threaded through all call sites in the three coordinator files.
- New test files cover the settings reader and updated evaluator cases; existing availability tests compile and pass unchanged.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the feature is default-off and the gating path has no effect on existing behavior when the flag is unset.

The AX ancestor walk in `webURL` uses a closed range (`0...maxClimb`) that makes one extra `parentElement()` call on the final iteration when no URL is found — a wasted AX round-trip per focus event when the feature is enabled. The coordinator files also call `PerDomainDisableSettings.disabledDomains()` independently at each evaluator site rather than reading once per event handler. Neither issue affects correctness, but the AX call is worth tidying before the feature exits dogfood.

Cotabby/Support/AXHelper.swift — the `webURL` loop boundary; Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift — redundant `disabledDomains()` reads per event.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/AXHelper.swift | Adds `webURL(near:maxClimb:)` + `urlString(on:)` helpers; closed-range loop makes one extra `parentElement()` AX call on the final iteration when no URL is found. |
| Cotabby/Support/PerDomainDisableSettings.swift | New thin UserDefaults reader for the per-site flag and domain list; default-off, cleanly injectable for tests. |
| Cotabby/Support/SuggestionAvailabilityEvaluator.swift | Adds `disabledDomains` parameter to all three evaluator entry points and wires the per-site gate to `focusSnapshot.context?.focusedURLString`; logic is correct and the gate stays inert when URL is nil. |
| Cotabby/Models/FocusModels.swift | Adds optional `focusedURLString` field to `FocusedInputSnapshot` with a nil default; existing call sites are unaffected. |
| Cotabby/Services/Focus/FocusSnapshotResolver.swift | Populates `focusedURLString` only when `PerDomainDisableSettings.isEnabled()` is true, keeping the default focus-capture path free of extra AX round-trips. |
| Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift | Threads `disabledDomains` through five evaluator call sites; `PerDomainDisableSettings.disabledDomains()` is called separately at each site rather than once per event handler. |
| CotabbyTests/PerDomainDisableSettingsTests.swift | New tests using an isolated UserDefaults suite; covers default-off and stored values for both the flag and domain list. |
| CotabbyTests/SuggestionAvailabilityEvaluatorTests.swift | Updates helper to pass `focusedURLString` through the snapshot; adds per-site disable and inert-by-default test cases. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Coord as SuggestionCoordinator
    participant Resolver as FocusSnapshotResolver
    participant Settings as PerDomainDisableSettings
    participant AX as AXHelper
    participant Eval as SuggestionAvailabilityEvaluator
    participant Domain as BrowserDomain

    Coord->>Resolver: resolve(focusedElement)
    Resolver->>Settings: isEnabled()
    alt feature enabled
        Settings-->>Resolver: true
        Resolver->>AX: webURL(near: focusedElement)
        AX->>AX: urlString(on: element) x up to maxClimb levels
        AX-->>Resolver: url string or nil
    else feature disabled
        Settings-->>Resolver: false
        Note over Resolver: focusedURLString = nil (no AX call)
    end
    Resolver-->>Coord: FocusSnapshot (focusedURLString set or nil)

    Coord->>Settings: disabledDomains()
    Settings-->>Coord: "Set<String>"
    Coord->>Eval: disabledReason(disabledDomains:focusSnapshot:...)
    Eval->>Eval: focusSnapshot.context?.focusedURLString
    alt URL present
        Eval->>Domain: host(fromURLString:)
        Domain-->>Eval: host string
        Eval->>Domain: isHostDisabled(host, disabledDomains)
        Domain-->>Eval: true/false
        alt host disabled
            Eval-->>Coord: Cotabby is disabled on host.
        else host not disabled
            Eval-->>Coord: nil (enabled)
        end
    else URL nil (feature off or non-browser)
        Eval-->>Coord: nil (enabled)
    end
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fper-domain-capture%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fper-domain-capture%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FSupport%2FAXHelper.swift%3A502-512%0AThe%20closed%20range%20%600...maxClimb%60%20makes%20%60maxClimb%20%2B%201%60%20iterations%20%28e.g.%2C%207%20when%20%60maxClimb%20%3D%206%60%29.%20On%20the%20last%20iteration%2C%20after%20the%20URL%20check%20fails%2C%20the%20function%20still%20calls%20%60parentElement%28of%3A%20current%29%60%20and%20assigns%20the%20result%20to%20%60current%60%2C%20but%20that%20value%20is%20never%20used%20%E2%80%94%20the%20loop%20ends.%20This%20is%20one%20wasted%20AX%20round-trip%20per%20call%20when%20no%20URL%20is%20found%20at%20the%20deepest%20level.%20Changing%20the%20range%20to%20%600..%3CmaxClimb%60%20and%20adding%20a%20final%20check%20outside%20the%20loop%20eliminates%20the%20extra%20call%20while%20preserving%20the%20same%20traversal%20depth.%0A%0A%60%60%60suggestion%0A%20%20%20%20static%20func%20webURL%28near%20element%3A%20AXUIElement%2C%20maxClimb%3A%20Int%20%3D%206%29%20-%3E%20String%3F%20%7B%0A%20%20%20%20%20%20%20%20var%20current%20%3D%20element%0A%20%20%20%20%20%20%20%20for%20_%20in%200..%3CmaxClimb%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20let%20url%20%3D%20urlString%28on%3A%20current%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%20url%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20guard%20let%20parent%20%3D%20parentElement%28of%3A%20current%29%20else%20%7B%20return%20nil%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20current%20%3D%20parent%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20return%20urlString%28on%3A%20current%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BInput.swift%3A50-54%0A%60PerDomainDisableSettings.disabledDomains%28%29%60%20is%20called%20at%20every%20evaluator%20call%20site%20independently%2C%20which%20means%20a%20single%20focus-change%20event%20%28e.g.%2C%20%60handleFocusSnapshotChange%60%29%20triggers%20multiple%20%60UserDefaults.stringArray%28forKey%3A%29%60%20reads%20in%20sequence.%20Within%20that%20one%20function%20call%20alone%20there%20are%20two%20consecutive%20reads%20%28one%20for%20%60shouldCaptureVisualContext%60%2C%20one%20for%20%60disabledReason%60%29.%20The%20same%20pattern%20appears%20across%20%60SuggestionCoordinator%2BLifecycle.swift%60%20and%20%60SuggestionCoordinator%2BPrediction.swift%60.%20Caching%20the%20result%20in%20a%20local%20%60let%60%20at%20the%20top%20of%20each%20event-handler%20function%20%28or%20reading%20it%20once%20in%20the%20coordinator%29%20would%20remove%20the%20redundant%20lookups.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FSupport%2FAXHelper.swift%3A502-512%0AThe%20closed%20range%20%600...maxClimb%60%20makes%20%60maxClimb%20%2B%201%60%20iterations%20%28e.g.%2C%207%20when%20%60maxClimb%20%3D%206%60%29.%20On%20the%20last%20iteration%2C%20after%20the%20URL%20check%20fails%2C%20the%20function%20still%20calls%20%60parentElement%28of%3A%20current%29%60%20and%20assigns%20the%20result%20to%20%60current%60%2C%20but%20that%20value%20is%20never%20used%20%E2%80%94%20the%20loop%20ends.%20This%20is%20one%20wasted%20AX%20round-trip%20per%20call%20when%20no%20URL%20is%20found%20at%20the%20deepest%20level.%20Changing%20the%20range%20to%20%600..%3CmaxClimb%60%20and%20adding%20a%20final%20check%20outside%20the%20loop%20eliminates%20the%20extra%20call%20while%20preserving%20the%20same%20traversal%20depth.%0A%0A%60%60%60suggestion%0A%20%20%20%20static%20func%20webURL%28near%20element%3A%20AXUIElement%2C%20maxClimb%3A%20Int%20%3D%206%29%20-%3E%20String%3F%20%7B%0A%20%20%20%20%20%20%20%20var%20current%20%3D%20element%0A%20%20%20%20%20%20%20%20for%20_%20in%200..%3CmaxClimb%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20let%20url%20%3D%20urlString%28on%3A%20current%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%20url%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20guard%20let%20parent%20%3D%20parentElement%28of%3A%20current%29%20else%20%7B%20return%20nil%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20current%20%3D%20parent%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20return%20urlString%28on%3A%20current%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BInput.swift%3A50-54%0A%60PerDomainDisableSettings.disabledDomains%28%29%60%20is%20called%20at%20every%20evaluator%20call%20site%20independently%2C%20which%20means%20a%20single%20focus-change%20event%20%28e.g.%2C%20%60handleFocusSnapshotChange%60%29%20triggers%20multiple%20%60UserDefaults.stringArray%28forKey%3A%29%60%20reads%20in%20sequence.%20Within%20that%20one%20function%20call%20alone%20there%20are%20two%20consecutive%20reads%20%28one%20for%20%60shouldCaptureVisualContext%60%2C%20one%20for%20%60disabledReason%60%29.%20The%20same%20pattern%20appears%20across%20%60SuggestionCoordinator%2BLifecycle.swift%60%20and%20%60SuggestionCoordinator%2BPrediction.swift%60.%20Caching%20the%20result%20in%20a%20local%20%60let%60%20at%20the%20top%20of%20each%20event-handler%20function%20%28or%20reading%20it%20once%20in%20the%20coordinator%29%20would%20remove%20the%20redundant%20lookups.%0A%0A&repo=fujacob%2Fcotabby&pr=529&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Make per-site disable live: capture the ..."](https://github.com/fujacob/cotabby/commit/f8016a8d0902b8efe640358fcf5c2d1434970724) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35059161)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->