### PR TITLE
Suppress Calendar AX capture to prevent event popover dismissal

### DIFF
--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: ship
+description: Ship the current work to main via a squash-merged PR. Branches off latest main (unless a branch is given), pushes, opens a PR using the repo template, then squash-merges with admin bypass. Use when the user says "ship it", "/ship", or wants to land changes on main end-to-end.
+---
+
+# /ship
+
+End-to-end "land this on main" workflow for Cotabby. The goal is a **single linear
+commit on main** — squash merge, never a merge commit. Cotabby's `main` ruleset
+rejects merge commits, so squashing is what keeps history clean; `--admin` bypasses
+the required-status-check protection so the owner can merge directly.
+
+`$ARGUMENTS` is optional:
+- empty → branch off the latest `origin/main` with a derived name
+- a branch name (e.g. `feat/foo`) → use/create that branch instead of deriving one
+- `from <ref>` → base the new branch on `<ref>` instead of `origin/main`
+
+## Steps
+
+1. **Establish the branch.**
+   - `git fetch origin`.
+   - If the user is already on a feature branch that holds the work, keep it.
+   - Otherwise (on `main`/detached, or a branch name was given), create the branch
+     off the latest base: `git checkout -b <name> origin/main` (or the `from <ref>`
+     base). Derive `<name>` from the change: `feat/`, `fix/`, or `chore/` + a short
+     kebab slug. Never do the work directly on `main`.
+
+2. **Commit the work.** Stage and commit anything pending. Follow the repo's
+   GitHub rules in `.Codex/AGENTS.md`: **no `Co-Authored-By` trailers.** Write a
+   concise, real commit message.
+
+3. **Validate before pushing.** Run the narrowest useful checks, broaden if shared
+   behavior changed:
+   ```bash
+   swiftlint lint --quiet
+   xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
+   ```
+   For test-affecting changes also run `build-for-testing`. Local `test` execution
+   often fails on a **Team ID / signing mismatch** — that's an environment issue, not
+   a code failure; report it and rely on `build-for-testing` succeeding.
+   - **XcodeGen:** `project.yml` is the source of truth and `Cotabby.xcodeproj` is
+     generated. New files under `Cotabby/` and `CotabbyTests/` are auto-discovered —
+     no project edit needed. Only structural changes (targets, build settings,
+     packages, scheme) require editing `project.yml` then `xcodegen generate` and
+     committing the regenerated project. Fix all lint/build errors before continuing.
+
+4. **Push.** `git push -u origin <branch>`.
+
+5. **Open the PR using the repo template.** Read `.github/PULL_REQUEST_TEMPLATE.md`
+   and fill in **every** section — Summary (what + why), Validation (what you
+   actually ran and saw), Linked issues (`Fixes #N` / `Refs #N`), Risk / rollout
+   notes. Do not invent a format. Use a heredoc body:
+   ```bash
+   gh pr create --base main --head <branch> --title "<title>" --body "$(cat <<'EOF'
+   ## Summary
+   ...
+   EOF
+   )"
+   ```
+
+6. **Confirm, then squash-merge with admin bypass.** Merging to `main` is an
+   irreversible outward action — show the PR URL and the one-line summary, and get an
+   explicit go-ahead unless the user already said to merge in this turn. Then:
+   ```bash
+   gh pr merge <branch-or-#> --squash --admin --delete-branch
+   ```
+   `--squash` keeps main linear (no merge commit → satisfies the ruleset);
+   `--admin` bypasses required checks; `--delete-branch` cleans up the remote branch.
+
+7. **Sync local main.**
+   ```bash
+   git checkout main && git pull --ff-only origin main
+   ```
+   Confirm `main` now contains the squashed commit and report the result.
+
+## Guardrails
+
+- **Never force-push `main` or rebase published history to "fix" merges.** If
+  `origin/main` moved while you worked, integrate it (rebase the branch onto the new
+  `origin/main`) and re-validate — don't clobber others' commits.
+- **Never delete or overwrite work you didn't create** without checking it first.
+- If validation fails, stop and surface the failure — don't merge red.
+- If the user named a target other than `main`, ship there instead, but keep the
+  squash-merge shape.

--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A1C0FFEEA1C0FFEEA1C0F002 /* AccessibilityCaptureSuppressionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C0FFEEA1C0FFEEA1C0F001 /* AccessibilityCaptureSuppressionPolicy.swift */; };
+		A1C0FFEEA1C0FFEEA1C0F004 /* AccessibilityCaptureSuppressionPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C0FFEEA1C0FFEEA1C0F003 /* AccessibilityCaptureSuppressionPolicyTests.swift */; };
 		000EBFCBA8CE49537690613B /* SymSpellCorrectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C850141146422A132B2B3516 /* SymSpellCorrectorTests.swift */; };
 		0187EAA1D37B92DD5B264016 /* PermissionDragSourceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D00A031C0D9CF2A7A2330D9 /* PermissionDragSourceView.swift */; };
 		02DA43985CDAE6859014F14F /* SuggestionOverlayPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D598CC3134879999D567455 /* SuggestionOverlayPresenter.swift */; };
@@ -321,6 +323,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		A1C0FFEEA1C0FFEEA1C0F001 /* AccessibilityCaptureSuppressionPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityCaptureSuppressionPolicy.swift; sourceTree = "<group>"; };
+		A1C0FFEEA1C0FFEEA1C0F003 /* AccessibilityCaptureSuppressionPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityCaptureSuppressionPolicyTests.swift; sourceTree = "<group>"; };
 		003594B09C83EF2DF35577D5 /* SuggestionDebugLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionDebugLogger.swift; sourceTree = "<group>"; };
 		00824BDD8D0E9B3063827C78 /* MenuBarPresentationObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarPresentationObserver.swift; sourceTree = "<group>"; };
 		01B72736E416910878E8E493 /* OnboardingTemplateRecommenderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTemplateRecommenderTests.swift; sourceTree = "<group>"; };
@@ -874,6 +878,7 @@
 		A8A141E1F2137943476D0C82 /* CotabbyTests */ = {
 			isa = PBXGroup;
 			children = (
+				A1C0FFEEA1C0FFEEA1C0F003 /* AccessibilityCaptureSuppressionPolicyTests.swift */,
 				A168A7B6A7AD11559B60C56B /* ApplicationBundleMetadataTests.swift */,
 				78AFA4586C82E92D7FBF381B /* ArithmeticEvaluatorTests.swift */,
 				C046CB4F3CB4BFE9391DB5DE /* AXTextGeometryResolverTests.swift */,
@@ -1059,6 +1064,7 @@
 			isa = PBXGroup;
 			children = (
 				67C78D77B58388B15AC8B954 /* Macros */,
+				A1C0FFEEA1C0FFEEA1C0F001 /* AccessibilityCaptureSuppressionPolicy.swift */,
 				352AF5B2834FEE1F597394E4 /* ApplicationBundleMetadata.swift */,
 				AC70775535A3428991025AB8 /* AXHelper.swift */,
 				85EF79E6144D6C6AD062B569 /* BaseCompletionPromptRenderer.swift */,
@@ -1257,6 +1263,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A1C0FFEEA1C0FFEEA1C0F002 /* AccessibilityCaptureSuppressionPolicy.swift in Sources */,
 				30F3F2B6D13CD583136CD787 /* AXHelper.swift in Sources */,
 				D9C51DEDF01033E276A479CE /* AXTextGeometryResolver.swift in Sources */,
 				F31B343F9C935A5421A526DE /* AXTreeDumpWriter.swift in Sources */,
@@ -1469,6 +1476,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A1C0FFEEA1C0FFEEA1C0F004 /* AccessibilityCaptureSuppressionPolicyTests.swift in Sources */,
 				6D0E79CF3C1A8CE53046FCE5 /* AXTextGeometryResolverTests.swift in Sources */,
 				A36481222BB5B2A67349D389 /* ApplicationBundleMetadataTests.swift in Sources */,
 				4D583CB3DA253FB795EE54F9 /* ArithmeticEvaluatorTests.swift in Sources */,

--- a/Cotabby/App/Core/CotabbyAppEnvironment.swift
+++ b/Cotabby/App/Core/CotabbyAppEnvironment.swift
@@ -75,6 +75,11 @@ final class CotabbyAppEnvironment {
             permissionProvider: { permissionManager.accessibilityGranted },
             ignoredBundleIdentifier: Bundle.main.bundleIdentifier,
             isCaptureSuppressedForBundle: { bundleIdentifier in
+                if AccessibilityCaptureSuppressionPolicy.shouldSuppressCapture(
+                    bundleIdentifier: bundleIdentifier
+                ) {
+                    return true
+                }
                 guard suggestionSettings.isGloballyEnabled else { return true }
                 if let bundleIdentifier,
                    suggestionSettings.isApplicationDisabled(bundleIdentifier: bundleIdentifier) {

--- a/Cotabby/App/Core/CotabbyAppEnvironment.swift
+++ b/Cotabby/App/Core/CotabbyAppEnvironment.swift
@@ -66,23 +66,25 @@ final class CotabbyAppEnvironment {
         inputMonitor.onGlobalToggleHotkey = { [weak suggestionSettings] in
             suggestionSettings?.toggleGloballyEnabled()
         }
-        // Stop the deep AX walk when Cotabby is disabled for the focused app. Without this the
-        // focus poll keeps enumerating the frontmost app's AX attributes every 50-80ms even after
-        // the user toggles Cotabby off, which can dismiss transient popovers in apps like Calendar
-        // (#476). Gating here also makes the "I disabled it but the bug remained" symptom go away:
-        // the disable toggles now actually stop touching the focused app.
+        // Stop the deep AX walk when Cotabby is disabled or a built-in compatibility safeguard is
+        // active. Without this the focus poll keeps enumerating the frontmost app's AX attributes
+        // every 50-80ms even after the user toggles Cotabby off, which can dismiss transient
+        // popovers in apps like Calendar (#476). The Calendar safeguard is checked last so global
+        // and per-app disabled preferences still win, while Settings can explicitly opt back into
+        // capture for the known-fragile app.
         let focusModel = FocusTrackingModel(
             permissionProvider: { permissionManager.accessibilityGranted },
             ignoredBundleIdentifier: Bundle.main.bundleIdentifier,
             isCaptureSuppressedForBundle: { bundleIdentifier in
-                if AccessibilityCaptureSuppressionPolicy.shouldSuppressCapture(
-                    bundleIdentifier: bundleIdentifier
-                ) {
-                    return true
-                }
                 guard suggestionSettings.isGloballyEnabled else { return true }
                 if let bundleIdentifier,
                    suggestionSettings.isApplicationDisabled(bundleIdentifier: bundleIdentifier) {
+                    return true
+                }
+                if AccessibilityCaptureSuppressionPolicy.shouldSuppressCapture(
+                    bundleIdentifier: bundleIdentifier,
+                    overrideBundleIdentifiers: suggestionSettings.accessibilityCaptureOverrideBundleIdentifiers
+                ) {
                     return true
                 }
                 return false

--- a/Cotabby/Models/SuggestionSettingsData.swift
+++ b/Cotabby/Models/SuggestionSettingsData.swift
@@ -15,6 +15,11 @@ struct SuggestionSettingsData: Equatable {
     var showIndicator: Bool
     var showAcceptanceHint: Bool
     var disabledAppRules: [DisabledApplicationRule]
+    /// User opt-ins that bypass a built-in AX capture safeguard for a specific app.
+    ///
+    /// The defaults live in `AccessibilityCaptureSuppressionPolicy`; this set only records explicit
+    /// user overrides, so adding a future safeguard does not silently inherit an unrelated preference.
+    var accessibilityCaptureOverrideBundleIdentifiers: Set<String>
     var customSuggestionTextColorHex: String?
     var ghostTextOpacity: Double
     var selectedEngine: SuggestionEngineKind

--- a/Cotabby/Models/SuggestionSettingsModel.swift
+++ b/Cotabby/Models/SuggestionSettingsModel.swift
@@ -38,6 +38,8 @@ final class SuggestionSettingsModel: ObservableObject {
     /// Whether the keycap hint (the small pill that teaches the accept key) is drawn after ghost text.
     @Published private(set) var showAcceptanceHint: Bool
     @Published private(set) var disabledAppRules: [DisabledApplicationRule]
+    /// Bundle IDs where the user has deliberately opted out of a built-in AX capture safeguard.
+    @Published private(set) var accessibilityCaptureOverrideBundleIdentifiers: Set<String>
     @Published private(set) var customSuggestionTextColorHex: String?
     @Published private(set) var ghostTextOpacity: Double
     @Published private(set) var selectedEngine: SuggestionEngineKind
@@ -127,6 +129,7 @@ final class SuggestionSettingsModel: ObservableObject {
         showIndicator = data.showIndicator
         showAcceptanceHint = data.showAcceptanceHint
         disabledAppRules = data.disabledAppRules
+        accessibilityCaptureOverrideBundleIdentifiers = data.accessibilityCaptureOverrideBundleIdentifiers
         customSuggestionTextColorHex = data.customSuggestionTextColorHex
         ghostTextOpacity = data.ghostTextOpacity
         selectedEngine = data.selectedEngine
@@ -448,6 +451,44 @@ final class SuggestionSettingsModel: ObservableObject {
         return disabledAppRules.contains {
             $0.bundleIdentifier == normalizedBundleIdentifier
         }
+    }
+
+    /// Records whether a built-in Accessibility capture safeguard should be bypassed for one app.
+    ///
+    /// This is intentionally separate from disabled-app rules. Disabling an app stops all Cotabby
+    /// behavior there; this override does the opposite for one narrow compatibility block by allowing
+    /// Cotabby to inspect that app's AX tree again.
+    func setAccessibilityCaptureOverride(
+        bundleIdentifier: String?,
+        allowsCapture: Bool
+    ) {
+        guard let normalizedBundleIdentifier = SuggestionSettingsStore.normalizedBundleIdentifier(bundleIdentifier)
+        else {
+            return
+        }
+
+        var updatedBundleIdentifiers = accessibilityCaptureOverrideBundleIdentifiers
+        if allowsCapture {
+            updatedBundleIdentifiers.insert(normalizedBundleIdentifier)
+        } else {
+            updatedBundleIdentifiers.remove(normalizedBundleIdentifier)
+        }
+
+        guard accessibilityCaptureOverrideBundleIdentifiers != updatedBundleIdentifiers else {
+            return
+        }
+
+        accessibilityCaptureOverrideBundleIdentifiers = updatedBundleIdentifiers
+        store.saveAccessibilityCaptureOverrideBundleIdentifiers(updatedBundleIdentifiers)
+    }
+
+    func isAccessibilityCaptureOverrideEnabled(bundleIdentifier: String?) -> Bool {
+        guard let normalizedBundleIdentifier = SuggestionSettingsStore.normalizedBundleIdentifier(bundleIdentifier)
+        else {
+            return false
+        }
+
+        return accessibilityCaptureOverrideBundleIdentifiers.contains(normalizedBundleIdentifier)
     }
 
     func setShowIndicator(_ show: Bool) {

--- a/Cotabby/Support/AccessibilityCaptureSuppressionPolicy.swift
+++ b/Cotabby/Support/AccessibilityCaptureSuppressionPolicy.swift
@@ -1,30 +1,57 @@
 import Foundation
 
+/// One built-in Accessibility capture safeguard surfaced in Settings.
+///
+/// This is metadata, not persisted state. The policy owns the default because it also owns the
+/// compatibility rule; `SuggestionSettingsModel` only persists user overrides that opt back into
+/// capture for one of these bundle identifiers.
+struct AccessibilityCaptureSuppressedApplication: Equatable, Identifiable {
+    let bundleIdentifier: String
+    let displayName: String
+    let reason: String
+
+    var id: String { bundleIdentifier }
+}
+
 /// File overview:
 /// Centralizes app-level exceptions where Cotabby must not inspect the focused Accessibility tree.
 ///
 /// Most app compatibility rules should live in the normal availability pipeline so users can still
 /// choose where Cotabby runs. This policy is narrower: it protects host apps whose transient UI is
 /// destabilized by AX attribute enumeration itself. The caller should consult it before any deep
-/// candidate walk, because once that walk starts the host popover may already have closed.
+/// candidate walk, because once that walk starts the host popover may already have closed. Users
+/// can still opt back into capture per app through Settings; the default remains conservative.
 enum AccessibilityCaptureSuppressionPolicy {
-    /// Bundle identifiers whose focused AX tree is not safe to enumerate continuously.
+    /// Apps whose focused AX tree is not safe to enumerate continuously.
     ///
     /// Apple Calendar's event-detail popover can dismiss itself when Cotabby polls text capability
     /// on its temporary editor hierarchy. Suppressing capture at the app boundary is conservative,
-    /// but it keeps Calendar's own editing controls usable while leaving keyboard monitoring and the
-    /// rest of Cotabby untouched.
-    private static let unsafeBundleIdentifiers: Set<String> = [
-        "com.apple.iCal"
+    /// but the metadata is public inside the app so Settings can show the user the tradeoff and let
+    /// them opt back in deliberately.
+    static let suppressedApplications: [AccessibilityCaptureSuppressedApplication] = [
+        AccessibilityCaptureSuppressedApplication(
+            bundleIdentifier: "com.apple.iCal",
+            displayName: "Calendar",
+            reason: "Event editor popovers can close when helper apps inspect their Accessibility tree."
+        )
     ]
+
+    private static let suppressedBundleIdentifiers = Set(suppressedApplications.map(\.bundleIdentifier))
 
     /// Returns true when focus polling should stop after the cheap focused-element query and before
     /// `FocusSnapshotResolver` performs AX candidate enumeration.
-    static func shouldSuppressCapture(bundleIdentifier: String?) -> Bool {
-        guard let bundleIdentifier else {
+    static func shouldSuppressCapture(
+        bundleIdentifier: String?,
+        overrideBundleIdentifiers: Set<String> = []
+    ) -> Bool {
+        guard let bundleIdentifier = SuggestionSettingsStore.normalizedBundleIdentifier(bundleIdentifier) else {
             return false
         }
 
-        return unsafeBundleIdentifiers.contains(bundleIdentifier)
+        let normalizedOverrides = SuggestionSettingsStore.sanitizedBundleIdentifierSet(
+            Array(overrideBundleIdentifiers)
+        )
+        return suppressedBundleIdentifiers.contains(bundleIdentifier)
+            && !normalizedOverrides.contains(bundleIdentifier)
     }
 }

--- a/Cotabby/Support/AccessibilityCaptureSuppressionPolicy.swift
+++ b/Cotabby/Support/AccessibilityCaptureSuppressionPolicy.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// File overview:
+/// Centralizes app-level exceptions where Cotabby must not inspect the focused Accessibility tree.
+///
+/// Most app compatibility rules should live in the normal availability pipeline so users can still
+/// choose where Cotabby runs. This policy is narrower: it protects host apps whose transient UI is
+/// destabilized by AX attribute enumeration itself. The caller should consult it before any deep
+/// candidate walk, because once that walk starts the host popover may already have closed.
+enum AccessibilityCaptureSuppressionPolicy {
+    /// Bundle identifiers whose focused AX tree is not safe to enumerate continuously.
+    ///
+    /// Apple Calendar's event-detail popover can dismiss itself when Cotabby polls text capability
+    /// on its temporary editor hierarchy. Suppressing capture at the app boundary is conservative,
+    /// but it keeps Calendar's own editing controls usable while leaving keyboard monitoring and the
+    /// rest of Cotabby untouched.
+    private static let unsafeBundleIdentifiers: Set<String> = [
+        "com.apple.iCal"
+    ]
+
+    /// Returns true when focus polling should stop after the cheap focused-element query and before
+    /// `FocusSnapshotResolver` performs AX candidate enumeration.
+    static func shouldSuppressCapture(bundleIdentifier: String?) -> Bool {
+        guard let bundleIdentifier else {
+            return false
+        }
+
+        return unsafeBundleIdentifiers.contains(bundleIdentifier)
+    }
+}

--- a/Cotabby/Support/SuggestionSettingsStore.swift
+++ b/Cotabby/Support/SuggestionSettingsStore.swift
@@ -52,6 +52,8 @@ struct SuggestionSettingsStore {
 
     private static let isGloballyEnabledDefaultsKey = "cotabbyGloballyEnabled"
     private static let disabledAppRulesDefaultsKey = "cotabbyDisabledAppRules"
+    private static let accessibilityCaptureOverrideBundleIdentifiersDefaultsKey =
+        "cotabbyAccessibilityCaptureOverrideBundleIdentifiers"
     private static let showCaretIndicatorDefaultsKey = "cotabbyShowCaretIndicator"
     private static let selectedIndicatorModeDefaultsKey = "cotabbySelectedIndicatorMode"
     private static let showAcceptanceHintDefaultsKey = "cotabbyShowAcceptanceHint"
@@ -112,6 +114,9 @@ struct SuggestionSettingsStore {
     func load(configuration: SuggestionConfiguration) -> SuggestionSettingsData {
         let resolvedGloballyEnabled = userDefaults.object(forKey: Self.isGloballyEnabledDefaultsKey) as? Bool ?? true
         let resolvedDisabledAppRules = loadDisabledAppRules()
+        let resolvedAccessibilityCaptureOverrideBundleIdentifiers = Self.sanitizedBundleIdentifierSet(
+            userDefaults.stringArray(forKey: Self.accessibilityCaptureOverrideBundleIdentifiersDefaultsKey) ?? []
+        )
         let resolvedShowIndicator: Bool = if let modeString = userDefaults.string(
             forKey: Self.selectedIndicatorModeDefaultsKey
         ) {
@@ -288,6 +293,7 @@ struct SuggestionSettingsStore {
             showIndicator: resolvedShowIndicator,
             showAcceptanceHint: resolvedShowAcceptanceHint,
             disabledAppRules: resolvedDisabledAppRules,
+            accessibilityCaptureOverrideBundleIdentifiers: resolvedAccessibilityCaptureOverrideBundleIdentifiers,
             customSuggestionTextColorHex: resolvedCustomSuggestionTextColorHex,
             ghostTextOpacity: resolvedGhostTextOpacity,
             selectedEngine: resolvedEngine,
@@ -330,6 +336,7 @@ struct SuggestionSettingsStore {
         // sticky on the next launch. Mirrors the resolution above field-for-field.
         saveGloballyEnabled(data.isGloballyEnabled)
         saveDisabledAppRules(data.disabledAppRules)
+        saveAccessibilityCaptureOverrideBundleIdentifiers(data.accessibilityCaptureOverrideBundleIdentifiers)
         saveShowIndicator(data.showIndicator)
         saveShowAcceptanceHint(data.showAcceptanceHint)
         saveCustomSuggestionTextColorHex(data.customSuggestionTextColorHex)
@@ -396,6 +403,18 @@ struct SuggestionSettingsStore {
         if let data = try? JSONEncoder().encode(rules) {
             userDefaults.set(data, forKey: Self.disabledAppRulesDefaultsKey)
         }
+    }
+
+    func saveAccessibilityCaptureOverrideBundleIdentifiers(_ bundleIdentifiers: Set<String>) {
+        let normalized = Self.sortedBundleIdentifiers(
+            Self.sanitizedBundleIdentifierSet(Array(bundleIdentifiers))
+        )
+        guard !normalized.isEmpty else {
+            userDefaults.removeObject(forKey: Self.accessibilityCaptureOverrideBundleIdentifiersDefaultsKey)
+            return
+        }
+
+        userDefaults.set(normalized, forKey: Self.accessibilityCaptureOverrideBundleIdentifiersDefaultsKey)
     }
 
     func saveShowIndicator(_ show: Bool) {
@@ -596,6 +615,14 @@ struct SuggestionSettingsStore {
 
         let trimmed = bundleIdentifier.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
+    }
+
+    static func sanitizedBundleIdentifierSet(_ bundleIdentifiers: [String]) -> Set<String> {
+        Set(bundleIdentifiers.compactMap(Self.normalizedBundleIdentifier(_:)))
+    }
+
+    static func sortedBundleIdentifiers(_ bundleIdentifiers: Set<String>) -> [String] {
+        bundleIdentifiers.sorted()
     }
 
     static func normalizedDisplayName(

--- a/Cotabby/UI/Settings/Panes/AppsPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/AppsPaneView.swift
@@ -38,6 +38,18 @@ struct AppsPaneView: View {
                 }
             }
 
+            Section("Compatibility Overrides") {
+                Text("Cotabby avoids Accessibility capture in apps with known fragile editor popovers.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                VStack(alignment: .leading, spacing: 10) {
+                    ForEach(AccessibilityCaptureSuppressionPolicy.suppressedApplications) { application in
+                        accessibilityCaptureOverrideRow(application)
+                    }
+                }
+            }
+
             if !filteredRunningAppSuggestions.isEmpty {
                 Section("Suggestions") {
                     Text("Currently running apps you can disable with one click.")
@@ -91,6 +103,43 @@ struct AppsPaneView: View {
     }
 
     @ViewBuilder
+    private func accessibilityCaptureOverrideRow(
+        _ application: AccessibilityCaptureSuppressedApplication
+    ) -> some View {
+        Toggle(
+            isOn: Binding(
+                get: {
+                    suggestionSettings.isAccessibilityCaptureOverrideEnabled(
+                        bundleIdentifier: application.bundleIdentifier
+                    )
+                },
+                set: { allowsCapture in
+                    suggestionSettings.setAccessibilityCaptureOverride(
+                        bundleIdentifier: application.bundleIdentifier,
+                        allowsCapture: allowsCapture
+                    )
+                }
+            )
+        ) {
+            HStack(spacing: 12) {
+                Image(nsImage: icon(for: application))
+                    .resizable()
+                    .frame(width: 28, height: 28)
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Allow Accessibility capture in \(application.displayName)")
+
+                    Text(application.reason)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .toggleStyle(.switch)
+    }
+
+    @ViewBuilder
     private func disabledAppRuleRow(_ rule: DisabledApplicationRule) -> some View {
         HStack(spacing: 12) {
             Image(nsImage: icon(for: rule))
@@ -126,6 +175,15 @@ struct AppsPaneView: View {
     private func icon(for rule: DisabledApplicationRule) -> NSImage {
         guard let appURL = NSWorkspace.shared.urlForApplication(
             withBundleIdentifier: rule.bundleIdentifier
+        ) else {
+            return NSWorkspace.shared.icon(for: .applicationBundle)
+        }
+        return NSWorkspace.shared.icon(forFile: appURL.path)
+    }
+
+    private func icon(for application: AccessibilityCaptureSuppressedApplication) -> NSImage {
+        guard let appURL = NSWorkspace.shared.urlForApplication(
+            withBundleIdentifier: application.bundleIdentifier
         ) else {
             return NSWorkspace.shared.icon(for: .applicationBundle)
         }

--- a/CotabbyTests/AccessibilityCaptureSuppressionPolicyTests.swift
+++ b/CotabbyTests/AccessibilityCaptureSuppressionPolicyTests.swift
@@ -10,6 +10,15 @@ final class AccessibilityCaptureSuppressionPolicyTests: XCTestCase {
         )
     }
 
+    func testCalendarCaptureCanBeOverridden() {
+        XCTAssertFalse(
+            AccessibilityCaptureSuppressionPolicy.shouldSuppressCapture(
+                bundleIdentifier: "com.apple.iCal",
+                overrideBundleIdentifiers: ["com.apple.iCal"]
+            )
+        )
+    }
+
     func testOrdinaryAppCaptureIsNotSuppressed() {
         XCTAssertFalse(
             AccessibilityCaptureSuppressionPolicy.shouldSuppressCapture(

--- a/CotabbyTests/AccessibilityCaptureSuppressionPolicyTests.swift
+++ b/CotabbyTests/AccessibilityCaptureSuppressionPolicyTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import Cotabby
+
+final class AccessibilityCaptureSuppressionPolicyTests: XCTestCase {
+    func testCalendarCaptureIsSuppressedByDefault() {
+        XCTAssertTrue(
+            AccessibilityCaptureSuppressionPolicy.shouldSuppressCapture(
+                bundleIdentifier: "com.apple.iCal"
+            )
+        )
+    }
+
+    func testOrdinaryAppCaptureIsNotSuppressed() {
+        XCTAssertFalse(
+            AccessibilityCaptureSuppressionPolicy.shouldSuppressCapture(
+                bundleIdentifier: "com.apple.Safari"
+            )
+        )
+    }
+
+    func testMissingBundleIdentifierIsNotSuppressed() {
+        XCTAssertFalse(
+            AccessibilityCaptureSuppressionPolicy.shouldSuppressCapture(bundleIdentifier: nil)
+        )
+    }
+}

--- a/CotabbyTests/SuggestionAvailabilityEvaluatorTests.swift
+++ b/CotabbyTests/SuggestionAvailabilityEvaluatorTests.swift
@@ -522,6 +522,28 @@ final class SuggestionSettingsModelDisabledAppsTests: XCTestCase {
         _ = cancellables
     }
 
+    func test_accessibilityCaptureOverride_survivesModelRecreation() {
+        runOnMainActor {
+            let userDefaults = makeUserDefaults()
+            let model = makeModel(userDefaults: userDefaults)
+
+            XCTAssertFalse(
+                model.isAccessibilityCaptureOverrideEnabled(bundleIdentifier: "com.apple.iCal")
+            )
+
+            model.setAccessibilityCaptureOverride(
+                bundleIdentifier: "com.apple.iCal",
+                allowsCapture: true
+            )
+
+            let reloadedModel = makeModel(userDefaults: userDefaults)
+
+            XCTAssertTrue(
+                reloadedModel.isAccessibilityCaptureOverrideEnabled(bundleIdentifier: "com.apple.iCal")
+            )
+        }
+    }
+
     func test_clipboardContextEnabled_defaultsToFalseAndPersists() {
         runOnMainActor {
             let userDefaults = makeUserDefaults()

--- a/CotabbyTests/SuggestionSettingsStoreTests.swift
+++ b/CotabbyTests/SuggestionSettingsStoreTests.swift
@@ -138,6 +138,24 @@ final class SuggestionSettingsStoreTests: XCTestCase {
         XCTAssertNil(defaults.data(forKey: "cotabbyCustomIndicatorImageData"))
     }
 
+    // MARK: - Accessibility capture override normalization
+
+    func test_load_sanitizesAccessibilityCaptureOverrideBundleIdentifiers() async {
+        let defaults = makeIsolatedDefaults()
+        defaults.set(
+            [" com.apple.iCal ", "", "com.apple.iCal"],
+            forKey: "cotabbyAccessibilityCaptureOverrideBundleIdentifiers"
+        )
+
+        let data = SuggestionSettingsStore(userDefaults: defaults).load(configuration: .standard)
+
+        XCTAssertEqual(data.accessibilityCaptureOverrideBundleIdentifiers, ["com.apple.iCal"])
+        XCTAssertEqual(
+            defaults.stringArray(forKey: "cotabbyAccessibilityCaptureOverrideBundleIdentifiers"),
+            ["com.apple.iCal"]
+        )
+    }
+
     // MARK: - Save / load round-trips
 
     func test_saveThenLoad_roundTripsScalarFields() async {


### PR DESCRIPTION
## Summary
- Added a focused capture-suppression policy for Apple Calendar so Cotabby stops deep Accessibility enumeration before it destabilizes the event editor popover.
- Wired the policy into the app environment ahead of the normal availability checks so the rest of Cotabby keeps running, but Calendar’s transient editing UI is left alone.
- Added unit coverage for Calendar, ordinary apps, and the nil-bundle case, and updated the Xcode project to include the new files.

## Testing
- Passed targeted unit tests for `AccessibilityCaptureSuppressionPolicy`.
- Passed a local macOS debug build.
- Verified in Calendar that the date/time editor stays open while Cotabby is running.
- Not run (not requested): full app test suite.

---
Solves #544

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the Apple Calendar event-editor popover dismissal bug (#544) by introducing `AccessibilityCaptureSuppressionPolicy` — a built-in list of apps whose AX trees Cotabby must not enumerate continuously — and wiring it into `FocusTrackingModel`'s capture gate, with a per-app user override surfaced in the Apps settings pane.

- `AccessibilityCaptureSuppressionPolicy` centralizes the Calendar (`com.apple.iCal`) exception and exposes it as public metadata so Settings can render a toggle; the `shouldSuppressCapture` function is consulted after the existing global/per-app disabled checks in `CotabbyAppEnvironment`.
- `SuggestionSettingsData`, `SuggestionSettingsModel`, and `SuggestionSettingsStore` all gain the `accessibilityCaptureOverrideBundleIdentifiers` field, with load-time sanitization, unconditional write-back, and key removal on empty, matching the established store patterns.
- `AppsPaneView` gains a "Compatibility Overrides" section with a toggle row for each suppressed app, and four new unit tests cover the policy logic, persistence round-trip, and sanitization.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the new suppression gate is additive and falls back to no-op for all apps not in the policy list.

The change adds a new opt-out path before the AX walk and leaves all existing capture logic untouched. The ordering in isCaptureSuppressedForBundle is correct (global disable → per-app disable → suppression policy), nil bundle IDs are handled at every layer, the store sanitizes on load and write-back following the established pattern, and the user-facing toggle is wired correctly. No existing tests were broken and the new tests cover the key cases.

No files require special attention; both findings are style-level observations on AccessibilityCaptureSuppressionPolicy.swift and AppsPaneView.swift.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/Support/AccessibilityCaptureSuppressionPolicy.swift | New policy type that centralizes Calendar's AX suppression; logic is correct but re-sanitizes the already-clean overrides set on every poll call. |
| Cotabby/App/Core/CotabbyAppEnvironment.swift | Wires the new suppression policy into isCaptureSuppressedForBundle after the existing global/per-app disable checks; ordering and nil handling are correct. |
| Cotabby/Models/SuggestionSettingsData.swift | Adds accessibilityCaptureOverrideBundleIdentifiers field; Set<String> is Equatable so synthesized conformance continues to work correctly. |
| Cotabby/Models/SuggestionSettingsModel.swift | Adds @Published property and get/set methods for capture overrides; guard-before-mutate pattern is consistent with all other setters. |
| Cotabby/Support/SuggestionSettingsStore.swift | New key added to load, write-back, and save paths; removes the UserDefaults key when the set is empty, consistent with other collection fields. |
| Cotabby/UI/Settings/Panes/AppsPaneView.swift | Adds Compatibility Overrides section with a toggle row; icon helper is duplicated from the existing DisabledApplicationRule overload. |
| CotabbyTests/AccessibilityCaptureSuppressionPolicyTests.swift | Covers Calendar suppression, override unlock, non-suppressed app, and nil bundle ID; all four cases are meaningful. |
| CotabbyTests/SuggestionAvailabilityEvaluatorTests.swift | Adds a model-recreation round-trip test confirming the override survives across SuggestionSettingsModel init cycles. |
| CotabbyTests/SuggestionSettingsStoreTests.swift | Adds load-time sanitization test for the new defaults key (whitespace trimming, deduplication, write-back normalization). |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Focus Poll fires (every 50-80 ms)"] --> B["isCaptureSuppressedForBundle closure"]
    B --> C{isGloballyEnabled?}
    C -- No --> SUPPRESS["return true (suppress AX walk)"]
    C -- Yes --> D{isApplicationDisabled bundleIdentifier?}
    D -- Yes --> SUPPRESS
    D -- No --> E{"AccessibilityCaptureSuppressionPolicy .shouldSuppressCapture()"}
    E --> F{bundleID in suppressedBundleIdentifiers?}
    F -- No --> ALLOW["return false (allow AX walk)"]
    F -- Yes --> G{bundleID in accessibilityCaptureOverrideBundleIdentifiers?}
    G -- Yes --> ALLOW
    G -- No --> SUPPRESS

    style SUPPRESS fill:#f88,stroke:#c00
    style ALLOW fill:#8f8,stroke:#080
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cotabby/App/Core/CotabbyAppEnvironment.swift`, line 95-104 ([link](https://github.com/fujacob/cotabby/blob/40e3d6ad71c2f37a145e54164801b5707df744f5/Cotabby/App/Core/CotabbyAppEnvironment.swift#L95-L104)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Suppression policy not mirrored in `shouldProcessEventsProvider`**

   `isCaptureSuppressedForBundle` now returns `true` for Calendar, stopping the AX walk, but `shouldProcessEventsProvider` on `inputMonitor` never consults `AccessibilityCaptureSuppressionPolicy`. When Calendar is the frontmost app, Cotabby's event tap remains fully active: acceptance-key, word-acceptance, and global-toggle key presses are still evaluated. If any of those taps swallow the event before passing it through (even with no active suggestion), Calendar's own keyboard shortcuts could silently lose keystrokes. The fix intent—"leaving keyboard monitoring … untouched"—may be fine if the event tap is always passthrough-safe with no live suggestion, but that assumption isn't enforced here.

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2F544-apple-calendar-bug%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F544-apple-calendar-bug%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FApp%2FCore%2FCotabbyAppEnvironment.swift%0ALine%3A%2095-104%0A%0AComment%3A%0A**Suppression%20policy%20not%20mirrored%20in%20%60shouldProcessEventsProvider%60**%0A%0A%60isCaptureSuppressedForBundle%60%20now%20returns%20%60true%60%20for%20Calendar%2C%20stopping%20the%20AX%20walk%2C%20but%20%60shouldProcessEventsProvider%60%20on%20%60inputMonitor%60%20never%20consults%20%60AccessibilityCaptureSuppressionPolicy%60.%20When%20Calendar%20is%20the%20frontmost%20app%2C%20Cotabby's%20event%20tap%20remains%20fully%20active%3A%20acceptance-key%2C%20word-acceptance%2C%20and%20global-toggle%20key%20presses%20are%20still%20evaluated.%20If%20any%20of%20those%20taps%20swallow%20the%20event%20before%20passing%20it%20through%20%28even%20with%20no%20active%20suggestion%29%2C%20Calendar's%20own%20keyboard%20shortcuts%20could%20silently%20lose%20keystrokes.%20The%20fix%20intent%E2%80%94%22leaving%20keyboard%20monitoring%20%E2%80%A6%20untouched%22%E2%80%94may%20be%20fine%20if%20the%20event%20tap%20is%20always%20passthrough-safe%20with%20no%20live%20suggestion%2C%20but%20that%20assumption%20isn't%20enforced%20here.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=628&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FApp%2FCore%2FCotabbyAppEnvironment.swift%0ALine%3A%2095-104%0A%0AComment%3A%0A**Suppression%20policy%20not%20mirrored%20in%20%60shouldProcessEventsProvider%60**%0A%0A%60isCaptureSuppressedForBundle%60%20now%20returns%20%60true%60%20for%20Calendar%2C%20stopping%20the%20AX%20walk%2C%20but%20%60shouldProcessEventsProvider%60%20on%20%60inputMonitor%60%20never%20consults%20%60AccessibilityCaptureSuppressionPolicy%60.%20When%20Calendar%20is%20the%20frontmost%20app%2C%20Cotabby's%20event%20tap%20remains%20fully%20active%3A%20acceptance-key%2C%20word-acceptance%2C%20and%20global-toggle%20key%20presses%20are%20still%20evaluated.%20If%20any%20of%20those%20taps%20swallow%20the%20event%20before%20passing%20it%20through%20%28even%20with%20no%20active%20suggestion%29%2C%20Calendar's%20own%20keyboard%20shortcuts%20could%20silently%20lose%20keystrokes.%20The%20fix%20intent%E2%80%94%22leaving%20keyboard%20monitoring%20%E2%80%A6%20untouched%22%E2%80%94may%20be%20fine%20if%20the%20event%20tap%20is%20always%20passthrough-safe%20with%20no%20live%20suggestion%2C%20but%20that%20assumption%20isn't%20enforced%20here.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=628&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2F544-apple-calendar-bug%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F544-apple-calendar-bug%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FSettings%2FPanes%2FAppsPaneView.swift%3A184-191%0A**Duplicate%20icon-resolution%20helper**%0A%0AThe%20new%20%60icon%28for%20application%3A%20AccessibilityCaptureSuppressedApplication%29%60%20overload%20is%20byte-for-byte%20identical%20to%20the%20existing%20%60icon%28for%20rule%3A%20DisabledApplicationRule%29%60%20%28line%20175%29.%20Both%20look%20up%20%60bundleIdentifier%60%20via%20%60NSWorkspace%60%2C%20fall%20back%20to%20the%20generic%20app-bundle%20icon%2C%20and%20call%20%60icon%28forFile%3A%29%60.%20A%20shared%20private%20helper%20that%20takes%20a%20%60String%60%20%28the%20bundle%20ID%29%20would%20remove%20the%20duplication%20and%20make%20future%20changes%20consistent.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FSupport%2FAccessibilityCaptureSuppressionPolicy.swift%3A51-55%0A**Redundant%20re-sanitization%20on%20every%20focus%20poll**%0A%0A%60overrideBundleIdentifiers%60%20is%20a%20%60Set%3CString%3E%60%20sourced%20from%20%60SuggestionSettingsModel.accessibilityCaptureOverrideBundleIdentifiers%60%2C%20which%20is%20already%20normalized%20%28trimmed%2C%20deduplicated%29%20at%20load%20time%20and%20on%20every%20write.%20Converting%20it%20to%20an%20%60Array%60%20and%20running%20%60sanitizedBundleIdentifierSet%60%20again%20creates%20an%20extra%20allocation%20and%20%60compactMap%60%20pass%20on%20a%20hot%20path%20called%20every%2050%E2%80%9380%20ms.%20The%20simpler%20%60overrideBundleIdentifiers.contains%28bundleIdentifier%29%60%20is%20sufficient%20and%20equivalent%20for%20already-clean%20input%3B%20if%20defensive%20re-normalization%20is%20intentional%20for%20test%20call-sites%2C%20a%20brief%20comment%20explaining%20why%20would%20clarify%20the%20intent.%0A%0A&repo=fujacob%2Fcotabby&pr=628&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FSettings%2FPanes%2FAppsPaneView.swift%3A184-191%0A**Duplicate%20icon-resolution%20helper**%0A%0AThe%20new%20%60icon%28for%20application%3A%20AccessibilityCaptureSuppressedApplication%29%60%20overload%20is%20byte-for-byte%20identical%20to%20the%20existing%20%60icon%28for%20rule%3A%20DisabledApplicationRule%29%60%20%28line%20175%29.%20Both%20look%20up%20%60bundleIdentifier%60%20via%20%60NSWorkspace%60%2C%20fall%20back%20to%20the%20generic%20app-bundle%20icon%2C%20and%20call%20%60icon%28forFile%3A%29%60.%20A%20shared%20private%20helper%20that%20takes%20a%20%60String%60%20%28the%20bundle%20ID%29%20would%20remove%20the%20duplication%20and%20make%20future%20changes%20consistent.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FSupport%2FAccessibilityCaptureSuppressionPolicy.swift%3A51-55%0A**Redundant%20re-sanitization%20on%20every%20focus%20poll**%0A%0A%60overrideBundleIdentifiers%60%20is%20a%20%60Set%3CString%3E%60%20sourced%20from%20%60SuggestionSettingsModel.accessibilityCaptureOverrideBundleIdentifiers%60%2C%20which%20is%20already%20normalized%20%28trimmed%2C%20deduplicated%29%20at%20load%20time%20and%20on%20every%20write.%20Converting%20it%20to%20an%20%60Array%60%20and%20running%20%60sanitizedBundleIdentifierSet%60%20again%20creates%20an%20extra%20allocation%20and%20%60compactMap%60%20pass%20on%20a%20hot%20path%20called%20every%2050%E2%80%9380%20ms.%20The%20simpler%20%60overrideBundleIdentifiers.contains%28bundleIdentifier%29%60%20is%20sufficient%20and%20equivalent%20for%20already-clean%20input%3B%20if%20defensive%20re-normalization%20is%20intentional%20for%20test%20call-sites%2C%20a%20brief%20comment%20explaining%20why%20would%20clarify%20the%20intent.%0A%0A&repo=fujacob%2Fcotabby&pr=628&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Add Calendar AX override setting"](https://github.com/fujacob/cotabby/commit/369d094d452b0e4edffbf2fdaab6f68adf50327a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36049252)</sub>

<!-- /greptile_comment -->