### PR TITLE
Fix LM Studio model folder being ignored (#542)

### DIFF
--- a/Cotabby/Services/Utilities/ModelDownloadManager.swift
+++ b/Cotabby/Services/Utilities/ModelDownloadManager.swift
@@ -60,43 +60,49 @@ final class ModelDownloadManager: ObservableObject {
 
     private let runtimeDirectoryURL: URL
     private var runtimeSearchDirectories: [URL]
+    /// GGUF filenames discovered across every search directory, recomputed whenever the search set
+    /// or on-disk contents change. Cached so the per-catalog-model install check in
+    /// `refreshModelStates` does not re-walk the (recursively scanned) directories once per model.
+    private var installedModelFilenames: Set<String> = []
     private var downloadTasks: [String: Task<Void, Never>] = [:]
 
     init(runtimeDirectoryURL: URL? = nil) {
         let primaryDirectoryURL =
             runtimeDirectoryURL ?? BundledRuntimeLocator.userRuntimeDirectoryURL()
         self.runtimeDirectoryURL = primaryDirectoryURL
+        runtimeSearchDirectories = Self.resolveSearchDirectories(primary: primaryDirectoryURL)
 
-        var directories = [primaryDirectoryURL]
+        refreshModelStates()
+    }
+
+    /// Cotabby's own directory first (authoritative + download target), then any additive sources
+    /// (the LM Studio library when enabled), deduped by normalized path.
+    private static func resolveSearchDirectories(primary: URL) -> [URL] {
+        var directories = [primary]
         for directoryURL in BundledRuntimeLocator.runtimeSearchDirectories() {
             let normalizedPath = directoryURL.standardizedFileURL.path
             if !directories.contains(where: { $0.standardizedFileURL.path == normalizedPath }) {
                 directories.append(directoryURL)
             }
         }
-        runtimeSearchDirectories = directories
-
-        refreshModelStates()
+        return directories
     }
 
     var models: [DownloadableRuntimeModel] {
         RuntimeModelCatalog.downloadableModels
     }
 
+    /// The path shown in Settings and opened by "Open Folder". This is always Cotabby's own writable
+    /// directory because that is where downloads and imports land; additive sources such as LM Studio
+    /// are read-only and surfaced only through the model picker, not this control.
     var modelsDirectoryPath: String {
-        BundledRuntimeLocator.customModelDirectoryURL()?.path ?? runtimeDirectoryURL.path
+        runtimeDirectoryURL.path
     }
 
-    /// Re-reads the current search directories (including any custom path) and refreshes model states.
+    /// Re-reads the current search directories (including the LM Studio source when toggled) and
+    /// refreshes model states.
     func refreshSearchDirectories() {
-        var directories = [runtimeDirectoryURL]
-        for directoryURL in BundledRuntimeLocator.runtimeSearchDirectories() {
-            let normalizedPath = directoryURL.standardizedFileURL.path
-            if !directories.contains(where: { $0.standardizedFileURL.path == normalizedPath }) {
-                directories.append(directoryURL)
-            }
-        }
-        runtimeSearchDirectories = directories
+        runtimeSearchDirectories = Self.resolveSearchDirectories(primary: runtimeDirectoryURL)
         refreshModelStates()
     }
 
@@ -105,6 +111,7 @@ final class ModelDownloadManager: ObservableObject {
     }
 
     func refreshModelStates() {
+        recomputeInstalledModelFilenames()
         let catalogFilenames = Set(models.map(\.filename))
 
         for model in models {
@@ -395,10 +402,20 @@ final class ModelDownloadManager: ObservableObject {
     }
 
     private func isInstalled(filename: String) -> Bool {
-        runtimeSearchDirectories.contains { directoryURL in
-            let fileURL = directoryURL.appendingPathComponent(filename, isDirectory: false)
-            return FileManager.default.fileExists(atPath: fileURL.path)
+        installedModelFilenames.contains(filename)
+    }
+
+    /// Rebuilds the discovered-filename cache by recursively scanning every search directory. The
+    /// recursion is what lets a nested LM Studio install (`<publisher>/<repo>/<file>.gguf`) be
+    /// recognized as installed; a flat `directory/filename` join would miss it.
+    private func recomputeInstalledModelFilenames() {
+        var filenames: Set<String> = []
+        for directoryURL in runtimeSearchDirectories {
+            for modelURL in BundledRuntimeLocator.discoverGGUFModelURLs(in: directoryURL) {
+                filenames.insert(modelURL.lastPathComponent)
+            }
         }
+        installedModelFilenames = filenames
     }
 
 }

--- a/Cotabby/Services/Utilities/ModelDownloadManager.swift
+++ b/Cotabby/Services/Utilities/ModelDownloadManager.swift
@@ -293,6 +293,9 @@ final class ModelDownloadManager: ObservableObject {
             try await performSingleFileDownload(model, url: model.downloadURL)
 
             CotabbyLogger.models.info("Download complete for \(model.filename)")
+            // Keep the discovered-filename cache in step with the new file on disk so an immediate
+            // re-`download(_:)` of the same model is recognized as installed instead of re-fetched.
+            recomputeInstalledModelFilenames()
             modelStates[model.filename] = .downloaded
             onModelDirectoryChanged?()
         } catch {

--- a/Cotabby/Support/BundledRuntimeLocator.swift
+++ b/Cotabby/Support/BundledRuntimeLocator.swift
@@ -121,8 +121,15 @@ struct BundledRuntimeLocator {
                 enumerator.skipDescendants()
                 continue
             }
+            // A directory can carry a `.gguf` extension; only regular files are loadable models, and
+            // passing a directory path to the runtime would surface a confusing error instead of a
+            // clean "model missing".
+            guard (try? url.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) == true
+            else { continue }
             guard url.pathExtension.caseInsensitiveCompare("gguf") == .orderedSame else { continue }
-            guard !url.lastPathComponent.lowercased().hasPrefix("mmproj") else { continue }
+            // LM Studio always names projector sidecars `mmproj-…`; the trailing dash avoids
+            // excluding a legitimately named model that merely starts with "mmproj".
+            guard !url.lastPathComponent.lowercased().hasPrefix("mmproj-") else { continue }
             results.append(url)
         }
         return results

--- a/Cotabby/Support/BundledRuntimeLocator.swift
+++ b/Cotabby/Support/BundledRuntimeLocator.swift
@@ -53,19 +53,28 @@ struct BundledRuntimeLocator {
             .appendingPathComponent(Self.runtimeFolderName, isDirectory: true)
     }
 
-    private static let customModelDirectoryKey = "customModelDirectoryPath"
+    /// Toggle key for "also read models from LM Studio". The LM Studio library is an *additional*
+    /// read-only source, never a replacement: Cotabby's own writable directory is always scanned and
+    /// is always where downloads land. This is a Bool, not a stored path, because the only opt-in
+    /// source we support is LM Studio's well-known location.
+    static let lmStudioSourceEnabledKey = "lmStudioModelsEnabled"
 
-    /// Returns the user-configured custom model directory, if one is set.
-    static func customModelDirectoryURL() -> URL? {
-        guard let path = UserDefaults.standard.string(forKey: customModelDirectoryKey),
-              !path.isEmpty
-        else { return nil }
-        return URL(fileURLWithPath: path, isDirectory: true)
+    /// Whether the user opted to also scan their LM Studio library for GGUF models.
+    static func isLMStudioSourceEnabled() -> Bool {
+        UserDefaults.standard.bool(forKey: lmStudioSourceEnabledKey)
     }
 
-    /// Persists (or clears) a custom model directory that is searched before the default path.
-    static func setCustomModelDirectory(_ url: URL?) {
-        UserDefaults.standard.set(url?.path, forKey: customModelDirectoryKey)
+    /// Persists the LM Studio additive-source toggle.
+    static func setLMStudioSourceEnabled(_ enabled: Bool) {
+        UserDefaults.standard.set(enabled, forKey: lmStudioSourceEnabledKey)
+    }
+
+    /// The LM Studio models directory only when the user enabled the source *and* it exists on disk.
+    /// A stale toggle (enabled, but LM Studio later uninstalled) resolves to nil so callers never
+    /// scan a missing directory.
+    static func enabledLMStudioModelsDirectory() -> URL? {
+        guard isLMStudioSourceEnabled() else { return nil }
+        return lmStudioModelsDirectoryIfAvailable()
     }
 
     /// The LM Studio models directory (`~/.lmstudio/models`) when it exists on disk, else nil.
@@ -78,14 +87,45 @@ struct BundledRuntimeLocator {
     }
 
     /// Ordered runtime search directories used to discover GGUF files.
-    /// This mirrors runtime resolution order and is shared by model-install status checks.
+    /// Cotabby's own directory is always first (it is authoritative and the download target); the LM
+    /// Studio library, when enabled, is appended as an additive source.
     static func runtimeSearchDirectories(bundle: Bundle = .main) -> [URL] {
-        var directories: [URL] = []
-        if let custom = customModelDirectoryURL() {
-            directories.append(custom)
+        var directories: [URL] = [userRuntimeDirectoryURL(bundle: bundle)]
+        if let lmStudio = enabledLMStudioModelsDirectory() {
+            directories.append(lmStudio)
         }
-        directories.append(userRuntimeDirectoryURL(bundle: bundle))
         return directories
+    }
+
+    /// Recursively discovers loadable GGUF model files under `directoryURL`.
+    ///
+    /// Recursion is required because third-party libraries (notably LM Studio) nest models as
+    /// `<publisher>/<repo>/<file>.gguf` rather than as a flat folder, so a shallow listing of the
+    /// root finds nothing and silently falls back to the default directory. Depth is bounded so a
+    /// user pointing at a large tree cannot trigger an unbounded walk. `mmproj-*.gguf` files are
+    /// vision/CLIP projector sidecars, not standalone language models, so they are skipped to keep
+    /// them out of the model picker.
+    static func discoverGGUFModelURLs(in directoryURL: URL, maxDepth: Int = 4) -> [URL] {
+        let fileManager = FileManager.default
+        guard let enumerator = fileManager.enumerator(
+            at: directoryURL,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles, .skipsPackageDescendants]
+        ) else {
+            return []
+        }
+
+        var results: [URL] = []
+        for case let url as URL in enumerator {
+            if enumerator.level > maxDepth {
+                enumerator.skipDescendants()
+                continue
+            }
+            guard url.pathExtension.caseInsensitiveCompare("gguf") == .orderedSame else { continue }
+            guard !url.lastPathComponent.lowercased().hasPrefix("mmproj") else { continue }
+            results.append(url)
+        }
+        return results
     }
 
     /// Finds the first preferred local model that exists and returns the fully resolved runtime asset paths.
@@ -135,24 +175,35 @@ struct BundledRuntimeLocator {
                 "No runtime candidates were available.")
     }
 
-    /// Lists all GGUF models in deterministic display order for the highest-priority runtime candidate.
+    /// Lists all GGUF models in deterministic display order, merged across every runtime candidate.
+    ///
+    /// Merging (rather than returning the first non-empty candidate) is what makes the LM Studio
+    /// source additive: the picker shows Cotabby's own models plus the LM Studio library together.
+    /// Candidate order is preserved (Cotabby's directory first) and duplicate filenames are deduped,
+    /// keeping the first occurrence so the authoritative directory wins a name collision.
     func availableModels(configuration: LlamaRuntimeConfiguration) -> [RuntimeModelOption] {
+        var merged: [RuntimeModelOption] = []
+        var seenFilenames = Set<String>()
+
         for candidate in runtimeCandidates(for: configuration) {
-            if let modelOptions = try? availableModels(
+            guard let modelOptions = try? availableModels(
                 candidate: candidate,
                 preferredModelNames: configuration.preferredModelNames
-            ),
-                !modelOptions.isEmpty {
-                return modelOptions
+            ) else {
+                continue
+            }
+
+            for option in modelOptions where seenFilenames.insert(option.filename).inserted {
+                merged.append(option)
             }
         }
 
-        return []
+        return merged
     }
 
-    /// Enumerates runtime directories. By default we only load from the user-managed model directory.
+    /// Enumerates runtime directories. By default we load from the user-managed model directory and,
+    /// when the user enabled it, additionally from the LM Studio library.
     /// An explicit `runtimeDirectoryPath` can override this for tests or advanced local setups.
-    /// A user-configured custom directory (e.g. LM Studio) is searched before the default.
     private func runtimeCandidates(for configuration: LlamaRuntimeConfiguration)
         -> [RuntimeCandidate] {
         if let runtimeDirectoryPath = configuration.runtimeDirectoryPath,
@@ -166,22 +217,21 @@ struct BundledRuntimeLocator {
             ]
         }
 
-        var candidates: [RuntimeCandidate] = []
-        if let custom = Self.customModelDirectoryURL() {
-            candidates.append(
-                RuntimeCandidate(
-                    runtimeDirectoryURL: custom,
-                    modelDirectoryURL: custom
-                )
-            )
-        }
         let userDir = Self.userRuntimeDirectoryURL(bundle: bundle)
-        candidates.append(
+        var candidates: [RuntimeCandidate] = [
             RuntimeCandidate(
                 runtimeDirectoryURL: userDir,
                 modelDirectoryURL: userDir
             )
-        )
+        ]
+        if let lmStudio = Self.enabledLMStudioModelsDirectory() {
+            candidates.append(
+                RuntimeCandidate(
+                    runtimeDirectoryURL: lmStudio,
+                    modelDirectoryURL: lmStudio
+                )
+            )
+        }
         return candidates
     }
 
@@ -212,25 +262,21 @@ struct BundledRuntimeLocator {
             throw BundledRuntimeLocatorError.modelMissing(candidate.modelDirectoryURL.path)
         }
 
-        let discoveredModelURLs = try fileManager.contentsOfDirectory(
-            at: candidate.modelDirectoryURL,
-            includingPropertiesForKeys: nil,
-            options: [.skipsHiddenFiles]
-        )
-        .filter { $0.pathExtension.caseInsensitiveCompare("gguf") == .orderedSame }
+        let discoveredModelURLs = Self.discoverGGUFModelURLs(in: candidate.modelDirectoryURL)
 
         guard !discoveredModelURLs.isEmpty else {
             throw BundledRuntimeLocatorError.modelMissing(candidate.modelDirectoryURL.path)
         }
 
-        let modelOptionsByFilename = Dictionary(
-            uniqueKeysWithValues: discoveredModelURLs.map { modelURL in
-                let option = RuntimeModelOption(
-                    filename: modelURL.lastPathComponent,
-                    url: modelURL
-                )
-                return (option.filename, option)
-            })
+        // Recursive discovery can surface the same filename from two nested repos. Dedupe by
+        // filename keeping the first occurrence so a name collision resolves deterministically and
+        // the keyed lookup below cannot trap on duplicate keys.
+        var modelOptionsByFilename: [String: RuntimeModelOption] = [:]
+        for modelURL in discoveredModelURLs {
+            let filename = modelURL.lastPathComponent
+            guard modelOptionsByFilename[filename] == nil else { continue }
+            modelOptionsByFilename[filename] = RuntimeModelOption(filename: filename, url: modelURL)
+        }
 
         var orderedModels: [RuntimeModelOption] = []
         var seenFilenames = Set<String>()

--- a/Cotabby/UI/Settings/Panes/EngineAndModelPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/EngineAndModelPaneView.swift
@@ -50,6 +50,12 @@ struct EngineAndModelPaneView: View {
         .onAppear {
             foundationModelAvailabilityService.refresh()
             lmStudioModelsURL = BundledRuntimeLocator.lmStudioModelsDirectoryIfAvailable()
+            // If LM Studio was uninstalled while the source was enabled, clear the persisted flag so
+            // the toggle does not sit checked-but-disabled with no way to turn it off (and so the
+            // source does not silently reactivate if LM Studio is later reinstalled).
+            if lmStudioModelsURL == nil, lmStudioSourceEnabled {
+                lmStudioSourceEnabled = false
+            }
         }
         .alert(
             "Delete Model?",

--- a/Cotabby/UI/Settings/Panes/EngineAndModelPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/EngineAndModelPaneView.swift
@@ -15,8 +15,12 @@ struct EngineAndModelPaneView: View {
 
     @State private var pendingDeletionModel: RuntimeModelOption?
     /// The LM Studio models directory if it exists, probed once in `onAppear` so the filesystem
-    /// `fileExists` check never runs on the SwiftUI render path. Nil disables the "Use LM Studio" button.
+    /// `fileExists` check never runs on the SwiftUI render path. Nil disables the LM Studio toggle.
     @State private var lmStudioModelsURL: URL?
+    /// Whether to also scan the user's LM Studio library. Persisted via the same key the locator
+    /// reads, so the toggle and the model scan stay in sync. LM Studio models are an additive,
+    /// read-only source; Cotabby's own folder is always scanned and is always the download target.
+    @AppStorage(BundledRuntimeLocator.lmStudioSourceEnabledKey) private var lmStudioSourceEnabled = false
 
     var body: some View {
         SettingsPaneScaffold(callout: callout) {
@@ -135,22 +139,6 @@ struct EngineAndModelPaneView: View {
                         .multilineTextAlignment(.trailing)
 
                     HStack(spacing: 8) {
-                        let isUsingCustomPath = BundledRuntimeLocator.customModelDirectoryURL() != nil
-                        Button("Use LM Studio") {
-                            guard let lmStudioModelsURL else { return }
-                            BundledRuntimeLocator.setCustomModelDirectory(lmStudioModelsURL)
-                            modelDownloadManager.refreshSearchDirectories()
-                            refreshModels()
-                        }
-                        .disabled(lmStudioModelsURL == nil)
-
-                        Button("Reset Path") {
-                            BundledRuntimeLocator.setCustomModelDirectory(nil)
-                            modelDownloadManager.refreshSearchDirectories()
-                            refreshModels()
-                        }
-                        .disabled(!isUsingCustomPath)
-
                         Button("Open Folder") {
                             modelDownloadManager.openModelsDirectory()
                         }
@@ -160,6 +148,21 @@ struct EngineAndModelPaneView: View {
                         }
                     }
                 }
+            }
+
+            Toggle(isOn: $lmStudioSourceEnabled) {
+                SettingsRowLabel(
+                    title: "Also use LM Studio models",
+                    description: lmStudioModelsURL == nil
+                        ? "Install LM Studio to load models from its library here."
+                        : "Add models from your LM Studio library (~/.lmstudio/models) to the picker " +
+                            "above. Downloads still save to Cotabby's own folder."
+                )
+            }
+            .disabled(lmStudioModelsURL == nil)
+            .onChange(of: lmStudioSourceEnabled) { _, _ in
+                modelDownloadManager.refreshSearchDirectories()
+                refreshModels()
             }
         }
 

--- a/CotabbyTests/BundledRuntimeLocatorTests.swift
+++ b/CotabbyTests/BundledRuntimeLocatorTests.swift
@@ -174,7 +174,99 @@ final class BundledRuntimeLocatorTests: XCTestCase {
         XCTAssertTrue(namedError.errorDescription?.contains("test.gguf") ?? false)
     }
 
+    // MARK: - Recursive discovery (LM Studio nested layout)
+
+    func test_discoverGGUFModelURLs_findsNestedModels() throws {
+        // Mirrors LM Studio's `<publisher>/<repo>/<file>.gguf` layout, which a flat scan misses.
+        let root = try makeTemporaryDirectory()
+        try writeFile(at: root, relativePath: "publisher/repo/model.gguf")
+        try writeFile(at: root, relativePath: "publisher/other-repo/another.gguf")
+
+        let discovered = BundledRuntimeLocator.discoverGGUFModelURLs(in: root)
+            .map(\.lastPathComponent)
+            .sorted()
+
+        XCTAssertEqual(discovered, ["another.gguf", "model.gguf"])
+    }
+
+    func test_discoverGGUFModelURLs_skipsMmprojSidecars() throws {
+        let root = try makeTemporaryDirectory()
+        try writeFile(at: root, relativePath: "publisher/repo/model.gguf")
+        try writeFile(at: root, relativePath: "publisher/repo/mmproj-model-BF16.gguf")
+
+        let discovered = BundledRuntimeLocator.discoverGGUFModelURLs(in: root)
+            .map(\.lastPathComponent)
+
+        XCTAssertEqual(discovered, ["model.gguf"], "mmproj projector sidecars are not loadable models")
+    }
+
+    func test_discoverGGUFModelURLs_respectsMaxDepth() throws {
+        let root = try makeTemporaryDirectory()
+        try writeFile(at: root, relativePath: "a/b/c/deep.gguf")
+
+        let shallow = BundledRuntimeLocator.discoverGGUFModelURLs(in: root, maxDepth: 2)
+        XCTAssertTrue(shallow.isEmpty, "A file below the depth bound should not be discovered")
+
+        let deep = BundledRuntimeLocator.discoverGGUFModelURLs(in: root, maxDepth: 4)
+        XCTAssertEqual(deep.map(\.lastPathComponent), ["deep.gguf"])
+    }
+
+    func test_availableModels_discoversNestedLayoutThroughPublicAPI() throws {
+        let root = try makeTemporaryDirectory()
+        try writeFile(at: root, relativePath: "publisher/repo/nested.gguf")
+        let config = makeConfig(runtimePath: root.path, preferred: [])
+        let locator = BundledRuntimeLocator()
+
+        let filenames = locator.availableModels(configuration: config).map(\.filename)
+        XCTAssertEqual(filenames, ["nested.gguf"])
+    }
+
+    func test_availableModels_dedupesDuplicateFilenamesAcrossNestedRepos() throws {
+        // Two repos shipping the same filename must not trap the keyed lookup or appear twice.
+        let root = try makeTemporaryDirectory()
+        try writeFile(at: root, relativePath: "publisher/repo-a/model.gguf")
+        try writeFile(at: root, relativePath: "publisher/repo-b/model.gguf")
+        let config = makeConfig(runtimePath: root.path, preferred: [])
+        let locator = BundledRuntimeLocator()
+
+        let filenames = locator.availableModels(configuration: config).map(\.filename)
+        XCTAssertEqual(filenames, ["model.gguf"])
+    }
+
+    // MARK: - LM Studio source toggle
+
+    func test_lmStudioSourceToggle_persistsAndClears() {
+        let key = BundledRuntimeLocator.lmStudioSourceEnabledKey
+        let original = UserDefaults.standard.object(forKey: key)
+        defer { UserDefaults.standard.set(original, forKey: key) }
+
+        BundledRuntimeLocator.setLMStudioSourceEnabled(true)
+        XCTAssertTrue(BundledRuntimeLocator.isLMStudioSourceEnabled())
+
+        BundledRuntimeLocator.setLMStudioSourceEnabled(false)
+        XCTAssertFalse(BundledRuntimeLocator.isLMStudioSourceEnabled())
+        // Disabled means no LM Studio directory is ever returned, even if it exists on disk.
+        XCTAssertNil(BundledRuntimeLocator.enabledLMStudioModelsDirectory())
+    }
+
     // MARK: - Helpers
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("Cotabby-locator-test-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        temporaryDirectories.append(dir)
+        return dir
+    }
+
+    private func writeFile(at root: URL, relativePath: String) throws {
+        let fileURL = root.appendingPathComponent(relativePath, isDirectory: false)
+        try FileManager.default.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        FileManager.default.createFile(atPath: fileURL.path, contents: nil)
+    }
 
     private func makeTemporaryRuntimeDirectory(ggufFilenames: [String]) throws -> URL {
         let dir = FileManager.default.temporaryDirectory

--- a/CotabbyTests/BundledRuntimeLocatorTests.swift
+++ b/CotabbyTests/BundledRuntimeLocatorTests.swift
@@ -200,6 +200,21 @@ final class BundledRuntimeLocatorTests: XCTestCase {
         XCTAssertEqual(discovered, ["model.gguf"], "mmproj projector sidecars are not loadable models")
     }
 
+    func test_discoverGGUFModelURLs_skipsDirectoriesWithGGUFExtension() throws {
+        // A directory can legitimately carry a `.gguf` name; it is not a loadable model file.
+        let root = try makeTemporaryDirectory()
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent("bundle.gguf", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        try writeFile(at: root, relativePath: "real.gguf")
+
+        let discovered = BundledRuntimeLocator.discoverGGUFModelURLs(in: root)
+            .map(\.lastPathComponent)
+
+        XCTAssertEqual(discovered, ["real.gguf"])
+    }
+
     func test_discoverGGUFModelURLs_respectsMaxDepth() throws {
         let root = try makeTemporaryDirectory()
         try writeFile(at: root, relativePath: "a/b/c/deep.gguf")


### PR DESCRIPTION
## Summary

Pointing Cotabby at an LM Studio model folder did nothing: the picker kept showing the default models, the runtime kept loading from `~/Library/Application Support/Cotabby/LlamaRuntime`, and "Open Folder" opened that default path. Two independent defects caused it, and the directory model is reshaped to match how users actually expect a second library to behave.

Root causes:
- **Non-recursive scan.** `BundledRuntimeLocator` listed a directory with a flat `contentsOfDirectory` + `.gguf` filter, but LM Studio nests models as `<publisher>/<repo>/<file>.gguf`. The root holds only subfolders, so zero models were found and the locator silently fell back to the default directory.
- **Frozen open/display target.** `ModelDownloadManager` captured its directory once at init (always the default) and never updated it, so "Open Folder" opened the default path while the displayed path showed the custom one.

This PR makes GGUF discovery recursive (bounded depth, skipping `mmproj-*.gguf` projector sidecars that LM Studio ships alongside real models) and turns the custom directory into an **additive, opt-in LM Studio source**:
- Cotabby's own folder is always scanned and is always where downloads/imports land and where "Open Folder" points.
- The "Use LM Studio" / "Reset Path" buttons become a single "Also use LM Studio models" toggle. When on, the LM Studio library is merged into the model picker alongside Cotabby's own models (deduped by filename, Cotabby's folder authoritative on collisions).
- `availableModels(configuration:)` now merges across candidates instead of returning the first non-empty one, which is what makes the source additive rather than a replacement.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  -only-testing:CotabbyTests/BundledRuntimeLocatorTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
# ** TEST SUCCEEDED **  18 tests, 0 failures (6 new)

swiftlint lint --quiet <changed files>
# exit 0
```

New tests cover: nested (`publisher/repo/file.gguf`) discovery, `mmproj` filtering, depth bounding, duplicate-filename dedupe across nested repos, nested discovery through the public `availableModels` API, and the LM Studio toggle persistence.

Confirmed against the real on-disk LM Studio layout (`~/.lmstudio/models/lmstudio-community/gemma-4-E4B-it-GGUF/gemma-4-E4B-it-Q4_K_M.gguf`).

## Linked issues

Fixes #542

## Risk / rollout notes

- **Settings/behavior change.** The custom-directory model changed from "replace default path" to "additive LM Studio source". The persisted key changed from `customModelDirectoryPath` (a path) to `lmStudioModelsEnabled` (a Bool); any previously stored custom path is ignored after upgrade (beta only). Downloads/imports/Open Folder now always target Cotabby's own writable folder, by design, so they can never write into LM Studio's tree.
- **Performance.** Discovery is now recursive but depth-bounded (default 4) and skips hidden files/package descendants; the install-state check caches discovered filenames so `refreshModelStates` does not re-walk per catalog model.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two independent defects that prevented LM Studio model folders from working: non-recursive GGUF discovery (models nested as `publisher/repo/model.gguf` were invisible to the flat `contentsOfDirectory` scan) and a frozen open/display target in `ModelDownloadManager` (always defaulted to Cotabby's own directory). The solution also reshapes the directory model from "replace default path" to "additive, opt-in LM Studio source."

- `BundledRuntimeLocator` gains a bounded-depth recursive `discoverGGUFModelURLs` (default depth 4, skips hidden files and `mmproj-` sidecars), `availableModels(configuration:)` now merges across all candidates rather than returning the first non-empty one, and the custom-path `String` key is replaced by a boolean `lmStudioModelsEnabled` toggle.
- `ModelDownloadManager` adds an `installedModelFilenames: Set<String>` cache (rebuilt atop every `refreshModelStates` and immediately after download completion) so the install-state check correctly matches nested LM Studio filenames; `modelsDirectoryPath` and "Open Folder" now always point to the writable Cotabby directory.
- `EngineAndModelPaneView` replaces the two-button flow with a single `@AppStorage`-backed toggle; `onAppear` clears a stale `true` flag when LM Studio is no longer on disk.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The two root-cause fixes are correct, the additive LM Studio source is gated by an existence check on every resolution path, and Cotabby's writable directory remains the exclusive download/import target.

All changed code paths are covered by the new tests. The recursive enumerator is depth-bounded and handles missing directories gracefully. The `installedModelFilenames` cache is kept consistent at every write point. The stale-toggle cleanup in `onAppear` correctly resets both the persisted flag and the search-directory list before the model states are refreshed. No correctness issues were found across any of the four changed files.

No files require special attention. The two minor observations (depth pruning inefficiency and redundant `refreshModelStates` call) are non-functional.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/BundledRuntimeLocator.swift | Core locator overhauled: flat GGUF scan replaced with bounded-depth recursive enumerator, custom-path replaced by boolean LM Studio toggle, and `availableModels` now merges across all candidates instead of returning the first non-empty one. Previous review findings (isRegularFile guard, mmproj- dash) are all addressed. |
| Cotabby/Services/Utilities/ModelDownloadManager.swift | Adds an `installedModelFilenames` Set cache so the per-model install check no longer flat-joins directory + filename (which would miss nested LM Studio models). Cache is refreshed at the top of `refreshModelStates` and immediately after a completed download. |
| Cotabby/UI/Settings/Panes/EngineAndModelPaneView.swift | Replaces the two-button (Use LM Studio / Reset Path) UI with a single `@AppStorage`-backed toggle. The `onAppear` handler clears the persisted flag when LM Studio is no longer present, addressing the stuck-checked-when-uninstalled issue from the previous round. |
| CotabbyTests/BundledRuntimeLocatorTests.swift | Six new tests cover: nested model discovery, mmproj sidecar filtering, `.gguf`-named directory exclusion, depth bounding, nested discovery through the public API, cross-repo dedup, and toggle persistence. All tests are well-structured with proper tearDown cleanup. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User opens Settings pane] --> B[onAppear: probe ~/.lmstudio/models]
    B --> C{LM Studio exists?}
    C -- No --> D[lmStudioModelsURL = nil / Disable toggle]
    C -- No --> E{lmStudioSourceEnabled was true?}
    E -- Yes --> F[Clear lmStudioSourceEnabled / triggers onChange]
    C -- Yes --> G[lmStudioModelsURL = URL / Enable toggle]
    F --> H[refreshSearchDirectories]
    G --> O[User toggles ON]
    O --> H
    H --> I[enabledLMStudioModelsDirectory]
    I -- enabled + exists --> M[runtimeSearchDirectories: Cotabby + LM Studio]
    I -- disabled or missing --> N[runtimeSearchDirectories: Cotabby only]
    M --> P[discoverGGUFModelURLs / depth=4 / skips mmproj- and dirs]
    N --> P
    P --> Q[installedModelFilenames cache]
    P --> R[Model picker: merged / Cotabby first / deduped by filename]
    R --> S{User selects model}
    S -- Cotabby model --> T[resolve: Cotabby candidate succeeds]
    S -- LM Studio model --> U[resolve: Cotabby candidate fails namedModelMissing]
    U --> V[resolve: LM Studio candidate finds nested file]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2F542-model-folder-path%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F542-model-folder-path%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FSupport%2FBundledRuntimeLocator.swift%3A118-123%0AThe%20depth-pruning%20loop%20only%20calls%20%60skipDescendants%28%29%60%20when%20%60level%20%3E%20maxDepth%60.%20This%20means%20a%20directory%20sitting%20at%20exactly%20%60maxDepth%60%20is%20entered%3A%20every%20one%20of%20its%20children%20is%20fetched%20from%20the%20OS%2C%20checked%20against%20the%20guard%2C%20and%20discarded%20via%20%60continue%60.%20Calling%20%60skipDescendants%28%29%60%20on%20the%20directory%20itself%20at%20%60level%20%3D%3D%20maxDepth%60%20avoids%20traversing%20the%20subtree%20entirely.%20For%20the%20default%20depth%20of%204%20and%20typical%20LM%20Studio%20layouts%20%283%20levels%20deep%29%20the%20waste%20is%20negligible%2C%20but%20a%20user%20pointing%20Cotabby%20at%20a%20wide%20mirror%20directory%20at%20the%20boundary%20could%20trigger%20many%20redundant%20%60stat%60%20calls.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20var%20results%3A%20%5BURL%5D%20%3D%20%5B%5D%0A%20%20%20%20%20%20%20%20for%20case%20let%20url%20as%20URL%20in%20enumerator%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20enumerator.level%20%3E%3D%20maxDepth%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20At%20or%20beyond%20the%20depth%20bound%3A%20skip%20any%20subtree%20rooted%20here%20so%20we%20don't%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20pay%20for%20fetching%20children%20only%20to%20discard%20them%20individually.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20enumerator.skipDescendants%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20enumerator.level%20%3E%20maxDepth%20%7B%20continue%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FUI%2FSettings%2FPanes%2FEngineAndModelPaneView.swift%3A169-172%0A%60refreshSearchDirectories%28%29%60%20already%20calls%20%60refreshModelStates%28%29%60%20internally%20before%20returning%2C%20so%20the%20subsequent%20%60refreshModels%28%29%60%20call%20triggers%20a%20second%20full%20%60recomputeInstalledModelFilenames%28%29%60%20%2B%20%60modelStates%60%20scan%20on%20the%20same%20data.%20The%20same%20redundancy%20occurs%20in%20the%20%60onAppear%60%20stale-flag%20path%20where%20setting%20%60lmStudioSourceEnabled%20%3D%20false%60%20fires%20this%20handler.%20Neither%20call%20is%20wrong%2C%20but%20the%20duplicate%20filesystem%20walk%20is%20unnecessary.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FSupport%2FBundledRuntimeLocator.swift%3A118-123%0AThe%20depth-pruning%20loop%20only%20calls%20%60skipDescendants%28%29%60%20when%20%60level%20%3E%20maxDepth%60.%20This%20means%20a%20directory%20sitting%20at%20exactly%20%60maxDepth%60%20is%20entered%3A%20every%20one%20of%20its%20children%20is%20fetched%20from%20the%20OS%2C%20checked%20against%20the%20guard%2C%20and%20discarded%20via%20%60continue%60.%20Calling%20%60skipDescendants%28%29%60%20on%20the%20directory%20itself%20at%20%60level%20%3D%3D%20maxDepth%60%20avoids%20traversing%20the%20subtree%20entirely.%20For%20the%20default%20depth%20of%204%20and%20typical%20LM%20Studio%20layouts%20%283%20levels%20deep%29%20the%20waste%20is%20negligible%2C%20but%20a%20user%20pointing%20Cotabby%20at%20a%20wide%20mirror%20directory%20at%20the%20boundary%20could%20trigger%20many%20redundant%20%60stat%60%20calls.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20var%20results%3A%20%5BURL%5D%20%3D%20%5B%5D%0A%20%20%20%20%20%20%20%20for%20case%20let%20url%20as%20URL%20in%20enumerator%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20enumerator.level%20%3E%3D%20maxDepth%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20At%20or%20beyond%20the%20depth%20bound%3A%20skip%20any%20subtree%20rooted%20here%20so%20we%20don't%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20pay%20for%20fetching%20children%20only%20to%20discard%20them%20individually.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20enumerator.skipDescendants%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20enumerator.level%20%3E%20maxDepth%20%7B%20continue%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FUI%2FSettings%2FPanes%2FEngineAndModelPaneView.swift%3A169-172%0A%60refreshSearchDirectories%28%29%60%20already%20calls%20%60refreshModelStates%28%29%60%20internally%20before%20returning%2C%20so%20the%20subsequent%20%60refreshModels%28%29%60%20call%20triggers%20a%20second%20full%20%60recomputeInstalledModelFilenames%28%29%60%20%2B%20%60modelStates%60%20scan%20on%20the%20same%20data.%20The%20same%20redundancy%20occurs%20in%20the%20%60onAppear%60%20stale-flag%20path%20where%20setting%20%60lmStudioSourceEnabled%20%3D%20false%60%20fires%20this%20handler.%20Neither%20call%20is%20wrong%2C%20but%20the%20duplicate%20filesystem%20walk%20is%20unnecessary.%0A%0A&repo=fujacob%2Fcotabby&pr=567&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Address Greptile review on #542 fix"](https://github.com/fujacob/cotabby/commit/0559180199bcf713ed3913e3d421b02bf1be22ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35773786)</sub>

<!-- /greptile_comment -->