### PR TITLE
Shrink the field-edge indicator to 0.7 of its size

### DIFF
--- a/Cotabby/UI/FieldEdgeIconIndicatorView.swift
+++ b/Cotabby/UI/FieldEdgeIconIndicatorView.swift
@@ -4,8 +4,9 @@ import SwiftUI
 /// The small Cotabby affordance shown just outside a supported text field. Always renders the
 /// built-in cat glyph on Cotabby's dark rounded chip.
 struct FieldEdgeIconIndicatorView: View {
-    private let side: CGFloat = 20
-    private let cornerRadius: CGFloat = 5
+    // Sized at 0.7 of the original chip so the affordance sits more discreetly beside the input.
+    private let side: CGFloat = 14
+    private let cornerRadius: CGFloat = 3.5
 
     var body: some View {
         ZStack {
@@ -15,7 +16,7 @@ struct FieldEdgeIconIndicatorView: View {
                 .renderingMode(.template)
                 .resizable()
                 .scaledToFit()
-                .frame(height: 13)
+                .frame(height: 9.1)
                 .foregroundStyle(.white)
         }
         .frame(width: side, height: side)


### PR DESCRIPTION
## Summary

Shrinks the field-edge activation indicator (the small cat chip shown just outside a supported text field) to **0.7 of its previous size** for a more discreet affordance: chip 20pt → 14pt, glyph 13pt → 9.1pt, corner radius 5 → 3.5. The host panel (`ActivationIndicatorController`) sizes itself from the view's fitting size, so edge positioning is unchanged.

## Validation

```bash
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build \
  -derivedDataPath build/DerivedData
# ** BUILD SUCCEEDED **
swiftlint lint --quiet
# exit 0
```

Pure proportional resize; not captured visually in this environment.

## Linked issues

None.

## Risk / rollout notes

UI-only. Touches just `FieldEdgeIconIndicatorView` sizing constants; no positioning or layout logic changed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR proportionally shrinks the field-edge activation indicator to 70% of its previous size by adjusting three constants in `FieldEdgeIconIndicatorView`: the chip side (20 → 14 pt), corner radius (5 → 3.5 pt), and glyph height (13 → 9.1 pt). Because the parent `ActivationIndicatorController` derives the panel size from the view's fitting size, no positioning logic needs to change.

- All three values are correctly scaled by exactly 0.7; the glyph-to-chip ratio (0.65) is preserved.
- The glyph height remains a separate hardcoded literal rather than being derived from `side`, so a future adjustment to `side` alone would silently leave the glyph out of proportion.

<h3>Confidence Score: 5/5</h3>

Pure cosmetic resize of three constants in one view; no logic, layout, or API surface is touched.

The change is narrowly scoped to visual sizing constants, the math is correct, and the parent controller adapts automatically via fittingSize. The only open question is whether the glyph height should be derived from side rather than hardcoded, which is a minor maintainability concern with no current breakage.

No files require special attention; FieldEdgeIconIndicatorView.swift is the sole change and it is straightforward.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/FieldEdgeIconIndicatorView.swift | Three sizing constants scaled to 0.7: chip side 20→14pt, corner radius 5→3.5pt, glyph height 13→9.1pt; no logic or layout changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[FieldEdgeIconIndicatorView] --> B[ZStack]
    B --> C[RoundedRectangle cornerRadius: 3.5 was 5]
    B --> D[Image MenuBarCatIcon height: 9.1pt was 13pt]
    A --> E[.frame width/height: 14pt was 20pt]
    E --> F[.clipShape RoundedRectangle cornerRadius: 3.5]
    F --> G[.shadow + .fixedSize]
    G --> H[ActivationIndicatorController sizes panel from fittingSize no positional change]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fsmaller-indicator%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsmaller-indicator%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FFieldEdgeIconIndicatorView.swift%3A7-9%0AThe%20glyph%20%60frame%28height%3A%29%60%20is%20a%20separate%20hardcoded%20literal%20that%20must%20stay%20in%20sync%20with%20%60side%60%20manually.%20Both%20old%20%2813%2F20%20%3D%200.65%29%20and%20new%20%289.1%2F14%20%3D%200.65%29%20values%20happen%20to%20share%20the%20same%20ratio%2C%20so%20deriving%20the%20glyph%20height%20from%20%60side%60%20would%20make%20the%20relationship%20explicit%20and%20prevent%20drift%20if%20%60side%60%20is%20adjusted%20again.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%20Sized%20at%200.7%20of%20the%20original%20chip%20so%20the%20affordance%20sits%20more%20discreetly%20beside%20the%20input.%0A%20%20%20%20private%20let%20side%3A%20CGFloat%20%3D%2014%0A%20%20%20%20private%20let%20cornerRadius%3A%20CGFloat%20%3D%203.5%0A%20%20%20%20private%20var%20glyphHeight%3A%20CGFloat%20%7B%20side%20*%200.65%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FUI%2FFieldEdgeIconIndicatorView.swift%3A19%0AIf%20the%20computed%20%60glyphHeight%60%20property%20above%20is%20adopted%2C%20the%20literal%20%609.1%60%20can%20be%20replaced%20with%20it%20so%20the%20two%20values%20are%20never%20out%20of%20step.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.frame%28height%3A%20glyphHeight%29%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FFieldEdgeIconIndicatorView.swift%3A7-9%0AThe%20glyph%20%60frame%28height%3A%29%60%20is%20a%20separate%20hardcoded%20literal%20that%20must%20stay%20in%20sync%20with%20%60side%60%20manually.%20Both%20old%20%2813%2F20%20%3D%200.65%29%20and%20new%20%289.1%2F14%20%3D%200.65%29%20values%20happen%20to%20share%20the%20same%20ratio%2C%20so%20deriving%20the%20glyph%20height%20from%20%60side%60%20would%20make%20the%20relationship%20explicit%20and%20prevent%20drift%20if%20%60side%60%20is%20adjusted%20again.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%20Sized%20at%200.7%20of%20the%20original%20chip%20so%20the%20affordance%20sits%20more%20discreetly%20beside%20the%20input.%0A%20%20%20%20private%20let%20side%3A%20CGFloat%20%3D%2014%0A%20%20%20%20private%20let%20cornerRadius%3A%20CGFloat%20%3D%203.5%0A%20%20%20%20private%20var%20glyphHeight%3A%20CGFloat%20%7B%20side%20*%200.65%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FUI%2FFieldEdgeIconIndicatorView.swift%3A19%0AIf%20the%20computed%20%60glyphHeight%60%20property%20above%20is%20adopted%2C%20the%20literal%20%609.1%60%20can%20be%20replaced%20with%20it%20so%20the%20two%20values%20are%20never%20out%20of%20step.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.frame%28height%3A%20glyphHeight%29%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=582&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Shrink the field-edge indicator to 0.7 o..."](https://github.com/fujacob/cotabby/commit/c2cf190040491aa5119e32ba491fbe71c35b1163) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35796634)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->