### PR TITLE
README: bump demo gif grid to 400x225

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Everything runs on-device. No hosted API, no cloud round-trip.
 
 |  |  |
 |:---:|:---:|
-| <img src="gifs/slack.gif" alt="Cotabby emoji autocomplete demo" width="320" height="180" /> | <img src="gifs/imessage.gif" alt="Cotabby autocomplete demo" width="320" height="180" /> |
-| <img src="gifs/autocorrect.gif" alt="Cotabby autocorrect demo" width="320" height="180" /> | <img src="gifs/macros.gif" alt="Cotabby inline macros demo" width="320" height="180" /> |
+| <img src="gifs/slack.gif" alt="Cotabby emoji autocomplete demo" width="400" height="225" /> | <img src="gifs/imessage.gif" alt="Cotabby autocomplete demo" width="400" height="225" /> |
+| <img src="gifs/autocorrect.gif" alt="Cotabby autocorrect demo" width="400" height="225" /> | <img src="gifs/macros.gif" alt="Cotabby inline macros demo" width="400" height="225" /> |
 
 </div>
 


### PR DESCRIPTION
## Summary

Bumps each demo gif from 320x180 to 400x225 so the grid reads more comfortably without going edge-to-edge.

## Validation

Visual.

## Linked issues

Refs #612.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Resizes the four demo gif `<img>` elements in the README from `320×180` to `400×225`, keeping the 16:9 aspect ratio intact for a more comfortable grid presentation.

- All four images (`slack.gif`, `imessage.gif`, `autocorrect.gif`, `macros.gif`) receive the same dimension bump, so the 2×2 grid remains symmetrical.
- No functional code, logic, or configuration is touched — this is a documentation-only change.

<h3>Confidence Score: 5/5</h3>

Safe to merge — only HTML attribute values in the README are changed, with no effect on any code or configuration.

The change is limited to two lines of Markdown, updating width and height on four img tags. The aspect ratio is preserved (16:9 both before and after), and all four images are updated consistently, so the grid stays symmetrical.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Bumps all four demo gif img tag dimensions from 320×180 to 400×225 (both 16:9); purely cosmetic README change. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[README.md demo grid] --> B[slack.gif]
    A --> C[imessage.gif]
    A --> D[autocorrect.gif]
    A --> E[macros.gif]
    B -->|320×180 → 400×225| B2[Resized]
    C -->|320×180 → 400×225| C2[Resized]
    D -->|320×180 → 400×225| D2[Resized]
    E -->|320×180 → 400×225| E2[Resized]
```

<sub>Reviews (1): Last reviewed commit: ["README: bump demo gif grid to 400x225"](https://github.com/fujacob/cotabby/commit/b49c63c15bd73c893679b831ea5deb4fdd6f6713) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35815521)</sub>

<!-- /greptile_comment -->