### PR TITLE
Fix three bugs found in a pre-release audit

### DIFF
--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
@@ -319,6 +319,7 @@ extension SuggestionCoordinator {
             completeActiveSuggestion(
                 reason: "Overlay hidden because the user typed through the rest of the suggestion.",
                 scheduleNextPrediction: true,
+                awaitHostPublish: true,
                 stage: "typed-match-exhausted",
                 message: "The user typed the remaining suggestion characters exactly.",
                 acceptanceAction: "User typed through the rest of the suggestion."
@@ -356,6 +357,7 @@ extension SuggestionCoordinator {
     func completeActiveSuggestion(
         reason: String,
         scheduleNextPrediction: Bool,
+        awaitHostPublish: Bool = false,
         stage: String,
         message: String,
         acceptanceAction: String
@@ -368,7 +370,16 @@ extension SuggestionCoordinator {
         logStage(stage, workID: currentWorkID, generation: generation, message: message)
 
         if scheduleNextPrediction {
-            schedulePrediction()
+            // Callers reacting to a *synthetic-tap* keystroke (the user typing through a suggestion)
+            // must wait for the host to publish the keystroke before regenerating, or the new
+            // suggestion is built against pre-keystroke text in Chromium editors and looks like the
+            // typed characters were ignored. Reconcile-path callers, where AX has already settled,
+            // schedule immediately.
+            if awaitHostPublish {
+                schedulePredictionAfterHostPublishDelay()
+            } else {
+                schedulePrediction()
+            }
         }
     }
 

--- a/Cotabby/Services/Suggestion/SuggestionInserter.swift
+++ b/Cotabby/Services/Suggestion/SuggestionInserter.swift
@@ -16,6 +16,13 @@ final class SuggestionInserter {
 
     private(set) var lastErrorMessage: String?
 
+    /// In-flight state for the opt-in paste path. The user's real clipboard is snapshotted once and
+    /// restored after the paste lands. While a restore is pending, a second paste must NOT re-snapshot
+    /// (the pasteboard then holds OUR completion, which would leak back to the user), so overlapping
+    /// pastes coalesce onto this single saved clipboard and reschedule the one pending restore.
+    private var pendingPasteboardRestore: DispatchWorkItem?
+    private var savedClipboardForRestore: [[NSPasteboard.PasteboardType: Data]]?
+
     /// Virtual key code for Delete/Backspace. Posting these at the HID level deletes one UTF-16 unit
     /// of already-typed text per pair, which is how the picker removes the literal `:query` run.
     private static let backspaceKeyCode: CGKeyCode = 0x33
@@ -152,17 +159,28 @@ final class SuggestionInserter {
     /// ignores it.
     private func insertViaPaste(_ text: String) -> Bool {
         let pasteboard = NSPasteboard.general
-        let saved = Self.snapshotPasteboard(pasteboard)
+        // Snapshot the user's clipboard only when no restore is already pending. If one is (an
+        // overlapping paste), the pasteboard currently holds our previous completion, so re-snapshotting
+        // would save that and leak it back to the user; reuse the already-saved real clipboard.
+        if pendingPasteboardRestore == nil {
+            savedClipboardForRestore = Self.snapshotPasteboard(pasteboard)
+        }
+        let saved = savedClipboardForRestore ?? []
 
         pasteboard.clearContents()
         guard pasteboard.setString(text, forType: .string) else {
+            pendingPasteboardRestore?.cancel()
             Self.restorePasteboard(saved, to: pasteboard)
+            clearPendingPasteboardRestore()
             return false
         }
+        let expectedChangeCount = pasteboard.changeCount
 
         guard let keyDown = CGEvent(keyboardEventSource: nil, virtualKey: Self.vKeyCode, keyDown: true),
               let keyUp = CGEvent(keyboardEventSource: nil, virtualKey: Self.vKeyCode, keyDown: false) else {
+            pendingPasteboardRestore?.cancel()
             Self.restorePasteboard(saved, to: pasteboard)
+            clearPendingPasteboardRestore()
             return false
         }
         keyDown.flags = .maskCommand
@@ -173,11 +191,27 @@ final class SuggestionInserter {
         keyDown.post(tap: .cghidEventTap)
         keyUp.post(tap: .cghidEventTap)
 
-        // Give the host time to service Cmd-V, then hand the clipboard back to the user.
-        DispatchQueue.main.asyncAfter(deadline: .now() + Self.pasteboardRestoreDelay) {
-            Self.restorePasteboard(saved, to: NSPasteboard.general)
+        // Give the host time to service Cmd-V, then hand the clipboard back, but only if our completion
+        // is still the thing on it. If the user copied something during the window, `changeCount`
+        // advanced and we leave their new clipboard alone. An overlapping paste cancels this restore
+        // and reschedules one for the same saved clipboard.
+        pendingPasteboardRestore?.cancel()
+        let restore = DispatchWorkItem { [weak self] in
+            if NSPasteboard.general.changeCount == expectedChangeCount {
+                Self.restorePasteboard(saved, to: NSPasteboard.general)
+            }
+            self?.clearPendingPasteboardRestore()
         }
+        pendingPasteboardRestore = restore
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.pasteboardRestoreDelay, execute: restore)
         return true
+    }
+
+    /// Clears the in-flight paste-restore bookkeeping once a restore has run (or been abandoned on a
+    /// failure path), so the next paste snapshots the user's real clipboard afresh.
+    private func clearPendingPasteboardRestore() {
+        pendingPasteboardRestore = nil
+        savedClipboardForRestore = nil
     }
 
     /// Captures every representation of every pasteboard item so the user's clipboard can be restored

--- a/Cotabby/Support/InsertionSafetyGate.swift
+++ b/Cotabby/Support/InsertionSafetyGate.swift
@@ -25,9 +25,10 @@ enum InsertionSafetyGate {
             if scalar == "\u{FFFD}" {
                 return false
             }
-            // C0 control range and DEL. Newlines are already handled upstream; an interior tab or
-            // other control character is corruption, not content.
-            if scalar.value < 0x20 || scalar.value == 0x7F {
+            // C0 control range and DEL. A line feed is legitimate content in a multi-line completion
+            // (the normalizer keeps newlines when multi-line mode is on), so it must pass; any other
+            // control character (an interior tab, a stray escape) is corruption, not content.
+            if scalar.value != 0x0A, scalar.value < 0x20 || scalar.value == 0x7F {
                 return false
             }
             if !CharacterSet.whitespacesAndNewlines.contains(scalar) {

--- a/CotabbyTests/InsertionSafetyGateTests.swift
+++ b/CotabbyTests/InsertionSafetyGateTests.swift
@@ -29,4 +29,15 @@ final class InsertionSafetyGateTests: XCTestCase {
     func test_interiorControlCharacter_isUnsafe() {
         XCTAssertFalse(InsertionSafetyGate.isSafeToInsert("a\tb"))
     }
+
+    func test_multiLineContent_isSafe() {
+        // A line feed is legitimate content in a multi-line completion, so it must pass (the previous
+        // behavior rejected it, silently suppressing every multi-line completion).
+        XCTAssertTrue(InsertionSafetyGate.isSafeToInsert("first line\nsecond line"))
+    }
+
+    func test_newlineOnly_isUnsafe() {
+        // Newlines are whitespace; a newline-only completion is still nothing worth inserting.
+        XCTAssertFalse(InsertionSafetyGate.isSafeToInsert("\n\n"))
+    }
 }


### PR DESCRIPTION
## Summary

A pre-release bug audit (fanned out across the runtime, coordinator, insertion, support helpers, and settings). Three confirmed bugs fixed; two findings deliberately left alone and explained below. No new features.

**Fixed**

1. **Multi-line completions were silently suppressed (real shipping toggle broken).** `cotabbyMultiLineEnabled` is a user-facing toggle, but `InsertionSafetyGate` rejected every control char `< 0x20`, including the line feed the normalizer keeps in multi-line mode. So multi-line completions always normalized to empty and never appeared. Now `0x0A` passes; tab/other C0/`U+FFFD` are still rejected. Tests added.
2. **Typing through a suggestion regenerated against pre-keystroke text in Chromium.** `completeActiveSuggestion` always called `schedulePrediction()`, but the typed-through-exhaustion caller runs from the synchronous input tap *before* the host publishes the keystroke. The next suggestion was built against stale text and looked like the typed chars were ignored (the exact Chromium AX-publish race that `schedulePredictionAfterHostPublishDelay` exists to fix). That path now awaits host publish; the reconcile-path caller, where AX has settled, still schedules immediately.
3. **The opt-in paste path could clobber or leak the clipboard.** Restore ran unconditionally after a fixed delay (a copy during the window was overwritten), and overlapping pastes snapshotted each other's injected text (leaving a completion stuck on the clipboard). Restore is now guarded by `changeCount` (only restore if our completion is still there) and overlapping pastes coalesce onto one saved clipboard with a single rescheduled restore.

**Deliberately not fixed (flagged for later, with reasons)**

- **Fill-in-middle is currently inert.** FIM markers are control tokens that detokenize to empty, so marker detection never matches and the runtime always falls back to the forward prompt. This is *safe* (no crash, no wrong output). "Fixing" it would activate an unvalidated feature and expose a second bug (stray BOS tokens injected mid-prompt), which is the opposite of a stability release. Needs an on-device fix later (detect markers by tokenizing with `parse_special`, and tokenize FIM prefix/suffix without BOS).
- **Beam KV-desync on a failed `trimKV`.** Only reachable on the non-default beam path (we ship greedy, width 1) and only when a rare KV removal fails. Low severity, delicate code; left for a focused follow-up.

## Validation

```
xcodebuild ... test ... -only-testing:CotabbyTests/InsertionSafetyGateTests
  -only-testing:CotabbyTests/SuggestionTextNormalizerTests
  -only-testing:CotabbyTests/LlamaSuggestionEngineCancellationTests
# ** TEST SUCCEEDED **  (34 tests, 0 failures)
swiftlint --strict   # exit 0
```

The coordinator and paste fixes live in CGEvent / NSPasteboard / @MainActor code the repo intentionally does not unit-test; both were verified by tracing the paths. Paste is default-off, so fix 3 affects only opt-in users.

## Linked issues

None. Pre-release hardening.

## Risk / rollout notes

- Fix 1 changes shipped behavior for multi-line mode (it now actually shows multi-line completions). Single-line mode is unaffected (the normalizer strips newlines before the gate there).
- Fix 2 touches the acceptance hot path; the change is one routing flag, default `false` preserves the reconcile path.
- Fix 3 is contained to the opt-in paste path (default off).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes three pre-release bugs: multi-line completions were silently rejected by `InsertionSafetyGate` because `\n` was caught by the C0 control-character check, the typed-through-exhaustion path scheduled the next prediction against pre-keystroke AX text in Chromium, and the opt-in paste path could clobber or leak the clipboard when pastes overlapped or the user copied during the restore window.

- **Fix 1 (`InsertionSafetyGate`):** Exempts `0x0A` from the C0 rejection so `\n` inside a multi-line completion passes the gate; all other control characters and `U+FFFD` are still rejected. The normalizer already strips `\r` before reaching the gate, so Windows line endings cannot bypass the fix.
- **Fix 2 (`SuggestionCoordinator+Acceptance`):** Routes the typed-match-exhausted caller through `schedulePredictionAfterHostPublishDelay()` via a new `awaitHostPublish` parameter (default `false`); all existing callers are unaffected.
- **Fix 3 (`SuggestionInserter`):** Coalesces overlapping pastes onto one saved clipboard, guards the async restore with a `changeCount` equality check, and cancels/reschedules the restore on each subsequent paste.

<h3>Confidence Score: 4/5</h3>

Safe to merge. All three bug fixes are well-reasoned and the changed paths are narrow: the gate fix only affects multi-line mode, the coordinator change is one routing flag with a safe default, and the paste fix is confined to a default-off opt-in path guarded by @MainActor serial execution.

The three fixes are individually correct and touch isolated paths. The only findings are a readability nit on the Swift condition-list form in InsertionSafetyGate and a missing test asserting that 
 remains rejected — both editorial rather than functional.

InsertionSafetyGate.swift has the minor readability issue on line 31; InsertionSafetyGateTests.swift is missing the 
-still-rejected test case.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/InsertionSafetyGate.swift | Exempts 0x0A (line feed) from the C0 control-character rejection so multi-line completions can reach ghost text; logic correct, but comma vs && readability nit on line 31. |
| Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift | Adds awaitHostPublish: Bool = false to completeActiveSuggestion and routes typed-match-exhausted through schedulePredictionAfterHostPublishDelay(); all existing callers unaffected. |
| Cotabby/Services/Suggestion/SuggestionInserter.swift | Adds pendingPasteboardRestore/savedClipboardForRestore state to coalesce overlapping pastes and guard the async restore with changeCount equality; logic sound given @MainActor serial execution. |
| CotabbyTests/InsertionSafetyGateTests.swift | Adds test_multiLineContent_isSafe and test_newlineOnly_isUnsafe — both correct — but missing explicit test that \r remains rejected after the 0x0A exemption. |

</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fpre-release-audit-bugs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpre-release-audit-bugs%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FSupport%2FInsertionSafetyGate.swift%3A31%0AThe%20comma-separated%20condition%20mixes%20Swift's%20condition-list%20%60%26%26%60%20semantics%20with%20an%20infix%20%60%7C%7C%60%20inside%20the%20second%20clause.%20The%20logic%20is%20correct%2C%20but%20a%20reader%20who%20doesn't%20notice%20that%20the%20comma%20binds%20looser%20than%20%60%7C%7C%60%20could%20misread%20it%20as%20%60%28scalar.value%20!%3D%200x0A%2C%20scalar.value%20%3C%200x20%29%20%7C%7C%20scalar.value%20%3D%3D%200x7F%60.%20Using%20%60%26%26%60%20with%20explicit%20parentheses%20makes%20the%20grouping%20unambiguous.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20scalar.value%20!%3D%200x0A%20%26%26%20%28scalar.value%20%3C%200x20%20%7C%7C%20scalar.value%20%3D%3D%200x7F%29%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabbyTests%2FInsertionSafetyGateTests.swift%3A39-43%0AThe%20new%20tests%20document%20that%20%60%0A%60%20now%20passes%20and%20that%20a%20newline-only%20string%20still%20fails%2C%20but%20there%20is%20no%20explicit%20test%20showing%20that%20%60%0A%60%20%280x0D%29%20is%20still%20rejected.%20%60%0A%60%20is%20stripped%20by%20%60SuggestionTextNormalizer%60%20before%20it%20can%20reach%20the%20gate%20in%20production%2C%20but%20a%20gate-level%20test%20would%20make%20the%200x0A-only%20exemption%20self-documenting%20and%20guard%20against%20future%20normalizer%20changes%20that%20might%20pass%20%60%0A%60%20through.%0A%0A%60%60%60suggestion%0A%20%20%20%20func%20test_newlineOnly_isUnsafe%28%29%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20Newlines%20are%20whitespace%3B%20a%20newline-only%20completion%20is%20still%20nothing%20worth%20inserting.%0A%20%20%20%20%20%20%20%20XCTAssertFalse%28InsertionSafetyGate.isSafeToInsert%28%22%5Cn%5Cn%22%29%29%0A%20%20%20%20%7D%0A%0A%20%20%20%20func%20test_carriageReturn_isUnsafe%28%29%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20Only%200x0A%20is%20exempted%3B%20%5Cr%20%280x0D%29%20is%20still%20a%20rejected%20C0%20control%20character.%0A%20%20%20%20%20%20%20%20XCTAssertFalse%28InsertionSafetyGate.isSafeToInsert%28%22a%5Crb%22%29%29%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FSupport%2FInsertionSafetyGate.swift%3A31%0AThe%20comma-separated%20condition%20mixes%20Swift's%20condition-list%20%60%26%26%60%20semantics%20with%20an%20infix%20%60%7C%7C%60%20inside%20the%20second%20clause.%20The%20logic%20is%20correct%2C%20but%20a%20reader%20who%20doesn't%20notice%20that%20the%20comma%20binds%20looser%20than%20%60%7C%7C%60%20could%20misread%20it%20as%20%60%28scalar.value%20!%3D%200x0A%2C%20scalar.value%20%3C%200x20%29%20%7C%7C%20scalar.value%20%3D%3D%200x7F%60.%20Using%20%60%26%26%60%20with%20explicit%20parentheses%20makes%20the%20grouping%20unambiguous.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20scalar.value%20!%3D%200x0A%20%26%26%20%28scalar.value%20%3C%200x20%20%7C%7C%20scalar.value%20%3D%3D%200x7F%29%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabbyTests%2FInsertionSafetyGateTests.swift%3A39-43%0AThe%20new%20tests%20document%20that%20%60%0A%60%20now%20passes%20and%20that%20a%20newline-only%20string%20still%20fails%2C%20but%20there%20is%20no%20explicit%20test%20showing%20that%20%60%0A%60%20%280x0D%29%20is%20still%20rejected.%20%60%0A%60%20is%20stripped%20by%20%60SuggestionTextNormalizer%60%20before%20it%20can%20reach%20the%20gate%20in%20production%2C%20but%20a%20gate-level%20test%20would%20make%20the%200x0A-only%20exemption%20self-documenting%20and%20guard%20against%20future%20normalizer%20changes%20that%20might%20pass%20%60%0A%60%20through.%0A%0A%60%60%60suggestion%0A%20%20%20%20func%20test_newlineOnly_isUnsafe%28%29%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20Newlines%20are%20whitespace%3B%20a%20newline-only%20completion%20is%20still%20nothing%20worth%20inserting.%0A%20%20%20%20%20%20%20%20XCTAssertFalse%28InsertionSafetyGate.isSafeToInsert%28%22%5Cn%5Cn%22%29%29%0A%20%20%20%20%7D%0A%0A%20%20%20%20func%20test_carriageReturn_isUnsafe%28%29%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20Only%200x0A%20is%20exempted%3B%20%5Cr%20%280x0D%29%20is%20still%20a%20rejected%20C0%20control%20character.%0A%20%20%20%20%20%20%20%20XCTAssertFalse%28InsertionSafetyGate.isSafeToInsert%28%22a%5Crb%22%29%29%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=534&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Fix three bugs found in a pre-release au..."](https://github.com/fujacob/cotabby/commit/076c93d9d48e3f268b69dc3e9f2113158ce457a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35070980)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->