### PR TITLE
Home pane: one-line intro, Support directly below it

### DIFF
--- a/Cotabby/UI/Settings/Panes/HomePaneView.swift
+++ b/Cotabby/UI/Settings/Panes/HomePaneView.swift
@@ -14,8 +14,8 @@ struct HomePaneView: View {
     var body: some View {
         SettingsPaneScaffold {
             Section { introHeader }
-            Section("See it in action") { OnboardingFeatureShowcase(autoplay: false) }
             Section("Support") { supportRow }
+            Section("See it in action") { OnboardingFeatureShowcase(autoplay: false) }
         }
     }
 
@@ -38,14 +38,10 @@ struct HomePaneView: View {
                 }
             }
 
-            Text(
-                "Cotabby suggests the next few words as ghost text in any text field, system-wide. "
-                + "Press Tab to accept, or keep typing to ignore. It also completes inline :emoji: "
-                + "shortcuts. Everything runs on your device; nothing is sent to the cloud."
-            )
-            .font(.callout)
-            .foregroundStyle(.secondary)
-            .fixedSize(horizontal: false, vertical: true)
+            Text("Ghost-text suggestions in any field, accepted with Tab. Everything runs on your device.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
         }
         .padding(.vertical, 4)
     }


### PR DESCRIPTION
Shorten the Home pane intro paragraph to a single line and move the Support section above the feature showcase (right below the intro). View-only change to HomePaneView; build + SwiftLint pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes two purely visual changes to `HomePaneView`: it shortens the intro paragraph to a single sentence and swaps the order of the "Support" and "See it in action" sections so that Support appears immediately after the intro.

- The intro text is condensed from three sentences (covering ghost-text, Tab acceptance, emoji shortcuts, and on-device processing) to one: `"Ghost-text suggestions in any field, accepted with Tab. Everything runs on your device."` — the emoji-shortcut mention is intentionally dropped.
- The `Section("Support")` block is moved above `Section("See it in action")`, making the Ko-fi call-to-action more prominent on the pane.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is confined to static copy and section ordering in a single SwiftUI view, with no logic, state, or data flow affected.

Both changes (text shortening and section reorder) are purely declarative: a Text literal replacement and swapping two Section calls. Nothing is wired to business logic, persistence, or networking, so there is no regression risk beyond the visible layout itself.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/Settings/Panes/HomePaneView.swift | View-only layout change: intro text shortened to one line, Support section moved above the feature showcase. No logic, data, or state is affected. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["SettingsPaneScaffold"] --> B["Section (no title)\nintroHeader"]
    B --> B1["Logo + title"]
    B --> B2["One-line description"]
    A --> C["Section: Support\n(moved up)"]
    C --> C1["Support blurb"]
    C --> C2["Ko-fi Link button"]
    A --> D["Section: See it in action\n(moved down)"]
    D --> D1["OnboardingFeatureShowcase\nautoplay: false"]
```

<sub>Reviews (1): Last reviewed commit: ["Home pane: one-line intro, Support direc..."](https://github.com/fujacob/cotabby/commit/b390cec4fcbebcabe39b78e07fba831d4f9a0461) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35808135)</sub>

<!-- /greptile_comment -->