### PR TITLE
Fix mid-word completion inserting a stray space on accept

### DIFF
--- a/Cotabby/Support/SuggestionSessionReconciler.swift
+++ b/Cotabby/Support/SuggestionSessionReconciler.swift
@@ -401,54 +401,43 @@ enum SuggestionSessionReconciler {
         return wordEnd
     }
 
-    /// Returns the text to actually type for an acceptance chunk, reconciling the word boundary
-    /// against the live text before the caret. Two complementary rules run here:
+    /// Returns the text to actually type for an acceptance chunk, reconciling the chunk's leading
+    /// whitespace against the live text before the caret.
     ///
-    /// 1. If the live preceding text already ends in horizontal whitespace, drop the chunk's leading
-    ///    whitespace run so we never stack a second space onto a boundary the field already provides.
-    /// 2. If the live preceding text ends in a word character and the chunk starts in a word
-    ///    character, insert a single space between them so the suggestion doesn't glue onto the
-    ///    user's last word.
+    /// One rule runs here: if the live preceding text already ends in horizontal whitespace, drop the
+    /// chunk's leading whitespace run so we never stack a second space onto a boundary the field
+    /// already provides. This is the accept-time counterpart to the generation-time space handling in
+    /// `SuggestionTextNormalizer`, re-checked against live text because the request-time prefix
+    /// snapshot can be stale by the time the user accepts — most often because they typed the
+    /// separating space themselves after the ghost appeared, or because AX reported the prefix before
+    /// that space landed.
     ///
-    /// Rule 1 is the accept-time counterpart to the generation-time space handling in
-    /// `SuggestionTextNormalizer`. That normalizer decides whether to keep the model's leading space
-    /// against a prefix *snapshot* taken when the request was built, which can be stale by the time
-    /// the user accepts — most often because they typed the separating space themselves after the
-    /// ghost appeared, or because AX reported the prefix before that space landed.
+    /// We deliberately do NOT synthesize a word boundary. The base-model prompt ends at a clean
+    /// boundary (`BaseCompletionPromptRenderer` trims trailing whitespace), so the model's first token
+    /// already encodes intent: a leading space means "new word", none means "continue the current
+    /// word". Honoring that is what makes a mid-word completion like "after" + "noon" land as
+    /// "afternoon" instead of "after noon", while a genuine new word arrives with the model's own
+    /// leading space already attached to the first acceptance chunk (`nextAcceptanceChunk` keeps it).
+    /// The cost of trusting the model is that when it omits a space it should have emitted, the words
+    /// glue ("Hello" + "World" -> "HelloWorld") — but that glue is exactly what the ghost text showed,
+    /// so accept stays WYSIWYG rather than inserting a separator the user never saw. A previous
+    /// version synthesized that separator here and produced the inverse, more confusing bug: ghost
+    /// text "afternoon" that committed as "after noon".
     ///
-    /// Rule 2 is the inverse: when the model emits a fresh word without its own leading space
-    /// (either because the small local model just omitted one, or because the normalizer stripped it
-    /// against a stale snapshot that thought the field ended in whitespace), there is no boundary in
-    /// the chunk and none in the field. We add the boundary explicitly here so accept never glues
-    /// "Hello"+"World" into "HelloWorld". The tradeoff is that we don't try to distinguish a fresh
-    /// new word from a partial-word completion — Cotabby's prompt is biased toward continuing at the
-    /// caret with multi-word output, so the "new word" interpretation matches what users see.
-    ///
-    /// Session accounting: rule 1 advances the session by the full (untrimmed) acceptedChunk; the
+    /// Session accounting: the session advances by the full (untrimmed) acceptedChunk; the only
     /// whitespace we skip typing is the field's own, so the consumed-suffix reconciliation lines up.
-    /// Rule 2 types one character the session does NOT account for — fullText has no leading space
-    /// to consume, so the post-insertion reconciler enters its tolerate path and the session stays
-    /// alive for follow-up word-by-word accepts. A user who then types a character that would have
-    /// typed-matched the next suggestion char will fall out of the tolerate window and the session
-    /// will be invalidated, which is acceptable: the next prediction picks up from the corrected
-    /// field state without any visible glue.
     static func insertionChunk(forAcceptedChunk chunk: String, precedingText: String) -> String {
-        if let lastScalar = precedingText.unicodeScalars.last,
-           CharacterSet.whitespaces.contains(lastScalar) {
-            // The drop predicate mirrors the guard's horizontal-whitespace definition so a chunk
-            // that legitimately starts with a newline (e.g. a full-accept spanning a line break) is
-            // not silently dropped when the field happens to end in a space or tab.
-            return String(chunk.drop(while: { $0.unicodeScalars.allSatisfy(CharacterSet.whitespaces.contains) }))
-        }
-
-        guard let firstChunkChar = chunk.first,
-              firstChunkChar.isAcceptanceWordCharacter,
-              let lastPrecedingChar = precedingText.last,
-              lastPrecedingChar.isAcceptanceWordCharacter else {
+        guard let lastScalar = precedingText.unicodeScalars.last,
+              CharacterSet.whitespaces.contains(lastScalar) else {
+            // Field does not end in whitespace: type the chunk verbatim and let the model's own
+            // leading space (or its absence) decide the boundary.
             return chunk
         }
 
-        return " " + chunk
+        // The drop predicate mirrors the guard's horizontal-whitespace definition so a chunk that
+        // legitimately starts with a newline (e.g. a full-accept spanning a line break) is not
+        // silently dropped when the field happens to end in a space or tab.
+        return String(chunk.drop(while: { $0.unicodeScalars.allSatisfy(CharacterSet.whitespaces.contains) }))
     }
 
     /// Counts word-like tokens so punctuation-only accepts do not inflate productivity metrics.

--- a/CotabbyTests/SuggestionSessionReconcilerTests.swift
+++ b/CotabbyTests/SuggestionSessionReconcilerTests.swift
@@ -383,35 +383,42 @@ final class SuggestionSessionReconcilerTests: XCTestCase {
         )
     }
 
-    func test_insertionChunk_addsBoundarySpaceWhenChunkAndFieldWouldGlue() {
-        // The reported "no space" regression: the chunk has no leading whitespace (model omitted it,
-        // or the normalizer stripped it against a stale prefix snapshot) and the field doesn't have
-        // a trailing one either, so we synthesize the word boundary at insert time.
+    func test_insertionChunk_continuesPartialWordWhenModelOmitsLeadingSpace() {
+        // Regression for issue #621 ("after" -> "afternoon" committing as "after noon"): the caret
+        // sits at the end of a partial word and the model continues it with no leading space. We type
+        // the continuation verbatim so it glues into one word instead of synthesizing a boundary.
+        XCTAssertEqual(
+            SuggestionSessionReconciler.insertionChunk(forAcceptedChunk: "noon", precedingText: "after"),
+            "noon"
+        )
+    }
+
+    func test_insertionChunk_trustsModelAndDoesNotSynthesizeBoundary() {
+        // Trust-the-model: when the chunk has no leading space and the field ends in a word
+        // character, we no longer insert one. A genuine new word arrives with the model's own leading
+        // space (see `keepsLeadingSpaceWhenPrecedingTextHasNoTrailingWhitespace`); when the model
+        // omits it the words glue, which is exactly what the ghost text showed, so accept stays
+        // WYSIWYG.
         XCTAssertEqual(
             SuggestionSessionReconciler.insertionChunk(forAcceptedChunk: "World", precedingText: "Hello"),
-            " World"
+            "World"
         )
-    }
-
-    func test_insertionChunk_addsBoundarySpaceForLowercaseNewWord() {
-        // Lowercase new words are the harder half of the model-omission case; the heuristic still
-        // fires because both boundary characters are word characters.
         XCTAssertEqual(
             SuggestionSessionReconciler.insertionChunk(forAcceptedChunk: "world", precedingText: "the"),
-            " world"
+            "world"
         )
     }
 
-    func test_insertionChunk_addsBoundarySpaceAcrossDigitWordBoundary() {
-        // A digit followed by a letter (or letter followed by digit) is still a word/word boundary
-        // that the user expects to read as two tokens.
+    func test_insertionChunk_doesNotSynthesizeBoundaryAcrossDigitWordBoundary() {
+        // Same trust-the-model contract across a digit/letter boundary: no synthesized separator, so
+        // the model decides whether "123" continues into "abc" or stands apart.
         XCTAssertEqual(
             SuggestionSessionReconciler.insertionChunk(forAcceptedChunk: "abc", precedingText: "123"),
-            " abc"
+            "abc"
         )
         XCTAssertEqual(
             SuggestionSessionReconciler.insertionChunk(forAcceptedChunk: "1st", precedingText: "Hello"),
-            " 1st"
+            "1st"
         )
     }
 


### PR DESCRIPTION
## Summary

On Tab, a completion that continued the user's partial word (caret at the end of `after`, model suggests `noon`) committed as `after noon` instead of `afternoon`. The accept path synthesized a word boundary the ghost text never showed, so the inserted text disagreed with the overlay. This removes that synthesis and trusts the model's own leading-space signal, so what Tab inserts matches what the ghost showed.

The base-model prompt ends at a clean boundary (`BaseCompletionPromptRenderer` trims trailing whitespace), so the model's first token already encodes intent: a leading space means "new word", none means "continue the current word". `insertionChunk` now types the chunk verbatim and lets that decide the boundary, instead of injecting a separator whenever a word character met a word character.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build \
  -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO
# ** BUILD SUCCEEDED **

xcodebuild ... test-without-building \
  -only-testing:CotabbyTests/SuggestionSessionReconcilerTests \
  -only-testing:CotabbyTests/SuggestionTextNormalizerTests \
  -only-testing:CotabbyTests/SuggestionCoordinatorAcceptanceTests
# SuggestionSessionReconcilerTests: 72 tests, 0 failures
# Normalizer + CoordinatorAcceptance: 29 tests, 0 failures

swiftlint lint --quiet <changed files>
# exit 0
```

Added a regression test pinning the reported case: `insertionChunk(forAcceptedChunk: "noon", precedingText: "after") == "noon"` (was `" noon"`). Manually confirmed in-app that mid-word completions now accept without a stray space, and that genuine new-word completions still arrive with their space.

## Linked issues

Master tracking issue: #623

Fixes #621
Fixes #620
Fixes #617
Fixes #615
Fixes #614
Fixes #559
Fixes #557
Fixes #553
Fixes #548
Fixes #547
Fixes #525
Fixes #491
Fixes #479
Fixes #395
Fixes #549
Fixes #543
Fixes #507

## Risk / rollout notes

- Behavior change on the accept path only. `insertionChunk` no longer synthesizes a separator when a word-character chunk meets a word-character prefix; it types the chunk verbatim. The model's leading space (already carried into the first chunk by `nextAcceptanceChunk`) is what now marks a new word.
- The leading-space dedup (drop a leading space when the live field already ends in whitespace) is unchanged, so between-words completions do not double-space. This dedup is load-bearing because the prompt is trimmed before generation, so the model always emits a leading space for a new word.
- Tradeoff: if the model omits a space it should have emitted (`Hello` + `World`), the words now glue into `HelloWorld` rather than being separated. This is WYSIWYG, the ghost text showed the glue, and it is strictly less confusing than the previous silent injection that produced `after noon` from a ghost reading `afternoon`.
- Possible follow-up: a SymSpell dictionary tiebreak (the 82k-word corrector is already wired into the coordinator) to split genuine two-word cases while keeping real compounds like `afternoon` glued. The data to tune it lives in `llm-io.jsonl`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a bug where mid-word Tab completions committed with a stray synthesized space — `after` + `noon` became `after noon` instead of `afternoon`. The fix removes the old word-boundary synthesis in `insertionChunk`, leaving only the double-space dedup, so the accepted text now matches exactly what the ghost overlay showed (WYSIWYG).

- **`SuggestionSessionReconciler.insertionChunk`**: Old Rule 2 (inject a space whenever chunk-starts-with-word-char meets prefix-ends-in-word-char) is dropped entirely. The function now either strips a redundant leading space (when the live field already ends in whitespace) or types the chunk verbatim, trusting the model's own leading-space signal.
- **Tests**: Three tests are renamed and their expected values inverted to pin the new no-synthesis contract; a new `test_insertionChunk_continuesPartialWordWhenModelOmitsLeadingSpace` regression case locks in the exact `after`/`noon` → `afternoon` scenario from issue #621.

<h3>Confidence Score: 4/5</h3>

Safe to merge; change is confined to the accept path and makes committed text match what the ghost overlay showed.

The removal of word-boundary synthesis is clearly correct and matches the documented WYSIWYG intent. The doc comment for `insertionChunk` grounds its reasoning in `BaseCompletionPromptRenderer`'s prompt-trimming behaviour, but the function is also exercised by the Foundation Model backend whose prompt renderer does not trim trailing whitespace — the contract still holds, but the stated rationale only covers one of the two code paths.

The doc comment in `SuggestionSessionReconciler.insertionChunk` (lines 415–420) deserves a second look to confirm it accurately describes both the llama and Foundation Model backends.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/SuggestionSessionReconciler.swift | Removes the word-boundary synthesis (old Rule 2) from `insertionChunk`, leaving only the double-space dedup (old Rule 1); logic is clean and well-commented, with a minor doc-comment gap for the Foundation Model path |
| CotabbyTests/SuggestionSessionReconcilerTests.swift | Renames and rewrites three tests to pin the new trust-the-model contract; adds the specific "#621" regression case; all assertions align with the updated behavior |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["insertionChunk(chunk, precedingText)"] --> B{precedingText ends\nin horizontal whitespace?}
    B -- Yes --> C["Drop leading horizontal\nwhitespace from chunk"]
    C --> D["Return stripped chunk\n(prevents double-space)"]
    B -- No --> E["Return chunk verbatim\n(trust model's leading-space signal)"]
    E --> F{Did model include\nleading space?}
    F -- "Yes, e.g. ' World'" --> G["'Hello' + ' World'\n→ 'Hello World' ✓"]
    F -- "No, e.g. 'noon'" --> H["'after' + 'noon'\n→ 'afternoon' ✓ (was 'after noon')"]
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2F621-trust-model-word-boundary%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F621-trust-model-word-boundary%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FSupport%2FSuggestionSessionReconciler.swift%3A415-420%0A**Doc%20comment%20cites%20only%20the%20base-model%20path%20for%20a%20shared%20function**%0A%0AThe%20rationale%20%22the%20base-model%20prompt%20ends%20at%20a%20clean%20boundary%20%28%60BaseCompletionPromptRenderer%60%20trims%20trailing%20whitespace%29%22%20is%20accurate%20for%20the%20llama%20path%2C%20but%20%60insertionChunk%60%20is%20also%20reached%20via%20%60FoundationModelSuggestionEngine%60%2C%20whose%20%60FoundationModelPromptRenderer.prompt%28%29%60%20feeds%20the%20raw%20%60request.prefixText%60%20%E2%80%94%20including%20trailing%20whitespace%20%E2%80%94%20directly%20to%20the%20model.%20The%20WYSIWYG%20contract%20still%20holds%20regardless%20%28if%20the%20Foundation%20model%20emits%20a%20space-less%20continuation%20the%20ghost%20also%20showed%20it%20space-less%29%2C%20but%20the%20stated%20reasoning%20could%20mislead%20a%20future%20maintainer%20into%20thinking%20the%20invariant%20depends%20on%20prompt%20trimming%20that%20doesn't%20apply%20to%20the%20FM%20path.%0A%0A&repo=fujacob%2Fcotabby&pr=622&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FSupport%2FSuggestionSessionReconciler.swift%3A415-420%0A**Doc%20comment%20cites%20only%20the%20base-model%20path%20for%20a%20shared%20function**%0A%0AThe%20rationale%20%22the%20base-model%20prompt%20ends%20at%20a%20clean%20boundary%20%28%60BaseCompletionPromptRenderer%60%20trims%20trailing%20whitespace%29%22%20is%20accurate%20for%20the%20llama%20path%2C%20but%20%60insertionChunk%60%20is%20also%20reached%20via%20%60FoundationModelSuggestionEngine%60%2C%20whose%20%60FoundationModelPromptRenderer.prompt%28%29%60%20feeds%20the%20raw%20%60request.prefixText%60%20%E2%80%94%20including%20trailing%20whitespace%20%E2%80%94%20directly%20to%20the%20model.%20The%20WYSIWYG%20contract%20still%20holds%20regardless%20%28if%20the%20Foundation%20model%20emits%20a%20space-less%20continuation%20the%20ghost%20also%20showed%20it%20space-less%29%2C%20but%20the%20stated%20reasoning%20could%20mislead%20a%20future%20maintainer%20into%20thinking%20the%20invariant%20depends%20on%20prompt%20trimming%20that%20doesn't%20apply%20to%20the%20FM%20path.%0A%0A&repo=fujacob%2Fcotabby&pr=622&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Trust the model&#39;s word boundary on sugge..."](https://github.com/fujacob/cotabby/commit/204af73b18b6cfa90d643f6f928598cea5e77a7c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35977508)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->