### PR TITLE
Fix an overlay crash and two dead settings (pre-release audit, wave 2)

### DIFF
--- a/Cotabby/App/Core/AppDelegate.swift
+++ b/Cotabby/App/Core/AppDelegate.swift
@@ -31,6 +31,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private let activationIndicatorController: ActivationIndicatorController
     private let focusDebugOverlayController: FocusDebugOverlayController?
+    /// Retained for the app's lifetime because the environment owns its own `cancellables` (the only
+    /// subscriptions wiring the focus-poll-interval setting and the global-toggle hotkey rebind to the
+    /// runtime). If the environment deallocated when `init` returned, those subscriptions would be
+    /// cancelled and both settings would silently stop working until the next relaunch.
+    private let environment: CotabbyAppEnvironment
     private var cancellables = Set<AnyCancellable>()
     private var didStartServices = false
 
@@ -38,9 +43,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         CotabbyLogger.bootstrap()
 
         // Build the dependency graph once up front so every scene/view observes the same
-        // long-lived objects for the entire app session. `CotabbyAppEnvironment` is a composition
-        // helper here; the app delegate retains the root objects it needs directly.
+        // long-lived objects for the entire app session.
         let environment = CotabbyAppEnvironment()
+        self.environment = environment
         permissionManager = environment.permissionManager
         runtimeModel = environment.runtimeModel
         modelDownloadManager = environment.modelDownloadManager

--- a/Cotabby/Services/UI/OverlayController.swift
+++ b/Cotabby/Services/UI/OverlayController.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import Logging
 import SwiftUI
 
 /// File overview:
@@ -183,6 +184,13 @@ final class OverlayController: SuggestionOverlayControlling {
 
         let frame = layout.panelFrame(for: contentSize, caretRect: geometry.caretRect)
 
+        // Last-resort guard: AppKit raises on a non-finite frame. The AX ingest boundary already
+        // rejects NaN/Inf rects, so reaching here means the layout math produced one; skip the show
+        // rather than crash on the hottest path.
+        guard AXHelper.rectHasFiniteComponents(frame) else {
+            CotabbyLogger.suggestion.warning("Skipped inline overlay: computed a non-finite frame")
+            return
+        }
         panel.setFrame(frame.integral, display: true)
         panel.orderFrontRegardless()
     }
@@ -231,7 +239,12 @@ final class OverlayController: SuggestionOverlayControlling {
             panel.contentView = contentView
         }
 
-        panel.setFrame(layout.panelFrame, display: true)
+        let panelFrame = layout.panelFrame
+        guard AXHelper.rectHasFiniteComponents(panelFrame) else {
+            CotabbyLogger.suggestion.warning("Skipped mirror overlay: computed a non-finite frame")
+            return
+        }
+        panel.setFrame(panelFrame, display: true)
         panel.orderFrontRegardless()
     }
 

--- a/Cotabby/Support/AXHelper.swift
+++ b/Cotabby/Support/AXHelper.swift
@@ -590,6 +590,9 @@ enum AXHelper {
     /// Use this for element-level rects (AXFrame) that are reliably in Cocoa points.
     /// For text-range rects (BoundsForRange, TextMarker), use `validatedCocoaTextRect` instead.
     static func cocoaRect(fromAccessibilityRect rect: CGRect) -> CGRect {
+        guard rectHasFiniteComponents(rect) else {
+            return .zero
+        }
         guard !rect.isNull, rect != .zero else {
             return rect
         }
@@ -605,6 +608,15 @@ enum AXHelper {
         return legacyDesktopUnionFlip(rect)
     }
 
+    /// True only when every component of `rect` is a finite number. Some host AX implementations
+    /// (Chromium/Electron, especially mid-scroll or under load) return NaN/Inf bounds; AppKit raises
+    /// on a non-finite window frame and `Int(.nan)` traps, so such rects are rejected here at the AX
+    /// ingest boundary before they can reach geometry math or `NSWindow.setFrame`.
+    static func rectHasFiniteComponents(_ rect: CGRect) -> Bool {
+        rect.origin.x.isFinite && rect.origin.y.isFinite
+            && rect.size.width.isFinite && rect.size.height.isFinite
+    }
+
     /// Converts a text-range AX rect to Cocoa coordinates, using the element's AXFrame (already
     /// in Cocoa coordinates) as a ground-truth anchor to detect whether pixel-to-point scaling
     /// is needed. This replaces the old bundle-ID heuristic with empirical geometric validation:
@@ -615,6 +627,9 @@ enum AXHelper {
         fromAccessibilityRect textRect: CGRect,
         anchorFrame cocoaAnchorFrame: CGRect?
     ) -> CGRect {
+        guard rectHasFiniteComponents(textRect) else {
+            return .zero
+        }
         guard !textRect.isNull, textRect != .zero else {
             return textRect
         }

--- a/CotabbyTests/AXTextGeometryResolverTests.swift
+++ b/CotabbyTests/AXTextGeometryResolverTests.swift
@@ -146,4 +146,20 @@ final class AXTextGeometryResolverTests: XCTestCase {
         XCTAssertTrue(resolver.rectIsNearAnchor(rect, anchor: nil))
         XCTAssertTrue(resolver.rectIsNearAnchor(rect, anchor: .zero))
     }
+
+    // MARK: - Non-finite AX rect rejection (crash guard)
+
+    func test_rectHasFiniteComponents_rejectsNaNAndInfinity() {
+        XCTAssertTrue(AXHelper.rectHasFiniteComponents(CGRect(x: 1, y: 2, width: 3, height: 4)))
+        XCTAssertFalse(AXHelper.rectHasFiniteComponents(CGRect(x: CGFloat.nan, y: 0, width: 10, height: 10)))
+        XCTAssertFalse(AXHelper.rectHasFiniteComponents(CGRect(x: 0, y: 0, width: CGFloat.infinity, height: 10)))
+        XCTAssertFalse(AXHelper.rectHasFiniteComponents(CGRect(x: 0, y: CGFloat.nan, width: 10, height: CGFloat.nan)))
+    }
+
+    func test_validatedCocoaTextRect_collapsesNonFiniteRectToZero() {
+        // A NaN/Inf AX rect must collapse to .zero, never propagate toward NSWindow.setFrame (a crash).
+        let nan = CGRect(x: CGFloat.nan, y: 10, width: 20, height: 14)
+        XCTAssertEqual(AXHelper.validatedCocoaTextRect(fromAccessibilityRect: nan, anchorFrame: nil), .zero)
+        XCTAssertEqual(AXHelper.cocoaRect(fromAccessibilityRect: nan), .zero)
+    }
 }


### PR DESCRIPTION
## Summary

Wave 2 of the pre-release audit. Two fixes: a crash and two silently-dead settings.

1. **Crash on a non-finite caret rect.** Misbehaving host AX (Chromium/Electron, mid-scroll or under load) can return `NaN`/`Inf` caret bounds. The existing guards (`isNull`, `!= .zero`, `isEmpty`) do not reject non-finite values, so they flowed into `NSWindow.setFrame`, which raises `NSInvalidArgumentException` and crashes the app on the hottest path (every suggestion shown). Now rejected at the AX ingest boundary: `cocoaRect` / `validatedCocoaTextRect` collapse a non-finite rect to `.zero` (which also removes a latent `Int(.nan)` trap in `OverlayState.detail`), plus a last-resort finite guard before each `OverlayController.setFrame`.
2. **Two Settings controls were silently dead.** `AppDelegate` built the graph as a local `let environment` and copied the services out, but never retained the environment. The environment owns the *only* subscriptions for the focus-poll-interval setting (→ `updatePollInterval`) and the global-toggle hotkey rebind (→ `refreshToggleTap`); both were cancelled when the environment deallocated as `init` returned, so changing the poll interval did nothing and rebinding the hotkey did nothing until the next relaunch. Now the environment is retained for the app lifetime.

## Validation

```
xcodebuild ... test ... -only-testing:CotabbyTests/AXTextGeometryResolverTests
# ** TEST SUCCEEDED **  (new: finite-check rejects NaN/Inf; non-finite AX rect collapses to .zero)
swiftlint --strict   # exit 0
```

The AppDelegate retain is verified by trace (app-lifecycle code is not unit-tested); the caret guard is unit-tested.

## Linked issues

None. Pre-release hardening, wave 2.

## Risk / rollout notes

- The caret guard is purely defensive: a non-finite rect that previously crashed now produces no overlay for that frame (graceful). Finite rects are unaffected.
- Retaining the environment adds no retain cycle (the services were already retained directly; subscriptions use `[weak self]`/`[weak ...]`).
- **Deferred, flagged:** `PermissionManager` / `PermissionGuidanceController` have isolated `deinit`s (the macOS 14 double-free class), but they are app-lifetime singletons that never dealloc, so it is latent only and the fix is non-trivial (those deinits do real cleanup, unlike the empty-`nonisolated deinit` precedent).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two independent bugs found during a pre-release audit: a crash caused by non-finite (NaN/Inf) AX caret rects flowing into `NSWindow.setFrame`, and two Settings controls (focus poll interval, global-toggle hotkey rebind) that were silently non-functional because the `CotabbyAppEnvironment` owning their Combine subscriptions was immediately deallocated.

- **Crash fix**: `rectHasFiniteComponents` is added as an ingest-boundary guard in `cocoaRect` and `validatedCocoaTextRect`, collapsing non-finite rects to `.zero` before they reach layout math or `NSPanel.setFrame`; last-resort guards are also added directly before both `setFrame` call sites in `OverlayController`.
- **Settings fix**: `AppDelegate` now holds `private let environment: CotabbyAppEnvironment`, keeping the environment (and its `cancellables`) alive for the app's full lifetime so the poll-interval and hotkey-rebind subscriptions are never prematurely cancelled.
- **Tests**: New unit tests cover `rectHasFiniteComponents` rejection and `validatedCocoaTextRect`/`cocoaRect` collapse for NaN inputs; the `CGFloat.infinity` and `CGRect.null` cases are not yet exercised in the collapse test.

<h3>Confidence Score: 4/5</h3>

Safe to merge; both fixes are narrowly scoped defensive changes with no new logic paths for the happy-path.

The crash fix and settings-lifetime fix are both correct. The subtle behavior change around `CGRect.null` collapsing to `.zero` is worth a quick caller audit but does not affect observed code paths.

Callers of `cocoaRect` and `validatedCocoaTextRect` that may check `.isNull` on the returned rect, given the new `CGRect.null` to `.zero` collapse behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/AXHelper.swift | Adds `rectHasFiniteComponents` guard at the top of `cocoaRect` and `validatedCocoaTextRect`; minor side-effect: `CGRect.null` (origin = +∞) now collapses to `.zero` instead of propagating as the null rect |
| Cotabby/Services/UI/OverlayController.swift | Adds last-resort finite checks before `NSPanel.setFrame` in both inline and mirror paths; straightforward defensive guard |
| Cotabby/App/Core/AppDelegate.swift | Promotes `environment` to a `private let` instance property so the `CotabbyAppEnvironment`'s Combine subscriptions are not prematurely cancelled; correct and low-risk |
| CotabbyTests/AXTextGeometryResolverTests.swift | Adds tests for `rectHasFiniteComponents` (NaN + infinity) and `validatedCocoaTextRect`/`cocoaRect` collapse; `CGFloat.infinity` case is not tested in the collapse test, and `CGRect.null` collapse to `.zero` is untested |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    AX[Host AX: BoundsForRange / AXFrame] --> ingest["cocoaRect / validatedCocoaTextRect\n(AX ingest boundary)"]
    ingest -->|non-finite NaN/Inf| zero[Return .zero]
    ingest -->|finite| geom[Layout geometry math]
    geom --> frame["panelFrame (inline) / panelFrame (mirror)"]
    frame -->|non-finite last-resort| skip[Log warning, skip setFrame]
    frame -->|finite| setFrame["NSPanel.setFrame → orderFrontRegardless"]
    zero --> overlaySkip[Overlay suppressed — no crash]
    skip --> overlaySkip
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Foverlay-and-lifecycle-hardening%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Foverlay-and-lifecycle-hardening%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FSupport%2FAXHelper.swift%3A593-596%0A**%60CGRect.null%60%20silently%20collapses%20to%20%60.zero%60**%0A%0A%60CGRect.null%60%20has%20its%20origin%20at%20%60%28%2B%E2%88%9E%2C%20%2B%E2%88%9E%29%60%20in%20CoreGraphics%2C%20so%20%60rectHasFiniteComponents%28CGRect.null%29%60%20returns%20%60false%60%20and%20both%20%60cocoaRect%60%20and%20%60validatedCocoaTextRect%60%20now%20return%20%60.zero%60%20for%20a%20null%20rect.%20Previously%20the%20%60guard%20!rect.isNull%60%20branch%20caught%20it%20and%20returned%20the%20null%20rect%20itself.%20Any%20downstream%20caller%20that%20distinguishes%20null%20from%20zero%20%28e.g.%20an%20%60isNull%60%20check%29%20will%20now%20see%20%60.zero%60%20instead.%20Worth%20verifying%20that%20every%20caller%20only%20guards%20with%20%60!%3D%20.zero%60%20%28not%20%60.isNull%60%29%20so%20no%20silent%20pass-through%20occurs%20after%20this%20change.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabbyTests%2FAXTextGeometryResolverTests.swift%3A159-164%0A**%60CGFloat.infinity%60%20and%20%60CGRect.null%60%20not%20covered%20by%20collapse%20test**%0A%0A%60test_validatedCocoaTextRect_collapsesNonFiniteRectToZero%60%20only%20exercises%20a%20NaN%20input.%20Adding%20a%20%60CGFloat.infinity%60%20case%20and%20a%20%60CGRect.null%60%20case%20%28which%20now%20also%20returns%20%60.zero%60%20due%20to%20the%20new%20finite%20guard%29%20would%20round%20out%20coverage%20and%20document%20the%20newly%20observed%20behavior%20for%20%60CGRect.null%60.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FSupport%2FAXHelper.swift%3A593-596%0A**%60CGRect.null%60%20silently%20collapses%20to%20%60.zero%60**%0A%0A%60CGRect.null%60%20has%20its%20origin%20at%20%60%28%2B%E2%88%9E%2C%20%2B%E2%88%9E%29%60%20in%20CoreGraphics%2C%20so%20%60rectHasFiniteComponents%28CGRect.null%29%60%20returns%20%60false%60%20and%20both%20%60cocoaRect%60%20and%20%60validatedCocoaTextRect%60%20now%20return%20%60.zero%60%20for%20a%20null%20rect.%20Previously%20the%20%60guard%20!rect.isNull%60%20branch%20caught%20it%20and%20returned%20the%20null%20rect%20itself.%20Any%20downstream%20caller%20that%20distinguishes%20null%20from%20zero%20%28e.g.%20an%20%60isNull%60%20check%29%20will%20now%20see%20%60.zero%60%20instead.%20Worth%20verifying%20that%20every%20caller%20only%20guards%20with%20%60!%3D%20.zero%60%20%28not%20%60.isNull%60%29%20so%20no%20silent%20pass-through%20occurs%20after%20this%20change.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabbyTests%2FAXTextGeometryResolverTests.swift%3A159-164%0A**%60CGFloat.infinity%60%20and%20%60CGRect.null%60%20not%20covered%20by%20collapse%20test**%0A%0A%60test_validatedCocoaTextRect_collapsesNonFiniteRectToZero%60%20only%20exercises%20a%20NaN%20input.%20Adding%20a%20%60CGFloat.infinity%60%20case%20and%20a%20%60CGRect.null%60%20case%20%28which%20now%20also%20returns%20%60.zero%60%20due%20to%20the%20new%20finite%20guard%29%20would%20round%20out%20coverage%20and%20document%20the%20newly%20observed%20behavior%20for%20%60CGRect.null%60.%0A%0A&repo=fujacob%2Fcotabby&pr=535&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Fix an overlay crash and two dead settin..."](https://github.com/fujacob/cotabby/commit/9ca9cff09a494025419ccf9b7e08b4ea36a27fdd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35072350)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->