### PR TITLE
fix(overlay): light up the popup completion card green for typo corrections

### DIFF
--- a/Cotabby/Services/UI/OverlayController.swift
+++ b/Cotabby/Services/UI/OverlayController.swift
@@ -314,7 +314,8 @@ final class OverlayController: SuggestionOverlayControlling {
             layout: layout,
             customColor: customGhostColor,
             keycapLabel: acceptanceHintLabel,
-            opacity: ghostOpacity
+            opacity: ghostOpacity,
+            isCorrection: geometry.isCorrection
         )
 
         let contentView: NSHostingView<MirrorOverlayView>
@@ -419,6 +420,19 @@ private final class OverlayPanel: NSPanel {
     override var canBecomeMain: Bool { false }
 }
 
+/// The green used to signal a typo correction. Tuned per color scheme so it stays legible in both
+/// appearances without dropping below a comfortable contrast floor against typical text-field
+/// backgrounds. Shared by the inline ghost and the mirror card so a correction reads identically in
+/// either display mode; the user's custom suggestion color is intentionally bypassed for corrections
+/// because semantic communication beats personalization here.
+private enum SuggestionCorrectionStyle {
+    static func color(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark
+            ? Color(red: 0.45, green: 0.85, blue: 0.45)
+            : Color(red: 0.15, green: 0.60, blue: 0.20)
+    }
+}
+
 /// Small SwiftUI view hosted inside the floating AppKit panel.
 /// Keeping the rendered content separate from the window controller makes styling easier to evolve
 /// without touching the AppKit positioning code.
@@ -446,12 +460,7 @@ private struct GhostSuggestionView: View {
     /// field color is pre-filtered upstream so invisible extremes already fall back to nil here.
     var ghostColor: Color {
         if isCorrection {
-            // Tuned per color scheme so the green stays legible in both appearances without dropping
-            // below a comfortable contrast floor against typical text-field backgrounds.
-            let correctionColor = colorScheme == .dark
-                ? Color(red: 0.45, green: 0.85, blue: 0.45)
-                : Color(red: 0.15, green: 0.60, blue: 0.20)
-            return correctionColor.opacity(opacity)
+            return SuggestionCorrectionStyle.color(for: colorScheme).opacity(opacity)
         }
         let baseColor = customColor
             ?? fieldColor
@@ -549,8 +558,14 @@ private struct MirrorOverlayView: View {
     let customColor: Color?
     let keycapLabel: String?
     let opacity: Double
+    /// When true, the suggestion replaces a typo'd word; the whole card lights up green to match the
+    /// inline ghost, and the next-accept-word highlight is suppressed (the correction is one unit).
+    let isCorrection: Bool
 
     private var ghostColor: Color {
+        if isCorrection {
+            return SuggestionCorrectionStyle.color(for: colorScheme).opacity(opacity)
+        }
         let baseColor = customColor
             ?? (
                 colorScheme == .dark
@@ -575,6 +590,10 @@ private struct MirrorOverlayView: View {
         var attributed = AttributedString(layout.suggestionText)
         attributed.font = .system(size: layout.fontSize)
         attributed.foregroundColor = ghostColor
+
+        // A correction replaces the whole word, so the entire run stays green; the next-accept-word
+        // highlight (which marks where Tab stops mid-completion) does not apply to a correction.
+        guard !isCorrection else { return attributed }
 
         let prefix = layout.highlightedPrefix
         guard !prefix.isEmpty, layout.suggestionText.hasPrefix(prefix) else {


### PR DESCRIPTION
## Summary

The inline autocorrect feature renders a typo correction in green (in the inline ghost text) to signal that accepting will *replace* the last word rather than extend it. The popup completion card (mirror display mode, used when the caret rect is unreliable or the user pins popup mode) never got that treatment: `showInline` passed `isCorrection` to `GhostSuggestionView`, but `showMirror` built `MirrorOverlayView` without it, so a correction shown in the popup card stayed in the muted gray suggestion color. This makes the popup card light up green for corrections too, matching the inline ghost.

## What changed

- Extracted the correction green into a shared `SuggestionCorrectionStyle.color(for:)` helper so the inline ghost and the popup card use the *identical* color in both light and dark mode (previously the green was inlined in `GhostSuggestionView` only).
- Threaded `isCorrection` into `MirrorOverlayView` and passed `geometry.isCorrection` from `showMirror`.
- For a correction, the whole card text renders green; the next-accept-word highlight (the semibold prefix that marks where Tab stops mid-completion) is suppressed because a correction replaces the word as one unit.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' test \
  -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
# ** TEST SUCCEEDED **  920 tests, 4 skipped, 0 failures

swiftlint lint --quiet
# 0 violations in changed file
```

The change is a SwiftUI rendering tweak in the private overlay views; it mirrors the existing inline correction path exactly. Recommend a quick live check: trigger a typo correction with the display set to popup mode and confirm the card text is green.

## Linked issues

None.

## Risk / rollout notes

- Rendering-only change in `OverlayController`'s private overlay views. No model, settings, or input-path changes; normal (non-correction) completions in the popup card are unchanged.
- The custom suggestion text color is intentionally bypassed for corrections (as it already is inline): the green is a semantic signal, so it wins over personalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The popup completion card (`MirrorOverlayView`) now lights up green for typo corrections, matching the already-implemented inline ghost text behavior. The inline correction green is also refactored out of `GhostSuggestionView` into a shared `SuggestionCorrectionStyle.color(for:)` helper so both display modes use identical color values.

- `isCorrection` is threaded from `geometry.isCorrection` through `showMirror` into `MirrorOverlayView` as a new `let` property; `ghostColor` branches on it to return the correction green, bypassing `customColor` intentionally.
- `styledSuggestionText` in `MirrorOverlayView` returns early (before the semibold prefix-highlight pass) when `isCorrection` is true, correctly treating the replacement as an atomic unit with no word-by-word stop marker.
- `SuggestionCorrectionStyle` is a private enum scoped to this file, sharing exactly one color definition between both rendering paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is scoped entirely to private SwiftUI views and has no effect on model, settings, or input-path code.

The correction color was already proven correct in the inline ghost path; this PR simply reuses the same value via a shared helper and wires the same boolean through mirror mode. The early-return guard in styledSuggestion correctly prevents the semibold prefix highlight from appearing on a correction. All changed code is private to the file, normal (non-correction) completions are unaffected, and the test suite passes.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Services/UI/OverlayController.swift | Threads `isCorrection` into `MirrorOverlayView`, extracts correction green into shared `SuggestionCorrectionStyle`, and guards the prefix-highlight attribution path for corrections — mirrors the existing inline correction path exactly with no logic gaps. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[showSuggestion] --> B{RenderMode?}
    B -- inline --> C[showInline]
    B -- mirror --> D[showMirror]

    C --> E[GhostSuggestionView\nisCorrection: geometry.isCorrection]
    D --> F[MirrorOverlayView\nisCorrection: geometry.isCorrection]

    E --> G{isCorrection?}
    F --> H{isCorrection?}

    G -- yes --> I[SuggestionCorrectionStyle.color\nopacity applied\nno prefix highlight needed]
    G -- no --> J[customColor ?? fieldColor ?? defaultGray\nopacity applied]

    H -- yes --> K[SuggestionCorrectionStyle.color\nopacity applied\nguard early-return skips prefix highlight]
    H -- no --> L[customColor ?? defaultGray\nopacity applied\nsemibold prefix highlight applied]

    I --> M[Identical green in both modes]
    K --> M
```

<sub>Reviews (1): Last reviewed commit: ["fix(overlay): light up the popup card gr..."](https://github.com/fujacob/cotabby/commit/a107408899f514d5d0eb383c0661014ae8b2faf6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35799320)</sub>

<!-- /greptile_comment -->