### PR TITLE
Refresh README header and features for autocorrect, macros, and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <h1 align="center">Cotabby [beta]</h1>
 
-<p align="center"><em>Open-source, local-first AI autocomplete for macOS, with inline <code>:emoji:</code> suggestions.</em></p>
+<p align="center"><em>Open-source, local-first AI autocomplete for macOS, a productivity layer for everything you type.</em></p>
 
 <p align="center">
   <a href="https://cotabby.app"><strong>Visit the landing page →</strong></a>
@@ -39,6 +39,8 @@ Cotabby brings AI autocomplete to the text fields you already use on macOS. It w
 
 It also includes inline emoji autocomplete: type `:smile`, `:tada`, or `:+1` and pick the emoji without leaving your current app.
 
+Inline macros turn `/` into instant in-field results: arithmetic, unit and currency conversions, dates, and random values (`/5+5=`, `/10km->mi`, `/100usd->eur`, `/today`). Optional autocorrect flags likely typos and offers a one-key fix as you type.
+
 Everything runs on-device. No hosted API, no cloud round-trip.
 
 ## Demo
@@ -57,7 +59,11 @@ Everything runs on-device. No hosted API, no cloud round-trip.
 - **System-wide completions** -- Works in any macOS text field (Safari, Notes, Mail, etc.)
 - **Ghost text UI** -- Suggestions appear as translucent overlay text at your cursor
 - **Inline emoji autocomplete** -- Type `:emoji:`-style shortcuts and insert the selected emoji without leaving your current app
-- **100% local** -- AI inference and emoji matching run on-device
+- **Inline macros** -- Type `/` for instant math, unit and currency conversions, dates, and random values
+- **Autocorrect** -- Catches likely typos and offers a one-key correction, fully on-device
+- **Two engines** -- Apple Intelligence (macOS 26+) or downloadable on-device base models via llama.cpp
+- **Make it yours** -- Name, languages, suggestion length, extended context, and per-app enable/disable
+- **100% local** -- AI inference, macros, and autocorrect run on-device
 - **Visual context** -- Screenshot OCR gives the model awareness of what's on screen
 - **Low latency** -- Optimized for fast response on Apple Silicon
 


### PR DESCRIPTION
## Summary
The README's user-facing copy still described an emoji-only tool even though autocorrect, inline macros, and more have shipped (only the Acknowledgments/License already referenced SymSpell). This updates the stale sections:

- **Header (line 1 tagline):** reframed from "with inline :emoji: suggestions" to "a productivity layer for everything you type" so it reads as the broader product it now is, without dumping a feature list.
- **What It Does:** added a sentence on inline macros (`/5+5=`, `/10km->mi`, `/100usd->eur`, `/today`) and one on optional autocorrect.
- **Features:** added Inline macros, Autocorrect, Two engines, and Make it yours (personalization + per-app), and noted macros/autocorrect run on-device under 100% local.

No em dashes; the existing `--` list style is preserved. Engines table, Install, Acknowledgments, and License were already accurate and are unchanged.

## Validation
Docs-only. Verified no em dash characters in the file.

## Linked issues
None.

## Risk / rollout notes
README copy only; no code or build impact.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refreshes the README's user-facing copy to reflect features that have shipped since the original emoji-only framing: inline macros, optional autocorrect, two AI engine options, and personalization settings.

- The tagline is reframed from emoji-specific to the broader \"productivity layer\" positioning, and a new paragraph in \"What It Does\" describes macros and autocorrect with inline examples.
- Four new feature bullets are added (Inline macros, Autocorrect, Two engines, Make it yours), and the existing \"100% local\" bullet is updated to include macros and autocorrect alongside AI inference.

<h3>Confidence Score: 5/5</h3>

README-only change with no code, build, or runtime impact; safe to merge.

All changes are confined to documentation copy. The new feature descriptions (macros, autocorrect, engine options) are internally consistent with the existing Engines section and Acknowledgments. No em dashes were introduced, the -- bullet style is preserved, and the 100% local claim is correctly updated to enumerate the three on-device subsystems.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Documentation-only update adding feature descriptions for macros, autocorrect, and engine options; copy is accurate and internally consistent with existing sections. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User types in any macOS text field] --> B{Input type?}
    B -->|Normal text| C[AI autocomplete ghost text]
    B -->|:emoji: shortcut| D[Inline emoji autocomplete]
    B -->|/macro trigger| E[Inline macros]
    B -->|Typo detected| F[Autocorrect suggestion]

    C --> G{Press Tab?}
    G -->|Yes| H[Accept word completion]
    G -->|No| I[Keep typing / ignore]

    E --> E1[Math: /5+5=]
    E --> E2[Unit: /10km->mi]
    E --> E3[Currency: /100usd->eur]
    E --> E4[Date: /today]

    C --> J{AI Engine}
    J -->|macOS 26+| K[Apple Intelligence FoundationModels]
    J -->|macOS 14+| L[Open Source llama.cpp / GGUF models]
```

<sub>Reviews (1): Last reviewed commit: ["Refresh README header and features for a..."](https://github.com/fujacob/cotabby/commit/810488c4fffa46799acac79a63d9bb87ea8d07b3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35805254)</sub>

<!-- /greptile_comment -->