### PR TITLE
Add a Custom starting point to onboarding

### DIFF
--- a/Cotabby/Models/OnboardingTemplate.swift
+++ b/Cotabby/Models/OnboardingTemplate.swift
@@ -11,11 +11,14 @@ import Foundation
 /// static value type should not capture. Keeping the data here and the rules in `Support/` keeps the
 /// resolution pure and unit-testable.
 
-/// One of the three onboarding starting points the user chooses from.
+/// One of the onboarding starting points the user chooses from. Quick, Everyday, and Powerful are
+/// curated tiers; Custom is the neutral "set it up yourself" option that applies lean defaults so a
+/// user who does not want a curated tier can still get going and configure the rest in Settings.
 enum OnboardingTemplate: String, CaseIterable, Identifiable, Equatable, Sendable {
     case quick
     case everyday
     case powerful
+    case custom
 
     var id: String { rawValue }
 
@@ -27,6 +30,8 @@ enum OnboardingTemplate: String, CaseIterable, Identifiable, Equatable, Sendable
             return "Everyday"
         case .powerful:
             return "Powerful"
+        case .custom:
+            return "Custom"
         }
     }
 
@@ -39,6 +44,8 @@ enum OnboardingTemplate: String, CaseIterable, Identifiable, Equatable, Sendable
             return "Balanced for daily writing"
         case .powerful:
             return "Highest quality"
+        case .custom:
+            return "Set it up yourself"
         }
     }
 
@@ -53,6 +60,8 @@ enum OnboardingTemplate: String, CaseIterable, Identifiable, Equatable, Sendable
             return "A balance of speed and quality for everyday writing."
         case .powerful:
             return "Longer suggestions and higher quality on harder prompts."
+        case .custom:
+            return "Start with Cotabby's lean defaults, then fine-tune length, model, and behavior in Settings."
         }
     }
 
@@ -64,6 +73,8 @@ enum OnboardingTemplate: String, CaseIterable, Identifiable, Equatable, Sendable
             return "sparkles"
         case .powerful:
             return "bolt.fill"
+        case .custom:
+            return "slider.horizontal.3"
         }
     }
 
@@ -75,6 +86,8 @@ enum OnboardingTemplate: String, CaseIterable, Identifiable, Equatable, Sendable
             return .sevenToTwelve
         case .powerful:
             return .twelveToTwenty
+        case .custom:
+            return .sevenToTwelve
         }
     }
 
@@ -83,17 +96,23 @@ enum OnboardingTemplate: String, CaseIterable, Identifiable, Equatable, Sendable
         self == .quick
     }
 
-    /// Multi-line is off in every tier — the onboarding presets stay single-line so a fresh user
-    /// doesn't get long block completions before they've chosen that tradeoff in General.
+    /// Multi-line is off in every tier so a fresh user does not get long block completions before
+    /// they have chosen that tradeoff in General.
     var enablesMultiLine: Bool { false }
 
-    /// Quick stays lean by skipping the per-keystroke clipboard read and the extra prompt bytes
-    /// it adds; Everyday and Powerful pay that small cost for the extra signal.
+    /// Quick and Custom stay lean by skipping the per-keystroke clipboard read and the extra prompt
+    /// bytes it adds; Everyday and Powerful pay that small cost for the extra signal.
     var enablesClipboardContext: Bool {
-        self != .quick
+        switch self {
+        case .quick, .custom:
+            return false
+        case .everyday, .powerful:
+            return true
+        }
     }
 
-    /// The local GGUF this template installs when the Open Source engine is selected.
+    /// The local GGUF this template installs when the Open Source engine is selected. Custom uses the
+    /// same balanced base model as Everyday so it works out of the box; the user can swap it later.
     var openSourceModelFilename: String {
         switch self {
         case .quick:
@@ -102,6 +121,8 @@ enum OnboardingTemplate: String, CaseIterable, Identifiable, Equatable, Sendable
             return "gemma-4-E2B.i1-Q6_K.gguf"
         case .powerful:
             return "gemma-4-E4B.i1-Q4_K_M.gguf"
+        case .custom:
+            return "gemma-4-E2B.i1-Q6_K.gguf"
         }
     }
 }

--- a/Cotabby/Support/OnboardingTemplateRecommender.swift
+++ b/Cotabby/Support/OnboardingTemplateRecommender.swift
@@ -64,7 +64,7 @@ enum OnboardingTemplateRecommender {
             switch template {
             case .quick:
                 break
-            case .everyday:
+            case .everyday, .custom:
                 if gigabytes < everydayWarnBelowGigabytes {
                     warning = "Uses a \(modelSizeLabel(for: template)) model, which may run slowly on this Mac."
                 }

--- a/CotabbyTests/OnboardingTemplateRecommenderTests.swift
+++ b/CotabbyTests/OnboardingTemplateRecommenderTests.swift
@@ -48,7 +48,8 @@ final class OnboardingTemplateRecommenderTests: XCTestCase {
         let expected: [OnboardingTemplate: String] = [
             .quick: "Qwen3.5-0.8B-Base.i1-Q6_K.gguf",
             .everyday: "gemma-4-E2B.i1-Q6_K.gguf",
-            .powerful: "gemma-4-E4B.i1-Q4_K_M.gguf"
+            .powerful: "gemma-4-E4B.i1-Q4_K_M.gguf",
+            .custom: "gemma-4-E2B.i1-Q6_K.gguf"
         ]
         for (template, filename) in expected {
             let plan = OnboardingTemplateRecommender.resolvePlan(for: template, engine: .llamaOpenSource)


### PR DESCRIPTION
## Summary
Adds a fourth onboarding starting point, **Custom** ("Set it up yourself"), next to Quick / Everyday / Powerful. It applies Cotabby's lean defaults (balanced 7-12 word length, fast mode and clipboard context off, single-line) and uses the default base model on the Open Source engine, so users who don't want a curated tier get a neutral starting point they can fine-tune in Settings.

## Validation
- Onboarding unit tests (`OnboardingTemplateRecommenderTests`, `OnboardingTemplateFeatureListTests`) build and run; `swiftlint --quiet` clean on changed files.
- The template UI is a generic `ForEach(OnboardingTemplate.allCases)`, so the new card renders automatically; `applyTemplate` and the feature list read template properties generically.

## Linked issues
None.

## Risk / rollout notes
Onboarding-only. Custom is never the auto-recommended tier and uses the same base model as Everyday, so it is safe on any Mac that can run Everyday.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a fourth onboarding template, `custom`, alongside the existing Quick / Everyday / Powerful tiers. It applies lean defaults (7–12 word length, clipboard context off, fast mode off, single-line) and uses the same E2B GGUF as Everyday, giving users who prefer a neutral starting point a clean slate to configure in Settings.

- `OnboardingTemplate` gains a `.custom` case with all required properties populated correctly and consistently, including the `enablesClipboardContext` refactor from a negation to an explicit switch.
- `OnboardingTemplateRecommender` groups `.custom` with `.everyday` in the low-memory warning branch, which is correct since they share the same model. Custom is never auto-recommended, matching the stated intent.
- Tests cover the new GGUF mapping and the Apple Intelligence no-download invariant, but the behavior-flag test and the low-memory warning test do not yet have explicit assertions for `.custom`.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the new template is onboarding-only and its model/behavior defaults are consistent with the existing tiers.

The implementation is correct and internally consistent throughout all three files. The only gaps are in the test file: testAppleIntelligenceStillCarriesTierBehaviorFlags does not assert custom's behavior flags, and there is no test confirming that custom shows the low-memory warning on Open Source — both cases where future edits could silently break the stated contract.

CotabbyTests/OnboardingTemplateRecommenderTests.swift would benefit from explicit custom-template assertions in the behavior-flag and low-memory-warning tests.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/Models/OnboardingTemplate.swift | Adds `.custom` case with all required property implementations; behavior flags (clipboard off, fast mode off, word count sevenToTwelve, same Everyday GGUF) are internally consistent and match the PR description. |
| Cotabby/Support/OnboardingTemplateRecommender.swift | Groups `.custom` with `.everyday` in the low-memory availability warning switch, which is correct since both use the same E2B GGUF. Custom is never auto-recommended, consistent with the PR intent. |
| CotabbyTests/OnboardingTemplateRecommenderTests.swift | Adds `.custom` to the Open Source model-mapping test. However, the behavior-flags test and the low-memory warning test do not have explicit coverage for the custom template. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    User([User picks a template]) --> T{OnboardingTemplate}
    T --> Q[quick]
    T --> E[everyday]
    T --> P[powerful]
    T --> C[custom]

    subgraph Behavior Flags
        Q --> QF["fastMode=true\nclipboard=false\nwords=4-7"]
        E --> EF["fastMode=false\nclipboard=true\nwords=7-12"]
        P --> PF["fastMode=false\nclipboard=true\nwords=12-20"]
        C --> CF["fastMode=false\nclipboard=false\nwords=7-12"]
    end

    subgraph Engine Resolution
        AI[Apple Intelligence] --> NoDownload[modelToDownload = nil]
        OS[Open Source / llama] --> GGUF{Template GGUF}
        GGUF -->|quick| M1[Qwen3.5-0.8B]
        GGUF -->|everyday| M2[gemma-4-E2B]
        GGUF -->|powerful| M3[gemma-4-E4B]
        GGUF -->|custom| M2
    end

    subgraph Availability
        AV{RAM check on OS engine}
        AV -->|quick| OK1[always OK]
        AV -->|everyday or custom| W1["warn if < 8 GB"]
        AV -->|powerful| W2["disable if < 8 GB, warn if < 16 GB"]
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `CotabbyTests/OnboardingTemplateRecommenderTests.swift`, line 27-43 ([link](https://github.com/fujacob/cotabby/blob/5c47914992b426b814c28d5e444a446f7553310b/CotabbyTests/OnboardingTemplateRecommenderTests.swift#L27-L43)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Missing behavior-flag assertions for `.custom`**

   `testAppleIntelligenceStillCarriesTierBehaviorFlags` explicitly validates quick, everyday, and powerful but skips custom. If `enablesClipboardContext`, `wordCountPreset`, or `enablesFastMode` are accidentally changed for `.custom` later, no test catches it. Adding a `custom` block (e.g., asserting `wordCountPreset == .sevenToTwelve`, `enablesFastMode == false`, `enablesClipboardContext == false`) would pin those decisions the same way the other tiers are pinned.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fonboarding-blank-template%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fonboarding-blank-template%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20CotabbyTests%2FOnboardingTemplateRecommenderTests.swift%0ALine%3A%2027-43%0A%0AComment%3A%0A**Missing%20behavior-flag%20assertions%20for%20%60.custom%60**%0A%0A%60testAppleIntelligenceStillCarriesTierBehaviorFlags%60%20explicitly%20validates%20quick%2C%20everyday%2C%20and%20powerful%20but%20skips%20custom.%20If%20%60enablesClipboardContext%60%2C%20%60wordCountPreset%60%2C%20or%20%60enablesFastMode%60%20are%20accidentally%20changed%20for%20%60.custom%60%20later%2C%20no%20test%20catches%20it.%20Adding%20a%20%60custom%60%20block%20%28e.g.%2C%20asserting%20%60wordCountPreset%20%3D%3D%20.sevenToTwelve%60%2C%20%60enablesFastMode%20%3D%3D%20false%60%2C%20%60enablesClipboardContext%20%3D%3D%20false%60%29%20would%20pin%20those%20decisions%20the%20same%20way%20the%20other%20tiers%20are%20pinned.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20CotabbyTests%2FOnboardingTemplateRecommenderTests.swift%0ALine%3A%2027-43%0A%0AComment%3A%0A**Missing%20behavior-flag%20assertions%20for%20%60.custom%60**%0A%0A%60testAppleIntelligenceStillCarriesTierBehaviorFlags%60%20explicitly%20validates%20quick%2C%20everyday%2C%20and%20powerful%20but%20skips%20custom.%20If%20%60enablesClipboardContext%60%2C%20%60wordCountPreset%60%2C%20or%20%60enablesFastMode%60%20are%20accidentally%20changed%20for%20%60.custom%60%20later%2C%20no%20test%20catches%20it.%20Adding%20a%20%60custom%60%20block%20%28e.g.%2C%20asserting%20%60wordCountPreset%20%3D%3D%20.sevenToTwelve%60%2C%20%60enablesFastMode%20%3D%3D%20false%60%2C%20%60enablesClipboardContext%20%3D%3D%20false%60%29%20would%20pin%20those%20decisions%20the%20same%20way%20the%20other%20tiers%20are%20pinned.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=589&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>


2. `CotabbyTests/OnboardingTemplateRecommenderTests.swift`, line 101-110 ([link](https://github.com/fujacob/cotabby/blob/5c47914992b426b814c28d5e444a446f7553310b/CotabbyTests/OnboardingTemplateRecommenderTests.swift#L101-L110)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **No low-memory warning test for `.custom`**

   `testEverydayWarnsOnLowMemoryUnderOpenSource` covers everyday, but there is no parallel test for `.custom` even though the availability switch now groups them on the same branch. Since both use the same GGUF, a dedicated `testCustomWarnsOnLowMemoryUnderOpenSource` case with `gigabytes: 6` would make that contract explicit and guard against the two cases accidentally diverging in the future.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fonboarding-blank-template%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fonboarding-blank-template%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20CotabbyTests%2FOnboardingTemplateRecommenderTests.swift%0ALine%3A%20101-110%0A%0AComment%3A%0A**No%20low-memory%20warning%20test%20for%20%60.custom%60**%0A%0A%60testEverydayWarnsOnLowMemoryUnderOpenSource%60%20covers%20everyday%2C%20but%20there%20is%20no%20parallel%20test%20for%20%60.custom%60%20even%20though%20the%20availability%20switch%20now%20groups%20them%20on%20the%20same%20branch.%20Since%20both%20use%20the%20same%20GGUF%2C%20a%20dedicated%20%60testCustomWarnsOnLowMemoryUnderOpenSource%60%20case%20with%20%60gigabytes%3A%206%60%20would%20make%20that%20contract%20explicit%20and%20guard%20against%20the%20two%20cases%20accidentally%20diverging%20in%20the%20future.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20CotabbyTests%2FOnboardingTemplateRecommenderTests.swift%0ALine%3A%20101-110%0A%0AComment%3A%0A**No%20low-memory%20warning%20test%20for%20%60.custom%60**%0A%0A%60testEverydayWarnsOnLowMemoryUnderOpenSource%60%20covers%20everyday%2C%20but%20there%20is%20no%20parallel%20test%20for%20%60.custom%60%20even%20though%20the%20availability%20switch%20now%20groups%20them%20on%20the%20same%20branch.%20Since%20both%20use%20the%20same%20GGUF%2C%20a%20dedicated%20%60testCustomWarnsOnLowMemoryUnderOpenSource%60%20case%20with%20%60gigabytes%3A%206%60%20would%20make%20that%20contract%20explicit%20and%20guard%20against%20the%20two%20cases%20accidentally%20diverging%20in%20the%20future.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=589&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fonboarding-blank-template%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fonboarding-blank-template%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabbyTests%2FOnboardingTemplateRecommenderTests.swift%3A27-43%0A**Missing%20behavior-flag%20assertions%20for%20%60.custom%60**%0A%0A%60testAppleIntelligenceStillCarriesTierBehaviorFlags%60%20explicitly%20validates%20quick%2C%20everyday%2C%20and%20powerful%20but%20skips%20custom.%20If%20%60enablesClipboardContext%60%2C%20%60wordCountPreset%60%2C%20or%20%60enablesFastMode%60%20are%20accidentally%20changed%20for%20%60.custom%60%20later%2C%20no%20test%20catches%20it.%20Adding%20a%20%60custom%60%20block%20%28e.g.%2C%20asserting%20%60wordCountPreset%20%3D%3D%20.sevenToTwelve%60%2C%20%60enablesFastMode%20%3D%3D%20false%60%2C%20%60enablesClipboardContext%20%3D%3D%20false%60%29%20would%20pin%20those%20decisions%20the%20same%20way%20the%20other%20tiers%20are%20pinned.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabbyTests%2FOnboardingTemplateRecommenderTests.swift%3A101-110%0A**No%20low-memory%20warning%20test%20for%20%60.custom%60**%0A%0A%60testEverydayWarnsOnLowMemoryUnderOpenSource%60%20covers%20everyday%2C%20but%20there%20is%20no%20parallel%20test%20for%20%60.custom%60%20even%20though%20the%20availability%20switch%20now%20groups%20them%20on%20the%20same%20branch.%20Since%20both%20use%20the%20same%20GGUF%2C%20a%20dedicated%20%60testCustomWarnsOnLowMemoryUnderOpenSource%60%20case%20with%20%60gigabytes%3A%206%60%20would%20make%20that%20contract%20explicit%20and%20guard%20against%20the%20two%20cases%20accidentally%20diverging%20in%20the%20future.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabbyTests%2FOnboardingTemplateRecommenderTests.swift%3A27-43%0A**Missing%20behavior-flag%20assertions%20for%20%60.custom%60**%0A%0A%60testAppleIntelligenceStillCarriesTierBehaviorFlags%60%20explicitly%20validates%20quick%2C%20everyday%2C%20and%20powerful%20but%20skips%20custom.%20If%20%60enablesClipboardContext%60%2C%20%60wordCountPreset%60%2C%20or%20%60enablesFastMode%60%20are%20accidentally%20changed%20for%20%60.custom%60%20later%2C%20no%20test%20catches%20it.%20Adding%20a%20%60custom%60%20block%20%28e.g.%2C%20asserting%20%60wordCountPreset%20%3D%3D%20.sevenToTwelve%60%2C%20%60enablesFastMode%20%3D%3D%20false%60%2C%20%60enablesClipboardContext%20%3D%3D%20false%60%29%20would%20pin%20those%20decisions%20the%20same%20way%20the%20other%20tiers%20are%20pinned.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabbyTests%2FOnboardingTemplateRecommenderTests.swift%3A101-110%0A**No%20low-memory%20warning%20test%20for%20%60.custom%60**%0A%0A%60testEverydayWarnsOnLowMemoryUnderOpenSource%60%20covers%20everyday%2C%20but%20there%20is%20no%20parallel%20test%20for%20%60.custom%60%20even%20though%20the%20availability%20switch%20now%20groups%20them%20on%20the%20same%20branch.%20Since%20both%20use%20the%20same%20GGUF%2C%20a%20dedicated%20%60testCustomWarnsOnLowMemoryUnderOpenSource%60%20case%20with%20%60gigabytes%3A%206%60%20would%20make%20that%20contract%20explicit%20and%20guard%20against%20the%20two%20cases%20accidentally%20diverging%20in%20the%20future.%0A%0A&repo=fujacob%2Fcotabby&pr=589&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add a Custom starting point to onboardin..."](https://github.com/fujacob/cotabby/commit/5c47914992b426b814c28d5e444a446f7553310b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35799015)</sub>

<!-- /greptile_comment -->