### PR TITLE
Add a Download for macOS button beside the Ko-fi button in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 
 <p align="center">
   <a href='https://ko-fi.com/I2F22066MI' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://storage.ko-fi.com/cdn/kofi6.png?v=6' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
+  <a href="https://github.com/FuJacob/cotabby/releases/latest"><img height="36" alt="Download for macOS" src="https://img.shields.io/badge/Download%20for%20macOS-181717?style=for-the-badge&logo=github&logoColor=white" /></a>
 </p>
 
 ---


### PR DESCRIPTION
## Summary

Adds a "Download for macOS" call-to-action button to the README support row, immediately to the right of the existing Ko-fi "Buy Me a Coffee" button. It links to the latest GitHub release, so the two action buttons (download the app, support development) sit side by side. Styled as a shields.io `for-the-badge` button with the GitHub logo at the same 36px height as the Ko-fi button so they line up visually.

## Validation

- Docs-only change. The badge endpoint resolves: `curl` of the shields.io URL returns `200 image/svg+xml`.
- GitHub's rendered markdown preview was not generated locally; the markup is a standard shields.io image consistent with the existing badges in the header.

## Linked issues

None (README enhancement, no tracking issue).

## Risk / rollout notes

Docs-only; no code, build, or runtime impact.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Docs-only change that adds a "Download for macOS" call-to-action button to the README's support row, immediately beside the existing Ko-fi badge, both styled at 36px height.

- The new button links to `https://github.com/FuJacob/cotabby/releases/latest`, the same URL already referenced by the existing \"Latest release\" badge in the header row.
- The Ko-fi anchor uses `target='_blank'` to open in a new tab, but the new download anchor does not — a minor visual/UX inconsistency for readers browsing GitHub.

<h3>Confidence Score: 4/5</h3>

Safe to merge — a single line of Markdown with no code, build, or runtime impact.

The change is straightforward: one new badge anchor in the README. The only thing worth addressing is that the new button navigates the current tab while the Ko-fi button beside it opens a new tab, creating an inconsistent experience for readers.

README.md — the single changed file; the `target` attribute inconsistency is the only item to review.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Adds a shields.io "Download for macOS" badge linking to the latest GitHub release, placed alongside the Ko-fi button. Minor: new link lacks `target='_blank'` unlike the adjacent Ko-fi anchor. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User views README on GitHub] --> B{Clicks which button?}
    B -->|Ko-fi button| C["Opens ko-fi.com in new tab"]
    B -->|Download for macOS button| D["Navigates current tab to releases/latest"]
    D -.->|Suggested fix| E["Opens releases/latest in new tab"]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22docs%2Fdownload-badge%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Fdownload-badge%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AREADME.md%3A30%0AThe%20new%20download%20anchor%20is%20missing%20%60target%3D'_blank'%60%2C%20so%20clicking%20it%20navigates%20the%20current%20tab%20away%20from%20the%20README.%20The%20adjacent%20Ko-fi%20button%20includes%20%60target%3D'_blank'%60%20and%20opens%20in%20a%20new%20tab%20%E2%80%94%20the%20two%20buttons%20should%20behave%20consistently.%0A%0A%60%60%60suggestion%0A%20%20%3Ca%20href%3D%22https%3A%2F%2Fgithub.com%2FFuJacob%2Fcotabby%2Freleases%2Flatest%22%20target%3D%22_blank%22%3E%3Cimg%20height%3D%2236%22%20alt%3D%22Download%20for%20macOS%22%20src%3D%22https%3A%2F%2Fimg.shields.io%2Fbadge%2FDownload%2520for%2520macOS-181717%3Fstyle%3Dfor-the-badge%26logo%3Dgithub%26logoColor%3Dwhite%22%20%2F%3E%3C%2Fa%3E%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AREADME.md%3A30%0AThe%20new%20download%20anchor%20is%20missing%20%60target%3D'_blank'%60%2C%20so%20clicking%20it%20navigates%20the%20current%20tab%20away%20from%20the%20README.%20The%20adjacent%20Ko-fi%20button%20includes%20%60target%3D'_blank'%60%20and%20opens%20in%20a%20new%20tab%20%E2%80%94%20the%20two%20buttons%20should%20behave%20consistently.%0A%0A%60%60%60suggestion%0A%20%20%3Ca%20href%3D%22https%3A%2F%2Fgithub.com%2FFuJacob%2Fcotabby%2Freleases%2Flatest%22%20target%3D%22_blank%22%3E%3Cimg%20height%3D%2236%22%20alt%3D%22Download%20for%20macOS%22%20src%3D%22https%3A%2F%2Fimg.shields.io%2Fbadge%2FDownload%2520for%2520macOS-181717%3Fstyle%3Dfor-the-badge%26logo%3Dgithub%26logoColor%3Dwhite%22%20%2F%3E%3C%2Fa%3E%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=572&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add a Download for macOS button beside t..."](https://github.com/fujacob/cotabby/commit/bff0e7632d8566ca382c9176b6f5d7e405efa2ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35777889)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->