### PR TITLE
Fix autocorrect demo card: missing cancellation check after 450ms sleep

### DIFF
--- a/Cotabby/UI/Onboarding/OnboardingFeatureShowcase.swift
+++ b/Cotabby/UI/Onboarding/OnboardingFeatureShowcase.swift
@@ -261,7 +261,9 @@ private struct AutocorrectDemoCard: View {
 
     private func runLoop() async {
         // Idle (not animating) and reduce-motion both rest on the green-correction frame so the
-        // card reads as "typos get a green fix" without looping.
+        // card reads as "typos get a green fix" without looping. Keeping `accepted = false` here is
+        // deliberate: it leaves the correction in its green (not-yet-accepted) color, so the static
+        // frame still reads as a correction rather than ordinary solid text.
         guard animating, !reduceMotion else {
             typedCount = fullTyped.count
             showCorrection = true
@@ -288,6 +290,7 @@ private struct AutocorrectDemoCard: View {
 
             // The typo is detected and a green correction is offered.
             try? await Task.sleep(nanoseconds: 450 * nsPerMillisecond)
+            if Task.isCancelled { return }
             withAnimation(.easeInOut(duration: 0.20)) { showCorrection = true }
             try? await Task.sleep(nanoseconds: 1300 * nsPerMillisecond)
             if Task.isCancelled { return }


### PR DESCRIPTION
## Summary

Lands the Greptile fix for #600, which was merged before the fix made it onto the branch.

In `AutocorrectDemoCard.runLoop` (onboarding/Home feature showcase), the 450ms sleep that precedes the "show correction" animation was the only `Task.sleep` in the loop not followed by an `if Task.isCancelled { return }`. So if the `.task` was cancelled during that window (view disappears, or hover ends on the Home pane), the loop would still run `withAnimation { showCorrection = true }` and mutate `@State` after cancellation. This adds the guard for consistency with every other step, and clarifies why the resting frame deliberately keeps `accepted = false`.

## Validation

```
xcodebuild ... build      # ** BUILD SUCCEEDED **
swiftlint lint --quiet    # exit 0
```
(The identical change passed the full 927-test suite when staged on the #600 merge.)

## Linked issues

Follow-up to #600 (Greptile).

## Risk / rollout notes

- One-line correctness fix plus a comment in a decorative onboarding view. No behavior change to the visible animation.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Plugs a missing Swift structured-concurrency guard in the `AutocorrectDemoCard` demo loop: after the 450ms "typo detected" sleep, `withAnimation { showCorrection = true }` could still fire even when the enclosing `.task` had been cancelled (e.g. view disappears, hover ends). The fix inserts the same `if Task.isCancelled { return }` check already present after every other `Task.sleep` call in the function, and adds an explanatory comment for the idle/reduce-motion early-return path.

- **Cancellation guard added** at line 293 — the only `Task.sleep` in `runLoop` that lacked a subsequent cancellation check, preventing a stale `@State` mutation after task teardown.
- **Comment clarification** at the top of `runLoop` explains why `accepted = false` is kept intentionally in the non-animating branch, so the static correction frame renders in its green (unaccepted) color.

<h3>Confidence Score: 5/5</h3>

One-line correctness fix in a decorative onboarding animation — no data, no networking, no shared state outside the view.

The change is a targeted single-line addition that mirrors the exact guard pattern used at every other Task.sleep site in the same function. The affected code is a cosmetic demo card; the fix can only improve behaviour (preventing a stale mutation) and cannot regress anything visible.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/Onboarding/OnboardingFeatureShowcase.swift | Adds missing `if Task.isCancelled { return }` guard after the 450ms sleep in `AutocorrectDemoCard.runLoop`, consistent with every other sleep site; also expands a clarifying comment for the idle/reduce-motion branch. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant T as .task modifier
    participant L as runLoop()
    participant UI as SwiftUI State

    T->>L: start async task
    L->>L: sleep 1100ms
    L->>L: if Task.isCancelled → return

    loop animation cycle
        L->>UI: reset typedCount / showCorrection / accepted
        L->>L: sleep 350ms → isCancelled?
        L->>UI: type characters (55ms each, isCancelled? each)
        L->>L: sleep 450ms
        Note over L: NEW guard added here
        L->>L: if Task.isCancelled → return
        L->>UI: "withAnimation showCorrection = true"
        L->>L: sleep 1300ms → isCancelled?
        L->>UI: "withAnimation accepted = true"
        L->>L: sleep 900ms → isCancelled?
        L->>UI: withAnimation reset all
        L->>L: sleep 600ms → while !isCancelled
    end

    T-->>L: cancel (view disappears / hover ends)
    L-->>T: "return (before any further @State mutation)"
```

<sub>Reviews (1): Last reviewed commit: ["Fix autocorrect demo card: cancel-check ..."](https://github.com/fujacob/cotabby/commit/f27010acc6e4951e186b638f07e211e471c479ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35807433)</sub>

<!-- /greptile_comment -->