### PR TITLE
Make / macros forgiving: aliases, symbols, and a 'to' separator

### DIFF
--- a/Cotabby/Support/Macros/CurrencyEvaluator.swift
+++ b/Cotabby/Support/Macros/CurrencyEvaluator.swift
@@ -1,9 +1,11 @@
 import Foundation
 
 /// File overview:
-/// Currency conversion macros: `/123.45CAD->USD`. Rates come from a bundled, offline, approximate
-/// table (Section: never touches the network), and the result is formatted with the target
-/// currency's locale-aware style via `NumberFormatter` (so JPY shows no decimals, USD shows two).
+/// Currency conversion macros: `/123.45CAD->USD`, plus forgiving variants like `/100 usd to eur`,
+/// `/$100 to eur`, and `/100 dollars to yen`. Tokens resolve through an alias table (names, symbols,
+/// short forms) on top of any 3-letter ISO code. Rates come from a bundled, offline, approximate
+/// table (never touches the network), and the result is formatted with the target currency's
+/// locale-aware style via `NumberFormatter` (so JPY shows no decimals, USD shows two).
 struct CurrencyEvaluator: MacroEvaluating {
     private let locale: Locale
     private let table: CurrencyRateTable
@@ -14,14 +16,10 @@ struct CurrencyEvaluator: MacroEvaluating {
     }
 
     func evaluate(_ query: String) -> MacroResult? {
-        guard let arrow = query.range(of: "->") else { return nil }
-        let lhs = query[query.startIndex..<arrow.lowerBound].trimmingCharacters(in: .whitespaces)
-        let toCode = query[arrow.upperBound...].trimmingCharacters(in: .whitespaces).uppercased()
-
-        let numberPart = lhs.prefix { $0.isNumber || $0 == "." || $0 == "-" || $0 == "+" }
-        let fromCode = lhs.dropFirst(numberPart.count).trimmingCharacters(in: .whitespaces).uppercased()
-        guard let amount = Double(numberPart),
-              fromCode.count == 3, toCode.count == 3,
+        guard let (lhsRaw, rhsRaw) = ConversionSeparator.split(query),
+              let (amount, fromToken) = Self.parseAmount(lhsRaw),
+              let fromCode = Self.resolveCode(fromToken),
+              let toCode = Self.resolveCode(rhsRaw.trimmingCharacters(in: .whitespaces)),
               let fromRate = table.rate(for: fromCode),
               let toRate = table.rate(for: toCode) else {
             return nil
@@ -32,6 +30,59 @@ struct CurrencyEvaluator: MacroEvaluating {
         let formatted = formatCurrency(converted, code: toCode)
         return MacroResult(formatted)
     }
+
+    /// Parses the amount and source-currency token from the left side, accepting a leading symbol
+    /// (`$100`), a trailing code or word (`100usd`, `100 dollars`), and short forms (`100us`).
+    private static func parseAmount(_ lhs: String) -> (amount: Double, token: String)? {
+        let trimmed = lhs.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return nil }
+        if let first = trimmed.first, aliases[String(first)] != nil {
+            guard let amount = Double(trimmed.dropFirst().trimmingCharacters(in: .whitespaces)) else {
+                return nil
+            }
+            return (amount, String(first))
+        }
+        let numberPart = trimmed.prefix { $0.isNumber || $0 == "." || $0 == "-" || $0 == "+" }
+        guard let amount = Double(numberPart) else { return nil }
+        return (amount, trimmed.dropFirst(numberPart.count).trimmingCharacters(in: .whitespaces))
+    }
+
+    /// Resolves a currency token to a 3-letter code: through the alias table (names, symbols, short
+    /// forms) first, then accepting any 3-letter code as-is (the rate table validates it downstream).
+    private static func resolveCode(_ token: String) -> String? {
+        if let code = aliases[token.lowercased()] { return code }
+        let upper = token.uppercased()
+        return upper.count == 3 ? upper : nil
+    }
+
+    /// Names, symbols, and short forms that map to a 3-letter code (codes themselves are accepted
+    /// directly by `resolveCode`, so they are not listed). Genuinely ambiguous words shared across
+    /// countries (kr / krona / krone / lira / koruna / dinar) are deliberately omitted so the macro
+    /// returns nothing rather than silently converting the wrong currency.
+    private static let aliases: [String: String] = [
+        "us": "USD", "usa": "USD", "dollar": "USD", "dollars": "USD", "buck": "USD", "bucks": "USD", "$": "USD",
+        "euro": "EUR", "euros": "EUR", "€": "EUR",
+        "pound": "GBP", "pounds": "GBP", "quid": "GBP", "sterling": "GBP", "£": "GBP",
+        "yen": "JPY", "¥": "JPY",
+        "yuan": "CNY", "rmb": "CNY", "renminbi": "CNY",
+        "rupee": "INR", "rupees": "INR", "₹": "INR",
+        "peso": "MXN", "pesos": "MXN",
+        "real": "BRL", "reais": "BRL", "r$": "BRL",
+        "rand": "ZAR",
+        "won": "KRW", "₩": "KRW",
+        "ruble": "RUB", "rubles": "RUB", "rouble": "RUB", "₽": "RUB",
+        "baht": "THB", "฿": "THB",
+        "shekel": "ILS", "shekels": "ILS", "₪": "ILS",
+        "forint": "HUF",
+        "zloty": "PLN", "zł": "PLN",
+        "ringgit": "MYR",
+        "rupiah": "IDR",
+        "dirham": "AED", "dirhams": "AED",
+        "riyal": "SAR", "rial": "SAR",
+        "franc": "CHF", "francs": "CHF",
+        "₱": "PHP",
+        "c$": "CAD", "a$": "AUD", "hk$": "HKD", "nz$": "NZD", "nt$": "TWD", "s$": "SGD"
+    ]
 
     private func formatCurrency(_ value: Double, code: String) -> String {
         let formatter = NumberFormatter()

--- a/Cotabby/Support/Macros/DateMacroEvaluator.swift
+++ b/Cotabby/Support/Macros/DateMacroEvaluator.swift
@@ -2,9 +2,10 @@ import Foundation
 
 /// File overview:
 /// Locale-aware date and time macros: `/today`, `/now`, `/datetime`, `/tomorrow`, `/yesterday`,
-/// `/noon`, `/midnight`, weekday navigation (`/next-fri`, `/this-mon`, `/last-tue`), and relative
-/// offsets (`/+3d`, `/-5d`, `/+2w`, `/+1mo`, `/+1y`). An optional format argument tunes the
-/// output: `/today(iso)`, `/today(long)`, `/today(short)`, `/now(24h)`.
+/// `/noon`, `/midnight`, weekday navigation (`/next-fri`, also `/next fri` and `/nextfri`), and
+/// relative offsets (`/+3d`, `/-5d`, `/+2w`, `/+1mo`, `/+1y`, with spelled-out units like `/+1week`).
+/// Common short forms are accepted too (`/tdy`, `/tmrw`, `/rn`). An optional format argument tunes
+/// the output: `/today(iso)`, `/today(long)`, `/today(short)`, `/now(24h)`.
 ///
 /// Pure given an injected clock so tests are deterministic. Output respects `Locale.current`; the
 /// input keywords are fixed (English), like code, so they do not change per locale.
@@ -23,7 +24,8 @@ struct DateMacroEvaluator: MacroEvaluating {
 
     func evaluate(_ query: String) -> MacroResult? {
         let lower = query.lowercased()
-        let (base, argument) = Self.splitArgument(lower)
+        let (rawBase, argument) = Self.splitArgument(lower)
+        let base = Self.canonicalBase(rawBase)
 
         if let relative = relativeDate(base) {
             return MacroResult(formatDate(relative, style: dateStyle(for: argument)))
@@ -74,10 +76,10 @@ struct DateMacroEvaluator: MacroEvaluating {
         let unit = String(rest.dropFirst(digits.count))
         let value = (sign == "-" ? -1 : 1) * magnitude
         switch unit {
-        case "d": return calendar.date(byAdding: .day, value: value, to: now())
-        case "w": return calendar.date(byAdding: .weekOfYear, value: value, to: now())
-        case "mo": return calendar.date(byAdding: .month, value: value, to: now())
-        case "y": return calendar.date(byAdding: .year, value: value, to: now())
+        case "d", "day", "days": return calendar.date(byAdding: .day, value: value, to: now())
+        case "w", "wk", "wks", "week", "weeks": return calendar.date(byAdding: .weekOfYear, value: value, to: now())
+        case "mo", "month", "months": return calendar.date(byAdding: .month, value: value, to: now())
+        case "y", "yr", "yrs", "year", "years": return calendar.date(byAdding: .year, value: value, to: now())
         default: return nil
         }
     }
@@ -176,6 +178,35 @@ struct DateMacroEvaluator: MacroEvaluating {
         let base = String(string[string.startIndex..<open])
         let argument = String(string[string.index(after: open)..<string.index(before: string.endIndex)])
         return (base, argument.isEmpty ? nil : argument)
+    }
+
+    /// Common short forms and misspellings mapped to a canonical keyword, applied before matching so
+    /// `/tdy`, `/tmrw`, `/rn`, and friends resolve. Weekday navigation (`next fri`, `nextfri`) is
+    /// normalized separately in `canonicalBase` because it is prefix-based rather than a fixed word.
+    private static let baseAliases: [String: String] = [
+        "tdy": "today", "tod": "today", "tody": "today", "2day": "today",
+        "tmr": "tomorrow", "tmrw": "tomorrow", "tmw": "tomorrow", "tom": "tomorrow", "tomo": "tomorrow",
+        "tomorow": "tomorrow", "2moro": "tomorrow", "2mrw": "tomorrow",
+        "yest": "yesterday", "yday": "yesterday", "ystdy": "yesterday", "yesty": "yesterday", "yesterdy": "yesterday",
+        "rn": "now", "rightnow": "now", "atm": "now",
+        "midday": "noon", "noontime": "noon", "midnite": "midnight",
+        "dt": "datetime"
+    ]
+
+    /// Normalizes a base keyword: applies `baseAliases`, then rewrites a `next`/`this`/`last` weekday
+    /// prefix written with a space or no separator (`next fri`, `nextfri`) into the dash form the
+    /// weekday resolver expects (`next-fri`).
+    private static func canonicalBase(_ base: String) -> String {
+        if let alias = baseAliases[base] {
+            return alias
+        }
+        for prefix in ["next", "this", "last"] where base.hasPrefix(prefix) && base.count > prefix.count {
+            let rest = base.dropFirst(prefix.count).drop { $0 == " " || $0 == "-" || $0 == "_" }
+            if !rest.isEmpty {
+                return "\(prefix)-\(rest)"
+            }
+        }
+        return base
     }
 
     /// Maps weekday tokens to `Calendar` weekday indices (Sunday = 1 ... Saturday = 7).

--- a/Cotabby/Support/Macros/MacroModels.swift
+++ b/Cotabby/Support/Macros/MacroModels.swift
@@ -33,3 +33,22 @@ protocol MacroEvaluating {
     /// family understands, or `nil` to let the next family try.
     func evaluate(_ query: String) -> MacroResult?
 }
+
+/// Splits a conversion-style query (`<value><from> <sep> <to>`) on the first separator Cotabby
+/// accepts: `->`, the arrow `→`, or a space-delimited `to`. This lets `10km->mi`, `10km→mi`, and
+/// `10 km to mi` all parse identically. Shared by the unit and currency evaluators so they accept the
+/// same separators. Returns the (still untrimmed) left and right sides, or nil when there is no
+/// separator.
+enum ConversionSeparator {
+    static func split(_ query: String) -> (left: String, right: String)? {
+        for token in ["->", "→"] where query.contains(token) {
+            if let range = query.range(of: token) {
+                return (String(query[..<range.lowerBound]), String(query[range.upperBound...]))
+            }
+        }
+        if let range = query.range(of: " to ", options: [.caseInsensitive]) {
+            return (String(query[..<range.lowerBound]), String(query[range.upperBound...]))
+        }
+        return nil
+    }
+}

--- a/Cotabby/Support/Macros/RandomMacroEvaluator.swift
+++ b/Cotabby/Support/Macros/RandomMacroEvaluator.swift
@@ -1,8 +1,9 @@
 import Foundation
 
 /// File overview:
-/// Random and generator macros: `/random`, `/random(n)`, `/random(a,b)`, `/dice`, `/coin`,
-/// `/uuid`. The RNG and UUID source are injected so tests are deterministic.
+/// Random and generator macros: `/random` (`/rand`, `/rnd`), `/random(n)`, `/random(a,b)`, `/dice`
+/// (`/roll`, `/die`, and `/dN` dice notation like `/d20`), `/coin` (`/flip`), `/uuid` (`/guid`). The
+/// RNG and UUID source are injected so tests are deterministic.
 struct RandomMacroEvaluator: MacroEvaluating {
     private let randomSource: (ClosedRange<Int>) -> Int
     private let uuidSource: () -> String
@@ -18,22 +19,37 @@ struct RandomMacroEvaluator: MacroEvaluating {
     func evaluate(_ query: String) -> MacroResult? {
         let lower = query.lowercased()
         switch lower {
-        case "uuid":
+        case "uuid", "guid":
             return MacroResult(uuidSource())
-        case "dice":
+        case "dice", "die", "roll":
             return MacroResult(String(randomSource(1...6)))
-        case "coin":
+        case "coin", "flip", "coinflip", "coin-flip":
             return MacroResult(randomSource(0...1) == 0 ? "Heads" : "Tails")
-        case "random":
+        case "random", "rand", "rnd":
             return MacroResult(String(randomSource(0...100)))
         default:
+            if let sides = Self.diceSides(lower) {
+                return MacroResult(String(randomSource(1...sides)))
+            }
             return parameterizedRandom(lower)
         }
     }
 
-    /// Handles `random(n)` and `random(a,b)` with integer arguments, normalizing reversed bounds.
+    /// `dN` dice notation: `/d20` rolls 1...20. Returns the side count, or nil when the token is not
+    /// `d` followed by a positive integer (so `/d` and `/dollar` fall through to other families).
+    private static func diceSides(_ lower: String) -> Int? {
+        guard lower.hasPrefix("d"), lower.count > 1, let sides = Int(lower.dropFirst()), sides >= 1 else {
+            return nil
+        }
+        return sides
+    }
+
+    /// Handles `random(n)` / `random(a,b)` (and the `rand(...)` / `rnd(...)` short forms) with integer
+    /// arguments, normalizing reversed bounds.
     private func parameterizedRandom(_ lower: String) -> MacroResult? {
-        guard lower.hasPrefix("random("), lower.hasSuffix(")"), let open = lower.firstIndex(of: "(") else {
+        let prefixes = ["random(", "rand(", "rnd("]
+        guard prefixes.contains(where: { lower.hasPrefix($0) }),
+              lower.hasSuffix(")"), let open = lower.firstIndex(of: "(") else {
             return nil
         }
         let inner = String(lower[lower.index(after: open)..<lower.index(before: lower.endIndex)])

--- a/Cotabby/Support/Macros/UnitConversionEvaluator.swift
+++ b/Cotabby/Support/Macros/UnitConversionEvaluator.swift
@@ -17,9 +17,9 @@ struct UnitConversionEvaluator: MacroEvaluating {
     }
 
     func evaluate(_ query: String) -> MacroResult? {
-        guard let arrow = query.range(of: "->") else { return nil }
-        let lhs = query[query.startIndex..<arrow.lowerBound].trimmingCharacters(in: .whitespaces)
-        let toToken = query[arrow.upperBound...].trimmingCharacters(in: .whitespaces).lowercased()
+        guard let (lhsRaw, rhsRaw) = ConversionSeparator.split(query) else { return nil }
+        let lhs = lhsRaw.trimmingCharacters(in: .whitespaces)
+        let toToken = rhsRaw.trimmingCharacters(in: .whitespaces).lowercased()
 
         let numberPart = lhs.prefix { $0.isNumber || $0 == "." || $0 == "-" || $0 == "+" }
         let fromToken = lhs.dropFirst(numberPart.count).trimmingCharacters(in: .whitespaces).lowercased()
@@ -64,18 +64,41 @@ struct UnitConversionEvaluator: MacroEvaluating {
 
     private static let units: [String: Quantity] = [
         // Length
-        "mm": .length(.millimeters), "cm": .length(.centimeters), "m": .length(.meters),
-        "km": .length(.kilometers), "in": .length(.inches), "ft": .length(.feet),
-        "yd": .length(.yards), "mi": .length(.miles),
+        "mm": .length(.millimeters), "millimeter": .length(.millimeters), "millimeters": .length(.millimeters),
+        "millimetre": .length(.millimeters), "millimetres": .length(.millimeters),
+        "cm": .length(.centimeters), "centimeter": .length(.centimeters), "centimeters": .length(.centimeters),
+        "centimetre": .length(.centimeters), "centimetres": .length(.centimeters),
+        "m": .length(.meters), "meter": .length(.meters), "meters": .length(.meters),
+        "metre": .length(.meters), "metres": .length(.meters),
+        "km": .length(.kilometers), "kilometer": .length(.kilometers), "kilometers": .length(.kilometers),
+        "kilometre": .length(.kilometers), "kilometres": .length(.kilometers),
+        "in": .length(.inches), "inch": .length(.inches), "inches": .length(.inches),
+        "ft": .length(.feet), "foot": .length(.feet), "feet": .length(.feet),
+        "yd": .length(.yards), "yard": .length(.yards), "yards": .length(.yards),
+        "mi": .length(.miles), "mile": .length(.miles), "miles": .length(.miles),
         // Mass
-        "mg": .mass(.milligrams), "g": .mass(.grams), "kg": .mass(.kilograms),
-        "oz": .mass(.ounces), "lb": .mass(.pounds), "lbs": .mass(.pounds), "st": .mass(.stones),
+        "mg": .mass(.milligrams), "milligram": .mass(.milligrams), "milligrams": .mass(.milligrams),
+        "g": .mass(.grams), "gram": .mass(.grams), "grams": .mass(.grams),
+        "kg": .mass(.kilograms), "kgs": .mass(.kilograms), "kilo": .mass(.kilograms), "kilos": .mass(.kilograms),
+        "kilogram": .mass(.kilograms), "kilograms": .mass(.kilograms),
+        "oz": .mass(.ounces), "ounce": .mass(.ounces), "ounces": .mass(.ounces),
+        "lb": .mass(.pounds), "lbs": .mass(.pounds), "pound": .mass(.pounds), "pounds": .mass(.pounds),
+        "st": .mass(.stones), "stone": .mass(.stones), "stones": .mass(.stones),
         // Temperature
-        "c": .temperature(.celsius), "f": .temperature(.fahrenheit), "k": .temperature(.kelvin),
+        "c": .temperature(.celsius), "celsius": .temperature(.celsius), "centigrade": .temperature(.celsius),
+        "f": .temperature(.fahrenheit), "fahrenheit": .temperature(.fahrenheit),
+        "k": .temperature(.kelvin), "kelvin": .temperature(.kelvin),
         // Volume
-        "ml": .volume(.milliliters), "l": .volume(.liters), "cup": .volume(.cups),
-        "cups": .volume(.cups), "tbsp": .volume(.tablespoons), "tsp": .volume(.teaspoons),
-        "floz": .volume(.fluidOunces), "gal": .volume(.gallons), "pt": .volume(.pints),
-        "qt": .volume(.quarts)
+        "ml": .volume(.milliliters), "milliliter": .volume(.milliliters), "milliliters": .volume(.milliliters),
+        "millilitre": .volume(.milliliters), "millilitres": .volume(.milliliters),
+        "l": .volume(.liters), "liter": .volume(.liters), "liters": .volume(.liters),
+        "litre": .volume(.liters), "litres": .volume(.liters),
+        "cup": .volume(.cups), "cups": .volume(.cups),
+        "tbsp": .volume(.tablespoons), "tablespoon": .volume(.tablespoons), "tablespoons": .volume(.tablespoons),
+        "tsp": .volume(.teaspoons), "teaspoon": .volume(.teaspoons), "teaspoons": .volume(.teaspoons),
+        "floz": .volume(.fluidOunces),
+        "gal": .volume(.gallons), "gallon": .volume(.gallons), "gallons": .volume(.gallons),
+        "pt": .volume(.pints), "pint": .volume(.pints), "pints": .volume(.pints),
+        "qt": .volume(.quarts), "quart": .volume(.quarts), "quarts": .volume(.quarts)
     ]
 }

--- a/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
@@ -73,8 +73,9 @@ struct GeneralPaneView: View {
                 Toggle(isOn: macroExpansionEnabledBinding) {
                     SettingsRowLabel(
                         title: "Inline Macros",
-                        description: "Type / then a macro like today, 5+5=, 10km->mi, or random(1,6), " +
-                            "then press your accept-word shortcut to insert the result.",
+                        description: "Type / then a macro: dates (today, tmrw, next-fri), math (5+5=), " +
+                            "units (10km to mi), currency ($100 to eur), or random (dice, random(1,6)). " +
+                            "Then press your accept-word shortcut to insert the result.",
                         systemImage: "slash.circle"
                     )
                 }

--- a/CotabbyTests/DateMacroEvaluatorTests.swift
+++ b/CotabbyTests/DateMacroEvaluatorTests.swift
@@ -52,4 +52,24 @@ final class DateMacroEvaluatorTests: XCTestCase {
     func test_unknownKeyword_returnsNil() {
         XCTAssertNil(makeEvaluator().evaluate("someday"))
     }
+
+    func test_shortFormAliases() {
+        let sut = makeEvaluator()
+        XCTAssertEqual(sut.evaluate("tdy")?.insertionText, "Jun 4, 2026")
+        XCTAssertEqual(sut.evaluate("tmrw")?.insertionText, "Jun 5, 2026")
+        XCTAssertEqual(sut.evaluate("yest")?.insertionText, "Jun 3, 2026")
+        XCTAssertEqual(sut.evaluate("rn")?.insertionText, sut.evaluate("now")?.insertionText)
+    }
+
+    func test_weekdaySeparatorVariants() {
+        let sut = makeEvaluator()
+        XCTAssertEqual(sut.evaluate("next fri")?.insertionText, "Jun 5, 2026")
+        XCTAssertEqual(sut.evaluate("nextfri")?.insertionText, "Jun 5, 2026")
+    }
+
+    func test_spelledOutRelativeUnits() {
+        let sut = makeEvaluator()
+        XCTAssertEqual(sut.evaluate("+1week")?.insertionText, "Jun 11, 2026")
+        XCTAssertEqual(sut.evaluate("+2days")?.insertionText, "Jun 6, 2026")
+    }
 }

--- a/CotabbyTests/MacroEngineTests.swift
+++ b/CotabbyTests/MacroEngineTests.swift
@@ -40,6 +40,15 @@ final class RandomMacroEvaluatorTests: XCTestCase {
         XCTAssertNil(sut.evaluate("random(abc)"))
         XCTAssertNil(sut.evaluate("random(0)"))
     }
+
+    func test_aliasesAndDiceNotation() {
+        XCTAssertEqual(sut.evaluate("rand")?.insertionText, "0")
+        XCTAssertEqual(sut.evaluate("roll")?.insertionText, "1")
+        XCTAssertEqual(sut.evaluate("flip")?.insertionText, "Heads")
+        XCTAssertEqual(sut.evaluate("guid")?.insertionText, "FIXED-UUID")
+        XCTAssertEqual(sut.evaluate("d20")?.insertionText, "1")
+        XCTAssertEqual(sut.evaluate("rnd(7,7)")?.insertionText, "7")
+    }
 }
 
 final class UnitConversionEvaluatorTests: XCTestCase {
@@ -65,6 +74,12 @@ final class UnitConversionEvaluatorTests: XCTestCase {
     func test_nonUnitTokens_returnNil() {
         XCTAssertNil(sut.evaluate("100USD->EUR"))
     }
+
+    func test_toSeparatorAndFullNames() {
+        XCTAssertEqual(sut.evaluate("10 km to mi")?.insertionText, "6.214 mi")
+        XCTAssertEqual(sut.evaluate("1 kilometer to meters")?.insertionText, "1000 meters")
+        XCTAssertEqual(sut.evaluate("100 fahrenheit to celsius")?.insertionText, "37.78 celsius")
+    }
 }
 
 final class CurrencyEvaluatorTests: XCTestCase {
@@ -87,6 +102,13 @@ final class CurrencyEvaluatorTests: XCTestCase {
 
     func test_unknownCode_returnsNil() {
         XCTAssertNil(sut.evaluate("100XXX->USD"))
+    }
+
+    func test_aliasesSymbolsAndToSeparator() {
+        let canonical = sut.evaluate("100USD->EUR")?.insertionText
+        XCTAssertEqual(sut.evaluate("100us->eur")?.insertionText, canonical)
+        XCTAssertEqual(sut.evaluate("$100 to eur")?.insertionText, canonical)
+        XCTAssertEqual(sut.evaluate("100 dollars to euros")?.insertionText, canonical)
     }
 }
 
@@ -118,5 +140,13 @@ final class MacroEngineRoutingTests: XCTestCase {
         XCTAssertNil(engine.evaluate("   "))
         XCTAssertNil(engine.evaluate("5"))
         XCTAssertNil(engine.evaluate("zzz"))
+    }
+
+    func test_routesForgivingAliases() {
+        let engine = makeEngine()
+        XCTAssertEqual(engine.evaluate("tdy")?.insertionText, "Jun 4, 2026")
+        XCTAssertEqual(engine.evaluate("10 km to mi")?.insertionText, "6.214 mi")
+        XCTAssertEqual(engine.evaluate("$100 to eur")?.insertionText, "€92.00")
+        XCTAssertEqual(engine.evaluate("roll")?.insertionText, "1")
     }
 }


### PR DESCRIPTION
## Summary

People type `/` macros all sorts of ways. Previously only the strict forms worked, so a near-miss (e.g. `/tmrw`, `/100 usd to eur`, `/$100 to eur`) returned nothing and the feature looked broken. This adds broad, forgiving fallbacks across every macro family while keeping the strict forms intact.

- **Dates**: short forms (`tdy`, `tmrw`, `tom`, `rn`, `yest`, `atm`, `midnite`...), weekday nav written as `next fri` / `nextfri` (not just `next-fri`), and spelled-out relative units (`+1week`, `+2days`, `+1month`).
- **Units**: full names and plurals (`miles`, `kilometers`, `pounds`, `celsius`, `cups`...) plus a natural `to` separator, so `10 km to mi` works alongside `10km->mi`. (`->` and `→` still work.)
- **Currency**: names, symbols, and short forms (`us`, `usa`, `dollars`, `$`, `euro`, `€`, `pound`, `£`, `yen`, `¥`, `yuan`, `rupee`, `won`, `peso`, `real`, `franc`...), leading-symbol amounts (`$100`), and the `to` separator. Genuinely ambiguous words (`kr`, `krona`, `krone`, `lira`, `koruna`, `dinar`) are deliberately **omitted** so the macro returns nothing rather than silently converting the wrong currency.
- **Random**: `rand`/`rnd`, `roll`/`die`, `flip`, `guid`, and `dN` dice notation (`d20`).

The `->`, `→`, and ` to ` separators are shared via a small `ConversionSeparator` helper so the unit and currency families stay consistent.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  build -derivedDataPath build/DerivedData
# ** BUILD SUCCEEDED **

xcodebuild test ... -only-testing:CotabbyTests/DateMacroEvaluatorTests \
  -only-testing:CotabbyTests/RandomMacroEvaluatorTests \
  -only-testing:CotabbyTests/UnitConversionEvaluatorTests \
  -only-testing:CotabbyTests/CurrencyEvaluatorTests \
  -only-testing:CotabbyTests/MacroEngineRoutingTests
# Executed 35 tests, with 0 failures

swiftlint lint --quiet
# exit 0, 0 violations
```

New tests cover the alias/short-form/`to`/symbol paths, and the existing strict-form tests (including the negative cases `100USD->EUR` rejected by the unit family and `100XXX->USD` rejected by currency) still pass.

## Risk / rollout notes

- Pure-logic change to the macro evaluators (`Support/Macros`). No AX, event-tap, insertion, or UI-pipeline changes; the macros stay deterministic given their injected clock/RNG.
- New matches are additive (more inputs resolve); existing inputs are unchanged. Ambiguous currency words were intentionally left out to avoid wrong conversions.
- The Inline Macros settings description was refreshed to advertise the flexibility.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the `/` macro system broadly forgiving by adding aliases, short forms, currency symbols, spelled-out unit names, and a natural `to` separator across all macro families, while keeping all existing strict forms intact.

- **Date macros** gain short-form aliases (`tdy`, `tmrw`, `rn`), weekday navigation without a dash (`next fri`, `nextfri`), and spelled-out relative units (`+1week`, `+2days`) via a new `canonicalBase` normalization step.
- **Unit and currency evaluators** share a new `ConversionSeparator` helper that unifies `->`, `\u2192`, and ` to ` parsing; the unit table is expanded with full names and plurals; the currency evaluator adds an alias table for names, symbols, and short forms.
- **Random macros** pick up `rand`/`rnd`, `roll`/`die`/`flip`, `guid`, and standard `dN` dice notation.

<h3>Confidence Score: 3/5</h3>

Safe to merge for the random, unit, and date families; the currency alias table needs the peso/₱ inconsistency resolved before shipping.

The date, unit, and random evaluators are well-structured and purely additive. The currency evaluator has a real behavioral inconsistency: 'peso' resolves to MXN while the ₱ symbol resolves to PHP — the same word and its symbol route to different countries, so a Filipino user typing '1000 peso to usd' silently gets a Mexican rate. The PR itself establishes the principle of omitting ambiguous terms to prevent this exact class of error.

Cotabby/Support/Macros/CurrencyEvaluator.swift — specifically the aliases dictionary and parseAmount leading-symbol branch.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/Macros/CurrencyEvaluator.swift | Adds alias resolution for currency names, symbols, and short forms. Contains an inconsistency where 'peso' maps to MXN while the ₱ symbol maps to PHP, and includes arguably ambiguous words ('franc', 'riyal', 'rial'). Multi-character leading-symbol aliases (c$, a$, hk$) silently fail. |
| Cotabby/Support/Macros/MacroModels.swift | Adds ConversionSeparator helper shared by unit and currency evaluators; clean abstraction with minor redundancy in the arrow-search loop. |
| Cotabby/Support/Macros/DateMacroEvaluator.swift | Adds short-form aliases and weekday separator normalization; logic is correct and benign non-weekday strings pass through to nil without side effects. |
| Cotabby/Support/Macros/UnitConversionEvaluator.swift | Expands unit alias table with full names, plurals, and British spellings; no logic changes, only additive alias entries. |
| Cotabby/Support/Macros/RandomMacroEvaluator.swift | Adds rand/rnd/roll/die/flip/guid aliases and dN dice notation; guard on diceSides correctly rejects bare 'd' and non-numeric suffixes. |
| CotabbyTests/MacroEngineTests.swift | New tests cover aliases, dice notation, to-separator, full unit names, currency symbols, and end-to-end routing; all deterministic via injected RNG/clock. |
| CotabbyTests/DateMacroEvaluatorTests.swift | New tests cover short-form aliases, weekday separator variants, and spelled-out relative units; assertions are consistent with the fixed clock date. |
| Cotabby/UI/Settings/Panes/GeneralPaneView.swift | UI description string refreshed to advertise the new flexible macro syntax; no logic changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["/query input"] --> B[MacroEngine: try each evaluator]
    B --> C[DateMacroEvaluator]
    C --> C1["splitArgument → rawBase, arg"]
    C1 --> C2["canonicalBase(rawBase)"]
    C2 --> C3{"alias table lookup"}
    C3 -->|"tdy→today / tmrw→tomorrow"| C4[canonical keyword]
    C3 -->|"next fri / nextfri"| C5["rewrite → next-fri"]
    C4 --> C6[match keyword / weekday / relative offset]
    C5 --> C6
    C6 --> R[MacroResult]
    B --> D[UnitConversionEvaluator]
    D --> S["ConversionSeparator.split"]
    S -->|"-> / → / to"| D1["lhs, rhs"]
    D1 --> D2["units table lookup"]
    D2 --> D3["Foundation Measurement convert"]
    D3 --> R
    B --> E[CurrencyEvaluator]
    E --> S
    S --> E1["parseAmount(lhs)"]
    E1 --> E2["resolveCode(token) → 3-letter code"]
    E2 --> E3["CurrencyRateTable.rate(for:)"]
    E3 --> R
    B --> F[RandomMacroEvaluator]
    F --> F1{"switch lower"}
    F1 -->|"uuid/guid"| F2[uuidSource]
    F1 -->|"dice/die/roll"| F3["randomSource(1...6)"]
    F1 -->|"coin/flip"| F4["randomSource(0...1)"]
    F1 -->|"random/rand/rnd"| F5["randomSource(0...100)"]
    F1 -->|"dN"| F6["diceSides → randomSource(1...N)"]
    F1 -->|"rand/rnd(a,b)"| F7[parameterizedRandom]
    F2 & F3 & F4 & F5 & F6 & F7 --> R
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fmacro-aliases%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fmacro-aliases%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0ACotabby%2FSupport%2FMacros%2FCurrencyEvaluator.swift%3A69-70%0A**%60peso%60%20and%20%60%E2%82%B1%60%20resolve%20to%20different%20currencies**%0A%0A%60%22peso%22%60%20maps%20to%20MXN%20%28line%2069%29%2C%20but%20%60%22%E2%82%B1%22%60%20already%20maps%20to%20PHP%20%28line%2083%29.%20%22Peso%22%20is%20the%20official%20name%20of%20the%20Philippine%20Peso%2C%20so%20a%20Filipino%20user%20typing%20%601000%20peso%20to%20usd%60%20would%20silently%20receive%20an%20MXN%E2%86%92USD%20conversion%20instead%20of%20PHP%E2%86%92USD%20%E2%80%94%20exactly%20the%20wrong-conversion%20scenario%20the%20PR%20explicitly%20designed%20the%20omission%20list%20to%20prevent.%20The%20PR%20notes%20that%20ambiguous%20currency%20words%20are%20deliberately%20excluded%2C%20yet%20%60peso%60%20is%20included%20with%20an%20MXN%20assumption%20while%20the%20symbol%20for%20the%20very%20same%20word%20points%20at%20PHP.%0A%0A%23%23%23%20Issue%202%20of%204%0ACotabby%2FSupport%2FMacros%2FCurrencyEvaluator.swift%3A81-82%0A**%60franc%60%2C%20%60riyal%60%2C%20and%20%60rial%60%20are%20as%20ambiguous%20as%20the%20excluded%20%60krone%60%2F%60lira%60**%0A%0AThe%20PR%20explicitly%20omits%20%60krone%60%2C%20%60krona%60%2C%20%60lira%60%2C%20%60koruna%60%2C%20and%20%60dinar%60%20to%20avoid%20wrong%20conversions.%20By%20the%20same%20logic%3A%20%60%22franc%22%60%20could%20be%20CHF%2C%20XOF%2C%20XAF%2C%20or%20XPF%3B%20%60%22riyal%22%60%2F%60%22rial%22%60%20could%20be%20SAR%2C%20QAR%2C%20OMR%2C%20YER%2C%20or%20IRR.%20The%20current%20mappings%20to%20CHF%20and%20SAR%20will%20silently%20produce%20wrong%20results%20for%20Qatari%20or%20Omani%20users.%20Consider%20omitting%20them%20just%20as%20%60lira%60%20and%20%60krone%60%20were.%0A%0A%23%23%23%20Issue%203%20of%204%0ACotabby%2FSupport%2FMacros%2FCurrencyEvaluator.swift%3A39-44%0A**Multi-character%20currency%20prefixes%20%28%60c%24%60%2C%20%60a%24%60%2C%20%60hk%24%60%2C%20etc.%29%20silently%20fail%20as%20leading%20symbols**%0A%0A%60parseAmount%60%20handles%20leading%20symbols%20by%20checking%20only%20the%20first%20character%20against%20the%20alias%20table.%20Multi-character%20aliases%20like%20%60%22c%24%22%3A%20%22CAD%22%60%2C%20%60%22a%24%22%3A%20%22AUD%22%60%2C%20%60%22hk%24%22%3A%20%22HKD%22%60%2C%20%60%22nz%24%22%3A%20%22NZD%22%60%2C%20%60%22nt%24%22%3A%20%22TWD%22%60%2C%20and%20%60%22s%24%22%3A%20%22SGD%22%60%20therefore%20never%20match%20through%20this%20branch%20%E2%80%94%20%60aliases%5B%22c%22%5D%60%20is%20nil%2C%20causing%20the%20fallthrough%20number-prefix%20parse%20to%20find%20an%20empty%20%60numberPart%60%20and%20return%20%60nil%60.%20%60a%24100%20to%20usd%60%20silently%20fails%3B%20%60100%20a%24%20to%20usd%60%20works%20fine%20%28trailing-token%20path%29.%0A%0A%23%23%23%20Issue%204%20of%204%0ACotabby%2FSupport%2FMacros%2FMacroModels.swift%3A44-48%0AThe%20%60where%20query.contains%28token%29%60%20guard%20is%20redundant%20%E2%80%94%20%60query.range%28of%3A%20token%29%60%20already%20returns%20%60nil%60%20when%20the%20token%20is%20absent%2C%20and%20the%20%60if%20let%60%20handles%20that%20case.%20Removing%20the%20guard%20keeps%20the%20intent%20clearer.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20for%20token%20in%20%5B%22-%3E%22%2C%20%22%E2%86%92%22%5D%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20let%20range%20%3D%20query.range%28of%3A%20token%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%20%28String%28query%5B..%3Crange.lowerBound%5D%29%2C%20String%28query%5Brange.upperBound...%5D%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0ACotabby%2FSupport%2FMacros%2FCurrencyEvaluator.swift%3A69-70%0A**%60peso%60%20and%20%60%E2%82%B1%60%20resolve%20to%20different%20currencies**%0A%0A%60%22peso%22%60%20maps%20to%20MXN%20%28line%2069%29%2C%20but%20%60%22%E2%82%B1%22%60%20already%20maps%20to%20PHP%20%28line%2083%29.%20%22Peso%22%20is%20the%20official%20name%20of%20the%20Philippine%20Peso%2C%20so%20a%20Filipino%20user%20typing%20%601000%20peso%20to%20usd%60%20would%20silently%20receive%20an%20MXN%E2%86%92USD%20conversion%20instead%20of%20PHP%E2%86%92USD%20%E2%80%94%20exactly%20the%20wrong-conversion%20scenario%20the%20PR%20explicitly%20designed%20the%20omission%20list%20to%20prevent.%20The%20PR%20notes%20that%20ambiguous%20currency%20words%20are%20deliberately%20excluded%2C%20yet%20%60peso%60%20is%20included%20with%20an%20MXN%20assumption%20while%20the%20symbol%20for%20the%20very%20same%20word%20points%20at%20PHP.%0A%0A%23%23%23%20Issue%202%20of%204%0ACotabby%2FSupport%2FMacros%2FCurrencyEvaluator.swift%3A81-82%0A**%60franc%60%2C%20%60riyal%60%2C%20and%20%60rial%60%20are%20as%20ambiguous%20as%20the%20excluded%20%60krone%60%2F%60lira%60**%0A%0AThe%20PR%20explicitly%20omits%20%60krone%60%2C%20%60krona%60%2C%20%60lira%60%2C%20%60koruna%60%2C%20and%20%60dinar%60%20to%20avoid%20wrong%20conversions.%20By%20the%20same%20logic%3A%20%60%22franc%22%60%20could%20be%20CHF%2C%20XOF%2C%20XAF%2C%20or%20XPF%3B%20%60%22riyal%22%60%2F%60%22rial%22%60%20could%20be%20SAR%2C%20QAR%2C%20OMR%2C%20YER%2C%20or%20IRR.%20The%20current%20mappings%20to%20CHF%20and%20SAR%20will%20silently%20produce%20wrong%20results%20for%20Qatari%20or%20Omani%20users.%20Consider%20omitting%20them%20just%20as%20%60lira%60%20and%20%60krone%60%20were.%0A%0A%23%23%23%20Issue%203%20of%204%0ACotabby%2FSupport%2FMacros%2FCurrencyEvaluator.swift%3A39-44%0A**Multi-character%20currency%20prefixes%20%28%60c%24%60%2C%20%60a%24%60%2C%20%60hk%24%60%2C%20etc.%29%20silently%20fail%20as%20leading%20symbols**%0A%0A%60parseAmount%60%20handles%20leading%20symbols%20by%20checking%20only%20the%20first%20character%20against%20the%20alias%20table.%20Multi-character%20aliases%20like%20%60%22c%24%22%3A%20%22CAD%22%60%2C%20%60%22a%24%22%3A%20%22AUD%22%60%2C%20%60%22hk%24%22%3A%20%22HKD%22%60%2C%20%60%22nz%24%22%3A%20%22NZD%22%60%2C%20%60%22nt%24%22%3A%20%22TWD%22%60%2C%20and%20%60%22s%24%22%3A%20%22SGD%22%60%20therefore%20never%20match%20through%20this%20branch%20%E2%80%94%20%60aliases%5B%22c%22%5D%60%20is%20nil%2C%20causing%20the%20fallthrough%20number-prefix%20parse%20to%20find%20an%20empty%20%60numberPart%60%20and%20return%20%60nil%60.%20%60a%24100%20to%20usd%60%20silently%20fails%3B%20%60100%20a%24%20to%20usd%60%20works%20fine%20%28trailing-token%20path%29.%0A%0A%23%23%23%20Issue%204%20of%204%0ACotabby%2FSupport%2FMacros%2FMacroModels.swift%3A44-48%0AThe%20%60where%20query.contains%28token%29%60%20guard%20is%20redundant%20%E2%80%94%20%60query.range%28of%3A%20token%29%60%20already%20returns%20%60nil%60%20when%20the%20token%20is%20absent%2C%20and%20the%20%60if%20let%60%20handles%20that%20case.%20Removing%20the%20guard%20keeps%20the%20intent%20clearer.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20for%20token%20in%20%5B%22-%3E%22%2C%20%22%E2%86%92%22%5D%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20let%20range%20%3D%20query.range%28of%3A%20token%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%20%28String%28query%5B..%3Crange.lowerBound%5D%29%2C%20String%28query%5Brange.upperBound...%5D%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=601&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(macros): make / macros forgiving wi..."](https://github.com/fujacob/cotabby/commit/505a2299d7508415dc3dbb80ce9e76de900e20d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35805538)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->