### PR TITLE
Add opt-in clipboard paste insertion for long completions

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -178,6 +178,7 @@
 		9ABF75CDA78B27453C3F5B34 /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264CA64B2AB1611F82E5B760 /* WelcomeView.swift */; };
 		9ADFFF634912F638D079E1C7 /* SentenceBoundaryClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B56C250DDEF3E81F9DCBD7 /* SentenceBoundaryClassifier.swift */; };
 		9CEBD6AF4405F1BBE0E3D16C /* MidWordContinuationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 357C18383B047F24A531BDCD /* MidWordContinuationPolicy.swift */; };
+		9D0F4829D11BCD4DB1290410 /* InsertionStrategySelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0D2FEEA4304C86324BAADAB /* InsertionStrategySelector.swift */; };
 		9F2FDCABCC941CBECAA3B4AB /* CotabbyInference in Frameworks */ = {isa = PBXBuildFile; productRef = 48A46AD6B613CF06072603E4 /* CotabbyInference */; };
 		9F6F88ED74ECA3E23A8E3CC0 /* SecureFieldDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1827565F4FAD3E4E61CA65C3 /* SecureFieldDetector.swift */; };
 		A0657CE0488F69F0BD559CBC /* SuggestionCoordinator+Acceptance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72B13136DF7318F3E96DF0D3 /* SuggestionCoordinator+Acceptance.swift */; };
@@ -266,6 +267,7 @@
 		F8E86FA4D6CEEBFA7FB55F8D /* KeyRecorderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A567677424A82D9EEF47495 /* KeyRecorderView.swift */; };
 		FAC7FFC78BEBF62D5B7A2EFB /* DownloadOutcomeClassifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E217A66717D78E1E49350EC8 /* DownloadOutcomeClassifierTests.swift */; };
 		FBEDA005ECD53CD645CD4C64 /* EmojiPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3384FD33776960103D6E22A9 /* EmojiPickerView.swift */; };
+		FC255241A3B34A5717F09B36 /* InsertionStrategySelectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2960080A726E51198225147A /* InsertionStrategySelectorTests.swift */; };
 		FC6B0524B774F20C18BD6889 /* OnboardingTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4451D6673112575DF24C4A48 /* OnboardingTemplate.swift */; };
 		FCC571EC239846F06007BFCA /* CotabbyAppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 711293EA57808B9428C7B908 /* CotabbyAppEnvironment.swift */; };
 /* End PBXBuildFile section */
@@ -328,6 +330,7 @@
 		273B4DC844F79B4BE2C8910F /* FocusPollBackoffTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusPollBackoffTests.swift; sourceTree = "<group>"; };
 		276FA037D0F8DF51AABF4292 /* FillInMiddlePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FillInMiddlePolicy.swift; sourceTree = "<group>"; };
 		292DC9D4D9D5D26AE882E39B /* EmojiCatalogMatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiCatalogMatcherTests.swift; sourceTree = "<group>"; };
+		2960080A726E51198225147A /* InsertionStrategySelectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsertionStrategySelectorTests.swift; sourceTree = "<group>"; };
 		29ED42C4BDD0C521101AF95E /* DeviceInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceInfo.swift; sourceTree = "<group>"; };
 		2A02336442BB735EE2E8D064 /* SettingsAttentionEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAttentionEvaluator.swift; sourceTree = "<group>"; };
 		2B7A28471B8526C2693FFF65 /* AcknowledgementsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcknowledgementsView.swift; sourceTree = "<group>"; };
@@ -508,6 +511,7 @@
 		DDF6A4E9CE93FD53C60E67E3 /* EmojiQueryRun.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiQueryRun.swift; sourceTree = "<group>"; };
 		DEB16474A67CE1D210B944C9 /* SuggestionSubsystemContracts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionSubsystemContracts.swift; sourceTree = "<group>"; };
 		DEBD6113A3C1038BECC99245 /* PerformancePaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformancePaneView.swift; sourceTree = "<group>"; };
+		E0D2FEEA4304C86324BAADAB /* InsertionStrategySelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsertionStrategySelector.swift; sourceTree = "<group>"; };
 		E19A5B462891263BDFB56607 /* TrailingDuplicationFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrailingDuplicationFilterTests.swift; sourceTree = "<group>"; };
 		E217A66717D78E1E49350EC8 /* DownloadOutcomeClassifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadOutcomeClassifierTests.swift; sourceTree = "<group>"; };
 		E260C4D08C786CDBD527B329 /* PromptSectionBudgetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptSectionBudgetTests.swift; sourceTree = "<group>"; };
@@ -799,6 +803,7 @@
 				5AD3F4F9FBE82007E4E15F58 /* GhostSuggestionLayoutTests.swift */,
 				BAC01317B0B68E3C4125E421 /* InputMonitorTests.swift */,
 				43D627C4A55359EAF4676FF7 /* InsertionSafetyGateTests.swift */,
+				2960080A726E51198225147A /* InsertionStrategySelectorTests.swift */,
 				4793D4EA5D36D7E5CC216C27 /* LanguageSupportTests.swift */,
 				5807E8508D9355D0271A00C5 /* LaunchAtLoginStateTests.swift */,
 				0CA88BB29BC8727878C99E95 /* LlamaPromptCacheHintTrackerTests.swift */,
@@ -966,6 +971,7 @@
 				7E44E393DD58B978B1EAB6CF /* GhostTextColorPreset.swift */,
 				41BBD5A4BA08CABE77860886 /* HardwareCapabilityProbe.swift */,
 				7D472F9F396672E57873303B /* InsertionSafetyGate.swift */,
+				E0D2FEEA4304C86324BAADAB /* InsertionStrategySelector.swift */,
 				EAAE6B395FAB604DF059280A /* KeyCodeLabels.swift */,
 				8D610FCA3A97249DCCE7D0B8 /* LLMIOFileHandler.swift */,
 				A863F41C0C03D7B4AC5DC002 /* MarkerSelectionSynthesizer.swift */,
@@ -1199,6 +1205,7 @@
 				2DF5A3826AAB99C279EBB8DE /* InputMonitor.swift in Sources */,
 				6955C3A4D7AB3EEF7FA7C469 /* InputSuppressionController.swift in Sources */,
 				DCABB8D2B391C7820D6CA5FF /* InsertionSafetyGate.swift in Sources */,
+				9D0F4829D11BCD4DB1290410 /* InsertionStrategySelector.swift in Sources */,
 				F78F594F77C26C233377E71F /* KeyCodeLabels.swift in Sources */,
 				F8E86FA4D6CEEBFA7FB55F8D /* KeyRecorderView.swift in Sources */,
 				046C133967B32BBF9205EBB1 /* LLMIOFileHandler.swift in Sources */,
@@ -1341,6 +1348,7 @@
 				A0BB87E3665EF6C209034798 /* GhostSuggestionLayoutTests.swift in Sources */,
 				07D046D406411ED85AC5758A /* InputMonitorTests.swift in Sources */,
 				83EC3543DC45B1601F119BF9 /* InsertionSafetyGateTests.swift in Sources */,
+				FC255241A3B34A5717F09B36 /* InsertionStrategySelectorTests.swift in Sources */,
 				E912D4617AE1376061DF1F00 /* LanguageSupportTests.swift in Sources */,
 				E27E6377D36D4981301568DD /* LaunchAtLoginStateTests.swift in Sources */,
 				E38801433B99E65BD7E45A0E /* LlamaPromptCacheHintTrackerTests.swift in Sources */,

--- a/Cotabby/Services/Suggestion/SuggestionInserter.swift
+++ b/Cotabby/Services/Suggestion/SuggestionInserter.swift
@@ -1,3 +1,4 @@
+import AppKit
 import ApplicationServices
 import Foundation
 import Logging
@@ -19,6 +20,22 @@ final class SuggestionInserter {
     /// of already-typed text per pair, which is how the picker removes the literal `:query` run.
     private static let backspaceKeyCode: CGKeyCode = 0x33
 
+    /// Virtual key code for the `V` key, used to synthesize Cmd-V in the paste insertion path.
+    private static let vKeyCode: CGKeyCode = 0x09
+
+    /// UserDefaults key (no UI) that routes long or multi-line completions through a clipboard paste
+    /// instead of a synthetic Unicode keystroke. Default-off: paste touches the user's clipboard and
+    /// its restore timing needs on-device validation, so it stays a hidden dogfood toggle until then.
+    private static let pasteInsertionDefaultsKey = "cotabbyPasteInsertionEnabled"
+    private static var isPasteInsertionEnabled: Bool {
+        UserDefaults.standard.bool(forKey: pasteInsertionDefaultsKey)
+    }
+
+    /// How long to leave the completion on the pasteboard before restoring the user's clipboard. Long
+    /// enough for the host to service Cmd-V, short enough that the user's clipboard is theirs again
+    /// almost immediately. Catalogued in `docs/POLLING_AND_DELAYS.md`; tune on device.
+    private static let pasteboardRestoreDelay: TimeInterval = 0.15
+
     init(suppressionController: InputSuppressionController) {
         self.suppressionController = suppressionController
     }
@@ -30,6 +47,18 @@ final class SuggestionInserter {
             lastErrorMessage = "Suggestion was empty."
             CotabbyLogger.suggestion.warning("Insertion skipped: suggestion was empty after normalization")
             return false
+        }
+
+        // Paste path (opt-in): a long or multi-line completion is steadier as a clipboard paste in
+        // apps that mishandle a big synthetic Unicode string. On any failure we fall through to the
+        // reliable keystroke path below, so paste is never worse than the default keystroke insert.
+        if InsertionStrategySelector.strategy(
+            forChunk: normalized,
+            pasteEnabled: Self.isPasteInsertionEnabled
+        ) == .paste, insertViaPaste(normalized) {
+            lastErrorMessage = nil
+            CotabbyLogger.suggestion.debug("Inserted \(normalized.count) characters via clipboard paste")
+            return true
         }
 
         guard let keyDownEvent = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: true),
@@ -114,6 +143,69 @@ final class SuggestionInserter {
             "Replaced \(plan.backspaceCount) unit(s) with \(plan.insertUTF16.count)-unit text via synthetic keystrokes"
         )
         return true
+    }
+
+    /// Commits `text` by placing it on the pasteboard and synthesizing Cmd-V, then restoring the
+    /// user's clipboard shortly after. Returns false (having already restored the clipboard) if any
+    /// synthetic event could not be created, so the caller falls back to keystroke insertion. The
+    /// Cmd-V is tagged synthetic the same way `insert(_:)` tags its keydown so the consuming tap
+    /// ignores it.
+    private func insertViaPaste(_ text: String) -> Bool {
+        let pasteboard = NSPasteboard.general
+        let saved = Self.snapshotPasteboard(pasteboard)
+
+        pasteboard.clearContents()
+        guard pasteboard.setString(text, forType: .string) else {
+            Self.restorePasteboard(saved, to: pasteboard)
+            return false
+        }
+
+        guard let keyDown = CGEvent(keyboardEventSource: nil, virtualKey: Self.vKeyCode, keyDown: true),
+              let keyUp = CGEvent(keyboardEventSource: nil, virtualKey: Self.vKeyCode, keyDown: false) else {
+            Self.restorePasteboard(saved, to: pasteboard)
+            return false
+        }
+        keyDown.flags = .maskCommand
+        keyUp.flags = .maskCommand
+        suppressionController.markSynthetic(keyDown)
+        suppressionController.markSynthetic(keyUp)
+        suppressionController.registerSyntheticInsertion(expectedKeyDownCount: 1)
+        keyDown.post(tap: .cghidEventTap)
+        keyUp.post(tap: .cghidEventTap)
+
+        // Give the host time to service Cmd-V, then hand the clipboard back to the user.
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.pasteboardRestoreDelay) {
+            Self.restorePasteboard(saved, to: NSPasteboard.general)
+        }
+        return true
+    }
+
+    /// Captures every representation of every pasteboard item so the user's clipboard can be restored
+    /// exactly, not just its plain-text form.
+    private static func snapshotPasteboard(_ pasteboard: NSPasteboard) -> [[NSPasteboard.PasteboardType: Data]] {
+        (pasteboard.pasteboardItems ?? []).map { item in
+            var representations: [NSPasteboard.PasteboardType: Data] = [:]
+            for type in item.types where item.data(forType: type) != nil {
+                representations[type] = item.data(forType: type)
+            }
+            return representations
+        }
+    }
+
+    private static func restorePasteboard(
+        _ snapshot: [[NSPasteboard.PasteboardType: Data]],
+        to pasteboard: NSPasteboard
+    ) {
+        pasteboard.clearContents()
+        guard !snapshot.isEmpty else { return }
+        let items = snapshot.map { representations -> NSPasteboardItem in
+            let item = NSPasteboardItem()
+            for (type, data) in representations {
+                item.setData(data, forType: type)
+            }
+            return item
+        }
+        pasteboard.writeObjects(items)
     }
 }
 

--- a/Cotabby/Support/InsertionStrategySelector.swift
+++ b/Cotabby/Support/InsertionStrategySelector.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// File overview:
+/// Pure choice of how an accepted suggestion is committed to the host app. Synthetic Unicode
+/// keystrokes are reliable and clipboard-free for the common short, single-line completion, but some
+/// apps mishandle a long or multi-line synthetic string; pasting is steadier there. Keeping the
+/// decision here (separate from the side-effectful inserter) makes the policy trivially testable.
+enum InsertionStrategy: Equatable {
+    /// Synthesize the text as a Unicode keyboard event (the default, clipboard-free path).
+    case keystroke
+    /// Place the text on the pasteboard and synthesize Cmd-V. Only used when paste insertion is
+    /// enabled and the chunk is large or multi-line.
+    case paste
+}
+
+enum InsertionStrategySelector {
+    /// At or above this many characters a completion is a paste candidate. Short completions stay on
+    /// the keystroke path so the clipboard is never touched for the overwhelmingly common case.
+    static let pasteCharacterThreshold = 80
+
+    /// Picks the insertion strategy for `chunk`. Returns `.keystroke` whenever paste insertion is
+    /// disabled, so the default behavior is unchanged; otherwise it pastes multi-line or long chunks
+    /// and keystrokes the rest.
+    static func strategy(forChunk chunk: String, pasteEnabled: Bool) -> InsertionStrategy {
+        guard pasteEnabled else {
+            return .keystroke
+        }
+        if chunk.contains(where: \.isNewline) {
+            return .paste
+        }
+        return chunk.count >= pasteCharacterThreshold ? .paste : .keystroke
+    }
+}

--- a/CotabbyTests/InsertionStrategySelectorTests.swift
+++ b/CotabbyTests/InsertionStrategySelectorTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import Cotabby
+
+/// Tests for the pure keystroke-vs-paste insertion policy.
+///
+/// The contract: paste is opt-in and reserved for long or multi-line chunks; everything else stays on
+/// the default clipboard-free keystroke path, so enabling the flag never changes how short single-line
+/// completions are committed.
+final class InsertionStrategySelectorTests: XCTestCase {
+    func test_pasteDisabled_alwaysKeystroke() {
+        let long = String(repeating: "a", count: 200)
+        XCTAssertEqual(InsertionStrategySelector.strategy(forChunk: "hi", pasteEnabled: false), .keystroke)
+        XCTAssertEqual(InsertionStrategySelector.strategy(forChunk: long, pasteEnabled: false), .keystroke)
+        XCTAssertEqual(InsertionStrategySelector.strategy(forChunk: "a\nb", pasteEnabled: false), .keystroke)
+    }
+
+    func test_pasteEnabled_shortSingleLineKeystrokes() {
+        XCTAssertEqual(
+            InsertionStrategySelector.strategy(forChunk: "a short completion", pasteEnabled: true),
+            .keystroke
+        )
+    }
+
+    func test_pasteEnabled_multiLinePastes() {
+        XCTAssertEqual(
+            InsertionStrategySelector.strategy(forChunk: "line one\nline two", pasteEnabled: true),
+            .paste
+        )
+    }
+
+    func test_pasteEnabled_longChunkPastes() {
+        let long = String(repeating: "a", count: InsertionStrategySelector.pasteCharacterThreshold)
+        XCTAssertEqual(InsertionStrategySelector.strategy(forChunk: long, pasteEnabled: true), .paste)
+    }
+
+    func test_pasteEnabled_justBelowThresholdKeystrokes() {
+        let nearly = String(repeating: "a", count: InsertionStrategySelector.pasteCharacterThreshold - 1)
+        XCTAssertEqual(InsertionStrategySelector.strategy(forChunk: nearly, pasteEnabled: true), .keystroke)
+    }
+}

--- a/docs/POLLING_AND_DELAYS.md
+++ b/docs/POLLING_AND_DELAYS.md
@@ -31,6 +31,7 @@ Update this file whenever you add, remove, or change a timing constant.
 |----------|-------|---------|
 | `Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift:354` | 30 ms | Post-insertion refresh delay. Gives the host app time to process the synthetic keystroke before we snap the overlay caret to the new position. |
 | `Cotabby/Services/Input/InputMonitor.swift:137` | 50 ms | Accept-tap teardown delay. Defers mach-port invalidation so a final-chunk accept's synthetic keystroke can drain before the tap is removed. |
+| `Cotabby/Services/Suggestion/SuggestionInserter.swift` (`pasteboardRestoreDelay`) | 150 ms | Pasteboard restore delay for the opt-in paste insertion path (`cotabbyPasteInsertionEnabled`). How long the completion sits on the clipboard for the host to service Cmd-V before the user's clipboard is restored. Default-off; tune on device. |
 
 ## Visual Context
 


### PR DESCRIPTION
## Summary

`SuggestionInserter` commits a completion as one synthetic Unicode keydown, which some apps mishandle for long or multi-line text. This adds an opt-in paste path: place the completion on the pasteboard, synthesize Cmd-V, then restore the user's clipboard.

- **`InsertionStrategySelector`** (new, pure, tested): paste only when enabled *and* the chunk is long (>= 80 chars) or multi-line; keystroke otherwise.
- **`SuggestionInserter`** consults it at the top of `insert()`. If paste is chosen and anything fails (pasteboard write or event creation), it falls through to the existing keystroke path, so paste is never worse than the default. The Cmd-V is tagged synthetic like every other inserted event so the consuming tap ignores it, and the full pasteboard contents (every representation, not just plain text) are snapshotted and restored.

## Validation

```
xcodebuild ... test ... CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO \
  -only-testing:CotabbyTests/InsertionStrategySelectorTests
# ** TEST SUCCEEDED **  (full app target builds the inserter + clipboard path)
#   selector: disabled = always keystroke; enabled = paste for multi-line / >= threshold,
#     keystroke just below threshold

swiftlint --strict   # exit 0 (CI-equivalent)
xcodegen generate    # registered the new source + test file
```

To exercise on device: `defaults write com.jacobfu.tabby cotabbyPasteInsertionEnabled -bool YES`.

## Linked issues

None. Filtering/insertion parity: paste/chunk insertion strategy.

## Risk / rollout notes

- **Default-off and fail-safe.** With the flag off — or for a short single-line completion — the clipboard is never touched and behavior is byte-for-byte unchanged. If the paste path fails for any reason it falls back to the existing keystroke insert.
- The one residual risk is the pasteboard restore: the completion sits on the clipboard for `pasteboardRestoreDelay` (150 ms, catalogued in `docs/POLLING_AND_DELAYS.md`) before the user's clipboard is restored. Promoting this needs on-device validation of which apps actually benefit and tuning of that delay.
- `project.pbxproj` regenerated by XcodeGen for the two new files.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an opt-in clipboard-paste insertion path for long (≥ 80 chars) or multi-line completions, routing them through `NSPasteboard` + a synthetic Cmd-V instead of the existing single Unicode keystroke, to handle apps that mishandle large synthetic strings. The feature is default-off via a `UserDefaults` flag and falls back to the keystroke path on any failure.

- **`InsertionStrategySelector`** (new, pure, fully tested): decides keystroke vs. paste based on the flag, line count, and character threshold — cleanly separated from side effects.
- **`SuggestionInserter.insertViaPaste`**: snapshots the full pasteboard (all representations), writes the completion, synthesizes Cmd-V (tagged synthetic so the consuming tap ignores it), and schedules clipboard restoration after 150 ms.
- The main open risk is the pasteboard restore timing: if two completions are accepted within the 150 ms window, the second call snapshots the pasteboard while the first completion is still on it, causing the deferred restores to leave that completion string on the clipboard after both fire.

<h3>Confidence Score: 3/5</h3>

Safe to merge behind the default-off flag, but the clipboard restore logic has a correctness defect that should be fixed before the feature is promoted.

The paste path snapshots the pasteboard at the top of `insertViaPaste`, but if a second completion is accepted within the 150 ms restore window, that snapshot captures the first completion string rather than the user's original clipboard. Both timed restores then fire in sequence, and the second one writes the first completion back onto the pasteboard, permanently replacing whatever the user actually had. Since the feature is opt-in and default-off this cannot regress existing users, but anyone dogfooding the flag could end up with a stale completion string on their clipboard after back-to-back accepts.

The restore-race logic in `insertViaPaste` inside `SuggestionInserter.swift` needs attention before the flag is widened.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Services/Suggestion/SuggestionInserter.swift | Adds paste insertion path via `insertViaPaste`; the clipboard snapshot captured at the start of a second concurrent call can capture a prior completion instead of the user's original clipboard, leaving stale text on the clipboard after both restores fire. |
| Cotabby/Support/InsertionStrategySelector.swift | Pure strategy enum and selector; logic is correct and clearly separated from side effects. Uses Swift Character-count for the threshold, which is consistent and intentional. |
| CotabbyTests/InsertionStrategySelectorTests.swift | Covers all decision branches (disabled, short, multi-line, at-threshold, just-below-threshold). No issues. |
| docs/POLLING_AND_DELAYS.md | Documents the new 150 ms pasteboard restore delay with correct file reference and context. |
| Cotabby.xcodeproj/project.pbxproj | XcodeGen-regenerated project file; correctly registers InsertionStrategySelector.swift in the app target and InsertionStrategySelectorTests.swift in the test target. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant SuggestionInserter
    participant InsertionStrategySelector
    participant NSPasteboard
    participant CGEventTap

    Caller->>SuggestionInserter: insert(suggestion)
    SuggestionInserter->>InsertionStrategySelector: strategy(forChunk:pasteEnabled:)
    InsertionStrategySelector-->>SuggestionInserter: .paste / .keystroke

    alt "strategy == .paste"
        SuggestionInserter->>NSPasteboard: snapshotPasteboard() → saved
        SuggestionInserter->>NSPasteboard: clearContents() + setString(text)
        SuggestionInserter->>CGEventTap: post Cmd-V (keyDown + keyUp, tagged synthetic)
        SuggestionInserter->>SuggestionInserter: asyncAfter(150ms): restorePasteboard(saved)
        SuggestionInserter-->>Caller: true
    else "strategy == .keystroke (or paste failed)"
        SuggestionInserter->>CGEventTap: post Unicode keyDown + keyUp (virtualKey 0)
        SuggestionInserter-->>Caller: true / false
    end

    Note over SuggestionInserter,NSPasteboard: 150 ms later
    SuggestionInserter->>NSPasteboard: restorePasteboard(saved)
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fpaste-insertion%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fpaste-insertion%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FServices%2FSuggestion%2FSuggestionInserter.swift%3A153-181%0A**Clipboard%20snapshot%20captured%20after%20a%20previous%20paste%2C%20not%20before%20it**%0A%0AIf%20%60insertViaPaste%60%20is%20called%20a%20second%20time%20within%20the%20150%20ms%20restore%20window%20%28e.g.%2C%20rapid%20successive%20accepts%20or%20auto-accept%29%2C%20%60saved%60%20at%20line%20155%20snapshots%20the%20pasteboard%20while%20the%20first%20completion%20is%20still%20sitting%20on%20it%20%E2%80%94%20not%20the%20user's%20original%20clipboard.%20The%20first%20restore%20fires%20at%20T%2B150%20ms%20and%20correctly%20puts%20the%20original%20content%20back%2C%20but%20the%20second%20restore%20fires%20at%20T'%2B150%20ms%20and%20overwrites%20it%20with%20the%20first%20completion's%20text%2C%20permanently%20replacing%20the%20user's%20real%20clipboard%20with%20a%20stale%20completion%20string.%0A%0AA%20cancel-and-reschedule%20strategy%20%28cancel%20any%20in-flight%20restore%2C%20capture%20from%20the%20existing%20%60saved%60%20reference%20before%20overwriting%20it%29%20or%20a%20module-level%20%60originalClipboardSnapshot%60%20that%20is%20only%20populated%20when%20none%20is%20already%20pending%20would%20protect%20the%20invariant.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FServices%2FSuggestion%2FSuggestionInserter.swift%3A188-190%0A%60item.data%28forType%3A%20type%29%60%20is%20called%20twice%20for%20every%20pasteboard%20type%20%E2%80%94%20once%20in%20the%20%60where%60%20guard%20and%20once%20to%20fetch%20the%20value.%20For%20large%20items%20%28images%2C%20rich%20text%29%2C%20this%20doubles%20the%20copy%20cost%20and%20can%20be%20avoided%20with%20a%20single%20%60if%20let%60%20binding.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20for%20type%20in%20item.types%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20let%20data%20%3D%20item.data%28forType%3A%20type%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20representations%5Btype%5D%20%3D%20data%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FServices%2FSuggestion%2FSuggestionInserter.swift%3A153-181%0A**Clipboard%20snapshot%20captured%20after%20a%20previous%20paste%2C%20not%20before%20it**%0A%0AIf%20%60insertViaPaste%60%20is%20called%20a%20second%20time%20within%20the%20150%20ms%20restore%20window%20%28e.g.%2C%20rapid%20successive%20accepts%20or%20auto-accept%29%2C%20%60saved%60%20at%20line%20155%20snapshots%20the%20pasteboard%20while%20the%20first%20completion%20is%20still%20sitting%20on%20it%20%E2%80%94%20not%20the%20user's%20original%20clipboard.%20The%20first%20restore%20fires%20at%20T%2B150%20ms%20and%20correctly%20puts%20the%20original%20content%20back%2C%20but%20the%20second%20restore%20fires%20at%20T'%2B150%20ms%20and%20overwrites%20it%20with%20the%20first%20completion's%20text%2C%20permanently%20replacing%20the%20user's%20real%20clipboard%20with%20a%20stale%20completion%20string.%0A%0AA%20cancel-and-reschedule%20strategy%20%28cancel%20any%20in-flight%20restore%2C%20capture%20from%20the%20existing%20%60saved%60%20reference%20before%20overwriting%20it%29%20or%20a%20module-level%20%60originalClipboardSnapshot%60%20that%20is%20only%20populated%20when%20none%20is%20already%20pending%20would%20protect%20the%20invariant.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FServices%2FSuggestion%2FSuggestionInserter.swift%3A188-190%0A%60item.data%28forType%3A%20type%29%60%20is%20called%20twice%20for%20every%20pasteboard%20type%20%E2%80%94%20once%20in%20the%20%60where%60%20guard%20and%20once%20to%20fetch%20the%20value.%20For%20large%20items%20%28images%2C%20rich%20text%29%2C%20this%20doubles%20the%20copy%20cost%20and%20can%20be%20avoided%20with%20a%20single%20%60if%20let%60%20binding.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20for%20type%20in%20item.types%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20let%20data%20%3D%20item.data%28forType%3A%20type%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20representations%5Btype%5D%20%3D%20data%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=530&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add opt-in clipboard paste insertion for..."](https://github.com/fujacob/cotabby/commit/7a1266390d73503393a35645b3728aeae75f556d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35059781)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->