### PR TITLE
Onboarding: stack Keybinds step vertically to fix overflow

### DIFF
--- a/Cotabby/UI/WelcomeView.swift
+++ b/Cotabby/UI/WelcomeView.swift
@@ -413,11 +413,11 @@ extension WelcomeView {
                     .multilineTextAlignment(.center)
             }
 
-            // 2x2 layout: the two suggestion-acceptance keys stack in the left column, while the
-            // opt-in Toggle Tabby hotkey sits on the right. `.top` alignment keeps the left column's
-            // first row visually aligned with the single right-column row.
-            HStack(alignment: .top, spacing: 32) {
-                VStack(spacing: 16) {
+            // A single vertical column of full-width rows. The previous 2x2 grid placed three
+            // recorder controls side by side and overflowed the window at narrow widths; a vertical
+            // list matches the other onboarding steps and scrolls cleanly.
+            VStack(spacing: 10) {
+                VStack(spacing: 10) {
                     keybindRow(
                         title: "Accept Word",
                         keyLabel: suggestionSettings.acceptanceKeyLabel,
@@ -470,7 +470,7 @@ extension WelcomeView {
                 // No `onReset` here: the toggle hotkey is opt-in and has no factory default, so the
                 // only meaningful "reset" is unbind, which the Clear gesture in the recorder covers.
                 keybindRow(
-                    title: "Toggle Tabby",
+                    title: "Toggle Cotabby",
                     keyLabel: suggestionSettings.globalToggleKeyLabel,
                     action: .toggleTabby,
                     isRecording: $isRecordingOnboardingGlobalToggleKeybind,
@@ -484,6 +484,7 @@ extension WelcomeView {
                     onReset: nil
                 )
             }
+            .frame(maxWidth: 440)
         }
     }
 
@@ -496,52 +497,60 @@ extension WelcomeView {
         onKeyRecorded: @escaping (CGKeyCode, ShortcutModifierMask, String) -> Void,
         onReset: (() -> Void)? = nil
     ) -> some View {
-        VStack(spacing: 6) {
+        HStack(spacing: 10) {
             Text(title)
-                .font(.system(size: 13, weight: .medium, design: .rounded))
-                .foregroundStyle(.secondary)
+                .font(.system(size: 14, weight: .medium, design: .rounded))
+                .frame(maxWidth: .infinity, alignment: .leading)
 
-            HStack(spacing: 12) {
-                Text(keyLabel)
-                    .font(.system(size: 18, weight: .medium, design: .rounded))
-                    .padding(.horizontal, 14)
-                    .padding(.vertical, 8)
-                    .background(
-                        RoundedRectangle(cornerRadius: 8, style: .continuous)
-                            .fill(.quaternary)
-                    )
+            Text(keyLabel)
+                .font(.system(size: 16, weight: .medium, design: .rounded))
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .fill(.quaternary)
+                )
 
-                if isRecording.wrappedValue {
-                    KeyRecorderView(
-                        onKeyRecorded: { keyCode, modifiers, label in
-                            onKeyRecorded(keyCode, modifiers, label)
-                            isRecording.wrappedValue = false
-                        },
-                        onCancelled: {
-                            isRecording.wrappedValue = false
-                        },
-                        conflictChecker: { keyCode, modifiers in
-                            suggestionSettings.conflictingShortcutName(
-                                keyCode: keyCode,
-                                modifiers: modifiers,
-                                excluding: action
-                            )
-                        }
-                    )
-                } else {
-                    Button("Change") {
-                        isRecording.wrappedValue = true
-                    }
-                }
-
-                if let onReset {
-                    Button("Reset") {
-                        onReset()
+            if isRecording.wrappedValue {
+                KeyRecorderView(
+                    onKeyRecorded: { keyCode, modifiers, label in
+                        onKeyRecorded(keyCode, modifiers, label)
                         isRecording.wrappedValue = false
+                    },
+                    onCancelled: {
+                        isRecording.wrappedValue = false
+                    },
+                    conflictChecker: { keyCode, modifiers in
+                        suggestionSettings.conflictingShortcutName(
+                            keyCode: keyCode,
+                            modifiers: modifiers,
+                            excluding: action
+                        )
                     }
+                )
+            } else {
+                Button("Change") {
+                    isRecording.wrappedValue = true
                 }
+                .controlSize(.small)
+            }
+
+            if let onReset {
+                Button("Reset") {
+                    onReset()
+                    isRecording.wrappedValue = false
+                }
+                .controlSize(.small)
             }
         }
+        // Full-width rows in a subtle card so each binding reads as its own tappable row, consistent
+        // with the labeled fields on the other onboarding steps.
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(.quaternary.opacity(0.35))
+        )
     }
 }
 


### PR DESCRIPTION
## Summary

The onboarding Keybinds step (step 4) used a 2x2 grid that placed three key-recorder controls side by side, which looked unbalanced (an empty bottom-right cell) and overflowed the window horizontally at narrow widths. This replaces it with a single vertical column of full-width rows: each binding is a subtle card with the title on the left and the keycap plus Change/Reset on the right, consistent with the labeled fields on the other onboarding steps. The column is width-capped so it stays centered and never overflows.

Also fixes a stale label: "Toggle Tabby" -> "Toggle Cotabby".

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build \
  -derivedDataPath build/DerivedData
# ** BUILD SUCCEEDED **

swiftlint lint --quiet
# exit 0
```

Pure SwiftUI layout change in `WelcomeView`'s keybind step (the recorder/Change/Reset behavior is unchanged), so it is not covered by unit tests; visual confirmation in the running onboarding flow is recommended.

## Linked issues

None.

## Risk / rollout notes

- View-only change to `WelcomeView.keybindStep`/`keybindRow`; no new files, no settings or pbxproj changes.
- Key-recording, conflict-checking, and reset logic are byte-for-byte the same, just reorganized from a centered column-pair into stacked full-width rows.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the onboarding Keybinds step's two-column grid with a single vertical stack of full-width card rows, preventing horizontal overflow at narrow window widths and aligning the layout with other onboarding steps. It also fixes the stale user-facing label "Toggle Tabby" → "Toggle Cotabby".

- `keybindRow` is reshaped from a `VStack`-with-nested-`HStack` to a single `HStack` with the title expanding left and the keycap/Change/Reset controls pinned right, padded into a subtle card.
- A `.frame(maxWidth: 440)` cap on the outer `VStack` keeps the list centered and prevents overflow regardless of window size.
- All key-recording, conflict-checking, and reset logic is unchanged; only the layout hierarchy was reorganized.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is layout-only, all key-recording and reset logic is byte-for-byte identical to before.

The diff touches only SwiftUI view hierarchy and a display-string fix. No state, no business logic, no persistence, and no new dependencies are altered. The only structural note is a redundant nested VStack that has no behavioral impact.

No files require special attention; manual visual confirmation of the onboarding flow at narrow window widths is recommended per the PR description.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/WelcomeView.swift | Keybinds step restructured from a 2x2 HStack/VStack grid to a flat vertical list of full-width HStack rows; also fixes the stale "Toggle Tabby" label to "Toggle Cotabby". Key-recording logic and state are untouched. One minor nit: a redundant nested VStack remains. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[keybindStep VStack] --> B[Header: icon + titles]
    A --> C[Outer VStack maxWidth:440]
    C --> D[Inner VStack\nAccept Word row\nAccept Entire Suggestion row]
    C --> E[Toggle Cotabby row]
    D --> F[keybindRow HStack]
    E --> G[keybindRow HStack]
    F --> F1[Title — maxWidth .infinity leading]
    F --> F2[keycap Text]
    F --> F3{isRecording?}
    F3 -- yes --> F4[KeyRecorderView]
    F3 -- no --> F5[Change Button]
    F --> F6{onReset != nil?}
    F6 -- yes --> F7[Reset Button]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22onboarding-keybinds-layout%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22onboarding-keybinds-layout%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FWelcomeView.swift%3A419-420%0A**Redundant%20nested%20%60VStack%60**%0A%0AThe%20outer%20%60VStack%28spacing%3A%2010%29%60%20wraps%20an%20inner%20%60VStack%28spacing%3A%2010%29%60%20that%20holds%20the%20first%20two%20rows%2C%20but%20both%20levels%20share%20the%20same%20spacing%20value%20and%20carry%20no%20additional%20modifiers.%20The%20inner%20grouping%20adds%20no%20visual%20distinction%20between%20the%20first%20two%20rows%20and%20the%20%22Toggle%20Cotabby%22%20row%20%E2%80%94%20spacing%20between%20all%20three%20rows%20will%20be%20identical%20either%20way.%20Flattening%20to%20a%20single%20%60VStack%28spacing%3A%2010%29%60%20would%20simplify%20the%20layout%20tree%20without%20any%20change%20in%20appearance.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FWelcomeView.swift%3A419-420%0A**Redundant%20nested%20%60VStack%60**%0A%0AThe%20outer%20%60VStack%28spacing%3A%2010%29%60%20wraps%20an%20inner%20%60VStack%28spacing%3A%2010%29%60%20that%20holds%20the%20first%20two%20rows%2C%20but%20both%20levels%20share%20the%20same%20spacing%20value%20and%20carry%20no%20additional%20modifiers.%20The%20inner%20grouping%20adds%20no%20visual%20distinction%20between%20the%20first%20two%20rows%20and%20the%20%22Toggle%20Cotabby%22%20row%20%E2%80%94%20spacing%20between%20all%20three%20rows%20will%20be%20identical%20either%20way.%20Flattening%20to%20a%20single%20%60VStack%28spacing%3A%2010%29%60%20would%20simplify%20the%20layout%20tree%20without%20any%20change%20in%20appearance.%0A%0A&repo=fujacob%2Fcotabby&pr=588&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Onboarding: stack Keybinds step vertical..."](https://github.com/fujacob/cotabby/commit/e88092d9d217ef592657ca666434e4411a116ded) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35798838)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->