### PR TITLE
Resume onboarding at the furthest step instead of restarting (#314)

### DIFF
--- a/Cotabby/App/Coordinators/WelcomeCoordinator.swift
+++ b/Cotabby/App/Coordinators/WelcomeCoordinator.swift
@@ -45,6 +45,14 @@ final class WelcomeCoordinator: NSObject, NSWindowDelegate {
     /// flow, which is the opposite of what a version bump is for.
     private static let onboardingCompletedVersionKey = "cotabbyOnboardingCompletedVersion"
 
+    /// Furthest onboarding step the user has reached, stored as the step's raw index. Lets the wizard
+    /// *resume* instead of restarting when the user is pulled out mid-flow: granting Accessibility or
+    /// Input Monitoring on the permissions step typically only takes effect after the user quits and
+    /// relaunches Cotabby, which lands before the final "Start Using Cotabby" tap that stamps
+    /// completion. Without this, that relaunch drops them back at step one and onboarding repeats
+    /// every time (issue #314). Cleared on completion so a future version bump starts clean.
+    private static let onboardingProgressStepKey = "cotabbyOnboardingProgressStep"
+
     init(
         permissionManager: PermissionManager,
         permissionGuidanceController: PermissionGuidanceController,
@@ -122,6 +130,10 @@ final class WelcomeCoordinator: NSObject, NSWindowDelegate {
                 },
                 onDismiss: { [weak self] in
                     self?.completeOnboarding()
+                },
+                initialStepIndex: userDefaults.integer(forKey: Self.onboardingProgressStepKey),
+                onStepChange: { [weak self] stepIndex in
+                    self?.recordProgress(stepIndex: stepIndex)
                 }
             )
         )
@@ -171,8 +183,20 @@ final class WelcomeCoordinator: NSObject, NSWindowDelegate {
     /// version unchanged, so the wizard returns on next launch.
     private func completeOnboarding() {
         userDefaults.set(Self.currentOnboardingVersion, forKey: Self.onboardingCompletedVersionKey)
+        // Drop the resume marker so reopening the wizard later (menu entry point, or a future version
+        // bump re-showing it) starts from the welcome step rather than the last step of this run.
+        userDefaults.removeObject(forKey: Self.onboardingProgressStepKey)
         permissionGuidanceController.dismiss()
         welcomeWindowController?.close()
+    }
+
+    /// Persists the furthest step the wizard has reached. Monotonic: a user stepping back never
+    /// lowers the resume point, so closing the window always reopens at the deepest step they saw.
+    private func recordProgress(stepIndex: Int) {
+        guard stepIndex > userDefaults.integer(forKey: Self.onboardingProgressStepKey) else {
+            return
+        }
+        userDefaults.set(stepIndex, forKey: Self.onboardingProgressStepKey)
     }
 
     private func showPermissionReminder() {

--- a/Cotabby/UI/WelcomeView.swift
+++ b/Cotabby/UI/WelcomeView.swift
@@ -24,8 +24,11 @@ struct WelcomeView: View {
     let permissionGuidanceController: PermissionGuidanceController
     let onPreferredWindowSizeChange: (NSSize) -> Void
     let onDismiss: () -> Void
+    /// Reports the current step's raw index up to the coordinator so it can persist a resume point.
+    /// The wizard is re-shown from this step if the user is pulled out before finishing (see #314).
+    let onStepChange: (Int) -> Void
 
-    @State private var step: WelcomeStep = .welcome
+    @State private var step: WelcomeStep
     @State private var selectedTemplate: OnboardingTemplate?
     /// The engine chosen at the top of the template step. Seeded in `init` from Apple Intelligence
     /// availability (Apple Intelligence when the Mac supports it, otherwise Open Source) so the
@@ -49,7 +52,9 @@ struct WelcomeView: View {
         foundationModelAvailabilityService: FoundationModelAvailabilityService,
         permissionGuidanceController: PermissionGuidanceController,
         onPreferredWindowSizeChange: @escaping (NSSize) -> Void,
-        onDismiss: @escaping () -> Void
+        onDismiss: @escaping () -> Void,
+        initialStepIndex: Int = 0,
+        onStepChange: @escaping (Int) -> Void = { _ in }
     ) {
         _permissionManager = ObservedObject(wrappedValue: permissionManager)
         _runtimeModel = ObservedObject(wrappedValue: runtimeModel)
@@ -59,6 +64,10 @@ struct WelcomeView: View {
         self.permissionGuidanceController = permissionGuidanceController
         self.onPreferredWindowSizeChange = onPreferredWindowSizeChange
         self.onDismiss = onDismiss
+        self.onStepChange = onStepChange
+        // Resume at the furthest step the user previously reached. An out-of-range or absent value
+        // (0) falls back to `.welcome`, so brand-new users still start at the beginning.
+        _step = State(initialValue: WelcomeStep(rawValue: initialStepIndex) ?? .welcome)
         // Seed the engine before the first render so the template step never shows a frame of "Open
         // Source" selected on an Apple Intelligence-capable Mac and then snaps to it. Availability is
         // resolved well before onboarding appears, so reading it here is reliable.
@@ -78,6 +87,12 @@ struct WelcomeView: View {
             .animation(.easeInOut(duration: 0.25), value: preferredWindowSize)
             .onAppear {
                 onPreferredWindowSizeChange(preferredWindowSize)
+                // Stamp the resume point for the step we open on. Matters when resuming directly onto
+                // a later step: without this, quitting again before advancing would not re-persist it.
+                onStepChange(step.rawValue)
+            }
+            .onChange(of: step) { _, newStep in
+                onStepChange(newStep.rawValue)
             }
             .onChange(of: preferredWindowSize) { _, newValue in
                 onPreferredWindowSizeChange(newValue)


### PR DESCRIPTION
## Summary

Fixes #314 (onboarding runs multiple times). The completion flag (`cotabbyOnboardingCompletedVersion`) is written only when the user taps "Start Using Cotabby" on the final step. The permissions step in the middle of onboarding routinely forces a quit/relaunch: Accessibility and especially Input Monitoring only take effect after the user quits Cotabby from the menu bar and relaunches. That relaunch happens before the final tap, so completion is never recorded and the wizard restarts from step one, repeating on every attempt. This persists the furthest step reached and resumes there, so a mid-flow quit reopens where the user left off and lets them finish (and stamp completion).

This delivers the behavior the existing `presentIfNeeded` doc comment already promises ("the wizard will reappear on next launch so they don't lose their place"), which the code did not actually implement.

### Root cause investigation

- Verified the persisted state on disk (`defaults read com.jacobfu.tabby`): `cotabbyOnboardingCompletedVersion = 2` is present, so the flag **does** reach disk and survive quit/relaunch. The "missing `UserDefaults.synchronize()`" hypothesis is incorrect; on modern macOS `cfprefsd` persists `set()` independently of the app process.
- Bundle id `com.jacobfu.tabby` is stable across Debug/Release and there is no app-sandbox entitlement, so the defaults domain does not change between launches (no orphaning).
- The repeated onboarding has one live cause (completion recorded only at the final tap, while the permission grant forces a relaunch first) addressed here, plus a historical one (the `#238` key rename and `#467` versioned-key migration each re-showed onboarding once on upgrade, by design for version bumps). The latter is intentional and unchanged.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build \
  -derivedDataPath build/DerivedData
# ** BUILD SUCCEEDED **

swiftlint lint --quiet Cotabby/App/Coordinators/WelcomeCoordinator.swift Cotabby/UI/WelcomeView.swift
# exit 0
```

Behavior reasoning (no automated onboarding-flow test exists in the suite):
- New user: progress key absent (`integer(forKey:)` returns 0), wizard starts at `.welcome` as before.
- Quit on the permissions step, relaunch: `presentIfNeeded` re-shows the wizard, now seeded to `.permissions`; the user advances and taps "Start Using Cotabby", stamping completion.
- Progress recording is monotonic (stepping back never lowers the resume point) and is cleared in `completeOnboarding()`, so the menu re-entry point and any future version-bump re-show start cleanly at `.welcome`.

## Linked issues

Fixes #314.

## Risk / rollout notes

- New UserDefaults key `cotabbyOnboardingProgressStep` (Int, defaults to 0). No migration needed; absent reads as 0 = welcome.
- `WelcomeView.init` gains two parameters with defaults (`initialStepIndex: Int = 0`, `onStepChange: (Int) -> Void = { _ in }`), so existing/previews construction stays source-compatible.
- Resuming jumps directly to a middle step. Each onboarding step reads its state from `suggestionSettings`/`permissionManager` independently, so there is no cross-step setup that a resumed step depends on.
- No pbxproj change (no files added or removed).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes repeated onboarding (#314) by persisting the furthest wizard step reached (`cotabbyOnboardingProgressStep`) and resuming there on relaunch, instead of always restarting at `.welcome`. The root cause was that granting Accessibility/Input Monitoring forces a quit-and-relaunch before the user can tap \"Start Using Cotabby,\" so the completion flag was never stamped.

- `WelcomeCoordinator` reads the stored step index in `showWelcome()`, passes it to `WelcomeView`, and writes it monotonically via `recordProgress`; `completeOnboarding()` clears it so menu re-entry and future version-bump re-shows always start clean.
- `WelcomeView` gains `initialStepIndex`/`onStepChange` parameters (both defaulted for source compatibility), initialises `step` State from the index, and fires `onStepChange` on `onAppear` and `onChange(of: step)`.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the resume logic is straightforward and the monotonic guard prevents any regression in the progress key.

The core fix is correct: persisting and restoring the furthest step solves the quit-on-permissions loop without touching any other flow. The new UserDefaults key has a safe fallback, the completion path clears it, and existing callers are unaffected by the defaulted parameters. The findings are style and forward-looking design concerns rather than present defects in the changed code.

Both changed files are worth a second look — WelcomeView.swift for the backward-navigation template state limitation, and WelcomeCoordinator.swift for the unversioned progress key if a step-structure change ships alongside a future currentOnboardingVersion bump.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/App/Coordinators/WelcomeCoordinator.swift | Adds `cotabbyOnboardingProgressStep` UserDefaults key; reads it in `showWelcome()` to seed the wizard, writes it monotonically via `recordProgress`, and clears it in `completeOnboarding()`. Logic is sound; minor concern that the key is not version-namespaced. |
| Cotabby/UI/WelcomeView.swift | Adds `initialStepIndex`/`onStepChange` parameters (with backward-compatible defaults), initialises `step` State from `initialStepIndex`, and fires `onStepChange` on `onAppear` and `onChange(of: step)`. The `onAppear` stamp comment is misleading; backward navigation to the template step after resuming leaves `selectedTemplate` nil. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App
    participant WelcomeCoordinator
    participant UserDefaults
    participant WelcomeView

    App->>WelcomeCoordinator: presentIfNeeded()
    WelcomeCoordinator->>UserDefaults: integer(forKey: onboardingProgressStepKey)
    UserDefaults-->>WelcomeCoordinator: stepIndex (e.g. 2)
    WelcomeCoordinator->>WelcomeView: init(initialStepIndex: 2, onStepChange: recordProgress)
    WelcomeView->>WelcomeView: "_step = State(.template)"
    WelcomeView->>WelcomeCoordinator: "onAppear -> onStepChange(2)"
    WelcomeCoordinator->>UserDefaults: "recordProgress(2) -> 2>2 false, no-op"

    Note over WelcomeView: User advances to .aboutYou
    WelcomeView->>WelcomeCoordinator: "onChange(step) -> onStepChange(3)"
    WelcomeCoordinator->>UserDefaults: set(3, forKey: onboardingProgressStepKey)

    Note over App: User quits (window closes)
    WelcomeCoordinator->>WelcomeCoordinator: windowWillClose - no completeOnboarding

    Note over App: User relaunches
    App->>WelcomeCoordinator: presentIfNeeded()
    WelcomeCoordinator->>UserDefaults: integer(forKey: onboardingProgressStepKey)
    UserDefaults-->>WelcomeCoordinator: 3
    WelcomeCoordinator->>WelcomeView: init(initialStepIndex: 3)
    Note over WelcomeView: Resumes at .aboutYou

    Note over WelcomeView: User completes wizard
    WelcomeView->>WelcomeCoordinator: onDismiss()
    WelcomeCoordinator->>UserDefaults: set(currentVersion, forKey: completedVersionKey)
    WelcomeCoordinator->>UserDefaults: removeObject(forKey: onboardingProgressStepKey)
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cotabby/UI/WelcomeView.swift`, line 209-215 ([link](https://github.com/fujacob/cotabby/blob/920ac5a676dba4b0f78571e9873802712b864652/Cotabby/UI/WelcomeView.swift#L209-L215)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Backward navigation from a resumed step leaves the template step unselectable**

   `selectedTemplate` is local `@State` always initialized to `nil`. If the user resumes at `.aboutYou` (or later) and presses "Back" to reach `.template`, every template card appears unselected and `canContinueFromTemplate` returns `false` (the guard on `selectedTemplate == nil`), blocking the Continue button even though the template settings were already applied to `suggestionSettings` in the prior session. The user must re-tap a card to proceed. `applyTemplate` handles a re-tap gracefully (recognises the model as already installing), so there is no data corruption, but the UX is surprising: the step looks incomplete when the underlying settings are already configured.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix-onboarding-resume-314%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix-onboarding-resume-314%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FWelcomeView.swift%0ALine%3A%20209-215%0A%0AComment%3A%0A**Backward%20navigation%20from%20a%20resumed%20step%20leaves%20the%20template%20step%20unselectable**%0A%0A%60selectedTemplate%60%20is%20local%20%60%40State%60%20always%20initialized%20to%20%60nil%60.%20If%20the%20user%20resumes%20at%20%60.aboutYou%60%20%28or%20later%29%20and%20presses%20%22Back%22%20to%20reach%20%60.template%60%2C%20every%20template%20card%20appears%20unselected%20and%20%60canContinueFromTemplate%60%20returns%20%60false%60%20%28the%20guard%20on%20%60selectedTemplate%20%3D%3D%20nil%60%29%2C%20blocking%20the%20Continue%20button%20even%20though%20the%20template%20settings%20were%20already%20applied%20to%20%60suggestionSettings%60%20in%20the%20prior%20session.%20The%20user%20must%20re-tap%20a%20card%20to%20proceed.%20%60applyTemplate%60%20handles%20a%20re-tap%20gracefully%20%28recognises%20the%20model%20as%20already%20installing%29%2C%20so%20there%20is%20no%20data%20corruption%2C%20but%20the%20UX%20is%20surprising%3A%20the%20step%20looks%20incomplete%20when%20the%20underlying%20settings%20are%20already%20configured.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FWelcomeView.swift%0ALine%3A%20209-215%0A%0AComment%3A%0A**Backward%20navigation%20from%20a%20resumed%20step%20leaves%20the%20template%20step%20unselectable**%0A%0A%60selectedTemplate%60%20is%20local%20%60%40State%60%20always%20initialized%20to%20%60nil%60.%20If%20the%20user%20resumes%20at%20%60.aboutYou%60%20%28or%20later%29%20and%20presses%20%22Back%22%20to%20reach%20%60.template%60%2C%20every%20template%20card%20appears%20unselected%20and%20%60canContinueFromTemplate%60%20returns%20%60false%60%20%28the%20guard%20on%20%60selectedTemplate%20%3D%3D%20nil%60%29%2C%20blocking%20the%20Continue%20button%20even%20though%20the%20template%20settings%20were%20already%20applied%20to%20%60suggestionSettings%60%20in%20the%20prior%20session.%20The%20user%20must%20re-tap%20a%20card%20to%20proceed.%20%60applyTemplate%60%20handles%20a%20re-tap%20gracefully%20%28recognises%20the%20model%20as%20already%20installing%29%2C%20so%20there%20is%20no%20data%20corruption%2C%20but%20the%20UX%20is%20surprising%3A%20the%20step%20looks%20incomplete%20when%20the%20underlying%20settings%20are%20already%20configured.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=568&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix-onboarding-resume-314%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix-onboarding-resume-314%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0ACotabby%2FUI%2FWelcomeView.swift%3A88-93%0A**Misleading%20comment%20%E2%80%94%20%60onAppear%60%20stamp%20is%20a%20no-op%20in%20all%20current%20paths**%0A%0AWhen%20the%20view%20appears%20on%20resume%2C%20the%20stored%20progress%20value%20is%20already%20N%20%28the%20key%20was%20written%20in%20the%20previous%20session%29.%20%60recordProgress%28N%29%60%20immediately%20returns%20because%20%60N%20%3E%20N%60%20is%20false%2C%20so%20the%20key%20is%20never%20re-written%20here.%20The%20comment's%20claim%20that%20%22without%20this%2C%20quitting%20again%20before%20advancing%20would%20not%20re-persist%20it%22%20is%20incorrect%3A%20the%20key%20simply%20persists%20as-is%20across%20quits%20without%20any%20re-stamping%20needed.%20The%20%60onAppear%60%20call%20is%20harmless%2C%20but%20the%20comment%20may%20mislead%20a%20future%20reader%20into%20thinking%20the%20call%20actively%20prevents%20a%20data-loss%20scenario.%0A%0A%23%23%23%20Issue%202%20of%203%0ACotabby%2FApp%2FCoordinators%2FWelcomeCoordinator.swift%3A54%0A**Progress%20key%20is%20not%20namespaced%20to%20the%20onboarding%20version**%0A%0A%60cotabbyOnboardingProgressStep%60%20carries%20no%20version%20tag.%20Consider%20a%20user%20who%20starts%20onboarding%20version%202%2C%20reaches%20step%203%2C%20then%20quits.%20Before%20completing%2C%20the%20app%20ships%20version%203%20with%20%60currentOnboardingVersion%20%3D%203%60%20and%20a%20restructured%20step%20order.%20On%20the%20next%20launch%2C%20%60presentIfNeeded%60%20re-shows%20onboarding%20%28completed%20version%20is%20still%202%29%20and%20seeds%20%60initialStepIndex%60%20from%20the%20stale%20progress%20key%2C%20landing%20the%20user%20at%20what%20is%20now%20a%20conceptually%20different%20step.%20%60WelcomeStep%28rawValue%3A%29%20%3F%3F%20.welcome%60%20catches%20out-of-range%20indices%2C%20but%20a%20same-range%20reordering%20silently%20drops%20the%20user%20into%20the%20middle%20of%20the%20wrong%20step.%20A%20version-tagged%20key%20%28e.g.%20%60cotabbyOnboardingProgressStep_v2%60%29%20would%20guarantee%20a%20clean%20start%20whenever%20the%20step%20structure%20changes%20alongside%20a%20version%20bump.%0A%0A%23%23%23%20Issue%203%20of%203%0ACotabby%2FUI%2FWelcomeView.swift%3A209-215%0A**Backward%20navigation%20from%20a%20resumed%20step%20leaves%20the%20template%20step%20unselectable**%0A%0A%60selectedTemplate%60%20is%20local%20%60%40State%60%20always%20initialized%20to%20%60nil%60.%20If%20the%20user%20resumes%20at%20%60.aboutYou%60%20%28or%20later%29%20and%20presses%20%22Back%22%20to%20reach%20%60.template%60%2C%20every%20template%20card%20appears%20unselected%20and%20%60canContinueFromTemplate%60%20returns%20%60false%60%20%28the%20guard%20on%20%60selectedTemplate%20%3D%3D%20nil%60%29%2C%20blocking%20the%20Continue%20button%20even%20though%20the%20template%20settings%20were%20already%20applied%20to%20%60suggestionSettings%60%20in%20the%20prior%20session.%20The%20user%20must%20re-tap%20a%20card%20to%20proceed.%20%60applyTemplate%60%20handles%20a%20re-tap%20gracefully%20%28recognises%20the%20model%20as%20already%20installing%29%2C%20so%20there%20is%20no%20data%20corruption%2C%20but%20the%20UX%20is%20surprising%3A%20the%20step%20looks%20incomplete%20when%20the%20underlying%20settings%20are%20already%20configured.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0ACotabby%2FUI%2FWelcomeView.swift%3A88-93%0A**Misleading%20comment%20%E2%80%94%20%60onAppear%60%20stamp%20is%20a%20no-op%20in%20all%20current%20paths**%0A%0AWhen%20the%20view%20appears%20on%20resume%2C%20the%20stored%20progress%20value%20is%20already%20N%20%28the%20key%20was%20written%20in%20the%20previous%20session%29.%20%60recordProgress%28N%29%60%20immediately%20returns%20because%20%60N%20%3E%20N%60%20is%20false%2C%20so%20the%20key%20is%20never%20re-written%20here.%20The%20comment's%20claim%20that%20%22without%20this%2C%20quitting%20again%20before%20advancing%20would%20not%20re-persist%20it%22%20is%20incorrect%3A%20the%20key%20simply%20persists%20as-is%20across%20quits%20without%20any%20re-stamping%20needed.%20The%20%60onAppear%60%20call%20is%20harmless%2C%20but%20the%20comment%20may%20mislead%20a%20future%20reader%20into%20thinking%20the%20call%20actively%20prevents%20a%20data-loss%20scenario.%0A%0A%23%23%23%20Issue%202%20of%203%0ACotabby%2FApp%2FCoordinators%2FWelcomeCoordinator.swift%3A54%0A**Progress%20key%20is%20not%20namespaced%20to%20the%20onboarding%20version**%0A%0A%60cotabbyOnboardingProgressStep%60%20carries%20no%20version%20tag.%20Consider%20a%20user%20who%20starts%20onboarding%20version%202%2C%20reaches%20step%203%2C%20then%20quits.%20Before%20completing%2C%20the%20app%20ships%20version%203%20with%20%60currentOnboardingVersion%20%3D%203%60%20and%20a%20restructured%20step%20order.%20On%20the%20next%20launch%2C%20%60presentIfNeeded%60%20re-shows%20onboarding%20%28completed%20version%20is%20still%202%29%20and%20seeds%20%60initialStepIndex%60%20from%20the%20stale%20progress%20key%2C%20landing%20the%20user%20at%20what%20is%20now%20a%20conceptually%20different%20step.%20%60WelcomeStep%28rawValue%3A%29%20%3F%3F%20.welcome%60%20catches%20out-of-range%20indices%2C%20but%20a%20same-range%20reordering%20silently%20drops%20the%20user%20into%20the%20middle%20of%20the%20wrong%20step.%20A%20version-tagged%20key%20%28e.g.%20%60cotabbyOnboardingProgressStep_v2%60%29%20would%20guarantee%20a%20clean%20start%20whenever%20the%20step%20structure%20changes%20alongside%20a%20version%20bump.%0A%0A%23%23%23%20Issue%203%20of%203%0ACotabby%2FUI%2FWelcomeView.swift%3A209-215%0A**Backward%20navigation%20from%20a%20resumed%20step%20leaves%20the%20template%20step%20unselectable**%0A%0A%60selectedTemplate%60%20is%20local%20%60%40State%60%20always%20initialized%20to%20%60nil%60.%20If%20the%20user%20resumes%20at%20%60.aboutYou%60%20%28or%20later%29%20and%20presses%20%22Back%22%20to%20reach%20%60.template%60%2C%20every%20template%20card%20appears%20unselected%20and%20%60canContinueFromTemplate%60%20returns%20%60false%60%20%28the%20guard%20on%20%60selectedTemplate%20%3D%3D%20nil%60%29%2C%20blocking%20the%20Continue%20button%20even%20though%20the%20template%20settings%20were%20already%20applied%20to%20%60suggestionSettings%60%20in%20the%20prior%20session.%20The%20user%20must%20re-tap%20a%20card%20to%20proceed.%20%60applyTemplate%60%20handles%20a%20re-tap%20gracefully%20%28recognises%20the%20model%20as%20already%20installing%29%2C%20so%20there%20is%20no%20data%20corruption%2C%20but%20the%20UX%20is%20surprising%3A%20the%20step%20looks%20incomplete%20when%20the%20underlying%20settings%20are%20already%20configured.%0A%0A&repo=fujacob%2Fcotabby&pr=568&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Resume onboarding at the furthest step i..."](https://github.com/fujacob/cotabby/commit/920ac5a676dba4b0f78571e9873802712b864652) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35775143)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->