### PR TITLE
Index the Writing Corrections toggles for Settings search

### DIFF
--- a/Cotabby/UI/Settings/SettingsIndex.swift
+++ b/Cotabby/UI/Settings/SettingsIndex.swift
@@ -34,6 +34,8 @@ enum SettingsItem: String, CaseIterable, Identifiable {
     case length
     case name
     case languages
+    case hideSuggestionsOnTypo
+    case offerTypoCorrections
     // Context
     case extendedContext
     case contextLivePreview
@@ -86,6 +88,8 @@ enum SettingsItem: String, CaseIterable, Identifiable {
         case .length: return "Length"
         case .name: return "Name"
         case .languages: return "Languages"
+        case .hideSuggestionsOnTypo: return "Hide Suggestions on Typo"
+        case .offerTypoCorrections: return "Offer Corrections on Typo"
         case .extendedContext: return "Extended Context"
         case .contextLivePreview: return "Live Preview"
         case .engine: return "Engine"
@@ -131,6 +135,8 @@ enum SettingsItem: String, CaseIterable, Identifiable {
         case .length: return "ruler"
         case .name: return "person"
         case .languages: return "globe"
+        case .hideSuggestionsOnTypo: return "eye.slash"
+        case .offerTypoCorrections: return "checkmark.bubble"
         case .extendedContext: return "doc.text"
         case .contextLivePreview: return "text.cursor"
         case .engine: return "cpu"
@@ -163,7 +169,7 @@ enum SettingsItem: String, CaseIterable, Identifiable {
             return .appearance
         case .emojiPicker, .emojiSkinTone, .emojiPeopleStyle, .emojiHistory:
             return .emoji
-        case .length, .name, .languages:
+        case .length, .name, .languages, .hideSuggestionsOnTypo, .offerTypoCorrections:
             return .writing
         case .extendedContext, .contextLivePreview:
             return .context
@@ -206,6 +212,8 @@ enum SettingsItem: String, CaseIterable, Identifiable {
         case .length: return ["length", "words", "short", "long", "count", "verbose"]
         case .name: return ["name", "persona", "profile", "you"]
         case .languages: return ["language", "locale", "translate", "multilingual"]
+        case .hideSuggestionsOnTypo: return ["typo", "misspell", "spelling", "hide", "suppress", "correction"]
+        case .offerTypoCorrections: return ["typo", "correct", "correction", "fix", "spelling", "autocorrect"]
         case .extendedContext: return ["context", "glossary", "reference", "notes", "jargon"]
         case .contextLivePreview: return ["live", "preview", "test", "ghost", "try", "playground"]
         case .engine: return ["engine", "apple intelligence", "open source", "llama", "backend"]


### PR DESCRIPTION
## Summary
Audited the `SettingsItem` search index against every control rendered in the Settings panes. The only gaps were the two **Writing > Corrections** toggles, which use plain `Toggle("...")` (not `SettingsRowLabel`) and so were never added to the index:

- **Hide Suggestions on Typo** (`suppressCompletionsOnTypo`)
- **Offer Corrections on Typo** (`offerTypoCorrections`)

Both are now indexed under the Writing category with keywords (typo / spelling / correct / fix / autocorrect). Every other rendered setting was already covered; the remaining unindexed rows are status readouts (Status, Availability, Path), not settings.

## Validation
- `xcodebuild ... build` -> ** BUILD SUCCEEDED **
- `swiftlint --quiet` clean (longest line 125 < 140).

## Linked issues
None.

## Risk / rollout notes
Search-index only; no behavior change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the two previously missing Writing > Corrections toggles — `hideSuggestionsOnTypo` and `offerTypoCorrections` — to the `SettingsItem` search index, closing the last audit gap identified across all Settings panes.

- Each new case is wired with a display title, an SF Symbol (`eye.slash` / `checkmark.bubble`), the `.writing` category, and a keyword array covering terms like `typo`, `spelling`, `suppress`, `autocorrect`, and `correction`.
- The change is index-only; no rendering, persistence, or behavioral logic is modified.

<h3>Confidence Score: 5/5</h3>

Safe to merge — adds two enum cases to a read-only search index with no behavioral side effects.

The change is entirely additive: two new cases in a Swift enum, each with a title, SF Symbol, category, and keyword list. The surrounding matches and results logic is untouched, and nothing that persists state, drives UI rendering, or affects feature behavior is modified. All four switch arms are exhaustively handled, so there is no risk of a compiler-invisible missing-case crash at runtime.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/Settings/SettingsIndex.swift | Adds hideSuggestionsOnTypo and offerTypoCorrections enum cases to the search index with titles, SF Symbols, category assignment (writing), and keyword arrays — no logic or behavior changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User types query in Settings search] --> B[results called]
    B --> C{trimmed isEmpty?}
    C -- Yes --> D[Return empty array]
    C -- No --> E[Iterate allCases]
    E --> F[matches called per item]
    F --> G{title contains query?}
    G -- Yes --> H[Include item in results]
    G -- No --> I{category label contains query?}
    I -- Yes --> H
    I -- No --> J{any keyword contains query?}
    J -- Yes --> H
    J -- No --> K[Skip item]
    H --> L[Filtered results returned to UI]

    subgraph NEW[Newly Indexed in this PR]
        M[hideSuggestionsOnTypo - Hide Suggestions on Typo]
        N[offerTypoCorrections - Offer Corrections on Typo]
    end

    E --> NEW
    NEW --> F
```

<sub>Reviews (1): Last reviewed commit: ["Index the Writing Corrections toggles fo..."](https://github.com/fujacob/cotabby/commit/ba3864b1844495730b9dc67f6ee19c9b6d773915) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35802870)</sub>

<!-- /greptile_comment -->