### PR TITLE
Highlight the next accept-word in the popup completion card

### DIFF
--- a/Cotabby/Services/UI/OverlayController.swift
+++ b/Cotabby/Services/UI/OverlayController.swift
@@ -302,6 +302,7 @@ final class OverlayController: SuggestionOverlayControlling {
             geometry: geometry,
             visibleFrame: visibleFrame,
             showsAcceptanceHint: acceptanceHintLabel != nil,
+            autoAcceptTrailingPunctuation: suggestionSettings.autoAcceptTrailingPunctuation,
             reason: reason
         )
         let customGhostColor = SuggestionTextColorCodec.color(
@@ -559,6 +560,34 @@ private struct MirrorOverlayView: View {
         return baseColor.opacity(opacity)
     }
 
+    /// The next-accept word renders at full strength so it reads as "this is what Tab takes next."
+    /// The user's custom suggestion color (if set) is honored at full opacity; otherwise the primary
+    /// label color keeps strong contrast against the card backdrop in both appearances.
+    private var highlightColor: Color {
+        customColor ?? .primary
+    }
+
+    /// The suggestion as one attributed run: the highlighted prefix (the next accept-word) is drawn
+    /// full-strength and semibold so it "lights up" as the word being completed, while the rest keeps
+    /// the muted ghost color. Building one `AttributedString` instead of two `Text`s keeps the card on
+    /// a single line and lets tail-truncation treat the whole suggestion as one unit.
+    private var styledSuggestion: AttributedString {
+        var attributed = AttributedString(layout.suggestionText)
+        attributed.font = .system(size: layout.fontSize)
+        attributed.foregroundColor = ghostColor
+
+        let prefix = layout.highlightedPrefix
+        guard !prefix.isEmpty, layout.suggestionText.hasPrefix(prefix) else {
+            return attributed
+        }
+        let characters = attributed.characters
+        let highlightEnd = characters.index(characters.startIndex, offsetBy: prefix.count)
+        let highlightRange = characters.startIndex..<highlightEnd
+        attributed[highlightRange].foregroundColor = highlightColor
+        attributed[highlightRange].font = .system(size: layout.fontSize, weight: .semibold)
+        return attributed
+    }
+
     private var backdropColor: Color {
         colorScheme == .dark
             ? Color(white: 0.16).opacity(0.96)
@@ -571,9 +600,7 @@ private struct MirrorOverlayView: View {
 
     var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: 6) {
-            Text(layout.suggestionText)
-                .font(.system(size: layout.fontSize))
-                .foregroundStyle(ghostColor)
+            Text(styledSuggestion)
                 .lineLimit(1)
                 .truncationMode(.tail)
 

--- a/Cotabby/Support/MirrorOverlayLayout.swift
+++ b/Cotabby/Support/MirrorOverlayLayout.swift
@@ -24,6 +24,11 @@ struct MirrorOverlayLayout: Equatable {
     /// The suggestion to render. Whitespace collapsed for single-line display.
     let suggestionText: String
 
+    /// The leading run of `suggestionText` that the next accept-word keypress will insert, so the
+    /// card can highlight it as the word being completed. Always a prefix of `suggestionText` (empty
+    /// when there is nothing to highlight) so the renderer can split safely on its length.
+    let highlightedPrefix: String
+
     /// Reading direction for the host text. The card lays out left-to-right even in RTL hosts so the
     /// "[hint] [Tab]" pattern stays readable; the field is repeated as `isRightToLeft` for callers
     /// that need to flip secondary chrome (Phase 3 prefix hint will use this).
@@ -76,9 +81,14 @@ struct MirrorOverlayLayout: Equatable {
         geometry: SuggestionOverlayGeometry,
         visibleFrame: CGRect,
         showsAcceptanceHint: Bool,
+        autoAcceptTrailingPunctuation: Bool = true,
         reason: CompletionRenderMode.MirrorReason
     ) -> MirrorOverlayLayout {
         let normalizedSuggestion = normalizedDisplayText(suggestion)
+        let highlightedPrefix = highlightedAcceptancePrefix(
+            in: normalizedSuggestion,
+            autoAcceptTrailingPunctuation: autoAcceptTrailingPunctuation
+        )
         let measuredTextWidth = measuredWidth(of: normalizedSuggestion, fontSize: Metrics.fontSize)
         let keycapReservation = showsAcceptanceHint ? Metrics.keycapReservation : 0
 
@@ -127,6 +137,7 @@ struct MirrorOverlayLayout: Equatable {
             panelFrame: panelFrame,
             fontSize: Metrics.fontSize,
             suggestionText: normalizedSuggestion,
+            highlightedPrefix: highlightedPrefix,
             isRightToLeft: geometry.isRightToLeft,
             reason: reason
         )
@@ -182,6 +193,21 @@ struct MirrorOverlayLayout: Equatable {
             return inputFrame.midX
         }
         return geometry.caretRect.midX
+    }
+
+    /// The leading run of `suggestionText` the accept-word key will insert next, reused from the real
+    /// acceptance chunker (`SuggestionSessionReconciler.nextAcceptanceChunk`) so the highlight matches
+    /// exactly what one Tab takes, including the trailing-punctuation policy. Guarded to be a prefix of
+    /// `suggestionText` so the renderer's split-by-length is always safe; returns "" otherwise.
+    static func highlightedAcceptancePrefix(
+        in suggestionText: String,
+        autoAcceptTrailingPunctuation: Bool
+    ) -> String {
+        let chunk = SuggestionSessionReconciler.nextAcceptanceChunk(
+            from: suggestionText,
+            autoAcceptTrailingPunctuation: autoAcceptTrailingPunctuation
+        )
+        return suggestionText.hasPrefix(chunk) ? chunk : ""
     }
 
     /// Collapses internal whitespace and trims edges so the card never renders a multi-line block.

--- a/CotabbyTests/MirrorOverlayLayoutTests.swift
+++ b/CotabbyTests/MirrorOverlayLayoutTests.swift
@@ -235,6 +235,53 @@ final class MirrorOverlayLayoutTests: XCTestCase {
         XCTAssertEqual(layout.suggestionText, "hello world foo")
     }
 
+    // MARK: - First-word highlight
+
+    func test_make_highlightsFirstWordAsAcceptancePrefix() {
+        let geometry = CotabbyTestFixtures.overlayGeometry()
+        let layout = MirrorOverlayLayout.make(
+            suggestion: "tomorrow afternoon at noon",
+            geometry: geometry,
+            visibleFrame: screen,
+            showsAcceptanceHint: true,
+            reason: .userPreference
+        )
+
+        // The highlighted run is the first accept-word and is always a prefix of the displayed text,
+        // so the renderer can split it off by length safely.
+        XCTAssertEqual(layout.highlightedPrefix, "tomorrow")
+        XCTAssertTrue(layout.suggestionText.hasPrefix(layout.highlightedPrefix))
+    }
+
+    func test_make_highlightIncludesTrailingPunctuationByDefault() {
+        let geometry = CotabbyTestFixtures.overlayGeometry()
+        let layout = MirrorOverlayLayout.make(
+            suggestion: "you? me",
+            geometry: geometry,
+            visibleFrame: screen,
+            showsAcceptanceHint: false,
+            reason: .userPreference
+        )
+
+        XCTAssertEqual(layout.highlightedPrefix, "you?")
+    }
+
+    func test_make_highlightExcludesTrailingPunctuationWhenSettingOff() {
+        let geometry = CotabbyTestFixtures.overlayGeometry()
+        let layout = MirrorOverlayLayout.make(
+            suggestion: "you? me",
+            geometry: geometry,
+            visibleFrame: screen,
+            showsAcceptanceHint: false,
+            autoAcceptTrailingPunctuation: false,
+            reason: .userPreference
+        )
+
+        // Matches the accept-word chunk: with the setting off, trailing punctuation is its own part,
+        // so the highlight stops before it.
+        XCTAssertEqual(layout.highlightedPrefix, "you")
+    }
+
     // MARK: - Direction passthrough
 
     func test_make_preservesRightToLeftFlag() {


### PR DESCRIPTION
## Summary

The mirror-mode **popup completion card** now highlights the next accept-word. The first word (the chunk the accept key inserts next) renders full-strength and semibold so it "lights up" as the word being completed, while the rest of the suggestion stays in the muted ghost color. This makes it obvious what one Tab will take.

The highlight reuses the real acceptance chunker (`SuggestionSessionReconciler.nextAcceptanceChunk`), so the highlighted run is exactly what gets accepted and it honors the "accept trailing punctuation" setting. Because the card re-renders with the shortened tail after each word accept, the highlight advances to the new first word on its own.

- `MirrorOverlayLayout` gains a guarded `highlightedPrefix`, computed in pure code (always a prefix of the displayed text, so the renderer can split by length safely).
- `MirrorOverlayView` renders it as one `AttributedString` so the card stays single-line and tail-truncates as a unit.
- `OverlayController` threads the user's trailing-punctuation setting into the layout.

Scope note: this is the popup (mirror) card only, per the request; inline ghost text is unchanged. The highlight is the first word; in phrase-accept mode the accept key takes more, but the first word still marks where the completion begins.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  build -derivedDataPath build/DerivedData
# ** BUILD SUCCEEDED **  (no warnings in the changed files)

xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO \
  -only-testing:CotabbyTests/MirrorOverlayLayoutTests
# Executed 15 tests, with 0 failures  (3 new: prefix boundary + punctuation policy)

swiftlint lint --quiet
# exit 0, 0 violations
```

UI note: a short screen recording of the lit-up first word in the popup is a follow-up (it needs a running build with a model and Accessibility/Input Monitoring permissions). The highlight boundary is locked down by the new unit tests.

## Linked issues

None.

## Risk / rollout notes

- Overlay-only, mirror (popup) mode only. Inline ghost text and the acceptance pipeline are unchanged; the highlight is a pure rendering split over the same `suggestionText` the card already displayed.
- The boundary reuses the production accept-word chunker, so the highlight cannot drift from what the accept key actually inserts.
- No settings, schema, or project changes, and no new files.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a visual "next accept-word" highlight to the mirror-mode popup completion card: the first word Tab will insert renders full-strength and semibold, while the remaining suggestion text stays in the dimmed ghost color. The highlight is derived directly from `SuggestionSessionReconciler.nextAcceptanceChunk`, so it tracks the trailing-punctuation setting and stays in sync with actual acceptance behavior.

- `MirrorOverlayLayout` gains a `highlightedPrefix` field computed via the production acceptance chunker and guarded to always be a true prefix of `suggestionText`, keeping the renderer's index arithmetic safe.
- `MirrorOverlayView.styledSuggestion` builds a single `AttributedString` so the card stays on one line with unified tail-truncation, applying semibold + full-opacity color only to the prefix range.
- Three new unit tests lock in the highlight boundary, the default trailing-punctuation behavior, and the explicit off-case.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the highlight is additive rendering only and does not touch the acceptance pipeline or any persistent state.

The card width is measured using the regular-weight font in MirrorOverlayLayout.measuredWidth, but the highlighted prefix renders as .semibold in MirrorOverlayView. Semibold glyphs are modestly wider, so a long first word can cause the card to be sized a few points narrower than the rendered text, leading to earlier-than-intended tail truncation. Everything else looks correct.

Cotabby/Services/UI/OverlayController.swift — the width/semibold mismatch lives in the interplay between MirrorOverlayLayout.measuredWidth (regular weight) and styledSuggestion (semibold prefix).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Services/UI/OverlayController.swift | Adds highlightColor and styledSuggestion computed properties to MirrorOverlayView; card width is measured in regular weight but the prefix renders semibold, causing marginally tighter truncation for long first words. |
| Cotabby/Support/MirrorOverlayLayout.swift | Adds highlightedPrefix field and highlightedAcceptancePrefix helper; reuses the production acceptance chunker so the highlighted run matches exactly what Tab inserts. |
| CotabbyTests/MirrorOverlayLayoutTests.swift | Adds three new unit tests covering: first-word highlight boundary, trailing-punctuation inclusion, and trailing-punctuation exclusion. |

</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fpopup-first-word-highlight%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fpopup-first-word-highlight%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FServices%2FUI%2FOverlayController.swift%3A574-577%0AThe%20card%20width%20is%20measured%20using%20the%20regular-weight%20system%20font%2C%20but%20the%20highlighted%20prefix%20is%20rendered%20as%20%60.semibold%60.%20Semibold%20glyphs%20are%20typically%202%E2%80%935%25%20wider%20than%20their%20regular%20counterparts%2C%20so%20for%20a%20long%20first%20word%20the%20measured%20card%20width%20will%20be%20slightly%20narrower%20than%20what%20SwiftUI%20actually%20renders%2C%20causing%20the%20text%20to%20hit%20%60truncationMode%28.tail%29%60%20a%20few%20characters%20earlier%20than%20intended.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20var%20styledSuggestion%3A%20AttributedString%20%7B%0A%20%20%20%20%20%20%20%20var%20attributed%20%3D%20AttributedString%28layout.suggestionText%29%0A%20%20%20%20%20%20%20%20%2F%2F%20Use%20the%20base%20regular%20weight%20for%20consistency%20with%20the%20width%20measurement%20in%0A%20%20%20%20%20%20%20%20%2F%2F%20MirrorOverlayLayout%3B%20the%20semibold%20override%20below%20is%20applied%20to%20the%20prefix%20range%20only.%0A%20%20%20%20%20%20%20%20attributed.font%20%3D%20.system%28size%3A%20layout.fontSize%29%0A%20%20%20%20%20%20%20%20attributed.foregroundColor%20%3D%20ghostColor%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FServices%2FUI%2FOverlayController.swift%3A574-577%0AThe%20card%20width%20is%20measured%20using%20the%20regular-weight%20system%20font%2C%20but%20the%20highlighted%20prefix%20is%20rendered%20as%20%60.semibold%60.%20Semibold%20glyphs%20are%20typically%202%E2%80%935%25%20wider%20than%20their%20regular%20counterparts%2C%20so%20for%20a%20long%20first%20word%20the%20measured%20card%20width%20will%20be%20slightly%20narrower%20than%20what%20SwiftUI%20actually%20renders%2C%20causing%20the%20text%20to%20hit%20%60truncationMode%28.tail%29%60%20a%20few%20characters%20earlier%20than%20intended.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20var%20styledSuggestion%3A%20AttributedString%20%7B%0A%20%20%20%20%20%20%20%20var%20attributed%20%3D%20AttributedString%28layout.suggestionText%29%0A%20%20%20%20%20%20%20%20%2F%2F%20Use%20the%20base%20regular%20weight%20for%20consistency%20with%20the%20width%20measurement%20in%0A%20%20%20%20%20%20%20%20%2F%2F%20MirrorOverlayLayout%3B%20the%20semibold%20override%20below%20is%20applied%20to%20the%20prefix%20range%20only.%0A%20%20%20%20%20%20%20%20attributed.font%20%3D%20.system%28size%3A%20layout.fontSize%29%0A%20%20%20%20%20%20%20%20attributed.foregroundColor%20%3D%20ghostColor%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=583&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(overlay): highlight the next accept..."](https://github.com/fujacob/cotabby/commit/ef7e89c6c019a8c07f6b5952ae3b0413900b891c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35797252)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->