### PR TITLE
Match Extended Context cap to what the engine actually uses

### DIFF
--- a/Cotabby/Models/SuggestionSettingsModel.swift
+++ b/Cotabby/Models/SuggestionSettingsModel.swift
@@ -138,12 +138,15 @@ final class SuggestionSettingsModel: ObservableObject {
     static let defaultGhostTextOpacity: Double = 1.0
     static let ghostTextOpacityStep: Double = 0.1
 
-    /// Hard upper bound on the persisted Extended Context blob, in characters. Sized so the user
-    /// can paste a meaningful glossary or style guide without crowding the model's shared context:
-    /// roughly ~1000 tokens of English, which still leaves headroom for instructions, prefix text,
-    /// clipboard, and visual context inside Apple's 4096-token window. Larger pastes are truncated
-    /// at write time so the cost is bounded on every subsequent request.
-    static let maximumExtendedContextCharacters: Int = 4_000
+    /// Hard upper bound on the persisted Extended Context blob, in characters. Sized to match what the
+    /// engines actually consume rather than what they can store: the OSS base path renders this as a
+    /// budgeted "notes" section (`BaseCompletionPromptRenderer`, `maxChars` 1300) inside a 2400-char
+    /// prompt, so a larger cap would just be clipped on-device instead of used. ~1200 chars (~300
+    /// tokens) is a meaningful glossary or style guide that still leaves room for the prefix and other
+    /// context, and stays well inside Apple's 4096-token window on the Foundation Models path. Keep this
+    /// at or below the notes section's `maxChars` minus its label so the full blob survives on the OSS
+    /// path. Larger pastes are truncated at write time so the cost is bounded on every request.
+    static let maximumExtendedContextCharacters: Int = 1_200
 
     init(
         configuration: SuggestionConfiguration,

--- a/Cotabby/Support/BaseCompletionPromptRenderer.swift
+++ b/Cotabby/Support/BaseCompletionPromptRenderer.swift
@@ -43,7 +43,12 @@ enum BaseCompletionPromptRenderer {
             sections.append(Self.contextSection("language", language, priority: 50, maxChars: 300))
         }
         if let notes = Self.nonEmpty(extendedContext) {
-            sections.append(Self.contextSection("notes", "Notes the writer keeps in mind: \(notes)", priority: 40, maxChars: 600))
+            // `maxChars` must stay at or above `SuggestionSettingsModel.maximumExtendedContextCharacters`
+            // plus this label (~32 chars) so the full user-entered Extended Context survives here instead
+            // of being silently clipped far under the advertised cap. It still competes for the 2400-char
+            // total budget below (priority 40), so an unusually long prefix can trim it, but in normal use
+            // the whole blob lands.
+            sections.append(Self.contextSection("notes", "Notes the writer keeps in mind: \(notes)", priority: 40, maxChars: 1300))
         }
         if let clip = Self.nonEmpty(clipboardContext) {
             sections.append(Self.contextSection("clipboard", "On the clipboard: \(clip)", priority: 35, maxChars: 400))


### PR DESCRIPTION
## Summary

Extended Context advertised a 4000-character cap in the UI, but the Open Source
(base-model) path only ever used the first ~570 characters: the prompt's "notes"
section was hard-capped at 600 chars including its ~32-char label, so up to ~85%
of a long entry was silently dropped on-device, with the only on-screen signal a
counter that implied all 4000 were used.

This aligns the two ends: lower the user-facing/storage cap to **1200** characters
and raise the notes section cap to **1300** (covers the full 1200 plus the label)
so the whole entry actually reaches the local model. The total base-prompt budget
is unchanged (2400 chars), so the latency envelope is identical to today; this
only stops wasting that budget, it does not enlarge the prompt.

Why 1200: ~300 tokens is a meaningful glossary or style guide, it fits the
2400-char base prompt even alongside a maxed 1000-char prefix, and it stays well
inside Apple's 4096-token window on the Foundation Models path (which also reduces
the nano-model truncation reported in #486). Both caps now carry comments stating
the invariant (notes `maxChars` >= UI cap + label) so they cannot silently
diverge again.

## Validation

```
swiftlint lint --quiet \
  Cotabby/Models/SuggestionSettingsModel.swift Cotabby/Support/BaseCompletionPromptRenderer.swift
# exit 0, no violations

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  -only-testing:CotabbyTests/ExtendedContextTests \
  -only-testing:CotabbyTests/BaseCompletionPromptRendererTests \
  CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
# ** TEST SUCCEEDED **  Executed 17 tests, with 0 failures
```

The cap-sensitive test (`ExtendedContextTests`) asserts truncation against
`SuggestionSettingsModel.maximumExtendedContextCharacters` dynamically rather than
a hardcoded number, so it tracks the new 1200 value automatically; the renderer
tests use short fixtures that hit neither the old nor the new cap.

## Linked issues

Refs #486 (extended context not reliably used on Apple Intelligence + nano):
lowering the cap shrinks the FM/nano context-window overflow this describes. It
does not close it; the Performance-window context-usage instrumentation that
issue also asks for is separate follow-up.

## Risk / rollout notes

- Behavior change: the Extended Context field now caps at 1200 chars instead of
  4000. Existing saved entries longer than 1200 are normalized to 1200 (keeping
  the start) and re-persisted on next launch (`normalizedExtendedContext` runs at
  load). Foundation Models users who previously had up to 4000 chars fed in will
  lose the tail beyond 1200; this is intentional for latency and consistency, and
  is still strictly more than the OSS path ever used (~570).
- Latency: unchanged. The total base-prompt budget stays 2400 chars; this only
  reallocates within it so the user's notes are no longer the section that gets
  starved.
- No migration code and no schema change; the storage key and format are the same.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a silent data-loss bug where the Extended Context field advertised a 4000-character cap but the OSS/llama rendering path hard-truncated notes at ~570 characters, meaning up to 85% of a user's entry was dropped on every request. The fix is a two-sided alignment: lower the model/UI cap to 1200 chars and raise the renderer's notes `maxChars` from 600 to 1300, so the full user-entered text (up to 1200 chars + 32-char label = 1232 chars) survives the prompt build step.

- **`SuggestionSettingsModel.swift`**: `maximumExtendedContextCharacters` 4000 → 1200; the UI character-counter and tests both reference this constant dynamically, so they track the new value without further changes.
- **`BaseCompletionPromptRenderer.swift`**: notes section `maxChars` 600 → 1300; the invariant `maxChars ≥ cap + label_length` (1300 ≥ 1232) holds and is documented via comment, but there is no programmatic assertion linking the two constants.
- Existing entries longer than 1200 chars are truncated at first launch via the `normalizedExtendedContext` path, which also re-persists the shortened value.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the two changed constants are correctly aligned and all referencing code (UI counter, truncation logic, tests) already reads from the constant dynamically.

Both constants are correctly set (1200 cap, 1300 renderer budget, 1232 combined need), existing users' over-long entries are quietly truncated and re-persisted on load, and no schema change is required. The one outstanding gap is that the coupling between `maximumExtendedContextCharacters` and the renderer's `maxChars` is enforced only through comments — a future independent edit to either value would silently reintroduce the clipping bug without any test catching it.

BaseCompletionPromptRenderer.swift — the notes `maxChars` value has no test or assertion verifying it stays large enough relative to the model's cap.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Models/SuggestionSettingsModel.swift | Reduces `maximumExtendedContextCharacters` from 4000 to 1200; UI character-count label and tests both reference the constant dynamically so they update automatically with no hardcoded references to change. |
| Cotabby/Support/BaseCompletionPromptRenderer.swift | Raises notes section `maxChars` from 600 to 1300, covering the new 1200-char cap plus the 32-char label (1232 ≤ 1300); the invariant is documented via comment only with no runtime assertion or dedicated test. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant AdvancedPaneView
    participant SuggestionSettingsModel
    participant BaseCompletionPromptRenderer
    participant FoundationModelPromptRenderer

    User->>AdvancedPaneView: Pastes/types Extended Context
    AdvancedPaneView->>SuggestionSettingsModel: setExtendedContext(text)
    SuggestionSettingsModel->>SuggestionSettingsModel: normalizedExtendedContext() truncates to 1200 chars
    SuggestionSettingsModel-->>AdvancedPaneView: "extendedContext (<=1200 chars)"
    Note over AdvancedPaneView: Counter shows X / 1200 characters

    User->>BaseCompletionPromptRenderer: Request prompt (OSS path)
    BaseCompletionPromptRenderer->>BaseCompletionPromptRenderer: contextSection notes maxChars 1300 was 600
    Note over BaseCompletionPromptRenderer: 1200 + 32-char label = 1232 <= 1300, full blob survives

    User->>FoundationModelPromptRenderer: Request prompt (FM/Apple path)
    FoundationModelPromptRenderer->>FoundationModelPromptRenderer: sessionInstructions() injects extendedContext directly
    Note over FoundationModelPromptRenderer: Smaller token footprint in Apple 4096-token window
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fextended-context-cap-mismatch%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fextended-context-cap-mismatch%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FSupport%2FBaseCompletionPromptRenderer.swift%3A46-51%0A**Invariant%20is%20comment-only%20with%20no%20programmatic%20guard**%0A%0AThe%20relationship%20between%20%60notes%20maxChars%60%20%281300%29%20and%20%60SuggestionSettingsModel.maximumExtendedContextCharacters%20%2B%20label_length%60%20%281200%20%2B%2032%20%3D%201232%29%20is%20documented%20in%20the%20comment%20but%20never%20asserted.%20If%20the%20label%20string%20in%20line%2051%20grows%20or%20%60maximumExtendedContextCharacters%60%20rises%20above%201268%20%281300%20%E2%88%92%2032%29%2C%20notes%20will%20again%20be%20silently%20clipped%20without%20any%20failing%20test%20or%20compile-time%20signal.%20The%20%60ExtendedContextTests%60%20only%20validate%20the%20model-layer%20cap%2C%20not%20that%20the%20renderer's%20%60maxChars%60%20is%20large%20enough%20to%20pass%20the%20full%20blob%20through.%0A%0AConsider%20a%20%60%23if%20DEBUG%60%20assertion%20in%20%60BaseCompletionPromptRenderer%60%20or%20an%20%60XCTAssert%60%20in%20the%20renderer%20tests%20that%20directly%20checks%20%60notes%20maxChars%20%3E%3D%20SuggestionSettingsModel.maximumExtendedContextCharacters%20%2B%20labelLength%60%20so%20the%20two%20constants%20cannot%20diverge%20silently%20again.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FSupport%2FBaseCompletionPromptRenderer.swift%3A46-51%0A**Invariant%20is%20comment-only%20with%20no%20programmatic%20guard**%0A%0AThe%20relationship%20between%20%60notes%20maxChars%60%20%281300%29%20and%20%60SuggestionSettingsModel.maximumExtendedContextCharacters%20%2B%20label_length%60%20%281200%20%2B%2032%20%3D%201232%29%20is%20documented%20in%20the%20comment%20but%20never%20asserted.%20If%20the%20label%20string%20in%20line%2051%20grows%20or%20%60maximumExtendedContextCharacters%60%20rises%20above%201268%20%281300%20%E2%88%92%2032%29%2C%20notes%20will%20again%20be%20silently%20clipped%20without%20any%20failing%20test%20or%20compile-time%20signal.%20The%20%60ExtendedContextTests%60%20only%20validate%20the%20model-layer%20cap%2C%20not%20that%20the%20renderer's%20%60maxChars%60%20is%20large%20enough%20to%20pass%20the%20full%20blob%20through.%0A%0AConsider%20a%20%60%23if%20DEBUG%60%20assertion%20in%20%60BaseCompletionPromptRenderer%60%20or%20an%20%60XCTAssert%60%20in%20the%20renderer%20tests%20that%20directly%20checks%20%60notes%20maxChars%20%3E%3D%20SuggestionSettingsModel.maximumExtendedContextCharacters%20%2B%20labelLength%60%20so%20the%20two%20constants%20cannot%20diverge%20silently%20again.%0A%0A&repo=fujacob%2Fcotabby&pr=537&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Match Extended Context cap to what the e..."](https://github.com/fujacob/cotabby/commit/5902078a5917ec58e21d86b90c46e9b7ab9dfa4e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35073427)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->