### PR TITLE
Fix translucent menu bar popup background on macOS 26

### DIFF
--- a/Cotabby/UI/MenuBarView.swift
+++ b/Cotabby/UI/MenuBarView.swift
@@ -367,11 +367,13 @@ private struct MenuBarWindowBackgroundModifier: ViewModifier {
     func body(content: Content) -> some View {
         if #available(macOS 15.0, *) {
             // MenuBarExtra's `.window` style already gives us native rounded window chrome.
-            // On newer macOS builds, leaving the root fill implicit can make SwiftUI draw a
-            // second, inset window-colored rectangle inside that chrome. A container background
-            // belongs to the hosting window instead of this view's local bounds, so the fill
-            // reaches the native rounded frame and avoids the double-border look.
-            content.containerBackground(.windowBackground, for: .window)
+            // Place the fill at the hosting window instead of this view's local bounds so it
+            // reaches the native rounded frame as one surface (avoids the older double-border
+            // look). Use an opaque window *color*, not the `.windowBackground` *material*: under
+            // macOS 26 Liquid Glass the material is translucent, so the desktop/app behind the
+            // popup bleeds through and the native chrome and shadow detach from the content,
+            // worst on light backgrounds (issue #492). An opaque fill reads as one solid panel.
+            content.containerBackground(Color(nsColor: .windowBackgroundColor), for: .window)
         } else {
             content
         }

--- a/Cotabby/UI/MenuBarView.swift
+++ b/Cotabby/UI/MenuBarView.swift
@@ -365,15 +365,19 @@ struct MenuBarView: View {
 private struct MenuBarWindowBackgroundModifier: ViewModifier {
     @ViewBuilder
     func body(content: Content) -> some View {
-        if #available(macOS 15.0, *) {
-            // MenuBarExtra's `.window` style already gives us native rounded window chrome.
-            // Place the fill at the hosting window instead of this view's local bounds so it
-            // reaches the native rounded frame as one surface (avoids the older double-border
-            // look). Use an opaque window *color*, not the `.windowBackground` *material*: under
-            // macOS 26 Liquid Glass the material is translucent, so the desktop/app behind the
-            // popup bleeds through and the native chrome and shadow detach from the content,
-            // worst on light backgrounds (issue #492). An opaque fill reads as one solid panel.
+        if #available(macOS 26.0, *) {
+            // macOS 26 Liquid Glass renders the `.windowBackground` *material* as translucent
+            // glass, so the app/desktop behind the popup bleeds through and the native chrome and
+            // shadow detach from the content, worst on light backgrounds (issue #492). Fill with
+            // an opaque window *color* instead so the popup reads as one solid rounded panel.
             content.containerBackground(Color(nsColor: .windowBackgroundColor), for: .window)
+        } else if #available(macOS 15.0, *) {
+            // MenuBarExtra's `.window` style already gives us native rounded window chrome. Place
+            // the fill at the hosting window instead of this view's local bounds so it reaches the
+            // native rounded frame as one surface (avoids the double-border look fixed in #403).
+            // The `.windowBackground` material renders correctly on macOS 15 through pre-26, so
+            // keep it there to preserve the vibrant appearance and only patch the 26 regression.
+            content.containerBackground(.windowBackground, for: .window)
         } else {
             content
         }


### PR DESCRIPTION
## Summary

The menu bar popup (`MenuBarExtra(.window)`) relied solely on `.containerBackground(.windowBackground, for: .window)` for its fill. `.windowBackground` is a translucent *material*, so on macOS 26 (Liquid Glass) the window or desktop behind the popup bleeds through and the native window chrome and its shadow appear detached from the content, most visible on light backgrounds (issue #492). This swaps the material for an opaque `NSColor.windowBackgroundColor`, keeping the window-container placement introduced in #403 so the popup renders as one solid rounded panel in both light and dark.

## Validation

```bash
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build \
  -derivedDataPath build/DerivedData
# ** BUILD SUCCEEDED **

swiftlint lint --quiet Cotabby/UI/MenuBarView.swift
# exit 0, no warnings
```

Not yet confirmed visually end-to-end: the reporter's screenshot is on macOS 26.5 in light mode, and I could not reproduce a clean before/after capture on a light-mode desktop in this environment. Recommend a quick manual check on macOS 26: open the popup over a light or busy window (e.g. a browser) and confirm the background is opaque to the rounded edge with the shadow hugging the content, then sanity-check dark mode.

## Linked issues

Fixes #492
Refs #403, #402 (the prior double-border fix this change evolves)

## Risk / rollout notes

- Scoped to the menu bar panel presentation layer; no behavior changes elsewhere.
- The `#available(macOS 15.0, *)` guard and the macOS 14 fallback path are unchanged. Shipping baseline is macOS 15+ regardless, so every user hits the updated branch.
- `NSColor.windowBackgroundColor` is opaque and adapts to light/dark appearance. The intended trade-off is that the popup no longer picks up a translucent Liquid Glass tint, since that translucency was the source of the bug.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a translucent bleed-through bug in the menu bar popup on macOS 26 (Liquid Glass), where `.windowBackground` — a translucent material — let the app or desktop behind the popup show through, causing the native chrome and shadow to appear detached from the content. The fix adds a narrowly-scoped `#available(macOS 26.0, *)` branch that replaces the material with an opaque `Color(nsColor: .windowBackgroundColor)`, while the macOS 15–25 path keeps the original vibrant material unchanged.

- **Targeted regression fix**: only macOS 26+ gets the opaque `NSColor.windowBackgroundColor` fill; macOS 15–25 continues to use `.windowBackground` for vibrant/translucent appearance, preserving the prior behavior.
- **Minimal surface area**: the change is confined to `MenuBarWindowBackgroundModifier`, a single private struct with no behavioral impact outside the popup's presentation layer.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the change is a one-file, presentation-layer fix with no behavioral impact outside the menu bar popup.

The three-way availability guard is correctly ordered and properly scoped: macOS 26+ gets the opaque fix, macOS 15–25 keeps the original vibrant material, and macOS 14 keeps the no-op path. Color(nsColor: .windowBackgroundColor) conforms to ShapeStyle so the containerBackground call is type-safe, and the color is system-adaptive (light/dark). No logic outside this modifier is touched.

No files require special attention; manual visual verification on macOS 26 in light mode (as noted in the PR description) is the only remaining validation gap.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/MenuBarView.swift | Adds a dedicated macOS 26+ branch in MenuBarWindowBackgroundModifier that swaps the translucent `.windowBackground` material for an opaque `Color(nsColor: .windowBackgroundColor)`, while preserving the original vibrant-material path for macOS 15–25. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[MenuBarWindowBackgroundModifier.body] --> B{macOS 26+?}
    B -- Yes --> C["containerBackground(Color(nsColor: .windowBackgroundColor), for: .window)\nOpaque fill — fixes Liquid Glass bleed-through #492"]
    B -- No --> D{macOS 15+?}
    D -- Yes --> E["containerBackground(.windowBackground, for: .window)\nVibrant material — original behavior preserved"]
    D -- No --> F["content (no background modifier)\nFallback for macOS 14 and below"]
```

<sub>Reviews (2): Last reviewed commit: ["Limit opaque popup fill to macOS 26, kee..."](https://github.com/fujacob/cotabby/commit/f053b3c5584f23021c905dde59ec4ccd5c19279b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35773253)</sub>

<!-- /greptile_comment -->