### PR TITLE
Animate the Home pane feature showcase only on hover (fixes high CPU while Settings is open)

### DIFF
--- a/Cotabby/UI/Onboarding/OnboardingFeatureShowcase.swift
+++ b/Cotabby/UI/Onboarding/OnboardingFeatureShowcase.swift
@@ -14,14 +14,27 @@ import SwiftUI
 /// Lifecycle: each card owns its `@State` and drives a looping animation from a `.task`, which
 /// SwiftUI cancels automatically when the view leaves the hierarchy. Each card also keeps a *fixed*
 /// height so the onboarding window never resizes mid-loop. Continuous looping is skipped when the
-/// system Reduce Motion setting is on, in which case the card shows a static accepted state.
+/// system Reduce Motion setting is on (or when not animating, see below), in which case the card
+/// shows a static accepted state.
+///
+/// `autoplay`: the one-time onboarding screen passes `true` so the demos play on their own. The
+/// persistent Settings Home pane passes `false`, which keeps the loops idle (static resting frame)
+/// until the pointer is over the showcase. Without that gate the looping animations would burn CPU
+/// the entire time the Settings window sits on Home.
 struct OnboardingFeatureShowcase: View {
+    var autoplay: Bool = true
+
+    @State private var isHovering = false
+
+    private var animating: Bool { autoplay || isHovering }
+
     var body: some View {
         VStack(spacing: 12) {
-            GhostTextDemoCard()
-            EmojiPickerDemoCard()
-            MacroDemoCard()
+            GhostTextDemoCard(animating: animating)
+            EmojiPickerDemoCard(animating: animating)
+            MacroDemoCard(animating: animating)
         }
+        .onHover { isHovering = $0 }
         // Purely decorative looping demo: hide it from VoiceOver so the
         // mid-animation text fragments are never read out to AT users.
         .accessibilityHidden(true)
@@ -65,6 +78,7 @@ private struct DemoCard<Content: View>: View {
 // MARK: - Demo 1: inline autocomplete ghost text
 
 private struct GhostTextDemoCard: View {
+    let animating: Bool
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
@@ -98,7 +112,7 @@ private struct GhostTextDemoCard: View {
                 Spacer(minLength: 0)
             }
         }
-        .task(id: reduceMotion) {
+        .task(id: [reduceMotion, animating]) {
             await runLoop()
         }
     }
@@ -110,7 +124,9 @@ private struct GhostTextDemoCard: View {
     }
 
     private func runLoop() async {
-        guard !reduceMotion else {
+        // Idle (not animating) shows the same finished frame as reduce-motion, so the card looks
+        // complete at rest and only plays the full typing demo while hovered.
+        guard animating, !reduceMotion else {
             typedCount = base.count
             showGhost = true
             accepted = true
@@ -177,6 +193,7 @@ private struct DemoGhostKeycap: View {
 // MARK: - Demo 2: inline emoji picker
 
 private struct EmojiPickerDemoCard: View {
+    let animating: Bool
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     /// Number of trigger characters (":smi") revealed so far.
@@ -206,7 +223,7 @@ private struct EmojiPickerDemoCard: View {
             }
             .frame(maxWidth: .infinity, alignment: .topLeading)
         }
-        .task(id: reduceMotion) {
+        .task(id: [reduceMotion, animating]) {
             await runLoop()
         }
     }
@@ -219,7 +236,7 @@ private struct EmojiPickerDemoCard: View {
     }
 
     private func runLoop() async {
-        guard !reduceMotion else {
+        guard animating, !reduceMotion else {
             triggerCount = trigger.count
             committed = true
             showPopup = false
@@ -360,6 +377,7 @@ private struct DemoEmojiKeycap: View {
 /// never stale. Like the cards above it stays inert (no AX, event tap, or insertion); reduce-motion
 /// shows a single static example per row with no cycling.
 private struct MacroDemoCard: View {
+    let animating: Bool
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     /// How many rows have faded in so far.
@@ -416,7 +434,7 @@ private struct MacroDemoCard: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .task(id: reduceMotion) {
+        .task(id: [reduceMotion, animating]) {
             await run()
         }
     }
@@ -432,7 +450,7 @@ private struct MacroDemoCard: View {
             indices = Array(repeating: 0, count: categories.count)
         }
 
-        guard !reduceMotion else {
+        guard animating, !reduceMotion else {
             revealed = categories.count
             return
         }

--- a/Cotabby/UI/Settings/Panes/HomePaneView.swift
+++ b/Cotabby/UI/Settings/Panes/HomePaneView.swift
@@ -7,13 +7,14 @@ import SwiftUI
 /// Cotabby call to action. It is the default pane on a fresh install; returning users still land on
 /// their last-viewed pane.
 ///
-/// The feature demos are inert, self-playing animations that never touch the real suggestion
-/// pipeline, so this pane is safe to keep open without side effects.
+/// The feature demos are inert (they never touch the real suggestion pipeline). They are passed
+/// `autoplay: false` here so the looping animations stay idle on a static frame until the pointer is
+/// over them, keeping this pane cheap to leave open. (Onboarding uses the default autoplay.)
 struct HomePaneView: View {
     var body: some View {
         SettingsPaneScaffold {
             Section { introHeader }
-            Section("See it in action") { OnboardingFeatureShowcase() }
+            Section("See it in action") { OnboardingFeatureShowcase(autoplay: false) }
             Section("Support") { supportRow }
         }
     }


### PR DESCRIPTION
## Summary

The Settings **Home** pane (added in #591, and the default landing pane) embeds `OnboardingFeatureShowcase`, whose three demo cards each run a continuous `while !Task.isCancelled` animation loop with `withAnimation` re-renders as frequent as every 55-130ms. So while the Settings window sits on Home, those loops run nonstop and consume a lot of CPU. Before #591 the showcase only ran briefly on the one-time onboarding "done" screen.

This adds an `autoplay` flag to the showcase (default `true`, used by onboarding). The Home pane passes `autoplay: false`, so the cards rest on their static finished frame (the same frame used for Reduce Motion) and only run the looping animation **while the pointer is over the showcase**. Each card's `.task` is keyed on the animating state, so hovering starts the loop and moving away stops it; SwiftUI still cancels on disappear.

Net effect: zero steady-state CPU from the showcase while Settings is open and idle on Home; the demos still play on hover, and onboarding is unchanged.

## Validation

```
xcodebuild ... build                      # ** BUILD SUCCEEDED **
xcodebuild ... test ... CODE_SIGNING_ALLOWED=NO   # Executed 946 tests, 0 failures
swiftlint lint --quiet                     # exit 0
```

Pure SwiftUI view change; behavior is best confirmed by opening Settings on Home (CPU should be idle) and hovering the showcase (demos play). Onboarding still auto-plays.

## Linked issues

Follow-up to #591 (perf regression).

## Risk / rollout notes

- View-only change to `OnboardingFeatureShowcase` and `HomePaneView`. No new files, no settings/pbxproj.
- Onboarding (`WelcomeView`) keeps the default `autoplay: true`, so the first-run experience is unchanged.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an `autoplay` flag to `OnboardingFeatureShowcase` (default `true`) so the Settings Home pane can pass `autoplay: false`, keeping the looping demo animations idle on a static "finished" frame until the pointer enters the showcase. This eliminates the continuous CPU churn from three tight `Task.sleep` animation loops that fired whenever Settings was open on Home.

- `animating = autoplay || isHovering` is threaded down to each card as a `let` constant; the `.task(id: [reduceMotion, animating])` key restarts the task whenever hover or reduce-motion changes, and the `runLoop`/`run` guards short-circuit to the static finished state when `animating` is `false`.
- Onboarding (`WelcomeView`) is unaffected — `autoplay` defaults to `true`, and `.onHover` is a no-op there because `animating` is always `true`.
- The `[Bool]` array used as the task id is `Equatable` (Swift arrays inherit element equatability), so both bits of the id are evaluated correctly on every change.

<h3>Confidence Score: 5/5</h3>

Safe to merge — view-only change with no new files, no settings mutations, and no impact on the real suggestion pipeline.

The change is tightly scoped: `autoplay` defaults to `true` so onboarding is untouched, `[Bool]` is correctly `Equatable` for the task id, hover-in/-out transitions deterministically restart the task into either the loop or the static frame, and task cancellation via SwiftUI's `.task` lifecycle handles window close and disappear automatically. No regressions are visible in the logic.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/Onboarding/OnboardingFeatureShowcase.swift | Adds `autoplay: Bool = true` param and `isHovering` state; threads `animating` down to each card; changes `.task(id:)` from `reduceMotion` alone to `[reduceMotion, animating]` so tasks restart on hover; guards are correctly updated to short-circuit to the static finished frame when not animating. |
| Cotabby/UI/Settings/Panes/HomePaneView.swift | Single-line change: passes `autoplay: false` to `OnboardingFeatureShowcase`; doc-comment updated to reflect the new idle-until-hover behaviour. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[OnboardingFeatureShowcase mounted] --> B{autoplay?}
    B -- true\nonboarding --> C[animating = true always]
    B -- false\nHome pane --> D{isHovering?}
    D -- yes --> C
    D -- no --> E[animating = false]

    C --> F["task(id: [reduceMotion, true])"]
    E --> G["task(id: [reduceMotion, false])"]

    F --> H{reduceMotion?}
    H -- yes --> I[Static finished frame\nreturn]
    H -- no --> J[while !Task.isCancelled\nAnimation loop]

    G --> K[Static finished frame\nreturn]

    L[.onHover fires] --> D

    J -->|hover leaves| M[Task cancelled]
    M --> G
```

<sub>Reviews (1): Last reviewed commit: ["Animate the Home pane feature showcase o..."](https://github.com/fujacob/cotabby/commit/8d5ba348f121e16e367ff4e29e9b5cac789b16f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35804703)</sub>

<!-- /greptile_comment -->