### PR TITLE
Onboarding: wrap long Custom template description to satisfy line_length lint

### DIFF
--- a/Cotabby/Models/OnboardingTemplate.swift
+++ b/Cotabby/Models/OnboardingTemplate.swift
@@ -61,7 +61,8 @@ enum OnboardingTemplate: String, CaseIterable, Identifiable, Equatable, Sendable
         case .powerful:
             return "Longer suggestions and higher quality on harder prompts."
         case .custom:
-            return "Returning users keep every setting they've already tuned. New users start from Cotabby's lean defaults and fine-tune length, model, and behavior in Settings."
+            return "Returning users keep every setting they've already tuned. "
+                + "New users start from Cotabby's lean defaults and fine-tune length, model, and behavior in Settings."
         }
     }
 


### PR DESCRIPTION
## Summary

Wraps the Custom onboarding template's description string across two lines so it fits within the 140-char `line_length` SwiftLint rule. Pure formatting change, no behavior impact.

## Validation

```
swiftlint lint --quiet
# exit 0
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build -derivedDataPath build/DerivedData
# ** BUILD SUCCEEDED **
```

## Linked issues

None.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reformats a single long string literal in `OnboardingTemplate.swift` by splitting it across two lines with a compile-time `+` concatenation, bringing it within the SwiftLint 140-character `line_length` limit. The trailing space on the first fragment preserves the word boundary correctly.

- Splits the `.custom` case `detail` string into two adjacent string literals joined by `+`; Swift folds these at compile time, so the runtime value is unchanged.

<h3>Confidence Score: 5/5</h3>

Pure formatting change that splits a string literal for linting compliance; the concatenated string is identical at runtime.

The only modified line is a string literal split into two adjacent fragments joined by `+`. Swift evaluates adjacent string concatenation at compile time, so the value returned from `detail` for the `.custom` case is byte-for-byte identical before and after this change. No logic, types, or data flow are affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Models/OnboardingTemplate.swift | Single-line string literal in `detail` (`.custom` case) split across two lines using compile-time concatenation to satisfy the SwiftLint 140-char `line_length` rule. No behavioral change. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["OnboardingTemplate.detail (computed var)"] --> B{switch self}
    B -->|.quick| C["Short, snappy completions…"]
    B -->|.everyday| D["A balance of speed and quality…"]
    B -->|.powerful| E["Longer suggestions and higher quality…"]
    B -->|.custom| F["Returning users keep every setting… (line 1)\n+ New users start from Cotabby's lean defaults… (line 2)"]
    F --> G["Compile-time string concatenation\n→ identical runtime String value"]
```

<sub>Reviews (1): Last reviewed commit: ["Onboarding: wrap long Custom template de..."](https://github.com/fujacob/cotabby/commit/caa2807f4fd0bd0ed56ce767207dbf729e72692e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35813186)</sub>

<!-- /greptile_comment -->