### PR TITLE
README: shrink demo gif grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Everything runs on-device. No hosted API, no cloud round-trip.
 
 |  |  |
 |:---:|:---:|
-| <img src="gifs/slack.gif" alt="Cotabby emoji autocomplete demo" width="440" height="220" /> | <img src="gifs/imessage.gif" alt="Cotabby autocomplete demo" width="440" height="220" /> |
-| <img src="gifs/autocorrect.gif" alt="Cotabby autocorrect demo" width="440" height="220" /> | <img src="gifs/macros.gif" alt="Cotabby inline macros demo" width="440" height="220" /> |
+| <img src="gifs/slack.gif" alt="Cotabby emoji autocomplete demo" width="320" height="180" /> | <img src="gifs/imessage.gif" alt="Cotabby autocomplete demo" width="320" height="180" /> |
+| <img src="gifs/autocorrect.gif" alt="Cotabby autocorrect demo" width="320" height="180" /> | <img src="gifs/macros.gif" alt="Cotabby inline macros demo" width="320" height="180" /> |
 
 </div>
 


### PR DESCRIPTION
## Summary

Drops every demo gif from 440x220 to 320x180 so the 2x2 grid stops filling the full README viewport on wide screens.

## Validation

Visual.

## Linked issues

Refs #611.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR shrinks the four demo `<img>` tags in the README from 440×220 to 320×180 to make the 2×2 grid less dominant on wide-screen viewports.

- The width reduction from 440 to 320 achieves the stated layout goal, but the new height of 180 shifts the aspect ratio from 2:1 to 16:9 (≈1.78:1). With both `width` and `height` attributes set, browsers stretch the image to fit exactly, so if the source GIFs have a 2:1 native ratio they will appear vertically squished at the new size.
- Dropping the `height` attribute and keeping only `width=\"320\"` would let browsers scale proportionally and avoid any distortion regardless of the GIFs' native dimensions.

<h3>Confidence Score: 3/5</h3>

The change successfully reduces grid width, but the new height introduces an aspect-ratio mismatch that will visually distort all four demo GIFs.

The width reduction is straightforward, but changing height from 220 to 180 shifts the aspect ratio from 2:1 to 16:9. Because both width and height are explicitly set, the browser will stretch every GIF to fit, which would make 2:1 content appear squished. The fix is simple (remove the height attribute), but as written the demo GIFs are likely to render incorrectly.

README.md — the explicit height value on all four img tags needs a second look to confirm it matches the native GIF dimensions.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Resizes four demo `<img>` tags from 440×220 (2:1) to 320×180 (16:9), changing the aspect ratio, which will distort GIFs unless they are natively 16:9. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["README 2×2 GIF grid"] --> B["Before: width=440 height=220\n(2:1 aspect ratio)"]
    A --> C["After: width=320 height=180\n(16:9 aspect ratio)"]
    B --> D["Native GIF dimensions unknown"]
    C --> D
    D -->|"GIFs are 2:1"| E["⚠️ New size distorts vertically"]
    D -->|"GIFs are 16:9"| F["✅ New size renders correctly"]
    D -->|"GIFs are 2:1"| G["Old size rendered correctly"]
    D -->|"GIFs are 16:9"| H["⚠️ Old size was distorted horizontally"]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22docs%2Freadme-shrink-gifs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Freadme-shrink-gifs%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AREADME.md%3A54-55%0A**Aspect%20ratio%20mismatch%20may%20distort%20GIFs**%0A%0AThe%20original%20dimensions%20%28440%C3%97220%29%20have%20a%202%3A1%20aspect%20ratio%3B%20the%20new%20dimensions%20%28320%C3%97180%29%20are%2016%3A9%20%28%E2%89%881.78%3A1%29.%20When%20both%20%60width%60%20and%20%60height%60%20are%20set%20on%20an%20%60%3Cimg%3E%60%20element%2C%20the%20browser%20stretches%20the%20image%20to%20fill%20those%20exact%20pixels.%20If%20the%20source%20GIFs%20are%20actually%202%3A1%2C%20they%20will%20appear%20vertically%20squished%20in%20the%20new%20size.%20If%20they%20are%2016%3A9%2C%20the%20original%20render%20was%20horizontally%20stretched.%20Either%20way%2C%20one%20of%20the%20two%20sizes%20is%20wrong.%20Consider%20specifying%20only%20%60width%3D%22320%22%60%20%28dropping%20%60height%60%29%20so%20the%20browser%20scales%20proportionally%20and%20preserves%20the%20native%20aspect%20ratio.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AREADME.md%3A54-55%0A**Aspect%20ratio%20mismatch%20may%20distort%20GIFs**%0A%0AThe%20original%20dimensions%20%28440%C3%97220%29%20have%20a%202%3A1%20aspect%20ratio%3B%20the%20new%20dimensions%20%28320%C3%97180%29%20are%2016%3A9%20%28%E2%89%881.78%3A1%29.%20When%20both%20%60width%60%20and%20%60height%60%20are%20set%20on%20an%20%60%3Cimg%3E%60%20element%2C%20the%20browser%20stretches%20the%20image%20to%20fill%20those%20exact%20pixels.%20If%20the%20source%20GIFs%20are%20actually%202%3A1%2C%20they%20will%20appear%20vertically%20squished%20in%20the%20new%20size.%20If%20they%20are%2016%3A9%2C%20the%20original%20render%20was%20horizontally%20stretched.%20Either%20way%2C%20one%20of%20the%20two%20sizes%20is%20wrong.%20Consider%20specifying%20only%20%60width%3D%22320%22%60%20%28dropping%20%60height%60%29%20so%20the%20browser%20scales%20proportionally%20and%20preserves%20the%20native%20aspect%20ratio.%0A%0A&repo=fujacob%2Fcotabby&pr=612&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["README: shrink demo gif grid to 320x180 ..."](https://github.com/fujacob/cotabby/commit/13e12d2a049c82deba6f59c724d908ba5fad2f31) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35814647)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->