### PR TITLE
Fix constrained-decode latency: bounded top-K, skip unused logSumExp

### DIFF
--- a/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
+++ b/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
@@ -335,7 +335,12 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
             // Accumulate raw bytes and decode once at the end: a single token may carry only part of
             // a multi-byte UTF-8 scalar, so per-token String decoding would corrupt CJK / emoji.
             let tokenBytes = profile.bytes(for: tokenID)
-            if let logProb = ConstrainedSampler.logProb(ofTokenAt: tokenID, in: logits) {
+            // Scoring each step calls `logSumExp` over the full vocabulary — an O(vocab) exp pass per
+            // token. It only feeds the confidence-floor suppression check, which `shouldSuppress`
+            // short-circuits to a no-op when the floor is -infinity (the shipped default). Skip the
+            // work entirely in that case and only pay it when a caller has actually raised the floor.
+            if options.confidenceFloor > -.infinity,
+               let logProb = ConstrainedSampler.logProb(ofTokenAt: tokenID, in: logits) {
                 sumLogprob += logProb
             }
             generatedBytes.append(contentsOf: tokenBytes)

--- a/Cotabby/Support/ConstrainedSampler.swift
+++ b/Cotabby/Support/ConstrainedSampler.swift
@@ -140,20 +140,58 @@ enum ConstrainedSampler {
     }
 
     /// The token ids to consider this step, ordered by id. When `limit` is at least `count` every id
-    /// is returned (still id-ordered). Otherwise the ids are ranked by descending logit, the top
-    /// `limit` are kept, and that subset is re-sorted by id so downstream tie-breaking stays stable.
+    /// is returned (still id-ordered). Otherwise the `limit` highest-logit ids are kept and returned
+    /// re-sorted by id so downstream tie-breaking stays stable.
+    ///
+    /// Performance invariant: this runs once per generated token and `count` is the full vocabulary
+    /// (~150k-256k for the shipped base models), so it must not sort the whole vocabulary. The earlier
+    /// `(0..<count).sorted` did exactly that — an O(count log count) closure sort plus a count-sized
+    /// allocation on every decode step — which made generation take seconds once the constrained
+    /// decoder became the only decode path. We instead select the top `limit` in a single O(count)
+    /// scan against a fixed-size buffer. Determinism is preserved bit-for-bit: ids are scanned
+    /// ascending and a candidate only displaces the current worst on a STRICTLY higher logit, so
+    /// equal-logit ties resolve to the lower id exactly as the full sort's `lhs < rhs` cut did.
     private static func candidatePool(count: Int, logits: [Float], limit: Int) -> [Int] {
         guard limit < count else {
             return Array(0..<count)
         }
-        let ranked = (0..<count).sorted { lhs, rhs in
-            if logits[lhs] != logits[rhs] {
-                return logits[lhs] > logits[rhs]
+        var keptIDs = [Int](repeating: 0, count: limit)
+        var filled = 0
+        // Index into `keptIDs` of the candidate to evict first (lowest logit; ties toward the larger
+        // id). Only meaningful once the buffer is full; recomputed after every displacement.
+        var worstIndex = 0
+        for id in 0 ..< count {
+            if filled < limit {
+                keptIDs[filled] = id
+                filled += 1
+                if filled == limit {
+                    worstIndex = worstCandidateIndex(in: keptIDs, count: limit, logits: logits)
+                }
+                continue
             }
-            // Stable id ordering for equal logits so the kept set is deterministic at the cut line.
-            return lhs < rhs
+            if logits[id] > logits[keptIDs[worstIndex]] {
+                keptIDs[worstIndex] = id
+                worstIndex = worstCandidateIndex(in: keptIDs, count: limit, logits: logits)
+            }
         }
-        return ranked.prefix(limit).sorted()
+        return keptIDs.sorted()
+    }
+
+    /// Index into `keptIDs` of the candidate that should leave the kept set first: the lowest logit,
+    /// breaking ties toward the larger id so the smaller id is retained. This matches the top-`limit`
+    /// cut line of a full `(logit desc, id asc)` sort, which is what `candidatePool` reproduces without
+    /// sorting. `count` candidates is at most `limit` (small), so this O(limit) scan is cheap.
+    private static func worstCandidateIndex(in keptIDs: [Int], count: Int, logits: [Float]) -> Int {
+        var worst = 0
+        for index in 1 ..< count {
+            let candidate = keptIDs[index]
+            let current = keptIDs[worst]
+            if logits[candidate] < logits[current]
+                || (logits[candidate] == logits[current] && candidate > current) {
+                worst = index
+            }
+        }
+        return worst
     }
 
     /// Numerically stable log(sum(exp(row))): subtract the max before exponentiating so large logits

--- a/CotabbyTests/ConstrainedSamplerTests.swift
+++ b/CotabbyTests/ConstrainedSamplerTests.swift
@@ -188,6 +188,110 @@ final class ConstrainedSamplerTests: XCTestCase {
         XCTAssertNil(id)
     }
 
+    // MARK: - candidatePool equivalence (top-K selection without a full sort)
+
+    /// Deterministic, seedable RNG so the randomized equivalence sweep is reproducible across runs and
+    /// machines (no dependence on `SystemRandomNumberGenerator`).
+    private struct SplitMix64: RandomNumberGenerator {
+        private var state: UInt64
+        init(seed: UInt64) { state = seed }
+        mutating func next() -> UInt64 {
+            state &+= 0x9E37_79B9_7F4A_7C15
+            var mixed = state
+            mixed = (mixed ^ (mixed >> 30)) &* 0xBF58_476D_1CE4_E5B9
+            mixed = (mixed ^ (mixed >> 27)) &* 0x94D0_49BB_1331_11EB
+            return mixed ^ (mixed >> 31)
+        }
+    }
+
+    /// Reference selection that mirrors the *old* implementation exactly: rank the whole vocabulary by
+    /// (logit desc, id asc), keep the top `topK`, then argmax the survivors. `selectToken` now skips
+    /// the full sort, so this is the oracle the fast path must reproduce bit-for-bit.
+    private func referenceSelect(
+        logits: [Float],
+        control: Set<Int>,
+        admissible: Set<Int>?,
+        topK: Int,
+        blocked: Set<Int>
+    ) -> Int? {
+        guard topK > 0, !logits.isEmpty else { return nil }
+        if let admissible, admissible.isEmpty { return nil }
+        let ranked = (0 ..< logits.count).sorted { lhs, rhs in
+            if logits[lhs] != logits[rhs] { return logits[lhs] > logits[rhs] }
+            return lhs < rhs
+        }
+        let pool = Array(ranked.prefix(topK)).sorted()
+        var best: Int?
+        var bestLogit: Float = -.infinity
+        for id in pool {
+            if control.contains(id) || blocked.contains(id) { continue }
+            if let admissible, !admissible.contains(id) { continue }
+            if best == nil || logits[id] > bestLogit {
+                best = id
+                bestLogit = logits[id]
+            }
+        }
+        return best
+    }
+
+    /// The fast top-K selection must match the old full-sort behavior for every combination of vocab
+    /// size, tie structure, topK cut, exclusions, blocks, and admissibility. Logits are quantized to a
+    /// few distinct values on many trials so exact-tie cut-line behavior (lower id wins) is exercised
+    /// heavily, which is where a hand-rolled top-K is most likely to diverge from a full sort.
+    func test_select_matchesFullSortReferenceAcrossRandomInputs() {
+        var rng = SplitMix64(seed: 0xC0FFEE_D00D)
+        for trial in 0 ..< 4000 {
+            let count = Int.random(in: 1 ... 120, using: &rng)
+            // Alternate between coarse (tie-heavy) and fine logit granularity.
+            let distinctValues = trial.isMultiple(of: 2) ? 4 : 64
+            let logits = (0 ..< count).map { _ in
+                Float(Int.random(in: 0 ..< distinctValues, using: &rng))
+            }
+            let control = Set((0 ..< count).filter { _ in Int.random(in: 0 ..< 5, using: &rng) == 0 })
+            let blocked = Set((0 ..< count).filter { _ in Int.random(in: 0 ..< 6, using: &rng) == 0 })
+            let admissible: Set<Int>? = Int.random(in: 0 ..< 3, using: &rng) == 0
+                ? nil
+                : Set((0 ..< count).filter { _ in Int.random(in: 0 ..< 2, using: &rng) == 0 })
+            let topK = Int.random(in: 0 ... (count + 2), using: &rng)
+
+            let actual = ConstrainedSampler.selectToken(
+                logits: logits,
+                profile: plainProfile(count: count, control: control),
+                admissibleTokenIDs: admissible,
+                topK: topK,
+                blockedTokenIDs: blocked
+            )
+            let expected = referenceSelect(
+                logits: logits,
+                control: control,
+                admissible: admissible,
+                topK: topK,
+                blocked: blocked
+            )
+            XCTAssertEqual(
+                actual,
+                expected,
+                "trial \(trial): count=\(count) topK=\(topK) diverged from full-sort reference"
+            )
+        }
+    }
+
+    /// Cut-line tie-break: when the top-`topK` boundary falls in a run of equal logits, the lower ids
+    /// must be the ones kept (so the selected token is the lowest id in the tied run), exactly as the
+    /// previous full sort guaranteed. A large vocab makes a regression in the bounded selection obvious.
+    func test_select_largeVocabEqualLogits_keepsLowestIDsAtCut() {
+        let count = 5000
+        let logits = [Float](repeating: 1.0, count: count)
+        let id = ConstrainedSampler.selectToken(
+            logits: logits,
+            profile: plainProfile(count: count),
+            admissibleTokenIDs: nil,
+            topK: 20
+        )
+        // All logits equal -> the kept pool is ids 0...19 and argmax breaks to the lowest id.
+        XCTAssertEqual(id, 0)
+    }
+
     // MARK: - averageLogProb
 
     func test_averageLogProb_uniformRow_matchesNegativeLogVocab() {


### PR DESCRIPTION
## Summary

Making the constrained decoder the only llama decode path (#532) silently moved every suggestion onto the Swift constrained decoder, which ran two O(vocab) operations per generated token that the deleted native sampler never paid. `ConstrainedSampler.candidatePool` sorted the entire vocabulary (150k-256k tokens) every step just to take the top `topK`, and `runConstrainedDecode` scored every token with a full-vocab `logSumExp` to feed a confidence floor that defaults to `-infinity` (suppression off). With a 25-token budget that was dozens of full-vocab sorts per suggestion, so generation took seconds. This replaces the full sort with a single-pass bounded top-K selection and skips the per-token `logSumExp` at the default floor, with no change to which tokens get selected.

## Validation

```
swiftlint lint --quiet
# exit 0, no violations

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  build-for-testing -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
# ** TEST BUILD SUCCEEDED **

xcodebuild ... test-without-building \
  -only-testing:CotabbyTests/ConstrainedSamplerTests \
  -only-testing:CotabbyTests/ConstrainedBeamSearchTests \
  -only-testing:CotabbyTests/RepetitionGuardTests \
  -only-testing:CotabbyTests/LlamaSuggestionEngineCancellationTests
# ConstrainedSamplerTests: Executed 27 tests, 0 failures
#   (incl. test_select_matchesFullSortReferenceAcrossRandomInputs, a 4000-trial randomized
#    equivalence sweep proving the bounded top-K matches the old full sort bit-for-bit)
# ConstrainedBeamSearchTests / RepetitionGuardTests / LlamaSuggestionEngineCancellationTests: all passed
```

A throwaway micro-benchmark over a representative 200k vocab and 25-token budget (debug build) measured token selection at ~8.0s before vs ~0.55s after (14.5x), with identical selected-token sums confirming output is unchanged. The removed `logSumExp` is additional savings on top of that. Not verified end-to-end on device (needs a model + Accessibility + a live field); the function-level equivalence test plus the benchmark cover the change.

## Linked issues

Refs #532 (introduced the regression by making the constrained decoder the only decode path).

## Risk / rollout notes

- Performance only; no behavior change on the default path. The new `candidatePool` returns the same token set with the same lower-id tie-break as the old full sort, proven by the 4000-trial randomized equivalence test.
- The `logSumExp` skip is gated on `confidenceFloor == -.infinity` (the shipped default). When a caller raises the floor, per-token scoring runs exactly as before, so confidence suppression is unaffected.
- No settings, schema, or pbxproj changes. No public API changes. The beam path (non-default, `beamWidth > 1`) is untouched.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a latency regression introduced in #532, which moved all suggestion generation onto the Swift constrained decoder and exposed two expensive O(vocab) operations per token. The fix replaces the full-vocabulary sort in `candidatePool` with a bounded top-K scan and skips the per-token `logSumExp` when the confidence floor is at its default (`-.infinity`), with no change to which tokens are selected.

- **Bounded top-K in `candidatePool`**: replaces `(0..<count).sorted` (O(vocab log vocab)) with a single O(vocab) scan over a `limit`-sized fixed buffer, evicting the worst candidate on each improvement; tie-breaking (lower id wins) is preserved exactly by evicting the larger id on equal logits.
- **`logSumExp` skip in `runConstrainedDecode`**: the per-token softmax computation is now guarded by `options.confidenceFloor > -.infinity`; when the shipped default is in effect, `sumLogprob` stays at `0.0` and `shouldSuppress` still fires correctly because the policy treats `-.infinity` as "never suppress".
- **New tests**: a 4000-trial deterministic equivalence sweep against the old full-sort reference (using a seeded `SplitMix64` RNG with heavy tie-heavy cases) and a large-vocab equal-logit cut-line test both accompany the change.

<h3>Confidence Score: 5/5</h3>

Safe to merge — pure performance change with no behavioral difference on the default configuration path.

The bounded top-K scan in `candidatePool` is algorithmically equivalent to the old full sort: tie-breaking (lower id wins) is reproduced exactly by evicting the larger id on equal logits, and a 4000-trial deterministic sweep against the old reference confirms bit-for-bit agreement. The `logSumExp` skip is correctly gated on `confidenceFloor > -.infinity` so `shouldSuppress` still receives the right inputs when a caller raises the floor. No schema, API, or behavioral changes are introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/ConstrainedSampler.swift | Replaces O(vocab log vocab) full sort in `candidatePool` with an O(vocab) bounded top-K scan plus an O(limit) `worstCandidateIndex` helper; tie-breaking logic is correct and bit-for-bit equivalent to the old sort. |
| Cotabby/Services/Runtime/LlamaRuntimeCore.swift | Adds a `confidenceFloor > -.infinity` guard before the per-token `logSumExp` call; when the floor is at its default the computation is skipped entirely and `shouldSuppress` still evaluates correctly with the zero-initialized `sumLogprob`. |
| CotabbyTests/ConstrainedSamplerTests.swift | Adds a seeded 4000-trial randomized equivalence sweep against the old full-sort reference and a large-vocab equal-logit cut-line test; both new tests are deterministic and exercise the tie-heavy edge cases most likely to expose divergence. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[runConstrainedDecode called] --> B[Get logits from engine]
    B --> C[RepetitionGuard: compute blockedTokenIDs]
    C --> D[ConstrainedSampler.selectToken]
    D --> E[candidatePool: limit < count?]
    E -->|No - return all IDs| F[id-ordered full vocab]
    E -->|Yes| G[O-vocab scan: fixed-size buffer, worstCandidateIndex evicts on better logit]
    G --> F
    F --> H[argmax over surviving admissible/unblocked tokens]
    H --> I{Token found?}
    I -->|nil| J[stopReason = no_admissible_token]
    I -->|tokenID| K[preCommitStopReason check]
    K -->|stop| L[break loop]
    K -->|continue| M{confidenceFloor > -.infinity?}
    M -->|No - skip logSumExp| N[Append bytes, tokensGenerated++]
    M -->|Yes| O[logProb: logSumExp over full vocab]
    O --> P[sumLogprob += logProb]
    P --> N
    N --> Q[engine.acceptToken]
    Q --> R{Sentence boundary?}
    R -->|Yes| S[break loop]
    R -->|No| B
    J --> T[shouldSuppress]
    L --> T
    S --> T
    T -->|suppress| U[return empty string]
    T -->|pass| V[return generatedText]
```

<sub>Reviews (1): Last reviewed commit: ["Fix constrained-decode latency: bounded ..."](https://github.com/fujacob/cotabby/commit/1817bd5761154fc3277fb53431d8713d98cea8b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35074991)</sub>

<!-- /greptile_comment -->