### PR TITLE
feat(overlay): match ghost text to the host field's font, color, and size

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		19CB55B62977376E9AE8D428 /* VisualContextStartCoalescer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F01FAC4F57EB08471521196 /* VisualContextStartCoalescer.swift */; };
 		1B3FFCB9A979F49BF86EAAD4 /* ScreenshotContextGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2BFD19A159680A495EE02FD /* ScreenshotContextGeneratorTests.swift */; };
 		1D1C6FF0B8F50AC14A1000F4 /* SentenceBoundaryClassifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7360A6D4261989A66658ED /* SentenceBoundaryClassifierTests.swift */; };
+		1D424A103EF7BFE45518F45E /* GhostFontMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E41890930AA80910E461EF /* GhostFontMetricsTests.swift */; };
 		1F8CC88AFFE67C08944CF506 /* WindowScreenshotService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B0121E7BB173F8A2B0B108 /* WindowScreenshotService.swift */; };
 		2197B68F1E4D0C3497DAC061 /* LlamaSuggestionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE04620C905041680116BE80 /* LlamaSuggestionEngine.swift */; };
 		22DF59FD6F3B83B092A6F5ED /* WordCountFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 815F2ABAF6AB75DA3AFBBCEF /* WordCountFormatter.swift */; };
@@ -50,6 +51,7 @@
 		261FA692D19C48E53D6999BC /* DeepGeometryWalkThrottle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684737E62EE6495A71344923 /* DeepGeometryWalkThrottle.swift */; };
 		26C5604C3CEF43FC755FD24E /* EmojiUsageStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224438039A86E5619294EAF7 /* EmojiUsageStoreTests.swift */; };
 		26E0331E9E2F92FAE531BDEE /* ActivationIndicatorController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84D4528EEC9EFEB8AE8E318 /* ActivationIndicatorController.swift */; };
+		2784A3A838FF122678547ECA /* GhostFontMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6439213F2A273702A6E26B /* GhostFontMetrics.swift */; };
 		279F017530A86AF62EB17918 /* EmojiSynonymCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0846DE4E0293AF13890620D3 /* EmojiSynonymCatalog.swift */; };
 		27D4F5CACADE171F142178B4 /* SettingsSidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BADB38D0160B47637572FC5E /* SettingsSidebarView.swift */; };
 		286B7022E2A2774275004447 /* WelcomeTemplateStepView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9199B9CEAB320982CA333B8 /* WelcomeTemplateStepView.swift */; };
@@ -196,6 +198,7 @@
 		B0B115C6EBAC37FF6115B4BE /* SuggestionCoordinator+Lifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78E280F4F39A9D86840800D2 /* SuggestionCoordinator+Lifecycle.swift */; };
 		B2F7589B8D32ACF97BB642AB /* HuggingFaceModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A520809E71697E3BB9A8139C /* HuggingFaceModels.swift */; };
 		B6652D81162C64248AA4CF0B /* EmojiPickerPanelController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 764659D09C3F0E8FBD267102 /* EmojiPickerPanelController.swift */; };
+		B782EC08B7516791BDB21172 /* FieldStyleCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7FBF2B766E728F25899B64E /* FieldStyleCache.swift */; };
 		B93AB7E845086F6FBB068369 /* SuggestionRequestFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE94342B888A5A2CCF66BC93 /* SuggestionRequestFactoryTests.swift */; };
 		BB6325CA50F97B18B9725918 /* SuggestionTextNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B424E2AC97C99D335B0D5751 /* SuggestionTextNormalizer.swift */; };
 		BBE22CE4EF43247F8775B25D /* FocusPollBackoff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09FADF683BE7B3558377FA76 /* FocusPollBackoff.swift */; };
@@ -353,6 +356,7 @@
 		51020F8CD58338BD643FBF63 /* ModelDownloadManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelDownloadManager.swift; sourceTree = "<group>"; };
 		52BAFA2F989C3C4F7FB892B5 /* MarkerSelectionSynthesizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkerSelectionSynthesizerTests.swift; sourceTree = "<group>"; };
 		53CF416511099C6818110F01 /* CompletionRenderModePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionRenderModePolicy.swift; sourceTree = "<group>"; };
+		53E41890930AA80910E461EF /* GhostFontMetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostFontMetricsTests.swift; sourceTree = "<group>"; };
 		54150A507B03221F137D539B /* MirrorOverlayLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MirrorOverlayLayout.swift; sourceTree = "<group>"; };
 		5484C8A04B9C00CF79D589EB /* ScreenFrameReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenFrameReader.swift; sourceTree = "<group>"; };
 		54BC85605541E913EE57B258 /* ExtendedContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtendedContextTests.swift; sourceTree = "<group>"; };
@@ -428,6 +432,7 @@
 		9D598CC3134879999D567455 /* SuggestionOverlayPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionOverlayPresenter.swift; sourceTree = "<group>"; };
 		9D82FFC568527700EC17C07D /* PermissionModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionModels.swift; sourceTree = "<group>"; };
 		9E5F074ED7E340E9B9E4C5E0 /* EmojiPickerModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiPickerModels.swift; sourceTree = "<group>"; };
+		9E6439213F2A273702A6E26B /* GhostFontMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostFontMetrics.swift; sourceTree = "<group>"; };
 		9E72A3972E15749337539C2D /* EmojiRecents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiRecents.swift; sourceTree = "<group>"; };
 		A168A7B6A7AD11559B60C56B /* ApplicationBundleMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationBundleMetadataTests.swift; sourceTree = "<group>"; };
 		A3E8E86A14090BC7BD13BA76 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -459,6 +464,7 @@
 		B6D42CD456B4B3C988B148A6 /* FocusTrackingModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusTrackingModel.swift; sourceTree = "<group>"; };
 		B78AA11B52A6588119ABF76F /* TokenCountEstimatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenCountEstimatorTests.swift; sourceTree = "<group>"; };
 		B7B185BA246A526CBA85E581 /* EmojiPickerPanelLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiPickerPanelLayoutTests.swift; sourceTree = "<group>"; };
+		B7FBF2B766E728F25899B64E /* FieldStyleCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FieldStyleCache.swift; sourceTree = "<group>"; };
 		B81DD30EB657368AACE9625A /* InputMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputMonitor.swift; sourceTree = "<group>"; };
 		B997EC69E1C65B1E18234221 /* BrowserAppDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserAppDetector.swift; sourceTree = "<group>"; };
 		BA705EDFE1C41294F0E381F1 /* FocusSnapshotResolverSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusSnapshotResolverSelectionTests.swift; sourceTree = "<group>"; };
@@ -675,6 +681,7 @@
 				B27492B04B627DA53BDAD938 /* AXTreeDumpWriter.swift */,
 				8896D976C7F116EBA0F3969F /* ChromiumAccessibilityEnabler.swift */,
 				684737E62EE6495A71344923 /* DeepGeometryWalkThrottle.swift */,
+				B7FBF2B766E728F25899B64E /* FieldStyleCache.swift */,
 				04E25414C307A20B6F9F20EC /* FocusSnapshotResolver.swift */,
 				5C9FDF029F7828CAF3FE8850 /* FocusTracker.swift */,
 			);
@@ -788,6 +795,7 @@
 				273B4DC844F79B4BE2C8910F /* FocusPollBackoffTests.swift */,
 				BA705EDFE1C41294F0E381F1 /* FocusSnapshotResolverSelectionTests.swift */,
 				D49F3B597374208594861B9B /* FoundationModelDriftEvalTests.swift */,
+				53E41890930AA80910E461EF /* GhostFontMetricsTests.swift */,
 				335BF59EE80F3A0143B79740 /* GhostFontSizeStabilizerTests.swift */,
 				5AD3F4F9FBE82007E4E15F58 /* GhostSuggestionLayoutTests.swift */,
 				BAC01317B0B68E3C4125E421 /* InputMonitorTests.swift */,
@@ -950,6 +958,7 @@
 				70367FCC1E0F08EE3B8EB26F /* FocusCapabilityResolver.swift */,
 				09FADF683BE7B3558377FA76 /* FocusPollBackoff.swift */,
 				FE7BF162A12703249726F20A /* FoundationModelPromptRenderer.swift */,
+				9E6439213F2A273702A6E26B /* GhostFontMetrics.swift */,
 				9458F0820B3161FE9CF1DDAF /* GhostFontSizeStabilizer.swift */,
 				043E8AA850F930222DD112C0 /* GhostSuggestionLayout.swift */,
 				7E44E393DD58B978B1EAB6CF /* GhostTextColorPreset.swift */,
@@ -1161,6 +1170,7 @@
 				0FF600435A2EFA9437E36B6F /* EmojiVariantResolver.swift in Sources */,
 				5DF31F465A3A1233260BD3A4 /* EngineAndModelPaneView.swift in Sources */,
 				5BE53CE921664582F593B7B0 /* FieldEdgeIconIndicatorView.swift in Sources */,
+				B782EC08B7516791BDB21172 /* FieldStyleCache.swift in Sources */,
 				6E49ADEB31D04DC77A47DEB0 /* FileLogHandler.swift in Sources */,
 				C0FE11D76BDF01A5470C554D /* FocusCapabilityFlickerGate.swift in Sources */,
 				CC98B842D10574C5206BEFA7 /* FocusCapabilityResolver.swift in Sources */,
@@ -1174,6 +1184,7 @@
 				36312821AEE03E3E62845958 /* FoundationModelPromptRenderer.swift in Sources */,
 				6DD1E22151571E1A22FF22F4 /* FoundationModelSuggestionEngine.swift in Sources */,
 				4134ADBE464D00BB748BD9AE /* GeneralPaneView.swift in Sources */,
+				2784A3A838FF122678547ECA /* GhostFontMetrics.swift in Sources */,
 				42D40F37086294D0E58200C5 /* GhostFontSizeStabilizer.swift in Sources */,
 				ED9C51B0D7056F0753AADF2D /* GhostSuggestionLayout.swift in Sources */,
 				F4EEE6291095B0BF2D3FBA21 /* GhostTextColorPreset.swift in Sources */,
@@ -1322,6 +1333,7 @@
 				A147C5EC3F2214A670F7556E /* FocusPollBackoffTests.swift in Sources */,
 				156E6AB3D24134EEC29FDB93 /* FocusSnapshotResolverSelectionTests.swift in Sources */,
 				31DCCE980B6708401256D4D1 /* FoundationModelDriftEvalTests.swift in Sources */,
+				1D424A103EF7BFE45518F45E /* GhostFontMetricsTests.swift in Sources */,
 				2EE05B312C990104BE934772 /* GhostFontSizeStabilizerTests.swift in Sources */,
 				A0BB87E3665EF6C209034798 /* GhostSuggestionLayoutTests.swift in Sources */,
 				07D046D406411ED85AC5758A /* InputMonitorTests.swift in Sources */,

--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
@@ -493,7 +493,8 @@ extension SuggestionCoordinator {
             observedCharWidth: context.observedCharWidth,
             isRightToLeft: isRightToLeft,
             focusChangeSequence: context.focusChangeSequence,
-            focusedInputIdentityKey: context.focusedInputIdentityKey
+            focusedInputIdentityKey: context.focusedInputIdentityKey,
+            resolvedFieldStyle: context.resolvedFieldStyle
         )
         if let message = overlayPresenter.present(
             text: text,

--- a/Cotabby/Models/FocusModels.swift
+++ b/Cotabby/Models/FocusModels.swift
@@ -105,6 +105,25 @@ struct FocusInspectionSnapshot: Equatable {
     let missingCapabilities: [FocusCapabilityRequirement]
 }
 
+/// Visual style of the focused field's own text, resolved from Accessibility so ghost text can be
+/// rendered to match it instead of always using the system font and a fixed gray.
+///
+/// Every field is optional: any attribute the host does not expose stays nil and the overlay falls
+/// back to its default styling. Stored as plain value types (no `NSFont`/`NSColor`) so the snapshot
+/// stays `Equatable`/`Sendable` and is cheap to carry across async boundaries.
+struct ResolvedFieldStyle: Equatable, Sendable {
+    /// PostScript font name suitable for `NSFont(name:size:)`.
+    let fontName: String?
+    /// Host-reported point size, used only as the reference for scale-invariant metric sizing.
+    let fontPointSize: CGFloat?
+    /// Foreground text color as a 6-digit hex string (see `SuggestionTextColorCodec`).
+    let colorHex: String?
+
+    var isEmpty: Bool {
+        fontName == nil && colorHex == nil
+    }
+}
+
 /// This snapshot is the future handoff point into suggestion generation.
 /// We store enough information to understand text context and caret placement without generating yet.
 struct FocusedInputSnapshot: Equatable {
@@ -143,6 +162,11 @@ struct FocusedInputSnapshot: Equatable {
     /// initializer default keeps every existing call site compiling unchanged.
     let focusedURLString: String?
 
+    /// The host field's own text font/color, resolved once per focused element so ghost text can
+    /// match it. Nil when the host exposes no usable style. The initializer default keeps existing
+    /// call sites compiling unchanged.
+    let resolvedFieldStyle: ResolvedFieldStyle?
+
     /// Explicit initializer keeps `focusChangeSequence` immutable while preserving the old
     /// memberwise-call ergonomics for tests that do not care about focus identity.
     ///
@@ -166,7 +190,8 @@ struct FocusedInputSnapshot: Equatable {
         selection: NSRange,
         isSecure: Bool,
         focusChangeSequence: UInt64 = 0,
-        focusedURLString: String? = nil
+        focusedURLString: String? = nil,
+        resolvedFieldStyle: ResolvedFieldStyle? = nil
     ) {
         self.applicationName = applicationName
         self.bundleIdentifier = bundleIdentifier
@@ -185,6 +210,7 @@ struct FocusedInputSnapshot: Equatable {
         self.isSecure = isSecure
         self.focusChangeSequence = focusChangeSequence
         self.focusedURLString = focusedURLString
+        self.resolvedFieldStyle = resolvedFieldStyle
     }
 
     var identity: FocusedInputIdentity {

--- a/Cotabby/Models/SuggestionModels.swift
+++ b/Cotabby/Models/SuggestionModels.swift
@@ -154,6 +154,8 @@ struct FocusedInputContext: Equatable, Sendable {
     let trailingText: String
     let selection: NSRange
     let isSecure: Bool
+    /// The host field's own text font/color, carried through so the overlay can match it.
+    let resolvedFieldStyle: ResolvedFieldStyle?
     /// Carries the immutable focus-observation identity across debounce/generation boundaries.
     /// Without this, later visual-context lookups could fall back to `elementIdentifier` alone and
     /// reintroduce the CFHash collision class this sequence is meant to avoid.
@@ -175,6 +177,7 @@ struct FocusedInputContext: Equatable, Sendable {
         trailingText = snapshot.trailingText
         selection = snapshot.selection
         isSecure = snapshot.isSecure
+        resolvedFieldStyle = snapshot.resolvedFieldStyle
         focusChangeSequence = snapshot.focusChangeSequence
         self.generation = generation
     }
@@ -475,6 +478,9 @@ struct SuggestionOverlayGeometry: Equatable, Sendable {
     /// self-growing inputs. It DOES change when the user focuses a genuinely different field.
     /// Defaults to 0 for tests that do not exercise session-scoped behavior.
     let focusedInputIdentityKey: UInt64
+    /// The host field's own text font/color, so the overlay can render ghost text that matches the
+    /// field instead of always using the system font and a fixed gray. Nil falls back to defaults.
+    let resolvedFieldStyle: ResolvedFieldStyle?
 
     init(
         caretRect: CGRect,
@@ -483,7 +489,8 @@ struct SuggestionOverlayGeometry: Equatable, Sendable {
         observedCharWidth: CGFloat?,
         isRightToLeft: Bool,
         focusChangeSequence: UInt64 = 0,
-        focusedInputIdentityKey: UInt64 = 0
+        focusedInputIdentityKey: UInt64 = 0,
+        resolvedFieldStyle: ResolvedFieldStyle? = nil
     ) {
         self.caretRect = caretRect
         self.inputFrameRect = inputFrameRect
@@ -492,6 +499,7 @@ struct SuggestionOverlayGeometry: Equatable, Sendable {
         self.isRightToLeft = isRightToLeft
         self.focusChangeSequence = focusChangeSequence
         self.focusedInputIdentityKey = focusedInputIdentityKey
+        self.resolvedFieldStyle = resolvedFieldStyle
     }
 }
 

--- a/Cotabby/Services/Focus/FieldStyleCache.swift
+++ b/Cotabby/Services/Focus/FieldStyleCache.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Caches the resolved field text style per focused element so the `AXAttributedStringForRange`
+/// read happens once per field, not on every focus poll.
+///
+/// Reading per-character font/color is a synchronous cross-process Accessibility call. The focus
+/// resolver runs many times per second while focus stays on one field, so re-reading every poll
+/// would add avoidable main-thread latency on the hot path. Keying on element identity collapses
+/// that to one read per field. A nil result (host exposes no style) is cached too, so a plain field
+/// is not re-probed on every poll.
+///
+/// A reference type so it can carry state across the value-typed `FocusSnapshotResolver`'s
+/// non-mutating `resolveSnapshot`, mirroring `DeepGeometryWalkThrottle`. The resolver is constructed
+/// once and retained by `FocusTracker`.
+@MainActor
+final class FieldStyleCache {
+    private var key: String?
+    private var style: ResolvedFieldStyle?
+
+    /// Returns the cached style when `key` matches the last resolution, otherwise resolves once and
+    /// caches the result (including nil).
+    func style(forKey key: String, resolve: () -> ResolvedFieldStyle?) -> ResolvedFieldStyle? {
+        if key == self.key {
+            return style
+        }
+
+        let resolved = resolve()
+        self.key = key
+        style = resolved
+        return resolved
+    }
+}

--- a/Cotabby/Services/Focus/FocusSnapshotResolver.swift
+++ b/Cotabby/Services/Focus/FocusSnapshotResolver.swift
@@ -25,6 +25,11 @@ struct FocusSnapshotResolver {
     /// Carries deep-walk throttle state across the value-typed resolver's non-mutating polls.
     private let deepWalkThrottle = DeepGeometryWalkThrottle()
 
+    /// Caches the resolved field font/color per focused element so the attributed-string AX read
+    /// happens once per field rather than on every poll. Reference type for the same reason as
+    /// `deepWalkThrottle`: it carries state across the value-typed resolver's non-mutating polls.
+    private let fieldStyleCache = FieldStyleCache()
+
     init(geometryResolver: AXTextGeometryResolver? = nil) {
         self.geometryResolver = geometryResolver ?? AXTextGeometryResolver()
     }
@@ -187,6 +192,22 @@ struct FocusSnapshotResolver {
         let focusedURLString = PerDomainDisableSettings.isEnabled()
             ? AXHelper.webURL(near: focusedElement)
             : nil
+        // Resolve the host field's own font/color so ghost text can match it. Cached by element
+        // identity (this is a synchronous AX read and the resolver runs on the focus poll), and
+        // skipped for secure fields, which are never styled or assisted.
+        let resolvedFieldStyle: ResolvedFieldStyle?
+        if resolvedCandidate.isSecure {
+            resolvedFieldStyle = nil
+        } else {
+            let styleKey = "\(application.processIdentifier):\(resolvedCandidate.elementIdentifier)"
+            resolvedFieldStyle = fieldStyleCache.style(forKey: styleKey) {
+                AXHelper.resolveFieldStyle(
+                    for: resolvedCandidate.element,
+                    caretLocation: selection.location,
+                    textLength: value.utf16.count
+                )
+            }
+        }
         let context = FocusedInputSnapshot(
             applicationName: applicationName,
             bundleIdentifier: bundleIdentifier,
@@ -204,7 +225,8 @@ struct FocusSnapshotResolver {
             selection: contextWindow.selection,
             isSecure: resolvedCandidate.isSecure,
             focusChangeSequence: focusChangeSequence,
-            focusedURLString: focusedURLString
+            focusedURLString: focusedURLString,
+            resolvedFieldStyle: resolvedFieldStyle
         )
 
         if resolvedCandidate.isSecure {

--- a/Cotabby/Services/UI/OverlayController.swift
+++ b/Cotabby/Services/UI/OverlayController.swift
@@ -135,10 +135,17 @@ final class OverlayController: SuggestionOverlayControlling {
             geometry.caretRect.height,
             focusSessionKey: geometry.focusedInputIdentityKey
         )
+        // The host field's own font, when AX exposed it. Instantiated at the reported size only to
+        // read its (scale-invariant) glyph-box ratio; the rendered size comes from the caret height.
+        let referenceFieldFont = geometry.resolvedFieldStyle.flatMap(fieldFont(from:))
         let fontSize = resolvedGhostFontSize(
             forCaretHeight: stabilizedCaretHeight,
-            caretQuality: geometry.caretQuality
+            caretQuality: geometry.caretQuality,
+            fieldFont: referenceFieldFont
         )
+        // Render in the field's typeface at the derived size so the ghost reads as a continuation of
+        // the host text rather than pasted-on system font. Nil falls back to the system font.
+        let renderFont = referenceFieldFont.flatMap { NSFont(name: $0.fontName, size: fontSize) }
         // `nil` when the user disabled the hint or no accept key is bound — in that case the layout
         // drops the keycap and its reserved width so ghost text can use the full line.
         let acceptanceHintLabel = suggestionSettings.acceptanceHintLabel
@@ -147,7 +154,8 @@ final class OverlayController: SuggestionOverlayControlling {
             geometry: geometry,
             fontSize: fontSize,
             visibleFrame: targetScreenVisibleFrame(for: geometry.caretRect),
-            showsAcceptanceHint: acceptanceHintLabel != nil
+            showsAcceptanceHint: acceptanceHintLabel != nil,
+            font: renderFont
         )
         let customGhostColor = SuggestionTextColorCodec.color(
             fromHex: suggestionSettings.customSuggestionTextColorHex
@@ -157,6 +165,8 @@ final class OverlayController: SuggestionOverlayControlling {
         let rootView = GhostSuggestionView(
             layout: layout,
             fontSize: fontSize,
+            fieldFont: renderFont,
+            fieldColor: fieldGhostColor(from: geometry.resolvedFieldStyle),
             customColor: customGhostColor,
             keycapLabel: acceptanceHintLabel,
             opacity: ghostOpacity
@@ -255,17 +265,56 @@ final class OverlayController: SuggestionOverlayControlling {
     /// by `ghostFontStabilizer`, so this only applies the static floor and quality ceilings.
     private func resolvedGhostFontSize(
         forCaretHeight caretHeight: CGFloat,
-        caretQuality: CaretGeometryQuality
+        caretQuality: CaretGeometryQuality,
+        fieldFont: NSFont?
     ) -> CGFloat {
-        let proposedSize = max(
-            Layout.minimumGhostFontSize,
-            caretHeight * Layout.fontToLineHeightRatio
-        )
         let qualityCap = caretQuality == .estimated
             ? Layout.maximumEstimatedGhostFontSize
             : Layout.maximumGhostFontSize
 
-        return min(proposedSize, qualityCap)
+        let fieldMetrics = fieldFont.map {
+            GhostFontMetrics.FieldFontMetrics(
+                pointSize: $0.pointSize,
+                ascender: $0.ascender,
+                descender: $0.descender
+            )
+        }
+
+        return GhostFontMetrics.pointSize(
+            caretHeight: caretHeight,
+            fieldMetrics: fieldMetrics,
+            fallbackRatio: Layout.fontToLineHeightRatio,
+            minimum: Layout.minimumGhostFontSize,
+            maximum: qualityCap
+        )
+    }
+
+    /// Builds the host field's `NSFont` from a resolved style, or nil when the name is missing or the
+    /// font cannot be instantiated. The size is only a reference for metric extraction; the rendered
+    /// size is derived from caret height in `resolvedGhostFontSize`.
+    private func fieldFont(from style: ResolvedFieldStyle) -> NSFont? {
+        guard let name = style.fontName else { return nil }
+        return NSFont(name: name, size: style.fontPointSize ?? Layout.minimumGhostFontSize)
+    }
+
+    /// Maps the host field's foreground color to a ghost color, or nil to fall back to the default
+    /// gray. Near-white / near-black extremes are treated as untrustworthy (some browsers report the
+    /// page background as the text color) and fall back, so ghost text never renders invisibly.
+    private func fieldGhostColor(from style: ResolvedFieldStyle?) -> Color? {
+        guard let hex = style?.colorHex,
+              let nsColor = SuggestionTextColorCodec.nsColor(fromHex: hex)?.usingColorSpace(.sRGB)
+        else {
+            return nil
+        }
+
+        let luminance = 0.299 * nsColor.redComponent
+            + 0.587 * nsColor.greenComponent
+            + 0.114 * nsColor.blueComponent
+        guard luminance > 0.06, luminance < 0.94 else {
+            return nil
+        }
+
+        return Color(nsColor: nsColor)
     }
 
     private func targetScreenVisibleFrame(for caretRect: CGRect) -> CGRect {
@@ -295,6 +344,10 @@ private struct GhostSuggestionView: View {
     @Environment(\.colorScheme) var colorScheme
     let layout: GhostSuggestionLayout
     let fontSize: CGFloat
+    /// The host field's font at the rendered size, or nil to use the system font at `fontSize`.
+    let fieldFont: NSFont?
+    /// The host field's foreground color mapped to a ghost color, or nil to use the default gray.
+    let fieldColor: Color?
     let customColor: Color?
     /// The accept key to print inside the keycap pill, or `nil` when the hint is suppressed. Pairs
     /// with `layout.lines`, where `showsKeycap` is already false on every line when this is `nil`.
@@ -303,14 +356,25 @@ private struct GhostSuggestionView: View {
     /// not the keycap, so the acceptance hint stays legible at low opacities.
     let opacity: Double
 
+    /// Priority: explicit user override, then the host field's color, then the default gray. The
+    /// field color is pre-filtered upstream so invisible extremes already fall back to nil here.
     var ghostColor: Color {
         let baseColor = customColor
+            ?? fieldColor
             ?? (
                 colorScheme == .dark
                     ? Color(red: 0.65, green: 0.65, blue: 0.65)
                     : Color(red: 0.45, green: 0.45, blue: 0.45)
             )
         return baseColor.opacity(opacity)
+    }
+
+    /// The host field's typeface when known, otherwise the system font at the derived size.
+    private var resolvedFont: Font {
+        if let fieldFont {
+            return Font(fieldFont as CTFont)
+        }
+        return .system(size: fontSize)
     }
 
     var body: some View {
@@ -324,7 +388,7 @@ private struct GhostSuggestionView: View {
                     }
 
                     Text(line.text)
-                        .font(.system(size: fontSize))
+                        .font(resolvedFont)
                         .foregroundStyle(ghostColor)
                         .lineLimit(1)
                         .fixedSize(horizontal: true, vertical: true)

--- a/Cotabby/Support/AXHelper.swift
+++ b/Cotabby/Support/AXHelper.swift
@@ -283,15 +283,16 @@ enum AXHelper {
         var colorHex: String?
         if let nsColor = attributes[.foregroundColor] as? NSColor {
             colorHex = SuggestionTextColorCodec.hexString(from: nsColor)
-        } else if let foreground = attributes[.foregroundColor] {
-            // AX commonly hands back a `CGColor` for the foreground color. Verify the CF type id
-            // before bridging, mirroring the typed-value guard used elsewhere in this file.
-            let candidate = foreground as CFTypeRef
-            if CFGetTypeID(candidate) == CGColor.typeID {
-                let cgColor = unsafeBitCast(candidate, to: CGColor.self)
-                if let nsColor = NSColor(cgColor: cgColor) {
-                    colorHex = SuggestionTextColorCodec.hexString(from: nsColor)
-                }
+        } else if let foreground = attributes[.foregroundColor],
+                  CFGetTypeID(foreground as CFTypeRef) == CGColor.typeID {
+            // AX often reports the foreground as a CGColor. A conditional `as? CGColor` does not
+            // compile against `Any` (the compiler treats the CF downcast as always-succeeding), so we
+            // verify the CF type id and force-cast. Unlike `unsafeBitCast`, this keeps normal ARC
+            // ownership and cannot fail given the verified type id.
+            // swiftlint:disable:next force_cast
+            let cgColor = foreground as! CGColor
+            if let nsColor = NSColor(cgColor: cgColor) {
+                colorHex = SuggestionTextColorCodec.hexString(from: nsColor)
             }
         }
 

--- a/Cotabby/Support/AXHelper.swift
+++ b/Cotabby/Support/AXHelper.swift
@@ -205,6 +205,100 @@ enum AXHelper {
         return nil
     }
 
+    /// Reads a parameterized attributed-string range (e.g. `AXAttributedStringForRange`) so callers
+    /// can inspect per-character styling such as font and foreground color without serializing the
+    /// whole field. Returns nil for hosts that do not implement the attribute.
+    static func parameterizedAttributedStringValue(
+        for attribute: CFString,
+        range: NSRange,
+        on element: AXUIElement
+    ) -> NSAttributedString? {
+        var cfRange = CFRange(location: range.location, length: range.length)
+        guard let parameter = AXValueCreate(.cfRange, &cfRange) else {
+            return nil
+        }
+
+        var value: CFTypeRef?
+        let result = AXUIElementCopyParameterizedAttributeValue(element, attribute, parameter, &value)
+        guard result == .success, let value else { return nil }
+
+        return value as? NSAttributedString
+    }
+
+    /// Resolves the focused field's own text font and color from Accessibility so ghost text can
+    /// match the host instead of always rendering in the system font and a fixed gray.
+    ///
+    /// This is a single `AXAttributedStringForRange` read over one character near the caret. The font
+    /// arrives either as a real `NSFont` under `.font` or as the AX font dictionary
+    /// (`AXFontName`/`AXFontSize`); the color as an `NSColor` or a `CGColor` under the foreground key.
+    /// Every path is optional and any miss returns nil, so callers fall back to default styling.
+    ///
+    /// Intended to be called once per focused-element identity (see `FieldStyleCache`); it is a
+    /// synchronous cross-process AX call and must stay off the per-keystroke path.
+    static func resolveFieldStyle(
+        for element: AXUIElement,
+        caretLocation: Int,
+        textLength: Int
+    ) -> ResolvedFieldStyle? {
+        guard textLength > 0 else { return nil }
+
+        // Prefer the character just before the caret (the text the user is extending), then the
+        // first character. Clamp into range so an off-by-one caret never reads out of bounds.
+        let clampedCaret = min(max(caretLocation - 1, 0), textLength - 1)
+        let candidateIndices = clampedCaret == 0 ? [0] : [clampedCaret, 0]
+
+        for index in candidateIndices {
+            guard let attributed = parameterizedAttributedStringValue(
+                for: "AXAttributedStringForRange" as CFString,
+                range: NSRange(location: index, length: 1),
+                on: element
+            ), attributed.length > 0 else {
+                continue
+            }
+
+            let attributes = attributed.attributes(at: 0, effectiveRange: nil)
+            if let style = fieldStyle(from: attributes) {
+                return style
+            }
+        }
+
+        return nil
+    }
+
+    /// Extracts a `ResolvedFieldStyle` from one character's attributes, handling both the AppKit
+    /// `.font`/`.foregroundColor` shapes and the AX-specific font dictionary / `CGColor` shapes.
+    private static func fieldStyle(from attributes: [NSAttributedString.Key: Any]) -> ResolvedFieldStyle? {
+        var fontName: String?
+        var fontPointSize: CGFloat?
+        if let font = attributes[.font] as? NSFont {
+            fontName = font.fontName
+            fontPointSize = font.pointSize
+        } else if let fontInfo = attributes[NSAttributedString.Key("AXFont")] as? [String: Any] {
+            fontName = fontInfo["AXFontName"] as? String
+            if let size = fontInfo["AXFontSize"] as? NSNumber {
+                fontPointSize = CGFloat(size.doubleValue)
+            }
+        }
+
+        var colorHex: String?
+        if let nsColor = attributes[.foregroundColor] as? NSColor {
+            colorHex = SuggestionTextColorCodec.hexString(from: nsColor)
+        } else if let foreground = attributes[.foregroundColor] {
+            // AX commonly hands back a `CGColor` for the foreground color. Verify the CF type id
+            // before bridging, mirroring the typed-value guard used elsewhere in this file.
+            let candidate = foreground as CFTypeRef
+            if CFGetTypeID(candidate) == CGColor.typeID {
+                let cgColor = unsafeBitCast(candidate, to: CGColor.self)
+                if let nsColor = NSColor(cgColor: cgColor) {
+                    colorHex = SuggestionTextColorCodec.hexString(from: nsColor)
+                }
+            }
+        }
+
+        let style = ResolvedFieldStyle(fontName: fontName, fontPointSize: fontPointSize, colorHex: colorHex)
+        return style.isEmpty ? nil : style
+    }
+
     /// Some applications (like Chromium and WebKit browsers) do not properly support `AXBoundsForRange`
     /// using `NSRange`. Instead, they use a private, undocumented Accessibility object called `AXTextMarker`.
     ///

--- a/Cotabby/Support/GhostFontMetrics.swift
+++ b/Cotabby/Support/GhostFontMetrics.swift
@@ -1,0 +1,49 @@
+import CoreGraphics
+import Foundation
+
+/// Derives the ghost-text point size from the measured caret height.
+///
+/// When the host field's font metrics are known, the ghost text scales by that font's own glyph-box
+/// ratio (`pointSize / (ascender - descender)`) so it visually matches the field's text. Different
+/// typefaces have different ascender/descender ratios, so a single fixed ratio mis-sizes monospace
+/// and display fonts; using the field font's real metrics fixes that. When no field font is available
+/// the helper falls back to the previous fixed ratio, preserving prior behavior exactly.
+///
+/// Kept as a pure value helper (no AppKit) so the sizing math is unit-testable in isolation; callers
+/// extract the metrics from an `NSFont` and pass plain numbers.
+enum GhostFontMetrics {
+    /// Glyph-box metrics of the host field's font. `ascender - descender` is the full glyph box
+    /// height (`NSFont.descender` is negative). The derived ratio is scale-invariant, so callers may
+    /// instantiate the reference font at any size.
+    struct FieldFontMetrics: Equatable {
+        let pointSize: CGFloat
+        let ascender: CGFloat
+        let descender: CGFloat
+    }
+
+    static func pointSize(
+        caretHeight: CGFloat,
+        fieldMetrics: FieldFontMetrics?,
+        fallbackRatio: CGFloat,
+        minimum: CGFloat,
+        maximum: CGFloat
+    ) -> CGFloat {
+        let ratio = metricRatio(fieldMetrics) ?? fallbackRatio
+        let proposed = max(minimum, caretHeight * ratio)
+        return min(proposed, maximum)
+    }
+
+    /// `pointSize / (ascender - descender)` for the field font, or nil when the metrics are unusable.
+    private static func metricRatio(_ metrics: FieldFontMetrics?) -> CGFloat? {
+        guard let metrics, metrics.pointSize > 0 else {
+            return nil
+        }
+
+        let glyphBoxHeight = metrics.ascender - metrics.descender
+        guard glyphBoxHeight > 0 else {
+            return nil
+        }
+
+        return metrics.pointSize / glyphBoxHeight
+    }
+}

--- a/Cotabby/Support/GhostSuggestionLayout.swift
+++ b/Cotabby/Support/GhostSuggestionLayout.swift
@@ -35,16 +35,31 @@ struct GhostSuggestionLayout: Equatable {
         static let lineHeightMultiplier: CGFloat = 1.25
     }
 
+    /// Inputs for measuring rendered text width: the size, the AX-observed average char width when
+    /// available, and the host field font used for the fallback measurement. Bundled so the wrapping
+    /// helpers stay within a small parameter count and so width is measured with the rendered glyphs.
+    private struct TextMeasure {
+        let fontSize: CGFloat
+        let observedCharWidth: CGFloat?
+        let font: NSFont?
+    }
+
     static func make(
         text: String,
         geometry: SuggestionOverlayGeometry,
         fontSize: CGFloat,
         visibleFrame: CGRect,
-        showsAcceptanceHint: Bool = true
+        showsAcceptanceHint: Bool = true,
+        font: NSFont? = nil
     ) -> GhostSuggestionLayout {
         let normalizedText = normalizedDisplayText(text)
         let lineHeight = ceil(fontSize * Metrics.lineHeightMultiplier)
         let isRTL = geometry.isRightToLeft
+        let measure = TextMeasure(
+            fontSize: fontSize,
+            observedCharWidth: geometry.observedCharWidth,
+            font: font
+        )
         // When the keycap is hidden the text can use the full width, so we stop reserving room for it.
         let keycapReservation = showsAcceptanceHint ? Metrics.estimatedKeycapAndSpacingWidth : 0
         let usableFrame = usableTextFrame(
@@ -82,11 +97,8 @@ struct GhostSuggestionLayout: Equatable {
             usableFrame.width - keycapReservation
         )
 
-        let singleLineFits = !normalizedText.contains("\n") && measuredWidth(
-            of: normalizedText,
-            fontSize: fontSize,
-            observedCharWidth: geometry.observedCharWidth
-        ) <= firstLineBudget
+        let singleLineFits = !normalizedText.contains("\n")
+            && measuredWidth(of: normalizedText, using: measure) <= firstLineBudget
 
         if singleLineFits {
             return GhostSuggestionLayout(
@@ -111,8 +123,7 @@ struct GhostSuggestionLayout: Equatable {
             let split = splitPrefix(
                 from: remainingText,
                 maxWidth: firstLineBudget,
-                fontSize: fontSize,
-                observedCharWidth: geometry.observedCharWidth
+                using: measure
             )
             if !split.line.isEmpty {
                 let indent: CGFloat
@@ -134,8 +145,7 @@ struct GhostSuggestionLayout: Equatable {
             let split = splitPrefix(
                 from: remainingText,
                 maxWidth: overflowBudget,
-                fontSize: fontSize,
-                observedCharWidth: geometry.observedCharWidth
+                using: measure
             )
             guard !split.line.isEmpty else {
                 break
@@ -238,8 +248,7 @@ struct GhostSuggestionLayout: Equatable {
     private static func splitPrefix(
         from text: String,
         maxWidth: CGFloat,
-        fontSize: CGFloat,
-        observedCharWidth: CGFloat?
+        using measure: TextMeasure
     ) -> (line: String, remainder: String) {
         let source = text.trimmingCharacters(in: .whitespaces)
         guard !source.isEmpty else {
@@ -254,12 +263,11 @@ struct GhostSuggestionLayout: Equatable {
                 source: source,
                 newlineIndex: newlineIndex,
                 maxWidth: maxWidth,
-                fontSize: fontSize,
-                observedCharWidth: observedCharWidth
+                using: measure
             )
         }
 
-        if measuredWidth(of: source, fontSize: fontSize, observedCharWidth: observedCharWidth) <= safeMaxWidth {
+        if measuredWidth(of: source, using: measure) <= safeMaxWidth {
             return (source, "")
         }
 
@@ -272,7 +280,7 @@ struct GhostSuggestionLayout: Equatable {
                 lastWhitespaceBreak = endIndex + 1
             }
 
-            if measuredWidth(of: prefix, fontSize: fontSize, observedCharWidth: observedCharWidth) > safeMaxWidth {
+            if measuredWidth(of: prefix, using: measure) > safeMaxWidth {
                 if let breakIndex = lastWhitespaceBreak, breakIndex > 0 {
                     let line = String(characters[..<breakIndex])
                         .trimmingCharacters(in: .whitespaces)
@@ -298,8 +306,7 @@ struct GhostSuggestionLayout: Equatable {
         source: String,
         newlineIndex: String.Index,
         maxWidth: CGFloat,
-        fontSize: CGFloat,
-        observedCharWidth: CGFloat?
+        using measure: TextMeasure
     ) -> (line: String, remainder: String) {
         let safeMaxWidth = max(maxWidth, Metrics.minimumLineWidth)
         let segment = String(source[..<newlineIndex]).trimmingCharacters(in: .whitespaces)
@@ -309,15 +316,15 @@ struct GhostSuggestionLayout: Equatable {
             : ""
 
         guard !segment.isEmpty else {
-            return splitPrefix(from: afterNewline, maxWidth: maxWidth, fontSize: fontSize, observedCharWidth: observedCharWidth)
+            return splitPrefix(from: afterNewline, maxWidth: maxWidth, using: measure)
         }
 
-        if measuredWidth(of: segment, fontSize: fontSize, observedCharWidth: observedCharWidth) <= safeMaxWidth {
+        if measuredWidth(of: segment, using: measure) <= safeMaxWidth {
             return (segment, afterNewline)
         }
 
         // Segment before newline is too wide — width-wrap it, keep post-newline as remainder.
-        let widthSplit = splitPrefix(from: segment, maxWidth: maxWidth, fontSize: fontSize, observedCharWidth: observedCharWidth)
+        let widthSplit = splitPrefix(from: segment, maxWidth: maxWidth, using: measure)
         let combined: String
         if widthSplit.remainder.isEmpty {
             combined = afterNewline
@@ -329,17 +336,15 @@ struct GhostSuggestionLayout: Equatable {
         return (widthSplit.line, combined)
     }
 
-    private static func measuredWidth(
-        of text: String,
-        fontSize: CGFloat,
-        observedCharWidth: CGFloat?
-    ) -> CGFloat {
-        if let observedCharWidth, observedCharWidth > 0 {
+    private static func measuredWidth(of text: String, using measure: TextMeasure) -> CGFloat {
+        if let observedCharWidth = measure.observedCharWidth, observedCharWidth > 0 {
             return CGFloat((text as NSString).length) * observedCharWidth
         }
 
+        // Measure with the host field's font when known so wrapping matches the rendered glyphs;
+        // this matters most in monospace editors where the system font's advances differ.
         return (text as NSString).size(withAttributes: [
-            .font: NSFont.systemFont(ofSize: fontSize)
+            .font: measure.font ?? NSFont.systemFont(ofSize: measure.fontSize)
         ]).width
     }
 }

--- a/CotabbyTests/GhostFontMetricsTests.swift
+++ b/CotabbyTests/GhostFontMetricsTests.swift
@@ -1,0 +1,105 @@
+import CoreGraphics
+import XCTest
+@testable import Cotabby
+
+/// Tests for the pure ghost-text sizing math. These lock in two behaviors: the fixed-ratio fallback
+/// (unchanged from before field-style resolution) and the metric-based path that scales by the host
+/// font's own glyph-box ratio so ghost text matches the field's apparent size.
+final class GhostFontMetricsTests: XCTestCase {
+    private let fallbackRatio: CGFloat = 0.78
+    private let minimum: CGFloat = 14
+    private let maximum: CGFloat = 24
+
+    private func metrics(pointSize: CGFloat, ascender: CGFloat, descender: CGFloat) -> GhostFontMetrics.FieldFontMetrics {
+        GhostFontMetrics.FieldFontMetrics(pointSize: pointSize, ascender: ascender, descender: descender)
+    }
+
+    func testFallsBackToFixedRatioWhenNoFieldMetrics() {
+        let size = GhostFontMetrics.pointSize(
+            caretHeight: 20,
+            fieldMetrics: nil,
+            fallbackRatio: fallbackRatio,
+            minimum: minimum,
+            maximum: maximum
+        )
+        // max(14, 20 * 0.78) = 15.6, under the cap.
+        XCTAssertEqual(size, 15.6, accuracy: 0.0001)
+    }
+
+    func testUsesFieldFontGlyphBoxRatioWhenAvailable() {
+        // Glyph box = ascender - descender = 11 - (-3) = 14, ratio = 12 / 14.
+        let size = GhostFontMetrics.pointSize(
+            caretHeight: 20,
+            fieldMetrics: metrics(pointSize: 12, ascender: 11, descender: -3),
+            fallbackRatio: fallbackRatio,
+            minimum: minimum,
+            maximum: maximum
+        )
+        XCTAssertEqual(size, 20 * (12.0 / 14.0), accuracy: 0.0001)
+    }
+
+    func testMetricRatioIsScaleInvariant() {
+        // The same typeface reported at two sizes must yield the same ghost size, since the helper
+        // uses only the ratio. This is why callers may instantiate the reference font at any size.
+        let small = GhostFontMetrics.pointSize(
+            caretHeight: 18,
+            fieldMetrics: metrics(pointSize: 12, ascender: 11, descender: -3),
+            fallbackRatio: fallbackRatio,
+            minimum: minimum,
+            maximum: maximum
+        )
+        let large = GhostFontMetrics.pointSize(
+            caretHeight: 18,
+            fieldMetrics: metrics(pointSize: 24, ascender: 22, descender: -6),
+            fallbackRatio: fallbackRatio,
+            minimum: minimum,
+            maximum: maximum
+        )
+        XCTAssertEqual(small, large, accuracy: 0.0001)
+    }
+
+    func testAppliesMinimumFloor() {
+        let size = GhostFontMetrics.pointSize(
+            caretHeight: 5,
+            fieldMetrics: nil,
+            fallbackRatio: fallbackRatio,
+            minimum: minimum,
+            maximum: maximum
+        )
+        XCTAssertEqual(size, minimum, accuracy: 0.0001)
+    }
+
+    func testAppliesMaximumCap() {
+        let size = GhostFontMetrics.pointSize(
+            caretHeight: 100,
+            fieldMetrics: metrics(pointSize: 12, ascender: 11, descender: -3),
+            fallbackRatio: fallbackRatio,
+            minimum: minimum,
+            maximum: maximum
+        )
+        XCTAssertEqual(size, maximum, accuracy: 0.0001)
+    }
+
+    func testDegenerateGlyphBoxFallsBackToFixedRatio() {
+        // ascender - descender <= 0 is unusable, so the fixed ratio must be used instead.
+        let size = GhostFontMetrics.pointSize(
+            caretHeight: 20,
+            fieldMetrics: metrics(pointSize: 12, ascender: 5, descender: 5),
+            fallbackRatio: fallbackRatio,
+            minimum: minimum,
+            maximum: maximum
+        )
+        XCTAssertEqual(size, 20 * fallbackRatio, accuracy: 0.0001)
+    }
+
+    func testNonPositivePointSizeFallsBackToFixedRatio() {
+        let size = GhostFontMetrics.pointSize(
+            caretHeight: 20,
+            fieldMetrics: metrics(pointSize: 0, ascender: 11, descender: -3),
+            fallbackRatio: fallbackRatio,
+            minimum: minimum,
+            maximum: maximum
+        )
+        XCTAssertEqual(size, 20 * fallbackRatio, accuracy: 0.0001)
+    }
+}


### PR DESCRIPTION
## Summary

Inline ghost text always rendered in the system font at a fixed gray and a guessed size ratio, so it read as pasted-on in monospace editors, dark-mode fields, and apps with custom fonts. This resolves the focused field's own font and foreground color from Accessibility and renders the ghost text with them, so a suggestion looks like a natural continuation of the host text.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build \
  -derivedDataPath build/DerivedData
# ** BUILD SUCCEEDED **

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' test \
  -derivedDataPath build/DerivedData \
  -only-testing:CotabbyTests/GhostFontMetricsTests \
  -only-testing:CotabbyTests/GhostSuggestionLayoutTests \
  -only-testing:CotabbyTests/ModelAndPresentationValueTests \
  -only-testing:CotabbyTests/SuggestionOverlayStabilityGateTests \
  -only-testing:CotabbyTests/GhostFontSizeStabilizerTests \
  CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
# Executed 72 tests, with 0 failures

swiftlint lint --strict --quiet   # changed files: exit 0, no violations
```

New pure sizing math is covered by `GhostFontMetricsTests` (fallback ratio, metric-based ratio, scale invariance, floor/cap, degenerate metrics).

## Linked issues

None.

## Risk / rollout notes

- **Additive / fail-safe.** Every new path falls back to the previous behavior when Accessibility exposes no usable style: no field font resolved means the system font and the existing `caretHeight * 0.78` ratio; an untrustworthy near-white/near-black reported color falls back to the default gray, so ghost text can never render invisibly.
- **Latency.** The one new Accessibility read (`AXAttributedStringForRange`) is cached per focused-element identity via `FieldStyleCache`, so it runs once per field, never on the per-keystroke or per-suggestion path, and is skipped for secure fields.
- **Project file.** `Cotabby.xcodeproj/project.pbxproj` is regenerated by `xcodegen generate` to pick up three new source files; no `project.yml` edit was needed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes ghost text visually match the focused field's own typeface and foreground color by reading one character's `AXAttributedStringForRange` attributes once per focused element identity, caching the result in `FieldStyleCache`, and threading the resolved font/color through `FocusedInputSnapshot` → `SuggestionOverlayGeometry` → `OverlayController` → `GhostSuggestionView`. The sizing math is extracted into the pure, unit-tested `GhostFontMetrics` helper so the ghost font scales by the host font's actual glyph-box ratio rather than a fixed multiplier.

- **New files**: `FieldStyleCache` (per-element AX style cache), `GhostFontMetrics` (pure sizing math), and `GhostFontMetricsTests` (covering fallback ratio, metric ratio, scale invariance, floor/cap, and degenerate metrics).
- **Fail-safes**: secure fields are skipped entirely; near-white/near-black colors fall back to default gray; any nil at any resolution stage reverts to system font + existing ratio.
- **One caching gap**: `FieldStyleCache` stores nil under the element key when the field is empty at focus time (`textLength == 0`), and that nil is never evicted while focus stays on the same element — so suggestions in a field that was empty when focused always render with default system styling regardless of the field's actual typeface.

<h3>Confidence Score: 4/5</h3>

Safe to merge with the empty-field caching gap fixed or acknowledged; all other paths are fail-safe and well-tested.

The cache stores nil when a field is empty at focus time and never re-probes once text is present. Any user who focuses an empty field before typing will see default ghost styling for their entire focus session, silently defeating the feature this PR is meant to deliver. Everything else — the AX read, font/color derivation, luminance guard, sizing math, and fallback chain — is well-structured and covered by tests.

Cotabby/Services/Focus/FieldStyleCache.swift and the cache call site in Cotabby/Services/Focus/FocusSnapshotResolver.swift warrant a closer look for the empty-field nil-caching issue.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Services/Focus/FieldStyleCache.swift | New single-entry cache for resolved field font/color. Caches nil results for empty fields using the same key as non-empty ones, causing style resolution to be permanently skipped for fields focused while empty. |
| Cotabby/Services/Focus/FocusSnapshotResolver.swift | Wires FieldStyleCache into the focus polling path. Passes value.utf16.count as textLength, which is the correct AX-unit measure; the cache key is constructed from PID and element identity. |
| Cotabby/Support/AXHelper.swift | Adds resolveFieldStyle and supporting helpers. Handles both NSFont/.font and AX dict/CGColor attribute shapes; the force-cast after CFGetTypeID verification is correct and well-documented. |
| Cotabby/Support/GhostFontMetrics.swift | Pure value helper deriving ghost-text point size from caret height and optional field font metrics. Degeneracy guards (pointSize ≤ 0, glyphBoxHeight ≤ 0) are correct and covered by unit tests. |
| Cotabby/Services/UI/OverlayController.swift | Extracts field font/color from resolvedFieldStyle, applies luminance guard to filter near-white/near-black colors, and passes both into GhostSuggestionView. Fail-safe on nil throughout. |
| Cotabby/Support/GhostSuggestionLayout.swift | Refactors text-width measurement into a TextMeasure bundle so width is computed with the same font that renders the text; no logic changes beyond the parameter consolidation. |
| Cotabby/Models/FocusModels.swift | Adds ResolvedFieldStyle (Equatable/Sendable value type) and threads resolvedFieldStyle? through FocusedInputSnapshot with a nil default, keeping all existing call sites unchanged. |
| Cotabby/Models/SuggestionModels.swift | Propagates resolvedFieldStyle? through FocusedInputContext and SuggestionOverlayGeometry with nil defaults, preserving test call-site compatibility. |
| CotabbyTests/GhostFontMetricsTests.swift | Good coverage of the pure sizing math: fallback ratio, metric-based ratio, scale invariance, floor/cap, and two degenerate-metrics cases. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[FocusSnapshotResolver.resolveSnapshot] --> B{isSecure?}
    B -- yes --> C[resolvedFieldStyle = nil]
    B -- no --> D{textLength == 0?}
    D -- yes --> E[resolveFieldStyle returns nil\nguard textLength > 0]
    D -- no --> F[FieldStyleCache.style forKey pid:elementId]
    F --> G{cache hit?}
    G -- yes --> H[return cached style or nil]
    G -- no --> I[AXHelper.resolveFieldStyle\nAXAttributedStringForRange x 1-2 chars]
    I --> J{attributes found?}
    J -- yes --> K[ResolvedFieldStyle\nfontName + fontPointSize + colorHex]
    J -- no --> L[return nil, cache nil]
    K --> M[cache style, return]
    E --> N[nil cached under same key\n stale if field later has text]
    C --> O[FocusedInputSnapshot\nresolvedFieldStyle?]
    H --> O
    M --> O
    N --> O
    O --> P[SuggestionOverlayGeometry]
    P --> Q[OverlayController]
    Q --> R[fieldFont: NSFont name+size]
    Q --> S[fieldGhostColor: luminance filter\n0.06 < L < 0.94]
    R --> T[GhostFontMetrics.pointSize\ncaret height x glyph-box ratio]
    T --> U[renderFont: NSFont at derived size]
    U --> V[GhostSuggestionView\nfont = field typeface or system\ncolor = field color or gray]
    S --> V
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fghost-text-native-styling%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fghost-text-native-styling%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FServices%2FFocus%2FFieldStyleCache.swift%3A22-31%0A**Stale%20nil%20cached%20for%20initially-empty%20fields**%0A%0AWhen%20the%20user%20focuses%20an%20empty%20text%20field%2C%20%60AXHelper.resolveFieldStyle%60%20returns%20nil%20immediately%20%28the%20%60guard%20textLength%20%3E%200%60%20fires%29%2C%20and%20%60FieldStyleCache%60%20writes%20that%20nil%20under%20the%20element's%20style%20key.%20Because%20the%20cache%20key%20is%20keyed%20on%20element%20identity%20only%20%E2%80%94%20not%20on%20whether%20the%20field%20was%20empty%20at%20probe%20time%20%E2%80%94%20every%20subsequent%20poll%20on%20that%20same%20focused%20element%20hits%20the%20cache%20and%20returns%20the%20previously%20cached%20nil%20without%20calling%20%60resolve%28%29%60%20again.%20Any%20ghost%20suggestion%20that%20appears%20after%20the%20user%20has%20typed%20content%20will%20therefore%20always%20render%20in%20the%20default%20system%20font%20and%20gray%2C%20defeating%20the%20feature%20this%20PR%20introduces.%0A%0AConcretely%3A%20focus%20an%20empty%20field%2C%20type%20several%20words%2C%20accept%20a%20suggestion%20%E2%80%94%20the%20ghost%20text%20uses%20the%20system%20font%20regardless%20of%20the%20field's%20typeface%2C%20because%20the%20nil%20resolved%20when%20the%20field%20was%20empty%20is%20never%20evicted.%0A%0AA%20targeted%20fix%20is%20to%20bypass%20the%20cache%20when%20%60textLength%20%3D%3D%200%60%20at%20the%20resolver%20call%20site%2C%20so%20the%20first%20poll%20with%20actual%20content%20still%20calls%20%60resolve%28%29%60%3A%0A%0A%60%60%60swift%0AresolvedFieldStyle%20%3D%20value.utf16.count%20%3D%3D%200%0A%20%20%20%20%3F%20nil%0A%20%20%20%20%3A%20fieldStyleCache.style%28forKey%3A%20styleKey%29%20%7B%0A%20%20%20%20%20%20%20%20AXHelper.resolveFieldStyle%28%0A%20%20%20%20%20%20%20%20%20%20%20%20for%3A%20resolvedCandidate.element%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20caretLocation%3A%20selection.location%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20textLength%3A%20value.utf16.count%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0AThis%20keeps%20one%20AX%20read%20per%20non-empty%20field%20while%20ensuring%20an%20empty-at-focus%20field%20doesn't%20poison%20the%20entry%20once%20text%20is%20present.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FServices%2FFocus%2FFieldStyleCache.swift%3A22-31%0A**Stale%20nil%20cached%20for%20initially-empty%20fields**%0A%0AWhen%20the%20user%20focuses%20an%20empty%20text%20field%2C%20%60AXHelper.resolveFieldStyle%60%20returns%20nil%20immediately%20%28the%20%60guard%20textLength%20%3E%200%60%20fires%29%2C%20and%20%60FieldStyleCache%60%20writes%20that%20nil%20under%20the%20element's%20style%20key.%20Because%20the%20cache%20key%20is%20keyed%20on%20element%20identity%20only%20%E2%80%94%20not%20on%20whether%20the%20field%20was%20empty%20at%20probe%20time%20%E2%80%94%20every%20subsequent%20poll%20on%20that%20same%20focused%20element%20hits%20the%20cache%20and%20returns%20the%20previously%20cached%20nil%20without%20calling%20%60resolve%28%29%60%20again.%20Any%20ghost%20suggestion%20that%20appears%20after%20the%20user%20has%20typed%20content%20will%20therefore%20always%20render%20in%20the%20default%20system%20font%20and%20gray%2C%20defeating%20the%20feature%20this%20PR%20introduces.%0A%0AConcretely%3A%20focus%20an%20empty%20field%2C%20type%20several%20words%2C%20accept%20a%20suggestion%20%E2%80%94%20the%20ghost%20text%20uses%20the%20system%20font%20regardless%20of%20the%20field's%20typeface%2C%20because%20the%20nil%20resolved%20when%20the%20field%20was%20empty%20is%20never%20evicted.%0A%0AA%20targeted%20fix%20is%20to%20bypass%20the%20cache%20when%20%60textLength%20%3D%3D%200%60%20at%20the%20resolver%20call%20site%2C%20so%20the%20first%20poll%20with%20actual%20content%20still%20calls%20%60resolve%28%29%60%3A%0A%0A%60%60%60swift%0AresolvedFieldStyle%20%3D%20value.utf16.count%20%3D%3D%200%0A%20%20%20%20%3F%20nil%0A%20%20%20%20%3A%20fieldStyleCache.style%28forKey%3A%20styleKey%29%20%7B%0A%20%20%20%20%20%20%20%20AXHelper.resolveFieldStyle%28%0A%20%20%20%20%20%20%20%20%20%20%20%20for%3A%20resolvedCandidate.element%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20caretLocation%3A%20selection.location%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20textLength%3A%20value.utf16.count%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0AThis%20keeps%20one%20AX%20read%20per%20non-empty%20field%20while%20ensuring%20an%20empty-at-focus%20field%20doesn't%20poison%20the%20entry%20once%20text%20is%20present.%0A%0A&repo=fujacob%2Fcotabby&pr=570&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["refactor(overlay): drop unsafeBitCast in..."](https://github.com/fujacob/cotabby/commit/94d39892929c9d4208e85e31c6b91b1e521211d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35777103)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->