### PR TITLE
README: move Download CTA beside the landing-page link; document macOS 14

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ review, validate, and revert safely.
 
 You need:
 
-- macOS 15.0 or later for running the app and tests. Apple Intelligence runtime work requires
+- macOS 14.0 or later for running the app and tests. Apple Intelligence runtime work requires
   macOS 26 or later.
 - Xcode with Command Line Tools installed.
 - A local Apple development team configured in Xcode if you want to launch the signed app from the

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 <p align="center">
   <a href="https://cotabby.app"><strong>Visit the landing page →</strong></a>
+  &nbsp;&nbsp;<strong>|</strong>&nbsp;&nbsp;
+  <a href="https://github.com/FuJacob/cotabby/releases/latest"><strong>Download for macOS →</strong></a>
 </p>
 
 <p align="center">
@@ -17,7 +19,7 @@
   <a href="https://github.com/FuJacob/cotabby/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/FuJacob/cotabby" /></a>
   <a href="https://github.com/FuJacob/cotabby/releases"><img alt="Downloads" src="https://img.shields.io/github/downloads/FuJacob/cotabby/total" /></a>
   <a href="https://github.com/FuJacob/cotabby/stargazers"><img alt="Stars" src="https://img.shields.io/github/stars/FuJacob/cotabby?style=flat" /></a>
-  <img alt="Platform" src="https://img.shields.io/badge/platform-macOS%2015%2B-lightgrey" />
+  <img alt="Platform" src="https://img.shields.io/badge/platform-macOS%2014%2B-lightgrey" />
   <img alt="Visitors" src="https://visitor-badge.laobi.icu/badge?page_id=FuJacob.tabby" />
 </p>
 
@@ -27,7 +29,6 @@
 
 <p align="center">
   <a href='https://ko-fi.com/I2F22066MI' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://storage.ko-fi.com/cdn/kofi6.png?v=6' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
-  <a href="https://github.com/FuJacob/cotabby/releases/latest"><img height="36" alt="Download for macOS" src="https://img.shields.io/badge/Download%20for%20macOS-181717?style=for-the-badge&logo=github&logoColor=white" /></a>
 </p>
 
 ---
@@ -83,7 +84,7 @@ Browse the [unsloth GGUF collection on Hugging Face](https://huggingface.co/unsl
 
 ## Install
 
-**Compatibility:** Requires macOS 15.0 or later. Apple Intelligence suggestions require macOS 26 or later; on earlier supported systems, use the Open Source engine.
+**Compatibility:** Requires macOS 14.0 or later. Apple Intelligence suggestions require macOS 26 or later; on earlier supported systems, use the Open Source engine.
 
 ### Homebrew
 


### PR DESCRIPTION
## Summary

README and docs polish:

- Move the **Download for macOS** call-to-action up beside **Visit the landing page**, rendered as a matching bold text link with a clear `|` vertical-bar separator between them. Removed the old download image badge from the support (Buy Me a Coffee) row so it lives in one place.
- Update the **platform badge** from `macOS 15+` to `macOS 14+`, which was outdated.
- Update the stated minimum in **README** and **CONTRIBUTING** from macOS 15.0 to **macOS 14.0**, matching the project's actual `deploymentTarget` (already 14.0 in `project.yml`). Apple Intelligence still notes macOS 26+.

## Validation

- Docs-only change. The new platform badge endpoint resolves (`curl` returns `200 image/svg+xml`).
- Verified no `macOS 15` / `15.0 or later` strings remain in README or CONTRIBUTING.

## Linked issues

None (docs and README polish).

## Risk / rollout notes

Docs-only; no code or build impact. The deployment target was already macOS 14.0, so this only aligns the badge and the written compatibility line with what the build already targets.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a documentation-only PR that aligns the README and CONTRIBUTING guide with the project's actual macOS deployment target (14.0) and reorganizes the download call-to-action for better discoverability.

- The **Download for macOS** link is moved from a standalone badge in the support row to sit inline beside the landing-page link, using a `|` separator; the old download badge is removed to avoid duplication.
- The platform badge and all prose compatibility statements are updated from `macOS 15+` / `macOS 15.0` to `macOS 14+` / `macOS 14.0`, matching the existing `deploymentTarget` in `project.yml`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely documentation changes with no code, build, or runtime impact.

Both files contain only prose and badge URL updates. The macOS 14.0 minimum now matches the project's existing deploymentTarget, so no new contract is introduced. The download link reorganization is cosmetic. Nothing here can regress behavior.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Moves download CTA to sit beside the landing-page link with a | separator, updates macOS platform badge from 15+ to 14+, removes duplicate download badge from support row, and corrects minimum compatibility statement to macOS 14.0. |
| CONTRIBUTING.md | Single-line change: minimum requirement updated from macOS 15.0 to macOS 14.0 to align with the project's actual deploymentTarget. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[README top section] --> B["Visit the landing page →"]
    A --> C["| Download for macOS → (moved here)"]
    A --> D[Badge row: release / downloads / stars / platform / visitors]
    D -- before --> E["platform: macOS 15+"]
    D -- after --> F["platform: macOS 14+"]
    G[Support row] -- before --> H[Ko-fi badge + Download badge]
    G -- after --> I[Ko-fi badge only]
    J[Install section] -- before --> K["Requires macOS 15.0 or later"]
    J -- after --> L["Requires macOS 14.0 or later"]
    M[CONTRIBUTING.md] -- before --> N["macOS 15.0 or later"]
    M -- after --> O["macOS 14.0 or later"]
```

<sub>Reviews (1): Last reviewed commit: ["README: move Download CTA beside the lan..."](https://github.com/fujacob/cotabby/commit/b4751a76ffdc80d3dbf1e7e3f882864bbdb189c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35793975)</sub>

<!-- /greptile_comment -->