### PR TITLE
Improve Settings UX: per-row icons, reorganized panes, and search

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		1D1C6FF0B8F50AC14A1000F4 /* SentenceBoundaryClassifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7360A6D4261989A66658ED /* SentenceBoundaryClassifierTests.swift */; };
 		1D424A103EF7BFE45518F45E /* GhostFontMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E41890930AA80910E461EF /* GhostFontMetricsTests.swift */; };
 		1F8CC88AFFE67C08944CF506 /* WindowScreenshotService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B0121E7BB173F8A2B0B108 /* WindowScreenshotService.swift */; };
+		2089E4C64C1BFDCDA9F2F721 /* ContextPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89497C35D1825BAE9625EE06 /* ContextPaneView.swift */; };
 		210EEE9D094586286EDD89E8 /* ControlTokenMarkers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC2D6472ACD377FD73A5801 /* ControlTokenMarkers.swift */; };
 		2197B68F1E4D0C3497DAC061 /* LlamaSuggestionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE04620C905041680116BE80 /* LlamaSuggestionEngine.swift */; };
 		22DF59FD6F3B83B092A6F5ED /* WordCountFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 815F2ABAF6AB75DA3AFBBCEF /* WordCountFormatter.swift */; };
@@ -95,6 +96,7 @@
 		4BFE7446533386550C839F25 /* EmojiTriggerStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312C7306D916963F519CE0D9 /* EmojiTriggerStateMachine.swift */; };
 		4C6D8ED0A7B45D2EADF06DA5 /* SuggestionOverlayStabilityGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB25ABC4FFB0E63477CDCB0 /* SuggestionOverlayStabilityGateTests.swift */; };
 		4CAFD8F3444FEDC9ACAFF529 /* LlamaRuntimeModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A804F4DB6FD9BC8C27B2B65F /* LlamaRuntimeModels.swift */; };
+		4E2DEFF3CA51E8B160B802CA /* SettingsIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34EF2406E7A384F3325AAF9A /* SettingsIndex.swift */; };
 		4F369F5284DDCEABF082E59B /* SuggestionAvailabilityEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3609CC88A5280B3AA40414DF /* SuggestionAvailabilityEvaluator.swift */; };
 		4F38CE1C2602CF4F41323032 /* PermissionOverlayTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12DD19BCE610808F1E38702D /* PermissionOverlayTrackerTests.swift */; };
 		4FC52FB28AFC013F000D8FF9 /* SecureFieldDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 474560E524C1D74BAB1570DA /* SecureFieldDetectorTests.swift */; };
@@ -132,7 +134,6 @@
 		66D9E37B12A9265D4733E72E /* LlamaRuntimeCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 944065A858D9BC936CB12B23 /* LlamaRuntimeCore.swift */; };
 		6955C3A4D7AB3EEF7FA7C469 /* InputSuppressionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1F9CEBAB0F330F8E7B61D8 /* InputSuppressionController.swift */; };
 		6AE0B46FB52D189D94E1F79A /* WordCountFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E0513E3B23937B099A3CFF2 /* WordCountFormatterTests.swift */; };
-		6B0186B9F3E6F654296B6D76 /* AdvancedPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E644072C123DC2D2B40274D /* AdvancedPaneView.swift */; };
 		6D0E79CF3C1A8CE53046FCE5 /* AXTextGeometryResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C046CB4F3CB4BFE9391DB5DE /* AXTextGeometryResolverTests.swift */; };
 		6DD1E22151571E1A22FF22F4 /* FoundationModelSuggestionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5664E34B23FBDF69292FEF43 /* FoundationModelSuggestionEngine.swift */; };
 		6E01052209B73D7361C12CEF /* ClipboardContentDistiller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96495E4147D828C0B1B22765 /* ClipboardContentDistiller.swift */; };
@@ -198,6 +199,7 @@
 		A93A741C8C3973687D28F0B6 /* SuggestionEngineModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADBE3E6CC585C1683787C877 /* SuggestionEngineModels.swift */; };
 		A982E243A4D8BC1BF7504B3E /* SuggestionInteractionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA942A53B7C09D1F4EC57239 /* SuggestionInteractionState.swift */; };
 		AA2E09FF7E430D66ECA8ECD5 /* CotabbyApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC1EDFB535AAA2EE0D67828A /* CotabbyApp.swift */; };
+		AB5D37BA744546F14C5566E8 /* AppearancePaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFBE491B3CA04FE9069B7B0F /* AppearancePaneView.swift */; };
 		AB9C9C001F97F9D14F8B192A /* TerminalAppDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F4C4A7EAF886E0CC945BFEF /* TerminalAppDetector.swift */; };
 		AECC7289DA796B071B4FE3C0 /* MenuBarStatusLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD42C7E2852F59BEF7972663 /* MenuBarStatusLabelView.swift */; };
 		B00FDD3DEE0B73FF5136C91C /* FocusTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C9FDF029F7828CAF3FE8850 /* FocusTracker.swift */; };
@@ -253,6 +255,7 @@
 		E912D4617AE1376061DF1F00 /* LanguageSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4793D4EA5D36D7E5CC216C27 /* LanguageSupportTests.swift */; };
 		E994FE418A961FB234D9057A /* DownloadFileRescuerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F46767D9D1F0D44E239CA8 /* DownloadFileRescuerTests.swift */; };
 		E9E4CC657771DF9F4C56183C /* VisualContextCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A854CAFB1F557BC4CAED8819 /* VisualContextCoordinator.swift */; };
+		EA89011A4D7ADD2A716D886E /* EmojiPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A28B4A4368DB33C25E3AB5F3 /* EmojiPaneView.swift */; };
 		EB13A392BFA5349DD8A0DD25 /* EmojiUsageStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE35C7770405ED368AA02448 /* EmojiUsageStore.swift */; };
 		ED0843752B297D7E9DB2C468 /* EmojiTriggerStateMachineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723E1EFA85D2E61B6C5F33E8 /* EmojiTriggerStateMachineTests.swift */; };
 		ED9C51B0D7056F0753AADF2D /* GhostSuggestionLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043E8AA850F930222DD112C0 /* GhostSuggestionLayout.swift */; };
@@ -345,6 +348,7 @@
 		3350EDE01ED5125520C79D53 /* SettingsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsCoordinator.swift; sourceTree = "<group>"; };
 		335BF59EE80F3A0143B79740 /* GhostFontSizeStabilizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostFontSizeStabilizerTests.swift; sourceTree = "<group>"; };
 		3384FD33776960103D6E22A9 /* EmojiPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiPickerView.swift; sourceTree = "<group>"; };
+		34EF2406E7A384F3325AAF9A /* SettingsIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsIndex.swift; sourceTree = "<group>"; };
 		352AF5B2834FEE1F597394E4 /* ApplicationBundleMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationBundleMetadata.swift; sourceTree = "<group>"; };
 		357C18383B047F24A531BDCD /* MidWordContinuationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MidWordContinuationPolicy.swift; sourceTree = "<group>"; };
 		3609CC88A5280B3AA40414DF /* SuggestionAvailabilityEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionAvailabilityEvaluator.swift; sourceTree = "<group>"; };
@@ -403,7 +407,6 @@
 		78E49BDA7F3A42455C4C5350 /* HuggingFaceModelBrowserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceModelBrowserView.swift; sourceTree = "<group>"; };
 		7D472F9F396672E57873303B /* InsertionSafetyGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsertionSafetyGate.swift; sourceTree = "<group>"; };
 		7E44E393DD58B978B1EAB6CF /* GhostTextColorPreset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostTextColorPreset.swift; sourceTree = "<group>"; };
-		7E644072C123DC2D2B40274D /* AdvancedPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedPaneView.swift; sourceTree = "<group>"; };
 		7F4C4A7EAF886E0CC945BFEF /* TerminalAppDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAppDetector.swift; sourceTree = "<group>"; };
 		807148A920E003DEF8BA6092 /* SystemMetricsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemMetricsStore.swift; sourceTree = "<group>"; };
 		815F2ABAF6AB75DA3AFBBCEF /* WordCountFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordCountFormatter.swift; sourceTree = "<group>"; };
@@ -414,6 +417,7 @@
 		86460C747AA883FDE756BDBA /* SuggestionSettingsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionSettingsModel.swift; sourceTree = "<group>"; };
 		8724ECA8FABBC82B0A2B943B /* FoundationModelAvailabilityService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoundationModelAvailabilityService.swift; sourceTree = "<group>"; };
 		8896D976C7F116EBA0F3969F /* ChromiumAccessibilityEnabler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromiumAccessibilityEnabler.swift; sourceTree = "<group>"; };
+		89497C35D1825BAE9625EE06 /* ContextPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextPaneView.swift; sourceTree = "<group>"; };
 		8D610FCA3A97249DCCE7D0B8 /* LLMIOFileHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMIOFileHandler.swift; sourceTree = "<group>"; };
 		8EA827D6A2A54DF4BAD56405 /* CaretLinePositionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaretLinePositionTests.swift; sourceTree = "<group>"; };
 		8F20A19A24D20E16D25ADCDA /* DeepGeometryWalkThrottleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepGeometryWalkThrottleTests.swift; sourceTree = "<group>"; };
@@ -442,6 +446,7 @@
 		9E6439213F2A273702A6E26B /* GhostFontMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostFontMetrics.swift; sourceTree = "<group>"; };
 		9E72A3972E15749337539C2D /* EmojiRecents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiRecents.swift; sourceTree = "<group>"; };
 		A168A7B6A7AD11559B60C56B /* ApplicationBundleMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationBundleMetadataTests.swift; sourceTree = "<group>"; };
+		A28B4A4368DB33C25E3AB5F3 /* EmojiPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiPaneView.swift; sourceTree = "<group>"; };
 		A3E8E86A14090BC7BD13BA76 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A3FA53BBC3D81503C1D17477 /* AboutPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutPaneView.swift; sourceTree = "<group>"; };
 		A520809E71697E3BB9A8139C /* HuggingFaceModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceModels.swift; sourceTree = "<group>"; };
@@ -459,6 +464,7 @@
 		AD9573F3504CAE6891DF9B7D /* AppUpdateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdateManager.swift; sourceTree = "<group>"; };
 		ADBE3E6CC585C1683787C877 /* SuggestionEngineModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionEngineModels.swift; sourceTree = "<group>"; };
 		AF1E065C7FFB697FCEB2FA5C /* CotabbyTestFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CotabbyTestFixtures.swift; sourceTree = "<group>"; };
+		AFBE491B3CA04FE9069B7B0F /* AppearancePaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearancePaneView.swift; sourceTree = "<group>"; };
 		AFCFCCCB69C29A86E726B10A /* PromptSectionBudget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptSectionBudget.swift; sourceTree = "<group>"; };
 		B22FDEB3B1DCC9ADE906CC73 /* OCRTextHygiene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCRTextHygiene.swift; sourceTree = "<group>"; };
 		B25C3087D4A9F4DC52FD5A69 /* PerDomainDisableSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerDomainDisableSettings.swift; sourceTree = "<group>"; };
@@ -626,8 +632,10 @@
 			children = (
 				A3FA53BBC3D81503C1D17477 /* AboutPaneView.swift */,
 				2B7A28471B8526C2693FFF65 /* AcknowledgementsView.swift */,
-				7E644072C123DC2D2B40274D /* AdvancedPaneView.swift */,
+				AFBE491B3CA04FE9069B7B0F /* AppearancePaneView.swift */,
 				D9C1C921A1CDA2ADFC39EA01 /* AppsPaneView.swift */,
+				89497C35D1825BAE9625EE06 /* ContextPaneView.swift */,
+				A28B4A4368DB33C25E3AB5F3 /* EmojiPaneView.swift */,
 				FC9ECD5408B0F5708149B5C0 /* EngineAndModelPaneView.swift */,
 				07480CE96ED0EBD94817C6B1 /* GeneralPaneView.swift */,
 				DEBD6113A3C1038BECC99245 /* PerformancePaneView.swift */,
@@ -897,6 +905,7 @@
 				2EE526D7C9284AF6687A556B /* Panes */,
 				5D0AEFF86F8210CBE7CFCBAD /* SettingsCategory.swift */,
 				DB0CE9AB1286367BA2E82392 /* SettingsContainerView.swift */,
+				34EF2406E7A384F3325AAF9A /* SettingsIndex.swift */,
 				BADB38D0160B47637572FC5E /* SettingsSidebarView.swift */,
 			);
 			path = Settings;
@@ -1139,9 +1148,9 @@
 				DDEDCBAA2196303455F6926A /* AcceptanceModePickerView.swift in Sources */,
 				0A658BF137DBD0898E40B87F /* AcknowledgementsView.swift in Sources */,
 				26E0331E9E2F92FAE531BDEE /* ActivationIndicatorController.swift in Sources */,
-				6B0186B9F3E6F654296B6D76 /* AdvancedPaneView.swift in Sources */,
 				0A3443AEE6540F11E5E6BF8F /* AppDelegate.swift in Sources */,
 				C4C6734678797669055988E0 /* AppUpdateManager.swift in Sources */,
+				AB5D37BA744546F14C5566E8 /* AppearancePaneView.swift in Sources */,
 				66C23A7C2FCDE0266FF425F8 /* ApplicationBundleMetadata.swift in Sources */,
 				EF0DE5E045F328F1E912A02A /* AppsPaneView.swift in Sources */,
 				E4382BEA8A8551612E5966B9 /* BaseCompletionPromptRenderer.swift in Sources */,
@@ -1158,6 +1167,7 @@
 				3985F0F2B3178DBB945B1064 /* CompletionRenderModePolicy.swift in Sources */,
 				429CE592897D8A952F2916C3 /* ConfidenceSuppressionPolicy.swift in Sources */,
 				8B2DFC860803C0A7C4D34A36 /* ContextBuffer.swift in Sources */,
+				2089E4C64C1BFDCDA9F2F721 /* ContextPaneView.swift in Sources */,
 				210EEE9D094586286EDD89E8 /* ControlTokenMarkers.swift in Sources */,
 				AA2E09FF7E430D66ECA8ECD5 /* CotabbyApp.swift in Sources */,
 				FCC571EC239846F06007BFCA /* CotabbyAppEnvironment.swift in Sources */,
@@ -1173,6 +1183,7 @@
 				7D6BB9AF72F7076A4E5EE96F /* DownloadableModelCatalogView.swift in Sources */,
 				4531645066A73971EB2A5FA1 /* EmojiCatalog.swift in Sources */,
 				9706D778FB549E9E7AE05F4F /* EmojiMatcher.swift in Sources */,
+				EA89011A4D7ADD2A716D886E /* EmojiPaneView.swift in Sources */,
 				F496D63FD0A163D222D8C76F /* EmojiPickerController.swift in Sources */,
 				F067EA26AC2D007382CE520F /* EmojiPickerModels.swift in Sources */,
 				B6652D81162C64248AA4CF0B /* EmojiPickerPanelController.swift in Sources */,
@@ -1266,6 +1277,7 @@
 				907A0BF56C3BB0CBAF2649AB /* SettingsCategory.swift in Sources */,
 				2E3DEB7E89D0146274596F2E /* SettingsContainerView.swift in Sources */,
 				644EEF959D07D54CC779BBF6 /* SettingsCoordinator.swift in Sources */,
+				4E2DEFF3CA51E8B160B802CA /* SettingsIndex.swift in Sources */,
 				4B93D26BACEEA932E92B1A19 /* SettingsPaneScaffold.swift in Sources */,
 				078FDE669437D756678E9AB7 /* SettingsRowLabel.swift in Sources */,
 				27D4F5CACADE171F142178B4 /* SettingsSidebarView.swift in Sources */,

--- a/Cotabby/Support/SettingsAttentionEvaluator.swift
+++ b/Cotabby/Support/SettingsAttentionEvaluator.swift
@@ -67,7 +67,7 @@ enum SettingsAttentionEvaluator {
                 return reason
             }
 
-        case .general, .writing, .advanced, .shortcuts, .apps, .performance, .about:
+        case .general, .appearance, .emoji, .writing, .context, .shortcuts, .apps, .performance, .about:
             return nil
         }
     }

--- a/Cotabby/UI/Settings/Components/AcceptanceModePickerView.swift
+++ b/Cotabby/UI/Settings/Components/AcceptanceModePickerView.swift
@@ -20,7 +20,8 @@ struct AcceptanceModePickerView: View {
             SettingsRowLabel(
                 title: "Acceptance Mode",
                 description: "What the Accept Word key takes per press. Word inserts one word at a time; " +
-                    "Phrase inserts up to the next sentence break."
+                    "Phrase inserts up to the next sentence break.",
+                systemImage: "textformat.abc"
             )
         }
         .pickerStyle(.menu)

--- a/Cotabby/UI/Settings/Components/SettingsRowLabel.swift
+++ b/Cotabby/UI/Settings/Components/SettingsRowLabel.swift
@@ -9,14 +9,32 @@ import SwiftUI
 struct SettingsRowLabel: View {
     let title: String
     let description: String
+    /// Optional leading SF Symbol. Rendered monochrome in secondary color so it aids scanning
+    /// without competing with the control on the trailing edge. Decorative: hidden from VoiceOver
+    /// because the title already names the setting.
+    var systemImage: String?
+
+    init(title: String, description: String, systemImage: String? = nil) {
+        self.title = title
+        self.description = description
+        self.systemImage = systemImage
+    }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            Text(title)
-            Text(description)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
+        HStack(alignment: .firstTextBaseline, spacing: 10) {
+            if let systemImage {
+                Image(systemName: systemImage)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 20, alignment: .center)
+                    .accessibilityHidden(true)
+            }
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                Text(description)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
         }
     }
 }

--- a/Cotabby/UI/Settings/Panes/AppearancePaneView.swift
+++ b/Cotabby/UI/Settings/Panes/AppearancePaneView.swift
@@ -1,0 +1,199 @@
+import SwiftUI
+
+/// File overview:
+/// "Appearance" detail pane: everything about how suggestions are presented, split out of the old
+/// General pane so each surface has one focus. Two sections: Display (where and how the suggestion
+/// shows) and Appearance (the ghost text's color and opacity). The `Suggestion Display` label
+/// matches the menu-bar quick control so users can connect the two.
+struct AppearancePaneView: View {
+    @ObservedObject var suggestionSettings: SuggestionSettingsModel
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        SettingsPaneScaffold {
+            Section("Display") {
+                Picker(selection: mirrorPreferenceBinding) {
+                    ForEach(MirrorPreference.allCases) { preference in
+                        Text(preference.displayLabel).tag(preference)
+                    }
+                } label: {
+                    SettingsRowLabel(
+                        title: "Suggestion Display",
+                        description: "Auto picks inline ghost text when the app's caret position is reliable, " +
+                            "and a popup card when it isn't. Inline or Popup pins one style for every app.",
+                        systemImage: "text.cursor"
+                    )
+                }
+                .pickerStyle(.menu)
+
+                Toggle(isOn: showIndicatorBinding) {
+                    SettingsRowLabel(
+                        title: "Show Field Indicator",
+                        description: "Show a small icon at the edge of a field when Cotabby is ready to suggest.",
+                        systemImage: "dot.viewfinder"
+                    )
+                }
+
+                Toggle(isOn: menuBarWordCountVisibleBinding) {
+                    SettingsRowLabel(
+                        title: "Show Word Count in Menu Bar",
+                        description: "Show a running count of words you've accepted next to the menu bar icon.",
+                        systemImage: "number"
+                    )
+                }
+
+                Toggle(isOn: showAcceptanceHintBinding) {
+                    HStack(alignment: .firstTextBaseline, spacing: 10) {
+                        Image(systemName: "keyboard")
+                            .foregroundStyle(.secondary)
+                            .frame(width: 20, alignment: .center)
+                            .accessibilityHidden(true)
+                        VStack(alignment: .leading, spacing: 2) {
+                            HStack(spacing: 4) {
+                                Text("Show")
+                                Text(suggestionSettings.acceptanceKeyLabel)
+                                    .font(.system(.body, design: .rounded).weight(.semibold))
+                                    .padding(.horizontal, 5)
+                                    .padding(.vertical, 1)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 4, style: .continuous)
+                                            .fill(.quaternary)
+                                    )
+                                Text("Key Hint")
+                            }
+                            Text("Show the accept-key badge next to the ghost text so you remember which key inserts it.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                }
+            }
+
+            Section("Appearance") {
+                LabeledContent {
+                    HStack(spacing: 8) {
+                        ForEach(GhostTextColorPreset.all) { preset in
+                            ghostColorSwatch(for: preset)
+                        }
+                    }
+                } label: {
+                    SettingsRowLabel(
+                        title: "Ghost Text Color",
+                        description: "The color of the inline suggestion. Automatic adapts to light and dark.",
+                        systemImage: "paintpalette"
+                    )
+                }
+
+                LabeledContent {
+                    HStack(spacing: 10) {
+                        TickMarkSlider(
+                            value: ghostTextOpacityBinding,
+                            range: SuggestionSettingsModel.minimumGhostTextOpacity
+                                ... SuggestionSettingsModel.maximumGhostTextOpacity,
+                            step: SuggestionSettingsModel.ghostTextOpacityStep
+                        )
+                        .frame(width: 180)
+
+                        Text(ghostTextOpacityLabel)
+                            .font(.callout)
+                            .monospacedDigit()
+                            .foregroundStyle(.secondary)
+                            .frame(width: 42, alignment: .trailing)
+                    }
+                } label: {
+                    SettingsRowLabel(
+                        title: "Ghost Text Opacity",
+                        description: "How faint the inline suggestion looks before you accept it.",
+                        systemImage: "circle.lefthalf.filled"
+                    )
+                }
+            }
+        }
+    }
+
+    // MARK: - Bindings
+
+    private var showIndicatorBinding: Binding<Bool> {
+        Binding(
+            get: { suggestionSettings.showIndicator },
+            set: { suggestionSettings.setShowIndicator($0) }
+        )
+    }
+
+    private var showAcceptanceHintBinding: Binding<Bool> {
+        Binding(
+            get: { suggestionSettings.showAcceptanceHint },
+            set: { suggestionSettings.setShowAcceptanceHint($0) }
+        )
+    }
+
+    private var mirrorPreferenceBinding: Binding<MirrorPreference> {
+        Binding(
+            get: { suggestionSettings.mirrorPreference },
+            set: { suggestionSettings.setMirrorPreference($0) }
+        )
+    }
+
+    private var menuBarWordCountVisibleBinding: Binding<Bool> {
+        Binding(
+            get: { suggestionSettings.isMenuBarWordCountVisible },
+            set: { suggestionSettings.setMenuBarWordCountVisible($0) }
+        )
+    }
+
+    private var ghostTextOpacityBinding: Binding<Double> {
+        Binding(
+            get: { suggestionSettings.ghostTextOpacity },
+            set: { suggestionSettings.setGhostTextOpacity($0) }
+        )
+    }
+
+    // MARK: - Ghost color swatch helpers
+
+    /// Mirrors the overlay's automatic fallback (`GhostSuggestionView.ghostColor`) so the Automatic
+    /// swatch previews the same gray the user will actually see.
+    private var automaticGhostTextColor: Color {
+        colorScheme == .dark
+            ? Color(red: 0.65, green: 0.65, blue: 0.65)
+            : Color(red: 0.45, green: 0.45, blue: 0.45)
+    }
+
+    private var ghostTextOpacityLabel: String {
+        "\(Int((suggestionSettings.ghostTextOpacity * 100).rounded()))%"
+    }
+
+    @ViewBuilder
+    private func ghostColorSwatch(for preset: GhostTextColorPreset) -> some View {
+        let isSelected = GhostTextColorPreset.matching(
+            hex: suggestionSettings.customSuggestionTextColorHex
+        ) == preset
+
+        Button {
+            suggestionSettings.setCustomSuggestionTextColorHex(preset.hex)
+        } label: {
+            Circle()
+                .fill(swatchFill(for: preset))
+                .frame(width: 18, height: 18)
+                .overlay(
+                    Circle()
+                        .strokeBorder(
+                            Color.primary.opacity(isSelected ? 0.9 : 0.18),
+                            lineWidth: isSelected ? 2 : 1
+                        )
+                )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func swatchFill(for preset: GhostTextColorPreset) -> Color {
+        guard let hex = preset.hex,
+              let color = SuggestionTextColorCodec.color(fromHex: hex)
+        else {
+            return automaticGhostTextColor
+        }
+
+        return color
+    }
+}

--- a/Cotabby/UI/Settings/Panes/ContextPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/ContextPaneView.swift
@@ -2,24 +2,20 @@ import Combine
 import SwiftUI
 
 /// File overview:
-/// "Advanced" detail pane of the Settings window. Holds the Extended Context editor (a free-form
+/// "Context" detail pane of the Settings window. Holds the Extended Context editor (a free-form
 /// text blob folded into every prompt) and a small "Try it" playground for verifying that the
-/// editor's content is actually shaping the model's output. The pane is named generically so
-/// future advanced toggles (model tuning, debug flags, prompt knobs) can land here without a
-/// second navigation rename.
+/// editor's content is actually shaping the model's output.
 ///
 /// Why a dedicated pane (not Writing):
-/// The Writing pane already carries the tag-style `customRules` editor (short imperative
-/// directives) plus name and language. Extended Context is a different shape: long-form, free
-/// markdown, and noticeably more expensive on the token budget. Keeping it in its own pane (a)
-/// leaves Writing focused on small, additive personalization, and (b) makes room for the
-/// cost-of-use warnings without crowding the existing settings.
+/// The Writing pane already carries name and language personalization. Extended Context is a
+/// different shape: long-form, free markdown, and noticeably more expensive on the token budget.
+/// Keeping it in its own pane (a) leaves Writing focused on small, additive personalization, and
+/// (b) makes room for the cost-of-use warnings without crowding the existing settings.
 ///
 /// The text editor binds through `SuggestionSettingsModel.setExtendedContext`, which length-caps
 /// the value on write. Whitespace is intentionally NOT trimmed in the setter so the user can type
-/// a space at the end of a word — `SuggestionRequestFactory` does the once-per-request trim
-/// instead.
-struct AdvancedPaneView: View {
+/// a space at the end of a word; `SuggestionRequestFactory` does the once-per-request trim instead.
+struct ContextPaneView: View {
     @ObservedObject var suggestionSettings: SuggestionSettingsModel
     let suggestionEngine: any SuggestionGenerating
     let configuration: SuggestionConfiguration
@@ -202,7 +198,7 @@ struct AdvancedPaneView: View {
         Section("How this is used") {
             VStack(alignment: .leading, spacing: 8) {
                 bulletLine(
-                    "Sent on every suggestion as reference material — not as instructions."
+                    "Sent on every suggestion as reference material, not as instructions."
                 )
                 bulletLine(
                     "Subordinate to Cotabby's base autocomplete rules, so it cannot override " +
@@ -256,10 +252,10 @@ struct AdvancedPaneView: View {
     }
 }
 
-/// View model for the Advanced pane's "Try it" playground. Owns the test input text, the most
+/// View model for the Context pane's "Try it" playground. Owns the test input text, the most
 /// recent completion (or error), and the actor-isolated generation task.
 ///
-/// Lives in this file because it is private to the Advanced pane and exists only to shape one
+/// Lives in this file because it is private to the Context pane and exists only to shape one
 /// section of UI; lifting it out would invite reuse the playground doesn't need.
 @MainActor
 final class ExtendedContextPlaygroundModel: ObservableObject {
@@ -339,7 +335,7 @@ final class ExtendedContextPlaygroundModel: ObservableObject {
                 self.currentGenerationID = nil
                 self.isGenerating = false
             } catch is CancellationError {
-                // Stale task — a newer `runCompletion` (or a future cancel handler) has already
+                // Stale task; a newer `runCompletion` (or a future cancel handler) has already
                 // stamped a fresh `currentGenerationID` or cleared it, so leave the spinner state
                 // for whoever owns the current generation. Touching `isGenerating` here would
                 // race with the active task.
@@ -356,12 +352,12 @@ final class ExtendedContextPlaygroundModel: ObservableObject {
     }
 
     /// Builds a `FocusedInputContext` from the user's test text. The values are intentionally
-    /// generic — the playground is a prompt-shape demo, not an attempt to mimic a specific host
+    /// generic; the playground is a prompt-shape demo, not an attempt to mimic a specific host
     /// app's accessibility surface.
     private static func makeSyntheticContext(prefixText: String) -> FocusedInputContext {
         let snapshot = FocusedInputSnapshot(
             applicationName: "Cotabby Playground",
-            bundleIdentifier: "com.cotabby.advanced.playground",
+            bundleIdentifier: "com.cotabby.context.playground",
             processIdentifier: 0,
             elementIdentifier: "playground-field",
             role: "AXTextArea",

--- a/Cotabby/UI/Settings/Panes/EmojiPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/EmojiPaneView.swift
@@ -1,0 +1,159 @@
+import SwiftUI
+
+/// File overview:
+/// "Emoji" detail pane: the inline emoji picker feature and its presentation options, split out of
+/// the old General pane so the feature has a home of its own. The skin-tone and people-style options
+/// only appear when the picker is enabled, so the pane stays empty-handed when the feature is off.
+struct EmojiPaneView: View {
+    @ObservedObject var suggestionSettings: SuggestionSettingsModel
+    let clearEmojiHistory: () -> Void
+
+    var body: some View {
+        SettingsPaneScaffold {
+            Section("Emoji Picker") {
+                Toggle(isOn: emojiPickerEnabledBinding) {
+                    SettingsRowLabel(
+                        title: "Inline Emoji Picker",
+                        description: "Type a name like :smile to search inline, then press your accept-word " +
+                            "shortcut to insert the selected emoji.",
+                        systemImage: "face.smiling"
+                    )
+                }
+            }
+
+            if suggestionSettings.isEmojiPickerEnabled {
+                Section("Suggestions") {
+                    LabeledContent {
+                        HStack(spacing: 8) {
+                            ForEach(EmojiSkinTone.allCases, id: \.self) { tone in
+                                skinToneOption(for: tone)
+                            }
+                        }
+                    } label: {
+                        SettingsRowLabel(
+                            title: "Skin Tone",
+                            description: "For non-default tones, suggestions show your selected tone first " +
+                                "and keep the default emoji next.",
+                            systemImage: "hand.raised.fingers.spread"
+                        )
+                    }
+
+                    LabeledContent {
+                        HStack(spacing: 8) {
+                            ForEach(EmojiGender.allCases, id: \.self) { gender in
+                                emojiGenderOption(for: gender)
+                            }
+                        }
+                    } label: {
+                        SettingsRowLabel(
+                            title: "People Emoji Style",
+                            description: "Choose person, man, or woman variants when an emoji offers them.",
+                            systemImage: "person.2"
+                        )
+                    }
+
+                    LabeledContent {
+                        Button("Clear History") {
+                            clearEmojiHistory()
+                        }
+                    } label: {
+                        SettingsRowLabel(
+                            title: "Emoji History",
+                            description: "Forget recently and frequently used emoji so the picker ranks from scratch.",
+                            systemImage: "clock.arrow.circlepath"
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Bindings
+
+    private var emojiPickerEnabledBinding: Binding<Bool> {
+        Binding(
+            get: { suggestionSettings.isEmojiPickerEnabled },
+            set: { suggestionSettings.setEmojiPickerEnabled($0) }
+        )
+    }
+
+    // MARK: - Option buttons
+
+    @ViewBuilder
+    private func skinToneOption(for tone: EmojiSkinTone) -> some View {
+        let isSelected = suggestionSettings.preferredEmojiSkinTone == tone
+
+        Button {
+            suggestionSettings.setPreferredEmojiSkinTone(tone)
+        } label: {
+            ZStack(alignment: .bottomTrailing) {
+                Text(tone.sampleGlyph)
+                    .font(.system(size: 19))
+                    .frame(width: 34, height: 30)
+                    .background(
+                        RoundedRectangle(cornerRadius: 7, style: .continuous)
+                            .fill(isSelected ? Color.accentColor.opacity(0.16) : Color.primary.opacity(0.06))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 7, style: .continuous)
+                            .strokeBorder(
+                                isSelected ? Color.accentColor : Color.primary.opacity(0.16),
+                                lineWidth: isSelected ? 2 : 1
+                            )
+                    )
+
+                if isSelected {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(Color.accentColor)
+                        .background(Circle().fill(Color(nsColor: .controlBackgroundColor)))
+                        .offset(x: 3, y: 3)
+                }
+            }
+            .contentShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .help("\(tone.displayName) skin tone")
+        .accessibilityLabel("\(tone.displayName) skin tone")
+        .accessibilityValue(isSelected ? "Selected" : "")
+    }
+
+    @ViewBuilder
+    private func emojiGenderOption(for gender: EmojiGender) -> some View {
+        let isSelected = suggestionSettings.preferredEmojiGender == gender
+
+        Button {
+            suggestionSettings.setPreferredEmojiGender(gender)
+        } label: {
+            ZStack(alignment: .bottomTrailing) {
+                Text(gender.sampleGlyph)
+                    .font(.system(size: 19))
+                    .frame(width: 34, height: 30)
+                    .background(
+                        RoundedRectangle(cornerRadius: 7, style: .continuous)
+                            .fill(isSelected ? Color.accentColor.opacity(0.16) : Color.primary.opacity(0.06))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 7, style: .continuous)
+                            .strokeBorder(
+                                isSelected ? Color.accentColor : Color.primary.opacity(0.16),
+                                lineWidth: isSelected ? 2 : 1
+                            )
+                    )
+
+                if isSelected {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(Color.accentColor)
+                        .background(Circle().fill(Color(nsColor: .controlBackgroundColor)))
+                        .offset(x: 3, y: 3)
+                }
+            }
+            .contentShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .help("\(gender.displayName) variant")
+        .accessibilityLabel("\(gender.displayName) variant")
+        .accessibilityValue(isSelected ? "Selected" : "")
+    }
+}

--- a/Cotabby/UI/Settings/Panes/EngineAndModelPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/EngineAndModelPaneView.swift
@@ -34,7 +34,8 @@ struct EngineAndModelPaneView: View {
                         title: "Engine",
                         description: "Apple Intelligence runs on-device using macOS's built-in model " +
                             "(newer Apple Silicon Macs only). Open Source runs a model file you download " +
-                            "and pick below."
+                            "and pick below.",
+                        systemImage: "cpu"
                     )
                 }
                 .pickerStyle(.menu)
@@ -97,7 +98,8 @@ struct EngineAndModelPaneView: View {
                 SettingsRowLabel(
                     title: "Status",
                     description: "Whether the local model is loaded and ready to generate. " +
-                        "Loading takes a few seconds the first time."
+                        "Loading takes a few seconds the first time.",
+                    systemImage: "info.circle"
                 )
             }
         }
@@ -119,7 +121,8 @@ struct EngineAndModelPaneView: View {
                     SettingsRowLabel(
                         title: "Selected Model",
                         description: "Which downloaded model file generates suggestions. " +
-                            "Larger models are slower but write better."
+                            "Larger models are slower but write better.",
+                        systemImage: "shippingbox"
                     )
                 }
             }
@@ -162,7 +165,8 @@ struct EngineAndModelPaneView: View {
                     description: lmStudioModelsURL == nil
                         ? "Install LM Studio to load models from its library here."
                         : "Add models from your LM Studio library (~/.lmstudio/models) to the picker " +
-                            "above. Downloads still save to Cotabby's own folder."
+                            "above. Downloads still save to Cotabby's own folder.",
+                    systemImage: "square.stack.3d.up"
                 )
             }
             .disabled(lmStudioModelsURL == nil)

--- a/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
@@ -2,52 +2,22 @@ import LaunchAtLogin
 import SwiftUI
 
 /// File overview:
-/// "General" detail pane of the redesigned Settings window. Groups settings into four visually
-/// separated `Section`s (`.formStyle(.grouped)` renders each as its own rounded card, which is
-/// the macOS-native equivalent of a divider): top-level on/off toggles, behavior tuning, display
-/// surface, and appearance. The `Display` picker label here matches the same name used by the
-/// menu-bar quick control so users can connect the two.
+/// "General" detail pane: the top-level on/off switches and the core behavior toggles a user
+/// reaches for most. How suggestions look moved to the Appearance pane and the emoji feature to the
+/// Emoji pane, which keeps this pane short and scannable. Each row carries a leading SF Symbol via
+/// `SettingsRowLabel` so the list reads at a glance.
 struct GeneralPaneView: View {
     @ObservedObject var suggestionSettings: SuggestionSettingsModel
     let onShowWelcome: () -> Void
-    let clearEmojiHistory: () -> Void
-
-    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         SettingsPaneScaffold {
-            if let kofiURL = URL(string: "https://ko-fi.com/cotabby") {
-                Section {
-                    HStack(spacing: 12) {
-                        Text("Enjoying Cotabby? Please consider supporting free open-source software")
-                            .font(.subheadline)
-                            .foregroundStyle(.white)
-                            .lineLimit(1)
-                        Spacer(minLength: 0)
-                        Link(destination: kofiURL) {
-                            HStack(spacing: 5) {
-                                Image(systemName: "heart.fill")
-                                    .foregroundStyle(.pink)
-                                Text("Support")
-                                    .fontWeight(.semibold)
-                            }
-                            .font(.subheadline)
-                            .foregroundStyle(Color.blue)
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 6)
-                            .background(Color.white, in: Capsule())
-                        }
-                        .buttonStyle(.plain)
-                    }
-                    .listRowBackground(Color.blue)
-                }
-            }
-
             Section("Status") {
                 Toggle(isOn: globallyEnabledBinding) {
                     SettingsRowLabel(
                         title: "Enable Globally",
-                        description: "Turn Cotabby off everywhere without quitting the app."
+                        description: "Turn Cotabby off everywhere without quitting the app.",
+                        systemImage: "power"
                     )
                 }
 
@@ -55,7 +25,8 @@ struct GeneralPaneView: View {
                     SettingsRowLabel(
                         title: "Fast Mode",
                         description: "Skip the screenshot-based context step for faster suggestions. " +
-                            "Suggestions rely only on the text you've typed."
+                            "Suggestions rely only on the text you've typed.",
+                        systemImage: "bolt.fill"
                     )
                 }
 
@@ -65,7 +36,8 @@ struct GeneralPaneView: View {
                 LaunchAtLogin.Toggle {
                     SettingsRowLabel(
                         title: "Open at Login",
-                        description: "Start Cotabby automatically when you log in to your Mac."
+                        description: "Start Cotabby automatically when you log in to your Mac.",
+                        systemImage: "arrow.right.circle"
                     )
                 }
             }
@@ -74,14 +46,16 @@ struct GeneralPaneView: View {
                 Toggle(isOn: clipboardContextEnabledBinding) {
                     SettingsRowLabel(
                         title: "Include Clipboard Context",
-                        description: "Let suggestions reference whatever you most recently copied."
+                        description: "Let suggestions reference whatever you most recently copied.",
+                        systemImage: "doc.on.clipboard"
                     )
                 }
 
                 Toggle(isOn: multiLineEnabledBinding) {
                     SettingsRowLabel(
                         title: "Allow Multi-line Suggestions",
-                        description: "Allow continuations that span more than one line. Off keeps suggestions to a single line."
+                        description: "Allow continuations that span more than one line. Off keeps suggestions to a single line.",
+                        systemImage: "text.alignleft"
                     )
                 }
 
@@ -89,145 +63,40 @@ struct GeneralPaneView: View {
                     SettingsRowLabel(
                         title: "Accept Punctuation With Word",
                         description: "When you accept a word, also accept the punctuation that follows it " +
-                            "(commas, periods) so you don't have to type it."
+                            "(commas, periods) so you don't have to type it.",
+                        systemImage: "textformat.abc"
                     )
-                }
-
-                Toggle(isOn: emojiPickerEnabledBinding) {
-                    SettingsRowLabel(
-                        title: "Inline Emoji Picker",
-                        description: "Type a name like :smile to search inline, then press your accept-word " +
-                            "shortcut to insert the selected emoji."
-                    )
-                }
-            }
-
-            if suggestionSettings.isEmojiPickerEnabled {
-                Section("Emoji Suggestions") {
-                    LabeledContent {
-                        HStack(spacing: 8) {
-                            ForEach(EmojiSkinTone.allCases, id: \.self) { tone in
-                                skinToneOption(for: tone)
-                            }
-                        }
-                    } label: {
-                        SettingsRowLabel(
-                            title: "Skin Tone",
-                            description: "For non-default tones, suggestions show your selected tone first " +
-                                "and keep the default emoji next."
-                        )
-                    }
-
-                    LabeledContent {
-                        HStack(spacing: 8) {
-                            ForEach(EmojiGender.allCases, id: \.self) { gender in
-                                emojiGenderOption(for: gender)
-                            }
-                        }
-                    } label: {
-                        SettingsRowLabel(
-                            title: "People Emoji Style",
-                            description: "Choose person, man, or woman variants when an emoji offers them."
-                        )
-                    }
-
-                    LabeledContent {
-                        Button("Clear History") {
-                            clearEmojiHistory()
-                        }
-                    } label: {
-                        SettingsRowLabel(
-                            title: "Emoji History",
-                            description: "Forget recently and frequently used emoji so the picker ranks from scratch."
-                        )
-                    }
-                }
-            }
-
-            Section("Display") {
-                // The `.help()` tooltip was promoted to inline subtext so a novice can read the
-                // same guidance without knowing to hover.
-                Picker(selection: mirrorPreferenceBinding) {
-                    ForEach(MirrorPreference.allCases) { preference in
-                        Text(preference.displayLabel).tag(preference)
-                    }
-                } label: {
-                    SettingsRowLabel(
-                        title: "Suggestion Display",
-                        description: "Auto picks inline ghost text when the app's caret position is reliable, " +
-                            "and a popup card when it isn't. Inline or Popup pins one style for every app."
-                    )
-                }
-                .pickerStyle(.menu)
-
-                Toggle(isOn: showIndicatorBinding) {
-                    SettingsRowLabel(
-                        title: "Show Field Indicator",
-                        description: "Show a small icon at the edge of a field when Cotabby is ready to suggest."
-                    )
-                }
-
-                Toggle(isOn: menuBarWordCountVisibleBinding) {
-                    SettingsRowLabel(
-                        title: "Show Word Count in Menu Bar",
-                        description: "Show a running count of words you've accepted next to the menu bar icon."
-                    )
-                }
-
-                Toggle(isOn: showAcceptanceHintBinding) {
-                    VStack(alignment: .leading, spacing: 2) {
-                        HStack(spacing: 4) {
-                            Text("Show")
-                            Text(suggestionSettings.acceptanceKeyLabel)
-                                .font(.system(.body, design: .rounded).weight(.semibold))
-                                .padding(.horizontal, 5)
-                                .padding(.vertical, 1)
-                                .background(
-                                    RoundedRectangle(cornerRadius: 4, style: .continuous)
-                                        .fill(.quaternary)
-                                )
-                            Text("Key Hint")
-                        }
-                        Text("Show the accept-key badge next to the ghost text so you remember which key inserts it.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-                }
-            }
-
-            Section("Appearance") {
-                LabeledContent("Ghost Text Color") {
-                    HStack(spacing: 8) {
-                        ForEach(GhostTextColorPreset.all) { preset in
-                            ghostColorSwatch(for: preset)
-                        }
-                    }
-                }
-
-                LabeledContent("Ghost Text Opacity") {
-                    HStack(spacing: 10) {
-                        TickMarkSlider(
-                            value: ghostTextOpacityBinding,
-                            range: SuggestionSettingsModel.minimumGhostTextOpacity
-                                ... SuggestionSettingsModel.maximumGhostTextOpacity,
-                            step: SuggestionSettingsModel.ghostTextOpacityStep
-                        )
-                        .frame(width: 180)
-
-                        Text(ghostTextOpacityLabel)
-                            .font(.callout)
-                            .monospacedDigit()
-                            .foregroundStyle(.secondary)
-                            .frame(width: 42, alignment: .trailing)
-                    }
                 }
             }
 
             Section("Help") {
-                LabeledContent("Onboarding") {
+                LabeledContent {
                     Button("Open Welcome Guide") {
                         onShowWelcome()
+                    }
+                } label: {
+                    SettingsRowLabel(
+                        title: "Onboarding",
+                        description: "Replay the first-run setup walkthrough.",
+                        systemImage: "graduationcap"
+                    )
+                }
+            }
+
+            // Support lives as a slim row at the bottom rather than a saturated banner pinned above
+            // the user's own settings. The About pane carries the fuller support pitch.
+            if let kofiURL = URL(string: "https://ko-fi.com/cotabby") {
+                Section {
+                    LabeledContent {
+                        Link(destination: kofiURL) {
+                            Label("Support", systemImage: "heart.fill")
+                        }
+                    } label: {
+                        SettingsRowLabel(
+                            title: "Support Cotabby",
+                            description: "Cotabby is free and open source. Tips help fund development.",
+                            systemImage: "heart"
+                        )
                     }
                 }
             }
@@ -240,48 +109,6 @@ struct GeneralPaneView: View {
         Binding(
             get: { suggestionSettings.isGloballyEnabled },
             set: { suggestionSettings.setGloballyEnabled($0) }
-        )
-    }
-
-    private var showIndicatorBinding: Binding<Bool> {
-        Binding(
-            get: { suggestionSettings.showIndicator },
-            set: { suggestionSettings.setShowIndicator($0) }
-        )
-    }
-
-    private var showAcceptanceHintBinding: Binding<Bool> {
-        Binding(
-            get: { suggestionSettings.showAcceptanceHint },
-            set: { suggestionSettings.setShowAcceptanceHint($0) }
-        )
-    }
-
-    private var mirrorPreferenceBinding: Binding<MirrorPreference> {
-        Binding(
-            get: { suggestionSettings.mirrorPreference },
-            set: { suggestionSettings.setMirrorPreference($0) }
-        )
-    }
-
-    private var multiLineEnabledBinding: Binding<Bool> {
-        Binding(
-            get: { suggestionSettings.isMultiLineEnabled },
-            set: { suggestionSettings.setMultiLineEnabled($0) }
-        )
-    }
-
-    private var emojiPickerEnabledBinding: Binding<Bool> {
-        Binding(
-            get: { suggestionSettings.isEmojiPickerEnabled },
-            set: { suggestionSettings.setEmojiPickerEnabled($0) }
-        )
-    }
-
-    private var autoAcceptTrailingPunctuationBinding: Binding<Bool> {
-        Binding(
-            get: { suggestionSettings.autoAcceptTrailingPunctuation },
-            set: { suggestionSettings.setAutoAcceptTrailingPunctuation($0) }
         )
     }
 
@@ -299,142 +126,17 @@ struct GeneralPaneView: View {
         )
     }
 
-    private var menuBarWordCountVisibleBinding: Binding<Bool> {
+    private var multiLineEnabledBinding: Binding<Bool> {
         Binding(
-            get: { suggestionSettings.isMenuBarWordCountVisible },
-            set: { suggestionSettings.setMenuBarWordCountVisible($0) }
+            get: { suggestionSettings.isMultiLineEnabled },
+            set: { suggestionSettings.setMultiLineEnabled($0) }
         )
     }
 
-    private var ghostTextOpacityBinding: Binding<Double> {
+    private var autoAcceptTrailingPunctuationBinding: Binding<Bool> {
         Binding(
-            get: { suggestionSettings.ghostTextOpacity },
-            set: { suggestionSettings.setGhostTextOpacity($0) }
+            get: { suggestionSettings.autoAcceptTrailingPunctuation },
+            set: { suggestionSettings.setAutoAcceptTrailingPunctuation($0) }
         )
-    }
-
-    // MARK: - Ghost color swatch helpers
-
-    /// Mirrors the overlay's automatic fallback (`GhostSuggestionView.ghostColor`) so the Automatic
-    /// swatch previews the same gray the user will actually see.
-    private var automaticGhostTextColor: Color {
-        colorScheme == .dark
-            ? Color(red: 0.65, green: 0.65, blue: 0.65)
-            : Color(red: 0.45, green: 0.45, blue: 0.45)
-    }
-
-    private var ghostTextOpacityLabel: String {
-        "\(Int((suggestionSettings.ghostTextOpacity * 100).rounded()))%"
-    }
-
-    @ViewBuilder
-    private func ghostColorSwatch(for preset: GhostTextColorPreset) -> some View {
-        let isSelected = GhostTextColorPreset.matching(
-            hex: suggestionSettings.customSuggestionTextColorHex
-        ) == preset
-
-        Button {
-            suggestionSettings.setCustomSuggestionTextColorHex(preset.hex)
-        } label: {
-            Circle()
-                .fill(swatchFill(for: preset))
-                .frame(width: 18, height: 18)
-                .overlay(
-                    Circle()
-                        .strokeBorder(
-                            Color.primary.opacity(isSelected ? 0.9 : 0.18),
-                            lineWidth: isSelected ? 2 : 1
-                        )
-                )
-        }
-        .buttonStyle(.plain)
-    }
-
-    @ViewBuilder
-    private func skinToneOption(for tone: EmojiSkinTone) -> some View {
-        let isSelected = suggestionSettings.preferredEmojiSkinTone == tone
-
-        Button {
-            suggestionSettings.setPreferredEmojiSkinTone(tone)
-        } label: {
-            ZStack(alignment: .bottomTrailing) {
-                Text(tone.sampleGlyph)
-                    .font(.system(size: 19))
-                    .frame(width: 34, height: 30)
-                    .background(
-                        RoundedRectangle(cornerRadius: 7, style: .continuous)
-                            .fill(isSelected ? Color.accentColor.opacity(0.16) : Color.primary.opacity(0.06))
-                    )
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 7, style: .continuous)
-                            .strokeBorder(
-                                isSelected ? Color.accentColor : Color.primary.opacity(0.16),
-                                lineWidth: isSelected ? 2 : 1
-                            )
-                    )
-
-                if isSelected {
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(.system(size: 10, weight: .semibold))
-                        .foregroundStyle(Color.accentColor)
-                        .background(Circle().fill(Color(nsColor: .controlBackgroundColor)))
-                        .offset(x: 3, y: 3)
-                }
-            }
-            .contentShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
-        }
-        .buttonStyle(.plain)
-        .help("\(tone.displayName) skin tone")
-        .accessibilityLabel("\(tone.displayName) skin tone")
-        .accessibilityValue(isSelected ? "Selected" : "")
-    }
-
-    @ViewBuilder
-    private func emojiGenderOption(for gender: EmojiGender) -> some View {
-        let isSelected = suggestionSettings.preferredEmojiGender == gender
-
-        Button {
-            suggestionSettings.setPreferredEmojiGender(gender)
-        } label: {
-            ZStack(alignment: .bottomTrailing) {
-                Text(gender.sampleGlyph)
-                    .font(.system(size: 19))
-                    .frame(width: 34, height: 30)
-                    .background(
-                        RoundedRectangle(cornerRadius: 7, style: .continuous)
-                            .fill(isSelected ? Color.accentColor.opacity(0.16) : Color.primary.opacity(0.06))
-                    )
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 7, style: .continuous)
-                            .strokeBorder(
-                                isSelected ? Color.accentColor : Color.primary.opacity(0.16),
-                                lineWidth: isSelected ? 2 : 1
-                            )
-                    )
-
-                if isSelected {
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(.system(size: 10, weight: .semibold))
-                        .foregroundStyle(Color.accentColor)
-                        .background(Circle().fill(Color(nsColor: .controlBackgroundColor)))
-                        .offset(x: 3, y: 3)
-                }
-            }
-            .contentShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
-        }
-        .buttonStyle(.plain)
-        .help("\(gender.displayName) variant")
-        .accessibilityLabel("\(gender.displayName) variant")
-        .accessibilityValue(isSelected ? "Selected" : "")
-    }
-
-    private func swatchFill(for preset: GhostTextColorPreset) -> Color {
-        guard let hex = preset.hex,
-              let color = SuggestionTextColorCodec.color(fromHex: hex)
-        else {
-            return automaticGhostTextColor
-        }
-
-        return color
     }
 }

--- a/Cotabby/UI/Settings/Panes/PerformancePaneView.swift
+++ b/Cotabby/UI/Settings/Panes/PerformancePaneView.swift
@@ -18,12 +18,15 @@ struct PerformancePaneView: View {
             liveResourceSection
 
             Section("Tracking") {
-                Toggle("Enable Performance Tracking", isOn: trackingEnabledBinding)
-                    .help(
-                        "When enabled, Cotabby records the timestamp, model, and elapsed time " +
-                        "of every LLM request. Only the most recent " +
-                        "\(PerformanceMetricsStore.maximumEntries) requests are retained."
+                Toggle(isOn: trackingEnabledBinding) {
+                    SettingsRowLabel(
+                        title: "Enable Performance Tracking",
+                        description: "Record the timestamp, model, and elapsed time of every LLM " +
+                            "request. Only the most recent " +
+                            "\(PerformanceMetricsStore.maximumEntries) requests are retained.",
+                        systemImage: "stopwatch"
                     )
+                }
             }
 
             Section {

--- a/Cotabby/UI/Settings/Panes/PermissionsPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/PermissionsPaneView.swift
@@ -19,6 +19,7 @@ struct PermissionsPaneView: View {
                     title: "Accessibility",
                     description: "Lets Cotabby see which text field has focus and read its contents " +
                         "so it knows what to continue.",
+                    systemImage: "accessibility",
                     granted: permissionManager.accessibilityGranted,
                     action: permissionManager.openAccessibilitySettings
                 )
@@ -27,6 +28,7 @@ struct PermissionsPaneView: View {
                     title: "Input Monitoring",
                     description: "Lets Cotabby see your keystrokes so it can detect when to suggest " +
                         "and which key you used to accept.",
+                    systemImage: "keyboard",
                     granted: permissionManager.inputMonitoringGranted,
                     action: permissionManager.openInputMonitoringSettings
                 )
@@ -35,6 +37,7 @@ struct PermissionsPaneView: View {
                     title: "Screen Recording",
                     description: "Lets Cotabby take a screenshot of the focused window to use as " +
                         "additional context. Required even when Fast Mode skips capture.",
+                    systemImage: "camera.viewfinder",
                     granted: permissionManager.screenRecordingGranted,
                     action: permissionManager.openScreenRecordingSettings
                 )
@@ -67,11 +70,12 @@ struct PermissionsPaneView: View {
     private func permissionRow(
         title: String,
         description: String,
+        systemImage: String,
         granted: Bool,
         action: @escaping () -> Void
     ) -> some View {
         HStack(spacing: 10) {
-            SettingsRowLabel(title: title, description: description)
+            SettingsRowLabel(title: title, description: description, systemImage: systemImage)
             Spacer(minLength: 0)
             Text(granted ? "Granted" : "Needs Access")
                 .font(.caption.weight(.medium))

--- a/Cotabby/UI/Settings/Panes/ShortcutsPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/ShortcutsPaneView.swift
@@ -51,7 +51,8 @@ struct ShortcutsPaneView: View {
                 } label: {
                     SettingsRowLabel(
                         title: "Accept Word",
-                        description: "Insert the next word of the suggestion."
+                        description: "Insert the next word of the suggestion.",
+                        systemImage: "arrow.right.to.line"
                     )
                 }
 
@@ -89,7 +90,8 @@ struct ShortcutsPaneView: View {
                 } label: {
                     SettingsRowLabel(
                         title: "Accept Entire Suggestion",
-                        description: "Insert the whole remaining suggestion in one keystroke."
+                        description: "Insert the whole remaining suggestion in one keystroke.",
+                        systemImage: "text.insert"
                     )
                 }
 
@@ -124,7 +126,8 @@ struct ShortcutsPaneView: View {
                 } label: {
                     SettingsRowLabel(
                         title: "Toggle Tabby",
-                        description: "Turn Cotabby on or off globally without opening the menu bar."
+                        description: "Turn Cotabby on or off globally without opening the menu bar.",
+                        systemImage: "power.circle"
                     )
                 }
             }

--- a/Cotabby/UI/Settings/Panes/WritingPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/WritingPaneView.swift
@@ -19,7 +19,8 @@ struct WritingPaneView: View {
                     SettingsRowLabel(
                         title: "Length",
                         description: "How many words Cotabby aims for per suggestion. Shorter is snappier; " +
-                            "longer covers more thoughts but takes longer to generate."
+                            "longer covers more thoughts but takes longer to generate.",
+                        systemImage: "ruler"
                     )
                 }
 

--- a/Cotabby/UI/Settings/SettingsCategory.swift
+++ b/Cotabby/UI/Settings/SettingsCategory.swift
@@ -1,16 +1,21 @@
 import Foundation
 
 /// File overview:
-/// The catalog of sidebar rows in the redesigned Settings window. The sidebar is intentionally a
-/// flat list with no section headers — System Settings-style grouping was tried earlier but the
-/// extra header chrome ate sidebar width and pushed labels into truncation. Engine-specific
-/// content (Apple Intelligence vs. Open Source) lives inside the single Engine & Model pane and
-/// is switched via the engine dropdown at the top of that pane.
+/// The catalog of sidebar rows in the Settings window. The sidebar is intentionally a flat list
+/// with no section headers: System Settings-style grouping was tried earlier but the extra header
+/// chrome ate sidebar width and pushed labels into truncation. Engine-specific content (Apple
+/// Intelligence vs. Open Source) lives inside the single Engine & Model pane and is switched via the
+/// engine dropdown at the top of that pane.
+///
+/// Order reflects a top-down reading: core behavior, how suggestions look, the emoji feature, what
+/// the model is told (writing then context), the model itself, input bindings, then system and info.
 enum SettingsCategory: String, CaseIterable, Hashable, Identifiable {
     case general
-    case engineAndModel
+    case appearance
+    case emoji
     case writing
-    case advanced
+    case context
+    case engineAndModel
     case shortcuts
     case apps
     case permissions
@@ -22,9 +27,11 @@ enum SettingsCategory: String, CaseIterable, Hashable, Identifiable {
     var label: String {
         switch self {
         case .general: return "General"
-        case .engineAndModel: return "Engine & Model"
+        case .appearance: return "Appearance"
+        case .emoji: return "Emoji"
         case .writing: return "Writing"
-        case .advanced: return "Advanced"
+        case .context: return "Context"
+        case .engineAndModel: return "Engine & Model"
         case .shortcuts: return "Shortcuts"
         case .apps: return "Apps"
         case .permissions: return "Permissions"
@@ -37,9 +44,11 @@ enum SettingsCategory: String, CaseIterable, Hashable, Identifiable {
     var systemImage: String {
         switch self {
         case .general: return "gearshape.fill"
-        case .engineAndModel: return "cpu.fill"
+        case .appearance: return "paintbrush.fill"
+        case .emoji: return "face.smiling"
         case .writing: return "square.and.pencil"
-        case .advanced: return "slider.horizontal.3"
+        case .context: return "doc.text"
+        case .engineAndModel: return "cpu.fill"
         case .shortcuts: return "keyboard.fill"
         case .apps: return "app.badge.fill"
         case .permissions: return "lock.shield.fill"

--- a/Cotabby/UI/Settings/SettingsContainerView.swift
+++ b/Cotabby/UI/Settings/SettingsContainerView.swift
@@ -22,7 +22,7 @@ struct SettingsContainerView: View {
     @ObservedObject var performanceMetricsStore: PerformanceMetricsStore
     @ObservedObject var systemMetricsStore: SystemMetricsStore
 
-    /// Live router used by the Advanced pane's "try it" playground so users can see the effect of
+    /// Live router used by the Context pane's "try it" playground so users can see the effect of
     /// Extended Context (and other prompt inputs) without leaving Settings. Threaded through the
     /// container rather than constructed locally so the playground reuses the same router the
     /// autocomplete pipeline uses.
@@ -98,7 +98,13 @@ struct SettingsContainerView: View {
         case .general:
             GeneralPaneView(
                 suggestionSettings: suggestionSettings,
-                onShowWelcome: onShowWelcome,
+                onShowWelcome: onShowWelcome
+            )
+        case .appearance:
+            AppearancePaneView(suggestionSettings: suggestionSettings)
+        case .emoji:
+            EmojiPaneView(
+                suggestionSettings: suggestionSettings,
                 clearEmojiHistory: clearEmojiHistory
             )
         case .engineAndModel:
@@ -111,8 +117,8 @@ struct SettingsContainerView: View {
             )
         case .writing:
             WritingPaneView(suggestionSettings: suggestionSettings)
-        case .advanced:
-            AdvancedPaneView(
+        case .context:
+            ContextPaneView(
                 suggestionSettings: suggestionSettings,
                 suggestionEngine: suggestionEngine,
                 configuration: configuration
@@ -141,6 +147,10 @@ struct SettingsContainerView: View {
         // Legacy sub-row raw values from the prior nested layout.
         if rawValue == "appleIntelligence" || rawValue == "openSource" {
             return .engineAndModel
+        }
+        // The Advanced pane was renamed to Context; keep returning users on the same pane.
+        if rawValue == "advanced" {
+            return .context
         }
         return .general
     }

--- a/Cotabby/UI/Settings/SettingsIndex.swift
+++ b/Cotabby/UI/Settings/SettingsIndex.swift
@@ -1,0 +1,240 @@
+import Foundation
+
+/// File overview:
+/// A searchable index of individual settings that powers the Settings search field. Each item knows
+/// its display title, the pane (`SettingsCategory`) that hosts it, an SF Symbol, and extra keywords
+/// so a query like "dark", "tab", or "startup" lands on the right pane.
+///
+/// This is a navigational map, not the rendering source: panes still own their own rows and labels.
+/// Keeping the index here means search coverage is reviewed in one place and a new setting is one
+/// case away from being findable.
+enum SettingsItem: String, CaseIterable, Identifiable {
+    // General
+    case enableGlobally
+    case fastMode
+    case openAtLogin
+    case includeClipboardContext
+    case allowMultiLine
+    case acceptPunctuation
+    case onboarding
+    // Appearance
+    case suggestionDisplay
+    case showFieldIndicator
+    case showWordCount
+    case showKeyHint
+    case ghostTextColor
+    case ghostTextOpacity
+    // Emoji
+    case emojiPicker
+    case emojiSkinTone
+    case emojiPeopleStyle
+    case emojiHistory
+    // Writing
+    case length
+    case name
+    case languages
+    // Context
+    case extendedContext
+    case contextPlayground
+    // Engine & Model
+    case engine
+    case selectedModel
+    case modelsFolder
+    case lmStudio
+    // Shortcuts
+    case acceptanceMode
+    case acceptWord
+    case acceptEntireSuggestion
+    case toggleTabby
+    // Apps
+    case disabledApps
+    // Permissions
+    case accessibility
+    case inputMonitoring
+    case screenRecording
+    // Performance
+    case performanceTracking
+    case resourceUsage
+    // About
+    case checkForUpdates
+    case support
+    case acknowledgements
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .enableGlobally: return "Enable Globally"
+        case .fastMode: return "Fast Mode"
+        case .openAtLogin: return "Open at Login"
+        case .includeClipboardContext: return "Include Clipboard Context"
+        case .allowMultiLine: return "Allow Multi-line Suggestions"
+        case .acceptPunctuation: return "Accept Punctuation With Word"
+        case .onboarding: return "Onboarding"
+        case .suggestionDisplay: return "Suggestion Display"
+        case .showFieldIndicator: return "Show Field Indicator"
+        case .showWordCount: return "Show Word Count in Menu Bar"
+        case .showKeyHint: return "Show Accept-Key Hint"
+        case .ghostTextColor: return "Ghost Text Color"
+        case .ghostTextOpacity: return "Ghost Text Opacity"
+        case .emojiPicker: return "Inline Emoji Picker"
+        case .emojiSkinTone: return "Skin Tone"
+        case .emojiPeopleStyle: return "People Emoji Style"
+        case .emojiHistory: return "Emoji History"
+        case .length: return "Length"
+        case .name: return "Name"
+        case .languages: return "Languages"
+        case .extendedContext: return "Extended Context"
+        case .contextPlayground: return "Try It"
+        case .engine: return "Engine"
+        case .selectedModel: return "Selected Model"
+        case .modelsFolder: return "Models Folder"
+        case .lmStudio: return "LM Studio Models"
+        case .acceptanceMode: return "Acceptance Mode"
+        case .acceptWord: return "Accept Word"
+        case .acceptEntireSuggestion: return "Accept Entire Suggestion"
+        case .toggleTabby: return "Toggle Tabby"
+        case .disabledApps: return "Disabled Apps"
+        case .accessibility: return "Accessibility"
+        case .inputMonitoring: return "Input Monitoring"
+        case .screenRecording: return "Screen Recording"
+        case .performanceTracking: return "Performance Tracking"
+        case .resourceUsage: return "Live Resource Usage"
+        case .checkForUpdates: return "Check for Updates"
+        case .support: return "Support Cotabby"
+        case .acknowledgements: return "Acknowledgements"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .enableGlobally: return "power"
+        case .fastMode: return "bolt.fill"
+        case .openAtLogin: return "arrow.right.circle"
+        case .includeClipboardContext: return "doc.on.clipboard"
+        case .allowMultiLine: return "text.alignleft"
+        case .acceptPunctuation: return "textformat.abc"
+        case .onboarding: return "graduationcap"
+        case .suggestionDisplay: return "text.cursor"
+        case .showFieldIndicator: return "dot.viewfinder"
+        case .showWordCount: return "number"
+        case .showKeyHint: return "keyboard"
+        case .ghostTextColor: return "paintpalette"
+        case .ghostTextOpacity: return "circle.lefthalf.filled"
+        case .emojiPicker: return "face.smiling"
+        case .emojiSkinTone: return "hand.raised.fingers.spread"
+        case .emojiPeopleStyle: return "person.2"
+        case .emojiHistory: return "clock.arrow.circlepath"
+        case .length: return "ruler"
+        case .name: return "person"
+        case .languages: return "globe"
+        case .extendedContext: return "doc.text"
+        case .contextPlayground: return "play.circle"
+        case .engine: return "cpu"
+        case .selectedModel: return "shippingbox"
+        case .modelsFolder: return "folder"
+        case .lmStudio: return "square.stack.3d.up"
+        case .acceptanceMode: return "textformat.abc"
+        case .acceptWord: return "arrow.right.to.line"
+        case .acceptEntireSuggestion: return "text.insert"
+        case .toggleTabby: return "power.circle"
+        case .disabledApps: return "nosign"
+        case .accessibility: return "accessibility"
+        case .inputMonitoring: return "keyboard"
+        case .screenRecording: return "camera.viewfinder"
+        case .performanceTracking: return "stopwatch"
+        case .resourceUsage: return "chart.line.uptrend.xyaxis"
+        case .checkForUpdates: return "arrow.triangle.2.circlepath"
+        case .support: return "heart.fill"
+        case .acknowledgements: return "doc.text"
+        }
+    }
+
+    var category: SettingsCategory {
+        switch self {
+        case .enableGlobally, .fastMode, .openAtLogin, .includeClipboardContext,
+             .allowMultiLine, .acceptPunctuation, .onboarding:
+            return .general
+        case .suggestionDisplay, .showFieldIndicator, .showWordCount, .showKeyHint,
+             .ghostTextColor, .ghostTextOpacity:
+            return .appearance
+        case .emojiPicker, .emojiSkinTone, .emojiPeopleStyle, .emojiHistory:
+            return .emoji
+        case .length, .name, .languages:
+            return .writing
+        case .extendedContext, .contextPlayground:
+            return .context
+        case .engine, .selectedModel, .modelsFolder, .lmStudio:
+            return .engineAndModel
+        case .acceptanceMode, .acceptWord, .acceptEntireSuggestion, .toggleTabby:
+            return .shortcuts
+        case .disabledApps:
+            return .apps
+        case .accessibility, .inputMonitoring, .screenRecording:
+            return .permissions
+        case .performanceTracking, .resourceUsage:
+            return .performance
+        case .checkForUpdates, .support, .acknowledgements:
+            return .about
+        }
+    }
+
+    /// Extra terms a user might type that are not in the title, so search still finds the row.
+    var keywords: [String] {
+        switch self {
+        case .enableGlobally: return ["on", "off", "disable", "toggle", "global", "pause"]
+        case .fastMode: return ["speed", "fast", "screenshot", "ocr", "context"]
+        case .openAtLogin: return ["startup", "launch", "boot", "login", "start"]
+        case .includeClipboardContext: return ["clipboard", "paste", "copy"]
+        case .allowMultiLine: return ["multiline", "line", "newline", "wrap"]
+        case .acceptPunctuation: return ["punctuation", "comma", "period", "accept"]
+        case .onboarding: return ["welcome", "guide", "tutorial", "intro"]
+        case .suggestionDisplay: return ["inline", "popup", "ghost", "card", "display", "mirror"]
+        case .showFieldIndicator: return ["indicator", "icon", "field", "ready"]
+        case .showWordCount: return ["word count", "menu bar", "stats", "counter"]
+        case .showKeyHint: return ["hint", "badge", "keycap", "accept key"]
+        case .ghostTextColor: return ["color", "ghost", "theme", "dark", "light"]
+        case .ghostTextOpacity: return ["opacity", "transparency", "fade", "alpha"]
+        case .emojiPicker: return ["emoji", "smile", "picker", "inline", "colon"]
+        case .emojiSkinTone: return ["skin", "tone", "color"]
+        case .emojiPeopleStyle: return ["gender", "person", "man", "woman", "people"]
+        case .emojiHistory: return ["history", "recent", "clear", "reset"]
+        case .length: return ["length", "words", "short", "long", "count", "verbose"]
+        case .name: return ["name", "persona", "profile", "you"]
+        case .languages: return ["language", "locale", "translate", "multilingual"]
+        case .extendedContext: return ["context", "glossary", "reference", "notes", "jargon"]
+        case .contextPlayground: return ["test", "playground", "try", "preview"]
+        case .engine: return ["engine", "apple intelligence", "open source", "llama", "backend"]
+        case .selectedModel: return ["model", "gguf", "pick", "selected"]
+        case .modelsFolder: return ["folder", "path", "directory", "models"]
+        case .lmStudio: return ["lm studio", "lmstudio", "import", "library"]
+        case .acceptanceMode: return ["acceptance", "word", "phrase", "mode"]
+        case .acceptWord: return ["accept", "word", "tab", "key", "shortcut"]
+        case .acceptEntireSuggestion: return ["accept all", "entire", "full", "shortcut"]
+        case .toggleTabby: return ["toggle", "global", "on off", "shortcut", "hotkey"]
+        case .disabledApps: return ["apps", "disable", "exclude", "block", "ignore"]
+        case .accessibility: return ["accessibility", "ax", "permission", "access"]
+        case .inputMonitoring: return ["input", "monitoring", "keystrokes", "permission"]
+        case .screenRecording: return ["screen", "recording", "screenshot", "permission", "ocr"]
+        case .performanceTracking: return ["performance", "tracking", "latency", "metrics"]
+        case .resourceUsage: return ["cpu", "memory", "ram", "usage", "resource"]
+        case .checkForUpdates: return ["update", "version", "upgrade", "sparkle"]
+        case .support: return ["donate", "support", "ko-fi", "kofi", "tip"]
+        case .acknowledgements: return ["licenses", "credits", "open source", "acknowledgements"]
+        }
+    }
+
+    func matches(_ query: String) -> Bool {
+        let needle = query.lowercased()
+        if title.lowercased().contains(needle) { return true }
+        if category.label.lowercased().contains(needle) { return true }
+        return keywords.contains { $0.lowercased().contains(needle) }
+    }
+
+    /// Items whose title or keywords match the query, in declaration order. Empty for a blank query.
+    static func results(for query: String) -> [SettingsItem] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+        return allCases.filter { $0.matches(trimmed) }
+    }
+}

--- a/Cotabby/UI/Settings/SettingsSidebarView.swift
+++ b/Cotabby/UI/Settings/SettingsSidebarView.swift
@@ -65,8 +65,10 @@ struct SettingsSidebarView: View {
         .padding(.vertical, 6)
         .background(.quaternary, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
         .padding(.horizontal, 10)
-        .padding(.top, 16)
-        .padding(.bottom, 8)
+        // Generous space above so the field sits well clear of the title bar, and only a small gap
+        // below so it reads as the head of the same group as the category rows beneath it.
+        .padding(.top, 28)
+        .padding(.bottom, 4)
     }
 
     private var categoryList: some View {

--- a/Cotabby/UI/Settings/SettingsSidebarView.swift
+++ b/Cotabby/UI/Settings/SettingsSidebarView.swift
@@ -1,18 +1,44 @@
 import SwiftUI
 
 /// File overview:
-/// Renders the sidebar list of the redesigned Settings window as a flat list of rows.
-/// `attentionCategories` is the set returned by `SettingsAttentionEvaluator` and decides which
-/// rows show a small orange attention dot at the trailing edge.
+/// Sidebar of the Settings window. With no search query it shows the flat list of category rows,
+/// each with an optional attention dot. With a query it shows the individual settings that match,
+/// grouped by their owning pane; selecting a result navigates to that pane and clears the search.
 ///
 /// Why this lives in its own file:
-/// keeping row ordering and attention rendering out of the container leaves the container as a
-/// small `NavigationSplitView` shell that is easy to skim.
+/// keeping row ordering, search, and attention rendering out of the container leaves the container
+/// as a small `NavigationSplitView` shell that is easy to skim. The search index itself lives in
+/// `SettingsItem` so coverage is maintained in one place.
 struct SettingsSidebarView: View {
     @Binding var selection: SettingsCategory
     let attentionCategories: Set<SettingsCategory>
 
+    @State private var searchText = ""
+
     var body: some View {
+        Group {
+            if trimmedQuery.isEmpty {
+                categoryList
+            } else {
+                searchResultsList
+            }
+        }
+        .searchable(text: $searchText, placement: .sidebar, prompt: "Search settings")
+        // `.navigationSplitViewColumnWidth` is only a hint — AppKit's underlying split view ignores
+        // it when the window is at or near its minimum, which is what truncated labels like
+        // "Engine &..." and "Permissio..." in the small-window screenshots. A direct `.frame()` is a
+        // real SwiftUI layout constraint, so the split view has to give the sidebar at least the
+        // minWidth. Keep the column-width hint as a paired ideal so a fresh window opens at the
+        // right size before the user resizes.
+        .frame(minWidth: 300, idealWidth: 340)
+        .navigationSplitViewColumnWidth(min: 300, ideal: 340, max: 420)
+    }
+
+    private var trimmedQuery: String {
+        searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var categoryList: some View {
         List(selection: $selection) {
             ForEach(SettingsCategory.allCases) { row(for: $0) }
         }
@@ -25,14 +51,40 @@ struct SettingsSidebarView: View {
         .safeAreaInset(edge: .top, spacing: 0) {
             Color.clear.frame(height: 12)
         }
-        // `.navigationSplitViewColumnWidth` is only a hint — AppKit's underlying split view ignores
-        // it when the window is at or near its minimum, which is what truncated labels like
-        // "Engine &..." and "Permissio..." in the small-window screenshots. A direct `.frame()` is a
-        // real SwiftUI layout constraint, so the split view has to give the sidebar at least the
-        // minWidth. Keep the column-width hint as a paired ideal so a fresh window opens at the
-        // right size before the user resizes.
-        .frame(minWidth: 300, idealWidth: 340)
-        .navigationSplitViewColumnWidth(min: 300, ideal: 340, max: 420)
+    }
+
+    private var searchResultsList: some View {
+        let groups = groupedResults(SettingsItem.results(for: trimmedQuery))
+        return List {
+            if groups.isEmpty {
+                Text("No settings match \u{201C}\(trimmedQuery)\u{201D}")
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(groups) { group in
+                    Section(group.category.label) {
+                        ForEach(group.items) { item in
+                            Button {
+                                selection = item.category
+                                searchText = ""
+                            } label: {
+                                Label(item.title, systemImage: item.systemImage)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .contentShape(Rectangle())
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                }
+            }
+        }
+        .listStyle(.sidebar)
+    }
+
+    private func groupedResults(_ items: [SettingsItem]) -> [SettingsSearchGroup] {
+        SettingsCategory.allCases.compactMap { category in
+            let matching = items.filter { $0.category == category }
+            return matching.isEmpty ? nil : SettingsSearchGroup(category: category, items: matching)
+        }
     }
 
     @ViewBuilder
@@ -49,4 +101,13 @@ struct SettingsSidebarView: View {
         }
         .tag(category)
     }
+}
+
+/// One pane's worth of search results. Identified by its category so the grouped result list has a
+/// stable identity for `ForEach`.
+private struct SettingsSearchGroup: Identifiable {
+    let category: SettingsCategory
+    let items: [SettingsItem]
+
+    var id: SettingsCategory { category }
 }

--- a/Cotabby/UI/Settings/SettingsSidebarView.swift
+++ b/Cotabby/UI/Settings/SettingsSidebarView.swift
@@ -1,14 +1,15 @@
 import SwiftUI
 
 /// File overview:
-/// Sidebar of the Settings window. With no search query it shows the flat list of category rows,
-/// each with an optional attention dot. With a query it shows the individual settings that match,
-/// grouped by their owning pane; selecting a result navigates to that pane and clears the search.
+/// Sidebar of the Settings window. A search field sits at the top with breathing room above it,
+/// then the content: with no query the flat list of category rows (each with an optional attention
+/// dot); with a query the individual settings that match, grouped by their owning pane. Selecting a
+/// result navigates to that pane and clears the search.
 ///
-/// Why this lives in its own file:
-/// keeping row ordering, search, and attention rendering out of the container leaves the container
-/// as a small `NavigationSplitView` shell that is easy to skim. The search index itself lives in
-/// `SettingsItem` so coverage is maintained in one place.
+/// Why a hand-rolled search field instead of `.searchable`:
+/// `.searchable(placement: .sidebar)` pins its field flush to the top of the column with no way to
+/// add padding above it, so it collides with the title bar. A plain field gives full control over
+/// the top inset while keeping the same look. The search index itself lives in `SettingsItem`.
 struct SettingsSidebarView: View {
     @Binding var selection: SettingsCategory
     let attentionCategories: Set<SettingsCategory>
@@ -16,20 +17,20 @@ struct SettingsSidebarView: View {
     @State private var searchText = ""
 
     var body: some View {
-        Group {
+        VStack(spacing: 0) {
+            searchField
+
             if trimmedQuery.isEmpty {
                 categoryList
             } else {
                 searchResultsList
             }
         }
-        .searchable(text: $searchText, placement: .sidebar, prompt: "Search settings")
         // `.navigationSplitViewColumnWidth` is only a hint — AppKit's underlying split view ignores
-        // it when the window is at or near its minimum, which is what truncated labels like
-        // "Engine &..." and "Permissio..." in the small-window screenshots. A direct `.frame()` is a
-        // real SwiftUI layout constraint, so the split view has to give the sidebar at least the
-        // minWidth. Keep the column-width hint as a paired ideal so a fresh window opens at the
-        // right size before the user resizes.
+        // it when the window is at or near its minimum, which truncated labels like "Engine &..." and
+        // "Permissio..." in earlier small-window screenshots. A direct `.frame()` is a real SwiftUI
+        // layout constraint, so the split view has to give the sidebar at least the minWidth. Keep
+        // the column-width hint as a paired ideal so a fresh window opens at the right size.
         .frame(minWidth: 300, idealWidth: 340)
         .navigationSplitViewColumnWidth(min: 300, ideal: 340, max: 420)
     }
@@ -38,19 +39,41 @@ struct SettingsSidebarView: View {
         searchText.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    /// Search field with deliberate top padding so it clears the title bar instead of butting
+    /// against it.
+    private var searchField: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+
+            TextField("Search settings", text: $searchText)
+                .textFieldStyle(.plain)
+
+            if !trimmedQuery.isEmpty {
+                Button {
+                    searchText = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear search")
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .background(.quaternary, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .padding(.horizontal, 10)
+        .padding(.top, 16)
+        .padding(.bottom, 8)
+    }
+
     private var categoryList: some View {
         List(selection: $selection) {
             ForEach(SettingsCategory.allCases) { row(for: $0) }
         }
         .listStyle(.sidebar)
-        // Restores the breathing room the previous clear-color top spacer used to provide. Without
-        // it, the first sidebar row snaps to the toolbar baseline while the detail pane's grouped
-        // `Form` keeps its own top inset, so the two columns visually disagree about where content
-        // begins. Insetting from the safe area keeps the inset out of scroll content so it never
-        // overlaps a row mid-scroll.
-        .safeAreaInset(edge: .top, spacing: 0) {
-            Color.clear.frame(height: 12)
-        }
     }
 
     private var searchResultsList: some View {


### PR DESCRIPTION
## Summary

Reworks the Settings window for clarity and scannability:

- **Per-row icons.** Every setting row now shows a leading SF Symbol via an optional `systemImage` on the shared `SettingsRowLabel`, so each list reads at a glance instead of as a wall of text.
- **Reorganized panes.** The overloaded General pane is split into **General** (core behavior), **Appearance** (how suggestions look), and **Emoji** (the inline picker). **Advanced** is renamed **Context** to say what it actually holds. The sidebar order is refreshed to read top-down: behavior, look, emoji, writing, context, model, input, then system and info.
- **Settings search.** A new sidebar search field is backed by a `SettingsItem` index (title, icon, keywords, owning pane). An empty query shows the categories; a query shows pane-grouped matches that navigate to the right pane on tap.
- **Consistency fixes.** The Performance tracking row moves from a hover-only `.help()` tooltip to the standard two-line label, and the support prompt moves from a saturated blue banner pinned above your settings to a slim row at the bottom of General.

## Validation

```bash
xcodegen generate
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build \
  -derivedDataPath build/DerivedData
# ** BUILD SUCCEEDED **

swiftlint lint --quiet
# exit 0, no violations
```

Not yet verified visually end-to-end: I could not capture the running UI in this environment (no Screen Recording access, and the session is in dark mode). Recommend a quick pass on a light background and on macOS 26: tab through every pane to confirm icon alignment, and try the sidebar search.

## Linked issues

None (Settings UX improvement; no tracking issue).

## Risk / rollout notes

- `Cotabby.xcodeproj` is regenerated from `project.yml` (adds the new pane/index files, drops `AdvancedPaneView.swift`). The commit matches `xcodegen generate` (2.45.4), so the XcodeGen CI check should pass; if CI pins a different version, re-run `xcodegen generate`.
- Pane structure changed. A persisted `advanced` sidebar selection migrates to Context (`SettingsContainerView.restoreSelection`). No settings values move or reset; only the navigation layout changed.
- Row icons are decorative and hidden from VoiceOver; the two-line text labels still carry the meaning.
- `SettingsItem` is the single source of truth for search coverage: a future setting needs a case there to stay findable.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reworks the Settings window with per-row SF Symbol icons, splits the overloaded General pane into General/Appearance/Emoji, renames Advanced to Context, and adds a sidebar search field backed by a new `SettingsItem` index.

- **Pane reorganization**: Three new pane files (`AppearancePaneView`, `EmojiPaneView`, `ContextPaneView`) extract settings from General; `SettingsContainerView` wires them in and adds a migration guard so persisted `\"advanced\"` selections redirect to the renamed Context pane.
- **Search index (`SettingsIndex.swift`)**: 39 items catalogued with titles, SF Symbols, and keyword aliases; `SettingsSidebarView` shows a hand-rolled search field that groups matches by pane and navigates on tap.
- **`SettingsRowLabel`**: Gains an optional `systemImage` parameter that renders a decorative, VoiceOver-hidden leading icon, backward-compatible with all existing callsites.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one fix: the search index routes Support Cotabby to the About pane after the row was moved to General in this same PR.

The structural reorganization is solid and the build succeeds. The one confirmed defect is in SettingsIndex.swift: SettingsItem.support.category returns .about, but the row now lives in GeneralPaneView. Any user searching support, donate, or kofi gets navigated to About and finds nothing.

Cotabby/UI/Settings/SettingsIndex.swift — the support case in the category computed property needs to return .general instead of grouping with checkForUpdates and acknowledgements.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/UI/Settings/SettingsIndex.swift | New search index — 39 items well-covered, but `support` maps to `.about` while the row now lives in `GeneralPaneView`; and `customRules` (Writing pane) has no index entry. |
| Cotabby/UI/Settings/SettingsSidebarView.swift | Hand-rolled search field with grouped results and clear button; `groupedResults` correctly preserves declaration order. |
| Cotabby/UI/Settings/SettingsCategory.swift | Adds `appearance`, `emoji`, and `context` cases; renames `advanced` to `context`; sidebar order updated per PR description. |
| Cotabby/UI/Settings/SettingsContainerView.swift | Wires in three new pane views and adds a migration guard (`"advanced" → .context`) to preserve persisted sidebar selection. |
| Cotabby/UI/Settings/Components/SettingsRowLabel.swift | Adds optional `systemImage` parameter with `accessibilityHidden(true)`; backward-compatible default of `nil` preserves all existing callsites. |
| Cotabby/UI/Settings/Panes/AppearancePaneView.swift | New pane splitting appearance settings out of General; the Show Key Hint toggle manually reconstructs the SettingsRowLabel icon/text layout instead of composing it. |
| Cotabby/UI/Settings/Panes/GeneralPaneView.swift | Correctly slimmed to core behavior toggles; display/emoji/appearance rows moved to their new panes; support banner converted to a slim row. |
| Cotabby/UI/Settings/Panes/ContextPaneView.swift | Rename of AdvancedPaneView with comment and bundle-identifier updates; playground bundle ID correctly updated. |
| Cotabby/UI/Settings/Panes/EmojiPaneView.swift | Clean extraction of emoji picker settings from GeneralPaneView; conditional sub-section correctly shown/hidden based on `isEmojiPickerEnabled`. |
| Cotabby/Support/SettingsAttentionEvaluator.swift | Exhaustive switch updated to include the four new/renamed categories; no attention logic changes. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SettingsSidebarView] --> B{searchText empty?}
    B -- Yes --> C[categoryList]
    B -- No --> D[searchResultsList]
    D --> E[SettingsItem.results for query]
    E --> F[groupedResults by SettingsCategory order]
    F --> G{Any groups?}
    G -- No --> H[No settings match message]
    G -- Yes --> I[Grouped Button rows]
    I --> J[on tap: selection = item.category, clear searchText]
    J --> C
    C --> K[SettingsContainerView routes to pane]
    K --> L[GeneralPaneView]
    K --> M[AppearancePaneView]
    K --> N[EmojiPaneView]
    K --> O[ContextPaneView]
    K --> P[Other panes]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `Cotabby/UI/Settings/SettingsIndex.swift`, line 1585-1587 ([link](https://github.com/fujacob/cotabby/blob/dbdb3fa69df3d3c70a54d978c95fd22d998602b4/Cotabby/UI/Settings/SettingsIndex.swift#L1585-L1587)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Search navigates to the wrong pane for "Support Cotabby"**

   `SettingsIndex.support` maps to `.about`, but the actual "Support Cotabby" row now lives in `GeneralPaneView`. Searching for "support", "donate", "kofi", or "tip" navigates the user to the About pane, where they won't find the row. The `support` case's `category` property needs to return `.general` to match where the row was moved in this PR.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fsettings-ux-revamp%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fsettings-ux-revamp%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FSettings%2FSettingsIndex.swift%0ALine%3A%201585-1587%0A%0AComment%3A%0A**Search%20navigates%20to%20the%20wrong%20pane%20for%20%22Support%20Cotabby%22**%0A%0A%60SettingsIndex.support%60%20maps%20to%20%60.about%60%2C%20but%20the%20actual%20%22Support%20Cotabby%22%20row%20now%20lives%20in%20%60GeneralPaneView%60.%20Searching%20for%20%22support%22%2C%20%22donate%22%2C%20%22kofi%22%2C%20or%20%22tip%22%20navigates%20the%20user%20to%20the%20About%20pane%2C%20where%20they%20won't%20find%20the%20row.%20The%20%60support%60%20case's%20%60category%60%20property%20needs%20to%20return%20%60.general%60%20to%20match%20where%20the%20row%20was%20moved%20in%20this%20PR.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FSettings%2FSettingsIndex.swift%0ALine%3A%201585-1587%0A%0AComment%3A%0A**Search%20navigates%20to%20the%20wrong%20pane%20for%20%22Support%20Cotabby%22**%0A%0A%60SettingsIndex.support%60%20maps%20to%20%60.about%60%2C%20but%20the%20actual%20%22Support%20Cotabby%22%20row%20now%20lives%20in%20%60GeneralPaneView%60.%20Searching%20for%20%22support%22%2C%20%22donate%22%2C%20%22kofi%22%2C%20or%20%22tip%22%20navigates%20the%20user%20to%20the%20About%20pane%2C%20where%20they%20won't%20find%20the%20row.%20The%20%60support%60%20case's%20%60category%60%20property%20needs%20to%20return%20%60.general%60%20to%20match%20where%20the%20row%20was%20moved%20in%20this%20PR.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=579&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

2. `Cotabby/UI/Settings/SettingsIndex.swift`, line 1570-1572 ([link](https://github.com/fujacob/cotabby/blob/dbdb3fa69df3d3c70a54d978c95fd22d998602b4/Cotabby/UI/Settings/SettingsIndex.swift#L1570-L1572)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`customRules` (Writing pane) is absent from the search index**

   The Writing pane still hosts the tag-style `customRules` editor (mentioned in `ContextPaneView`'s doc comment), but no corresponding case exists in `SettingsItem`. Users who search "rules", "custom", or "directives" will get no results pointing to Writing. Given that `SettingsItem` is the declared single source of truth for findability, this gap is worth closing with a new case.

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fsettings-ux-revamp%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fsettings-ux-revamp%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FSettings%2FSettingsIndex.swift%0ALine%3A%201570-1572%0A%0AComment%3A%0A**%60customRules%60%20%28Writing%20pane%29%20is%20absent%20from%20the%20search%20index**%0A%0AThe%20Writing%20pane%20still%20hosts%20the%20tag-style%20%60customRules%60%20editor%20%28mentioned%20in%20%60ContextPaneView%60's%20doc%20comment%29%2C%20but%20no%20corresponding%20case%20exists%20in%20%60SettingsItem%60.%20Users%20who%20search%20%22rules%22%2C%20%22custom%22%2C%20or%20%22directives%22%20will%20get%20no%20results%20pointing%20to%20Writing.%20Given%20that%20%60SettingsItem%60%20is%20the%20declared%20single%20source%20of%20truth%20for%20findability%2C%20this%20gap%20is%20worth%20closing%20with%20a%20new%20case.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FSettings%2FSettingsIndex.swift%0ALine%3A%201570-1572%0A%0AComment%3A%0A**%60customRules%60%20%28Writing%20pane%29%20is%20absent%20from%20the%20search%20index**%0A%0AThe%20Writing%20pane%20still%20hosts%20the%20tag-style%20%60customRules%60%20editor%20%28mentioned%20in%20%60ContextPaneView%60's%20doc%20comment%29%2C%20but%20no%20corresponding%20case%20exists%20in%20%60SettingsItem%60.%20Users%20who%20search%20%22rules%22%2C%20%22custom%22%2C%20or%20%22directives%22%20will%20get%20no%20results%20pointing%20to%20Writing.%20Given%20that%20%60SettingsItem%60%20is%20the%20declared%20single%20source%20of%20truth%20for%20findability%2C%20this%20gap%20is%20worth%20closing%20with%20a%20new%20case.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=579&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

3. `Cotabby/UI/Settings/Panes/AppearancePaneView.swift`, line 262-286 ([link](https://github.com/fujacob/cotabby/blob/dbdb3fa69df3d3c70a54d978c95fd22d998602b4/Cotabby/UI/Settings/Panes/AppearancePaneView.swift#L262-L286)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Inline icon layout duplicates `SettingsRowLabel` internals**

   The "Show Key Hint" toggle manually reconstructs the `HStack(alignment: .firstTextBaseline, spacing: 10)` / `Image(...).frame(width: 20)` / `accessibilityHidden(true)` pattern from `SettingsRowLabel` rather than composing it as a subview. Any future change to icon sizing or spacing in `SettingsRowLabel` will need to be mirrored here by hand. The dynamic `acceptanceKeyLabel` in the title is the only reason a plain `SettingsRowLabel` can't be used directly; consider a small overload or a custom title view passed into the label slot.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fsettings-ux-revamp%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fsettings-ux-revamp%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FSettings%2FPanes%2FAppearancePaneView.swift%0ALine%3A%20262-286%0A%0AComment%3A%0A**Inline%20icon%20layout%20duplicates%20%60SettingsRowLabel%60%20internals**%0A%0AThe%20%22Show%20Key%20Hint%22%20toggle%20manually%20reconstructs%20the%20%60HStack%28alignment%3A%20.firstTextBaseline%2C%20spacing%3A%2010%29%60%20%2F%20%60Image%28...%29.frame%28width%3A%2020%29%60%20%2F%20%60accessibilityHidden%28true%29%60%20pattern%20from%20%60SettingsRowLabel%60%20rather%20than%20composing%20it%20as%20a%20subview.%20Any%20future%20change%20to%20icon%20sizing%20or%20spacing%20in%20%60SettingsRowLabel%60%20will%20need%20to%20be%20mirrored%20here%20by%20hand.%20The%20dynamic%20%60acceptanceKeyLabel%60%20in%20the%20title%20is%20the%20only%20reason%20a%20plain%20%60SettingsRowLabel%60%20can't%20be%20used%20directly%3B%20consider%20a%20small%20overload%20or%20a%20custom%20title%20view%20passed%20into%20the%20label%20slot.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FSettings%2FPanes%2FAppearancePaneView.swift%0ALine%3A%20262-286%0A%0AComment%3A%0A**Inline%20icon%20layout%20duplicates%20%60SettingsRowLabel%60%20internals**%0A%0AThe%20%22Show%20Key%20Hint%22%20toggle%20manually%20reconstructs%20the%20%60HStack%28alignment%3A%20.firstTextBaseline%2C%20spacing%3A%2010%29%60%20%2F%20%60Image%28...%29.frame%28width%3A%2020%29%60%20%2F%20%60accessibilityHidden%28true%29%60%20pattern%20from%20%60SettingsRowLabel%60%20rather%20than%20composing%20it%20as%20a%20subview.%20Any%20future%20change%20to%20icon%20sizing%20or%20spacing%20in%20%60SettingsRowLabel%60%20will%20need%20to%20be%20mirrored%20here%20by%20hand.%20The%20dynamic%20%60acceptanceKeyLabel%60%20in%20the%20title%20is%20the%20only%20reason%20a%20plain%20%60SettingsRowLabel%60%20can't%20be%20used%20directly%3B%20consider%20a%20small%20overload%20or%20a%20custom%20title%20view%20passed%20into%20the%20label%20slot.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=579&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fsettings-ux-revamp%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fsettings-ux-revamp%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FSettings%2FSettingsIndex.swift%3A177-178%0AThe%20%60support%60%20case%20maps%20to%20%60.about%60%2C%20but%20%22Support%20Cotabby%22%20now%20lives%20in%20%60GeneralPaneView%60%20after%20this%20PR%20moves%20it%20from%20a%20banner%20to%20a%20slim%20row%20at%20the%20bottom%20of%20General.%20Searching%20%22support%22%2C%20%22donate%22%2C%20%22kofi%22%2C%20or%20%22tip%22%20will%20navigate%20to%20the%20About%20pane%2C%20where%20the%20row%20doesn't%20exist.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20case%20.support%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20.general%0A%20%20%20%20%20%20%20%20case%20.checkForUpdates%2C%20.acknowledgements%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20.about%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FUI%2FSettings%2FSettingsIndex.swift%3A57-60%0A**Writing%20pane%20%60customRules%60%20not%20indexed**%0A%0AThe%20Writing%20pane%20carries%20a%20tag-style%20%60customRules%60%20editor%20%28short%20imperative%20directives%29%2C%20but%20no%20case%20exists%20for%20it%20in%20%60SettingsItem%60.%20Searches%20for%20%22rules%22%2C%20%22custom%22%2C%20%22directives%22%2C%20or%20%22writing%20rules%22%20return%20no%20results%20pointing%20to%20Writing.%20Since%20%60SettingsItem%60%20is%20declared%20the%20single%20source%20of%20truth%20for%20findability%2C%20this%20gap%20means%20that%20setting%20is%20invisible%20to%20search.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FSettings%2FSettingsIndex.swift%3A177-178%0AThe%20%60support%60%20case%20maps%20to%20%60.about%60%2C%20but%20%22Support%20Cotabby%22%20now%20lives%20in%20%60GeneralPaneView%60%20after%20this%20PR%20moves%20it%20from%20a%20banner%20to%20a%20slim%20row%20at%20the%20bottom%20of%20General.%20Searching%20%22support%22%2C%20%22donate%22%2C%20%22kofi%22%2C%20or%20%22tip%22%20will%20navigate%20to%20the%20About%20pane%2C%20where%20the%20row%20doesn't%20exist.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20case%20.support%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20.general%0A%20%20%20%20%20%20%20%20case%20.checkForUpdates%2C%20.acknowledgements%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20.about%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FUI%2FSettings%2FSettingsIndex.swift%3A57-60%0A**Writing%20pane%20%60customRules%60%20not%20indexed**%0A%0AThe%20Writing%20pane%20carries%20a%20tag-style%20%60customRules%60%20editor%20%28short%20imperative%20directives%29%2C%20but%20no%20case%20exists%20for%20it%20in%20%60SettingsItem%60.%20Searches%20for%20%22rules%22%2C%20%22custom%22%2C%20%22directives%22%2C%20or%20%22writing%20rules%22%20return%20no%20results%20pointing%20to%20Writing.%20Since%20%60SettingsItem%60%20is%20declared%20the%20single%20source%20of%20truth%20for%20findability%2C%20this%20gap%20means%20that%20setting%20is%20invisible%20to%20search.%0A%0A&repo=fujacob%2Fcotabby&pr=579&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Move the Settings search field down and ..."](https://github.com/fujacob/cotabby/commit/d32b62e072748b5cf9afa79b0d4d436f0efe2fee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35790856)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->