### PR TITLE
Harden model download integrity (pre-release audit, wave 2)

### DIFF
--- a/Cotabby/Services/Utilities/ModelDownloadManager.swift
+++ b/Cotabby/Services/Utilities/ModelDownloadManager.swift
@@ -311,32 +311,61 @@ final class ModelDownloadManager: ObservableObject {
             }
         }
         let downloadResult = try await delegate.download(from: url)
-        try Task.checkCancellation()
-        try validate(response: downloadResult.response)
-
         let fileManager = FileManager.default
+        let temporaryURL = downloadResult.temporaryURL
+
+        // The rescued temp file is ours now. Any failure before it is moved into staging (a user
+        // cancel, a non-2xx response — exactly when HuggingFace returns a small HTML error page, or
+        // the move itself failing) must remove it, or it leaks in the temp directory.
+        do {
+            try Task.checkCancellation()
+            try validate(response: downloadResult.response)
+        } catch {
+            try? fileManager.removeItem(at: temporaryURL)
+            throw error
+        }
+
         let stagingURL = runtimeDirectoryURL.appendingPathComponent(
             "\(model.filename).staging-\(UUID().uuidString)",
             isDirectory: false
         )
-        try fileManager.moveItem(at: downloadResult.temporaryURL, to: stagingURL)
-
         do {
+            try fileManager.moveItem(at: temporaryURL, to: stagingURL)
+        } catch {
+            try? fileManager.removeItem(at: temporaryURL)
+            throw error
+        }
+
+        // From here the staged file must be removed on any validation OR promotion failure.
+        do {
+            try ModelFileValidator.validateCompleteness(
+                of: stagingURL, declaredContentLength: downloadResult.response.expectedContentLength
+            )
             try ModelFileValidator.validateSize(
                 of: stagingURL, expectedBytes: model.expectedSizeBytes
             )
             try ModelFileValidator.validateSHA256(
                 of: stagingURL, expectedSHA256: model.sha256
             )
+            try Self.promoteStagedFile(at: stagingURL, to: destinationURL, fileManager: fileManager)
         } catch {
             try? fileManager.removeItem(at: stagingURL)
             throw error
         }
+    }
 
+    /// Promotes a validated staged file into the install location. When a model already exists there,
+    /// an atomic replace is used so a crash or error mid-promotion can never destroy the existing good
+    /// model before the replacement is committed (the old delete-then-move could leave nothing
+    /// installed). `replaceItemAt` removes the staged file as part of the swap.
+    private static func promoteStagedFile(
+        at stagingURL: URL, to destinationURL: URL, fileManager: FileManager
+    ) throws {
         if fileManager.fileExists(atPath: destinationURL.path) {
-            try fileManager.removeItem(at: destinationURL)
+            _ = try fileManager.replaceItemAt(destinationURL, withItemAt: stagingURL)
+        } else {
+            try fileManager.moveItem(at: stagingURL, to: destinationURL)
         }
-        try fileManager.moveItem(at: stagingURL, to: destinationURL)
     }
 
     private func validate(response: URLResponse) throws {

--- a/Cotabby/Services/Utilities/ModelFileValidator.swift
+++ b/Cotabby/Services/Utilities/ModelFileValidator.swift
@@ -66,6 +66,25 @@ enum ModelFileValidator {
         }
     }
 
+    /// Throws if the file's byte size differs from the server's declared `Content-Length`.
+    ///
+    /// The curated catalog ships with nil `expectedSizeBytes`/`sha256`, so those validators no-op and
+    /// the only remaining integrity gate is the HTTP status check — which does NOT catch a body the
+    /// server truncated while ending the transfer "cleanly" (an HTTP/2 stream reset or a proxy closing
+    /// the connection both surface as a finished task with no error). Comparing the on-disk size to the
+    /// declared length closes that gap without needing catalog metadata. No-op when the length is
+    /// unknown (`expectedContentLength <= 0`, i.e. `NSURLSessionTransferSizeUnknown`).
+    static func validateCompleteness(
+        of url: URL,
+        declaredContentLength: Int64,
+        fileManager: FileManager = .default
+    ) throws {
+        guard declaredContentLength > 0 else {
+            return
+        }
+        try validateSize(of: url, expectedBytes: declaredContentLength, fileManager: fileManager)
+    }
+
     /// Throws if the file's SHA-256 differs from `expectedSHA256` (case-insensitive).
     /// No-op when `expectedSHA256` is nil.
     ///

--- a/CotabbyTests/ModelFileValidatorTests.swift
+++ b/CotabbyTests/ModelFileValidatorTests.swift
@@ -59,6 +59,29 @@ final class ModelFileValidatorTests: XCTestCase {
         }
     }
 
+    // MARK: - validateCompleteness
+
+    func test_validateCompleteness_passesWhenSizeMatchesDeclaredLength() throws {
+        let url = try makeFixture(contents: Data(repeating: 0xAB, count: 100))
+        XCTAssertNoThrow(try ModelFileValidator.validateCompleteness(of: url, declaredContentLength: 100))
+    }
+
+    func test_validateCompleteness_throwsOnTruncatedBody() throws {
+        let url = try makeFixture(contents: Data(repeating: 0xAB, count: 60))
+        XCTAssertThrowsError(try ModelFileValidator.validateCompleteness(of: url, declaredContentLength: 100)) { error in
+            guard case ModelFileValidator.ValidationError.sizeMismatch = error else {
+                XCTFail("Expected sizeMismatch, got \(error)")
+                return
+            }
+        }
+    }
+
+    func test_validateCompleteness_noOpsWhenLengthUnknown() throws {
+        let url = try makeFixture(contents: Data(repeating: 0xAB, count: 60))
+        XCTAssertNoThrow(try ModelFileValidator.validateCompleteness(of: url, declaredContentLength: -1))
+        XCTAssertNoThrow(try ModelFileValidator.validateCompleteness(of: url, declaredContentLength: 0))
+    }
+
     // MARK: - validateSHA256
 
     func test_validateSHA256_passesForKnownChecksum() throws {


### PR DESCRIPTION
## Summary

Wave 2 of the pre-release audit: model-download integrity. Every curated catalog model ships with nil `expectedSizeBytes`/`sha256`, so `validateSize`/`validateSHA256` no-op and the only integrity gate was the HTTP 2xx check. A body the server truncated while ending the transfer "cleanly" (an HTTP/2 stream reset, a proxy closing the connection) was therefore promoted as a complete model and later failed to load with an opaque llama.cpp error, with no way for the user to tell it was a bad download.

- **Completeness check.** New `ModelFileValidator.validateCompleteness` compares the staged file's byte size to the server's declared `Content-Length` (no-op when unknown). Catches truncation without needing catalog metadata.
- **Temp/staging cleanup.** The rescued temp file is now removed on every pre-staging failure (user cancel, non-2xx response — exactly when HuggingFace returns a small HTML error page, or the staging move failing), and the staged file on every validation/promotion failure. Both previously leaked.
- **Atomic promotion.** Promote with `replaceItemAt` when a model already exists, so a failure mid-promotion can never destroy the existing good model before the replacement lands (the old delete-then-move could leave nothing installed).

## Validation

```
xcodebuild ... test ... -only-testing:CotabbyTests/ModelFileValidatorTests
# ** TEST SUCCEEDED **  (14 tests; new: completeness passes on match, throws on truncation, no-ops when length unknown)
swiftlint --strict   # exit 0
```

The download manager's filesystem/network flow is not unit-tested (the repo pattern); the restructure was verified by trace, and the new validator is unit-tested.

## Linked issues

None. Pre-release hardening, wave 2.

## Risk / rollout notes

- The completeness check only fires when the server sends a `Content-Length`; HuggingFace's CDN does, so truncated downloads are now caught before promotion. A legitimately complete download is unaffected.
- Atomic promotion via `replaceItemAt` works because staging and the install location share the runtime directory (same volume).
- Follow-up not in this PR: a corrupt file that is *already* installed still reads as "installed" (a `fileExists` check), so it blocks redownload; with this PR truncated files no longer get promoted in the first place, but recovering an already-bad install (e.g. exposing delete for the selected model) is a separate UX change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the model download pipeline across three fronts: a `validateCompleteness` check that catches HTTP-cleanly-truncated bodies by comparing on-disk size to `Content-Length`, deterministic cleanup of both the temp and staging files on every failure path, and an atomic `replaceItemAt`-based promotion that prevents a crash from leaving the install location empty.

- **`ModelFileValidator.validateCompleteness`** delegates to the existing `validateSize`, no-ops when `Content-Length` is absent or zero, and is backed by three new unit tests.
- **Cleanup discipline** in `performSingleFileDownload` covers temp-file leaks on pre-staging failures (user cancel, non-2xx response, move error) and staging-file leaks on validation or promotion failures.
- **`promoteStagedFile`** replaces the old delete-then-move with `replaceItemAt` when the destination exists and `moveItem` when it does not, though the conditional introduces a TOCTOU that `replaceItemAt` alone would eliminate.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the cleanup and completeness-check logic is correct, and the only actionable finding is a narrow race in promoteStagedFile that causes a spurious download failure rather than data loss.

The promotion path has a fileExists-then-moveItem check that can fail if the destination is created between the two calls; the consequence is a failed download the user must retry, not a corrupted install. No data loss path was identified. The missing over-size test in ModelFileValidatorTests is the only other gap.

The promoteStagedFile method in ModelDownloadManager.swift and the validateCompleteness test block in ModelFileValidatorTests.swift would benefit from a second look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Services/Utilities/ModelDownloadManager.swift | Restructures download pipeline with temp/staging cleanup on every failure path, completeness validation, and atomic promotion via replaceItemAt; a subtle TOCTOU in promoteStagedFile can cause a spurious failure when the destination is concurrently created. |
| Cotabby/Services/Utilities/ModelFileValidator.swift | Adds validateCompleteness, which delegates to validateSize with the server's Content-Length; logic is correct and the fileManager injection is properly forwarded. |
| CotabbyTests/ModelFileValidatorTests.swift | Adds three tests for validateCompleteness (match, truncation, unknown length); missing a test for a file that is larger than the declared Content-Length, which is a valid failure case. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant DM as ModelDownloadManager
    participant Delegate as ModelDownloadSessionDelegate
    participant FS as FileSystem
    participant Validator as ModelFileValidator

    DM->>Delegate: download(from: url)
    Delegate-->>DM: DownloadResult(temporaryURL, response)

    alt Task cancelled or non-2xx response
        DM->>FS: removeItem(temporaryURL) [cleanup]
        DM-->>DM: throw error
    end

    DM->>FS: moveItem(temporaryURL → stagingURL)
    alt Move fails
        DM->>FS: removeItem(temporaryURL) [cleanup]
        DM-->>DM: throw error
    end

    DM->>Validator: validateCompleteness(stagingURL, Content-Length)
    DM->>Validator: validateSize(stagingURL, expectedSizeBytes)
    DM->>Validator: validateSHA256(stagingURL, sha256)

    alt Any validation fails
        DM->>FS: removeItem(stagingURL) [cleanup]
        DM-->>DM: throw error
    end

    alt Destination exists
        DM->>FS: replaceItemAt(destinationURL, withItemAt: stagingURL)
    else Destination absent
        DM->>FS: moveItem(stagingURL → destinationURL)
    end

    alt Promotion fails
        DM->>FS: removeItem(stagingURL) [cleanup]
        DM-->>DM: throw error
    end

    DM-->>DM: "modelState = .downloaded"
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fdownload-integrity%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fdownload-integrity%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FServices%2FUtilities%2FModelDownloadManager.swift%3A364-368%0ATOCTOU%20in%20%60promoteStagedFile%60%3A%20%60fileExists%60%20is%20checked%2C%20then%20%60moveItem%60%20is%20called%20in%20the%20%60else%60%20branch.%20If%20another%20process%20or%20a%20concurrent%20download%20creates%20the%20destination%20between%20those%20two%20calls%2C%20%60moveItem%60%20throws%20%22file%20already%20exists%2C%22%20the%20staging%20file%20is%20cleaned%20up%2C%20and%20the%20download%20is%20surfaced%20as%20failed%20%E2%80%94%20even%20though%20the%20data%20is%20fully%20valid.%20%60FileManager.replaceItemAt%60%20handles%20both%20the%20%22destination%20exists%22%20and%20%22destination%20absent%22%20cases%20atomically%2C%20so%20the%20%60fileExists%60%20branch%20is%20unnecessary.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20_%20%3D%20try%20fileManager.replaceItemAt%28destinationURL%2C%20withItemAt%3A%20stagingURL%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabbyTests%2FModelFileValidatorTests.swift%3A79%0A%60validateCompleteness%60%20rejects%20any%20size%20mismatch%20%28not%20just%20truncation%29%2C%20but%20the%20test%20suite%20only%20covers%20the%20under-size%20case.%20A%20file%20that%20is%20*larger*%20than%20the%20declared%20%60Content-Length%60%20%E2%80%94%20e.g.%2C%20a%20response%20with%20appended%20garbage%20bytes%20%E2%80%94%20also%20triggers%20%60sizeMismatch%60%20via%20%60validateSize%60%2C%20and%20having%20an%20explicit%20test%20documents%20that%20guarantee%20and%20guards%20against%20a%20future%20refactor%20that%20changes%20the%20comparison%20direction.%0A%0A%60%60%60suggestion%0A%20%20%20%20func%20test_validateCompleteness_throwsWhenFileLargerThanDeclaredLength%28%29%20throws%20%7B%0A%20%20%20%20%20%20%20%20let%20url%20%3D%20try%20makeFixture%28contents%3A%20Data%28repeating%3A%200xAB%2C%20count%3A%20120%29%29%0A%20%20%20%20%20%20%20%20XCTAssertThrowsError%28try%20ModelFileValidator.validateCompleteness%28of%3A%20url%2C%20declaredContentLength%3A%20100%29%29%20%7B%20error%20in%0A%20%20%20%20%20%20%20%20%20%20%20%20guard%20case%20ModelFileValidator.ValidationError.sizeMismatch%20%3D%20error%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20XCTFail%28%22Expected%20sizeMismatch%2C%20got%20%5C%28error%29%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%0A%20%20%20%20func%20test_validateCompleteness_noOpsWhenLengthUnknown%28%29%20throws%20%7B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FServices%2FUtilities%2FModelDownloadManager.swift%3A364-368%0ATOCTOU%20in%20%60promoteStagedFile%60%3A%20%60fileExists%60%20is%20checked%2C%20then%20%60moveItem%60%20is%20called%20in%20the%20%60else%60%20branch.%20If%20another%20process%20or%20a%20concurrent%20download%20creates%20the%20destination%20between%20those%20two%20calls%2C%20%60moveItem%60%20throws%20%22file%20already%20exists%2C%22%20the%20staging%20file%20is%20cleaned%20up%2C%20and%20the%20download%20is%20surfaced%20as%20failed%20%E2%80%94%20even%20though%20the%20data%20is%20fully%20valid.%20%60FileManager.replaceItemAt%60%20handles%20both%20the%20%22destination%20exists%22%20and%20%22destination%20absent%22%20cases%20atomically%2C%20so%20the%20%60fileExists%60%20branch%20is%20unnecessary.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20_%20%3D%20try%20fileManager.replaceItemAt%28destinationURL%2C%20withItemAt%3A%20stagingURL%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabbyTests%2FModelFileValidatorTests.swift%3A79%0A%60validateCompleteness%60%20rejects%20any%20size%20mismatch%20%28not%20just%20truncation%29%2C%20but%20the%20test%20suite%20only%20covers%20the%20under-size%20case.%20A%20file%20that%20is%20*larger*%20than%20the%20declared%20%60Content-Length%60%20%E2%80%94%20e.g.%2C%20a%20response%20with%20appended%20garbage%20bytes%20%E2%80%94%20also%20triggers%20%60sizeMismatch%60%20via%20%60validateSize%60%2C%20and%20having%20an%20explicit%20test%20documents%20that%20guarantee%20and%20guards%20against%20a%20future%20refactor%20that%20changes%20the%20comparison%20direction.%0A%0A%60%60%60suggestion%0A%20%20%20%20func%20test_validateCompleteness_throwsWhenFileLargerThanDeclaredLength%28%29%20throws%20%7B%0A%20%20%20%20%20%20%20%20let%20url%20%3D%20try%20makeFixture%28contents%3A%20Data%28repeating%3A%200xAB%2C%20count%3A%20120%29%29%0A%20%20%20%20%20%20%20%20XCTAssertThrowsError%28try%20ModelFileValidator.validateCompleteness%28of%3A%20url%2C%20declaredContentLength%3A%20100%29%29%20%7B%20error%20in%0A%20%20%20%20%20%20%20%20%20%20%20%20guard%20case%20ModelFileValidator.ValidationError.sizeMismatch%20%3D%20error%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20XCTFail%28%22Expected%20sizeMismatch%2C%20got%20%5C%28error%29%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%0A%20%20%20%20func%20test_validateCompleteness_noOpsWhenLengthUnknown%28%29%20throws%20%7B%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=536&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Harden model download integrity (pre-rel..."](https://github.com/fujacob/cotabby/commit/f36321cdbbedc94f30ecbe1e097c2cb5a0034579) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35072698)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->