### PR TITLE
docs(readme): tighten tagline, copy, and acknowledgments

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <h1 align="center">Cotabby [beta]</h1>
 
-<p align="center"><em>Open-source, local-first AI autocomplete for macOS, a productivity layer for everything you type.</em></p>
+<p align="center"><em>Open-source, local AI autocomplete for macOS - an AI-native productivity layer for everything you type.</em></p>
 
 <p align="center">
   <a href="https://cotabby.app"><strong>Visit the landing page →</strong></a>
@@ -37,7 +37,7 @@
 
 Cotabby shows AI suggestions as ghost text in any macOS text field. Press `Tab` to accept, or keep typing to ignore.
 
-It also does inline `:emoji:` autocomplete, `/` macros (math, unit and currency conversion, dates), and optional autocorrect that fixes typos with one keystroke.
+It also does inline `:emoji:` autocomplete, `/` macros (math, unit and currency conversion, dates), and autocorrect that fixes typos with one keystroke.
 
 Everything runs on-device. No hosted API, no cloud round-trip.
 
@@ -75,8 +75,6 @@ Everything runs on-device. No hosted API, no cloud round-trip.
 | `tabby-2-mini` | `Qwen3.5-2B-Base.i1-Q4_K_M.gguf` | ~1.4 GB | [mradermacher/Qwen3.5-2B-Base-i1-GGUF](https://huggingface.co/mradermacher/Qwen3.5-2B-Base-i1-GGUF)     |
 | `tabby-2-base` | `gemma-4-E2B.i1-Q6_K.gguf`       | ~4.5 GB | [mradermacher/gemma-4-E2B-i1-GGUF](https://huggingface.co/mradermacher/gemma-4-E2B-i1-GGUF)             |
 | `tabby-2-pro`  | `gemma-4-E4B.i1-Q4_K_M.gguf`     | ~5.0 GB | [mradermacher/gemma-4-E4B-i1-GGUF](https://huggingface.co/mradermacher/gemma-4-E4B-i1-GGUF)             |
-
-`tabby-2-base` (Gemma E2B) is the default and the recommended onboarding tier; `tabby-2-nano` is the lightweight option for low-memory Macs, `tabby-2-mini` is a smaller alternative, and `tabby-2-pro` is the largest. Apple Intelligence remains instruction-tuned and is unaffected by the base-model path.
 
 ### Bring your own model
 
@@ -125,11 +123,11 @@ Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, bui
 
 ## Acknowledgments
 
-- [llama.cpp](https://github.com/ggerganov/llama.cpp), [CotabbyInference](https://github.com/FuJacob/cotabbyinference), [Sparkle](https://github.com/sparkle-project/Sparkle), and [swift-log](https://github.com/apple/swift-log) for the core runtime, update, and logging infrastructure.
-- Apple's FoundationModels, Accessibility APIs, SwiftUI, and AppKit for the on-device generation and macOS integration layers.
-- [GitHub gemoji](https://github.com/github/gemoji), Hugging Face, and the model teams listed above for the emoji data and downloadable model ecosystem.
-- [SymSpell](https://github.com/wolfgarbe/SymSpell) by Wolf Garbe (MIT) for the symmetric-delete spelling-correction algorithm behind autocorrect, ported to Swift. The bundled `frequency_dictionary_en_82_765.txt` ships with SymSpell and is derived from [Google Books Ngram data](https://books.google.com/ngrams) (CC BY 3.0) and [SCOWL](http://wordlist.aspell.net/).
-- Everyone who has filed issues, tested prereleases, and contributed pull requests.
+- [llama.cpp](https://github.com/ggerganov/llama.cpp), [CotabbyInference](https://github.com/FuJacob/cotabbyinference), [Sparkle](https://github.com/sparkle-project/Sparkle), and [swift-log](https://github.com/apple/swift-log) for runtime, updates, and logging.
+- Apple's FoundationModels, Accessibility, SwiftUI, and AppKit for on-device generation and macOS integration.
+- [GitHub gemoji](https://github.com/github/gemoji) and Hugging Face for the emoji data and downloadable models.
+- [SymSpell](https://github.com/wolfgarbe/SymSpell) by Wolf Garbe (MIT) for autocorrect; dictionary from [Google Ngrams](https://books.google.com/ngrams) (CC BY 3.0) and [SCOWL](http://wordlist.aspell.net/).
+- Everyone who filed issues, tested prereleases, and sent pull requests.
 
 ## Created by
 


### PR DESCRIPTION
## Summary

README copy polish:

- **Tagline**: `local-first` -> `local`, and reframed as "macOS - an AI-native productivity layer for everything you type" (dash instead of comma).
- Dropped **"optional"** from the autocorrect feature line.
- Removed the per-model tier **paragraph** under Engines (the table above it already lists the four models).
- **Shortened the Acknowledgments bullets** to roughly one line each (the SymSpell / Google Ngrams / SCOWL attribution links are preserved; full notices remain in `THIRD_PARTY_LICENSES.md`).

## Validation

Docs-only change. No code, build, or project changes.

## Risk / rollout notes

README only.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR polishes README copy with four focused changes: tagline reframing, autocorrect description tweak, removal of a now-redundant tier-explanation paragraph, and shortened acknowledgment bullets.

- Tagline is reworded from \"local-first\" to \"local\" and restructured with a dash separator; \"optional\" is dropped from the autocorrect description; the per-model tier paragraph under Engines is removed since the table already enumerates all four models.
- Acknowledgments are condensed to one line each while retaining all attribution links (SymSpell/MIT, Google Ngrams CC BY 3.0, SCOWL); full third-party notices remain in `THIRD_PARTY_LICENSES.md`.

<h3>Confidence Score: 5/5</h3>

Docs-only change; no code, build, or license content is modified.

All changes are limited to README copy: a tagline reword, a one-word removal, a redundant paragraph deletion, and shorter acknowledgment bullets. Attribution links and license identifiers are intact, and full third-party notices remain in THIRD_PARTY_LICENSES.md. Nothing here can affect runtime behaviour or break any workflow.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Docs-only copy polish: tagline, autocorrect description, engine tier paragraph removal, and shortened acknowledgments. No code, build, or license content is affected. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[README.md] --> B[Tagline]
    A --> C[What It Does]
    A --> D[Engines]
    A --> E[Acknowledgments]

    B --> B1["Before: 'local-first … a productivity layer'"]
    B --> B2["After: 'local … - an AI-native productivity layer'"]

    C --> C1["Before: 'optional autocorrect'"]
    C --> C2["After: 'autocorrect'"]

    D --> D1["Before: table + tier-explanation paragraph"]
    D --> D2["After: table only (paragraph removed)"]

    E --> E1["Before: multi-sentence attribution bullets"]
    E --> E2["After: single-line bullets (links preserved)"]
```

<sub>Reviews (1): Last reviewed commit: ["docs(readme): tighten tagline, copy, and..."](https://github.com/fujacob/cotabby/commit/46e22cadccace0026179f1dfe24bbc2fa1f6a7eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35806500)</sub>

<!-- /greptile_comment -->