### PR TITLE
refactor(focus): consolidate caret geometry + throttle ownership (stacked on #560)

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		046C133967B32BBF9205EBB1 /* LLMIOFileHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D610FCA3A97249DCCE7D0B8 /* LLMIOFileHandler.swift */; };
 		078FDE669437D756678E9AB7 /* SettingsRowLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907549CB913B40C28B953A5D /* SettingsRowLabel.swift */; };
 		07D046D406411ED85AC5758A /* InputMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC01317B0B68E3C4125E421 /* InputMonitorTests.swift */; };
+		08E96A24AE5522352080BAA4 /* CaretGeometryResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262D93D4087E59FEA60473ED /* CaretGeometryResolverTests.swift */; };
 		0A2DDD946654076675AC0FC6 /* LanguageCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4BB93056F291FD24EFAD22 /* LanguageCatalog.swift */; };
 		0A3443AEE6540F11E5E6BF8F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E8E86A14090BC7BD13BA76 /* AppDelegate.swift */; };
 		0A658BF137DBD0898E40B87F /* AcknowledgementsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7A28471B8526C2693FFF65 /* AcknowledgementsView.swift */; };
@@ -127,7 +128,6 @@
 		6955C3A4D7AB3EEF7FA7C469 /* InputSuppressionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1F9CEBAB0F330F8E7B61D8 /* InputSuppressionController.swift */; };
 		6AE0B46FB52D189D94E1F79A /* WordCountFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E0513E3B23937B099A3CFF2 /* WordCountFormatterTests.swift */; };
 		6B0186B9F3E6F654296B6D76 /* AdvancedPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E644072C123DC2D2B40274D /* AdvancedPaneView.swift */; };
-		6D0E79CF3C1A8CE53046FCE5 /* AXTextGeometryResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C046CB4F3CB4BFE9391DB5DE /* AXTextGeometryResolverTests.swift */; };
 		6DD1E22151571E1A22FF22F4 /* FoundationModelSuggestionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5664E34B23FBDF69292FEF43 /* FoundationModelSuggestionEngine.swift */; };
 		6E01052209B73D7361C12CEF /* ClipboardContentDistiller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96495E4147D828C0B1B22765 /* ClipboardContentDistiller.swift */; };
 		6E49ADEB31D04DC77A47DEB0 /* FileLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8C2569A8217EE9BD3B197F /* FileLogHandler.swift */; };
@@ -225,7 +225,6 @@
 		D648DD70AD847F67B77CE052 /* OnboardingTemplateRecommenderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B72736E416910878E8E493 /* OnboardingTemplateRecommenderTests.swift */; };
 		D800277BE3296DE2FB8198A8 /* ChromiumAccessibilityEnabler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8896D976C7F116EBA0F3969F /* ChromiumAccessibilityEnabler.swift */; };
 		D90C889A623A928F4F5FDC7B /* HardwareCapabilityProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41BBD5A4BA08CABE77860886 /* HardwareCapabilityProbe.swift */; };
-		D9C51DEDF01033E276A479CE /* AXTextGeometryResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB58035EFFD65B767949BAE6 /* AXTextGeometryResolver.swift */; };
 		DA23422A2CF77CFD3B1283C8 /* OnboardingTemplateFeatureListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D814BBA41CF29E8DD9954651 /* OnboardingTemplateFeatureListTests.swift */; };
 		DB1310FF3576ACA6472C4DB1 /* TrailingDuplicationFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19A5B462891263BDFB56607 /* TrailingDuplicationFilterTests.swift */; };
 		DC84D6A6A2F9A1060CD20ABB /* TokenCountEstimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BA30E71C21C77BB6EA4C166 /* TokenCountEstimator.swift */; };
@@ -253,6 +252,7 @@
 		F067EA26AC2D007382CE520F /* EmojiPickerModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E5F074ED7E340E9B9E4C5E0 /* EmojiPickerModels.swift */; };
 		F08C139B246C1EC7BB435455 /* MenuBarPresentationObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00824BDD8D0E9B3063827C78 /* MenuBarPresentationObserver.swift */; };
 		F0DEEE8A866ABB560E7A7E6A /* LaunchAtLoginService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220CD4AFA1E96A37BC4514AD /* LaunchAtLoginService.swift */; };
+		F1F1C299BBCAB4141301C4A3 /* CaretGeometryResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CAF3A4DBC53F4159F9455A /* CaretGeometryResolver.swift */; };
 		F31B343F9C935A5421A526DE /* AXTreeDumpWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B27492B04B627DA53BDAD938 /* AXTreeDumpWriter.swift */; };
 		F496D63FD0A163D222D8C76F /* EmojiPickerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A3B81B92E0743C6152ED8DD /* EmojiPickerController.swift */; };
 		F4A01E4F12F0183449BCCBB9 /* BaseCompletionPromptRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9966D09D8D80F54BF2734E00 /* BaseCompletionPromptRendererTests.swift */; };
@@ -320,6 +320,7 @@
 		22544F4B756E3E4144497D17 /* SuggestionCoordinator+Input.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SuggestionCoordinator+Input.swift"; sourceTree = "<group>"; };
 		24F613F0E2F7046E6532A09C /* OnboardingTemplateFeatureList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTemplateFeatureList.swift; sourceTree = "<group>"; };
 		262BE2F1E97389FE8D7A5FB9 /* Cotabby.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Cotabby.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		262D93D4087E59FEA60473ED /* CaretGeometryResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaretGeometryResolverTests.swift; sourceTree = "<group>"; };
 		264CA64B2AB1611F82E5B760 /* WelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
 		273B4DC844F79B4BE2C8910F /* FocusPollBackoffTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusPollBackoffTests.swift; sourceTree = "<group>"; };
 		292DC9D4D9D5D26AE882E39B /* EmojiCatalogMatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiCatalogMatcherTests.swift; sourceTree = "<group>"; };
@@ -350,6 +351,7 @@
 		4696A84D17890B154533A08F /* PromptPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptPolicyTests.swift; sourceTree = "<group>"; };
 		474560E524C1D74BAB1570DA /* SecureFieldDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureFieldDetectorTests.swift; sourceTree = "<group>"; };
 		4793D4EA5D36D7E5CC216C27 /* LanguageSupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageSupportTests.swift; sourceTree = "<group>"; };
+		47CAF3A4DBC53F4159F9455A /* CaretGeometryResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaretGeometryResolver.swift; sourceTree = "<group>"; };
 		51020F8CD58338BD643FBF63 /* ModelDownloadManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelDownloadManager.swift; sourceTree = "<group>"; };
 		52BAFA2F989C3C4F7FB892B5 /* MarkerSelectionSynthesizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkerSelectionSynthesizerTests.swift; sourceTree = "<group>"; };
 		53CF416511099C6818110F01 /* CompletionRenderModePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionRenderModePolicy.swift; sourceTree = "<group>"; };
@@ -471,7 +473,6 @@
 		BE97A8169438D593C6C23412 /* VisualContextModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualContextModels.swift; sourceTree = "<group>"; };
 		BF474064973F4752F79BB041 /* EmojiSynonymCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiSynonymCatalogTests.swift; sourceTree = "<group>"; };
 		BF4BB93056F291FD24EFAD22 /* LanguageCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageCatalog.swift; sourceTree = "<group>"; };
-		C046CB4F3CB4BFE9391DB5DE /* AXTextGeometryResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AXTextGeometryResolverTests.swift; sourceTree = "<group>"; };
 		C05B0439348261163B37C508 /* SuggestionAvailabilityEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionAvailabilityEvaluatorTests.swift; sourceTree = "<group>"; };
 		C1C5DE0F3FF63545000E2453 /* DisplayCoordinateConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayCoordinateConverterTests.swift; sourceTree = "<group>"; };
 		C375227649689775275AA4B3 /* SuggestionCoordinatorAcceptanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionCoordinatorAcceptanceTests.swift; sourceTree = "<group>"; };
@@ -479,7 +480,6 @@
 		C71031E8DB171047318B92FC /* SyntheticReplacePlannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntheticReplacePlannerTests.swift; sourceTree = "<group>"; };
 		C7B2D34A6F3AC9DFD61350F7 /* CotabbyDebugOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CotabbyDebugOptions.swift; sourceTree = "<group>"; };
 		CA942A53B7C09D1F4EC57239 /* SuggestionInteractionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionInteractionState.swift; sourceTree = "<group>"; };
-		CB58035EFFD65B767949BAE6 /* AXTextGeometryResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AXTextGeometryResolver.swift; sourceTree = "<group>"; };
 		CBD5FCB8CC56AA6138382B2C /* FieldEdgeIconIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FieldEdgeIconIndicatorView.swift; sourceTree = "<group>"; };
 		CC1EDFB535AAA2EE0D67828A /* CotabbyApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CotabbyApp.swift; sourceTree = "<group>"; };
 		CDB25ABC4FFB0E63477CDCB0 /* SuggestionOverlayStabilityGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionOverlayStabilityGateTests.swift; sourceTree = "<group>"; };
@@ -671,8 +671,8 @@
 		59681B24821B0C960A656168 /* Focus */ = {
 			isa = PBXGroup;
 			children = (
-				CB58035EFFD65B767949BAE6 /* AXTextGeometryResolver.swift */,
 				B27492B04B627DA53BDAD938 /* AXTreeDumpWriter.swift */,
+				47CAF3A4DBC53F4159F9455A /* CaretGeometryResolver.swift */,
 				8896D976C7F116EBA0F3969F /* ChromiumAccessibilityEnabler.swift */,
 				684737E62EE6495A71344923 /* DeepGeometryWalkThrottle.swift */,
 				04E25414C307A20B6F9F20EC /* FocusSnapshotResolver.swift */,
@@ -756,11 +756,11 @@
 			isa = PBXGroup;
 			children = (
 				A168A7B6A7AD11559B60C56B /* ApplicationBundleMetadataTests.swift */,
-				C046CB4F3CB4BFE9391DB5DE /* AXTextGeometryResolverTests.swift */,
 				9966D09D8D80F54BF2734E00 /* BaseCompletionPromptRendererTests.swift */,
 				04D853218B0A77B0CE090828 /* BrowserAppDetectorTests.swift */,
 				1F761083EA5465023D82B5F4 /* BrowserDomainTests.swift */,
 				18D990E515E1AE4F312F4E95 /* BundledRuntimeLocatorTests.swift */,
+				262D93D4087E59FEA60473ED /* CaretGeometryResolverTests.swift */,
 				8EA827D6A2A54DF4BAD56405 /* CaretLinePositionTests.swift */,
 				EFD89799BB82AF7A92559AEB /* ClipboardContentDistillerTests.swift */,
 				90B0D133AB77A2503FB08827 /* ClipboardRelevanceFilterTests.swift */,
@@ -1108,7 +1108,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				30F3F2B6D13CD583136CD787 /* AXHelper.swift in Sources */,
-				D9C51DEDF01033E276A479CE /* AXTextGeometryResolver.swift in Sources */,
 				F31B343F9C935A5421A526DE /* AXTreeDumpWriter.swift in Sources */,
 				78FAE5DB691A1B71042B9D20 /* AboutPaneView.swift in Sources */,
 				DDEDCBAA2196303455F6926A /* AcceptanceModePickerView.swift in Sources */,
@@ -1123,6 +1122,7 @@
 				49C91DE326A590708D76102A /* BrowserAppDetector.swift in Sources */,
 				7D9C3D733CE7633FB12A35BE /* BrowserDomain.swift in Sources */,
 				3CBBC3BFAC0DC8952EE24EF7 /* BundledRuntimeLocator.swift in Sources */,
+				F1F1C299BBCAB4141301C4A3 /* CaretGeometryResolver.swift in Sources */,
 				76FD91607794883F8E121450 /* CaretGeometrySelector.swift in Sources */,
 				543D71217CA218426E9638BF /* CaretLinePosition.swift in Sources */,
 				D800277BE3296DE2FB8198A8 /* ChromiumAccessibilityEnabler.swift in Sources */,
@@ -1289,12 +1289,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6D0E79CF3C1A8CE53046FCE5 /* AXTextGeometryResolverTests.swift in Sources */,
 				A36481222BB5B2A67349D389 /* ApplicationBundleMetadataTests.swift in Sources */,
 				F4A01E4F12F0183449BCCBB9 /* BaseCompletionPromptRendererTests.swift in Sources */,
 				5C0D3B6012C7412001BE3773 /* BrowserAppDetectorTests.swift in Sources */,
 				C3B6C8B9DE20A71C65D390DA /* BrowserDomainTests.swift in Sources */,
 				58AC3193D846FDE88513377D /* BundledRuntimeLocatorTests.swift in Sources */,
+				08E96A24AE5522352080BAA4 /* CaretGeometryResolverTests.swift in Sources */,
 				62FADA407797998742502DD9 /* CaretLinePositionTests.swift in Sources */,
 				8865B95FE84198D70390DF80 /* ClipboardContentDistillerTests.swift in Sources */,
 				BFCA7FAFDAEBF586AB615567 /* ClipboardRelevanceFilterTests.swift in Sources */,

--- a/Cotabby/Services/Focus/CaretGeometryResolver.swift
+++ b/Cotabby/Services/Focus/CaretGeometryResolver.swift
@@ -30,7 +30,7 @@ struct CaretGeometryResult {
 }
 
 @MainActor
-struct AXTextGeometryResolver {
+struct CaretGeometryResolver {
     /// Resolves the full input frame for workflows that need the whole field bounds, such as
     /// screenshot cropping and field-level diagnostics. This stays separate from caret resolution
     /// because not every consumer wants the same geometry contract.
@@ -335,5 +335,134 @@ struct AXTextGeometryResolver {
         }
 
         return CGRect(x: rect.minX, y: rect.minY, width: normalizedWidth, height: rect.height)
+    }
+
+    // MARK: - Deep caret BFS
+
+    // Moved here from FocusSnapshotResolver so all caret-geometry resolution (the per-element
+    // branches above plus the cross-element deep walk below) lives in one type. Behavior is
+    // unchanged; the only edit is that the walk now calls `resolveCaretRect` on `self` instead of
+    // through an injected resolver.
+
+    /// Runs deep geometry search from the resolved editable candidate first, then falls back to
+    /// the raw focused node when those are different branches of the same local AX neighborhood.
+    func resolveDeepGeometrySource(
+        focusedElement: AXUIElement,
+        resolvedElement: AXUIElement,
+        cocoaAnchorFrame: CGRect?
+    ) -> CaretGeometryResult? {
+        if let result = findDeepGeometrySource(
+            from: resolvedElement,
+            cocoaAnchorFrame: cocoaAnchorFrame
+        ) {
+            return result
+        }
+
+        guard
+            AXHelper.elementIdentity(for: focusedElement)
+                != AXHelper.elementIdentity(for: resolvedElement)
+        else {
+            return nil
+        }
+
+        return findDeepGeometrySource(
+            from: focusedElement,
+            cocoaAnchorFrame: cocoaAnchorFrame
+        )
+    }
+
+    /// Searches deeper descendants of the focused element for a node with precise caret geometry.
+    ///
+    /// Chrome's AX tree nests live selection data on deep `AXStaticText` leaf nodes that have
+    /// tight per-text-run frames — far more precise than the parent text entry area's AXFrame.
+    /// We only read position from these nodes; the input target (where we type) stays unchanged.
+    private func findDeepGeometrySource(
+        from root: AXUIElement,
+        cocoaAnchorFrame: CGRect?
+    ) -> CaretGeometryResult? {
+        var queue: [(element: AXUIElement, depth: Int)] = [(root, 0)]
+        let maxDepth = 10
+        let maxNodes = 200
+        var visited = 0
+        var seen = Set<String>()
+        var bestResult: (result: CaretGeometryResult, depth: Int)?
+
+        while !queue.isEmpty, visited < maxNodes {
+            let (element, depth) = queue.removeFirst()
+
+            let identity = AXHelper.elementIdentity(for: element)
+            guard seen.insert(identity).inserted else { continue }
+            visited += 1
+
+            // Look for any node with an active caret (zero-length selection).
+            // Don't filter by role — Chrome uses AXStaticText for editable text runs.
+            if let range = AXHelper.rangeValue(
+                for: kAXSelectedTextRangeAttribute as CFString, on: element
+            ), range.length == 0 {
+                let paramAttrs = Set(AXHelper.parameterizedAttributeNames(on: element))
+                let attrs = Set(AXHelper.attributeNames(on: element))
+                let textValue =
+                    attrs.contains(kAXValueAttribute as String)
+                    ? AXHelper.stringValue(for: kAXValueAttribute as CFString, on: element)
+                    : nil
+                let result = resolveCaretRect(
+                    for: element,
+                    selection: range,
+                    supportsBoundsForRange: paramAttrs.contains(
+                        kAXBoundsForRangeParameterizedAttribute as String
+                    ),
+                    supportsFrame: attrs.contains("AXFrame"),
+                    cocoaAnchorFrame: cocoaAnchorFrame,
+                    textValue: textValue
+                )
+
+                if let result, result.quality == .exact || result.quality == .derived {
+                    if shouldPreferDeepResult(
+                        result,
+                        at: depth,
+                        over: bestResult
+                    ) {
+                        bestResult = (result, depth)
+                    }
+                }
+            }
+
+            guard depth < maxDepth else { continue }
+            for child in AXHelper.childElements(of: element) {
+                queue.append((child, depth + 1))
+            }
+        }
+
+        return bestResult?.result
+    }
+
+    /// Prefers deeper descendants because browser AX wrappers can expose superficially "valid"
+    /// geometry on shallow nodes while the real caret anchor lives lower in the text-run leaves.
+    private func shouldPreferDeepResult(
+        _ candidate: CaretGeometryResult,
+        at depth: Int,
+        over best: (result: CaretGeometryResult, depth: Int)?
+    ) -> Bool {
+        guard let best else {
+            return true
+        }
+
+        if depth != best.depth {
+            return depth > best.depth
+        }
+
+        return deepResultQualityScore(candidate.quality)
+            > deepResultQualityScore(best.result.quality)
+    }
+
+    private func deepResultQualityScore(_ quality: CaretGeometryQuality) -> Int {
+        switch quality {
+        case .exact:
+            return 2
+        case .derived:
+            return 1
+        case .estimated:
+            return 0
+        }
     }
 }

--- a/Cotabby/Services/Focus/FocusSnapshotResolver.swift
+++ b/Cotabby/Services/Focus/FocusSnapshotResolver.swift
@@ -9,7 +9,7 @@ import Logging
 /// polling shell in `FocusTracker`.
 @MainActor
 struct FocusSnapshotResolver {
-    private let geometryResolver: AXTextGeometryResolver
+    private let geometryResolver: CaretGeometryResolver
 
     /// Throttle window for the deep caret BFS. ~100ms keeps the walk off the per-keystroke hot path
     /// in Chromium editors while staying short enough that caret lag during fast typing stays minor.
@@ -22,11 +22,8 @@ struct FocusSnapshotResolver {
     /// signatures on every AX refresh.
     private static let focusedTextContextWindowUTF16 = 4096
 
-    /// Carries deep-walk throttle state across the value-typed resolver's non-mutating polls.
-    private let deepWalkThrottle = DeepGeometryWalkThrottle()
-
-    init(geometryResolver: AXTextGeometryResolver? = nil) {
-        self.geometryResolver = geometryResolver ?? AXTextGeometryResolver()
+    init(geometryResolver: CaretGeometryResolver? = nil) {
+        self.geometryResolver = geometryResolver ?? CaretGeometryResolver()
     }
 
     /// Resolves the best editable candidate around the focused AX node and materializes a focus snapshot.
@@ -34,10 +31,14 @@ struct FocusSnapshotResolver {
     /// `focusChangeSequence` is a monotonic counter owned by `FocusTracker`. The resolver threads
     /// it into the resulting `FocusedInputSnapshot` so downstream consumers can detect field
     /// switches even when `CFHash`-based `elementIdentifier` collides across recycled AX nodes.
+    ///
+    /// `deepWalkThrottle` is also owned by `FocusTracker` (a stable lifetime) and passed in so this
+    /// value-typed resolver carries no hidden mutable reference state.
     func resolveSnapshot(
         focusedElement: AXUIElement,
         application: NSRunningApplication,
-        focusChangeSequence: UInt64 = 0
+        focusChangeSequence: UInt64 = 0,
+        deepWalkThrottle: DeepGeometryWalkThrottle
     ) -> FocusSnapshot {
         let applicationName = application.localizedName ?? "Unknown"
         let bundleIdentifier = application.bundleIdentifier ?? "unknown.bundle"
@@ -150,7 +151,7 @@ struct FocusSnapshotResolver {
                 focusChangeSequence: focusChangeSequence,
                 interval: Self.deepWalkThrottleInterval
             ) {
-                resolveDeepGeometrySource(
+                geometryResolver.resolveDeepGeometrySource(
                     focusedElement: focusedElement,
                     resolvedElement: resolvedCandidate.element,
                     cocoaAnchorFrame: resolvedCandidate.inputFrameRect
@@ -426,128 +427,6 @@ struct FocusSnapshotResolver {
             return true
         }
         return false
-    }
-
-    /// Runs deep geometry search from the resolved editable candidate first, then falls back to
-    /// the raw focused node when those are different branches of the same local AX neighborhood.
-    private func resolveDeepGeometrySource(
-        focusedElement: AXUIElement,
-        resolvedElement: AXUIElement,
-        cocoaAnchorFrame: CGRect?
-    ) -> CaretGeometryResult? {
-        if let result = findDeepGeometrySource(
-            from: resolvedElement,
-            cocoaAnchorFrame: cocoaAnchorFrame
-        ) {
-            return result
-        }
-
-        guard
-            AXHelper.elementIdentity(for: focusedElement)
-                != AXHelper.elementIdentity(for: resolvedElement)
-        else {
-            return nil
-        }
-
-        return findDeepGeometrySource(
-            from: focusedElement,
-            cocoaAnchorFrame: cocoaAnchorFrame
-        )
-    }
-
-    /// Searches deeper descendants of the focused element for a node with precise caret geometry.
-    ///
-    /// Chrome's AX tree nests live selection data on deep `AXStaticText` leaf nodes that have
-    /// tight per-text-run frames — far more precise than the parent text entry area's AXFrame.
-    /// We only read position from these nodes; the input target (where we type) stays unchanged.
-    private func findDeepGeometrySource(
-        from root: AXUIElement,
-        cocoaAnchorFrame: CGRect?
-    ) -> CaretGeometryResult? {
-        var queue: [(element: AXUIElement, depth: Int)] = [(root, 0)]
-        let maxDepth = 10
-        let maxNodes = 200
-        var visited = 0
-        var seen = Set<String>()
-        var bestResult: (result: CaretGeometryResult, depth: Int)?
-
-        while !queue.isEmpty, visited < maxNodes {
-            let (element, depth) = queue.removeFirst()
-
-            let identity = AXHelper.elementIdentity(for: element)
-            guard seen.insert(identity).inserted else { continue }
-            visited += 1
-
-            // Look for any node with an active caret (zero-length selection).
-            // Don't filter by role — Chrome uses AXStaticText for editable text runs.
-            if let range = AXHelper.rangeValue(
-                for: kAXSelectedTextRangeAttribute as CFString, on: element
-            ), range.length == 0 {
-                let paramAttrs = Set(AXHelper.parameterizedAttributeNames(on: element))
-                let attrs = Set(AXHelper.attributeNames(on: element))
-                let textValue =
-                    attrs.contains(kAXValueAttribute as String)
-                    ? AXHelper.stringValue(for: kAXValueAttribute as CFString, on: element)
-                    : nil
-                let result = geometryResolver.resolveCaretRect(
-                    for: element,
-                    selection: range,
-                    supportsBoundsForRange: paramAttrs.contains(
-                        kAXBoundsForRangeParameterizedAttribute as String
-                    ),
-                    supportsFrame: attrs.contains("AXFrame"),
-                    cocoaAnchorFrame: cocoaAnchorFrame,
-                    textValue: textValue
-                )
-
-                if let result, result.quality == .exact || result.quality == .derived {
-                    if shouldPreferDeepResult(
-                        result,
-                        at: depth,
-                        over: bestResult
-                    ) {
-                        bestResult = (result, depth)
-                    }
-                }
-            }
-
-            guard depth < maxDepth else { continue }
-            for child in AXHelper.childElements(of: element) {
-                queue.append((child, depth + 1))
-            }
-        }
-
-        return bestResult?.result
-    }
-
-    /// Prefers deeper descendants because browser AX wrappers can expose superficially "valid"
-    /// geometry on shallow nodes while the real caret anchor lives lower in the text-run leaves.
-    private func shouldPreferDeepResult(
-        _ candidate: CaretGeometryResult,
-        at depth: Int,
-        over best: (result: CaretGeometryResult, depth: Int)?
-    ) -> Bool {
-        guard let best else {
-            return true
-        }
-
-        if depth != best.depth {
-            return depth > best.depth
-        }
-
-        return deepResultQualityScore(candidate.quality)
-            > deepResultQualityScore(best.result.quality)
-    }
-
-    private func deepResultQualityScore(_ quality: CaretGeometryQuality) -> Int {
-        switch quality {
-        case .exact:
-            return 2
-        case .derived:
-            return 1
-        case .estimated:
-            return 0
-        }
     }
 
     /// Extracts the AX properties Cotabby needs from one candidate element near the current focus.

--- a/Cotabby/Services/Focus/FocusTracker.swift
+++ b/Cotabby/Services/Focus/FocusTracker.swift
@@ -61,6 +61,11 @@ final class FocusTracker {
     // queries and hit-test fallback can actually resolve.
     private let chromiumAccessibilityEnabler = ChromiumAccessibilityEnabler()
 
+    /// Deep-walk throttle for the caret BFS. Owned here (a stable lifetime) and passed into each
+    /// `resolveSnapshot` call so the value-typed resolver carries no hidden mutable state. Its cache
+    /// persists across the twice-per-tick resolve and across ticks while focus stays in one field.
+    private let deepWalkThrottle = DeepGeometryWalkThrottle()
+
     init(
         pollInterval: TimeInterval = 0.08,
         permissionProvider: @escaping @MainActor () -> Bool,
@@ -249,7 +254,8 @@ final class FocusTracker {
         let firstPassSnapshot = snapshotResolver.resolveSnapshot(
             focusedElement: focusedElement,
             application: application,
-            focusChangeSequence: focusChangeSequence
+            focusChangeSequence: focusChangeSequence,
+            deepWalkThrottle: deepWalkThrottle
         )
         logResolveTiming(
             since: resolveStart,
@@ -275,7 +281,8 @@ final class FocusTracker {
         let finalSnapshot = snapshotResolver.resolveSnapshot(
             focusedElement: focusedElement,
             application: application,
-            focusChangeSequence: focusChangeSequence
+            focusChangeSequence: focusChangeSequence,
+            deepWalkThrottle: deepWalkThrottle
         )
         return FocusCaptureResult(snapshot: finalSnapshot, didChangeFocusedInput: true)
     }

--- a/CotabbyTests/CaretGeometryResolverTests.swift
+++ b/CotabbyTests/CaretGeometryResolverTests.swift
@@ -3,15 +3,15 @@ import ApplicationServices
 import XCTest
 @testable import Cotabby
 
-/// Tests for `AXTextGeometryResolver` caret resolution branch ordering.
+/// Tests for `CaretGeometryResolver` caret resolution branch ordering.
 ///
 /// These tests use a real `NSTextField` hosted in the test process to exercise the AX geometry
 /// pipeline end-to-end. Native AppKit text fields reliably support `AXBoundsForRange` and
 /// advertise it via `parameterizedAttributeNames`, so the resolver's Branch 1/2 are reachable
 /// when callers pass `supportsBoundsForRange: true`.
 @MainActor
-final class AXTextGeometryResolverTests: XCTestCase {
-    private let resolver = AXTextGeometryResolver()
+final class CaretGeometryResolverTests: XCTestCase {
+    private let resolver = CaretGeometryResolver()
 
     /// A real AppKit text field gives us a genuine AXUIElement that responds to BoundsForRange.
     private func makeTextField(text: String = "Hello world") -> (NSTextField, NSWindow) {


### PR DESCRIPTION
## Summary

Stacked on FuJacob/cotabby#560. Continues the `FocusSnapshotResolver` decomposition with two behavior-preserving moves:

- Move `DeepGeometryWalkThrottle` ownership from the value-typed resolver to `FocusTracker` (a stable lifetime), passing it into `resolveSnapshot`. Removes the value-type-with-hidden-mutable-reference smell.
- Rename `AXTextGeometryResolver` to `CaretGeometryResolver` and fold the cross-element deep caret walk (`resolveDeepGeometrySource` and its helpers) into it, so all caret-geometry resolution lives in one type. `FocusSnapshotResolver` 828 -> 707 lines.

## Validation

```
xcodebuild ... build -derivedDataPath build/DerivedData      # ** BUILD SUCCEEDED **
swiftlint lint --quiet                                       # 0 violations
xcodebuild ... test CODE_SIGNING_ALLOWED=NO ...              # ** TEST SUCCEEDED ** 777 tests, 4 skipped, 0 failures
```

## Linked issues

None. Stacked on FuJacob/cotabby#560.

## Risk / rollout notes

- **Stacked on #560** (this branch is based on it); review/merge that first, then retarget this to `main`.
- The deep walk is a **verbatim move**, but the live AX caret/candidate paths are not fully covered by automated tests. **Manual AX smoke recommended before merge**: a native `NSTextField`, a Chromium editor, an Electron app, and a secure field — confirm caret placement, field recognition, and that secure fields stay blocked.
- The remaining live-path piece (extracting candidate search + `candidateSnapshot`/`nativeTextWindow` into a `FocusCandidateResolver`) is deferred to a further follow-up, also needing manual smoke.
- `project.pbxproj` regenerated by `xcodegen` for the two file renames.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR continues the `FocusSnapshotResolver` decomposition with two behavior-preserving moves: `DeepGeometryWalkThrottle` ownership is lifted from the value-typed resolver into `FocusTracker` (a stable class lifetime) and threaded in as an explicit parameter, and `AXTextGeometryResolver` is renamed to `CaretGeometryResolver` while absorbing the cross-element deep caret BFS (`resolveDeepGeometrySource` and helpers) that previously lived in `FocusSnapshotResolver`.

- `CaretGeometryResolver` (was `AXTextGeometryResolver`) gains `resolveDeepGeometrySource` and its private helpers via a verbatim move; all caret geometry resolution now lives in one type, reducing `FocusSnapshotResolver` from 828 to 707 lines.
- `FocusTracker` gains a private `deepWalkThrottle` property and passes it into both `resolveSnapshot` call sites, removing the \"value type with a hidden mutable reference\" design smell without changing runtime behavior.
- `project.pbxproj` is xcodegen-regenerated to reflect both file renames.

<h3>Confidence Score: 4/5</h3>

The refactor is behavior-preserving: the deep BFS code is a verbatim move, throttle semantics are unchanged, and build + 777 tests all pass. The only live-path risk is the untested AX smoke scenarios called out in the PR description.

The logic moves are clean and the ownership change is an improvement. The only findings are the absence of unit tests for the newly-moved BFS logic in CaretGeometryResolverTests and the reduced call-site ergonomics of the now-required deepWalkThrottle parameter on resolveSnapshot.

CaretGeometryResolver.swift — the moved resolveDeepGeometrySource methods have no unit test coverage; CotabbyTests/CaretGeometryResolverTests.swift would be the right home for those tests.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Services/Focus/CaretGeometryResolver.swift | Renamed from AXTextGeometryResolver and extended with the deep-caret BFS (resolveDeepGeometrySource + helpers) moved verbatim from FocusSnapshotResolver; the new internal methods have no unit-test coverage in the companion test file. |
| Cotabby/Services/Focus/FocusSnapshotResolver.swift | Removes hidden mutable state (deepWalkThrottle as a class stored in a value type) by making deepWalkThrottle an explicit required parameter of resolveSnapshot; existing logic and control flow are unchanged. |
| Cotabby/Services/Focus/FocusTracker.swift | Adds deepWalkThrottle as a stable private property and threads it into both resolveSnapshot call sites; straightforward and correct. |
| CotabbyTests/CaretGeometryResolverTests.swift | Renamed from AXTextGeometryResolverTests with minimal updates; tests cover resolveCaretRect and rectIsNearAnchor but do not exercise the newly moved resolveDeepGeometrySource path. |
| Cotabby.xcodeproj/project.pbxproj | xcodegen-regenerated references for the two file renames; looks consistent (old UUIDs removed, new ones added for both source and test targets). |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant FT as FocusTracker
    participant DWT as DeepGeometryWalkThrottle
    participant FSR as FocusSnapshotResolver
    participant CGR as CaretGeometryResolver

    FT->>FSR: "resolveSnapshot(focusedElement, app, seq=N, deepWalkThrottle)"
    FSR->>CGR: resolveInputFrameRect(element)
    FSR->>CGR: resolveCaretRect(element, ...)
    alt primary quality is estimated
        FSR->>DWT: "result(seq=N, interval) { walk }"
        DWT->>CGR: resolveDeepGeometrySource(focused, resolved, anchor)
        CGR->>CGR: findDeepGeometrySource(from: resolved)
        CGR-->>DWT: CaretGeometryResult?
        DWT-->>FSR: CaretGeometryResult? (cached or fresh)
    end
    FSR-->>FT: FocusSnapshot (firstPass)

    alt focus field changed
        FT->>FT: "focusChangeSequence += 1 (seq=N+1)"
        FT->>FSR: "resolveSnapshot(focusedElement, app, seq=N+1, deepWalkThrottle)"
        FSR->>DWT: "result(seq=N+1, interval) { walk }"
        Note over DWT: New sequence forces fresh walk
        DWT->>CGR: resolveDeepGeometrySource(...)
        DWT-->>FSR: CaretGeometryResult?
        FSR-->>FT: FocusSnapshot (final)
    end
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22FuJacob%2Ffocus-live-path-split%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22FuJacob%2Ffocus-live-path-split%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabbyTests%2FCaretGeometryResolverTests.swift%3A13-14%0A**No%20coverage%20for%20the%20newly-moved%20deep-walk%20methods**%0A%0A%60resolveDeepGeometrySource%60%20and%20its%20private%20helpers%20%28%60findDeepGeometrySource%60%2C%20%60shouldPreferDeepResult%60%29%20were%20moved%20verbatim%20into%20%60CaretGeometryResolver%60%20but%20the%20companion%20test%20file%20only%20exercises%20%60resolveCaretRect%60%20and%20%60rectIsNearAnchor%60.%20The%20pure-logic%20parts%20of%20the%20BFS%20%28e.g.%20the%20depth-preference%20tie-breaking%20in%20%60shouldPreferDeepResult%60%2C%20the%20focused-vs-resolved%20fallback%20in%20%60resolveDeepGeometrySource%60%29%20are%20unit-testable%20without%20real%20AX%20elements%20and%20would%20benefit%20from%20coverage%20now%20that%20they%20live%20in%20an%20independently%20testable%20type.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FServices%2FFocus%2FFocusSnapshotResolver.swift%3A37-42%0A**%60deepWalkThrottle%60%20has%20no%20default%20value%2C%20reducing%20call-site%20ergonomics**%0A%0A%60focusChangeSequence%60%20keeps%20its%20%60%3D%200%60%20default%2C%20but%20%60deepWalkThrottle%3A%20DeepGeometryWalkThrottle%60%20has%20no%20default%2C%20so%20any%20call%20site%20that%20previously%20relied%20on%20the%20compact%20two-argument%20form%20now%20must%20construct%20and%20pass%20a%20throttle%20explicitly.%20Since%20%60DeepGeometryWalkThrottle%60%20is%20a%20%60%40MainActor%20final%20class%60%2C%20providing%20a%20lazy%20default%20isn't%20straightforward%20in%20a%20non-isolated%20context%2C%20but%20an%20optional%20overload%20or%20a%20dedicated%20test-only%20convenience%20init%20on%20%60FocusSnapshotResolver%60%20would%20restore%20that%20ergonomics%20gap%20without%20re-introducing%20the%20hidden-state%20smell.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabbyTests%2FCaretGeometryResolverTests.swift%3A13-14%0A**No%20coverage%20for%20the%20newly-moved%20deep-walk%20methods**%0A%0A%60resolveDeepGeometrySource%60%20and%20its%20private%20helpers%20%28%60findDeepGeometrySource%60%2C%20%60shouldPreferDeepResult%60%29%20were%20moved%20verbatim%20into%20%60CaretGeometryResolver%60%20but%20the%20companion%20test%20file%20only%20exercises%20%60resolveCaretRect%60%20and%20%60rectIsNearAnchor%60.%20The%20pure-logic%20parts%20of%20the%20BFS%20%28e.g.%20the%20depth-preference%20tie-breaking%20in%20%60shouldPreferDeepResult%60%2C%20the%20focused-vs-resolved%20fallback%20in%20%60resolveDeepGeometrySource%60%29%20are%20unit-testable%20without%20real%20AX%20elements%20and%20would%20benefit%20from%20coverage%20now%20that%20they%20live%20in%20an%20independently%20testable%20type.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FServices%2FFocus%2FFocusSnapshotResolver.swift%3A37-42%0A**%60deepWalkThrottle%60%20has%20no%20default%20value%2C%20reducing%20call-site%20ergonomics**%0A%0A%60focusChangeSequence%60%20keeps%20its%20%60%3D%200%60%20default%2C%20but%20%60deepWalkThrottle%3A%20DeepGeometryWalkThrottle%60%20has%20no%20default%2C%20so%20any%20call%20site%20that%20previously%20relied%20on%20the%20compact%20two-argument%20form%20now%20must%20construct%20and%20pass%20a%20throttle%20explicitly.%20Since%20%60DeepGeometryWalkThrottle%60%20is%20a%20%60%40MainActor%20final%20class%60%2C%20providing%20a%20lazy%20default%20isn't%20straightforward%20in%20a%20non-isolated%20context%2C%20but%20an%20optional%20overload%20or%20a%20dedicated%20test-only%20convenience%20init%20on%20%60FocusSnapshotResolver%60%20would%20restore%20that%20ergonomics%20gap%20without%20re-introducing%20the%20hidden-state%20smell.%0A%0A&repo=fujacob%2Fcotabby&pr=561&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["refactor(focus): consolidate caret geome..."](https://github.com/fujacob/cotabby/commit/d7467e9330e332481fdd21d47c81ad272b5d3a2e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35767856)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->