### PR TITLE
Revert "Make the constrained decoder the only llama decode path (#532)"

### DIFF
--- a/Cotabby/Models/LlamaRuntimeModels.swift
+++ b/Cotabby/Models/LlamaRuntimeModels.swift
@@ -193,9 +193,17 @@ struct LlamaGenerationOptions: Equatable, Sendable {
     /// Defaults to -infinity, which disables suppression entirely.
     var confidenceFloor: Double = -.infinity
 
-    /// Beam width for the constrained decoder. 1 is the single-path greedy decode; values > 1 run a
+    /// Routes generation through the deterministic constrained decoder (logit read + admissibility
+    /// mask + argmax + manual token commit) instead of the engine's built-in stochastic sampler.
+    /// Default off so the shipping sampleNext path is unaffected until the constrained decoder is
+    /// validated on device. Changing it does not affect KV reuse, so it is intentionally excluded
+    /// from `SamplingFingerprint`.
+    var useConstrainedDecoder: Bool = false
+
+    /// Beam width for the constrained decoder. 1 keeps the single-path greedy decode; values > 1 run a
     /// multi-branch beam search that explores several short continuations and keeps the highest-scoring
-    /// one. Does not affect KV reuse, so it is excluded from `SamplingFingerprint`.
+    /// one. Only consulted when `useConstrainedDecoder` is true. Like `useConstrainedDecoder`, it does
+    /// not affect KV reuse, so it is excluded from `SamplingFingerprint`.
     var beamWidth: Int = 1
 
     /// When set (and the model is FIM-capable), the runtime builds a fill-in-middle prompt from the

--- a/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
+++ b/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
@@ -212,9 +212,12 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
             autocompleteSamplingFingerprint = fingerprint
         }
 
-        // The KV-trim defer above runs after whichever decoder returns. Greedy and beam share the
-        // prepared sequence and the same confidence-suppression contract; they differ only in how far
-        // they explore before committing each token.
+        // The KV-trim defer above runs after whichever decoder returns. Both decoders share the
+        // prepared sequence and the same confidence-suppression contract; they differ only in how
+        // they pick each token (engine sampler vs. deterministic constrained selection).
+        guard options.useConstrainedDecoder else {
+            return runEngineSampledDecode(sequenceID: sequenceID, options: options)
+        }
         return options.beamWidth > 1
             ? try runConstrainedBeamDecode(
                 sequenceID: sequenceID,
@@ -265,6 +268,57 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
         // swiftlint:disable:next optional_data_string_conversion
         let decoded = String(decoding: generatedBytes, as: UTF8.self)
         return SentenceBoundaryClassifier.endsSentence(decoded)
+    }
+
+    /// The shipping decoder: delegates token selection to the engine's built-in sampler
+    /// (`sampleNext`), which applies temperature / top-k / top-p / min-p and commits each token.
+    private func runEngineSampledDecode(sequenceID: Int32, options: LlamaGenerationOptions) -> String {
+        var generatedText = ""
+        var tokensGenerated = 0
+        var sumLogprob = 0.0
+        var stopReason = "budget_exhausted"
+
+        for _ in 0 ..< options.maxPredictionTokens {
+            // Cooperative cancellation: when the wrapping Task is cancelled (caller hit a new
+            // keystroke, focus changed, Compose started), bail before the next sampleNext call so
+            // we release `autocompleteLock` instead of running the full prediction budget and
+            // making the next autocomplete wait behind us.
+            if Task.isCancelled {
+                stopReason = "cancelled"
+                break
+            }
+
+            let result = engine.sampleNext(sequenceID)
+
+            if result.was_cancelled {
+                stopReason = "engine_cancelled"
+                break
+            }
+            if result.is_eos {
+                stopReason = "eos"
+                break
+            }
+
+            let piece = Self.extractPiece(result)
+            generatedText += piece
+            tokensGenerated += 1
+            sumLogprob += Double(result.logprob)
+        }
+
+        CotabbyLogger.runtime.debug(
+            "Decode end",
+            metadata: [
+                "kind": .string("generate"),
+                "tokens_generated": .stringConvertible(tokensGenerated),
+                "chars_generated": .stringConvertible(generatedText.count),
+                "stop_reason": .string(stopReason)
+            ]
+        )
+
+        if Self.shouldSuppress(sumLogprob: sumLogprob, tokensGenerated: tokensGenerated, options: options) {
+            return ""
+        }
+        return generatedText
     }
 
     /// The constrained decoder: reads the raw next-token logits, masks structural / excluded tokens
@@ -848,6 +902,15 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
             return writtenLarge > 0 ? large.prefix(writtenLarge).map { UInt8(bitPattern: $0) } : []
         }
         return []
+    }
+
+    private static func extractPiece(_ result: SampleResult) -> String {
+        guard let piece = result.piece, result.piece_length > 0 else { return "" }
+        let buffer = UnsafeBufferPointer(
+            start: UnsafeRawPointer(piece).assumingMemoryBound(to: UInt8.self),
+            count: Int(result.piece_length)
+        )
+        return String(bytes: buffer, encoding: .utf8) ?? ""
     }
 
     private static func samplingConfig(from options: LlamaGenerationOptions) -> SamplingConfig {

--- a/Cotabby/Services/Runtime/LlamaRuntimeManager.swift
+++ b/Cotabby/Services/Runtime/LlamaRuntimeManager.swift
@@ -107,8 +107,8 @@ final class LlamaRuntimeManager: ObservableObject {
         do {
             // `Task.detached` does not inherit the caller's cancellation, so an outer cancel
             // would otherwise leave `core.generate` running to its full prediction budget while
-            // holding `autocompleteLock`. The handler forwards the cancel signal, and the decode
-            // loop inside `core.generate` polls `Task.isCancelled` between token steps.
+            // holding `autocompleteLock`. The handler forwards the cancel signal, and the loop
+            // inside `core.generate` polls `Task.isCancelled` between sampleNext calls.
             let task = Task.detached {
                 try core.generate(
                     prompt: prompt,

--- a/Cotabby/Services/Runtime/LlamaSuggestionEngine.swift
+++ b/Cotabby/Services/Runtime/LlamaSuggestionEngine.swift
@@ -13,19 +13,39 @@ final class LlamaSuggestionEngine {
     private let runtimeManager: LlamaRuntimeGenerating
     private var promptCacheHintTracker = LlamaPromptCacheHintTracker()
 
-    /// UserDefaults key (no UI) for the constrained decoder's beam width. 1 is greedy (the shipping
-    /// default); a value > 1 runs a multi-branch beam search. Kept as a tuning knob, not a feature
-    /// gate: beam-by-default still needs the batched-beam decode work to avoid per-branch latency.
+    /// UserDefaults key (no UI) that routes llama generation through the deterministic constrained
+    /// decoder instead of the engine's stochastic sampler. Default-off: decode quality can only be
+    /// judged with a real model in a real field, so this stays a hidden developer/dogfood toggle
+    /// until it is validated on device and promoted to the default.
+    private static let constrainedDecoderDefaultsKey = "cotabbyConstrainedDecoderEnabled"
+    private static var isConstrainedDecoderEnabled: Bool {
+        UserDefaults.standard.bool(forKey: constrainedDecoderDefaultsKey)
+    }
+
+    /// UserDefaults key (no UI) for the constrained decoder's beam width. Default 1 keeps the existing
+    /// single-path greedy decode; a value > 1 runs a multi-branch beam search. Paired with the
+    /// constrained-decoder flag as a hidden developer/dogfood knob until validated on device.
     private static let constrainedBeamWidthDefaultsKey = "cotabbyConstrainedBeamWidth"
     private static var constrainedBeamWidth: Int {
         let stored = UserDefaults.standard.integer(forKey: constrainedBeamWidthDefaultsKey)
         return stored > 0 ? stored : 1
     }
 
-    /// The fill-in-middle request for a generation, or nil to use the forward base prompt. Built when
-    /// the caret is genuinely mid-line (real text follows it on the same line); the runtime still falls
-    /// back to the base prompt when the model lacks the FIM marker tokens.
+    /// UserDefaults key (no UI) for fill-in-middle prompting. Default off: FIM only helps models that
+    /// ship the FIM marker tokens, and it changes the prompt structure, so it stays a developer toggle
+    /// until validated on device.
+    private static let fillInMiddleDefaultsKey = "cotabbyFillInMiddleEnabled"
+    private static var isFillInMiddleEnabled: Bool {
+        UserDefaults.standard.bool(forKey: fillInMiddleDefaultsKey)
+    }
+
+    /// The fill-in-middle request for a generation, or nil to use the forward base prompt. Built only
+    /// when the flag is on and the caret is genuinely mid-line (real text follows it on the same line);
+    /// the runtime still falls back to the base prompt when the model lacks FIM markers.
     private static func fillInMiddleRequest(for request: SuggestionRequest) -> FillInMiddleRequest? {
+        guard isFillInMiddleEnabled else {
+            return nil
+        }
         // A caret at end of line wants a forward continuation, not infilling — even if `trailingText`
         // is non-empty because a line break and later paragraphs follow it. Gating on end-of-line
         // (rather than `trailingText.isEmpty`) keeps FIM to the case it is actually meant for.
@@ -76,6 +96,7 @@ final class LlamaSuggestionEngine {
                         precedingText: request.context.precedingText,
                         trailingText: request.context.trailingText
                     ),
+                    useConstrainedDecoder: Self.isConstrainedDecoderEnabled,
                     beamWidth: Self.constrainedBeamWidth,
                     fillInMiddle: Self.fillInMiddleRequest(for: request)
                 )


### PR DESCRIPTION
## Summary

Restore the native sampler (`runEngineSampledDecode`) as the default llama decode path by reverting #532, and put the constrained decoder back behind its default-off `useConstrainedDecoder` flag. #538 removed the worst of the constrained-decode latency (the per-token full-vocab sort and an unused per-token `logSumExp`), but in real use the constrained path is still much slower than the native sampler users had before #532, so we fall back to native now and keep the constrained decoder behind its flag while the remaining slowness is investigated.

## Validation

```
swiftlint lint --quiet <reverted files>
# exit 0

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  build-for-testing -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
# ** TEST BUILD SUCCEEDED **   (restored runEngineSampledDecode compiles against the current engine)

xcodebuild ... test-without-building \
  -only-testing:CotabbyTests/ConstrainedSamplerTests \
  -only-testing:CotabbyTests/ConstrainedBeamSearchTests \
  -only-testing:CotabbyTests/RepetitionGuardTests \
  -only-testing:CotabbyTests/LlamaSuggestionEngineCancellationTests
# Executed 51 tests, with 0 failures
```

Real-world latency that motivated the revert (from `~/Library/Logs/Cotabby/llm-io.jsonl` on the post-#538 build): constrained decode p50 ~311ms, p99 ~2.1s, max ~6.4s on a 262k-vocab model, versus the snappy native path before #532.

## Linked issues

Refs #532 (this reverts it). Refs #538 (its ConstrainedSampler / `runConstrainedDecode` optimizations are intentionally kept).

## Risk / rollout notes

- Behavior revert to the known-good native sampler. Default generation no longer uses the constrained decoder; it stays available behind the hidden `cotabbyConstrainedDecoderEnabled` UserDefaults flag (default off), and behind `useConstrainedDecoder` in `LlamaGenerationOptions` (default false).
- #538's `candidatePool` bounded top-K and the `logSumExp` skip are kept, so the flagged constrained path is fast when enabled.
- Deferred for investigation (not blocking this revert): the constrained path appears to over-generate in multi-line fields (it cannot select an EOS token, since EOS is excluded as a control token, so it runs to the token budget instead of stopping early), plus per-token O(vocab) Swift work over a 262k vocab is costly in debug builds. These are why even the optimized constrained path is still slow.
- No settings, schema, or pbxproj changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reverts #532 by restoring the engine's native stochastic sampler (`runEngineSampledDecode` / `sampleNext`) as the default llama decode path, and puts the constrained decoder back behind the `useConstrainedDecoder` flag (default off) and its UserDefaults key. The #538 performance work on `ConstrainedSampler` is intentionally kept.

- `LlamaRuntimeCore.swift`: Adds a `guard options.useConstrainedDecoder else { return runEngineSampledDecode(...) }` guard so the fast native path runs by default, and introduces a new `extractPiece` helper that reads token bytes from the engine's `SampleResult` into a `String`.
- `LlamaSuggestionEngine.swift`: Restores `constrainedDecoderDefaultsKey` / `isFillInMiddleEnabled` UserDefaults flags (both default-off) and threads `useConstrainedDecoder: Self.isConstrainedDecoderEnabled` into `LlamaGenerationOptions`.
- `LlamaRuntimeModels.swift`: Adds `useConstrainedDecoder: Bool = false` to `LlamaGenerationOptions` with updated doc comments.

<h3>Confidence Score: 4/5</h3>

The revert to the native sampler is a well-scoped behavioral rollback that restores a previously working code path; the main risk is that the new extractPiece helper silently drops partial multi-byte UTF-8 token pieces, which could cause CJK or emoji text to be erased rather than rendered.

The routing change and flag restoration are clean and match the stated intent. The one functional concern is extractPiece's per-token failable UTF-8 decode, which mirrors the same pitfall the constrained-decoder code already documents and avoids — if the engine ever returns a token whose bytes are only part of a multi-byte scalar, that token's contribution is silently dropped. This was likely pre-existing behavior before #532, but the helper is newly written code in this PR.

Cotabby/Services/Runtime/LlamaRuntimeCore.swift — specifically the extractPiece helper and the per-token String decoding in runEngineSampledDecode.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Services/Runtime/LlamaRuntimeCore.swift | Restores runEngineSampledDecode as the default decode path behind a guard on useConstrainedDecoder; adds extractPiece helper that uses failable UTF-8 decoding per token, which can silently drop partial multi-byte sequences (CJK/emoji). |
| Cotabby/Models/LlamaRuntimeModels.swift | Adds useConstrainedDecoder: Bool = false field and updates beamWidth doc to note it is only consulted when constrained decode is on; documentation changes look correct. |
| Cotabby/Services/Runtime/LlamaRuntimeManager.swift | Comment-only update to reflect that the decode loop now polls Task.isCancelled between sampleNext calls; no functional change. |
| Cotabby/Services/Runtime/LlamaSuggestionEngine.swift | Restores constrainedDecoderDefaultsKey / isFillInMiddleEnabled flags (both default-off) and threads useConstrainedDecoder into LlamaGenerationOptions; logic is correct and matches the revert intent. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[generate called] --> B{useConstrainedDecoder?}
    B -- false default --> C[runEngineSampledDecode]
    B -- true --> D{beamWidth gt 1?}
    D -- false --> E[runConstrainedDecode]
    D -- true --> F[runConstrainedBeamDecode]
    C --> G[sampleNext loop\nextractPiece per token]
    E --> H[getNextTokenLogits\nConstrainedSampler.selectToken\nacceptToken manually]
    F --> I[EngineBeamStepper\nmulti-branch beam search]
    G --> J{shouldSuppress?}
    E --> J
    F --> J
    J -- yes --> K[return empty string]
    J -- no --> L[return generatedText]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Frevert-constrained-only-decode%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Frevert-constrained-only-decode%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%3A907-914%0A**Silent%20drop%20of%20partial-UTF-8%20token%20pieces**%0A%0A%60String%28bytes%3A%20buffer%2C%20encoding%3A%20.utf8%29%20%3F%3F%20%22%22%60%20returns%20%60%22%22%60%20whenever%20a%20token's%20bytes%20are%20not%20a%20complete%2C%20valid%20UTF-8%20sequence.%20The%20llama%20tokenizer%20can%20split%20a%20multi-byte%20scalar%20%28CJK%20character%2C%20emoji%29%20across%20adjacent%20tokens%2C%20so%20the%20first%20token%20carries%20only%20the%20leading%20byte%28s%29%20and%20the%20second%20carries%20the%20continuation%20byte%28s%29%20%E2%80%94%20neither%20fragment%20decodes%20independently%20as%20valid%20UTF-8.%20The%20consequence%20is%20that%20both%20tokens%20silently%20contribute%20nothing%20to%20%60generatedText%60%2C%20effectively%20erasing%20the%20character.%20%60runConstrainedDecode%60%20already%20documents%20this%20exact%20pitfall%20and%20works%20around%20it%20by%20accumulating%20raw%20bytes%20and%20decoding%20once%20at%20the%20end%20with%20%60String%28decoding%3Aas%3A%29%60.%20The%20native%20sampler%20path%20doesn't%20accumulate%20bytes%2C%20but%20the%20per-token%20fallback%20to%20%60%22%22%60%20means%20the%20same%20class%20of%20corruption%20applies.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%3A907-914%0A**Silent%20drop%20of%20partial-UTF-8%20token%20pieces**%0A%0A%60String%28bytes%3A%20buffer%2C%20encoding%3A%20.utf8%29%20%3F%3F%20%22%22%60%20returns%20%60%22%22%60%20whenever%20a%20token's%20bytes%20are%20not%20a%20complete%2C%20valid%20UTF-8%20sequence.%20The%20llama%20tokenizer%20can%20split%20a%20multi-byte%20scalar%20%28CJK%20character%2C%20emoji%29%20across%20adjacent%20tokens%2C%20so%20the%20first%20token%20carries%20only%20the%20leading%20byte%28s%29%20and%20the%20second%20carries%20the%20continuation%20byte%28s%29%20%E2%80%94%20neither%20fragment%20decodes%20independently%20as%20valid%20UTF-8.%20The%20consequence%20is%20that%20both%20tokens%20silently%20contribute%20nothing%20to%20%60generatedText%60%2C%20effectively%20erasing%20the%20character.%20%60runConstrainedDecode%60%20already%20documents%20this%20exact%20pitfall%20and%20works%20around%20it%20by%20accumulating%20raw%20bytes%20and%20decoding%20once%20at%20the%20end%20with%20%60String%28decoding%3Aas%3A%29%60.%20The%20native%20sampler%20path%20doesn't%20accumulate%20bytes%2C%20but%20the%20per-token%20fallback%20to%20%60%22%22%60%20means%20the%20same%20class%20of%20corruption%20applies.%0A%0A&repo=fujacob%2Fcotabby&pr=539&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Revert &quot;Make the constrained decoder the..."](https://github.com/fujacob/cotabby/commit/9f2a17815267b67ed0cbc8c28c2a006153301a0a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35076081)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->