### PR TITLE
Enable hands-off Sparkle auto-install

### DIFF
--- a/CotabbyInfo.plist
+++ b/CotabbyInfo.plist
@@ -25,9 +25,9 @@
 	<key>NSAccessibilityUsageDescription</key>
 	<string>Cotabby needs Accessibility access to read and insert text in other apps.</string>
 	<key>SUAllowsAutomaticUpdates</key>
-	<false/>
+	<true/>
 	<key>SUAutomaticallyUpdate</key>
-	<false/>
+	<true/>
 	<key>SUEnableAutomaticChecks</key>
 	<true/>
 	<key>SUScheduledCheckInterval</key>


### PR DESCRIPTION
## Summary

Turns on automatic download + install of updates. Cotabby already checks for updates automatically on launch and every 24 hours; this makes those updates install silently in the background rather than only notifying the user.

Flips two Info.plist keys:
- `SUAllowsAutomaticUpdates`: `false` -> `true`
- `SUAutomaticallyUpdate`: `false` -> `true`

`SUEnableAutomaticChecks` (true) and `SUScheduledCheckInterval` (86400s) are unchanged.

## Validation

```
plutil -lint CotabbyInfo.plist            # OK
plutil -extract SUAllowsAutomaticUpdates raw CotabbyInfo.plist   # true
plutil -extract SUAutomaticallyUpdate raw CotabbyInfo.plist      # true
xcodebuild ... build                      # ** BUILD SUCCEEDED **
```

These are read from the Info.plist as the defaults; no user-defaults override for these keys exists today (the app has no UI to toggle them), so the change takes effect for existing users too.

## Linked issues

None.

## Risk / rollout notes

- Updates will now install without a user click. Make sure the appcast (`https://updates.cotabby.app/appcast.xml`) only ever serves intended, signed builds, since users will receive them automatically.
- Sparkle still won't auto-install an update that requires action it can't take silently (e.g. one marked as a critical/major update needing consent), and EdDSA signature verification still gates every install.
- Info.plist-only change; no code, no pbxproj.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enables Sparkle's hands-off auto-update mode by flipping `SUAllowsAutomaticUpdates` and `SUAutomaticallyUpdate` from `false` to `true` in `CotabbyInfo.plist`. Updates will now download and install silently in the background rather than prompting for a user click.

- Existing users with no stored preference will have silent auto-updates enabled immediately on next launch, with no in-app way to opt out (the app has no settings UI for this toggle).
- EdDSA signature verification via `SUPublicEDKey` remains in place, so only appcast-served builds signed with the corresponding private key will install — but the appcast server becomes a critical trust dependency for all users automatically.

<h3>Confidence Score: 4/5</h3>

Safe to merge if the team is comfortable with silent auto-updates rolling out to all existing users without an opt-out UI, and the appcast pipeline is hardened.

The plist change is correct and the Sparkle keys are used as intended. The main concern is that existing users — who have no stored preference and no in-app toggle — will silently receive and install updates starting with the next launch. Cotabby holds broad Accessibility permissions, so the appcast server becomes a high-value delivery mechanism for every installed copy. There are no code defects in the change itself, but the absence of an opt-out path and the elevated trust placed in the appcast warrant a second look before shipping.

CotabbyInfo.plist — specifically the interaction between the two new true values and Sparkle’s user-defaults precedence for existing installs.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CotabbyInfo.plist | Flips SUAllowsAutomaticUpdates and SUAutomaticallyUpdate from false to true, enabling silent background download and install of Sparkle updates. Existing users with no stored preference will receive auto-updates without an explicit opt-in prompt; there is currently no in-app UI to disable this behavior. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as Cotabby (launch)
    participant Sparkle as Sparkle Framework
    participant Appcast as appcast.xml (CDN)
    participant EDKey as EdDSA Verifier

    App->>Sparkle: startUpdater()
    App->>Sparkle: checkForUpdatesInBackground()
    Sparkle->>Appcast: GET /appcast.xml
    Appcast-->>Sparkle: feed with version + delta URL + EdDSA sig
    Sparkle->>EDKey: verify signature (SUPublicEDKey)
    EDKey-->>Sparkle: ✓ valid
    Note over Sparkle: SUAutomaticallyUpdate=true<br/>SUAllowsAutomaticUpdates=true
    Sparkle->>Sparkle: download update silently
    Sparkle->>App: install on next quit (no user click required)
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22sparkle-auto-install%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22sparkle-auto-install%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabbyInfo.plist%3A29-30%0A**No%20in-app%20opt-out%20for%20auto-updates**%0A%0A%60SUAutomaticallyUpdate%20%3D%20true%60%20will%20silently%20enable%20background%20install%20for%20all%20existing%20users%20whose%20user%20defaults%20don't%20already%20contain%20an%20override%20%28per%20the%20PR%20description%2C%20none%20do%29.%20Because%20the%20app%20has%20no%20settings%20UI%20backed%20by%20%60SPUUpdater.automaticallyDownloadsUpdates%60%2C%20users%20have%20no%20way%20to%20disable%20this%20behavior%20without%20manually%20writing%20a%20user%20default%20via%20Terminal.%20Given%20that%20Cotabby%20holds%20Accessibility%20permission%20to%20read%20and%20insert%20text%20in%20any%20app%2C%20this%20makes%20the%20appcast%20a%20high-value%20target%3A%20a%20compromised%20or%20incorrectly%20signed%20build%20would%20auto-install%20on%20every%20user's%20machine%20without%20any%20interaction.%20Consider%20adding%20even%20a%20minimal%20toggle%20%E2%80%94%20or%20at%20minimum%20documenting%20the%20workaround%20%E2%80%94%20before%20shipping%20silent%20installs%20to%20existing%20users.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabbyInfo.plist%3A29-30%0A**No%20in-app%20opt-out%20for%20auto-updates**%0A%0A%60SUAutomaticallyUpdate%20%3D%20true%60%20will%20silently%20enable%20background%20install%20for%20all%20existing%20users%20whose%20user%20defaults%20don't%20already%20contain%20an%20override%20%28per%20the%20PR%20description%2C%20none%20do%29.%20Because%20the%20app%20has%20no%20settings%20UI%20backed%20by%20%60SPUUpdater.automaticallyDownloadsUpdates%60%2C%20users%20have%20no%20way%20to%20disable%20this%20behavior%20without%20manually%20writing%20a%20user%20default%20via%20Terminal.%20Given%20that%20Cotabby%20holds%20Accessibility%20permission%20to%20read%20and%20insert%20text%20in%20any%20app%2C%20this%20makes%20the%20appcast%20a%20high-value%20target%3A%20a%20compromised%20or%20incorrectly%20signed%20build%20would%20auto-install%20on%20every%20user's%20machine%20without%20any%20interaction.%20Consider%20adding%20even%20a%20minimal%20toggle%20%E2%80%94%20or%20at%20minimum%20documenting%20the%20workaround%20%E2%80%94%20before%20shipping%20silent%20installs%20to%20existing%20users.%0A%0A&repo=fujacob%2Fcotabby&pr=592&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Enable hands-off Sparkle auto-install"](https://github.com/fujacob/cotabby/commit/a2329e639a3966465613704faaa1a6cb3ae4aed7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35800732)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->