### PR TITLE
refactor(focus): extract FocusCandidateResolver (stacked on #561)

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -126,6 +126,7 @@
 		66C23A7C2FCDE0266FF425F8 /* ApplicationBundleMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 352AF5B2834FEE1F597394E4 /* ApplicationBundleMetadata.swift */; };
 		66D9E37B12A9265D4733E72E /* LlamaRuntimeCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 944065A858D9BC936CB12B23 /* LlamaRuntimeCore.swift */; };
 		6955C3A4D7AB3EEF7FA7C469 /* InputSuppressionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1F9CEBAB0F330F8E7B61D8 /* InputSuppressionController.swift */; };
+		6AA7B672BDF979459D6D3FEF /* FocusCandidateResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFAD8668A9007448D98D5E2E /* FocusCandidateResolver.swift */; };
 		6AE0B46FB52D189D94E1F79A /* WordCountFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E0513E3B23937B099A3CFF2 /* WordCountFormatterTests.swift */; };
 		6B0186B9F3E6F654296B6D76 /* AdvancedPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E644072C123DC2D2B40274D /* AdvancedPaneView.swift */; };
 		6DD1E22151571E1A22FF22F4 /* FoundationModelSuggestionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5664E34B23FBDF69292FEF43 /* FoundationModelSuggestionEngine.swift */; };
@@ -449,6 +450,7 @@
 		AD9573F3504CAE6891DF9B7D /* AppUpdateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdateManager.swift; sourceTree = "<group>"; };
 		ADBE3E6CC585C1683787C877 /* SuggestionEngineModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionEngineModels.swift; sourceTree = "<group>"; };
 		AF1E065C7FFB697FCEB2FA5C /* CotabbyTestFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CotabbyTestFixtures.swift; sourceTree = "<group>"; };
+		AFAD8668A9007448D98D5E2E /* FocusCandidateResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusCandidateResolver.swift; sourceTree = "<group>"; };
 		AFCFCCCB69C29A86E726B10A /* PromptSectionBudget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptSectionBudget.swift; sourceTree = "<group>"; };
 		B22FDEB3B1DCC9ADE906CC73 /* OCRTextHygiene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCRTextHygiene.swift; sourceTree = "<group>"; };
 		B25C3087D4A9F4DC52FD5A69 /* PerDomainDisableSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerDomainDisableSettings.swift; sourceTree = "<group>"; };
@@ -675,6 +677,7 @@
 				47CAF3A4DBC53F4159F9455A /* CaretGeometryResolver.swift */,
 				8896D976C7F116EBA0F3969F /* ChromiumAccessibilityEnabler.swift */,
 				684737E62EE6495A71344923 /* DeepGeometryWalkThrottle.swift */,
+				AFAD8668A9007448D98D5E2E /* FocusCandidateResolver.swift */,
 				04E25414C307A20B6F9F20EC /* FocusSnapshotResolver.swift */,
 				5C9FDF029F7828CAF3FE8850 /* FocusTracker.swift */,
 			);
@@ -1162,6 +1165,7 @@
 				5DF31F465A3A1233260BD3A4 /* EngineAndModelPaneView.swift in Sources */,
 				5BE53CE921664582F593B7B0 /* FieldEdgeIconIndicatorView.swift in Sources */,
 				6E49ADEB31D04DC77A47DEB0 /* FileLogHandler.swift in Sources */,
+				6AA7B672BDF979459D6D3FEF /* FocusCandidateResolver.swift in Sources */,
 				C0FE11D76BDF01A5470C554D /* FocusCapabilityFlickerGate.swift in Sources */,
 				CC98B842D10574C5206BEFA7 /* FocusCapabilityResolver.swift in Sources */,
 				924489CEE8171F7AD8579D71 /* FocusDebugOverlayController.swift in Sources */,

--- a/Cotabby/Services/Focus/FocusCandidateResolver.swift
+++ b/Cotabby/Services/Focus/FocusCandidateResolver.swift
@@ -1,0 +1,467 @@
+import ApplicationServices
+import CoreGraphics
+import Foundation
+import Logging
+
+/// File overview:
+/// Resolves the best editable AX candidate around the current focus and reads its per-element AX
+/// data. It searches the local AX neighborhood (the focused node, a couple of ancestors, their
+/// children, plus a bounded editable-descendant BFS for Chromium/Electron), reads each candidate's
+/// text/selection/caret data, and returns the first fully-capable target (or the best partial, for
+/// diagnostics).
+///
+/// Split out of `FocusSnapshotResolver` so candidate search and per-element AX reads stay separate
+/// from snapshot assembly. Holds a `CaretGeometryResolver` for caret and input-frame geometry.
+@MainActor
+struct FocusCandidateResolver {
+    private let geometryResolver: CaretGeometryResolver
+
+    /// Maximum UTF-16 units kept on each side of the caret when reading a native text window.
+    /// `FocusSnapshotResolver.boundedContextWindow` re-bounds the snapshot text to the same width,
+    /// so the two must stay in sync.
+    static let focusedTextContextWindowUTF16 = 4096
+
+    init(geometryResolver: CaretGeometryResolver? = nil) {
+        // Construct the default inside the actor-isolated body: Swift evaluates default parameter
+        // expressions before entering the `@MainActor` context, so a `= CaretGeometryResolver()`
+        // default would be a nonisolated call to a main-actor-isolated initializer.
+        self.geometryResolver = geometryResolver ?? CaretGeometryResolver()
+    }
+
+    /// Resolves candidate elements lazily and stops as soon as the first fully capable editable
+    /// target is found.
+    ///
+    /// The old eager map built an `AXFocusCandidate` for every nearby Chromium node before asking
+    /// `FocusCapabilityResolver` to pick the first supported one. In large web editors that meant
+    /// reading text/selection/caret data from many wrapper and static-text nodes even after the real
+    /// input target had already been discovered. This preserves the resolver's "first full
+    /// capability wins" policy while avoiding unnecessary synchronous AX IPC.
+    func resolve(
+        around focusedElement: AXUIElement,
+        bundleIdentifier: String,
+        deepDescendants: Bool
+    ) -> FocusCandidateResolution {
+        var bestPartial: (candidate: AXFocusCandidate, evaluation: FocusCapabilityCandidateEvaluation)?
+        var inspectedCount = 0
+
+        for element in candidateElements(around: focusedElement, deepDescendants: deepDescendants) {
+            inspectedCount += 1
+            let candidate = candidateSnapshot(for: element, bundleIdentifier: bundleIdentifier)
+            let evaluation = FocusCapabilityResolver.evaluate(candidate.resolverCandidate)
+
+            if evaluation.hasFullCapabilities {
+                return FocusCandidateResolution(
+                    resolvedCandidate: candidate,
+                    diagnosticCandidate: candidate,
+                    resolution: FocusCapabilityResolution(
+                        selectedEvaluation: evaluation,
+                        inspectedCandidateCount: inspectedCount
+                    )
+                )
+            }
+
+            if bestPartial == nil || evaluation.score > bestPartial!.evaluation.score {
+                bestPartial = (candidate, evaluation)
+            }
+        }
+
+        return FocusCandidateResolution(
+            resolvedCandidate: nil,
+            diagnosticCandidate: bestPartial?.candidate,
+            resolution: FocusCapabilityResolution(
+                selectedEvaluation: bestPartial?.evaluation,
+                inspectedCandidateCount: inspectedCount
+            )
+        )
+    }
+
+    private func candidateElements(
+        around focusedElement: AXUIElement, deepDescendants: Bool = false
+    ) -> [AXUIElement] {
+        var ordered: [AXUIElement] = []
+        var seen = Set<String>()
+
+        func append(_ element: AXUIElement?) {
+            guard let element else {
+                return
+            }
+
+            let identity = AXHelper.elementIdentity(for: element)
+            guard seen.insert(identity).inserted else {
+                return
+            }
+
+            ordered.append(element)
+        }
+
+        append(focusedElement)
+
+        var ancestors: [AXUIElement] = []
+        var currentElement = focusedElement
+        for _ in 0..<2 {
+            guard let parent = AXHelper.parentElement(of: currentElement) else {
+                break
+            }
+
+            ancestors.append(parent)
+            append(parent)
+            currentElement = parent
+        }
+
+        // The heuristic search order is:
+        // 1. focused node
+        // 2. a couple of ancestors
+        // 3. children of those nodes
+        //
+        // This is a pragmatic compromise for apps that focus a wrapper element instead of the real
+        // editable text node. We do not try to walk the entire AX tree.
+        for node in [focusedElement] + ancestors {
+            for child in AXHelper.childElements(of: node) {
+                append(child)
+            }
+        }
+
+        // Chromium reports focus on a wrapper above the editable (AXWebArea → AXGroup → … →
+        // AXTextField), so the shallow walk above can miss the real target. Search descendants for
+        // editable-looking nodes, bounded in depth and count and appending only likely editables
+        // (not every visited node) so per-tick candidateSnapshot cost stays in check.
+        if deepDescendants {
+            appendEditableDescendants(of: [focusedElement] + ancestors, append: append)
+        }
+
+        return ordered
+    }
+
+    /// Bounded BFS for editable-looking descendants, used only for Chromium/Electron. Traverses up
+    /// to `maxVisits` nodes / `maxDepth` deep but appends at most `maxAppended` likely-editable
+    /// nodes, keeping the downstream snapshotting cost roughly constant.
+    private func appendEditableDescendants(
+        of roots: [AXUIElement], append: (AXUIElement?) -> Void
+    ) {
+        let maxDepth = 6
+        let maxVisits = 200
+        let maxAppended = 12
+        var visited = 0
+        var appended = 0
+        var seenIdentity = Set<String>()
+        var queue: [(element: AXUIElement, depth: Int)] = roots.map { ($0, 0) }
+
+        while !queue.isEmpty, visited < maxVisits, appended < maxAppended {
+            let (element, depth) = queue.removeFirst()
+            guard seenIdentity.insert(AXHelper.elementIdentity(for: element)).inserted else {
+                continue
+            }
+            visited += 1
+
+            if looksEditable(element) {
+                append(element)
+                appended += 1
+            }
+
+            if depth < maxDepth {
+                for child in AXHelper.childElements(of: element) {
+                    queue.append((child, depth + 1))
+                }
+            }
+        }
+    }
+
+    /// Cheap editability probe for the descendant search: a known editable role, an explicit
+    /// editable flag, or either selection surface (native range or Chromium text markers). Cheaper
+    /// than a full `candidateSnapshot`, so it is safe to run across the bounded BFS.
+    private func looksEditable(_ element: AXUIElement) -> Bool {
+        let role = AXHelper.stringValue(for: kAXRoleAttribute as CFString, on: element) ?? ""
+        if AXHelper.isKnownEditableRole(role) {
+            return true
+        }
+        if AXHelper.isKnownReadOnlyRole(role) {
+            return false
+        }
+        let attributes = Set(AXHelper.attributeNames(on: element))
+        if attributes.contains("AXSelectedTextMarkerRange")
+            || attributes.contains(kAXSelectedTextRangeAttribute as String) {
+            return true
+        }
+        if attributes.contains("AXEditable"),
+            AXHelper.boolValue(for: "AXEditable" as CFString, on: element) == true {
+            return true
+        }
+        return false
+    }
+
+    /// Extracts the AX properties Cotabby needs from one candidate element near the current focus.
+    private func candidateSnapshot(for element: AXUIElement, bundleIdentifier: String)
+        -> AXFocusCandidate {
+        let role = AXHelper.stringValue(for: kAXRoleAttribute as CFString, on: element) ?? "Unknown"
+        let subrole = AXHelper.stringValue(for: kAXSubroleAttribute as CFString, on: element)
+        let supportedAttributes = Set(AXHelper.attributeNames(on: element))
+        let supportedParameterizedAttributes = Set(
+            AXHelper.parameterizedAttributeNames(on: element))
+        let explicitEditableFlag =
+            supportedAttributes.contains("AXEditable")
+            ? AXHelper.boolValue(for: "AXEditable" as CFString, on: element)
+            : nil
+        let editableHintScore = AXHelper.editabilityHintScore(
+            role: role,
+            explicitEditableFlag: explicitEditableFlag
+        )
+        let hasStrongEditabilitySignal = AXHelper.hasStrongEditabilitySignal(
+            role: role,
+            explicitEditableFlag: explicitEditableFlag
+        )
+        let isKnownReadOnlyRole = AXHelper.isKnownReadOnlyRole(role)
+        let canBeEditableTarget = hasStrongEditabilitySignal && !isKnownReadOnlyRole
+        let nativeSelection =
+            canBeEditableTarget && supportedAttributes.contains(kAXSelectedTextRangeAttribute as String)
+            ? AXHelper.rangeValue(for: kAXSelectedTextRangeAttribute as CFString, on: element)
+            : nil
+
+        // Chromium/WebKit contenteditables (Gmail body, Slack/Notion/Discord web, ClickUp chat)
+        // expose selection only through the opaque AXTextMarker API, never kAXSelectedTextRange,
+        // so they would otherwise fail the capability gate for a missing selection. Synthesize an
+        // NSRange + caret-windowed text from the markers, but only when the native range is absent.
+        let markerSelection =
+            canBeEditableTarget && nativeSelection == nil
+            ? AXHelper.synthesizeMarkerSelection(
+                on: element, parameterizedAttributes: supportedParameterizedAttributes)
+            : nil
+
+        let nativeTextSelection = nativeSelection.flatMap {
+            nativeTextWindow(
+                on: element,
+                selection: $0,
+                supportedAttributes: supportedAttributes,
+                supportedParameterizedAttributes: supportedParameterizedAttributes
+            )
+        }
+        // Prefer the marker-windowed text when we synthesized one so `selection` (window-relative)
+        // and `textValue` stay consistent; otherwise use a bounded native text window when the host
+        // supports `AXStringForRange`, falling back to the full value for older/native controls.
+        let textSelection = markerSelection.map {
+            AXTextSelection(text: $0.text, selection: $0.selection)
+        } ?? nativeTextSelection
+        let selection = textSelection?.selection
+        let selectionForGeometry = nativeSelection ?? markerSelection?.selection
+        let textValue = textSelection?.text
+
+        if let markerSelection {
+            let textLength = (markerSelection.text as NSString).length
+            let location = markerSelection.selection.location
+            let length = markerSelection.selection.length
+            CotabbyLogger.focus.trace(
+                "CHROME-CONTENTEDITABLE synthesized selection loc=\(location) len=\(length) textLen=\(textLength)")
+        }
+
+        var inputFrameRect =
+            supportedAttributes.contains("AXFrame")
+            ? geometryResolver.resolveInputFrameRect(for: element)
+            : nil
+
+        if let currentFrame = inputFrameRect {
+            var finalWidth = currentFrame.width
+            var finalX = currentFrame.minX
+
+            // Optimization: grab the parent container's width if the active element is narrow
+            // so we capture the whole input bar context (e.g. Discord/Slack dynamically sized nodes).
+            if let parent = AXHelper.parentElement(of: element),
+               let parentFrame = AXHelper.rectValue(for: "AXFrame" as CFString, on: parent) {
+                let parentCocoa = AXHelper.cocoaRect(fromAccessibilityRect: parentFrame)
+                if parentCocoa.width > finalWidth {
+                    finalWidth = parentCocoa.width
+                    finalX = parentCocoa.minX
+                }
+            }
+
+            // Enforce a minimum width to ensure we get a decent horizontal slice.
+            if finalWidth < 500 {
+                finalWidth = max(finalWidth, 500)
+            }
+
+            inputFrameRect = CGRect(
+                x: finalX,
+                y: currentFrame.minY,
+                width: finalWidth,
+                height: currentFrame.height
+            )
+        }
+        let caretResult = selectionForGeometry.flatMap {
+            geometryResolver.resolveCaretRect(
+                for: element,
+                selection: $0,
+                // A marker-synthesized selection's location is window-relative, not a document
+                // offset, so NSRange-based BoundsForRange would resolve the wrong caret. Native
+                // selections keep their document offset here, while `textSelection` below carries
+                // the bounded-window offset for text-based geometry fallbacks.
+                supportsBoundsForRange: markerSelection == nil
+                    && supportedParameterizedAttributes.contains(
+                        kAXBoundsForRangeParameterizedAttribute as String),
+                supportsFrame: supportedAttributes.contains("AXFrame"),
+                cocoaAnchorFrame: inputFrameRect,
+                textValue: textValue,
+                textSelection: selection
+            )
+        }
+        let caretRect = caretResult?.rect
+        let caretQuality = caretResult?.quality
+        let isSecure = isSecureElement(element: element, role: role, subrole: subrole)
+        let elementIdentifier = AXHelper.elementIdentifier(
+            for: element, bundleIdentifier: bundleIdentifier)
+        let resolverCandidate = FocusCapabilityCandidate(
+            elementIdentifier: elementIdentifier,
+            role: role,
+            subrole: subrole,
+            editableHintScore: editableHintScore,
+            hasStrongEditabilitySignal: hasStrongEditabilitySignal,
+            isKnownReadOnlyRole: isKnownReadOnlyRole,
+            hasTextValue: textValue != nil,
+            hasSelectionRange: selection != nil,
+            hasCaretBounds: caretRect != nil,
+            isSecure: isSecure
+        )
+
+        return AXFocusCandidate(
+            element: element,
+            elementIdentifier: elementIdentifier,
+            role: role,
+            subrole: subrole,
+            textValue: textValue,
+            selection: selection,
+            caretRect: caretRect,
+            caretQuality: caretQuality,
+            observedCharWidth: caretResult?.observedCharWidth,
+            inputFrameRect: inputFrameRect,
+            isSecure: isSecure,
+            resolverCandidate: resolverCandidate
+        )
+    }
+
+    /// Reads the smallest native text window the host can provide around the current selection.
+    ///
+    /// `AXStringForRange` is the important fast path for large Chrome and WebKit fields: instead of
+    /// pulling the whole `AXValue`, we ask for at most `focusedTextContextWindowUTF16` units before
+    /// and after the caret. Apps that do not expose the parameterized string API still fall back to
+    /// `AXValue`, preserving compatibility.
+    private func nativeTextWindow(
+        on element: AXUIElement,
+        selection: NSRange,
+        supportedAttributes: Set<String>,
+        supportedParameterizedAttributes: Set<String>
+    ) -> AXTextSelection? {
+        func fullTextSelection() -> AXTextSelection? {
+            guard supportedAttributes.contains(kAXValueAttribute as String),
+                  let value = AXHelper.stringValue(for: kAXValueAttribute as CFString, on: element)
+            else {
+                return nil
+            }
+
+            return AXTextSelection(text: value, selection: selection)
+        }
+
+        guard supportedParameterizedAttributes.contains(kAXStringForRangeParameterizedAttribute as String),
+              supportedAttributes.contains(kAXNumberOfCharactersAttribute as String),
+              let rawDocumentLength = AXHelper.intValue(
+                  for: kAXNumberOfCharactersAttribute as CFString,
+                  on: element
+              ),
+              rawDocumentLength >= 0
+        else {
+            return fullTextSelection()
+        }
+
+        let documentLength = rawDocumentLength
+        let safeLocation = min(max(selection.location, 0), documentLength)
+        let requestedEnd = selection.location > Int.max - selection.length
+            ? Int.max
+            : selection.location + selection.length
+        let safeEnd = min(max(requestedEnd, safeLocation), documentLength)
+
+        let beforeLength = min(safeLocation, Self.focusedTextContextWindowUTF16)
+        let beforeStart = safeLocation - beforeLength
+        let afterStart = safeEnd
+        let afterLength = min(max(documentLength - afterStart, 0), Self.focusedTextContextWindowUTF16)
+
+        guard let beforeText = AXHelper.parameterizedStringValue(
+            for: kAXStringForRangeParameterizedAttribute as CFString,
+            range: NSRange(location: beforeStart, length: beforeLength),
+            on: element
+        ) else {
+            return fullTextSelection()
+        }
+
+        let selectedText: String
+        if safeEnd > safeLocation {
+            guard let nativeSelectedText = AXHelper.parameterizedStringValue(
+                for: kAXStringForRangeParameterizedAttribute as CFString,
+                range: NSRange(location: safeLocation, length: safeEnd - safeLocation),
+                on: element
+            ) else {
+                return fullTextSelection()
+            }
+            selectedText = nativeSelectedText
+        } else {
+            selectedText = ""
+        }
+
+        let trailingText: String
+        if afterLength > 0 {
+            trailingText = AXHelper.parameterizedStringValue(
+                for: kAXStringForRangeParameterizedAttribute as CFString,
+                range: NSRange(location: afterStart, length: afterLength),
+                on: element
+            ) ?? ""
+        } else {
+            trailingText = ""
+        }
+
+        let text = beforeText + selectedText + trailingText
+        return AXTextSelection(
+            text: text,
+            selection: NSRange(
+                location: (beforeText as NSString).length,
+                length: (selectedText as NSString).length
+            )
+        )
+    }
+
+    /// Detects secure inputs so Cotabby can intentionally refuse to operate in sensitive fields.
+    private func isSecureElement(element: AXUIElement, role: String, subrole: String?) -> Bool {
+        // Read the role description too: a native NSSecureTextField announces its sensitivity there
+        // ("secure text field") rather than through AXDescription, so the previous role/desc/title-only
+        // check missed it. SecureFieldDetector owns the (pure, testable) marker policy.
+        SecureFieldDetector.isSecure(
+            role: role,
+            subrole: subrole,
+            roleDescription: AXHelper.stringValue(for: kAXRoleDescriptionAttribute as CFString, on: element),
+            title: AXHelper.stringValue(for: kAXTitleAttribute as CFString, on: element),
+            descriptionLabel: AXHelper.stringValue(for: kAXDescriptionAttribute as CFString, on: element)
+        )
+    }
+}
+
+struct FocusCandidateResolution {
+    let resolvedCandidate: AXFocusCandidate?
+    let diagnosticCandidate: AXFocusCandidate?
+    let resolution: FocusCapabilityResolution
+}
+
+private struct AXTextSelection {
+    let text: String
+    let selection: NSRange
+}
+
+/// AX data read from one candidate element near the current focus.
+/// This keeps candidate search state local to the resolver instead of leaking it into the tracker.
+struct AXFocusCandidate {
+    let element: AXUIElement
+    let elementIdentifier: String
+    let role: String
+    let subrole: String?
+    let textValue: String?
+    let selection: NSRange?
+    let caretRect: CGRect?
+    let caretQuality: CaretGeometryQuality?
+    let observedCharWidth: CGFloat?
+    let inputFrameRect: CGRect?
+    let isSecure: Bool
+    let resolverCandidate: FocusCapabilityCandidate
+}

--- a/Cotabby/Services/Focus/FocusSnapshotResolver.swift
+++ b/Cotabby/Services/Focus/FocusSnapshotResolver.swift
@@ -4,26 +4,24 @@ import Foundation
 import Logging
 
 /// File overview:
-/// Resolves the most usable editable candidate around the current AX focus and materializes a
-/// stable `FocusSnapshot`. This keeps AX candidate search and snapshot assembly separate from the
-/// polling shell in `FocusTracker`.
+/// Materializes a stable `FocusSnapshot` from the current AX focus. It delegates candidate search
+/// and per-element AX reads to `FocusCandidateResolver`, resolves caret geometry (primary plus the
+/// throttled deep walk) via `CaretGeometryResolver` / `CaretGeometrySelector`, and assembles the
+/// snapshot. This keeps snapshot assembly separate from both AX candidate search and the polling
+/// shell in `FocusTracker`.
 @MainActor
 struct FocusSnapshotResolver {
+    private let candidateResolver: FocusCandidateResolver
     private let geometryResolver: CaretGeometryResolver
 
     /// Throttle window for the deep caret BFS. ~100ms keeps the walk off the per-keystroke hot path
     /// in Chromium editors while staying short enough that caret lag during fast typing stays minor.
     private static let deepWalkThrottleInterval: TimeInterval = 0.1
-    /// Maximum UTF-16 units kept on each side of the caret in focus snapshots.
-    ///
-    /// The prompt builder uses a much smaller suffix of `precedingText`, and autocomplete only needs
-    /// a short trailing window for normalization. Keeping the focus snapshot bounded prevents a
-    /// large editor buffer from flowing through equality checks, Combine publishes, and stale-result
-    /// signatures on every AX refresh.
-    private static let focusedTextContextWindowUTF16 = 4096
 
     init(geometryResolver: CaretGeometryResolver? = nil) {
-        self.geometryResolver = geometryResolver ?? CaretGeometryResolver()
+        let resolver = geometryResolver ?? CaretGeometryResolver()
+        self.geometryResolver = resolver
+        self.candidateResolver = FocusCandidateResolver(geometryResolver: resolver)
     }
 
     /// Resolves the best editable candidate around the focused AX node and materializes a focus snapshot.
@@ -63,7 +61,7 @@ struct FocusSnapshotResolver {
         // apps we additionally search descendants for the editable node.
         let deepDescendants = BrowserAppDetector.needsWebAccessibilityPriming(
             bundleIdentifier: bundleIdentifier)
-        let candidateResolution = resolveCandidate(
+        let candidateResolution = candidateResolver.resolve(
             around: focusedElement,
             bundleIdentifier: bundleIdentifier,
             deepDescendants: deepDescendants
@@ -237,53 +235,6 @@ struct FocusSnapshotResolver {
         )
     }
 
-    /// Resolves candidate elements lazily and stops as soon as the first fully capable editable
-    /// target is found.
-    ///
-    /// The old eager map built an `AXFocusCandidate` for every nearby Chromium node before asking
-    /// `FocusCapabilityResolver` to pick the first supported one. In large web editors that meant
-    /// reading text/selection/caret data from many wrapper and static-text nodes even after the real
-    /// input target had already been discovered. This preserves the resolver's "first full
-    /// capability wins" policy while avoiding unnecessary synchronous AX IPC.
-    private func resolveCandidate(
-        around focusedElement: AXUIElement,
-        bundleIdentifier: String,
-        deepDescendants: Bool
-    ) -> FocusCandidateResolution {
-        var bestPartial: (candidate: AXFocusCandidate, evaluation: FocusCapabilityCandidateEvaluation)?
-        var inspectedCount = 0
-
-        for element in candidateElements(around: focusedElement, deepDescendants: deepDescendants) {
-            inspectedCount += 1
-            let candidate = candidateSnapshot(for: element, bundleIdentifier: bundleIdentifier)
-            let evaluation = FocusCapabilityResolver.evaluate(candidate.resolverCandidate)
-
-            if evaluation.hasFullCapabilities {
-                return FocusCandidateResolution(
-                    resolvedCandidate: candidate,
-                    diagnosticCandidate: candidate,
-                    resolution: FocusCapabilityResolution(
-                        selectedEvaluation: evaluation,
-                        inspectedCandidateCount: inspectedCount
-                    )
-                )
-            }
-
-            if bestPartial == nil || evaluation.score > bestPartial!.evaluation.score {
-                bestPartial = (candidate, evaluation)
-            }
-        }
-
-        return FocusCandidateResolution(
-            resolvedCandidate: nil,
-            diagnosticCandidate: bestPartial?.candidate,
-            resolution: FocusCapabilityResolution(
-                selectedEvaluation: bestPartial?.evaluation,
-                inspectedCandidateCount: inspectedCount
-            )
-        )
-    }
-
     /// Returns a caret-adjacent text window and rewrites `selection` into that window's coordinate
     /// space. `NSRange` is UTF-16 based, so all slicing goes through `NSString`.
     private func boundedContextWindow(text: String, selection: NSRange) -> (text: String, selection: NSRange) {
@@ -297,8 +248,8 @@ struct FocusSnapshotResolver {
             ? Int.max
             : selection.location + selection.length
         let safeEnd = min(max(requestedEnd, safeLocation), nsText.length)
-        let beforeStart = max(0, safeLocation - Self.focusedTextContextWindowUTF16)
-        let afterEnd = min(nsText.length, safeEnd + Self.focusedTextContextWindowUTF16)
+        let beforeStart = max(0, safeLocation - FocusCandidateResolver.focusedTextContextWindowUTF16)
+        let afterEnd = min(nsText.length, safeEnd + FocusCandidateResolver.focusedTextContextWindowUTF16)
         let rawWindow = NSRange(location: beforeStart, length: afterEnd - beforeStart)
         let composedWindow = nsText.rangeOfComposedCharacterSequences(for: rawWindow)
         let windowText = nsText.substring(with: composedWindow)
@@ -314,394 +265,4 @@ struct FocusSnapshotResolver {
             NSRange(location: adjustedLocation, length: adjustedLength)
         )
     }
-
-    private func candidateElements(
-        around focusedElement: AXUIElement, deepDescendants: Bool = false
-    ) -> [AXUIElement] {
-        var ordered: [AXUIElement] = []
-        var seen = Set<String>()
-
-        func append(_ element: AXUIElement?) {
-            guard let element else {
-                return
-            }
-
-            let identity = AXHelper.elementIdentity(for: element)
-            guard seen.insert(identity).inserted else {
-                return
-            }
-
-            ordered.append(element)
-        }
-
-        append(focusedElement)
-
-        var ancestors: [AXUIElement] = []
-        var currentElement = focusedElement
-        for _ in 0..<2 {
-            guard let parent = AXHelper.parentElement(of: currentElement) else {
-                break
-            }
-
-            ancestors.append(parent)
-            append(parent)
-            currentElement = parent
-        }
-
-        // The heuristic search order is:
-        // 1. focused node
-        // 2. a couple of ancestors
-        // 3. children of those nodes
-        //
-        // This is a pragmatic compromise for apps that focus a wrapper element instead of the real
-        // editable text node. We do not try to walk the entire AX tree.
-        for node in [focusedElement] + ancestors {
-            for child in AXHelper.childElements(of: node) {
-                append(child)
-            }
-        }
-
-        // Chromium reports focus on a wrapper above the editable (AXWebArea → AXGroup → … →
-        // AXTextField), so the shallow walk above can miss the real target. Search descendants for
-        // editable-looking nodes, bounded in depth and count and appending only likely editables
-        // (not every visited node) so per-tick candidateSnapshot cost stays in check.
-        if deepDescendants {
-            appendEditableDescendants(of: [focusedElement] + ancestors, append: append)
-        }
-
-        return ordered
-    }
-
-    /// Bounded BFS for editable-looking descendants, used only for Chromium/Electron. Traverses up
-    /// to `maxVisits` nodes / `maxDepth` deep but appends at most `maxAppended` likely-editable
-    /// nodes, keeping the downstream snapshotting cost roughly constant.
-    private func appendEditableDescendants(
-        of roots: [AXUIElement], append: (AXUIElement?) -> Void
-    ) {
-        let maxDepth = 6
-        let maxVisits = 200
-        let maxAppended = 12
-        var visited = 0
-        var appended = 0
-        var seenIdentity = Set<String>()
-        var queue: [(element: AXUIElement, depth: Int)] = roots.map { ($0, 0) }
-
-        while !queue.isEmpty, visited < maxVisits, appended < maxAppended {
-            let (element, depth) = queue.removeFirst()
-            guard seenIdentity.insert(AXHelper.elementIdentity(for: element)).inserted else {
-                continue
-            }
-            visited += 1
-
-            if looksEditable(element) {
-                append(element)
-                appended += 1
-            }
-
-            if depth < maxDepth {
-                for child in AXHelper.childElements(of: element) {
-                    queue.append((child, depth + 1))
-                }
-            }
-        }
-    }
-
-    /// Cheap editability probe for the descendant search: a known editable role, an explicit
-    /// editable flag, or either selection surface (native range or Chromium text markers). Cheaper
-    /// than a full `candidateSnapshot`, so it is safe to run across the bounded BFS.
-    private func looksEditable(_ element: AXUIElement) -> Bool {
-        let role = AXHelper.stringValue(for: kAXRoleAttribute as CFString, on: element) ?? ""
-        if AXHelper.isKnownEditableRole(role) {
-            return true
-        }
-        if AXHelper.isKnownReadOnlyRole(role) {
-            return false
-        }
-        let attributes = Set(AXHelper.attributeNames(on: element))
-        if attributes.contains("AXSelectedTextMarkerRange")
-            || attributes.contains(kAXSelectedTextRangeAttribute as String) {
-            return true
-        }
-        if attributes.contains("AXEditable"),
-            AXHelper.boolValue(for: "AXEditable" as CFString, on: element) == true {
-            return true
-        }
-        return false
-    }
-
-    /// Extracts the AX properties Cotabby needs from one candidate element near the current focus.
-    private func candidateSnapshot(for element: AXUIElement, bundleIdentifier: String)
-        -> AXFocusCandidate {
-        let role = AXHelper.stringValue(for: kAXRoleAttribute as CFString, on: element) ?? "Unknown"
-        let subrole = AXHelper.stringValue(for: kAXSubroleAttribute as CFString, on: element)
-        let supportedAttributes = Set(AXHelper.attributeNames(on: element))
-        let supportedParameterizedAttributes = Set(
-            AXHelper.parameterizedAttributeNames(on: element))
-        let explicitEditableFlag =
-            supportedAttributes.contains("AXEditable")
-            ? AXHelper.boolValue(for: "AXEditable" as CFString, on: element)
-            : nil
-        let editableHintScore = AXHelper.editabilityHintScore(
-            role: role,
-            explicitEditableFlag: explicitEditableFlag
-        )
-        let hasStrongEditabilitySignal = AXHelper.hasStrongEditabilitySignal(
-            role: role,
-            explicitEditableFlag: explicitEditableFlag
-        )
-        let isKnownReadOnlyRole = AXHelper.isKnownReadOnlyRole(role)
-        let canBeEditableTarget = hasStrongEditabilitySignal && !isKnownReadOnlyRole
-        let nativeSelection =
-            canBeEditableTarget && supportedAttributes.contains(kAXSelectedTextRangeAttribute as String)
-            ? AXHelper.rangeValue(for: kAXSelectedTextRangeAttribute as CFString, on: element)
-            : nil
-
-        // Chromium/WebKit contenteditables (Gmail body, Slack/Notion/Discord web, ClickUp chat)
-        // expose selection only through the opaque AXTextMarker API, never kAXSelectedTextRange,
-        // so they would otherwise fail the capability gate for a missing selection. Synthesize an
-        // NSRange + caret-windowed text from the markers, but only when the native range is absent.
-        let markerSelection =
-            canBeEditableTarget && nativeSelection == nil
-            ? AXHelper.synthesizeMarkerSelection(
-                on: element, parameterizedAttributes: supportedParameterizedAttributes)
-            : nil
-
-        let nativeTextSelection = nativeSelection.flatMap {
-            nativeTextWindow(
-                on: element,
-                selection: $0,
-                supportedAttributes: supportedAttributes,
-                supportedParameterizedAttributes: supportedParameterizedAttributes
-            )
-        }
-        // Prefer the marker-windowed text when we synthesized one so `selection` (window-relative)
-        // and `textValue` stay consistent; otherwise use a bounded native text window when the host
-        // supports `AXStringForRange`, falling back to the full value for older/native controls.
-        let textSelection = markerSelection.map {
-            AXTextSelection(text: $0.text, selection: $0.selection)
-        } ?? nativeTextSelection
-        let selection = textSelection?.selection
-        let selectionForGeometry = nativeSelection ?? markerSelection?.selection
-        let textValue = textSelection?.text
-
-        if let markerSelection {
-            let textLength = (markerSelection.text as NSString).length
-            let location = markerSelection.selection.location
-            let length = markerSelection.selection.length
-            CotabbyLogger.focus.trace(
-                "CHROME-CONTENTEDITABLE synthesized selection loc=\(location) len=\(length) textLen=\(textLength)")
-        }
-
-        var inputFrameRect =
-            supportedAttributes.contains("AXFrame")
-            ? geometryResolver.resolveInputFrameRect(for: element)
-            : nil
-
-        if let currentFrame = inputFrameRect {
-            var finalWidth = currentFrame.width
-            var finalX = currentFrame.minX
-
-            // Optimization: grab the parent container's width if the active element is narrow
-            // so we capture the whole input bar context (e.g. Discord/Slack dynamically sized nodes).
-            if let parent = AXHelper.parentElement(of: element),
-               let parentFrame = AXHelper.rectValue(for: "AXFrame" as CFString, on: parent) {
-                let parentCocoa = AXHelper.cocoaRect(fromAccessibilityRect: parentFrame)
-                if parentCocoa.width > finalWidth {
-                    finalWidth = parentCocoa.width
-                    finalX = parentCocoa.minX
-                }
-            }
-
-            // Enforce a minimum width to ensure we get a decent horizontal slice.
-            if finalWidth < 500 {
-                finalWidth = max(finalWidth, 500)
-            }
-
-            inputFrameRect = CGRect(
-                x: finalX,
-                y: currentFrame.minY,
-                width: finalWidth,
-                height: currentFrame.height
-            )
-        }
-        let caretResult = selectionForGeometry.flatMap {
-            geometryResolver.resolveCaretRect(
-                for: element,
-                selection: $0,
-                // A marker-synthesized selection's location is window-relative, not a document
-                // offset, so NSRange-based BoundsForRange would resolve the wrong caret. Native
-                // selections keep their document offset here, while `textSelection` below carries
-                // the bounded-window offset for text-based geometry fallbacks.
-                supportsBoundsForRange: markerSelection == nil
-                    && supportedParameterizedAttributes.contains(
-                        kAXBoundsForRangeParameterizedAttribute as String),
-                supportsFrame: supportedAttributes.contains("AXFrame"),
-                cocoaAnchorFrame: inputFrameRect,
-                textValue: textValue,
-                textSelection: selection
-            )
-        }
-        let caretRect = caretResult?.rect
-        let caretQuality = caretResult?.quality
-        let isSecure = isSecureElement(element: element, role: role, subrole: subrole)
-        let elementIdentifier = AXHelper.elementIdentifier(
-            for: element, bundleIdentifier: bundleIdentifier)
-        let resolverCandidate = FocusCapabilityCandidate(
-            elementIdentifier: elementIdentifier,
-            role: role,
-            subrole: subrole,
-            editableHintScore: editableHintScore,
-            hasStrongEditabilitySignal: hasStrongEditabilitySignal,
-            isKnownReadOnlyRole: isKnownReadOnlyRole,
-            hasTextValue: textValue != nil,
-            hasSelectionRange: selection != nil,
-            hasCaretBounds: caretRect != nil,
-            isSecure: isSecure
-        )
-
-        return AXFocusCandidate(
-            element: element,
-            elementIdentifier: elementIdentifier,
-            role: role,
-            subrole: subrole,
-            textValue: textValue,
-            selection: selection,
-            caretRect: caretRect,
-            caretQuality: caretQuality,
-            observedCharWidth: caretResult?.observedCharWidth,
-            inputFrameRect: inputFrameRect,
-            isSecure: isSecure,
-            resolverCandidate: resolverCandidate
-        )
-    }
-
-    /// Reads the smallest native text window the host can provide around the current selection.
-    ///
-    /// `AXStringForRange` is the important fast path for large Chrome and WebKit fields: instead of
-    /// pulling the whole `AXValue`, we ask for at most `focusedTextContextWindowUTF16` units before
-    /// and after the caret. Apps that do not expose the parameterized string API still fall back to
-    /// `AXValue`, preserving compatibility.
-    private func nativeTextWindow(
-        on element: AXUIElement,
-        selection: NSRange,
-        supportedAttributes: Set<String>,
-        supportedParameterizedAttributes: Set<String>
-    ) -> AXTextSelection? {
-        func fullTextSelection() -> AXTextSelection? {
-            guard supportedAttributes.contains(kAXValueAttribute as String),
-                  let value = AXHelper.stringValue(for: kAXValueAttribute as CFString, on: element)
-            else {
-                return nil
-            }
-
-            return AXTextSelection(text: value, selection: selection)
-        }
-
-        guard supportedParameterizedAttributes.contains(kAXStringForRangeParameterizedAttribute as String),
-              supportedAttributes.contains(kAXNumberOfCharactersAttribute as String),
-              let rawDocumentLength = AXHelper.intValue(
-                  for: kAXNumberOfCharactersAttribute as CFString,
-                  on: element
-              ),
-              rawDocumentLength >= 0
-        else {
-            return fullTextSelection()
-        }
-
-        let documentLength = rawDocumentLength
-        let safeLocation = min(max(selection.location, 0), documentLength)
-        let requestedEnd = selection.location > Int.max - selection.length
-            ? Int.max
-            : selection.location + selection.length
-        let safeEnd = min(max(requestedEnd, safeLocation), documentLength)
-
-        let beforeLength = min(safeLocation, Self.focusedTextContextWindowUTF16)
-        let beforeStart = safeLocation - beforeLength
-        let afterStart = safeEnd
-        let afterLength = min(max(documentLength - afterStart, 0), Self.focusedTextContextWindowUTF16)
-
-        guard let beforeText = AXHelper.parameterizedStringValue(
-            for: kAXStringForRangeParameterizedAttribute as CFString,
-            range: NSRange(location: beforeStart, length: beforeLength),
-            on: element
-        ) else {
-            return fullTextSelection()
-        }
-
-        let selectedText: String
-        if safeEnd > safeLocation {
-            guard let nativeSelectedText = AXHelper.parameterizedStringValue(
-                for: kAXStringForRangeParameterizedAttribute as CFString,
-                range: NSRange(location: safeLocation, length: safeEnd - safeLocation),
-                on: element
-            ) else {
-                return fullTextSelection()
-            }
-            selectedText = nativeSelectedText
-        } else {
-            selectedText = ""
-        }
-
-        let trailingText: String
-        if afterLength > 0 {
-            trailingText = AXHelper.parameterizedStringValue(
-                for: kAXStringForRangeParameterizedAttribute as CFString,
-                range: NSRange(location: afterStart, length: afterLength),
-                on: element
-            ) ?? ""
-        } else {
-            trailingText = ""
-        }
-
-        let text = beforeText + selectedText + trailingText
-        return AXTextSelection(
-            text: text,
-            selection: NSRange(
-                location: (beforeText as NSString).length,
-                length: (selectedText as NSString).length
-            )
-        )
-    }
-
-    /// Detects secure inputs so Cotabby can intentionally refuse to operate in sensitive fields.
-    private func isSecureElement(element: AXUIElement, role: String, subrole: String?) -> Bool {
-        // Read the role description too: a native NSSecureTextField announces its sensitivity there
-        // ("secure text field") rather than through AXDescription, so the previous role/desc/title-only
-        // check missed it. SecureFieldDetector owns the (pure, testable) marker policy.
-        SecureFieldDetector.isSecure(
-            role: role,
-            subrole: subrole,
-            roleDescription: AXHelper.stringValue(for: kAXRoleDescriptionAttribute as CFString, on: element),
-            title: AXHelper.stringValue(for: kAXTitleAttribute as CFString, on: element),
-            descriptionLabel: AXHelper.stringValue(for: kAXDescriptionAttribute as CFString, on: element)
-        )
-    }
-}
-
-private struct FocusCandidateResolution {
-    let resolvedCandidate: AXFocusCandidate?
-    let diagnosticCandidate: AXFocusCandidate?
-    let resolution: FocusCapabilityResolution
-}
-
-private struct AXTextSelection {
-    let text: String
-    let selection: NSRange
-}
-
-/// AX data read from one candidate element near the current focus.
-/// This keeps candidate search state local to the resolver instead of leaking it into the tracker.
-private struct AXFocusCandidate {
-    let element: AXUIElement
-    let elementIdentifier: String
-    let role: String
-    let subrole: String?
-    let textValue: String?
-    let selection: NSRange?
-    let caretRect: CGRect?
-    let caretQuality: CaretGeometryQuality?
-    let observedCharWidth: CGFloat?
-    let inputFrameRect: CGRect?
-    let isSecure: Bool
-    let resolverCandidate: FocusCapabilityCandidate
 }


### PR DESCRIPTION
## Summary

Stacked on FuJacob/cotabby#561 (which is stacked on #560). Completes the `FocusSnapshotResolver` decomposition by moving candidate search and per-element AX reads into a new `FocusCandidateResolver`:

- Candidate search: `resolveCandidate` (now `resolve`), `candidateElements`, `appendEditableDescendants`, `looksEditable`.
- Per-element AX read: `candidateSnapshot`, `nativeTextWindow`, `isSecureElement`, plus the `AXFocusCandidate` / `FocusCandidateResolution` / `AXTextSelection` types.

`FocusSnapshotResolver` is now a **268-line orchestrator** (down from 1020) that composes `FocusCandidateResolver`, `CaretGeometryResolver`, `DeepGeometryWalkThrottle`, and `AXTreeDumpWriter`.

## Validation

```
xcodebuild ... build -derivedDataPath build/DerivedData      # ** BUILD SUCCEEDED **
swiftlint lint --quiet                                       # 0 violations
xcodebuild ... test CODE_SIGNING_ALLOWED=NO ...              # ** TEST SUCCEEDED ** 777 tests, 4 skipped, 0 failures
```

## Linked issues

None. Stacked on FuJacob/cotabby#561.

## Risk / rollout notes

- **Stacked on #561** (which is stacked on #560); merge bottom-up, retargeting each to `main` as the one below lands.
- Verbatim move of the candidate-search and per-element AX logic. Build, lint, and the full suite pass, but the live AX caret/candidate paths are not fully covered by automated tests. **Manual AX smoke recommended before merge**: a native `NSTextField`, a Chromium editor, an Electron app, and a secure field — confirm caret placement, field recognition, and that secure fields stay blocked.
- `project.pbxproj` regenerated by `xcodegen` for the new file.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the decomposition of the monolithic `FocusSnapshotResolver` by extracting candidate search and per-element AX reads into a new `FocusCandidateResolver`, reducing the orchestrator to 268 lines. The logic is a verbatim move; the only structural change is that `FocusSnapshotResolver.boundedContextWindow` now references `FocusCandidateResolver.focusedTextContextWindowUTF16` to keep the two window bounds in sync.

- **`FocusCandidateResolver`** (new file): owns `candidateElements`, `appendEditableDescendants`, `looksEditable`, `candidateSnapshot`, `nativeTextWindow`, and `isSecureElement`, plus the `AXFocusCandidate` / `FocusCandidateResolution` / `AXTextSelection` types.
- **`FocusSnapshotResolver`** (slimmed): becomes a pure orchestrator that calls `FocusCandidateResolver.resolve`, drives the deep-geometry walk through `DeepGeometryWalkThrottle`, and assembles the final `FocusSnapshot`.
- **`project.pbxproj`**: regenerated by `xcodegen` to register the new file; no manual edits.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is a verbatim extraction with no logic rewrites, and the full test suite (777 tests, 0 failures) passes.

The extraction is clean and the shared CaretGeometryResolver instance is wired correctly through both resolvers. Two style-level observations are worth tracking: the appended counter in appendEditableDescendants can exhaust the BFS budget against elements already excluded by the outer deduplication set, and the focusedTextContextWindowUTF16 constant is now coupled across two types by convention rather than by any compiler-enforced mechanism.

Cotabby/Services/Focus/FocusCandidateResolver.swift — specifically the appendEditableDescendants BFS termination logic and the focusedTextContextWindowUTF16 constant that FocusSnapshotResolver now references across type boundaries.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Services/Focus/FocusCandidateResolver.swift | New file extracting candidate search and per-element AX reads from FocusSnapshotResolver; logic is verbatim with one latent issue: the `appended` counter in `appendEditableDescendants` increments even when `append()` silently no-ops. |
| Cotabby/Services/Focus/FocusSnapshotResolver.swift | Slimmed down to 268-line orchestrator; delegates candidate resolution to FocusCandidateResolver, correctly sharing the same CaretGeometryResolver instance. |
| Cotabby.xcodeproj/project.pbxproj | xcodegen-regenerated to register FocusCandidateResolver.swift; mechanical change, no concerns. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant FT as FocusTracker
    participant FSR as FocusSnapshotResolver
    participant FCR as FocusCandidateResolver
    participant CGR as CaretGeometryResolver
    participant DWT as DeepGeometryWalkThrottle

    FT->>FSR: resolveSnapshot(focusedElement, app, seq, throttle)
    FSR->>FCR: resolve(around:, bundleIdentifier:, deepDescendants:)
    loop for each candidateElement
        FCR->>FCR: candidateSnapshot(for:bundleIdentifier:)
        FCR->>CGR: resolveInputFrameRect(for:)
        FCR->>CGR: resolveCaretRect(for:selection:...)
        FCR->>FCR: FocusCapabilityResolver.evaluate(candidate)
        alt hasFullCapabilities
            FCR-->>FSR: FocusCandidateResolution (resolved)
        else keep bestPartial
        end
    end
    FCR-->>FSR: FocusCandidateResolution (partial/nil)
    FSR->>FSR: CaretGeometrySelector.shouldSearchDeep?
    alt primary geometry weak
        FSR->>DWT: result(focusChangeSequence:interval:)
        DWT->>CGR: resolveDeepGeometrySource(...)
        CGR-->>DWT: CaretGeometryResult
        DWT-->>FSR: CaretGeometryResult
    end
    FSR->>FSR: CaretGeometrySelector.select(primary, deep)
    FSR->>FSR: boundedContextWindow(text:selection:)
    FSR-->>FT: FocusSnapshot
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22FuJacob%2Ffocus-candidate-resolver%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22FuJacob%2Ffocus-candidate-resolver%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FServices%2FFocus%2FFocusCandidateResolver.swift%3A149-165%0A**%60appended%60%20counter%20overcounts%20when%20elements%20are%20already%20in%20outer%20%60seen%60**%0A%0A%60appended%60%20is%20incremented%20every%20time%20%60looksEditable%60%20returns%20true%20and%20%60append%28element%29%60%20is%20called%2C%20but%20the%20closure%20can%20silently%20no-op%20if%20the%20element%20is%20already%20in%20the%20outer%20%60seen%60%20set%20%28i.e.%2C%20it%20was%20added%20during%20the%20shallow%20walk%29.%20In%20the%20worst%20case%2C%20if%20several%20roots%20or%20their%20children%20look%20editable%20and%20are%20all%20already%20in%20%60seen%60%2C%20the%20BFS%20exits%20early%20having%20added%20zero%20net%20new%20candidates%20to%20%60ordered%60%2C%20while%20%60appended%60%20has%20already%20exhausted%20the%2012-slot%20budget.%20The%20stop%20condition%20should%20guard%20on%20actual%20insertions%2C%20not%20attempted%20ones.%20This%20is%20pre-existing%20behavior%20carried%20forward%20verbatim%2C%20but%20the%20refactoring%20is%20a%20good%20moment%20to%20fix%20the%20counter.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FServices%2FFocus%2FFocusCandidateResolver.swift%3A19-22%0A**Cross-type%20coupling%20on%20%60focusedTextContextWindowUTF16%60%20requires%20manual%20discipline**%0A%0A%60FocusSnapshotResolver.boundedContextWindow%60%20now%20references%20%60FocusCandidateResolver.focusedTextContextWindowUTF16%60%20so%20that%20the%20AX-read%20window%20and%20the%20snapshot%20re-bound%20stay%20in%20sync.%20The%20doc%20comment%20documents%20the%20dependency%2C%20but%20there%20is%20no%20compile-time%20enforcement%3A%20someone%20adjusting%20the%20constant%20for%20the%20AX-read%20side%20%28e.g.%20to%20reduce%20IPC%20cost%29%20would%20silently%20leave%20the%20snapshot%20window%20out%20of%20sync.%20Extracting%20the%20constant%20to%20a%20shared%20namespace%20%28e.g.%20a%20%60FocusConstants%60%20enum%29%20or%20adding%20a%20test%20assertion%20would%20make%20the%20coupling%20explicit.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FServices%2FFocus%2FFocusCandidateResolver.swift%3A149-165%0A**%60appended%60%20counter%20overcounts%20when%20elements%20are%20already%20in%20outer%20%60seen%60**%0A%0A%60appended%60%20is%20incremented%20every%20time%20%60looksEditable%60%20returns%20true%20and%20%60append%28element%29%60%20is%20called%2C%20but%20the%20closure%20can%20silently%20no-op%20if%20the%20element%20is%20already%20in%20the%20outer%20%60seen%60%20set%20%28i.e.%2C%20it%20was%20added%20during%20the%20shallow%20walk%29.%20In%20the%20worst%20case%2C%20if%20several%20roots%20or%20their%20children%20look%20editable%20and%20are%20all%20already%20in%20%60seen%60%2C%20the%20BFS%20exits%20early%20having%20added%20zero%20net%20new%20candidates%20to%20%60ordered%60%2C%20while%20%60appended%60%20has%20already%20exhausted%20the%2012-slot%20budget.%20The%20stop%20condition%20should%20guard%20on%20actual%20insertions%2C%20not%20attempted%20ones.%20This%20is%20pre-existing%20behavior%20carried%20forward%20verbatim%2C%20but%20the%20refactoring%20is%20a%20good%20moment%20to%20fix%20the%20counter.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FServices%2FFocus%2FFocusCandidateResolver.swift%3A19-22%0A**Cross-type%20coupling%20on%20%60focusedTextContextWindowUTF16%60%20requires%20manual%20discipline**%0A%0A%60FocusSnapshotResolver.boundedContextWindow%60%20now%20references%20%60FocusCandidateResolver.focusedTextContextWindowUTF16%60%20so%20that%20the%20AX-read%20window%20and%20the%20snapshot%20re-bound%20stay%20in%20sync.%20The%20doc%20comment%20documents%20the%20dependency%2C%20but%20there%20is%20no%20compile-time%20enforcement%3A%20someone%20adjusting%20the%20constant%20for%20the%20AX-read%20side%20%28e.g.%20to%20reduce%20IPC%20cost%29%20would%20silently%20leave%20the%20snapshot%20window%20out%20of%20sync.%20Extracting%20the%20constant%20to%20a%20shared%20namespace%20%28e.g.%20a%20%60FocusConstants%60%20enum%29%20or%20adding%20a%20test%20assertion%20would%20make%20the%20coupling%20explicit.%0A%0A&repo=fujacob%2Fcotabby&pr=562&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["refactor(focus): extract FocusCandidateR..."](https://github.com/fujacob/cotabby/commit/9085e1b81f09d45311f77dd17ff9fc8630b13d0c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35768736)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->