### PR TITLE
README: uniform demo gif sizing in the 2x2 grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,16 +47,14 @@ Everything runs on-device. No hosted API, no cloud round-trip.
   <a href="https://www.youtube.com/watch?v=p3TIgxQFQGE"><strong>Watch on YouTube →</strong></a>
 </p>
 
-<table align="center">
-  <tr>
-    <td><img src="gifs/slack.gif" alt="Cotabby emoji autocomplete demo" width="460" height="260" /></td>
-    <td><img src="gifs/imessage.gif" alt="Cotabby autocomplete demo" width="460" height="260" /></td>
-  </tr>
-  <tr>
-    <td><img src="gifs/autocorrect.gif" alt="Cotabby autocorrect demo" width="460" height="260" /></td>
-    <td><img src="gifs/macros.gif" alt="Cotabby inline macros demo" width="460" height="260" /></td>
-  </tr>
-</table>
+<div align="center">
+
+|  |  |
+|:---:|:---:|
+| <img src="gifs/slack.gif" alt="Cotabby emoji autocomplete demo" width="440" height="220" /> | <img src="gifs/imessage.gif" alt="Cotabby autocomplete demo" width="440" height="220" /> |
+| <img src="gifs/autocorrect.gif" alt="Cotabby autocorrect demo" width="440" height="220" /> | <img src="gifs/macros.gif" alt="Cotabby inline macros demo" width="440" height="220" /> |
+
+</div>
 
 ## Features
 


### PR DESCRIPTION
## Summary

Switches the demo gif grid from a raw HTML table to a markdown table with explicit width and height on every img, so GitHub renders all four cells at an identical 440x220 box instead of falling back to native aspect ratios. The four source gifs vary from 1.7:1 to 2.9:1, so a uniform render size means a slight stretch but a clean grid.

## Validation

Visual; previewed locally and the four cells are the same size.

## Linked issues

Refs #609.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the demo GIF grid in `README.md`, replacing a raw HTML `<table>` with a GFM markdown table wrapped in a `<div align=\"center\">` block, and reduces image dimensions from 460×260 to 440×220 to enforce a uniform 2:1 aspect ratio across all four cells.

- The old `<table align=\"center\">` with `width`/`height` on each `<img>` was apparently not enforcing uniform sizing (likely because GitHub's HTML sanitizer stripped those attributes in that context); the markdown table approach preserves the `<img>` attributes as expected.
- The 440×220 (2:1) constraint will lightly stretch or compress GIFs with non-2:1 native ratios — this is an intentional and documented trade-off in the PR description.

<h3>Confidence Score: 5/5</h3>

Documentation-only change to README.md; no application code is modified and the change is safe to merge.

The change is confined to a markdown formatting adjustment in README.md. The GFM table + div align center pattern is well-established on GitHub and the blank-line separation ensures the inner table is processed as markdown rather than raw HTML. The only cosmetic side-effect is the empty header row inherent to GFM tables, which is minor and intentional.

No files require special attention — README.md is the only file changed.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Replaces the HTML table demo grid with a markdown table inside a div align center block, reducing image dimensions from 460×260 to 440×220 (2:1 ratio) to enforce uniform cell sizing. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[README.md Demo Section] --> B{Rendering approach}
    B -->|Before| C[HTML table align center
 img width=460 height=260]
    B -->|After| D[div align center
 GFM markdown table
 img width=440 height=220]
    C --> E[Browser may ignore
width/height in sanitized HTML]
    D --> F[GitHub preserves
img width/height attributes]
    E --> G[Cells render at
native aspect ratios]
    F --> H[All cells render at
uniform 440x220 2:1]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22docs%2Freadme-equal-gif-size%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Freadme-equal-gif-size%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AREADME.md%3A52-53%0AThe%20markdown%20table's%20empty%20header%20row%20%28%60%7C%20%20%7C%20%20%7C%60%29%20renders%20as%20a%20thin%20visible%20row%20above%20the%20GIF%20cells.%20There%20is%20no%20way%20to%20omit%20the%20header%20row%20in%20GFM%20syntax%3B%20this%20is%20a%20known%20markdown%20table%20limitation.%20The%20empty%20cells%20are%20fine%20as-is%20%E2%80%94%20just%20noting%20it%20renders%20a%20slightly%20elevated%20first%20row%20of%20GIFs%2C%20which%20is%20likely%20acceptable%20but%20worth%20being%20aware%20of%20as%20intentional.%0A%0A%60%60%60suggestion%0A%7C%20%7C%20%7C%0A%7C%3A---%3A%7C%3A---%3A%7C%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AREADME.md%3A52-53%0AThe%20markdown%20table's%20empty%20header%20row%20%28%60%7C%20%20%7C%20%20%7C%60%29%20renders%20as%20a%20thin%20visible%20row%20above%20the%20GIF%20cells.%20There%20is%20no%20way%20to%20omit%20the%20header%20row%20in%20GFM%20syntax%3B%20this%20is%20a%20known%20markdown%20table%20limitation.%20The%20empty%20cells%20are%20fine%20as-is%20%E2%80%94%20just%20noting%20it%20renders%20a%20slightly%20elevated%20first%20row%20of%20GIFs%2C%20which%20is%20likely%20acceptable%20but%20worth%20being%20aware%20of%20as%20intentional.%0A%0A%60%60%60suggestion%0A%7C%20%7C%20%7C%0A%7C%3A---%3A%7C%3A---%3A%7C%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=611&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["README: render 2x2 demo gifs at a unifor..."](https://github.com/fujacob/cotabby/commit/2aa69409679d8b8a62a275cb621605d674903e92) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35814485)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->