### PR TITLE
Make Inline Macros findable in Settings search

### DIFF
--- a/Cotabby/UI/Settings/SettingsIndex.swift
+++ b/Cotabby/UI/Settings/SettingsIndex.swift
@@ -16,6 +16,7 @@ enum SettingsItem: String, CaseIterable, Identifiable {
     case includeClipboardContext
     case allowMultiLine
     case acceptPunctuation
+    case inlineMacros
     case onboarding
     // Appearance
     case suggestionDisplay
@@ -70,6 +71,7 @@ enum SettingsItem: String, CaseIterable, Identifiable {
         case .includeClipboardContext: return "Include Clipboard Context"
         case .allowMultiLine: return "Allow Multi-line Suggestions"
         case .acceptPunctuation: return "Accept Punctuation With Word"
+        case .inlineMacros: return "Inline Macros"
         case .onboarding: return "Onboarding"
         case .suggestionDisplay: return "Suggestion Display"
         case .showFieldIndicator: return "Show Field Indicator"
@@ -114,6 +116,7 @@ enum SettingsItem: String, CaseIterable, Identifiable {
         case .includeClipboardContext: return "doc.on.clipboard"
         case .allowMultiLine: return "text.alignleft"
         case .acceptPunctuation: return "textformat.abc"
+        case .inlineMacros: return "slash.circle"
         case .onboarding: return "graduationcap"
         case .suggestionDisplay: return "text.cursor"
         case .showFieldIndicator: return "dot.viewfinder"
@@ -153,7 +156,7 @@ enum SettingsItem: String, CaseIterable, Identifiable {
     var category: SettingsCategory {
         switch self {
         case .enableGlobally, .fastMode, .openAtLogin, .includeClipboardContext,
-             .allowMultiLine, .acceptPunctuation, .onboarding:
+             .allowMultiLine, .acceptPunctuation, .inlineMacros, .onboarding:
             return .general
         case .suggestionDisplay, .showFieldIndicator, .showWordCount, .showKeyHint,
              .ghostTextColor, .ghostTextOpacity:
@@ -188,6 +191,7 @@ enum SettingsItem: String, CaseIterable, Identifiable {
         case .includeClipboardContext: return ["clipboard", "paste", "copy"]
         case .allowMultiLine: return ["multiline", "line", "newline", "wrap"]
         case .acceptPunctuation: return ["punctuation", "comma", "period", "accept"]
+        case .inlineMacros: return ["macro", "macros", "math", "convert", "currency", "date", "random", "expansion", "slash"]
         case .onboarding: return ["welcome", "guide", "tutorial", "intro"]
         case .suggestionDisplay: return ["inline", "popup", "ghost", "card", "display", "mirror"]
         case .showFieldIndicator: return ["indicator", "icon", "field", "ready"]


### PR DESCRIPTION
## Summary
The General > Behavior "Inline Macros" toggle (and its runtime) were wired up, but the setting was missing from the `SettingsItem` search index, so the Settings search field returned nothing for "macro". This adds an `inlineMacros` entry (title, `slash.circle` icon, `.general` category, keywords: macro/macros/math/convert/currency/date/random/expansion/slash) so it shows up.

## Validation
- `xcodebuild ... build` -> ** BUILD SUCCEEDED **
- `swiftlint --quiet` clean (longest line 125 < 140).

## Linked issues
None.

## Risk / rollout notes
Search-index only; no behavior change to the macros feature itself.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `inlineMacros` as a new `SettingsItem` case so the existing Inline Macros toggle becomes discoverable via the Settings search field; previously, searching "macro" returned no results.

- All four required switch arms (`title`, `systemImage`, `category`, `keywords`) are populated, and the case is placed logically within the General section alongside neighboring behavior settings.
- The keyword set covers the main user-facing concepts (macro/macros, math, convert, currency, date, random, expansion, slash), with no behavioral change to the macros feature itself.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the change is confined to the search index enum with no effect on the macros feature itself.

All four switch arms required by the enum are updated consistently, the new case is placed correctly within the General section, and the keyword set covers the primary terms users would search for. There is no logic change, no new dependency, and no risk of breaking existing search results for other settings.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/Settings/SettingsIndex.swift | Adds inlineMacros case with title, icon (slash.circle), category (.general), and keywords array; all four switch arms updated consistently and correctly. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User types in Settings search field] --> B[results called]
    B --> C{trimmed query empty?}
    C -- yes --> D[return empty]
    C -- no --> E[allCases.filter matches]
    E --> F{matches query?}
    F --> G[title contains needle]
    F --> H[category label contains needle]
    F --> I[keywords contains needle]
    G -- true --> J[Include in results]
    H -- true --> J
    I -- true --> J
    J --> K[Show result row, navigate to general pane]
    style J fill:#4caf50,color:#fff
    subgraph New inlineMacros entry
        L[title: Inline Macros]
        M[icon: slash.circle]
        N[category: .general]
        O[keywords: macro macros math convert currency date random expansion slash]
    end
    L --> J
    M --> J
    N --> J
    O --> J
```

<sub>Reviews (1): Last reviewed commit: ["Make Inline Macros findable in Settings ..."](https://github.com/fujacob/cotabby/commit/9755a5339b4fdb14c7f820c46928b9dafdc9c120) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35801943)</sub>

<!-- /greptile_comment -->