### PR TITLE
Showcase / macros on the final onboarding screen

### DIFF
--- a/Cotabby/UI/Onboarding/OnboardingFeatureShowcase.swift
+++ b/Cotabby/UI/Onboarding/OnboardingFeatureShowcase.swift
@@ -2,8 +2,9 @@ import SwiftUI
 
 /// File overview:
 /// Decorative, self-playing demos shown on the final onboarding screen ("You're all set"). They
-/// mimic Cotabby's two flagship features, inline autocomplete ghost text and the inline `:emoji:`
-/// picker, using hardcoded strings and local state only.
+/// mimic Cotabby's headline features: inline autocomplete ghost text, the inline `:emoji:` picker,
+/// and `/` macros, using hardcoded strings (plus the current date for the date macro) and local
+/// state only.
 ///
 /// Nothing here touches the real suggestion pipeline, settings, Accessibility, the event tap, or the
 /// emoji catalog. The cards are inert content, so they can never steal focus or affect a real
@@ -19,6 +20,7 @@ struct OnboardingFeatureShowcase: View {
         VStack(spacing: 12) {
             GhostTextDemoCard()
             EmojiPickerDemoCard()
+            MacroDemoCard()
         }
         // Purely decorative looping demo: hide it from VoiceOver so the
         // mid-animation text fragments are never read out to AT users.
@@ -343,5 +345,97 @@ private struct DemoEmojiKeycap: View {
                 RoundedRectangle(cornerRadius: 6, style: .continuous).stroke(Color.white.opacity(0.35), lineWidth: 1)
             )
             .fixedSize()
+    }
+}
+
+// MARK: - Demo 3: inline `/` macros
+
+/// A compact summary of the `/` macro feature: one row per macro category (math, unit conversion,
+/// currency, date), each showing what you type and the result it inserts. Unlike the two cards
+/// above, this is a stagger-revealed summary rather than a typing loop, because the point is the
+/// breadth of macro types, which reads better all at once than one example cycling at a time.
+///
+/// The values mirror the real evaluators: arithmetic and unit conversion are deterministic; the
+/// currency row uses Cotabby's bundled offline EUR rate (0.92 per USD); the date row is computed
+/// live with a medium date style so `/today` never shows a stale date.
+private struct MacroDemoCard: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// How many rows have faded in so far.
+    @State private var revealed = 0
+
+    private struct MacroRow: Identifiable {
+        let category: String
+        let input: String
+        let result: String
+        var id: String { input }
+    }
+
+    private var rows: [MacroRow] {
+        [
+            MacroRow(category: "Math", input: "/5+5=", result: "10"),
+            MacroRow(category: "Convert", input: "/10km->mi", result: "6.214 mi"),
+            MacroRow(category: "Currency", input: "/100usd->eur", result: "€92.00"),
+            MacroRow(category: "Date", input: "/today", result: Self.todayMedium)
+        ]
+    }
+
+    var body: some View {
+        DemoCard(caption: "Inline macros", contentHeight: 96) {
+            Grid(alignment: .leadingFirstTextBaseline, horizontalSpacing: 10, verticalSpacing: 9) {
+                ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
+                    GridRow {
+                        Text(row.category)
+                            .font(.system(size: 11, weight: .medium, design: .rounded))
+                            .foregroundStyle(.secondary)
+
+                        Text(row.input)
+                            .font(.system(size: 13, design: .monospaced))
+                            .foregroundStyle(.primary)
+
+                        HStack(alignment: .firstTextBaseline, spacing: 6) {
+                            Text("→")
+                                .font(.system(size: 12))
+                                .foregroundStyle(.tertiary)
+                            Text(row.result)
+                                .font(.system(size: 13, weight: .medium, design: .rounded))
+                                .foregroundStyle(.primary)
+                        }
+                    }
+                    // Rows reserve their grid space even while hidden, so fading them in never shifts
+                    // the layout (and the card's fixed height stays honest).
+                    .opacity(index < revealed ? 1 : 0)
+                    .offset(y: index < revealed ? 0 : 4)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .task(id: reduceMotion) {
+            await revealRows()
+        }
+    }
+
+    private func revealRows() async {
+        guard !reduceMotion else {
+            revealed = rows.count
+            return
+        }
+        revealed = 0
+        // A short beat before the first row, then a gentle stagger so the list assembles itself.
+        try? await Task.sleep(nanoseconds: 250 * nsPerMillisecond)
+        for count in 1...rows.count {
+            if Task.isCancelled { return }
+            withAnimation(.easeOut(duration: 0.28)) { revealed = count }
+            try? await Task.sleep(nanoseconds: 130 * nsPerMillisecond)
+        }
+    }
+
+    /// `/today` rendered with the same medium date style the real `DateMacroEvaluator` uses, read at
+    /// render time so the showcase never displays a stale date.
+    private static var todayMedium: String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        return formatter.string(from: Date())
     }
 }


### PR DESCRIPTION
## Summary

The final onboarding screen ("You're all set") had self-playing demos for **Autocomplete** and **Inline emoji**, but nothing for the new **`/` macros**. This adds a third card, **Inline macros**, that conveys the feature's breadth at a glance.

Per discussion, it's one compact card with a labeled row per macro type shown **simultaneously** (rather than a single example or one big card per type), so the screen stays compact while still showing the range. Rows stagger in with a subtle fade.

The example values mirror the real evaluators so the showcase stays truthful:

| Row | You type | Result | Source |
| --- | --- | --- | --- |
| Math | `/5+5=` | `10` | `ArithmeticEvaluator` (deterministic) |
| Convert | `/10km->mi` | `6.214 mi` | `UnitConversionEvaluator` (`%.4g`) |
| Currency | `/100usd->eur` | `€92.00` | `CurrencyEvaluator`, bundled offline rate 0.92/USD |
| Date | `/today` | current date | `DateMacroEvaluator` medium style, computed live so it is never stale |

Like the existing two cards, it is decorative and inert (no real macro pipeline, `accessibilityHidden`), and **reduce-motion** shows the rows statically.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  build -derivedDataPath build/DerivedData
# ** BUILD SUCCEEDED **

swiftlint lint --quiet
# exit 0, 0 violations
```

This is a visual change; a screenshot / short recording of the final onboarding screen is a good follow-up to attach here (it needs the onboarding flow running).

## Linked issues

None.

## Risk / rollout notes

- Onboarding-only, and only the final ("You're all set") step. The step content is inside the welcome window's `ScrollView` with the action button reachable, so the extra card cannot push the button off-screen.
- No runtime or suggestion/macro pipeline changes, no new files, no `project.yml`/pbxproj changes.
- The date row reads the system clock at render time (so `/today` is current, not stale); the currency row uses the existing bundled offline rate table (illustrative, as in the app).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a third showcase card to the final onboarding screen, demonstrating the `/` macro feature with four rows (math, unit conversion, currency, date) that stagger in with a fade animation.

- The new `MacroDemoCard` follows the established pattern of the other two cards — `@Environment(\.accessibilityReduceMotion)` respected, `.task(id:)` for lifecycle, `accessibilityHidden` on the parent — and uses a `Grid` layout so all macro types are visible simultaneously.
- The date row calls `DateFormatter` on each body evaluation because both `todayMedium` and `rows` are computed properties; caching the formatter as a `static let` is a straightforward improvement.
- After the initial 250 ms pre-stagger sleep, there is no explicit cancellation check before the reveal loop begins, unlike the pattern in the other two cards.

<h3>Confidence Score: 4/5</h3>

Safe to merge — purely additive, decorative-only UI change scoped to the final onboarding step with no pipeline or settings impact.

The change is self-contained within the onboarding showcase file and touches no real suggestion pipeline, accessibility settings, or persisted state. The two findings are both style-level: a DateFormatter is re-created on every body evaluation (should be a cached static let), and the missing cancellation guard after the initial sleep is a minor inconsistency with the established pattern in the other two cards. Neither affects correctness or user-visible behavior in practice.

No files require special attention beyond the two suggestions in OnboardingFeatureShowcase.swift.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/Onboarding/OnboardingFeatureShowcase.swift | Adds MacroDemoCard (math, unit conversion, currency, date rows) to the final onboarding screen. Animation pattern mirrors existing cards. Two minor style improvements: cache the DateFormatter in a static let, and add a cancellation guard after the initial sleep. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[MacroDemoCard.task starts<br>id: reduceMotion] --> B{reduceMotion?}
    B -- Yes --> C[revealed = rows.count\nAll rows shown statically]
    B -- No --> D[revealed = 0\nAll rows hidden]
    D --> E[Sleep 250 ms]
    E --> F{Task cancelled?}
    F -- Yes --> G[Return]
    F -- No --> H[Loop: count 1..4]
    H --> I{Task cancelled?}
    I -- Yes --> G
    I -- No --> J[withAnimation\nrevealed = count]
    J --> K[Sleep 130 ms]
    K --> L{More rows?}
    L -- Yes --> H
    L -- No --> M[Done: all 4 rows visible]

    N[reduceMotion changes] --> O[SwiftUI cancels task]
    O --> A
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fonboarding-slash-commands%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fonboarding-slash-commands%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FOnboarding%2FOnboardingFeatureShowcase.swift%3A433-440%0A%60DateFormatter%60%20is%20expensive%20to%20construct%20and%20%60todayMedium%60%20is%20a%20computed%20%60static%20var%60%2C%20so%20a%20fresh%20%60DateFormatter%60%20is%20allocated%20every%20time%20the%20property%20is%20accessed.%20Because%20%60rows%60%20is%20also%20a%20computed%20property%20evaluated%20on%20every%20%60body%60%20pass%2C%20animations%20trigger%20repeated%20allocations.%20Caching%20the%20formatter%20as%20a%20%60static%20let%60%20while%20keeping%20the%20date%20read%20live%20avoids%20this.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20%60%2Ftoday%60%20rendered%20with%20the%20same%20medium%20date%20style%20the%20real%20%60DateMacroEvaluator%60%20uses%2C%20read%20at%0A%20%20%20%20%2F%2F%2F%20render%20time%20so%20the%20showcase%20never%20displays%20a%20stale%20date.%0A%20%20%20%20private%20static%20let%20mediumDateFormatter%3A%20DateFormatter%20%3D%20%7B%0A%20%20%20%20%20%20%20%20let%20f%20%3D%20DateFormatter%28%29%0A%20%20%20%20%20%20%20%20f.dateStyle%20%3D%20.medium%0A%20%20%20%20%20%20%20%20f.timeStyle%20%3D%20.none%0A%20%20%20%20%20%20%20%20return%20f%0A%20%20%20%20%7D%28%29%0A%0A%20%20%20%20private%20static%20var%20todayMedium%3A%20String%20%7B%0A%20%20%20%20%20%20%20%20mediumDateFormatter.string%28from%3A%20Date%28%29%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FUI%2FOnboarding%2FOnboardingFeatureShowcase.swift%3A423-426%0AAfter%20the%20initial%20250%20ms%20sleep%2C%20there%20is%20no%20cancellation%20guard%20before%20entering%20the%20stagger%20loop.%20If%20the%20task%20is%20cancelled%20while%20sleeping%20%28e.g.%2C%20because%20%60reduceMotion%60%20flipped%29%2C%20%60try%3F%60%20silently%20swallows%20the%20%60CancellationError%60%20and%20execution%20falls%20straight%20into%20the%20%60for%60%20loop.%20The%20first%20iteration's%20%60if%20Task.isCancelled%60%20check%20does%20catch%20it%2C%20but%20an%20explicit%20early-exit%20keeps%20the%20intent%20clear%20and%20matches%20the%20pattern%20used%20in%20the%20other%20two%20demo%20cards.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20revealed%20%3D%200%0A%20%20%20%20%20%20%20%20%2F%2F%20A%20short%20beat%20before%20the%20first%20row%2C%20then%20a%20gentle%20stagger%20so%20the%20list%20assembles%20itself.%0A%20%20%20%20%20%20%20%20try%3F%20await%20Task.sleep%28nanoseconds%3A%20250%20*%20nsPerMillisecond%29%0A%20%20%20%20%20%20%20%20if%20Task.isCancelled%20%7B%20return%20%7D%0A%20%20%20%20%20%20%20%20for%20count%20in%201...rows.count%20%7B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FOnboarding%2FOnboardingFeatureShowcase.swift%3A433-440%0A%60DateFormatter%60%20is%20expensive%20to%20construct%20and%20%60todayMedium%60%20is%20a%20computed%20%60static%20var%60%2C%20so%20a%20fresh%20%60DateFormatter%60%20is%20allocated%20every%20time%20the%20property%20is%20accessed.%20Because%20%60rows%60%20is%20also%20a%20computed%20property%20evaluated%20on%20every%20%60body%60%20pass%2C%20animations%20trigger%20repeated%20allocations.%20Caching%20the%20formatter%20as%20a%20%60static%20let%60%20while%20keeping%20the%20date%20read%20live%20avoids%20this.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20%60%2Ftoday%60%20rendered%20with%20the%20same%20medium%20date%20style%20the%20real%20%60DateMacroEvaluator%60%20uses%2C%20read%20at%0A%20%20%20%20%2F%2F%2F%20render%20time%20so%20the%20showcase%20never%20displays%20a%20stale%20date.%0A%20%20%20%20private%20static%20let%20mediumDateFormatter%3A%20DateFormatter%20%3D%20%7B%0A%20%20%20%20%20%20%20%20let%20f%20%3D%20DateFormatter%28%29%0A%20%20%20%20%20%20%20%20f.dateStyle%20%3D%20.medium%0A%20%20%20%20%20%20%20%20f.timeStyle%20%3D%20.none%0A%20%20%20%20%20%20%20%20return%20f%0A%20%20%20%20%7D%28%29%0A%0A%20%20%20%20private%20static%20var%20todayMedium%3A%20String%20%7B%0A%20%20%20%20%20%20%20%20mediumDateFormatter.string%28from%3A%20Date%28%29%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FUI%2FOnboarding%2FOnboardingFeatureShowcase.swift%3A423-426%0AAfter%20the%20initial%20250%20ms%20sleep%2C%20there%20is%20no%20cancellation%20guard%20before%20entering%20the%20stagger%20loop.%20If%20the%20task%20is%20cancelled%20while%20sleeping%20%28e.g.%2C%20because%20%60reduceMotion%60%20flipped%29%2C%20%60try%3F%60%20silently%20swallows%20the%20%60CancellationError%60%20and%20execution%20falls%20straight%20into%20the%20%60for%60%20loop.%20The%20first%20iteration's%20%60if%20Task.isCancelled%60%20check%20does%20catch%20it%2C%20but%20an%20explicit%20early-exit%20keeps%20the%20intent%20clear%20and%20matches%20the%20pattern%20used%20in%20the%20other%20two%20demo%20cards.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20revealed%20%3D%200%0A%20%20%20%20%20%20%20%20%2F%2F%20A%20short%20beat%20before%20the%20first%20row%2C%20then%20a%20gentle%20stagger%20so%20the%20list%20assembles%20itself.%0A%20%20%20%20%20%20%20%20try%3F%20await%20Task.sleep%28nanoseconds%3A%20250%20*%20nsPerMillisecond%29%0A%20%20%20%20%20%20%20%20if%20Task.isCancelled%20%7B%20return%20%7D%0A%20%20%20%20%20%20%20%20for%20count%20in%201...rows.count%20%7B%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=593&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(onboarding): showcase / macros on t..."](https://github.com/fujacob/cotabby/commit/570f4f8248d7cf81e0d9ea6881a810c2b129b147) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35800937)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->