### PR TITLE
Settings: Cotabby title in sidebar; Support pinned atop General as a button

### DIFF
--- a/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
@@ -12,6 +12,8 @@ struct GeneralPaneView: View {
 
     var body: some View {
         SettingsPaneScaffold {
+            supportSection
+
             Section("Status") {
                 Toggle(isOn: globallyEnabledBinding) {
                     SettingsRowLabel(
@@ -83,21 +85,34 @@ struct GeneralPaneView: View {
                 }
             }
 
-            // Support lives as a slim row at the bottom rather than a saturated banner pinned above
-            // the user's own settings. The About pane carries the fuller support pitch.
-            if let kofiURL = URL(string: "https://ko-fi.com/cotabby") {
-                Section {
-                    LabeledContent {
-                        Link(destination: kofiURL) {
-                            Label("Support", systemImage: "heart.fill")
-                        }
-                    } label: {
-                        SettingsRowLabel(
-                            title: "Support Cotabby",
-                            description: "Cotabby is free and open source. Tips help fund development.",
-                            systemImage: "heart"
-                        )
+        }
+    }
+
+    // MARK: - Support
+
+    /// Pinned at the top of General so the support pitch is the first thing in the pane. The action
+    /// is a filled pill (white background, pink "heart Support" text) so it reads as a real button to
+    /// tap rather than an easy-to-miss inline link.
+    @ViewBuilder
+    private var supportSection: some View {
+        if let kofiURL = URL(string: "https://ko-fi.com/cotabby") {
+            Section {
+                LabeledContent {
+                    Link(destination: kofiURL) {
+                        Label("Support", systemImage: "heart.fill")
+                            .font(.callout.weight(.semibold))
+                            .foregroundStyle(.pink)
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 6)
+                            .background(.white, in: Capsule())
                     }
+                    .buttonStyle(.plain)
+                } label: {
+                    SettingsRowLabel(
+                        title: "Support Cotabby",
+                        description: "Cotabby is free and open source. Tips help fund development.",
+                        systemImage: "heart"
+                    )
                 }
             }
         }

--- a/Cotabby/UI/Settings/SettingsSidebarView.swift
+++ b/Cotabby/UI/Settings/SettingsSidebarView.swift
@@ -18,6 +18,7 @@ struct SettingsSidebarView: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            appHeader
             searchField
 
             if trimmedQuery.isEmpty {
@@ -65,10 +66,37 @@ struct SettingsSidebarView: View {
         .padding(.vertical, 6)
         .background(.quaternary, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
         .padding(.horizontal, 10)
-        // Generous space above so the field sits well clear of the title bar, and only a small gap
-        // below so it reads as the head of the same group as the category rows beneath it.
-        .padding(.top, 28)
+        // The app header above now provides the clearance from the title bar; keep only a small gap
+        // here so the field reads as the head of the same group as the category rows beneath it.
+        .padding(.top, 0)
         .padding(.bottom, 4)
+    }
+
+    /// "Cotabby" wordmark with the app version in small secondary text beside it, sitting above the
+    /// search field. The top padding clears the title bar (the search field used to own that space).
+    private var appHeader: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
+            Text("Cotabby")
+                .font(.title3.weight(.semibold))
+            if let version = appVersionText {
+                Text(version)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 12)
+        .padding(.top, 24)
+        .padding(.bottom, 8)
+    }
+
+    /// Short marketing version (e.g. "v1.0"), or nil if the bundle has no version string.
+    private var appVersionText: String? {
+        guard let shortVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String,
+              !shortVersion.isEmpty else {
+            return nil
+        }
+        return "v\(shortVersion)"
     }
 
     private var categoryList: some View {


### PR DESCRIPTION
## Summary

Two Settings-window UI tweaks:

1. **Sidebar wordmark.** Adds a "Cotabby" title with the app version in small secondary text (e.g. `v1.0`) above the "Search settings" field. The header now provides the clearance from the title bar that the search field used to pad for, so the spacing is unchanged below it.
2. **Support card.** Moves the "Support Cotabby" card to the **top** of the General pane (it was a slim row at the bottom), and renders the action as a proper filled pill — white background with a pink heart + "Support" text — so it reads as a real button instead of an easy-to-miss inline link.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build \
  -derivedDataPath build/DerivedData
# ** BUILD SUCCEEDED **

xcodebuild ... test-without-building CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
# Executed 865 tests, 0 failures

swiftlint lint --quiet
# exit 0
```

These are pure SwiftUI view changes (no logic), so they are not covered by unit tests; visual confirmation in the running Settings window is recommended.

## Linked issues

None.

## Risk / rollout notes

- View-only changes to `SettingsSidebarView` and `GeneralPaneView`; no new files, no `project.yml`/pbxproj change.
- The Support button uses a literal white capsule with pink text per the requested look; it's tuned for the dark Settings appearance in the screenshots. If a light-appearance-adaptive treatment is wanted later, that's a follow-up.
- Version string is read from `CFBundleShortVersionString` (same source as the About pane); the header omits the version gracefully if the bundle has none.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Two pure-SwiftUI UI tweaks to the Settings window: a "Cotabby + version" wordmark is added to the sidebar above the search field (with the old top-padding migrated to the new header), and the Support card is promoted to the top of the General pane with a redesigned filled-pill action button.

- **Sidebar header** (`SettingsSidebarView`): `appVersionText` reads `CFBundleShortVersionString` once per render and gracefully returns `nil` when absent; the padding accounting is correct.
- **Support section** (`GeneralPaneView`): Moved to the top of the pane and given a white-capsule pill button styled for dark appearance — the hard-coded `.white` background will have near-zero contrast in light mode, making the button visually indistinguishable from the row background for users running light system appearance.

<h3>Confidence Score: 3/5</h3>

Safe to merge for dark-mode users; light-mode users will see the Support pill as essentially invisible text rather than a button.

The sidebar header change is clean and correct. The support card relocation is straightforward, but the white capsule background is hard-coded for dark appearance — on a light-mode Mac the pill blends into the row background, making the Support action appear as unstyled text. This affects any user whose system preference is light mode, which is a meaningful portion of the user base.

Cotabby/UI/Settings/Panes/GeneralPaneView.swift — the Support pill's appearance colour needs review for light mode compatibility.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/Settings/Panes/GeneralPaneView.swift | Moves support section to top of General pane and redesigns the action as a white-capsule pill button; the hard-coded `.white` background will be nearly invisible in light mode. |
| Cotabby/UI/Settings/SettingsSidebarView.swift | Adds 'Cotabby + version' app header above the search field; old top-padding is correctly relocated to the new header; logic is correct and gracefully handles a missing version string. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SettingsSidebarView] --> B[appHeader\n'Cotabby' + version]
    A --> C[searchField\npadding.top = 0]
    A --> D{trimmedQuery\nempty?}
    D -- yes --> E[categoryList]
    D -- no --> F[searchResultsList]

    G[GeneralPaneView] --> H[supportSection\nPINNED TOP]
    G --> I[Section: Status]
    G --> J[Section: Behavior]
    G --> K[Section: Help]

    H --> L{kofiURL\nvalid?}
    L -- yes --> M[LabeledContent\nLink to Ko-fi]
    M --> N[Label pill\nwhite capsule + pink text]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22settings-sidebar-title%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22settings-sidebar-title%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FSettings%2FSettingsSidebarView.swift%3A71-72%0A%60.padding%28.top%2C%200%29%60%20is%20a%20no-op%20%E2%80%94%20zero%20is%20already%20the%20default%20and%20the%20comment%20above%20explains%20the%20rationale%2C%20but%20this%20modifier%20adds%20visual%20noise%20without%20effect.%20Removing%20it%20makes%20the%20intent%20clearer.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20.padding%28.bottom%2C%204%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FUI%2FSettings%2FPanes%2FGeneralPaneView.swift%3A103-107%0AHard-coded%20white%20capsule%20is%20invisible%20in%20light%20mode.%20On%20a%20Mac%20running%20light%20appearance%2C%20the%20row%20background%20is%20white%2Fnear-white%2C%20so%20the%20white%20pill%20has%20essentially%20no%20contrast%20and%20reads%20as%20plain%20text%20rather%20than%20a%20button.%20Locking%20the%20colour%20scheme%20to%20%60.dark%60%20locally%20is%20a%20minimal%20fix%20that%20keeps%20the%20intended%20dark-mode%20look%20without%20needing%20a%20full%20adaptive%20colour%20ramp.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.font%28.callout.weight%28.semibold%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.foregroundStyle%28.pink%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.padding%28.horizontal%2C%2014%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.padding%28.vertical%2C%206%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.background%28.white%2C%20in%3A%20Capsule%28%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.colorScheme%28.dark%29%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FSettings%2FSettingsSidebarView.swift%3A71-72%0A%60.padding%28.top%2C%200%29%60%20is%20a%20no-op%20%E2%80%94%20zero%20is%20already%20the%20default%20and%20the%20comment%20above%20explains%20the%20rationale%2C%20but%20this%20modifier%20adds%20visual%20noise%20without%20effect.%20Removing%20it%20makes%20the%20intent%20clearer.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20.padding%28.bottom%2C%204%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FUI%2FSettings%2FPanes%2FGeneralPaneView.swift%3A103-107%0AHard-coded%20white%20capsule%20is%20invisible%20in%20light%20mode.%20On%20a%20Mac%20running%20light%20appearance%2C%20the%20row%20background%20is%20white%2Fnear-white%2C%20so%20the%20white%20pill%20has%20essentially%20no%20contrast%20and%20reads%20as%20plain%20text%20rather%20than%20a%20button.%20Locking%20the%20colour%20scheme%20to%20%60.dark%60%20locally%20is%20a%20minimal%20fix%20that%20keeps%20the%20intended%20dark-mode%20look%20without%20needing%20a%20full%20adaptive%20colour%20ramp.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.font%28.callout.weight%28.semibold%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.foregroundStyle%28.pink%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.padding%28.horizontal%2C%2014%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.padding%28.vertical%2C%206%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.background%28.white%2C%20in%3A%20Capsule%28%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.colorScheme%28.dark%29%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=585&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Settings: Cotabby title in sidebar; Supp..."](https://github.com/fujacob/cotabby/commit/4b43e333cb49636da91b6b5b359e50d13f59880a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35797675)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->