### PR TITLE
Add a Home pane to Settings

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -224,6 +224,7 @@
 		B00FDD3DEE0B73FF5136C91C /* FocusTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C9FDF029F7828CAF3FE8850 /* FocusTracker.swift */; };
 		B0B115C6EBAC37FF6115B4BE /* SuggestionCoordinator+Lifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78E280F4F39A9D86840800D2 /* SuggestionCoordinator+Lifecycle.swift */; };
 		B2F7589B8D32ACF97BB642AB /* HuggingFaceModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A520809E71697E3BB9A8139C /* HuggingFaceModels.swift */; };
+		B65B49F24F59154A7611FD22 /* HomePaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1123AB515110BD0CBA39490 /* HomePaneView.swift */; };
 		B6652D81162C64248AA4CF0B /* EmojiPickerPanelController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 764659D09C3F0E8FBD267102 /* EmojiPickerPanelController.swift */; };
 		B6703DAE949C7FB034634424 /* CurrentWordExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 247561C626843957CFB4B632 /* CurrentWordExtractor.swift */; };
 		B6815BBBC91809A6EAA914CB /* UnitConversionEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82E7794DF60664B1FA8F6E7B /* UnitConversionEvaluator.swift */; };
@@ -562,6 +563,7 @@
 		CDB25ABC4FFB0E63477CDCB0 /* SuggestionOverlayStabilityGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionOverlayStabilityGateTests.swift; sourceTree = "<group>"; };
 		CE0AA0503128B0FC3951D700 /* SuggestionSessionReconciler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionSessionReconciler.swift; sourceTree = "<group>"; };
 		CE8C2569A8217EE9BD3B197F /* FileLogHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileLogHandler.swift; sourceTree = "<group>"; };
+		D1123AB515110BD0CBA39490 /* HomePaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePaneView.swift; sourceTree = "<group>"; };
 		D12ABBCE23A946C22894945B /* DecodeStopPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodeStopPolicy.swift; sourceTree = "<group>"; };
 		D2D0FE44138BCA8B2EE05AFE /* TypoCaseTransferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypoCaseTransferTests.swift; sourceTree = "<group>"; };
 		D2F46767D9D1F0D44E239CA8 /* DownloadFileRescuerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadFileRescuerTests.swift; sourceTree = "<group>"; };
@@ -700,6 +702,7 @@
 				A28B4A4368DB33C25E3AB5F3 /* EmojiPaneView.swift */,
 				FC9ECD5408B0F5708149B5C0 /* EngineAndModelPaneView.swift */,
 				07480CE96ED0EBD94817C6B1 /* GeneralPaneView.swift */,
+				D1123AB515110BD0CBA39490 /* HomePaneView.swift */,
 				F4D5455C46AD9416FEFF2DB6 /* LivePreviewModel.swift */,
 				DEBD6113A3C1038BECC99245 /* PerformancePaneView.swift */,
 				7113D3373525113CA69E7597 /* PermissionsPaneView.swift */,
@@ -1333,6 +1336,7 @@
 				ED9C51B0D7056F0753AADF2D /* GhostSuggestionLayout.swift in Sources */,
 				F4EEE6291095B0BF2D3FBA21 /* GhostTextColorPreset.swift in Sources */,
 				D90C889A623A928F4F5FDC7B /* HardwareCapabilityProbe.swift in Sources */,
+				B65B49F24F59154A7611FD22 /* HomePaneView.swift in Sources */,
 				91C27021750AC03AA4A0115A /* HuggingFaceAPIClient.swift in Sources */,
 				EE87886AC1BFC8BB3DE09762 /* HuggingFaceModelBrowserView.swift in Sources */,
 				B2F7589B8D32ACF97BB642AB /* HuggingFaceModels.swift in Sources */,

--- a/Cotabby/Support/SettingsAttentionEvaluator.swift
+++ b/Cotabby/Support/SettingsAttentionEvaluator.swift
@@ -67,7 +67,7 @@ enum SettingsAttentionEvaluator {
                 return reason
             }
 
-        case .general, .appearance, .emoji, .writing, .context, .shortcuts, .apps, .performance, .about:
+        case .home, .general, .appearance, .emoji, .writing, .context, .shortcuts, .apps, .performance, .about:
             return nil
         }
     }

--- a/Cotabby/UI/Settings/Panes/HomePaneView.swift
+++ b/Cotabby/UI/Settings/Panes/HomePaneView.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+/// File overview:
+/// "Home" detail pane: the welcoming landing surface of the Settings window and the first sidebar
+/// row. It introduces what Cotabby is, replays the same inline-autocomplete and inline-emoji demos
+/// shown on the final onboarding screen (`OnboardingFeatureShowcase`), and surfaces the Support
+/// Cotabby call to action. It is the default pane on a fresh install; returning users still land on
+/// their last-viewed pane.
+///
+/// The feature demos are inert, self-playing animations that never touch the real suggestion
+/// pipeline, so this pane is safe to keep open without side effects.
+struct HomePaneView: View {
+    var body: some View {
+        SettingsPaneScaffold {
+            Section { introHeader }
+            Section("See it in action") { OnboardingFeatureShowcase() }
+            Section("Support") { supportRow }
+        }
+    }
+
+    @ViewBuilder
+    private var introHeader: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 12) {
+                Image("CotabbyLogo")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 44, height: 44)
+                    .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Welcome to Cotabby")
+                        .font(.system(size: 17, weight: .semibold, design: .rounded))
+                    Text("Local-first AI autocomplete for macOS")
+                        .font(.system(size: 12, design: .rounded))
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Text(
+                "Cotabby suggests the next few words as ghost text in any text field, system-wide. "
+                + "Press Tab to accept, or keep typing to ignore. It also completes inline :emoji: "
+                + "shortcuts. Everything runs on your device; nothing is sent to the cloud."
+            )
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.vertical, 4)
+    }
+
+    @ViewBuilder
+    private var supportRow: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(
+                "Cotabby is free and open source, maintained by two students in our spare time. "
+                + "If it's useful to you, supporting development helps us keep improving it."
+            )
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+
+            if let supportURL = URL(string: "https://ko-fi.com/cotabby") {
+                Link(destination: supportURL) {
+                    Label("Support Cotabby", systemImage: "heart.fill")
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.blue)
+            }
+        }
+    }
+}

--- a/Cotabby/UI/Settings/SettingsCategory.swift
+++ b/Cotabby/UI/Settings/SettingsCategory.swift
@@ -10,6 +10,7 @@ import Foundation
 /// Order reflects a top-down reading: core behavior, how suggestions look, the emoji feature, what
 /// the model is told (writing then context), the model itself, input bindings, then system and info.
 enum SettingsCategory: String, CaseIterable, Hashable, Identifiable {
+    case home
     case general
     case appearance
     case emoji
@@ -26,6 +27,7 @@ enum SettingsCategory: String, CaseIterable, Hashable, Identifiable {
 
     var label: String {
         switch self {
+        case .home: return "Home"
         case .general: return "General"
         case .appearance: return "Appearance"
         case .emoji: return "Emoji"
@@ -43,6 +45,7 @@ enum SettingsCategory: String, CaseIterable, Hashable, Identifiable {
     /// SF Symbol displayed at the left of each sidebar row.
     var systemImage: String {
         switch self {
+        case .home: return "house.fill"
         case .general: return "gearshape.fill"
         case .appearance: return "paintbrush.fill"
         case .emoji: return "face.smiling"

--- a/Cotabby/UI/Settings/SettingsContainerView.swift
+++ b/Cotabby/UI/Settings/SettingsContainerView.swift
@@ -32,9 +32,9 @@ struct SettingsContainerView: View {
     let clearEmojiHistory: () -> Void
 
     @AppStorage("cotabbySettingsSelectedCategoryV2")
-    private var storedCategoryRawValue: String = SettingsCategory.general.rawValue
+    private var storedCategoryRawValue: String = SettingsCategory.home.rawValue
 
-    @State private var selection: SettingsCategory = .general
+    @State private var selection: SettingsCategory = .home
     // Settings should behave like a traditional two-column preferences window: the sidebar is
     // always visible, but SwiftUI can still manage the native navigation/split-view chrome.
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
@@ -95,6 +95,8 @@ struct SettingsContainerView: View {
     @ViewBuilder
     private var detailPane: some View {
         switch selection {
+        case .home:
+            HomePaneView()
         case .general:
             GeneralPaneView(
                 suggestionSettings: suggestionSettings,


### PR DESCRIPTION
## Summary
Adds a **Home** pane as the first row in the Settings sidebar, and makes it the default landing pane for fresh installs (returning users still land on their last-viewed pane). Home gathers the welcoming content in one place:

- A short intro describing what Cotabby is (local-first, ghost-text autocomplete + inline `:emoji:`, all on-device).
- The same self-playing feature demos shown on the final onboarding screen, reusing `OnboardingFeatureShowcase` (inline autocomplete + emoji picker).
- A **Support Cotabby** call to action (Ko-fi), matching the About pane's pattern.

## Validation
```bash
xcodegen generate
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build -derivedDataPath build/DerivedData
# ** BUILD SUCCEEDED **
swiftlint lint --quiet
# exit 0
```
Not captured visually in this environment; recommend a quick look at the new pane (light + dark).

## Linked issues
None.

## Risk / rollout notes
- Adds `SettingsCategory.home` (first case) and routes it in `SettingsContainerView`; the attention-evaluator switch and the sidebar handle it generically.
- Default landing pane changes from General to Home for fresh installs only; the persisted last-pane selection is unchanged for existing users.
- The feature demos are the existing inert, self-playing `OnboardingFeatureShowcase` (no real pipeline, Accessibility, or event-tap access); they animate only while Home is open.
- `Cotabby.xcodeproj` regenerated via XcodeGen for the new file.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a **Home** pane as the first row in the Settings sidebar and makes it the default landing pane for fresh installs, while existing users continue to land on their last-viewed pane.

- `SettingsCategory.home` is added as the first enum case, with `house.fill` icon and full label coverage; `SettingsAttentionEvaluator` and `SettingsContainerView` are updated exhaustively.
- `HomePaneView` reuses `OnboardingFeatureShowcase` for self-playing demos and duplicates the Ko-fi support CTA already present in `AboutPaneView`, creating a dual-maintenance surface for that URL and copy.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all switch statements are exhaustive and the new pane wires up cleanly through the existing routing.

The change is narrow and well-contained: a new enum case, a new view, and two small edits to existing files. The only things worth a second look are the verbatim copy of the Ko-fi support block from AboutPaneView and the restoreSelection fallback that still returns .general rather than the new intended default .home.

HomePaneView.swift — duplicated support CTA relative to AboutPaneView; SettingsContainerView.swift — restoreSelection unknown-value fallback.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/UI/Settings/Panes/HomePaneView.swift | New Home pane view with intro header, OnboardingFeatureShowcase reuse, and Support CTA — nearly identical to AboutPaneView's support section, creating a dual-maintenance concern for the URL and copy. |
| Cotabby/UI/Settings/SettingsCategory.swift | Adds case home as first enum case with complete label/systemImage coverage; all switch exhaustions in the codebase are maintained. |
| Cotabby/UI/Settings/SettingsContainerView.swift | Changes default landing pane from .general to .home for fresh installs via @AppStorage default and @State initializer; restoreSelection fallback still returns .general for unknown raw values. |
| Cotabby/Support/SettingsAttentionEvaluator.swift | Adds .home to the no-attention catch-all in calloutMessage; switch remains exhaustive across all 12 categories. |
| Cotabby.xcodeproj/project.pbxproj | Standard XcodeGen-regenerated project file adding HomePaneView.swift with correct file reference and build phase entries. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Settings window opens] --> B{storedCategoryRawValue}
    B -->|fresh install: 'home'| C[restoreSelection → .home]
    B -->|returning user: last pane| D[restoreSelection → persisted pane]
    B -->|legacy 'appleIntelligence'/'openSource'| E[restoreSelection → .engineAndModel]
    B -->|legacy 'advanced'| F[restoreSelection → .context]
    B -->|unknown| G[restoreSelection → .general]
    C --> H[selection = .home]
    D --> I[selection = saved pane]
    E --> J[selection = .engineAndModel]
    F --> K[selection = .context]
    G --> L[selection = .general]
    H --> M[detailPane switch]
    M -->|.home| N[HomePaneView]
    M -->|.general| O[GeneralPaneView]
    M -->|other panes| P[...]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cotabby/UI/Settings/SettingsContainerView.swift`, line 157-158 ([link](https://github.com/fujacob/cotabby/blob/7980950690a8a1aca92c75d385d3a33d50b2f943/Cotabby/UI/Settings/SettingsContainerView.swift#L157-L158)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> When `storedCategoryRawValue` holds a completely unrecognised string, `restoreSelection` falls back to `.general` rather than the new `.home` default. This is a corner-case, but it's slightly inconsistent with the intent to make `.home` the canonical first-run landing pane. Consider returning `.home` here so the fallback aligns with the new default.

   

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fsettings-home%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fsettings-home%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FSettings%2FSettingsContainerView.swift%0ALine%3A%20157-158%0A%0AComment%3A%0AWhen%20%60storedCategoryRawValue%60%20holds%20a%20completely%20unrecognised%20string%2C%20%60restoreSelection%60%20falls%20back%20to%20%60.general%60%20rather%20than%20the%20new%20%60.home%60%20default.%20This%20is%20a%20corner-case%2C%20but%20it's%20slightly%20inconsistent%20with%20the%20intent%20to%20make%20%60.home%60%20the%20canonical%20first-run%20landing%20pane.%20Consider%20returning%20%60.home%60%20here%20so%20the%20fallback%20aligns%20with%20the%20new%20default.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20return%20.home%0A%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FSettings%2FSettingsContainerView.swift%0ALine%3A%20157-158%0A%0AComment%3A%0AWhen%20%60storedCategoryRawValue%60%20holds%20a%20completely%20unrecognised%20string%2C%20%60restoreSelection%60%20falls%20back%20to%20%60.general%60%20rather%20than%20the%20new%20%60.home%60%20default.%20This%20is%20a%20corner-case%2C%20but%20it's%20slightly%20inconsistent%20with%20the%20intent%20to%20make%20%60.home%60%20the%20canonical%20first-run%20landing%20pane.%20Consider%20returning%20%60.home%60%20here%20so%20the%20fallback%20aligns%20with%20the%20new%20default.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20return%20.home%0A%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=591&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fsettings-home%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fsettings-home%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FSettings%2FPanes%2FHomePaneView.swift%3A52-70%0AThe%20support%20block%20here%20%E2%80%94%20URL%2C%20copy%2C%20button%20style%2C%20and%20icon%20%E2%80%94%20is%20a%20verbatim%20copy%20of%20%60AboutPaneView%60's%20%60supportRow%60.%20If%20the%20Ko-fi%20URL%2C%20link%20text%2C%20or%20system%20image%20ever%20changes%2C%20both%20panes%20need%20updating%20in%20sync.%20Consider%20extracting%20a%20shared%20%60SupportCotabbyRow%60%20view%20%28or%20pulling%20the%20URL%20into%20a%20constant%29%20so%20there's%20a%20single%20source%20of%20truth.%0A%0A%60%60%60suggestion%0A%20%20%20%20%40ViewBuilder%0A%20%20%20%20private%20var%20supportRow%3A%20some%20View%20%7B%0A%20%20%20%20%20%20%20%20SupportCotabbyRow%28%0A%20%20%20%20%20%20%20%20%20%20%20%20blurb%3A%20%22Cotabby%20is%20free%20and%20open%20source%2C%20maintained%20by%20two%20students%20in%20our%20spare%20time.%20%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2B%20%22If%20it's%20useful%20to%20you%2C%20supporting%20development%20helps%20us%20keep%20improving%20it.%22%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FUI%2FSettings%2FSettingsContainerView.swift%3A157-158%0AWhen%20%60storedCategoryRawValue%60%20holds%20a%20completely%20unrecognised%20string%2C%20%60restoreSelection%60%20falls%20back%20to%20%60.general%60%20rather%20than%20the%20new%20%60.home%60%20default.%20This%20is%20a%20corner-case%2C%20but%20it's%20slightly%20inconsistent%20with%20the%20intent%20to%20make%20%60.home%60%20the%20canonical%20first-run%20landing%20pane.%20Consider%20returning%20%60.home%60%20here%20so%20the%20fallback%20aligns%20with%20the%20new%20default.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20return%20.home%0A%20%20%20%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FSettings%2FPanes%2FHomePaneView.swift%3A52-70%0AThe%20support%20block%20here%20%E2%80%94%20URL%2C%20copy%2C%20button%20style%2C%20and%20icon%20%E2%80%94%20is%20a%20verbatim%20copy%20of%20%60AboutPaneView%60's%20%60supportRow%60.%20If%20the%20Ko-fi%20URL%2C%20link%20text%2C%20or%20system%20image%20ever%20changes%2C%20both%20panes%20need%20updating%20in%20sync.%20Consider%20extracting%20a%20shared%20%60SupportCotabbyRow%60%20view%20%28or%20pulling%20the%20URL%20into%20a%20constant%29%20so%20there's%20a%20single%20source%20of%20truth.%0A%0A%60%60%60suggestion%0A%20%20%20%20%40ViewBuilder%0A%20%20%20%20private%20var%20supportRow%3A%20some%20View%20%7B%0A%20%20%20%20%20%20%20%20SupportCotabbyRow%28%0A%20%20%20%20%20%20%20%20%20%20%20%20blurb%3A%20%22Cotabby%20is%20free%20and%20open%20source%2C%20maintained%20by%20two%20students%20in%20our%20spare%20time.%20%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2B%20%22If%20it's%20useful%20to%20you%2C%20supporting%20development%20helps%20us%20keep%20improving%20it.%22%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FUI%2FSettings%2FSettingsContainerView.swift%3A157-158%0AWhen%20%60storedCategoryRawValue%60%20holds%20a%20completely%20unrecognised%20string%2C%20%60restoreSelection%60%20falls%20back%20to%20%60.general%60%20rather%20than%20the%20new%20%60.home%60%20default.%20This%20is%20a%20corner-case%2C%20but%20it's%20slightly%20inconsistent%20with%20the%20intent%20to%20make%20%60.home%60%20the%20canonical%20first-run%20landing%20pane.%20Consider%20returning%20%60.home%60%20here%20so%20the%20fallback%20aligns%20with%20the%20new%20default.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20return%20.home%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=591&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add a Home pane to Settings"](https://github.com/fujacob/cotabby/commit/7980950690a8a1aca92c75d385d3a33d50b2f943) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35800070)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->