### PR TITLE
Make the constrained decoder the only llama decode path

### DIFF
--- a/Cotabby/Models/LlamaRuntimeModels.swift
+++ b/Cotabby/Models/LlamaRuntimeModels.swift
@@ -193,17 +193,9 @@ struct LlamaGenerationOptions: Equatable, Sendable {
     /// Defaults to -infinity, which disables suppression entirely.
     var confidenceFloor: Double = -.infinity
 
-    /// Routes generation through the deterministic constrained decoder (logit read + admissibility
-    /// mask + argmax + manual token commit) instead of the engine's built-in stochastic sampler.
-    /// Default off so the shipping sampleNext path is unaffected until the constrained decoder is
-    /// validated on device. Changing it does not affect KV reuse, so it is intentionally excluded
-    /// from `SamplingFingerprint`.
-    var useConstrainedDecoder: Bool = false
-
-    /// Beam width for the constrained decoder. 1 keeps the single-path greedy decode; values > 1 run a
+    /// Beam width for the constrained decoder. 1 is the single-path greedy decode; values > 1 run a
     /// multi-branch beam search that explores several short continuations and keeps the highest-scoring
-    /// one. Only consulted when `useConstrainedDecoder` is true. Like `useConstrainedDecoder`, it does
-    /// not affect KV reuse, so it is excluded from `SamplingFingerprint`.
+    /// one. Does not affect KV reuse, so it is excluded from `SamplingFingerprint`.
     var beamWidth: Int = 1
 
     /// When set (and the model is FIM-capable), the runtime builds a fill-in-middle prompt from the

--- a/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
+++ b/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
@@ -212,12 +212,9 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
             autocompleteSamplingFingerprint = fingerprint
         }
 
-        // The KV-trim defer above runs after whichever decoder returns. Both decoders share the
-        // prepared sequence and the same confidence-suppression contract; they differ only in how
-        // they pick each token (engine sampler vs. deterministic constrained selection).
-        guard options.useConstrainedDecoder else {
-            return runEngineSampledDecode(sequenceID: sequenceID, options: options)
-        }
+        // The KV-trim defer above runs after whichever decoder returns. Greedy and beam share the
+        // prepared sequence and the same confidence-suppression contract; they differ only in how far
+        // they explore before committing each token.
         return options.beamWidth > 1
             ? try runConstrainedBeamDecode(
                 sequenceID: sequenceID,
@@ -268,57 +265,6 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
         // swiftlint:disable:next optional_data_string_conversion
         let decoded = String(decoding: generatedBytes, as: UTF8.self)
         return SentenceBoundaryClassifier.endsSentence(decoded)
-    }
-
-    /// The shipping decoder: delegates token selection to the engine's built-in sampler
-    /// (`sampleNext`), which applies temperature / top-k / top-p / min-p and commits each token.
-    private func runEngineSampledDecode(sequenceID: Int32, options: LlamaGenerationOptions) -> String {
-        var generatedText = ""
-        var tokensGenerated = 0
-        var sumLogprob = 0.0
-        var stopReason = "budget_exhausted"
-
-        for _ in 0 ..< options.maxPredictionTokens {
-            // Cooperative cancellation: when the wrapping Task is cancelled (caller hit a new
-            // keystroke, focus changed, Compose started), bail before the next sampleNext call so
-            // we release `autocompleteLock` instead of running the full prediction budget and
-            // making the next autocomplete wait behind us.
-            if Task.isCancelled {
-                stopReason = "cancelled"
-                break
-            }
-
-            let result = engine.sampleNext(sequenceID)
-
-            if result.was_cancelled {
-                stopReason = "engine_cancelled"
-                break
-            }
-            if result.is_eos {
-                stopReason = "eos"
-                break
-            }
-
-            let piece = Self.extractPiece(result)
-            generatedText += piece
-            tokensGenerated += 1
-            sumLogprob += Double(result.logprob)
-        }
-
-        CotabbyLogger.runtime.debug(
-            "Decode end",
-            metadata: [
-                "kind": .string("generate"),
-                "tokens_generated": .stringConvertible(tokensGenerated),
-                "chars_generated": .stringConvertible(generatedText.count),
-                "stop_reason": .string(stopReason)
-            ]
-        )
-
-        if Self.shouldSuppress(sumLogprob: sumLogprob, tokensGenerated: tokensGenerated, options: options) {
-            return ""
-        }
-        return generatedText
     }
 
     /// The constrained decoder: reads the raw next-token logits, masks structural / excluded tokens
@@ -897,15 +843,6 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
             return writtenLarge > 0 ? large.prefix(writtenLarge).map { UInt8(bitPattern: $0) } : []
         }
         return []
-    }
-
-    private static func extractPiece(_ result: SampleResult) -> String {
-        guard let piece = result.piece, result.piece_length > 0 else { return "" }
-        let buffer = UnsafeBufferPointer(
-            start: UnsafeRawPointer(piece).assumingMemoryBound(to: UInt8.self),
-            count: Int(result.piece_length)
-        )
-        return String(bytes: buffer, encoding: .utf8) ?? ""
     }
 
     private static func samplingConfig(from options: LlamaGenerationOptions) -> SamplingConfig {

--- a/Cotabby/Services/Runtime/LlamaRuntimeManager.swift
+++ b/Cotabby/Services/Runtime/LlamaRuntimeManager.swift
@@ -107,8 +107,8 @@ final class LlamaRuntimeManager: ObservableObject {
         do {
             // `Task.detached` does not inherit the caller's cancellation, so an outer cancel
             // would otherwise leave `core.generate` running to its full prediction budget while
-            // holding `autocompleteLock`. The handler forwards the cancel signal, and the loop
-            // inside `core.generate` polls `Task.isCancelled` between sampleNext calls.
+            // holding `autocompleteLock`. The handler forwards the cancel signal, and the decode
+            // loop inside `core.generate` polls `Task.isCancelled` between token steps.
             let task = Task.detached {
                 try core.generate(
                     prompt: prompt,

--- a/Cotabby/Services/Runtime/LlamaSuggestionEngine.swift
+++ b/Cotabby/Services/Runtime/LlamaSuggestionEngine.swift
@@ -13,39 +13,19 @@ final class LlamaSuggestionEngine {
     private let runtimeManager: LlamaRuntimeGenerating
     private var promptCacheHintTracker = LlamaPromptCacheHintTracker()
 
-    /// UserDefaults key (no UI) that routes llama generation through the deterministic constrained
-    /// decoder instead of the engine's stochastic sampler. Default-off: decode quality can only be
-    /// judged with a real model in a real field, so this stays a hidden developer/dogfood toggle
-    /// until it is validated on device and promoted to the default.
-    private static let constrainedDecoderDefaultsKey = "cotabbyConstrainedDecoderEnabled"
-    private static var isConstrainedDecoderEnabled: Bool {
-        UserDefaults.standard.bool(forKey: constrainedDecoderDefaultsKey)
-    }
-
-    /// UserDefaults key (no UI) for the constrained decoder's beam width. Default 1 keeps the existing
-    /// single-path greedy decode; a value > 1 runs a multi-branch beam search. Paired with the
-    /// constrained-decoder flag as a hidden developer/dogfood knob until validated on device.
+    /// UserDefaults key (no UI) for the constrained decoder's beam width. 1 is greedy (the shipping
+    /// default); a value > 1 runs a multi-branch beam search. Kept as a tuning knob, not a feature
+    /// gate: beam-by-default still needs the batched-beam decode work to avoid per-branch latency.
     private static let constrainedBeamWidthDefaultsKey = "cotabbyConstrainedBeamWidth"
     private static var constrainedBeamWidth: Int {
         let stored = UserDefaults.standard.integer(forKey: constrainedBeamWidthDefaultsKey)
         return stored > 0 ? stored : 1
     }
 
-    /// UserDefaults key (no UI) for fill-in-middle prompting. Default off: FIM only helps models that
-    /// ship the FIM marker tokens, and it changes the prompt structure, so it stays a developer toggle
-    /// until validated on device.
-    private static let fillInMiddleDefaultsKey = "cotabbyFillInMiddleEnabled"
-    private static var isFillInMiddleEnabled: Bool {
-        UserDefaults.standard.bool(forKey: fillInMiddleDefaultsKey)
-    }
-
-    /// The fill-in-middle request for a generation, or nil to use the forward base prompt. Built only
-    /// when the flag is on and the caret is genuinely mid-line (real text follows it on the same line);
-    /// the runtime still falls back to the base prompt when the model lacks FIM markers.
+    /// The fill-in-middle request for a generation, or nil to use the forward base prompt. Built when
+    /// the caret is genuinely mid-line (real text follows it on the same line); the runtime still falls
+    /// back to the base prompt when the model lacks the FIM marker tokens.
     private static func fillInMiddleRequest(for request: SuggestionRequest) -> FillInMiddleRequest? {
-        guard isFillInMiddleEnabled else {
-            return nil
-        }
         // A caret at end of line wants a forward continuation, not infilling — even if `trailingText`
         // is non-empty because a line break and later paragraphs follow it. Gating on end-of-line
         // (rather than `trailingText.isEmpty`) keeps FIM to the case it is actually meant for.
@@ -96,7 +76,6 @@ final class LlamaSuggestionEngine {
                         precedingText: request.context.precedingText,
                         trailingText: request.context.trailingText
                     ),
-                    useConstrainedDecoder: Self.isConstrainedDecoderEnabled,
                     beamWidth: Self.constrainedBeamWidth,
                     fillInMiddle: Self.fillInMiddleRequest(for: request)
                 )


### PR DESCRIPTION
## Summary

The constrained decoder is now validated on device, so it becomes the only llama decode path for every user, no flag required. This removes the dogfood gates and the code they guarded.

- Removed the `cotabbyConstrainedDecoderEnabled` and `cotabbyFillInMiddleEnabled` feature flags. The constrained decoder and fill-in-middle are now always on (FIM still gated by its real preconditions: a genuine mid-line caret and a model that ships the FIM markers).
- Removed the `useConstrainedDecoder` option and the routing guard; `generate()` routes straight to the greedy or beam constrained decoder.
- Removed the now-unreachable `runEngineSampledDecode` and its `extractPiece` helper (the old stochastic sampler path). Net change is -92 lines.
- Kept `cotabbyConstrainedBeamWidth` as a tuning knob (greedy by default), not a feature gate: it keeps the beam path reachable and is the basis for the batched-beam work, which is what beam-by-default needs to avoid per-branch latency.

## Validation

```
xcodebuild ... test ... -only-testing:CotabbyTests/LlamaSuggestionEngineCancellationTests
  -only-testing:CotabbyTests/ConstrainedBeamSearchTests -only-testing:CotabbyTests/FillInMiddlePolicyTests
# ** TEST SUCCEEDED **   swiftlint --strict exit 0
```

Dogfooded on device against a local base model (greedy) before flipping.

## Linked issues

None. Promotes the constrained decoder from dogfood flag to the default decode path.

## Risk / rollout notes

- **Behavior change for all llama users:** every local completion now goes through the constrained decoder instead of the stochastic sampler. Intended flip, validated on device first.
- Greedy (beam width 1) ships; beam-by-default waits on the batched-beam work to avoid per-branch latency.
- **Known follow-up (not here):** the decoder is deterministic, so the sampling parameters (temperature, top-k, top-p, min-p, seed) are now vestigial for token selection. They are still referenced (they configure the seed via `samplingConfig`, and feed `SamplingFingerprint`), so not dead symbols; removing them cleanly cascades into settings and request layers and is a separate change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR promotes the constrained decoder from a dogfood-gated opt-in to the sole llama decode path, removing `cotabbyConstrainedDecoderEnabled`, `cotabbyFillInMiddleEnabled`, and the `useConstrainedDecoder` routing guard. The net result is -92 lines and a cleaner, fully deterministic decode path for all users.

- Removed `runEngineSampledDecode` (and its `extractPiece` helper), the stochastic sampler path — `generate()` now routes unconditionally to `runConstrainedDecode` (greedy) or `runConstrainedBeamDecode` (beam).
- Fill-in-middle is now always attempted when the caret is genuinely mid-line (not just when a developer flag was set), with the existing model-capability fallback still in place.
- Sampling parameters (`temperature`, `topP`, `minP`, `repetitionPenalty`, `seed`) are now vestigial for token selection but remain in `LlamaGenerationOptions` and `SamplingFingerprint`; the PR description explicitly calls out cleanup as a follow-up.

<h3>Confidence Score: 4/5</h3>

The PR cleanly removes the old stochastic sampler path and its gating flags; all users now always go through the constrained decoder, which the author validated on device before this change.

The core decode routing change is straightforward and the constrained decoder already existed and was tested. FIM is now always attempted for mid-line carets, relying on the existing model-capability fallback — this is a subtle behavior change for users with non-FIM models in mid-line positions, but the fallback path appears sound. The vestigial sampling parameters remaining in SamplingFingerprint cause unnecessary KV cache invalidations when those settings change, but this is explicitly acknowledged as a follow-up. No correctness bugs are introduced.

Cotabby/Services/Runtime/LlamaSuggestionEngine.swift — the FIM always-on behavior for mid-line carets is new for all users and depends on the model-capability fallback working correctly for every deployed model configuration.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Services/Runtime/LlamaRuntimeCore.swift | Removed runEngineSampledDecode, extractPiece, and the useConstrainedDecoder guard; generate() now routes directly to runConstrainedDecode or runConstrainedBeamDecode. samplingConfig is still constructed and passed to the engine for prompt decode seeding, so those parameters are not dead in all paths — but token selection is now entirely deterministic. |
| Cotabby/Services/Runtime/LlamaSuggestionEngine.swift | Removed the cotabbyConstrainedDecoderEnabled and cotabbyFillInMiddleEnabled UserDefaults keys and their accessor properties. LlamaGenerationOptions is now constructed without useConstrainedDecoder. FIM is now always attempted for mid-line carets; SamplingFingerprint still includes vestigial sampling params — acknowledged as a follow-up cleanup. |
| Cotabby/Models/LlamaRuntimeModels.swift | Removed useConstrainedDecoder: Bool from LlamaGenerationOptions and updated the beamWidth doc comment. Clean, no logic issues. |
| Cotabby/Services/Runtime/LlamaRuntimeManager.swift | Comment-only update in generate() to drop the reference to sampleNext calls in the cancellation explanation. No logic changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[LlamaSuggestionEngine.generateSuggestion] --> B[LlamaRuntimeManager.generate]
    B --> C[LlamaRuntimeCore.generate]
    C --> D{beamWidth > 1?}
    D -- Yes --> E[runConstrainedBeamDecode]
    D -- No --> F[runConstrainedDecode]
    E --> G[ConstrainedSampler + EngineBeamStepper]
    F --> H[ConstrainedSampler.selectToken greedy argmax]
    G --> I[Return highest-scoring beam]
    H --> J[Return greedy completion]

    style E fill:#d4edda,stroke:#28a745
    style F fill:#d4edda,stroke:#28a745

    subgraph Removed
        R1[runEngineSampledDecode]
        R2[engine.sampleNext]
        R3[extractPiece]
        R4[useConstrainedDecoder guard]
    end
```

<sub>Reviews (1): Last reviewed commit: ["Make the constrained decoder the only ll..."](https://github.com/fujacob/cotabby/commit/30968938331b7eadac63f014952bba292b8a80fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35065484)</sub>

<!-- /greptile_comment -->