### PR TITLE
feat(overlay): show popup card when caret is mid-line

### DIFF
--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
@@ -599,6 +599,7 @@ extension SuggestionCoordinator {
             caretRect: caretRect,
             inputFrameRect: context.inputFrameRect,
             caretQuality: context.caretQuality,
+            isCaretAtEndOfLine: context.isCaretAtEndOfLine,
             observedCharWidth: context.observedCharWidth,
             isRightToLeft: isRightToLeft,
             focusChangeSequence: context.focusChangeSequence,

--- a/Cotabby/Models/CompletionRenderMode.swift
+++ b/Cotabby/Models/CompletionRenderMode.swift
@@ -29,8 +29,9 @@ nonisolated enum CompletionRenderMode: Equatable, Sendable {
 
         /// The caret sits mid-line: real characters follow it before the next line break. Inline
         /// ghost text would draw on top of those trailing characters, so the suggestion is promoted
-        /// to the card, which anchors to the field rect instead of the caret. This is also the
-        /// surface fill-in-middle completions render in, since a FIM result has no inline home.
+        /// to the card, which anchors to the caret rect (the geometry is trustworthy here) and sits
+        /// just under the cursor like an inline ghost would. This is also the surface fill-in-middle
+        /// completions render in, since a FIM result has no inline home.
         case caretMidLine
 
         /// User set their global preference to always use mirror mode. Phase 2 wiring.

--- a/Cotabby/Models/CompletionRenderMode.swift
+++ b/Cotabby/Models/CompletionRenderMode.swift
@@ -27,6 +27,12 @@ nonisolated enum CompletionRenderMode: Equatable, Sendable {
         /// drifts as the user types.
         case caretGeometryEstimated
 
+        /// The caret sits mid-line: real characters follow it before the next line break. Inline
+        /// ghost text would draw on top of those trailing characters, so the suggestion is promoted
+        /// to the card, which anchors to the field rect instead of the caret. This is also the
+        /// surface fill-in-middle completions render in, since a FIM result has no inline home.
+        case caretMidLine
+
         /// User set their global preference to always use mirror mode. Phase 2 wiring.
         case userPreference
 

--- a/Cotabby/Models/SuggestionModels.swift
+++ b/Cotabby/Models/SuggestionModels.swift
@@ -532,6 +532,12 @@ struct SuggestionOverlayGeometry: Equatable, Sendable {
     let caretRect: CGRect
     let inputFrameRect: CGRect?
     let caretQuality: CaretGeometryQuality
+    /// True when the caret is at the end of its line: only whitespace, if anything, precedes the
+    /// next line break. When false, real characters follow the caret on this line, so the
+    /// render-mode policy promotes the suggestion to the card: inline ghost text would otherwise
+    /// paint over those trailing characters. Carried from `FocusedInputContext.isCaretAtEndOfLine`.
+    /// Defaults to `true` so call sites that predate the mid-line rule keep the prior inline path.
+    let isCaretAtEndOfLine: Bool
     /// Average character width from AX child-frame sampling when available. Layout uses this as a
     /// cheap approximation for host-editor text width before falling back to local font metrics.
     let observedCharWidth: CGFloat?
@@ -560,6 +566,7 @@ struct SuggestionOverlayGeometry: Equatable, Sendable {
         caretRect: CGRect,
         inputFrameRect: CGRect?,
         caretQuality: CaretGeometryQuality,
+        isCaretAtEndOfLine: Bool = true,
         observedCharWidth: CGFloat?,
         isRightToLeft: Bool,
         focusChangeSequence: UInt64 = 0,
@@ -570,6 +577,7 @@ struct SuggestionOverlayGeometry: Equatable, Sendable {
         self.caretRect = caretRect
         self.inputFrameRect = inputFrameRect
         self.caretQuality = caretQuality
+        self.isCaretAtEndOfLine = isCaretAtEndOfLine
         self.observedCharWidth = observedCharWidth
         self.isRightToLeft = isRightToLeft
         self.focusChangeSequence = focusChangeSequence
@@ -585,6 +593,7 @@ struct SuggestionOverlayGeometry: Equatable, Sendable {
             caretRect: caretRect,
             inputFrameRect: inputFrameRect,
             caretQuality: caretQuality,
+            isCaretAtEndOfLine: isCaretAtEndOfLine,
             observedCharWidth: observedCharWidth,
             isRightToLeft: isRightToLeft,
             focusChangeSequence: focusChangeSequence,

--- a/Cotabby/Support/CompletionRenderModePolicy.swift
+++ b/Cotabby/Support/CompletionRenderModePolicy.swift
@@ -66,11 +66,11 @@ struct CompletionRenderModePolicy: Equatable, Sendable {
 
         // A caret parked mid-line (real characters follow it before the next line break) has no
         // inline home: ghost text would paint over those trailing characters. Promote any inline
-        // result to the card, which anchors to the field rect instead of the caret. This deliberately
-        // overrides an explicit `.alwaysInline` pin too, because inline cannot render mid-line at all,
-        // and the card is the surface fill-in-middle completions will use. The promotion only
-        // upgrades inline results; a presentation already routed to the card keeps its original, more
-        // specific reason (e.g. `.caretGeometryEstimated`).
+        // result to the card, which anchors to the caret rect (the geometry is trustworthy here). This
+        // deliberately overrides an explicit `.alwaysInline` pin too, because inline cannot render
+        // mid-line at all, and the card is the surface fill-in-middle completions will use. The
+        // promotion only upgrades inline results; a presentation already routed to the card keeps its
+        // original, more specific reason (e.g. `.caretGeometryEstimated`).
         if case .inline = baseMode, !geometry.isCaretAtEndOfLine {
             return .mirror(reason: .caretMidLine)
         }

--- a/Cotabby/Support/CompletionRenderModePolicy.swift
+++ b/Cotabby/Support/CompletionRenderModePolicy.swift
@@ -6,7 +6,9 @@ import Foundation
 /// to mirror mode. `alwaysInline` and `alwaysMirror` let power users pin a strategy when the
 /// auto rule misfires for their host mix.
 ///
-/// Phase 1 hardcodes `.auto` everywhere; the global setting and per-app overrides land in Phase 2.
+/// The global preference is live (Appearance settings Picker); per-app overrides are not wired yet.
+/// Note that a mid-line caret promotes inline to the card regardless of this preference; see
+/// `CompletionRenderModePolicy.mode(for:bundleIdentifier:)`.
 enum MirrorPreference: String, Codable, CaseIterable, Identifiable, Equatable, Sendable {
     case auto
     case alwaysInline
@@ -57,6 +59,28 @@ struct CompletionRenderModePolicy: Equatable, Sendable {
     /// Decides which render mode to use for one presentation. `bundleIdentifier` may be nil when the
     /// host app could not be identified; in that case only the global preference applies.
     func mode(
+        for geometry: SuggestionOverlayGeometry,
+        bundleIdentifier: String?
+    ) -> CompletionRenderMode {
+        let baseMode = preferenceMode(for: geometry, bundleIdentifier: bundleIdentifier)
+
+        // A caret parked mid-line (real characters follow it before the next line break) has no
+        // inline home: ghost text would paint over those trailing characters. Promote any inline
+        // result to the card, which anchors to the field rect instead of the caret. This deliberately
+        // overrides an explicit `.alwaysInline` pin too, because inline cannot render mid-line at all,
+        // and the card is the surface fill-in-middle completions will use. The promotion only
+        // upgrades inline results; a presentation already routed to the card keeps its original, more
+        // specific reason (e.g. `.caretGeometryEstimated`).
+        if case .inline = baseMode, !geometry.isCaretAtEndOfLine {
+            return .mirror(reason: .caretMidLine)
+        }
+        return baseMode
+    }
+
+    /// The render mode implied by the user (or per-app) preference and caret-geometry quality, before
+    /// the mid-line override in `mode(for:bundleIdentifier:)` is applied. Split out so that override
+    /// reads as a single, well-scoped rule rather than another branch threaded through the switch.
+    private func preferenceMode(
         for geometry: SuggestionOverlayGeometry,
         bundleIdentifier: String?
     ) -> CompletionRenderMode {

--- a/Cotabby/Support/MirrorOverlayLayout.swift
+++ b/Cotabby/Support/MirrorOverlayLayout.swift
@@ -151,11 +151,11 @@ struct MirrorOverlayLayout: Equatable {
     /// - `.caretGeometryEstimated` means the host did not expose any of the trusted caret paths, so
     ///   the caret rect itself is unreliable. We anchor to the input field rect when available
     ///   because the field rect stays stable even when the caret estimate drifts.
-    /// - `.userPreference` and `.perAppOverride` mean the user pinned popup mode despite the caret
-    ///   geometry being trustworthy (`.exact` or `.derived`). Anchoring to the field rect in this
-    ///   case wastes the precise caret signal and lands the card far below where the eye is. We
-    ///   anchor to the caret rect instead, with the input field as a safety net only for the
-    ///   degenerate case where the caret rect is empty.
+    /// - `.userPreference`, `.perAppOverride`, and `.caretMidLine` all mean the caret geometry is
+    ///   trustworthy (`.exact` or `.derived`); the card is up because the user pinned popup mode or
+    ///   the caret is mid-line. Anchoring to the field rect would waste the precise caret signal and
+    ///   land the card far below where the eye is, so we anchor to the caret rect instead, with the
+    ///   input field as a safety net only for the degenerate case where the caret rect is empty.
     private static func computeAnchorTopY(
         geometry: SuggestionOverlayGeometry,
         reason: CompletionRenderMode.MirrorReason
@@ -169,7 +169,7 @@ struct MirrorOverlayLayout: Equatable {
             // height as unreliable; the extra slack keeps the card from overlapping the typed line.
             return geometry.caretRect.minY - Metrics.caretFallbackVerticalOffset
 
-        case .userPreference, .perAppOverride:
+        case .userPreference, .perAppOverride, .caretMidLine:
             // Caret geometry is trustworthy in these cases. Sit just under the caret line so the
             // popup tracks the cursor like the inline ghost does, instead of floating below the
             // entire field.

--- a/CotabbyTests/CompletionRenderModePolicyTests.swift
+++ b/CotabbyTests/CompletionRenderModePolicyTests.swift
@@ -123,4 +123,108 @@ final class CompletionRenderModePolicyTests: XCTestCase {
             .mirror(reason: .userPreference)
         )
     }
+
+    // MARK: - Mid-line caret promotion
+
+    func test_auto_midLineCaret_promotesExactGeometryToMirror() {
+        // Exact geometry renders inline at end of line, but a caret with real characters after it has
+        // no inline home (the ghost would paint over the trailing text), so it promotes to the card.
+        let policy = CompletionRenderModePolicy(userPreference: .auto)
+        let geometry = CotabbyTestFixtures.overlayGeometry(
+            caretQuality: .exact,
+            isCaretAtEndOfLine: false
+        )
+
+        XCTAssertEqual(
+            policy.mode(for: geometry, bundleIdentifier: "com.apple.TextEdit"),
+            .mirror(reason: .caretMidLine)
+        )
+    }
+
+    func test_auto_midLineCaret_promotesDerivedGeometryToMirror() {
+        let policy = CompletionRenderModePolicy(userPreference: .auto)
+        let geometry = CotabbyTestFixtures.overlayGeometry(
+            caretQuality: .derived,
+            isCaretAtEndOfLine: false
+        )
+
+        XCTAssertEqual(
+            policy.mode(for: geometry, bundleIdentifier: "com.google.Chrome"),
+            .mirror(reason: .caretMidLine)
+        )
+    }
+
+    func test_auto_midLineCaret_keepsEstimatedReasonRatherThanOverwriting() {
+        // Estimated geometry already routes to the card; the promotion only upgrades inline results,
+        // so the more specific geometry reason is retained instead of being relabeled mid-line.
+        let policy = CompletionRenderModePolicy(userPreference: .auto)
+        let geometry = CotabbyTestFixtures.overlayGeometry(
+            caretQuality: .estimated,
+            isCaretAtEndOfLine: false
+        )
+
+        XCTAssertEqual(
+            policy.mode(for: geometry, bundleIdentifier: "com.microsoft.VSCode"),
+            .mirror(reason: .caretGeometryEstimated)
+        )
+    }
+
+    func test_alwaysInline_midLineCaret_isOverriddenToMirror() {
+        // Inline cannot render mid-line, so the mid-line rule overrides even an explicit inline pin.
+        // At the end of a line the pin is still honored (see the next test).
+        let policy = CompletionRenderModePolicy(userPreference: .alwaysInline)
+        let geometry = CotabbyTestFixtures.overlayGeometry(
+            caretQuality: .exact,
+            isCaretAtEndOfLine: false
+        )
+
+        XCTAssertEqual(
+            policy.mode(for: geometry, bundleIdentifier: nil),
+            .mirror(reason: .caretMidLine)
+        )
+    }
+
+    func test_alwaysInline_endOfLineCaret_staysInline() {
+        let policy = CompletionRenderModePolicy(userPreference: .alwaysInline)
+        let geometry = CotabbyTestFixtures.overlayGeometry(
+            caretQuality: .exact,
+            isCaretAtEndOfLine: true
+        )
+
+        XCTAssertEqual(
+            policy.mode(for: geometry, bundleIdentifier: nil),
+            .inline
+        )
+    }
+
+    func test_alwaysMirror_midLineCaret_keepsUserPreferenceReason() {
+        // Already a card; the promotion never runs, so the user-preference reason is preserved.
+        let policy = CompletionRenderModePolicy(userPreference: .alwaysMirror)
+        let geometry = CotabbyTestFixtures.overlayGeometry(
+            caretQuality: .exact,
+            isCaretAtEndOfLine: false
+        )
+
+        XCTAssertEqual(
+            policy.mode(for: geometry, bundleIdentifier: nil),
+            .mirror(reason: .userPreference)
+        )
+    }
+
+    func test_perAppInlineOverride_midLineCaret_isOverriddenToMirror() {
+        // A per-app inline override is still a request to render inline, which mid-line can't honor.
+        let policy = CompletionRenderModePolicy(
+            userPreference: .auto,
+            perAppOverrides: ["com.example.InlinePinned": .alwaysInline]
+        )
+        let geometry = CotabbyTestFixtures.overlayGeometry(
+            caretQuality: .exact,
+            isCaretAtEndOfLine: false
+        )
+
+        XCTAssertEqual(
+            policy.mode(for: geometry, bundleIdentifier: "com.example.InlinePinned"),
+            .mirror(reason: .caretMidLine)
+        )
+    }
 }

--- a/CotabbyTests/CotabbyTestFixtures.swift
+++ b/CotabbyTests/CotabbyTestFixtures.swift
@@ -157,6 +157,7 @@ enum CotabbyTestFixtures {
         caretRect: CGRect = CGRect(x: 10, y: 20, width: 2, height: 18),
         inputFrameRect: CGRect? = CGRect(x: 0, y: 0, width: 240, height: 32),
         caretQuality: CaretGeometryQuality = .exact,
+        isCaretAtEndOfLine: Bool = true,
         observedCharWidth: CGFloat? = nil,
         isRightToLeft: Bool = false
     ) -> SuggestionOverlayGeometry {
@@ -164,6 +165,7 @@ enum CotabbyTestFixtures {
             caretRect: caretRect,
             inputFrameRect: inputFrameRect,
             caretQuality: caretQuality,
+            isCaretAtEndOfLine: isCaretAtEndOfLine,
             observedCharWidth: observedCharWidth,
             isRightToLeft: isRightToLeft
         )


### PR DESCRIPTION
## Summary

When the caret sits mid-line (real characters follow it before the next line break), inline ghost text has no home: it would render on top of the text after the caret. This promotes any such presentation to the popup (mirror) card instead, anchored to the caret line. It is the first step toward fill-in-middle (FIM) completions, which structurally need the card because a mid-line completion cannot be drawn inline.

The signal is the existing `CaretLinePosition.isAtEndOfLine`, so an end-of-line caret that still has later paragraphs below it stays inline (only same-line trailing characters trigger the card).

## Validation

```
swiftlint lint --quiet <6 changed source files>
# exit 0

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  build-for-testing -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
# ** TEST BUILD SUCCEEDED **

xcodebuild test-without-building ... \
  -only-testing:CotabbyTests/CompletionRenderModePolicyTests \
  -only-testing:CotabbyTests/CaretLinePositionTests \
  -only-testing:CotabbyTests/MirrorOverlayLayoutTests
# Executed 39 tests, with 0 failures
```

App-hosted tests were run locally with signing disabled. The 7 new policy tests cover the auto / always-inline / always-mirror / per-app-override matrix at both end-of-line and mid-line carets; existing policy, caret-position, and mirror-layout suites still pass.

## Linked issues

No issue number provided. Groundwork for FIM completions.

## Risk / rollout notes

- Behavior change to an existing flow: a suggestion generated with the caret mid-line (e.g. the mid-word continuations that already fire via `MidWordContinuationPolicy`) previously rendered as inline ghost text overlapping the trailing characters. It now renders in the popup card. This is a net improvement for that case, but it is a visible change.
- The mid-line rule deliberately overrides an explicit "Inline" appearance preference, because inline cannot render mid-line without overlap. If we would rather honor the pin and leave those users on inline mid-line, the override is a one-line change in `CompletionRenderModePolicy.mode` (gate the promotion on `.auto` only). Flagging for a product call.
- No schema, settings, or `project.yml` / pbxproj migrations. No new files (test changes live in existing files, so XcodeGen does not drift).
- Mirror-card anchoring for the new `.caretMidLine` reason reuses the trustworthy-geometry path (anchors to the caret line), so there is no new positioning math.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces mid-line caret detection into the completion render-mode pipeline: when `isCaretAtEndOfLine` is `false`, any inline result is promoted to the popup (mirror) card via the new `.caretMidLine` reason, preventing ghost text from painting over trailing characters and laying the groundwork for fill-in-middle completions.

- Adds `isCaretAtEndOfLine: Bool` (default `true`) to `SuggestionOverlayGeometry` and threads it from `FocusedInputContext` through `SuggestionCoordinator+Acceptance`.
- Refactors `CompletionRenderModePolicy.mode` into a thin wrapper + a private `preferenceMode`, with the mid-line promotion expressed as a single, well-scoped guard; `MirrorOverlayLayout.computeAnchorTopY` groups `.caretMidLine` with the other trustworthy-geometry reasons and anchors to the caret rect.
- Adds 7 new policy tests covering the auto / alwaysInline / alwaysMirror / per-app-override matrix at both end-of-line and mid-line carets, including the important "estimated geometry keeps its own reason" invariant.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the behavior change (mid-line inline → popup card) is intentional, the promotion is correctly scoped to inline-only base modes, and the prior inline path is preserved by a safe default.

The policy refactor is small and well-contained: `preferenceMode` is the unchanged original logic, and the new wrapper adds a single, clearly-guarded promotion. The `isCaretAtEndOfLine` default of `true` ensures all pre-existing call sites keep their prior behavior. The 7 new tests cover the full preference × caret-position matrix, including the estimated-geometry invariant and the alwaysInline override case. No schema, persistence, or migration changes are involved.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/CompletionRenderModePolicy.swift | Public `mode` is now a thin wrapper that calls the renamed private `preferenceMode` and applies the mid-line promotion; logic is clean and all test scenarios pass. |
| Cotabby/Models/SuggestionModels.swift | Adds `isCaretAtEndOfLine: Bool = true` to `SuggestionOverlayGeometry`; default preserves prior inline behavior for existing call sites, and `replacingCaretRect` correctly forwards the value. |
| Cotabby/Support/MirrorOverlayLayout.swift | `computeAnchorTopY` groups `.caretMidLine` with `.userPreference` and `.perAppOverride` for caret-rect anchoring; doc comment updated accordingly. |
| Cotabby/Models/CompletionRenderMode.swift | New `.caretMidLine` reason added to `MirrorReason` with accurate doc comment describing caret-rect anchoring behavior. |
| Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift | Passes `isCaretAtEndOfLine: context.isCaretAtEndOfLine` to `SuggestionOverlayGeometry`; single-line, correct change. |
| CotabbyTests/CompletionRenderModePolicyTests.swift | Seven new tests cover the full preference × caret-position matrix, including the subtle "estimated geometry keeps its reason" and "alwaysInline is overridden mid-line" invariants. |
| CotabbyTests/CotabbyTestFixtures.swift | Fixture `overlayGeometry` gains `isCaretAtEndOfLine` parameter (default `true`) matching the production default. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SuggestionCoordinator\nreceives context] --> B[Build SuggestionOverlayGeometry\nwith isCaretAtEndOfLine]
    B --> C[CompletionRenderModePolicy\n.mode for:bundleIdentifier:]
    C --> D[preferenceMode\npreference + caretQuality]
    D --> E{baseMode == .inline?}
    E -- No --> F[Return baseMode\ne.g. .mirror caretGeometryEstimated\nor .mirror userPreference]
    E -- Yes --> G{isCaretAtEndOfLine?}
    G -- true --> H[Return .inline]
    G -- false --> I[Return .mirror reason: .caretMidLine]
    H --> J[MirrorOverlayLayout\nno card shown]
    I --> K[MirrorOverlayLayout\ncomputeAnchorTopY]
    F --> K
    K --> L{reason}
    L -- caretGeometryEstimated --> M[Anchor to inputFieldRect\nwith vertical slack offset]
    L -- userPreference / perAppOverride / caretMidLine --> N[Anchor to caretRect\nfield rect as fallback]
```

<sub>Reviews (2): Last reviewed commit: ["docs: correct caretMidLine anchor commen..."](https://github.com/fujacob/cotabby/commit/fdc541a4acc2fca69356b43bd565697fbeb601eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35977780)</sub>

<!-- /greptile_comment -->