### PR TITLE
Reproduce SymSpell + dictionary license notices; credit SymSpell in-app

### DIFF
--- a/Cotabby/Support/SymSpell.swift
+++ b/Cotabby/Support/SymSpell.swift
@@ -19,7 +19,7 @@ import Foundation
 ///
 /// Attribution — this is a Swift port of SymSpell, used under the MIT License:
 ///
-///   Copyright (c) 2022 Wolf Garbe (https://github.com/wolfgarbe/SymSpell)
+///   Copyright (c) 2018 Wolf Garbe (https://github.com/wolfgarbe/SymSpell)
 ///
 ///   Permission is hereby granted, free of charge, to any person obtaining a copy of this software
 ///   and associated documentation files (the "Software"), to deal in the Software without

--- a/Cotabby/UI/Settings/Panes/AcknowledgementsView.swift
+++ b/Cotabby/UI/Settings/Panes/AcknowledgementsView.swift
@@ -59,6 +59,13 @@ struct AcknowledgementsView: View {
             url: "https://github.com/apple/swift-log"
         ),
         AcknowledgementEntry(
+            name: "SymSpell",
+            summary: "Symmetric-delete spelling correction (MIT, by Wolf Garbe), ported to Swift for "
+                + "inline autocorrect. Its bundled frequency dictionary derives from Google Books "
+                + "Ngram data (CC BY 3.0) and SCOWL. See THIRD_PARTY_LICENSES.md for the notices.",
+            url: "https://github.com/wolfgarbe/SymSpell"
+        ),
+        AcknowledgementEntry(
             name: "CotabbyInference",
             summary: "Swift wrapper around llama.cpp that exposes the inference API Cotabby links against.",
             url: "https://github.com/FuJacob/cotabbyinference"

--- a/README.md
+++ b/README.md
@@ -137,4 +137,4 @@ Originally created by <a href="https://github.com/FuJacob">@FuJacob</a>, now dev
 
 Cotabby is licensed under the [GNU Affero General Public License v3.0](LICENSE). You can use, study, modify, and redistribute the app, but if you distribute a modified version or make one available to users over a network, you must provide the corresponding source code under the same license.
 
-Third-party dependencies, emoji data, and downloadable model weights keep their own licenses and usage terms.
+Third-party dependencies, emoji data, and downloadable model weights keep their own licenses and usage terms. Bundled third-party notices (SymSpell and the autocorrect frequency dictionary) are reproduced in [THIRD_PARTY_LICENSES.md](THIRD_PARTY_LICENSES.md).

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,80 @@
+# Third-Party Licenses
+
+Cotabby is licensed under the GNU Affero General Public License v3.0 (see
+[`LICENSE`](LICENSE)). It bundles third-party software and data that keep their own
+licenses; the notices that ask to be reproduced are included below.
+
+The Swift package dependencies Cotabby links against (llama.cpp, CotabbyInference,
+Sparkle, swift-log) are credited in the in-app Acknowledgements
+(Settings → About → Acknowledgements) and in the README, each linking to its
+upstream license text.
+
+## SymSpell
+
+The inline autocorrect feature uses a Swift port of SymSpell (Wolf Garbe's
+Symmetric Delete spelling-correction algorithm). The port lives in
+`Cotabby/Support/SymSpell.swift`. SymSpell is distributed under the MIT License:
+
+```
+MIT License
+
+Copyright (c) 2018 Wolf Garbe
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+Upstream: https://github.com/wolfgarbe/SymSpell
+
+## Frequency dictionary
+
+`Cotabby/Resources/frequency_dictionary_en_82_765.txt` is the English frequency
+dictionary that ships with SymSpell. Per SymSpell, it is derived from two sources.
+
+### Google Books Ngram data (CC BY 3.0)
+
+The word frequencies are derived from the Google Books Ngram dataset, released under
+the Creative Commons Attribution 3.0 Unported license (CC BY 3.0). The data is used
+in derived form (word/frequency pairs).
+
+- Dataset: https://books.google.com/ngrams
+- License: https://creativecommons.org/licenses/by/3.0/
+
+### SCOWL (Spell Checker Oriented Word Lists)
+
+The word list is derived from SCOWL by Kevin Atkinson:
+
+```
+Copyright 2000-2026 by Kevin Atkinson
+
+Permission to use, copy, modify, distribute, and sell any part of the English
+Speller Database (ESDB, previously known as SCOWLv2), or word lists
+created from it, is hereby granted without fee, provided that the above
+copyright notice appears in all copies and that both the above copyright
+notice and this notice appear in supporting documentation. Kevin Atkinson
+makes no representations about the suitability of this database for any
+purpose. It is provided "as is" without express or implied warranty.
+```
+
+SCOWL itself incorporates material from several sources (12dicts by Alan Beale,
+ENABLE2K, the UK Advanced Cryptics Dictionary by J Ross Beresford, WordNet by
+Princeton University, and others). Their individual copyright notices are in the
+full SCOWL copyright file.
+
+- Project: http://wordlist.aspell.net/
+- Full copyright: https://github.com/en-wl/wordlist/blob/v2/Copyright


### PR DESCRIPTION
## Summary

Audit + hardening of the SymSpell autocorrect attribution introduced in #574.

What was already correct: the README **Acknowledgments** section credits SymSpell (MIT, Wolf Garbe), Google Books Ngram (CC BY 3.0), and SCOWL with links; `SymSpell.swift`'s source header carries the MIT license text; and the app's AGPL-3.0 license is compatible with bundling MIT code and CC BY 3.0 / SCOWL data under attribution.

What was missing and is fixed here:
- The **in-app Acknowledgements** pane (Settings → About → Acknowledgements) listed llama.cpp, Sparkle, swift-log, and CotabbyInference but **omitted SymSpell**. Added it.
- No file reproduced the **verbatim notices** that MIT and SCOWL ask to be retained in documentation. Added `THIRD_PARTY_LICENSES.md` with:
  - the verbatim SymSpell **MIT** license,
  - the **Google Books Ngram CC BY 3.0** attribution (dataset + license links),
  - the **SCOWL** (Kevin Atkinson) copyright + permission notice, fetched verbatim from the upstream SCOWL `Copyright` file.
- Corrected the SymSpell copyright year in the source header (**2022 → 2018**) to match the upstream `LICENSE`.
- Pointed the README **License** section at `THIRD_PARTY_LICENSES.md`.

No code behavior change.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  build -derivedDataPath build/DerivedData
# ** BUILD SUCCEEDED **

swiftlint lint --quiet
# exit 0, 0 violations
```

(No tests: the change is documentation plus one in-app Acknowledgements row.)

## Linked issues

Refs #574.

## Risk / rollout notes

- Documentation and attribution only, plus one new row in the in-app Acknowledgements list. No runtime behavior change, no new bundled app resources, no `project.yml`/pbxproj changes.
- Verbatim notices were taken from upstream sources (SymSpell `LICENSE`, SCOWL `Copyright`) rather than paraphrased. Wording in `THIRD_PARTY_LICENSES.md` and the in-app entry is easy to tweak if you'd prefer different phrasing.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the attribution audit for SymSpell (introduced in #574) by adding the missing in-app acknowledgement, a new `THIRD_PARTY_LICENSES.md` with verbatim MIT/CC BY 3.0/SCOWL notices, and correcting the SymSpell copyright year from 2022 to 2018.

- **`THIRD_PARTY_LICENSES.md`** (new): reproduces the verbatim SymSpell MIT license, a CC BY 3.0 attribution for the Google Books Ngram frequency dictionary, and the SCOWL permission notice fetched from upstream.
- **`AcknowledgementsView.swift`**: inserts a SymSpell row (between swift-log and CotabbyInference) pointing to the upstream repo; the summary text references `THIRD_PARTY_LICENSES.md` by filename, which is inaccessible to end-users of the compiled app — a direct GitHub URL would be more actionable.
- **`SymSpell.swift` / `README.md`**: copyright year corrected and `LICENSE` section updated to link the new notices file.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely documentation and one new in-app acknowledgement row with no runtime behavior change.

All four changed files touch only attribution text, copyright year metadata, and a new markdown notice file. The frequency dictionary path referenced in THIRD_PARTY_LICENSES.md exists in the repo, the copyright year fix aligns with the upstream SymSpell LICENSE, and the new THIRD_PARTY_LICENSES.md reproduces verbatim upstream notices. The only observation is that the in-app summary directs users to a filename that isn't clickable from the compiled app.

No files require special attention; the suggestion in AcknowledgementsView.swift is purely cosmetic.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/SymSpell.swift | Copyright year corrected from 2022 to 2018 to match the upstream SymSpell LICENSE; no code changes. |
| Cotabby/UI/Settings/Panes/AcknowledgementsView.swift | Adds SymSpell entry between swift-log and CotabbyInference; summary text references THIRD_PARTY_LICENSES.md by filename without a clickable link, which is slightly awkward in a distributed app. |
| THIRD_PARTY_LICENSES.md | New file reproducing verbatim MIT (SymSpell), CC BY 3.0 attribution (Google Books Ngram), and SCOWL notices; frequency dictionary path and upstream links appear correct. |
| README.md | One-line update to the License section pointing readers to THIRD_PARTY_LICENSES.md; wording is accurate and non-breaking. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SymSpell.swift\nSource Header] -->|MIT notice + year 2018| B[In-repo attribution]
    C[AcknowledgementsView.swift\nIn-app Settings → About] -->|New SymSpell row| D[End-user sees entry]
    E[THIRD_PARTY_LICENSES.md\nNew file] -->|Verbatim MIT license| F[SymSpell / Wolf Garbe]
    E -->|CC BY 3.0 attribution| G[Google Books Ngram dataset]
    E -->|SCOWL notice| H[Kevin Atkinson / SCOWL]
    I[README.md\nLicense section] -->|Link added| E
    D -->|References by filename| E
    style E fill:#d4f1d4
    style C fill:#d4f1d4
    style A fill:#d4f1d4
    style I fill:#d4f1d4
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22chore%2Fsymspell-attribution-audit%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2Fsymspell-attribution-audit%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FSettings%2FPanes%2FAcknowledgementsView.swift%3A61-67%0AThe%20in-app%20summary%20tells%20end-users%20to%20%22See%20THIRD_PARTY_LICENSES.md%20for%20the%20notices%2C%22%20but%20they're%20looking%20at%20a%20compiled%20macOS%20app%20with%20no%20filesystem%20access%20to%20that%20file.%20A%20direct%20URL%20to%20the%20file%20on%20GitHub%20%28or%20the%20project%20site%29%20would%20let%20users%20actually%20follow%20the%20reference.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20AcknowledgementEntry%28%0A%20%20%20%20%20%20%20%20%20%20%20%20name%3A%20%22SymSpell%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20summary%3A%20%22Symmetric-delete%20spelling%20correction%20%28MIT%2C%20by%20Wolf%20Garbe%29%2C%20ported%20to%20Swift%20for%20%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2B%20%22inline%20autocorrect.%20Its%20bundled%20frequency%20dictionary%20derives%20from%20Google%20Books%20%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2B%20%22Ngram%20data%20%28CC%20BY%203.0%29%20and%20SCOWL.%20Full%20notices%3A%20%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2B%20%22https%3A%2F%2Fgithub.com%2FFuJacob%2Fcotabby%2Fblob%2Fmain%2FTHIRD_PARTY_LICENSES.md%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20url%3A%20%22https%3A%2F%2Fgithub.com%2Fwolfgarbe%2FSymSpell%22%0A%20%20%20%20%20%20%20%20%29%2C%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FSettings%2FPanes%2FAcknowledgementsView.swift%3A61-67%0AThe%20in-app%20summary%20tells%20end-users%20to%20%22See%20THIRD_PARTY_LICENSES.md%20for%20the%20notices%2C%22%20but%20they're%20looking%20at%20a%20compiled%20macOS%20app%20with%20no%20filesystem%20access%20to%20that%20file.%20A%20direct%20URL%20to%20the%20file%20on%20GitHub%20%28or%20the%20project%20site%29%20would%20let%20users%20actually%20follow%20the%20reference.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20AcknowledgementEntry%28%0A%20%20%20%20%20%20%20%20%20%20%20%20name%3A%20%22SymSpell%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20summary%3A%20%22Symmetric-delete%20spelling%20correction%20%28MIT%2C%20by%20Wolf%20Garbe%29%2C%20ported%20to%20Swift%20for%20%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2B%20%22inline%20autocorrect.%20Its%20bundled%20frequency%20dictionary%20derives%20from%20Google%20Books%20%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2B%20%22Ngram%20data%20%28CC%20BY%203.0%29%20and%20SCOWL.%20Full%20notices%3A%20%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2B%20%22https%3A%2F%2Fgithub.com%2FFuJacob%2Fcotabby%2Fblob%2Fmain%2FTHIRD_PARTY_LICENSES.md%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20url%3A%20%22https%3A%2F%2Fgithub.com%2Fwolfgarbe%2FSymSpell%22%0A%20%20%20%20%20%20%20%20%29%2C%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=587&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs(licenses): reproduce SymSpell + dic..."](https://github.com/fujacob/cotabby/commit/a6c0022e766de8aaa193ba3d0177101405a99044) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35798617)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->