### PR TITLE
README: show feature gifs in a 2x2 grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,16 @@ Everything runs on-device. No hosted API, no cloud round-trip.
   <a href="https://www.youtube.com/watch?v=p3TIgxQFQGE"><strong>Watch on YouTube →</strong></a>
 </p>
 
-<p align="center">
-  <img src="gifs/slack.gif" alt="Cotabby emoji autocomplete demo" width="700" height="240" style="margin-right:12px;" />
-  <img src="gifs/imessage.gif" alt="Cotabby autocomplete demo" width="700" height="240" />
-</p>
+<table align="center">
+  <tr>
+    <td><img src="gifs/slack.gif" alt="Cotabby emoji autocomplete demo" width="460" height="260" /></td>
+    <td><img src="gifs/imessage.gif" alt="Cotabby autocomplete demo" width="460" height="260" /></td>
+  </tr>
+  <tr>
+    <td><img src="gifs/autocorrect.gif" alt="Cotabby autocorrect demo" width="460" height="260" /></td>
+    <td><img src="gifs/macros.gif" alt="Cotabby inline macros demo" width="460" height="260" /></td>
+  </tr>
+</table>
 
 ## Features
 


### PR DESCRIPTION
## Summary

Adds the new autocorrect and macros gifs to the README header, and lays all four gifs out in an evenly sized 2x2 grid so they line up cleanly on GitHub.

## Validation

Visual only. Rendered locally; all four gifs resolve and the grid is symmetric.

## Linked issues

None.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Restructures the README demo section from two side-by-side `<img>` tags into an HTML `<table>`-based 2×2 grid, and introduces two new gif references (`autocorrect.gif`, `macros.gif`) alongside the existing `slack.gif` and `imessage.gif`.

- The table layout change is straightforward and renders correctly on GitHub for the two existing gifs.
- `gifs/autocorrect.gif` and `gifs/macros.gif` are referenced but not committed to the repository, so those two cells will show as broken images until the assets are added.

<h3>Confidence Score: 3/5</h3>

Two of the four referenced gif assets are not present in the repository, so merging as-is will display broken images in the README demo grid.

The grid layout itself is correct, but `gifs/autocorrect.gif` and `gifs/macros.gif` are absent from the repo. Visitors to the project page will see broken image placeholders in the bottom row until those files are committed.

README.md — the two new gif paths need their corresponding asset files added to the `gifs/` directory.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Replaces two side-by-side `<img>` tags with an HTML `<table>` 2×2 grid; adds two new gif references (`autocorrect.gif`, `macros.gif`) that do not exist in the repo. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[README Demo Section] --> B[Before: two img side-by-side]
    A --> C[After: table 2x2 grid]
    C --> D[Row 1: slack.gif checkmark]
    C --> E[Row 1: imessage.gif checkmark]
    C --> F[Row 2: autocorrect.gif missing]
    C --> G[Row 2: macros.gif missing]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22docs%2Freadme-2x2-gif-grid%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Freadme-2x2-gif-grid%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AREADME.md%3A56-57%0A**Missing%20gif%20assets%20in%20repository**%0A%0A%60gifs%2Fautocorrect.gif%60%20and%20%60gifs%2Fmacros.gif%60%20are%20referenced%20here%20but%20neither%20file%20exists%20in%20the%20repository%20%E2%80%94%20only%20%60gifs%2Fslack.gif%60%20and%20%60gifs%2Fimessage.gif%60%20are%20present.%20On%20GitHub%2C%20these%20two%20cells%20will%20render%20as%20broken%20image%20icons%20rather%20than%20the%20intended%20demos.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AREADME.md%3A56-57%0A**Missing%20gif%20assets%20in%20repository**%0A%0A%60gifs%2Fautocorrect.gif%60%20and%20%60gifs%2Fmacros.gif%60%20are%20referenced%20here%20but%20neither%20file%20exists%20in%20the%20repository%20%E2%80%94%20only%20%60gifs%2Fslack.gif%60%20and%20%60gifs%2Fimessage.gif%60%20are%20present.%20On%20GitHub%2C%20these%20two%20cells%20will%20render%20as%20broken%20image%20icons%20rather%20than%20the%20intended%20demos.%0A%0A&repo=fujacob%2Fcotabby&pr=609&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["README: show feature gifs in a 2x2 grid ..."](https://github.com/fujacob/cotabby/commit/af7f321244853156ad9631a27d0694276d3cfa79) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35814216)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->