### PR TITLE
Show the app version next to the title in the menu bar

### DIFF
--- a/Cotabby/UI/MenuBarView.swift
+++ b/Cotabby/UI/MenuBarView.swift
@@ -60,6 +60,13 @@ struct MenuBarView: View {
             Text("Cotabby")
                 .font(.headline)
 
+            if let appShortVersion {
+                Text(appShortVersion)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .accessibilityLabel("Version \(appShortVersion)")
+            }
+
             // Ko-fi tip jar lives next to the title because the menu bar surface is the most
             // frequented entry point. Using a Link lets SwiftUI hand the URL to NSWorkspace and
             // dismiss the popover; a Button would need its own handler plumbing for the same effect.
@@ -76,6 +83,12 @@ struct MenuBarView: View {
                 .font(.subheadline)
         }
         .padding(.bottom, 12)
+    }
+
+    /// Short, user-facing app version (e.g. "0.4.2-beta") shown next to the title. Reads the bundle's
+    /// `CFBundleShortVersionString`, the same canonical source the About pane uses.
+    private var appShortVersion: String? {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
     }
 
     // MARK: - Quick controls


### PR DESCRIPTION
## Summary

Show the app version next to the **Cotabby** title in the menu bar popup header, as a subtle secondary label (e.g. `0.4.2-beta`). It reads `CFBundleShortVersionString`, the same canonical source the About pane uses, so users can see which build they're on at a glance without opening Settings.

## Validation

```bash
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build \
  -derivedDataPath build/DerivedData
# ** BUILD SUCCEEDED **
swiftlint lint --quiet
# exit 0
```

## Linked issues

None.

## Risk / rollout notes

UI-only; adds one read-only label to the menu bar header. Falls back to showing nothing if the bundle has no short version string.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the app version string next to the "Cotabby" title in the menu bar popup header, letting users see their build at a glance without opening Settings.

- Reads `CFBundleShortVersionString` via `Bundle.main` in a new `appShortVersion` computed property; the optional binding means nothing is shown when the key is absent.
- Renders the version as a `.caption`-weight, `.secondary`-tinted `Text` view with a `"Version X"` accessibility label.

<h3>Confidence Score: 4/5</h3>

UI-only change; safe to merge. A single edge-case around empty version strings is the only gap.

The change is minimal and correctly falls back to showing nothing when the bundle key is absent. The one gap is that an empty-string CFBundleShortVersionString would still pass the if let guard, rendering an invisible Text("") and producing a truncated VoiceOver announcement ("Version "). This is unlikely in practice but easy to close with an isEmpty check.

Cotabby/UI/MenuBarView.swift — the appShortVersion computed property.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/MenuBarView.swift | Adds appShortVersion computed property and conditional Text label in the header HStack to display CFBundleShortVersionString next to the app title; no guard for an empty string value. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant SwiftUI as SwiftUI Runtime
    participant MenuBarView
    participant Bundle as Bundle.main

    SwiftUI->>MenuBarView: render headerSection
    MenuBarView->>Bundle: object(forInfoDictionaryKey: "CFBundleShortVersionString")
    Bundle-->>MenuBarView: String? (e.g. "0.4.2-beta" or nil)
    alt version string is non-nil
        MenuBarView->>SwiftUI: Text(appShortVersion) .caption .secondary
    else version is nil
        MenuBarView->>SwiftUI: (no label rendered)
    end
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fmenubar-version%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fmenubar-version%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FMenuBarView.swift%3A90-92%0AIf%20%60CFBundleShortVersionString%60%20is%20present%20but%20set%20to%20an%20empty%20string%20%60%22%22%60%2C%20the%20optional%20binding%20succeeds%20and%20%60Text%28%22%22%29%60%20is%20rendered%20%E2%80%94%20an%20invisible%20but%20space-consuming%20view%20%E2%80%94%20while%20%60.accessibilityLabel%28%22Version%20%22%29%60%20announces%20an%20incomplete%20string%20to%20VoiceOver.%20Adding%20an%20%60isEmpty%60%20guard%20prevents%20both.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20var%20appShortVersion%3A%20String%3F%20%7B%0A%20%20%20%20%20%20%20%20let%20version%20%3D%20Bundle.main.object%28forInfoDictionaryKey%3A%20%22CFBundleShortVersionString%22%29%20as%3F%20String%0A%20%20%20%20%20%20%20%20return%20version%3F.isEmpty%20%3D%3D%20false%20%3F%20version%20%3A%20nil%0A%20%20%20%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FMenuBarView.swift%3A90-92%0AIf%20%60CFBundleShortVersionString%60%20is%20present%20but%20set%20to%20an%20empty%20string%20%60%22%22%60%2C%20the%20optional%20binding%20succeeds%20and%20%60Text%28%22%22%29%60%20is%20rendered%20%E2%80%94%20an%20invisible%20but%20space-consuming%20view%20%E2%80%94%20while%20%60.accessibilityLabel%28%22Version%20%22%29%60%20announces%20an%20incomplete%20string%20to%20VoiceOver.%20Adding%20an%20%60isEmpty%60%20guard%20prevents%20both.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20var%20appShortVersion%3A%20String%3F%20%7B%0A%20%20%20%20%20%20%20%20let%20version%20%3D%20Bundle.main.object%28forInfoDictionaryKey%3A%20%22CFBundleShortVersionString%22%29%20as%3F%20String%0A%20%20%20%20%20%20%20%20return%20version%3F.isEmpty%20%3D%3D%20false%20%3F%20version%20%3A%20nil%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=584&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Show the app version next to the title i..."](https://github.com/fujacob/cotabby/commit/3333452931baa1a4aa3575ed33061f9165f5adda) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35797352)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->