### PR TITLE
Feature/power based model switching

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -112,6 +112,7 @@
 		4F38CE1C2602CF4F41323032 /* PermissionOverlayTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12DD19BCE610808F1E38702D /* PermissionOverlayTrackerTests.swift */; };
 		4FC52FB28AFC013F000D8FF9 /* SecureFieldDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 474560E524C1D74BAB1570DA /* SecureFieldDetectorTests.swift */; };
 		5009AF59DE8D40A45C0A5C2F /* ControlTokenMarkersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22707E26E2106DF0E826D32D /* ControlTokenMarkersTests.swift */; };
+		50E1247BE6A952AB1B12C444 /* PowerSourceMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB235F0DEA53295DAF8B4FA0 /* PowerSourceMonitor.swift */; };
 		51C069603DA16830868F1628 /* LanguageTagsEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7CDA90E128350BFF1A9D66 /* LanguageTagsEditor.swift */; };
 		52518CF0760DFEE9AF7C786C /* SuggestionEngineRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384FBCF5D7A3A446C5BE2B8D /* SuggestionEngineRouter.swift */; };
 		53FB56A095BCF0389DAC0A56 /* SuggestionTextColorCodec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CE61E74928C221B8BB261C6 /* SuggestionTextColorCodec.swift */; };
@@ -584,6 +585,7 @@
 		D93563FDA25DFC0038E5F887 /* SuggestionSettingsData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionSettingsData.swift; sourceTree = "<group>"; };
 		D9C1C921A1CDA2ADFC39EA01 /* AppsPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppsPaneView.swift; sourceTree = "<group>"; };
 		DB0CE9AB1286367BA2E82392 /* SettingsContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsContainerView.swift; sourceTree = "<group>"; };
+		DB235F0DEA53295DAF8B4FA0 /* PowerSourceMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowerSourceMonitor.swift; sourceTree = "<group>"; };
 		DDE858CB1E687E3CEB8FDD5B /* SuggestionRequestFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionRequestFactory.swift; sourceTree = "<group>"; };
 		DDF6A4E9CE93FD53C60E67E3 /* EmojiQueryRun.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiQueryRun.swift; sourceTree = "<group>"; };
 		DEB16474A67CE1D210B944C9 /* SuggestionSubsystemContracts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionSubsystemContracts.swift; sourceTree = "<group>"; };
@@ -667,6 +669,14 @@
 				2D1F9CEBAB0F330F8E7B61D8 /* InputSuppressionController.swift */,
 			);
 			path = Input;
+			sourceTree = "<group>";
+		};
+		1D6F00DFDE0013A930670603 /* Power */ = {
+			isa = PBXGroup;
+			children = (
+				DB235F0DEA53295DAF8B4FA0 /* PowerSourceMonitor.swift */,
+			);
+			path = Power;
 			sourceTree = "<group>";
 		};
 		1F3BF5BD8958D0D0C2E34AF1 /* Permission */ = {
@@ -1045,6 +1055,7 @@
 				59681B24821B0C960A656168 /* Focus */,
 				1A748DD787833F29034EF2EA /* Input */,
 				1F3BF5BD8958D0D0C2E34AF1 /* Permission */,
+				1D6F00DFDE0013A930670603 /* Power */,
 				FFF55D3CE9FF3B16845823F7 /* Runtime */,
 				6495533696D4461386265D05 /* Spelling */,
 				3B1B0D8E3400BE4FC26AF6B5 /* Suggestion */,
@@ -1396,6 +1407,7 @@
 				61EC9D635D416115E7C96E0F /* PermissionOverlayWindowController.swift in Sources */,
 				90DC9508F27F712EB61EEB06 /* PermissionReminderView.swift in Sources */,
 				39571AB31481959CD5C223AE /* PermissionsPaneView.swift in Sources */,
+				50E1247BE6A952AB1B12C444 /* PowerSourceMonitor.swift in Sources */,
 				98E2E14A069384C1088CDB44 /* PromptContextSanitizer.swift in Sources */,
 				3C561CD717064F9250200667 /* PromptSectionBudget.swift in Sources */,
 				25750F599635ED38E61517A3 /* RandomMacroEvaluator.swift in Sources */,

--- a/Cotabby/App/Core/CotabbyAppEnvironment.swift
+++ b/Cotabby/App/Core/CotabbyAppEnvironment.swift
@@ -288,43 +288,54 @@ final class CotabbyAppEnvironment {
             }
             .store(in: &cancellables)
 
-
-            powerSourceMonitor.$isPluggedIn
-    .removeDuplicates()
-    .sink { [weak runtimeModel, weak suggestionSettings] isPluggedIn in
-
-        guard let runtimeModel,
-              let suggestionSettings else {
-            return
-        }
-
-        guard suggestionSettings.isPowerBasedModelSwitchingEnabled else {
-            return
-        }
-
-        let filename =
-            isPluggedIn
-            ? suggestionSettings.pluggedInModelFilename
-            : suggestionSettings.batteryModelFilename
-
-        guard !filename.isEmpty else {
-            return
-        }
-
-        guard runtimeModel.availableModels.contains(
-            where: { $0.filename == filename }
-        ) else {
-            return
-        }
-
-        guard runtimeModel.selectedModelFilename != filename else {
-            return
-        }
-
-        Task {
-            await runtimeModel.selectModel(filename)
-        }
+        observePowerSourceModelSwitching(
+            powerSourceMonitor: powerSourceMonitor,
+            runtimeModel: runtimeModel,
+            suggestionSettings: suggestionSettings
+        )
     }
-    .store(in: &cancellables)
+
+    /// Switches the runtime model when the power source changes, if the user opted into power-based
+    /// switching. The guards bail early when the feature is off, the target model is unset or no
+    /// longer installed, or it is already selected, so the only side effect is a deliberate reload on
+    /// a genuine power transition. Extracted from `init` to keep the initializer's complexity bounded.
+    private func observePowerSourceModelSwitching(
+        powerSourceMonitor: PowerSourceMonitor,
+        runtimeModel: RuntimeBootstrapModel,
+        suggestionSettings: SuggestionSettingsModel
+    ) {
+        powerSourceMonitor.$isPluggedIn
+            .removeDuplicates()
+            .sink { [weak runtimeModel, weak suggestionSettings] isPluggedIn in
+                guard let runtimeModel,
+                      let suggestionSettings else {
+                    return
+                }
+
+                guard suggestionSettings.isPowerBasedModelSwitchingEnabled else {
+                    return
+                }
+
+                let filename = isPluggedIn
+                    ? suggestionSettings.pluggedInModelFilename
+                    : suggestionSettings.batteryModelFilename
+
+                guard !filename.isEmpty else {
+                    return
+                }
+
+                guard runtimeModel.availableModels.contains(where: { $0.filename == filename }) else {
+                    return
+                }
+
+                guard runtimeModel.selectedModelFilename != filename else {
+                    return
+                }
+
+                Task {
+                    await runtimeModel.selectModel(filename)
+                }
+            }
+            .store(in: &cancellables)
     }
 }

--- a/Cotabby/App/Core/CotabbyAppEnvironment.swift
+++ b/Cotabby/App/Core/CotabbyAppEnvironment.swift
@@ -20,6 +20,7 @@ final class CotabbyAppEnvironment {
     let permissionGuidanceController: PermissionGuidanceController
     let suggestionSettings: SuggestionSettingsModel
     let foundationModelAvailabilityService: FoundationModelAvailabilityService
+    let powerSourceMonitor: PowerSourceMonitor
     let clipboardContextProvider: ClipboardContextProvider
     let suggestionCoordinator: SuggestionCoordinator
     /// Shared with the Advanced settings pane so the user can fire an ad-hoc generation against
@@ -52,6 +53,7 @@ final class CotabbyAppEnvironment {
         let modelDownloadManager = ModelDownloadManager()
         let suggestionSettings = SuggestionSettingsModel(configuration: configuration)
         let foundationModelAvailabilityService = FoundationModelAvailabilityService()
+        let powerSourceMonitor = PowerSourceMonitor()
         let suppressionController = InputSuppressionController()
         let inputMonitor = InputMonitor(
             permissionProvider: { permissionManager.inputMonitoringGranted },
@@ -248,6 +250,7 @@ final class CotabbyAppEnvironment {
         self.permissionGuidanceController = permissionGuidanceController
         self.suggestionSettings = suggestionSettings
         self.foundationModelAvailabilityService = foundationModelAvailabilityService
+        self.powerSourceMonitor = powerSourceMonitor
         self.clipboardContextProvider = clipboardContextProvider
         self.suggestionCoordinator = suggestionCoordinator
         self.suggestionEngine = suggestionEngine
@@ -284,5 +287,44 @@ final class CotabbyAppEnvironment {
                 inputMonitor?.refreshToggleTap()
             }
             .store(in: &cancellables)
+
+
+            powerSourceMonitor.$isPluggedIn
+    .removeDuplicates()
+    .sink { [weak runtimeModel, weak suggestionSettings] isPluggedIn in
+
+        guard let runtimeModel,
+              let suggestionSettings else {
+            return
+        }
+
+        guard suggestionSettings.isPowerBasedModelSwitchingEnabled else {
+            return
+        }
+
+        let filename =
+            isPluggedIn
+            ? suggestionSettings.pluggedInModelFilename
+            : suggestionSettings.batteryModelFilename
+
+        guard !filename.isEmpty else {
+            return
+        }
+
+        guard runtimeModel.availableModels.contains(
+            where: { $0.filename == filename }
+        ) else {
+            return
+        }
+
+        guard runtimeModel.selectedModelFilename != filename else {
+            return
+        }
+
+        Task {
+            await runtimeModel.selectModel(filename)
+        }
+    }
+    .store(in: &cancellables)
     }
 }

--- a/Cotabby/Models/SuggestionSettingsData.swift
+++ b/Cotabby/Models/SuggestionSettingsData.swift
@@ -58,4 +58,7 @@ struct SuggestionSettingsData: Equatable {
     var globalToggleKeyModifiers: ShortcutModifierMask
     var globalToggleKeyLabel: String
     var acceptanceGranularity: AcceptanceGranularity
+    var isPowerBasedModelSwitchingEnabled: Bool
+    var batteryModelFilename: String
+    var pluggedInModelFilename: String
 }

--- a/Cotabby/Models/SuggestionSettingsModel.swift
+++ b/Cotabby/Models/SuggestionSettingsModel.swift
@@ -96,6 +96,9 @@ final class SuggestionSettingsModel: ObservableObject {
     @Published private(set) var globalToggleKeyModifiers: ShortcutModifierMask
     @Published private(set) var globalToggleKeyLabel: String
     @Published private(set) var acceptanceGranularity: AcceptanceGranularity
+    @Published private(set) var isPowerBasedModelSwitchingEnabled: Bool
+    @Published private(set) var batteryModelFilename: String
+    @Published private(set) var pluggedInModelFilename: String
 
     /// Owns the on-disk keys, defaults, migrations, and per-field writes. The facade holds one and
     /// routes every load and save through it.
@@ -163,6 +166,9 @@ final class SuggestionSettingsModel: ObservableObject {
         globalToggleKeyModifiers = data.globalToggleKeyModifiers
         globalToggleKeyLabel = data.globalToggleKeyLabel
         acceptanceGranularity = data.acceptanceGranularity
+        isPowerBasedModelSwitchingEnabled = data.isPowerBasedModelSwitchingEnabled
+        batteryModelFilename = data.batteryModelFilename
+        pluggedInModelFilename = data.pluggedInModelFilename
     }
 
     /// Legacy compatibility shim. Reads through to `showIndicator`.
@@ -206,6 +212,56 @@ final class SuggestionSettingsModel: ObservableObject {
         selectedEngine = engine
         store.saveSelectedEngine(engine)
     }
+
+
+    func setPowerBasedModelSwitchingEnabled(_ enabled: Bool) {
+    guard isPowerBasedModelSwitchingEnabled != enabled else {
+        return
+    }
+
+    isPowerBasedModelSwitchingEnabled = enabled
+    store.savePowerBasedModelSwitchingEnabled(enabled)
+    }
+
+    func setBatteryModelFilename(_ filename: String) {
+    guard batteryModelFilename != filename else {
+        return
+    }
+
+    batteryModelFilename = filename
+    store.saveBatteryModelFilename(filename)
+    }
+
+    func setPluggedInModelFilename(_ filename: String) {
+    guard pluggedInModelFilename != filename else {
+        return
+    }
+
+    pluggedInModelFilename = filename
+    store.savePluggedInModelFilename(filename)
+    }
+
+
+
+    func initializePowerModelSelections(
+    currentModelFilename: String?
+) {
+    guard let currentModelFilename else {
+        return
+    }
+
+    if batteryModelFilename.isEmpty {
+        batteryModelFilename = currentModelFilename
+        store.saveBatteryModelFilename(currentModelFilename)
+    }
+
+    if pluggedInModelFilename.isEmpty {
+        pluggedInModelFilename = currentModelFilename
+        store.savePluggedInModelFilename(currentModelFilename)
+    }
+}
+
+
 
     func selectWordCountPreset(_ preset: SuggestionWordCountPreset) {
         guard selectedWordCountPreset != preset else {

--- a/Cotabby/Models/SuggestionSettingsModel.swift
+++ b/Cotabby/Models/SuggestionSettingsModel.swift
@@ -213,55 +213,50 @@ final class SuggestionSettingsModel: ObservableObject {
         store.saveSelectedEngine(engine)
     }
 
-
     func setPowerBasedModelSwitchingEnabled(_ enabled: Bool) {
-    guard isPowerBasedModelSwitchingEnabled != enabled else {
-        return
-    }
+        guard isPowerBasedModelSwitchingEnabled != enabled else {
+            return
+        }
 
-    isPowerBasedModelSwitchingEnabled = enabled
-    store.savePowerBasedModelSwitchingEnabled(enabled)
+        isPowerBasedModelSwitchingEnabled = enabled
+        store.savePowerBasedModelSwitchingEnabled(enabled)
     }
 
     func setBatteryModelFilename(_ filename: String) {
-    guard batteryModelFilename != filename else {
-        return
-    }
+        guard batteryModelFilename != filename else {
+            return
+        }
 
-    batteryModelFilename = filename
-    store.saveBatteryModelFilename(filename)
+        batteryModelFilename = filename
+        store.saveBatteryModelFilename(filename)
     }
 
     func setPluggedInModelFilename(_ filename: String) {
-    guard pluggedInModelFilename != filename else {
-        return
+        guard pluggedInModelFilename != filename else {
+            return
+        }
+
+        pluggedInModelFilename = filename
+        store.savePluggedInModelFilename(filename)
     }
 
-    pluggedInModelFilename = filename
-    store.savePluggedInModelFilename(filename)
+    /// Seeds the per-power-source model selections from the active model the first time the feature
+    /// is configured, so both pickers default to something valid instead of an empty selection.
+    func initializePowerModelSelections(currentModelFilename: String?) {
+        guard let currentModelFilename else {
+            return
+        }
+
+        if batteryModelFilename.isEmpty {
+            batteryModelFilename = currentModelFilename
+            store.saveBatteryModelFilename(currentModelFilename)
+        }
+
+        if pluggedInModelFilename.isEmpty {
+            pluggedInModelFilename = currentModelFilename
+            store.savePluggedInModelFilename(currentModelFilename)
+        }
     }
-
-
-
-    func initializePowerModelSelections(
-    currentModelFilename: String?
-) {
-    guard let currentModelFilename else {
-        return
-    }
-
-    if batteryModelFilename.isEmpty {
-        batteryModelFilename = currentModelFilename
-        store.saveBatteryModelFilename(currentModelFilename)
-    }
-
-    if pluggedInModelFilename.isEmpty {
-        pluggedInModelFilename = currentModelFilename
-        store.savePluggedInModelFilename(currentModelFilename)
-    }
-}
-
-
 
     func selectWordCountPreset(_ preset: SuggestionWordCountPreset) {
         guard selectedWordCountPreset != preset else {

--- a/Cotabby/Services/Power/PowerSourceMonitor.swift
+++ b/Cotabby/Services/Power/PowerSourceMonitor.swift
@@ -28,12 +28,10 @@ final class PowerSourceMonitor: ObservableObject {
     }
 
     func refreshPowerState() {
-    guard let snapshot = IOPSCopyPowerSourcesInfo()?.takeRetainedValue() else {
-        return
-    }
+    let snapshot = IOPSCopyPowerSourcesInfo().takeRetainedValue()
 
     guard let source = IOPSGetProvidingPowerSourceType(snapshot)?
-        .takeUnretainedValue() as String? else {
+        .takeUnretainedValue() as String else {
         return
     }
 

--- a/Cotabby/Services/Power/PowerSourceMonitor.swift
+++ b/Cotabby/Services/Power/PowerSourceMonitor.swift
@@ -1,0 +1,42 @@
+import Foundation
+import AppKit
+import IOKit
+
+
+@MainActor
+final class PowerSourceMonitor: ObservableObject {
+    @Published private(set) var isPluggedIn = true
+
+    private var observer: NSObjectProtocol?
+
+    init() {
+        refreshPowerState()
+
+        observer = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didWakeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.refreshPowerState()
+        }
+    }
+
+    deinit {
+        if let observer {
+            NSWorkspace.shared.notificationCenter.removeObserver(observer)
+        }
+    }
+
+    func refreshPowerState() {
+    guard let snapshot = IOPSCopyPowerSourcesInfo()?.takeRetainedValue() else {
+        return
+    }
+
+    guard let source = IOPSGetProvidingPowerSourceType(snapshot)?
+        .takeUnretainedValue() as String? else {
+        return
+    }
+
+    isPluggedIn = source == kIOPSACPowerValue
+}
+}

--- a/Cotabby/Services/Power/PowerSourceMonitor.swift
+++ b/Cotabby/Services/Power/PowerSourceMonitor.swift
@@ -1,8 +1,14 @@
-import Foundation
 import AppKit
-import IOKit
+import Combine
+import Foundation
+import IOKit.ps
 
-
+/// Tracks whether the Mac is currently drawing AC power and publishes changes for power-aware
+/// features (such as switching the local model on battery vs. plugged in).
+///
+/// Lives on the main actor because `@Published` feeds SwiftUI and the wake observer is delivered on
+/// the main queue. State is refreshed at launch and on wake from sleep; live charger plug/unplug
+/// during an active session is not yet observed.
 @MainActor
 final class PowerSourceMonitor: ObservableObject {
     @Published private(set) var isPluggedIn = true
@@ -28,13 +34,13 @@ final class PowerSourceMonitor: ObservableObject {
     }
 
     func refreshPowerState() {
-    let snapshot = IOPSCopyPowerSourcesInfo().takeRetainedValue()
+        let snapshot = IOPSCopyPowerSourcesInfo().takeRetainedValue()
 
-    guard let source = IOPSGetProvidingPowerSourceType(snapshot)?
-        .takeUnretainedValue() as String else {
-        return
+        guard let powerSource = IOPSGetProvidingPowerSourceType(snapshot) else {
+            return
+        }
+
+        let source = powerSource.takeUnretainedValue() as String
+        isPluggedIn = source == kIOPSACPowerValue
     }
-
-    isPluggedIn = source == kIOPSACPowerValue
-}
 }

--- a/Cotabby/Support/SuggestionSettingsStore.swift
+++ b/Cotabby/Support/SuggestionSettingsStore.swift
@@ -102,6 +102,11 @@ struct SuggestionSettingsStore {
     private static let globalToggleKeyLabelDefaultsKey = "cotabbyGlobalToggleKeyLabel"
     private static let acceptanceGranularityDefaultsKey = "cotabbyAcceptanceGranularity"
 
+
+    private static let powerBasedModelSwitchingEnabledDefaultsKey = "cotabbyPowerBasedModelSwitchingEnabled"
+    private static let batteryModelFilenameDefaultsKey = "cotabbyBatteryModelFilename"
+    private static let pluggedInModelFilenameDefaultsKey = "cotabbyPluggedInModelFilename"
+
     // MARK: - Load
 
     /// Resolves every preference from `UserDefaults`, applying first-launch defaults and the legacy
@@ -283,6 +288,10 @@ struct SuggestionSettingsStore {
             .flatMap(AcceptanceGranularity.init(rawValue:))
             ?? .word
 
+        let resolvedPowerBasedModelSwitchingEnabled = userDefaults.object(forKey: Self.powerBasedModelSwitchingEnabledDefaultsKey) as? Bool ?? false
+        let resolvedBatteryModelFilename = userDefaults.string(forKey: Self.batteryModelFilenameDefaultsKey) ?? ""
+        let resolvedPluggedInModelFilename = userDefaults.string(forKey: Self.pluggedInModelFilenameDefaultsKey) ?? ""    
+
         let data = SuggestionSettingsData(
             isGloballyEnabled: resolvedGloballyEnabled,
             showIndicator: resolvedShowIndicator,
@@ -323,7 +332,10 @@ struct SuggestionSettingsStore {
             globalToggleKeyCode: resolvedGlobalToggleKeyCode,
             globalToggleKeyModifiers: resolvedGlobalToggleKeyModifiers,
             globalToggleKeyLabel: resolvedGlobalToggleKeyLabel,
-            acceptanceGranularity: resolvedAcceptanceGranularity
+            acceptanceGranularity: resolvedAcceptanceGranularity,
+            isPowerBasedModelSwitchingEnabled: resolvedPowerBasedModelSwitchingEnabled,
+            batteryModelFilename: resolvedBatteryModelFilename,
+            pluggedInModelFilename: resolvedPluggedInModelFilename
         )
 
         // Unconditional write-back so the resolved (possibly migrated or default-capped) values are
@@ -374,6 +386,15 @@ struct SuggestionSettingsStore {
         )
         saveAcceptanceGranularity(data.acceptanceGranularity)
 
+
+        savePowerBasedModelSwitchingEnabled(data.isPowerBasedModelSwitchingEnabled)
+
+        saveBatteryModelFilename( data.batteryModelFilename)
+
+        savePluggedInModelFilename(data.pluggedInModelFilename)
+
+
+
         // The custom indicator icon feature was removed; scrub any previously-persisted PNG so
         // users who picked one in an older build get the default cat icon back automatically.
         userDefaults.removeObject(forKey: "cotabbyCustomIndicatorImageData")
@@ -422,6 +443,27 @@ struct SuggestionSettingsStore {
 
     func saveSelectedEngine(_ engine: SuggestionEngineKind) {
         userDefaults.set(engine.rawValue, forKey: Self.selectedEngineDefaultsKey)
+    }
+
+    func savePowerBasedModelSwitchingEnabled(_ enabled: Bool) {
+    userDefaults.set(
+        enabled,
+        forKey: Self.powerBasedModelSwitchingEnabledDefaultsKey
+    )
+    }
+
+    func saveBatteryModelFilename(_ filename: String) {
+    userDefaults.set(
+        filename,
+        forKey: Self.batteryModelFilenameDefaultsKey
+    )
+    }
+
+    func savePluggedInModelFilename(_ filename: String) {
+    userDefaults.set(
+        filename,
+        forKey: Self.pluggedInModelFilenameDefaultsKey
+    )
     }
 
     func saveSelectedWordCountPreset(_ preset: SuggestionWordCountPreset) {

--- a/Cotabby/Support/SuggestionSettingsStore.swift
+++ b/Cotabby/Support/SuggestionSettingsStore.swift
@@ -102,8 +102,7 @@ struct SuggestionSettingsStore {
     private static let globalToggleKeyLabelDefaultsKey = "cotabbyGlobalToggleKeyLabel"
     private static let acceptanceGranularityDefaultsKey = "cotabbyAcceptanceGranularity"
 
-
-    private static let powerBasedModelSwitchingEnabledDefaultsKey = "cotabbyPowerBasedModelSwitchingEnabled"
+    private static let powerModelSwitchingEnabledDefaultsKey = "cotabbyPowerBasedModelSwitchingEnabled"
     private static let batteryModelFilenameDefaultsKey = "cotabbyBatteryModelFilename"
     private static let pluggedInModelFilenameDefaultsKey = "cotabbyPluggedInModelFilename"
 
@@ -288,9 +287,10 @@ struct SuggestionSettingsStore {
             .flatMap(AcceptanceGranularity.init(rawValue:))
             ?? .word
 
-        let resolvedPowerBasedModelSwitchingEnabled = userDefaults.object(forKey: Self.powerBasedModelSwitchingEnabledDefaultsKey) as? Bool ?? false
+        let resolvedPowerBasedModelSwitchingEnabled =
+            userDefaults.object(forKey: Self.powerModelSwitchingEnabledDefaultsKey) as? Bool ?? false
         let resolvedBatteryModelFilename = userDefaults.string(forKey: Self.batteryModelFilenameDefaultsKey) ?? ""
-        let resolvedPluggedInModelFilename = userDefaults.string(forKey: Self.pluggedInModelFilenameDefaultsKey) ?? ""    
+        let resolvedPluggedInModelFilename = userDefaults.string(forKey: Self.pluggedInModelFilenameDefaultsKey) ?? ""
 
         let data = SuggestionSettingsData(
             isGloballyEnabled: resolvedGloballyEnabled,
@@ -385,15 +385,9 @@ struct SuggestionSettingsStore {
             label: data.globalToggleKeyLabel
         )
         saveAcceptanceGranularity(data.acceptanceGranularity)
-
-
         savePowerBasedModelSwitchingEnabled(data.isPowerBasedModelSwitchingEnabled)
-
-        saveBatteryModelFilename( data.batteryModelFilename)
-
+        saveBatteryModelFilename(data.batteryModelFilename)
         savePluggedInModelFilename(data.pluggedInModelFilename)
-
-
 
         // The custom indicator icon feature was removed; scrub any previously-persisted PNG so
         // users who picked one in an older build get the default cat icon back automatically.
@@ -446,24 +440,15 @@ struct SuggestionSettingsStore {
     }
 
     func savePowerBasedModelSwitchingEnabled(_ enabled: Bool) {
-    userDefaults.set(
-        enabled,
-        forKey: Self.powerBasedModelSwitchingEnabledDefaultsKey
-    )
+        userDefaults.set(enabled, forKey: Self.powerModelSwitchingEnabledDefaultsKey)
     }
 
     func saveBatteryModelFilename(_ filename: String) {
-    userDefaults.set(
-        filename,
-        forKey: Self.batteryModelFilenameDefaultsKey
-    )
+        userDefaults.set(filename, forKey: Self.batteryModelFilenameDefaultsKey)
     }
 
     func savePluggedInModelFilename(_ filename: String) {
-    userDefaults.set(
-        filename,
-        forKey: Self.pluggedInModelFilenameDefaultsKey
-    )
+        userDefaults.set(filename, forKey: Self.pluggedInModelFilenameDefaultsKey)
     }
 
     func saveSelectedWordCountPreset(_ preset: SuggestionWordCountPreset) {

--- a/Cotabby/UI/Settings/Panes/EngineAndModelPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/EngineAndModelPaneView.swift
@@ -52,12 +52,10 @@ struct EngineAndModelPaneView: View {
             foundationModelAvailabilityService.refresh()
 
             suggestionSettings.initializePowerModelSelections(
-    currentModelFilename: runtimeModel.selectedModelFilename
-)
-
+                currentModelFilename: runtimeModel.selectedModelFilename
+            )
 
             lmStudioModelsURL = BundledRuntimeLocator.lmStudioModelsDirectoryIfAvailable()
-
 
             // If LM Studio was uninstalled while the source was enabled, clear the persisted flag so
             // the toggle does not sit checked-but-disabled with no way to turn it off (and so the
@@ -135,55 +133,54 @@ struct EngineAndModelPaneView: View {
                 }
             }
 
-
             Toggle(
-    isOn: Binding(
-        get: { suggestionSettings.isPowerBasedModelSwitchingEnabled },
-        set: { suggestionSettings.setPowerBasedModelSwitchingEnabled($0) }
-    )
-) {
-    SettingsRowLabel(
-        title: "Switch models based on power source",
-        description: "Use different models when running on battery or while plugged in.",
-        systemImage: "battery.100"
-    )
-}
+                isOn: Binding(
+                    get: { suggestionSettings.isPowerBasedModelSwitchingEnabled },
+                    set: { suggestionSettings.setPowerBasedModelSwitchingEnabled($0) }
+                )
+            ) {
+                SettingsRowLabel(
+                    title: "Switch models based on power source",
+                    description: "Use different models when running on battery or while plugged in.",
+                    systemImage: "battery.100"
+                )
+            }
 
-if suggestionSettings.isPowerBasedModelSwitchingEnabled {
-    Picker(
-        "Battery Model",
-        selection: Binding(
-           get: {
-    suggestionSettings.batteryModelFilename.isEmpty
-        ? (runtimeModel.selectedModelFilename ?? "")
-        : suggestionSettings.batteryModelFilename
-},
-            set: { suggestionSettings.setBatteryModelFilename($0) }
-        )
-    ) {
-        ForEach(runtimeModel.availableModels) { model in
-            Text(model.displayName)
-                .tag(model.filename)
-        }
-    }
+            if suggestionSettings.isPowerBasedModelSwitchingEnabled {
+                Picker(
+                    "Battery Model",
+                    selection: Binding(
+                        get: {
+                            suggestionSettings.batteryModelFilename.isEmpty
+                                ? (runtimeModel.selectedModelFilename ?? "")
+                                : suggestionSettings.batteryModelFilename
+                        },
+                        set: { suggestionSettings.setBatteryModelFilename($0) }
+                    )
+                ) {
+                    ForEach(runtimeModel.availableModels) { model in
+                        Text(model.displayName)
+                            .tag(model.filename)
+                    }
+                }
 
-    Picker(
-        "Plugged-in Model",
-        selection: Binding(
-           get: {
-    suggestionSettings.pluggedInModelFilename.isEmpty
-        ? (runtimeModel.selectedModelFilename ?? "")
-        : suggestionSettings.pluggedInModelFilename
-},
-            set: { suggestionSettings.setPluggedInModelFilename($0) }
-        )
-    ) {
-        ForEach(runtimeModel.availableModels) { model in
-            Text(model.displayName)
-                .tag(model.filename)
-        }
-    }
-}
+                Picker(
+                    "Plugged-in Model",
+                    selection: Binding(
+                        get: {
+                            suggestionSettings.pluggedInModelFilename.isEmpty
+                                ? (runtimeModel.selectedModelFilename ?? "")
+                                : suggestionSettings.pluggedInModelFilename
+                        },
+                        set: { suggestionSettings.setPluggedInModelFilename($0) }
+                    )
+                ) {
+                    ForEach(runtimeModel.availableModels) { model in
+                        Text(model.displayName)
+                            .tag(model.filename)
+                    }
+                }
+            }
 
             DownloadableModelCatalogView(
                 modelDownloadManager: modelDownloadManager,

--- a/Cotabby/UI/Settings/Panes/EngineAndModelPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/EngineAndModelPaneView.swift
@@ -50,7 +50,15 @@ struct EngineAndModelPaneView: View {
         }
         .onAppear {
             foundationModelAvailabilityService.refresh()
+
+            suggestionSettings.initializePowerModelSelections(
+    currentModelFilename: runtimeModel.selectedModelFilename
+)
+
+
             lmStudioModelsURL = BundledRuntimeLocator.lmStudioModelsDirectoryIfAvailable()
+
+
             // If LM Studio was uninstalled while the source was enabled, clear the persisted flag so
             // the toggle does not sit checked-but-disabled with no way to turn it off (and so the
             // source does not silently reactivate if LM Studio is later reinstalled).
@@ -126,6 +134,56 @@ struct EngineAndModelPaneView: View {
                     )
                 }
             }
+
+
+            Toggle(
+    isOn: Binding(
+        get: { suggestionSettings.isPowerBasedModelSwitchingEnabled },
+        set: { suggestionSettings.setPowerBasedModelSwitchingEnabled($0) }
+    )
+) {
+    SettingsRowLabel(
+        title: "Switch models based on power source",
+        description: "Use different models when running on battery or while plugged in.",
+        systemImage: "battery.100"
+    )
+}
+
+if suggestionSettings.isPowerBasedModelSwitchingEnabled {
+    Picker(
+        "Battery Model",
+        selection: Binding(
+           get: {
+    suggestionSettings.batteryModelFilename.isEmpty
+        ? (runtimeModel.selectedModelFilename ?? "")
+        : suggestionSettings.batteryModelFilename
+},
+            set: { suggestionSettings.setBatteryModelFilename($0) }
+        )
+    ) {
+        ForEach(runtimeModel.availableModels) { model in
+            Text(model.displayName)
+                .tag(model.filename)
+        }
+    }
+
+    Picker(
+        "Plugged-in Model",
+        selection: Binding(
+           get: {
+    suggestionSettings.pluggedInModelFilename.isEmpty
+        ? (runtimeModel.selectedModelFilename ?? "")
+        : suggestionSettings.pluggedInModelFilename
+},
+            set: { suggestionSettings.setPluggedInModelFilename($0) }
+        )
+    ) {
+        ForEach(runtimeModel.availableModels) { model in
+            Text(model.displayName)
+                .tag(model.filename)
+        }
+    }
+}
 
             DownloadableModelCatalogView(
                 modelDownloadManager: modelDownloadManager,


### PR DESCRIPTION
## Summary

This PR adds support for power-based model switching for local runtime models.

Users can optionally configure separate models for battery and plugged-in states. When enabled, Cotabby automatically switches to the configured model based on the current power source.

## Changes

- Added power-based model switching setting
- Added separate Battery Model and Plugged-in Model selectors
- Persisted power-switching preferences
- Added PowerSourceMonitor for power source detection
- Automatically switches runtime models when the power state changes
- Initializes battery and plugged-in selections to the current model

## Notes

I was unable to test live AC/Battery transitions on macOS hardware.

The current implementation uses power source detection through IOKit and refreshes state on startup and wake events. Feedback on the preferred power-source notification mechanism is welcome.

Closes #619

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces power-based model switching for local runtime models, automatically selecting a user-configured model depending on whether the Mac is running on battery or AC power.

- **`PowerSourceMonitor`** reads the current power state via IOKit at launch and on wake-from-sleep, publishing changes through a `@Published` property; live plug/unplug detection is acknowledged as out of scope.
- **`CotabbyAppEnvironment`** subscribes to power-state changes and selects the appropriate model via `observePowerSourceModelSwitching`, with guards that prevent switching when the feature is off, the filename is empty, or the target model is no longer installed.
- **`EngineAndModelPaneView`** adds a toggle and two model pickers, but they are placed outside the `availableModels.isEmpty` guard — leaving them visible and operable when no models are installed, which produces empty, non-functional pickers.

<h3>Confidence Score: 4/5</h3>

Safe to merge after the UI placement fix; the switching logic itself is well-guarded.

The power-switching backend (monitor, Combine subscription, settings store) is solid. The one concrete defect is in the settings view: the new toggle and its child pickers are rendered unconditionally instead of inside the existing availableModels.isEmpty else-branch, so users with no installed models see two empty, broken pickers the moment they enable the feature.

Cotabby/UI/Settings/Panes/EngineAndModelPaneView.swift — the placement of the power-switching toggle and pickers relative to the model-availability guard.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/Settings/Panes/EngineAndModelPaneView.swift | Adds power-switching toggle and battery/plugged-in pickers, but both are placed outside the availableModels.isEmpty guard — they appear and can be enabled when no models exist, producing empty, non-functional pickers. |
| Cotabby/Services/Power/PowerSourceMonitor.swift | New service reading IOKit power state; correctly handles AC vs battery via IOPSGetProvidingPowerSourceType; only refreshes at startup and wake (live plug/unplug unaddressed, noted in doc comment). |
| Cotabby/App/Core/CotabbyAppEnvironment.swift | Wires PowerSourceMonitor into the environment; Combine subscription in observePowerSourceModelSwitching has well-structured guards and correctly bails when the feature is off, the model is missing, or the model is already selected. |
| Cotabby/Models/SuggestionSettingsModel.swift | Adds three @Published properties and corresponding setters; initializePowerModelSelections seeds empty filenames from the current model selection on first use. |
| Cotabby/Support/SuggestionSettingsStore.swift | Adds UserDefaults keys, load paths, and save functions for the three new settings; follows existing patterns cleanly. |
| Cotabby/Models/SuggestionSettingsData.swift | Adds three fields to the data struct; straightforward, no issues. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as CotabbyAppEnvironment
    participant PSM as PowerSourceMonitor
    participant SS as SuggestionSettingsModel
    participant RM as RuntimeBootstrapModel

    App->>PSM: init() → refreshPowerState()
    PSM->>PSM: IOPSCopyPowerSourcesInfo / IOPSGetProvidingPowerSourceType
    PSM-->>App: $isPluggedIn (initial value)

    App->>App: observePowerSourceModelSwitching(...)
    Note over App: Subscribes to PSM.$isPluggedIn

    PSM-->>App: isPluggedIn changes (wake from sleep)
    App->>SS: isPowerBasedModelSwitchingEnabled?
    alt Feature disabled
        App-->>App: return (no-op)
    else Feature enabled
        App->>SS: batteryModelFilename / pluggedInModelFilename
        App->>RM: availableModels.contains(filename)?
        alt Model not installed
            App-->>App: return (no-op)
        else Model available and not already selected
            App->>RM: selectModel(filename)
        end
    end
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feature%2Fpower-based-model-switching%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fpower-based-model-switching%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FSettings%2FPanes%2FEngineAndModelPaneView.swift%3A118-183%0AThe%20power-switching%20%60Toggle%60%20and%20its%20child%20pickers%20are%20placed%20outside%20the%20%60if%20runtimeModel.availableModels.isEmpty%60%20branch%2C%20so%20they%20render%20even%20when%20no%20models%20are%20installed.%20A%20user%20who%20has%20never%20downloaded%20a%20model%20can%20enable%20the%20feature%20and%20will%20be%20shown%20two%20%60Picker%60%20controls%20with%20no%20selectable%20items%20%E2%80%94%20an%20empty%2C%20broken%20UI.%20Both%20controls%20should%20be%20gated%20the%20same%20way%20as%20the%20existing%20%22Selected%20Model%22%20picker.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20runtimeModel.availableModels.isEmpty%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Text%28%22No%20local%20GGUF%20models%20found.%20Download%20one%20below%20or%20add%20your%20own%20model%20file.%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.foregroundStyle%28.secondary%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Picker%28selection%3A%20selectedModelBinding%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20ForEach%28runtimeModel.availableModels%29%20%7B%20model%20in%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Text%28model.displayName%29.tag%28model.filename%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%20label%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20SettingsRowLabel%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20title%3A%20%22Selected%20Model%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20description%3A%20%22Which%20downloaded%20model%20file%20generates%20suggestions.%20%22%20%2B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22Larger%20models%20are%20slower%20but%20write%20better.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20systemImage%3A%20%22shippingbox%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Toggle%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20isOn%3A%20Binding%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20get%3A%20%7B%20suggestionSettings.isPowerBasedModelSwitchingEnabled%20%7D%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20set%3A%20%7B%20suggestionSettings.setPowerBasedModelSwitchingEnabled%28%240%29%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20SettingsRowLabel%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20title%3A%20%22Switch%20models%20based%20on%20power%20source%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20description%3A%20%22Use%20different%20models%20when%20running%20on%20battery%20or%20while%20plugged%20in.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20systemImage%3A%20%22battery.100%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20suggestionSettings.isPowerBasedModelSwitchingEnabled%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Picker%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22Battery%20Model%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20selection%3A%20Binding%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20get%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20suggestionSettings.batteryModelFilename.isEmpty%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3F%20%28runtimeModel.selectedModelFilename%20%3F%3F%20%22%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3A%20suggestionSettings.batteryModelFilename%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20set%3A%20%7B%20suggestionSettings.setBatteryModelFilename%28%240%29%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20ForEach%28runtimeModel.availableModels%29%20%7B%20model%20in%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Text%28model.displayName%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.tag%28model.filename%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Picker%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22Plugged-in%20Model%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20selection%3A%20Binding%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20get%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20suggestionSettings.pluggedInModelFilename.isEmpty%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3F%20%28runtimeModel.selectedModelFilename%20%3F%3F%20%22%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3A%20suggestionSettings.pluggedInModelFilename%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20set%3A%20%7B%20suggestionSettings.setPluggedInModelFilename%28%240%29%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20ForEach%28runtimeModel.availableModels%29%20%7B%20model%20in%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Text%28model.displayName%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.tag%28model.filename%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=630&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FSettings%2FPanes%2FEngineAndModelPaneView.swift%3A118-183%0AThe%20power-switching%20%60Toggle%60%20and%20its%20child%20pickers%20are%20placed%20outside%20the%20%60if%20runtimeModel.availableModels.isEmpty%60%20branch%2C%20so%20they%20render%20even%20when%20no%20models%20are%20installed.%20A%20user%20who%20has%20never%20downloaded%20a%20model%20can%20enable%20the%20feature%20and%20will%20be%20shown%20two%20%60Picker%60%20controls%20with%20no%20selectable%20items%20%E2%80%94%20an%20empty%2C%20broken%20UI.%20Both%20controls%20should%20be%20gated%20the%20same%20way%20as%20the%20existing%20%22Selected%20Model%22%20picker.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20runtimeModel.availableModels.isEmpty%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Text%28%22No%20local%20GGUF%20models%20found.%20Download%20one%20below%20or%20add%20your%20own%20model%20file.%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.foregroundStyle%28.secondary%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Picker%28selection%3A%20selectedModelBinding%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20ForEach%28runtimeModel.availableModels%29%20%7B%20model%20in%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Text%28model.displayName%29.tag%28model.filename%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%20label%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20SettingsRowLabel%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20title%3A%20%22Selected%20Model%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20description%3A%20%22Which%20downloaded%20model%20file%20generates%20suggestions.%20%22%20%2B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22Larger%20models%20are%20slower%20but%20write%20better.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20systemImage%3A%20%22shippingbox%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Toggle%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20isOn%3A%20Binding%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20get%3A%20%7B%20suggestionSettings.isPowerBasedModelSwitchingEnabled%20%7D%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20set%3A%20%7B%20suggestionSettings.setPowerBasedModelSwitchingEnabled%28%240%29%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20SettingsRowLabel%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20title%3A%20%22Switch%20models%20based%20on%20power%20source%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20description%3A%20%22Use%20different%20models%20when%20running%20on%20battery%20or%20while%20plugged%20in.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20systemImage%3A%20%22battery.100%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20suggestionSettings.isPowerBasedModelSwitchingEnabled%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Picker%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22Battery%20Model%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20selection%3A%20Binding%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20get%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20suggestionSettings.batteryModelFilename.isEmpty%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3F%20%28runtimeModel.selectedModelFilename%20%3F%3F%20%22%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3A%20suggestionSettings.batteryModelFilename%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20set%3A%20%7B%20suggestionSettings.setBatteryModelFilenam%0A%0A%5B%E2%80%A6truncated%20to%20fit%20Claude%20Code%20URL%20limit.%20Use%20individual%20%22Fix%20in%20Claude%20Code%22%20links%20for%20full%20context.%5D%0A&repo=fujacob%2Fcotabby&pr=630&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Fix build, lint, and project sync for po..."](https://github.com/fujacob/cotabby/commit/51cc74428ba69dc9acebf94f6eb5af2072f0013e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36064069)</sub>

<!-- /greptile_comment -->