### PR TITLE
Tighten README What It Does and Features

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,9 @@
 
 ## What It Does
 
-Cotabby brings AI autocomplete to the text fields you already use on macOS. It works system-wide, stays out of your way, and shows suggestions as ghost text beside your cursor. Press `Tab` to accept a word, keep pressing to take more, or keep typing to ignore it.
+Cotabby shows AI suggestions as ghost text in any macOS text field. Press `Tab` to accept, or keep typing to ignore.
 
-It also includes inline emoji autocomplete: type `:smile`, `:tada`, or `:+1` and pick the emoji without leaving your current app.
-
-Inline macros turn `/` into instant in-field results: arithmetic, unit and currency conversions, dates, and random values (`/5+5=`, `/10km->mi`, `/100usd->eur`, `/today`). Optional autocorrect flags likely typos and offers a one-key fix as you type.
+It also does inline `:emoji:` autocomplete, `/` macros (math, unit and currency conversion, dates), and optional autocorrect that fixes typos with one keystroke.
 
 Everything runs on-device. No hosted API, no cloud round-trip.
 
@@ -56,16 +54,14 @@ Everything runs on-device. No hosted API, no cloud round-trip.
 
 ## Features
 
-- **System-wide completions** -- Works in any macOS text field (Safari, Notes, Mail, etc.)
-- **Ghost text UI** -- Suggestions appear as translucent overlay text at your cursor
-- **Inline emoji autocomplete** -- Type `:emoji:`-style shortcuts and insert the selected emoji without leaving your current app
-- **Inline macros** -- Type `/` for instant math, unit and currency conversions, dates, and random values
-- **Autocorrect** -- Catches likely typos and offers a one-key correction, fully on-device
-- **Two engines** -- Apple Intelligence (macOS 26+) or downloadable on-device base models via llama.cpp
-- **Make it yours** -- Name, languages, suggestion length, extended context, and per-app enable/disable
-- **100% local** -- AI inference, macros, and autocorrect run on-device
-- **Visual context** -- Screenshot OCR gives the model awareness of what's on screen
-- **Low latency** -- Optimized for fast response on Apple Silicon
+- **Ghost-text autocomplete** -- Inline AI suggestions in any macOS text field; `Tab` to accept
+- **Emoji autocomplete** -- Type `:emoji:` and insert without leaving the field
+- **Inline macros** -- `/` for math, unit and currency conversion, dates, and random values
+- **Autocorrect** -- One-key fixes for likely typos
+- **Two engines** -- Apple Intelligence or local models via llama.cpp
+- **Personalize** -- Name, languages, length, and per-app control
+- **100% local** -- Everything runs on-device
+- **Visual context** -- Optional screenshot OCR for on-screen awareness
 
 ## Engines
 


### PR DESCRIPTION
## Summary
Shortens the README per feedback: a tighter **What It Does** (three short lines that still cover ghost-text autocomplete, emoji, `/` macros, and autocorrect) and a trimmed **Features** list (merged the two core autocomplete bullets, dropped fluff like the low-latency line, kept each item terse). Autocorrect is now explicitly called out in What It Does.

## Validation
Docs-only. Verified no em dash characters in the file (uses the existing `--` style).

## Linked issues
None.

## Risk / rollout notes
README copy only; no code or build impact.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Tightens the README's **What It Does** and **Features** sections: collapses three verbose paragraphs into two short ones, merges two autocomplete bullets into one, and drops the low-latency and extended-context items.

- **What It Does** is condensed to two short sentences plus one combined feature line covering emoji, macros, and autocorrect.
- **Features** is trimmed from 10 bullets to 8 by merging ghost-text and system-wide completions, dropping low-latency, and simplifying wording throughout.

<h3>Confidence Score: 4/5</h3>

Documentation-only change with no code impact; safe to merge after resolving the minor inconsistency noted below.

The What It Does paragraph omits "random values" from the macro feature list while the Features bullet directly below still includes it, leaving the two sections inconsistent with each other.

README.md — the macro description in What It Does should include "random values" to match the Features bullet.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Documentation-only tightening of What It Does and Features sections; one minor inconsistency — "random values" is omitted from the What It Does macro list but still appears in the Features bullet. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["README.md"] --> B["What It Does"]
    A --> C["Features"]
    B --> B1["Ghost text in any macOS field"]
    B --> B2["Emoji autocomplete"]
    B --> B3["/macros (math, dates, conversion)"]
    B --> B4["Optional autocorrect"]
    C --> C1["Ghost-text autocomplete"]
    C --> C2["Emoji autocomplete"]
    C --> C3["Inline macros + random values"]
    C --> C4["Autocorrect"]
    B3 -. "missing: random values" .-> C3
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22docs%2Freadme-tighten%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Freadme-tighten%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AREADME.md%3A40%0A**Inconsistency%3A%20%22random%20values%22%20dropped%20from%20What%20It%20Does%20but%20kept%20in%20Features**%0A%0AThe%20new%20%22What%20It%20Does%22%20paragraph%20lists%20%60%2F%60%20macros%20as%20%60%28math%2C%20unit%20and%20currency%20conversion%2C%20dates%29%60%20%E2%80%94%20omitting%20random%20values.%20The%20Features%20section%20still%20reads%20%22dates%2C%20and%20random%20values%22.%20A%20reader%20scanning%20the%20top%20summary%20won't%20see%20random%20values%20mentioned%2C%20but%20it%20reappears%20one%20section%20later%2C%20creating%20a%20minor%20inconsistency%20between%20the%20two%20descriptions%20of%20the%20same%20feature.%0A%0A%60%60%60suggestion%0AIt%20also%20does%20inline%20%60%3Aemoji%3A%60%20autocomplete%2C%20%60%2F%60%20macros%20%28math%2C%20unit%20and%20currency%20conversion%2C%20dates%2C%20and%20random%20values%29%2C%20and%20optional%20autocorrect%20that%20fixes%20typos%20with%20one%20keystroke.%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AREADME.md%3A40%0A**Inconsistency%3A%20%22random%20values%22%20dropped%20from%20What%20It%20Does%20but%20kept%20in%20Features**%0A%0AThe%20new%20%22What%20It%20Does%22%20paragraph%20lists%20%60%2F%60%20macros%20as%20%60%28math%2C%20unit%20and%20currency%20conversion%2C%20dates%29%60%20%E2%80%94%20omitting%20random%20values.%20The%20Features%20section%20still%20reads%20%22dates%2C%20and%20random%20values%22.%20A%20reader%20scanning%20the%20top%20summary%20won't%20see%20random%20values%20mentioned%2C%20but%20it%20reappears%20one%20section%20later%2C%20creating%20a%20minor%20inconsistency%20between%20the%20two%20descriptions%20of%20the%20same%20feature.%0A%0A%60%60%60suggestion%0AIt%20also%20does%20inline%20%60%3Aemoji%3A%60%20autocomplete%2C%20%60%2F%60%20macros%20%28math%2C%20unit%20and%20currency%20conversion%2C%20dates%2C%20and%20random%20values%29%2C%20and%20optional%20autocorrect%20that%20fixes%20typos%20with%20one%20keystroke.%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=602&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Tighten README What It Does and Features"](https://github.com/fujacob/cotabby/commit/ce801d96b62b4ce77113826130071fadf5ea717f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35805681)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->