### PR TITLE
Add token-aware prompt budgeting as an opt-in path

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -184,6 +184,7 @@
 		A0657CE0488F69F0BD559CBC /* SuggestionCoordinator+Acceptance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72B13136DF7318F3E96DF0D3 /* SuggestionCoordinator+Acceptance.swift */; };
 		A0BB87E3665EF6C209034798 /* GhostSuggestionLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AD3F4F9FBE82007E4E15F58 /* GhostSuggestionLayoutTests.swift */; };
 		A147C5EC3F2214A670F7556E /* FocusPollBackoffTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 273B4DC844F79B4BE2C8910F /* FocusPollBackoffTests.swift */; };
+		A26E14A6E73036222419C424 /* TokenCountEstimatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B78AA11B52A6588119ABF76F /* TokenCountEstimatorTests.swift */; };
 		A2B3F4D38BCB0FED452B2A3F /* FocusTrackingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D42CD456B4B3C988B148A6 /* FocusTrackingModel.swift */; };
 		A36481222BB5B2A67349D389 /* ApplicationBundleMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A168A7B6A7AD11559B60C56B /* ApplicationBundleMetadataTests.swift */; };
 		A5A6CE0EF01CA6A9AFA7A400 /* RequestID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DC693E00430F46E41CB56E6 /* RequestID.swift */; };
@@ -234,6 +235,7 @@
 		DA23422A2CF77CFD3B1283C8 /* OnboardingTemplateFeatureListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D814BBA41CF29E8DD9954651 /* OnboardingTemplateFeatureListTests.swift */; };
 		DA2A22F5386CC25420E98E6C /* FillInMiddlePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 276FA037D0F8DF51AABF4292 /* FillInMiddlePolicy.swift */; };
 		DB1310FF3576ACA6472C4DB1 /* TrailingDuplicationFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19A5B462891263BDFB56607 /* TrailingDuplicationFilterTests.swift */; };
+		DC84D6A6A2F9A1060CD20ABB /* TokenCountEstimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BA30E71C21C77BB6EA4C166 /* TokenCountEstimator.swift */; };
 		DCABB8D2B391C7820D6CA5FF /* InsertionSafetyGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D472F9F396672E57873303B /* InsertionSafetyGate.swift */; };
 		DD7FA343F1C21C4569F6D181 /* ScreenshotContextGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B84BAE361626891F19DC9DB /* ScreenshotContextGenerator.swift */; };
 		DDEDCBAA2196303455F6926A /* AcceptanceModePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5DAF68AEBFE334F68A65E82 /* AcceptanceModePickerView.swift */; };
@@ -314,6 +316,7 @@
 		19BE12C28A4AB8A4A58C2FF7 /* SettingsPaneScaffold.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPaneScaffold.swift; sourceTree = "<group>"; };
 		19DB9558F4D3AFB108D71649 /* SuggestionStateHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionStateHelperTests.swift; sourceTree = "<group>"; };
 		1A8414BEB7E34F57607E37FE /* EmojiVariantResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiVariantResolver.swift; sourceTree = "<group>"; };
+		1BA30E71C21C77BB6EA4C166 /* TokenCountEstimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenCountEstimator.swift; sourceTree = "<group>"; };
 		1BD71ECC2AE4821B643E0935 /* ConfidenceSuppressionPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfidenceSuppressionPolicy.swift; sourceTree = "<group>"; };
 		1CE61E74928C221B8BB261C6 /* SuggestionTextColorCodec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionTextColorCodec.swift; sourceTree = "<group>"; };
 		1D00A031C0D9CF2A7A2330D9 /* PermissionDragSourceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionDragSourceView.swift; sourceTree = "<group>"; };
@@ -465,6 +468,7 @@
 		B4B4A2E2DD6733658EC05BD8 /* DownloadFileRescuer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadFileRescuer.swift; sourceTree = "<group>"; };
 		B6ACCB12E4DB32D2F2BEA567 /* PermissionHostApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionHostApp.swift; sourceTree = "<group>"; };
 		B6D42CD456B4B3C988B148A6 /* FocusTrackingModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusTrackingModel.swift; sourceTree = "<group>"; };
+		B78AA11B52A6588119ABF76F /* TokenCountEstimatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenCountEstimatorTests.swift; sourceTree = "<group>"; };
 		B7B185BA246A526CBA85E581 /* EmojiPickerPanelLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiPickerPanelLayoutTests.swift; sourceTree = "<group>"; };
 		B81DD30EB657368AACE9625A /* InputMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputMonitor.swift; sourceTree = "<group>"; };
 		B997EC69E1C65B1E18234221 /* BrowserAppDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserAppDetector.swift; sourceTree = "<group>"; };
@@ -839,6 +843,7 @@
 				C71031E8DB171047318B92FC /* SyntheticReplacePlannerTests.swift */,
 				43E37A7E835D3BDE6265843C /* TerminalAppDetectorTests.swift */,
 				FC24FD54860CE6737E65EF65 /* TextDirectionDetectorTests.swift */,
+				B78AA11B52A6588119ABF76F /* TokenCountEstimatorTests.swift */,
 				F394B8A6E30CC47015772089 /* TokenProfileCacheTests.swift */,
 				E7D0BF193110927BEB865748 /* TokenProfileTests.swift */,
 				E19A5B462891263BDFB56607 /* TrailingDuplicationFilterTests.swift */,
@@ -998,6 +1003,7 @@
 				B424E2AC97C99D335B0D5751 /* SuggestionTextNormalizer.swift */,
 				7F4C4A7EAF886E0CC945BFEF /* TerminalAppDetector.swift */,
 				328847A0F494360033366791 /* TextDirectionDetector.swift */,
+				1BA30E71C21C77BB6EA4C166 /* TokenCountEstimator.swift */,
 				F3CEFE8C321E17BB3873C893 /* TokenProfile.swift */,
 				E73C04A71D85B25998144F11 /* TokenProfileCache.swift */,
 				D408D647412C59F3E692C42B /* TrailingDuplicationFilter.swift */,
@@ -1289,6 +1295,7 @@
 				AB9C9C001F97F9D14F8B192A /* TerminalAppDetector.swift in Sources */,
 				96782E57CA26A16409368B69 /* TextDirectionDetector.swift in Sources */,
 				6014B31E2570EFFE45557E33 /* TickMarkSlider.swift in Sources */,
+				DC84D6A6A2F9A1060CD20ABB /* TokenCountEstimator.swift in Sources */,
 				8EED2B55999A119AE3B67359 /* TokenProfile.swift in Sources */,
 				D747A2C2B49450D26C6179A7 /* TokenProfileCache.swift in Sources */,
 				D3B43622E5A41B11E7AF527E /* TrailingDuplicationFilter.swift in Sources */,
@@ -1384,6 +1391,7 @@
 				EF5BAB96DDADABB86F9E02D9 /* SyntheticReplacePlannerTests.swift in Sources */,
 				DE236C9285635C686D66A2F6 /* TerminalAppDetectorTests.swift in Sources */,
 				5A441797D71A880A7482077D /* TextDirectionDetectorTests.swift in Sources */,
+				A26E14A6E73036222419C424 /* TokenCountEstimatorTests.swift in Sources */,
 				D9B992A608F7FC9924D13271 /* TokenProfileCacheTests.swift in Sources */,
 				CA8F453AA4AD02FAA8C961F7 /* TokenProfileTests.swift in Sources */,
 				DB1310FF3576ACA6472C4DB1 /* TrailingDuplicationFilterTests.swift in Sources */,

--- a/Cotabby/Support/BaseCompletionPromptRenderer.swift
+++ b/Cotabby/Support/BaseCompletionPromptRenderer.swift
@@ -27,7 +27,8 @@ enum BaseCompletionPromptRenderer {
         languageInstruction: String? = nil,
         clipboardContext: String? = nil,
         visualContextSummary: String? = nil,
-        contextBudget: Int = defaultContextBudget
+        contextBudget: Int = defaultContextBudget,
+        tokenBudget: Int? = nil
     ) -> String {
         let trimmedPrefix = Self.trimmingTrailingWhitespace(prefixText)
 
@@ -65,7 +66,19 @@ enum BaseCompletionPromptRenderer {
             )
         )
 
-        let kept = PromptSectionBudget.allocate(sections, totalChars: contextBudget)
+        // Token-aware budgeting (opt-in): when a token budget is supplied, fill sections against an
+        // estimated-token window instead of the character approximation. Defaults to the character
+        // path so shipped behavior is unchanged.
+        let kept: [PromptSection]
+        if let tokenBudget {
+            kept = PromptSectionBudget.allocate(
+                sections,
+                totalTokens: tokenBudget,
+                estimate: TokenCountEstimator.estimate
+            )
+        } else {
+            kept = PromptSectionBudget.allocate(sections, totalChars: contextBudget)
+        }
         let prefix = kept.first { $0.name == "prefix" }?.content ?? trimmedPrefix
         let preface = kept.filter { $0.name != "prefix" }.map(\.content)
 

--- a/Cotabby/Support/PromptSectionBudget.swift
+++ b/Cotabby/Support/PromptSectionBudget.swift
@@ -106,7 +106,10 @@ enum PromptSectionBudget {
             var copy = section
             copy.content = truncated
             kept[index] = copy
-            remainingTokens -= estimate(truncated)
+            // Clamp: a truncated slice can be token-denser than the section average, so deducting its
+            // estimate could drive `remainingTokens` negative and wrongly drop the next section even
+            // when it would fit. Floor at zero so over-deduction never reads as a hard stop.
+            remainingTokens = max(0, remainingTokens - estimate(truncated))
         }
 
         return sections.indices.compactMap { kept[$0] }

--- a/Cotabby/Support/PromptSectionBudget.swift
+++ b/Cotabby/Support/PromptSectionBudget.swift
@@ -69,6 +69,49 @@ enum PromptSectionBudget {
         return sections.indices.compactMap { kept[$0] }
     }
 
+    /// Token-aware variant of `allocate`: the budget and remaining are counted in *estimated tokens*
+    /// (via `estimate`) instead of characters, so a base model's real context window is respected more
+    /// faithfully than a flat chars-per-token ratio — which matters most for code or non-Latin text,
+    /// where that ratio is far from four. Each section's intrinsic `minChars`/`maxChars` still bound
+    /// the content itself; the per-section token cap is converted to a character cap using that
+    /// content's own character-per-token density, so the character-based `truncate` is reused as is.
+    static func allocate(
+        _ sections: [PromptSection],
+        totalTokens: Int,
+        estimate: (String) -> Int
+    ) -> [PromptSection] {
+        var remainingTokens = max(0, totalTokens)
+
+        let fillOrder = sections.enumerated().sorted { lhs, rhs in
+            lhs.element.priority == rhs.element.priority
+                ? lhs.offset < rhs.offset
+                : lhs.element.priority > rhs.element.priority
+        }
+
+        var kept: [Int: PromptSection] = [:]
+        for (index, section) in fillOrder {
+            guard remainingTokens > 0 else { break }
+            let contentTokens = max(1, estimate(section.content))
+            let charsPerToken = Double(section.content.count) / Double(contentTokens)
+            let remainingChars = Int((Double(remainingTokens) * charsPerToken).rounded(.down))
+            let cap = min(section.maxChars, section.content.count, remainingChars)
+            if cap < section.minChars {
+                continue
+            }
+            let truncated = truncate(section.content, toChars: cap, mode: section.truncation)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !truncated.isEmpty else {
+                continue
+            }
+            var copy = section
+            copy.content = truncated
+            kept[index] = copy
+            remainingTokens -= estimate(truncated)
+        }
+
+        return sections.indices.compactMap { kept[$0] }
+    }
+
     /// Truncates `text` to at most `chars`, keeping the start or the end per `mode`. Returns the
     /// input unchanged when it already fits, and the empty string when `chars <= 0`.
     static func truncate(_ text: String, toChars chars: Int, mode: PromptSection.Truncation) -> String {

--- a/Cotabby/Support/TokenCountEstimator.swift
+++ b/Cotabby/Support/TokenCountEstimator.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// File overview:
+/// A pure, cheap estimate of how many model tokens a string occupies, used to budget the base-model
+/// prompt more faithfully than a flat character count without paying for a real tokenizer on the
+/// main-actor prompt path.
+///
+/// It is intentionally an approximation: a word-aware heuristic (roughly four characters per token
+/// within a word, every word at least one token) is closer to real subword tokenization than a single
+/// global chars-per-token ratio — especially for code or short function words — while staying
+/// allocation-light and deterministic for tests. It is not exact, so it is used only for relative
+/// budgeting decisions, never to assert a hard token limit.
+enum TokenCountEstimator {
+    static func estimate(_ text: String) -> Int {
+        let words = text.split(whereSeparator: { $0.isWhitespace })
+        guard !words.isEmpty else {
+            return 0
+        }
+        return words.reduce(0) { total, word in
+            total + max(1, Int((Double(word.count) / 4.0).rounded()))
+        }
+    }
+}

--- a/Cotabby/Support/TokenCountEstimator.swift
+++ b/Cotabby/Support/TokenCountEstimator.swift
@@ -12,7 +12,10 @@ import Foundation
 /// budgeting decisions, never to assert a hard token limit.
 enum TokenCountEstimator {
     static func estimate(_ text: String) -> Int {
-        let words = text.split(whereSeparator: { $0.isWhitespace })
+        // Split on punctuation as well as whitespace: real subword tokenizers break "can't", "end.",
+        // and "func()" into multiple tokens, so gluing punctuation to a word would systematically
+        // undercount code and punctuation-heavy prose.
+        let words = text.split(whereSeparator: { $0.isWhitespace || $0.isPunctuation })
         guard !words.isEmpty else {
             return 0
         }

--- a/CotabbyTests/BaseCompletionPromptRendererTests.swift
+++ b/CotabbyTests/BaseCompletionPromptRendererTests.swift
@@ -42,6 +42,22 @@ final class BaseCompletionPromptRendererTests: XCTestCase {
         XCTAssertTrue(prompt.hasSuffix("the meeting is at"))
     }
 
+    func test_tokenBudget_keepsCaretPrefixUnderATightBudget() {
+        // The opt-in token-budgeted path must keep the caret prefix (top priority) at the very end,
+        // exactly like the character path, while a tight budget trims lower-priority context.
+        let prompt = BaseCompletionPromptRenderer.prompt(
+            prefixText: "the meeting is at",
+            applicationName: "Slack",
+            userName: "Jacob",
+            customRules: ["terse"],
+            extendedContext: "Project Matcha ships in June with a great many additional notes kept here.",
+            clipboardContext: "zoom link",
+            visualContextSummary: "Calendar: Q3 planning 3pm",
+            tokenBudget: 8
+        )
+        XCTAssertTrue(prompt.hasSuffix("the meeting is at"), "the caret prefix is never starved under a token budget")
+    }
+
     func test_personaFramingConditionsOnNameStyleAndLanguage() {
         let prompt = BaseCompletionPromptRenderer.prompt(
             prefixText: "Hi team,",

--- a/CotabbyTests/PromptSectionBudgetTests.swift
+++ b/CotabbyTests/PromptSectionBudgetTests.swift
@@ -78,4 +78,39 @@ final class PromptSectionBudgetTests: XCTestCase {
     func test_truncate_returnsInputWhenItFits() {
         XCTAssertEqual(PromptSectionBudget.truncate("abc", toChars: 10, mode: .preserveEnd), "abc")
     }
+
+    // MARK: - Token-aware allocate
+
+    func test_tokenAllocate_keepsAllWhenBudgetAmple() {
+        let kept = PromptSectionBudget.allocate(
+            [section("a", "alpha", priority: 10), section("b", "beta", priority: 5)],
+            totalTokens: 1000,
+            estimate: TokenCountEstimator.estimate
+        )
+        XCTAssertEqual(kept.map(\.name), ["a", "b"])
+    }
+
+    func test_tokenAllocate_dropsLowerPriorityWhenBudgetTight() {
+        let low = String(repeating: "word ", count: 5)
+        let high = String(repeating: "term ", count: 5)
+        let kept = PromptSectionBudget.allocate(
+            [section("low", low, priority: 1), section("high", high, priority: 9)],
+            totalTokens: 5,
+            estimate: TokenCountEstimator.estimate
+        )
+        XCTAssertEqual(kept.map(\.name), ["high"])
+    }
+
+    func test_tokenAllocate_respectsTokenBudget() {
+        let kept = PromptSectionBudget.allocate(
+            [
+                section("a", String(repeating: "alpha ", count: 20), priority: 9),
+                section("b", String(repeating: "bravo ", count: 20), priority: 8)
+            ],
+            totalTokens: 25,
+            estimate: TokenCountEstimator.estimate
+        )
+        let used = kept.reduce(0) { $0 + TokenCountEstimator.estimate($1.content) }
+        XCTAssertLessThanOrEqual(used, 25)
+    }
 }

--- a/CotabbyTests/TokenCountEstimatorTests.swift
+++ b/CotabbyTests/TokenCountEstimatorTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import Cotabby
+
+/// Tests for the heuristic token-count estimator. It is deliberately approximate, so these lock down
+/// robust *relationships* (empty is zero, longer text estimates more, every word counts) rather than
+/// exact token counts a real tokenizer would produce.
+final class TokenCountEstimatorTests: XCTestCase {
+    func test_emptyOrWhitespaceIsZero() {
+        XCTAssertEqual(TokenCountEstimator.estimate(""), 0)
+        XCTAssertEqual(TokenCountEstimator.estimate("   \n\t "), 0)
+    }
+
+    func test_everyWordIsAtLeastOneToken() {
+        XCTAssertEqual(TokenCountEstimator.estimate("a"), 1)
+        XCTAssertGreaterThanOrEqual(TokenCountEstimator.estimate("hi there"), 2)
+    }
+
+    func test_longerTextEstimatesMoreTokens() {
+        let short = TokenCountEstimator.estimate("the cat sat")
+        let long = TokenCountEstimator.estimate("the cat sat on the warm windowsill all afternoon long")
+        XCTAssertGreaterThan(long, short)
+    }
+
+    func test_longWordCountsForMoreThanShortWord() {
+        XCTAssertGreaterThan(
+            TokenCountEstimator.estimate("internationalization"),
+            TokenCountEstimator.estimate("cat")
+        )
+    }
+
+    func test_scalesWithWordCount() {
+        let oneWord = TokenCountEstimator.estimate("word")
+        let fiveWords = TokenCountEstimator.estimate("word word word word word")
+        XCTAssertEqual(fiveWords, oneWord * 5)
+    }
+}

--- a/CotabbyTests/TokenCountEstimatorTests.swift
+++ b/CotabbyTests/TokenCountEstimatorTests.swift
@@ -33,4 +33,11 @@ final class TokenCountEstimatorTests: XCTestCase {
         let fiveWords = TokenCountEstimator.estimate("word word word word word")
         XCTAssertEqual(fiveWords, oneWord * 5)
     }
+
+    func test_splitsOnPunctuationBoundaries() {
+        // Punctuation creates token boundaries (like real subword tokenizers), so a contraction or a
+        // punctuation-joined identifier estimates more tokens than the same letters with none.
+        XCTAssertGreaterThan(TokenCountEstimator.estimate("can't"), TokenCountEstimator.estimate("cant"))
+        XCTAssertGreaterThan(TokenCountEstimator.estimate("foo.bar.baz"), TokenCountEstimator.estimate("foobarbaz"))
+    }
 }


### PR DESCRIPTION
## Summary

The base-model prompt is budgeted in characters as a deliberate ~4-chars-per-token approximation (see `PromptSectionBudget`'s own comment). That ratio is far off for code and non-Latin text. This adds a token-aware budgeting path — the swap the comment anticipated — without paying for the runtime tokenizer on the main-actor prompt path.

- **`TokenCountEstimator`** (new, pure, tested): a cheap word-aware heuristic (roughly four characters per token within a word, every word at least one token), closer to subword tokenization than a single global ratio and deterministic for tests.
- **`PromptSectionBudget.allocate(_:totalTokens:estimate:)`** (new, additive): fills by priority against an estimated-token budget, converting each section's token cap to a character cap via that content's own density so the existing character-based `truncate` is reused unchanged. The character `allocate` is untouched.
- **`BaseCompletionPromptRenderer`** takes an optional `tokenBudget`; nil keeps the character path.

## Validation

```
xcodebuild ... test ... CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO \
  -only-testing:CotabbyTests/TokenCountEstimatorTests \
  -only-testing:CotabbyTests/PromptSectionBudgetTests \
  -only-testing:CotabbyTests/BaseCompletionPromptRendererTests
# ** TEST SUCCEEDED **
#   estimator: empty=0, every word >=1 token, longer text estimates more, scales with word count
#   token allocate: priority fill, drops low priority when tight, respects the token budget
#   renderer: the caret prefix stays un-starved under a tight token budget; char-path tests unchanged

swiftlint --strict   # exit 0 (CI-equivalent)
xcodegen generate    # registered the new source + test file
```

## Linked issues

None. Prompting parity: token-aware (vs flat character) section budgeting.

## Risk / rollout notes

- **Opt-in, no behavior change.** `tokenBudget` defaults to nil, so the character path is taken and shipped behavior is byte-for-byte unchanged; the existing budget and renderer tests pass untouched.
- This lands the pure, tested estimator and token allocator. Wiring a caller to pass a real token budget is the follow-up: the right budget value and the quality delta over the character approximation need on-device validation, so it stays opt-in until then. The estimator is intentionally approximate and used only for relative budgeting, never a hard token limit.
- `project.pbxproj` regenerated by XcodeGen for the two new files.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces an opt-in token-aware prompt budgeting path as a drop-in complement to the existing character-based allocator. The `tokenBudget` parameter defaults to `nil` so no shipped behaviour changes until a caller is wired in a follow-up.

- **`TokenCountEstimator`** (new): a pure word-aware heuristic that splits on both whitespace and punctuation, giving closer approximations for code and punctuation-heavy prose without a real tokenizer on the main-actor path.
- **`PromptSectionBudget.allocate(_:totalTokens:estimate:)`** (new): fills sections by priority against an estimated-token budget, converting each section's token cap to chars via that section's own density so the existing `truncate` helper is reused unchanged; a `max(0,…)` clamp prevents density-inverted truncated slices from blocking subsequent sections.
- **`BaseCompletionPromptRenderer`**: routes to the new token allocator only when `tokenBudget` is non-nil, leaving the character path byte-for-byte identical.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the new token path is fully opt-in (nil default), all existing tests pass unchanged, and the two issues raised in the prior review round have been addressed.

The change is additive and isolated behind a nil-default parameter, so no existing behaviour can regress. The new allocator correctly handles priority ordering, the density-inversion clamp, and empty/whitespace content. The estimator now splits on punctuation as well as whitespace, matching what real subword tokenizers do. No caller yet passes a non-nil tokenBudget, so the new path has zero production exposure until explicitly wired.

No files require special attention. The one observation is a test-quality note in PromptSectionBudgetTests.swift around an assertion that holds only for uniform-density data.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/TokenCountEstimator.swift | New pure estimator; splits on both whitespace and punctuation (addressing the previous-thread finding), correctly floors at 1 token per word, returns 0 for empty/whitespace-only input. |
| Cotabby/Support/PromptSectionBudget.swift | Adds token-aware allocate overload; correctly converts remaining tokens to chars via per-section density, clamps to 0 on over-deduction (addressing prior thread). The max(0,…) clamp means a density-inverted truncated slice can push total token usage over totalTokens, but the relaxation is design-intentional. |
| Cotabby/Support/BaseCompletionPromptRenderer.swift | Clean opt-in: tokenBudget defaults to nil, preserving existing char-path behavior byte-for-byte; the if-let branch routes to the new token allocate only when a budget is supplied. |
| CotabbyTests/PromptSectionBudgetTests.swift | Three new token-allocate tests; priority fill and budget-drop are well-covered. The test_tokenAllocate_respectsTokenBudget assertion holds only because the test data is uniform density — non-uniform data can produce used > totalTokens by design. |
| CotabbyTests/TokenCountEstimatorTests.swift | Good relational test coverage (empty=0, minimum 1 token/word, monotone growth, punctuation boundary splitting); locks behaviour without over-specifying exact counts. |
| CotabbyTests/BaseCompletionPromptRendererTests.swift | New test verifies the highest-priority caret prefix survives a tight token budget (8 tokens); existing char-path tests left unchanged as claimed. |
| Cotabby.xcodeproj/project.pbxproj | XcodeGen-regenerated; correctly registers TokenCountEstimator.swift in the main target and TokenCountEstimatorTests.swift in the test target. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[BaseCompletionPromptRenderer.prompt] --> B{tokenBudget != nil?}
    B -- Yes --> C[PromptSectionBudget.allocate\ntotalTokens: tokenBudget\nestimate: TokenCountEstimator.estimate]
    B -- No --> D[PromptSectionBudget.allocate\ntotalChars: contextBudget]
    C --> E[Sort sections by priority descending]
    D --> F[Sort sections by priority descending]
    E --> G[For each section\ncompute charsPerToken density\nconvert remainingTokens to remainingChars\ncap = min maxChars, content.count, remainingChars]
    F --> H[For each section\ncap = min maxChars, content.count, remaining]
    G --> I{cap >= minChars?}
    H --> I
    I -- No --> J[Drop section, continue]
    I -- Yes --> K[truncate + trim]
    K --> L{truncated empty?}
    L -- Yes --> J
    L -- No --> M[Keep section\ndeduct from budget\nclamp to 0]
    M --> N[Return sections in original order]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Ftoken-budgeting%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Ftoken-budgeting%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabbyTests%2FPromptSectionBudgetTests.swift%3A101-113%0A**Test%20assertion%20silently%20relies%20on%20uniform-density%20data**%0A%0A%60XCTAssertLessThanOrEqual%28used%2C%2025%29%60%20holds%20for%20the%20specific%20%22alpha%22%2F%22bravo%22%20data%20%28each%20word%20is%201%20token%2C%20truncated%20slices%20stay%20at%206%20chars%2Ftoken%29%2C%20but%20the%20implementation's%20own%20comment%20acknowledges%20that%20a%20truncated%20slice%20can%20be%20token-denser%20than%20the%20section%20average%2C%20causing%20%60used%60%20to%20exceed%20%60totalTokens%60%20by%20design.%20A%20non-uniform%20section%20%E2%80%94%20e.g.%20many%20short%20words%20at%20the%20start%20followed%20by%20long%20words%2C%20taken%20with%20%60preserveStart%60%20%E2%80%94%20would%20trigger%20exactly%20that%20overrun%20and%20break%20this%20assertion%20without%20any%20code%20change.%20Consider%20either%20relaxing%20the%20bound%20%28e.g.%20%60XCTAssertLessThanOrEqual%28used%2C%2030%29%60%20with%20a%20comment%20explaining%20the%20%C2%B11-section%20margin%29%20or%20adding%20a%20separate%2C%20explicitly%20non-uniform%20test%20that%20documents%20the%20acknowledged%20overrun%20behaviour%20rather%20than%20hiding%20it.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabbyTests%2FPromptSectionBudgetTests.swift%3A101-113%0A**Test%20assertion%20silently%20relies%20on%20uniform-density%20data**%0A%0A%60XCTAssertLessThanOrEqual%28used%2C%2025%29%60%20holds%20for%20the%20specific%20%22alpha%22%2F%22bravo%22%20data%20%28each%20word%20is%201%20token%2C%20truncated%20slices%20stay%20at%206%20chars%2Ftoken%29%2C%20but%20the%20implementation's%20own%20comment%20acknowledges%20that%20a%20truncated%20slice%20can%20be%20token-denser%20than%20the%20section%20average%2C%20causing%20%60used%60%20to%20exceed%20%60totalTokens%60%20by%20design.%20A%20non-uniform%20section%20%E2%80%94%20e.g.%20many%20short%20words%20at%20the%20start%20followed%20by%20long%20words%2C%20taken%20with%20%60preserveStart%60%20%E2%80%94%20would%20trigger%20exactly%20that%20overrun%20and%20break%20this%20assertion%20without%20any%20code%20change.%20Consider%20either%20relaxing%20the%20bound%20%28e.g.%20%60XCTAssertLessThanOrEqual%28used%2C%2030%29%60%20with%20a%20comment%20explaining%20the%20%C2%B11-section%20margin%29%20or%20adding%20a%20separate%2C%20explicitly%20non-uniform%20test%20that%20documents%20the%20acknowledged%20overrun%20behaviour%20rather%20than%20hiding%20it.%0A%0A&repo=fujacob%2Fcotabby&pr=531&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Address review feedback on token budgeti..."](https://github.com/fujacob/cotabby/commit/a96eb89b87d5b9c08ddeac33f084f4c379b1fd85) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35060423)</sub>

<!-- /greptile_comment -->