### PR TITLE
Make Screen Recording permission optional

### DIFF
--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
@@ -11,12 +11,20 @@ extension SuggestionCoordinator {
         CotabbyLogger.suggestion.debug("Permission state changed, reconciling")
         reconcileWithCurrentEnvironment()
 
+        // Screen Recording is optional, so revoking it no longer trips `disabledReason` and the
+        // `disablePredictions` teardown that used to cancel the session. Cancel it here instead so a
+        // cached excerpt can't keep feeding screenshot-derived text into prompts after the user turns
+        // the permission off. Granting it falls through to the schedule path below, which restarts
+        // capture via `handleSupportedSnapshot`.
+        if !permissionManager.screenRecordingGranted {
+            visualContextCoordinator.cancel(resetState: true)
+        }
+
         if SuggestionAvailabilityEvaluator.shouldSchedulePrediction(
             globallyEnabled: settingsSnapshot.isGloballyEnabled,
             disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
             disabledDomains: PerDomainDisableSettings.disabledDomains(),
             inputMonitoringGranted: permissionManager.inputMonitoringGranted,
-            screenRecordingGranted: permissionManager.screenRecordingGranted,
             focusSnapshot: focusModel.snapshot
         ) {
             handleSupportedSnapshot(focusModel.snapshot)

--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Lifecycle.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Lifecycle.swift
@@ -87,7 +87,6 @@ extension SuggestionCoordinator {
             disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
             disabledDomains: PerDomainDisableSettings.disabledDomains(),
             inputMonitoringGranted: permissionManager.inputMonitoringGranted,
-            screenRecordingGranted: permissionManager.screenRecordingGranted,
             focusSnapshot: focusModel.snapshot
         ) {
             schedulePrediction()

--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
@@ -68,7 +68,11 @@ extension SuggestionCoordinator {
         }
 
         let context = interactionState.materializeContext(from: rawContext)
-        let visualContextSummary = visualContextCoordinator.excerpt(for: context)
+        // Screen Recording is optional. Re-check it live so a cached excerpt captured before the user
+        // revoked the permission can never be injected during the 2s permission-poll window.
+        let visualContextSummary = permissionManager.screenRecordingGranted
+            ? visualContextCoordinator.excerpt(for: context)
+            : nil
         let rawClipboard = settingsSnapshot.isClipboardContextEnabled
             ? clipboardContextProvider.currentContext()
             : nil
@@ -523,7 +527,6 @@ extension SuggestionCoordinator {
             disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
             disabledDomains: PerDomainDisableSettings.disabledDomains(),
             inputMonitoringGranted: permissionManager.inputMonitoringGranted,
-            screenRecordingGranted: permissionManager.screenRecordingGranted,
             focusSnapshot: focusSnapshot
         )
     }

--- a/Cotabby/Models/PermissionModels.swift
+++ b/Cotabby/Models/PermissionModels.swift
@@ -57,7 +57,7 @@ enum CotabbyPermissionKind: String, CaseIterable, Identifiable, Sendable {
         case .inputMonitoring:
             "Detect typing and accept with Tab."
         case .screenRecording:
-            "Capture screen context for visual reasoning."
+            "Optional: capture screen context for richer suggestions."
         }
     }
 
@@ -77,9 +77,27 @@ enum CotabbyPermissionKind: String, CaseIterable, Identifiable, Sendable {
         }
     }
 
+    /// Whether core autocomplete cannot function without this permission. Screen Recording is
+    /// excluded: it only enriches suggestions with screenshot-based visual context, and its absence
+    /// simply forces the text-only Fast Mode path rather than disabling autocomplete (see
+    /// `SuggestionAvailabilityEvaluator.shouldCaptureVisualContext`).
     var isRequiredForAutocomplete: Bool {
         switch self {
-        case .accessibility, .inputMonitoring, .screenRecording:
+        case .accessibility, .inputMonitoring:
+            true
+        case .screenRecording:
+            false
+        }
+    }
+
+    /// Whether first-run onboarding surfaces this permission as a skippable enhancement instead of a
+    /// required step. Currently only Screen Recording, which unlocks visual context but never blocks
+    /// autocomplete, so it is shown as optional rather than dropped from onboarding entirely.
+    var isOptionalEnhancement: Bool {
+        switch self {
+        case .accessibility, .inputMonitoring:
+            false
+        case .screenRecording:
             true
         }
     }

--- a/Cotabby/Models/PermissionModels.swift
+++ b/Cotabby/Models/PermissionModels.swift
@@ -93,6 +93,12 @@ enum CotabbyPermissionKind: String, CaseIterable, Identifiable, Sendable {
     /// Whether first-run onboarding surfaces this permission as a skippable enhancement instead of a
     /// required step. Currently only Screen Recording, which unlocks visual context but never blocks
     /// autocomplete, so it is shown as optional rather than dropped from onboarding entirely.
+    ///
+    /// Intentionally independent of `isRequiredForAutocomplete`, not derived from it. The two
+    /// booleans encode three onboarding states: required, optional, or hidden. A future permission
+    /// that is neither required nor an onboarding enhancement (a purely background capability) should
+    /// return `false` from both so it stays out of onboarding entirely; do not assume one is the
+    /// negation of the other.
     var isOptionalEnhancement: Bool {
         switch self {
         case .accessibility, .inputMonitoring:

--- a/Cotabby/Services/Permission/PermissionManager.swift
+++ b/Cotabby/Services/Permission/PermissionManager.swift
@@ -102,10 +102,9 @@ final class PermissionManager: ObservableObject {
         }
     }
 
-    /// Core autocomplete depends on Accessibility, Input Monitoring, and Screen Recording.
-    ///
-    /// Screen Recording was historically optional, but is now a core requirement for providing
-    /// visual context to the autocomplete engine.
+    /// Core autocomplete depends on Accessibility and Input Monitoring. Screen Recording is
+    /// optional (without it the app runs the text-only Fast Mode path), so it is intentionally
+    /// excluded here via `CotabbyPermissionKind.isRequiredForAutocomplete`.
     var requiredPermissionsGranted: Bool {
         CotabbyPermissionKind.allCases
             .filter(\.isRequiredForAutocomplete)

--- a/Cotabby/Support/SuggestionAvailabilityEvaluator.swift
+++ b/Cotabby/Support/SuggestionAvailabilityEvaluator.swift
@@ -12,7 +12,6 @@ enum SuggestionAvailabilityEvaluator {
         disabledAppBundleIdentifiers: Set<String> = [],
         disabledDomains: Set<String> = [],
         inputMonitoringGranted: Bool,
-        screenRecordingGranted: Bool,
         focusSnapshot: FocusSnapshot,
         checkCapability: Bool = true
     ) -> String? {
@@ -43,11 +42,6 @@ enum SuggestionAvailabilityEvaluator {
             return "Input Monitoring permission is required before Cotabby can react to typing."
         }
 
-        guard screenRecordingGranted else {
-            return "Screen Recording permission is required before Cotabby can build visual context "
-                + "for autocomplete."
-        }
-
         guard checkCapability else {
             return nil
         }
@@ -65,7 +59,6 @@ enum SuggestionAvailabilityEvaluator {
         disabledAppBundleIdentifiers: Set<String> = [],
         disabledDomains: Set<String> = [],
         inputMonitoringGranted: Bool,
-        screenRecordingGranted: Bool,
         focusSnapshot: FocusSnapshot
     ) -> Bool {
         disabledReason(
@@ -73,7 +66,6 @@ enum SuggestionAvailabilityEvaluator {
             disabledAppBundleIdentifiers: disabledAppBundleIdentifiers,
             disabledDomains: disabledDomains,
             inputMonitoringGranted: inputMonitoringGranted,
-            screenRecordingGranted: screenRecordingGranted,
             focusSnapshot: focusSnapshot
         ) == nil
     }
@@ -84,9 +76,12 @@ enum SuggestionAvailabilityEvaluator {
     /// states (text selected, secure field) are intentionally ignored — OCR should start
     /// early in those cases and be ready by the time the user begins typing.
     ///
-    /// Fast mode is checked here, and deliberately NOT in `disabledReason`: it suppresses only the
-    /// screenshot/OCR pipeline. Predictions still run (they just go out without visual context), so
-    /// `disabledReason` / `shouldSchedulePrediction` must stay unaffected.
+    /// Two conditions gate capture here and deliberately NOT in `disabledReason`, because both
+    /// suppress only the screenshot/OCR pipeline while predictions keep running (they just go out
+    /// without visual context):
+    /// - Fast mode: the user opted into faster, text-only suggestions.
+    /// - Missing Screen Recording permission: the permission is optional, so its absence forces the
+    ///   same text-only behavior as fast mode instead of disabling autocomplete.
     static func shouldCaptureVisualContext(
         globallyEnabled: Bool = true,
         disabledAppBundleIdentifiers: Set<String> = [],
@@ -100,12 +95,15 @@ enum SuggestionAvailabilityEvaluator {
             return false
         }
 
+        guard screenRecordingGranted else {
+            return false
+        }
+
         return disabledReason(
             globallyEnabled: globallyEnabled,
             disabledAppBundleIdentifiers: disabledAppBundleIdentifiers,
             disabledDomains: disabledDomains,
             inputMonitoringGranted: inputMonitoringGranted,
-            screenRecordingGranted: screenRecordingGranted,
             focusSnapshot: focusSnapshot,
             checkCapability: false
         ) == nil

--- a/Cotabby/UI/MenuBarView.swift
+++ b/Cotabby/UI/MenuBarView.swift
@@ -98,9 +98,18 @@ struct MenuBarView: View {
     @ViewBuilder
     private var controlsSection: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Toggle("Fast Mode", isOn: fastModeEnabledBinding)
-                .toggleStyle(.switch)
-                .controlSize(.small)
+            VStack(alignment: .leading, spacing: 2) {
+                Toggle("Fast Mode", isOn: fastModeForcedOn ? .constant(true) : fastModeEnabledBinding)
+                    .toggleStyle(.switch)
+                    .controlSize(.small)
+                    .disabled(fastModeForcedOn)
+
+                if fastModeForcedOn {
+                    Text("Forced on because Screen Recording is off")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
 
             Divider()
 
@@ -405,6 +414,13 @@ struct MenuBarView: View {
 
     private var allPermissionsGranted: Bool {
         permissionManager.requiredPermissionsGranted
+    }
+
+    /// Fast Mode is forced on and locked while Screen Recording is unavailable, since visual context
+    /// can't run without it. The user's stored preference is preserved and restored once the
+    /// permission is granted.
+    private var fastModeForcedOn: Bool {
+        !permissionManager.screenRecordingGranted
     }
 
 }

--- a/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 /// `SettingsRowLabel` so the list reads at a glance.
 struct GeneralPaneView: View {
     @ObservedObject var suggestionSettings: SuggestionSettingsModel
+    @ObservedObject var permissionManager: PermissionManager
     let onShowWelcome: () -> Void
 
     var body: some View {
@@ -23,14 +24,14 @@ struct GeneralPaneView: View {
                     )
                 }
 
-                Toggle(isOn: fastModeEnabledBinding) {
+                Toggle(isOn: fastModeForcedOn ? .constant(true) : fastModeEnabledBinding) {
                     SettingsRowLabel(
                         title: "Fast Mode",
-                        description: "Skip the screenshot-based context step for faster suggestions. " +
-                            "Suggestions rely only on the text you've typed.",
+                        description: fastModeDescription,
                         systemImage: "bolt.fill"
                     )
                 }
+                .disabled(fastModeForcedOn)
 
                 // Backed by `SMAppService.mainApp` via the LaunchAtLogin package, which owns the
                 // observable for the login-item status and refreshes the toggle if the user changes
@@ -149,6 +150,22 @@ struct GeneralPaneView: View {
             get: { suggestionSettings.isFastModeEnabled },
             set: { suggestionSettings.setFastModeEnabled($0) }
         )
+    }
+
+    /// Fast Mode is forced on and locked while Screen Recording is unavailable (visual context can't
+    /// run without it). The stored preference is left untouched so it returns when the permission is
+    /// granted.
+    private var fastModeForcedOn: Bool {
+        !permissionManager.screenRecordingGranted
+    }
+
+    private var fastModeDescription: String {
+        if fastModeForcedOn {
+            return "Forced on because Screen Recording is off. Suggestions rely only on the text " +
+                "you've typed; grant Screen Recording to add visual context."
+        }
+        return "Skip the screenshot-based context step for faster suggestions. " +
+            "Suggestions rely only on the text you've typed."
     }
 
     private var multiLineEnabledBinding: Binding<Bool> {

--- a/Cotabby/UI/Settings/Panes/PermissionsPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/PermissionsPaneView.swift
@@ -11,7 +11,8 @@ struct PermissionsPaneView: View {
     var body: some View {
         SettingsPaneScaffold(callout: callout) {
             Section("Permissions") {
-                Text("Cotabby needs Accessibility, Input Monitoring, and Screen Recording for autocomplete.")
+                Text("Cotabby needs Accessibility and Input Monitoring for autocomplete. " +
+                    "Screen Recording is optional and adds on-screen visual context.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
@@ -35,10 +36,11 @@ struct PermissionsPaneView: View {
 
                 permissionRow(
                     title: "Screen Recording",
-                    description: "Lets Cotabby take a screenshot of the focused window to use as " +
-                        "additional context. Required even when Fast Mode skips capture.",
+                    description: "Optional. Lets Cotabby screenshot the focused window for extra " +
+                        "context. Without it, Cotabby runs in Fast Mode using only the text you've typed.",
                     systemImage: "camera.viewfinder",
                     granted: permissionManager.screenRecordingGranted,
+                    isOptional: true,
                     action: permissionManager.openScreenRecordingSettings
                 )
             }
@@ -72,17 +74,20 @@ struct PermissionsPaneView: View {
         description: String,
         systemImage: String,
         granted: Bool,
+        isOptional: Bool = false,
         action: @escaping () -> Void
     ) -> some View {
         HStack(spacing: 10) {
             SettingsRowLabel(title: title, description: description, systemImage: systemImage)
             Spacer(minLength: 0)
-            Text(granted ? "Granted" : "Needs Access")
+            // An ungranted optional permission reads as a neutral "Off" rather than the orange
+            // "Needs Access" used for required ones, so it never looks like a broken setup.
+            Text(granted ? "Granted" : (isOptional ? "Off" : "Needs Access"))
                 .font(.caption.weight(.medium))
-                .foregroundStyle(granted ? .green : .orange)
+                .foregroundStyle(granted ? .green : (isOptional ? .secondary : .orange))
 
             if !granted {
-                Button("Open Settings") {
+                Button(isOptional ? "Enable" : "Open Settings") {
                     action()
                 }
                 .controlSize(.small)

--- a/Cotabby/UI/Settings/SettingsContainerView.swift
+++ b/Cotabby/UI/Settings/SettingsContainerView.swift
@@ -100,6 +100,7 @@ struct SettingsContainerView: View {
         case .general:
             GeneralPaneView(
                 suggestionSettings: suggestionSettings,
+                permissionManager: permissionManager,
                 onShowWelcome: onShowWelcome
             )
         case .appearance:

--- a/Cotabby/UI/WelcomePermissionStepView.swift
+++ b/Cotabby/UI/WelcomePermissionStepView.swift
@@ -10,16 +10,23 @@ import SwiftUI
 /// Navigation (Back/Continue) is owned by `WelcomeView`'s pinned footer rather than this view, so
 /// the Continue button can never scroll off-screen behind tall content.
 ///
-/// The onboarding list is derived from `CotabbyPermissionKind.isRequiredForAutocomplete` so the
+/// The onboarding list is derived from `CotabbyPermissionKind` (required cards from
+/// `isRequiredForAutocomplete`, then optional-enhancement cards from `isOptionalEnhancement`) so the
 /// product's permission model and first-run UI cannot drift apart.
 struct WelcomePermissionStepView: View {
     @ObservedObject var permissionManager: PermissionManager
 
     let permissionGuidanceController: PermissionGuidanceController
 
-    /// Only show permissions that block core autocomplete.
-    private var onboardingPermissions: [CotabbyPermissionKind] {
+    /// Permissions that block core autocomplete; the user must grant these to continue.
+    private var requiredPermissions: [CotabbyPermissionKind] {
         CotabbyPermissionKind.allCases.filter(\.isRequiredForAutocomplete)
+    }
+
+    /// Optional enhancements (Screen Recording today). Shown so visual context is discoverable at
+    /// first run, but they never block the Continue button.
+    private var optionalPermissions: [CotabbyPermissionKind] {
+        CotabbyPermissionKind.allCases.filter(\.isOptionalEnhancement)
     }
 
     var body: some View {
@@ -28,17 +35,28 @@ struct WelcomePermissionStepView: View {
                 Text("Enable Cotabby")
                     .font(.system(size: 24, weight: .semibold, design: .rounded))
 
-                Text("Grant permissions so Cotabby can\nread text, capture context, and accept completions.")
+                Text("Grant permissions so Cotabby can\nread text and accept completions.")
                     .font(.system(size: 14, design: .rounded))
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
             }
 
             VStack(spacing: 10) {
-                ForEach(onboardingPermissions) { permission in
+                ForEach(requiredPermissions) { permission in
                     PermissionCard(
                         permission: permission,
                         granted: permissionManager.isGranted(permission),
+                        permissionGuidanceController: permissionGuidanceController
+                    )
+                }
+
+                // Optional cards render after the required ones, tagged so the user can skip them
+                // without thinking they've left setup unfinished. The Continue gate ignores them.
+                ForEach(optionalPermissions) { permission in
+                    PermissionCard(
+                        permission: permission,
+                        granted: permissionManager.isGranted(permission),
+                        isOptional: true,
                         permissionGuidanceController: permissionGuidanceController
                     )
                 }
@@ -60,6 +78,7 @@ struct WelcomePermissionStepView: View {
 private struct PermissionCard: View {
     let permission: CotabbyPermissionKind
     let granted: Bool
+    var isOptional = false
     let permissionGuidanceController: PermissionGuidanceController
 
     @State private var actionButtonFrame = CGRect.zero
@@ -72,8 +91,19 @@ private struct PermissionCard: View {
             )
 
             VStack(alignment: .leading, spacing: 2) {
-                Text(permission.title)
-                    .font(.system(size: 14, weight: .medium))
+                HStack(spacing: 6) {
+                    Text(permission.title)
+                        .font(.system(size: 14, weight: .medium))
+
+                    if isOptional {
+                        Text("Optional")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 1)
+                            .background(.quaternary, in: Capsule())
+                    }
+                }
 
                 Text(permission.onboardingSubtitle)
                     .font(.system(size: 12))

--- a/CotabbyTests/PermissionAndContextModelTests.swift
+++ b/CotabbyTests/PermissionAndContextModelTests.swift
@@ -53,13 +53,18 @@ final class CotabbyPermissionKindTests: XCTestCase {
         }
     }
 
-    func test_isRequiredForAutocomplete_isTrueForAllCases() {
-        for kind in CotabbyPermissionKind.allCases {
-            XCTAssertTrue(
-                kind.isRequiredForAutocomplete,
-                "\(kind) should be required for autocomplete"
-            )
-        }
+    func test_isRequiredForAutocomplete_isTrueOnlyForCoreInputPermissions() {
+        XCTAssertTrue(CotabbyPermissionKind.accessibility.isRequiredForAutocomplete)
+        XCTAssertTrue(CotabbyPermissionKind.inputMonitoring.isRequiredForAutocomplete)
+        // Screen Recording is optional: missing it forces the text-only Fast Mode path rather than
+        // disabling autocomplete.
+        XCTAssertFalse(CotabbyPermissionKind.screenRecording.isRequiredForAutocomplete)
+    }
+
+    func test_isOptionalEnhancement_isTrueOnlyForScreenRecording() {
+        XCTAssertTrue(CotabbyPermissionKind.screenRecording.isOptionalEnhancement)
+        XCTAssertFalse(CotabbyPermissionKind.accessibility.isOptionalEnhancement)
+        XCTAssertFalse(CotabbyPermissionKind.inputMonitoring.isOptionalEnhancement)
     }
 
     func test_guidanceHint_isNonEmptyForAllCases() {

--- a/CotabbyTests/SuggestionAvailabilityEvaluatorTests.swift
+++ b/CotabbyTests/SuggestionAvailabilityEvaluatorTests.swift
@@ -69,7 +69,6 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
         let reason = SuggestionAvailabilityEvaluator.disabledReason(
             globallyEnabled: false,
             inputMonitoringGranted: true,
-            screenRecordingGranted: true,
             focusSnapshot: makeSnapshot(capability: .supported)
         )
 
@@ -81,7 +80,6 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
             globallyEnabled: true,
             disabledDomains: ["bank.com"],
             inputMonitoringGranted: true,
-            screenRecordingGranted: true,
             focusSnapshot: makeSupportedSnapshotWithContext(focusedURLString: "https://www.bank.com/account")
         )
 
@@ -94,7 +92,6 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
         let reason = SuggestionAvailabilityEvaluator.disabledReason(
             globallyEnabled: true,
             inputMonitoringGranted: true,
-            screenRecordingGranted: true,
             focusSnapshot: makeSupportedSnapshotWithContext(focusedURLString: "https://bank.com/account")
         )
 
@@ -105,26 +102,12 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
         let reason = SuggestionAvailabilityEvaluator.disabledReason(
             globallyEnabled: true,
             inputMonitoringGranted: false,
-            screenRecordingGranted: true,
             focusSnapshot: makeSnapshot(capability: .supported)
         )
 
         XCTAssertNotNil(reason)
         XCTAssertTrue(reason?.contains("Input Monitoring") ?? false,
                       "reason should point the user at the permission they need to grant")
-    }
-
-    func test_disabledReason_whenScreenRecordingDenied_mentionsPermission() {
-        let reason = SuggestionAvailabilityEvaluator.disabledReason(
-            globallyEnabled: true,
-            inputMonitoringGranted: true,
-            screenRecordingGranted: false,
-            focusSnapshot: makeSnapshot(capability: .supported)
-        )
-
-        XCTAssertNotNil(reason)
-        XCTAssertTrue(reason?.contains("Screen Recording") ?? false,
-                      "reason should point the user at the permission needed for visual context")
     }
 
     // MARK: - disabledReason: guard ordering
@@ -136,7 +119,6 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
         let reason = SuggestionAvailabilityEvaluator.disabledReason(
             globallyEnabled: false,
             inputMonitoringGranted: false,
-            screenRecordingGranted: false,
             focusSnapshot: makeSnapshot(capability: .supported)
         )
 
@@ -148,7 +130,6 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
             globallyEnabled: false,
             disabledAppBundleIdentifiers: ["app.test"],
             inputMonitoringGranted: true,
-            screenRecordingGranted: true,
             focusSnapshot: makeSnapshot(capability: .supported)
         )
 
@@ -160,7 +141,6 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
             globallyEnabled: true,
             disabledAppBundleIdentifiers: ["com.apple.Safari"],
             inputMonitoringGranted: true,
-            screenRecordingGranted: true,
             focusSnapshot: makeSnapshot(
                 applicationName: "Safari",
                 bundleIdentifier: "com.apple.Safari",
@@ -181,7 +161,6 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
         let reason = SuggestionAvailabilityEvaluator.disabledReason(
             globallyEnabled: true,
             inputMonitoringGranted: true,
-            screenRecordingGranted: true,
             focusSnapshot: makeSnapshot(capability: .blocked(blockReason))
         )
 
@@ -193,7 +172,6 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
         let reason = SuggestionAvailabilityEvaluator.disabledReason(
             globallyEnabled: true,
             inputMonitoringGranted: true,
-            screenRecordingGranted: true,
             focusSnapshot: makeSnapshot(capability: .unsupported(unsupportedReason))
         )
 
@@ -206,7 +184,6 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
         let reason = SuggestionAvailabilityEvaluator.disabledReason(
             globallyEnabled: true,
             inputMonitoringGranted: true,
-            screenRecordingGranted: true,
             focusSnapshot: makeSnapshot(capability: .supported)
         )
 
@@ -222,7 +199,6 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
         let ok = SuggestionAvailabilityEvaluator.shouldSchedulePrediction(
             globallyEnabled: true,
             inputMonitoringGranted: true,
-            screenRecordingGranted: true,
             focusSnapshot: makeSnapshot(capability: .supported)
         )
 
@@ -233,7 +209,6 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
         let ok = SuggestionAvailabilityEvaluator.shouldSchedulePrediction(
             globallyEnabled: false,
             inputMonitoringGranted: true,
-            screenRecordingGranted: true,
             focusSnapshot: makeSnapshot(capability: .supported)
         )
 
@@ -245,7 +220,6 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
             globallyEnabled: true,
             disabledAppBundleIdentifiers: ["app.test"],
             inputMonitoringGranted: true,
-            screenRecordingGranted: true,
             focusSnapshot: makeSnapshot(capability: .supported)
         )
 
@@ -257,7 +231,6 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
             globallyEnabled: true,
             disabledAppBundleIdentifiers: ["app.other"],
             inputMonitoringGranted: true,
-            screenRecordingGranted: true,
             focusSnapshot: makeSnapshot(capability: .supported)
         )
 
@@ -268,19 +241,7 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
         let ok = SuggestionAvailabilityEvaluator.shouldSchedulePrediction(
             globallyEnabled: true,
             inputMonitoringGranted: true,
-            screenRecordingGranted: true,
             focusSnapshot: makeSnapshot(capability: .unsupported("No focused text input"))
-        )
-
-        XCTAssertFalse(ok)
-    }
-
-    func test_shouldSchedulePrediction_falseWhenScreenRecordingDenied() {
-        let ok = SuggestionAvailabilityEvaluator.shouldSchedulePrediction(
-            globallyEnabled: true,
-            inputMonitoringGranted: true,
-            screenRecordingGranted: false,
-            focusSnapshot: makeSnapshot(capability: .supported)
         )
 
         XCTAssertFalse(ok)
@@ -316,6 +277,27 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
 
     // MARK: - shouldCaptureVisualContext + fast mode
 
+    /// Mirror of the fast-mode invariant for the now-optional Screen Recording permission: a missing
+    /// permission suppresses visual-context capture but leaves predictions running (text-only).
+    func test_noScreenRecording_suppressesVisualContextButNotPredictions() {
+        let snapshot = makeSnapshot(capability: .supported)
+
+        XCTAssertFalse(
+            SuggestionAvailabilityEvaluator.shouldCaptureVisualContext(
+                inputMonitoringGranted: true,
+                screenRecordingGranted: false,
+                focusSnapshot: snapshot,
+                isFastModeEnabled: false
+            )
+        )
+        XCTAssertTrue(
+            SuggestionAvailabilityEvaluator.shouldSchedulePrediction(
+                inputMonitoringGranted: true,
+                focusSnapshot: snapshot
+            )
+        )
+    }
+
     func test_shouldCaptureVisualContext_trueWhenAllowedAndNotFastMode() {
         let ok = SuggestionAvailabilityEvaluator.shouldCaptureVisualContext(
             globallyEnabled: true,
@@ -344,7 +326,6 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
         XCTAssertTrue(
             SuggestionAvailabilityEvaluator.shouldSchedulePrediction(
                 inputMonitoringGranted: true,
-                screenRecordingGranted: true,
                 focusSnapshot: snapshot
             )
         )

--- a/CotabbyTests/TerminalAppDetectorTests.swift
+++ b/CotabbyTests/TerminalAppDetectorTests.swift
@@ -69,7 +69,6 @@ final class TerminalAppDetectorTests: XCTestCase {
         let reason = SuggestionAvailabilityEvaluator.disabledReason(
             globallyEnabled: true,
             inputMonitoringGranted: true,
-            screenRecordingGranted: true,
             focusSnapshot: snapshot
         )
 
@@ -88,7 +87,6 @@ final class TerminalAppDetectorTests: XCTestCase {
         let reason = SuggestionAvailabilityEvaluator.disabledReason(
             globallyEnabled: true,
             inputMonitoringGranted: true,
-            screenRecordingGranted: true,
             focusSnapshot: snapshot
         )
 
@@ -108,7 +106,6 @@ final class TerminalAppDetectorTests: XCTestCase {
             SuggestionAvailabilityEvaluator.shouldSchedulePrediction(
                 globallyEnabled: true,
                 inputMonitoringGranted: true,
-                screenRecordingGranted: true,
                 focusSnapshot: snapshot
             )
         )
@@ -126,7 +123,6 @@ final class TerminalAppDetectorTests: XCTestCase {
         let reason = SuggestionAvailabilityEvaluator.disabledReason(
             globallyEnabled: false,
             inputMonitoringGranted: true,
-            screenRecordingGranted: true,
             focusSnapshot: snapshot
         )
 


### PR DESCRIPTION
## Summary

Screen Recording was a hard requirement that blocked all autocomplete when missing, even though Fast Mode already skips the screenshot/OCR pipeline (the Permissions pane even admitted it: "Required even when Fast Mode skips capture"). This makes the permission optional: without it, Cotabby runs the text-only Fast Mode path (predictions still work), and granting it later re-enables visual context per the user's stored preference. Users without the permission are effectively forced into Fast Mode rather than left with autocomplete fully disabled.

## Validation

Ran locally on macOS:

```
swiftlint lint --quiet
# exit 0 (one pre-existing warning on an untouched long test-class name)

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build \
  -derivedDataPath build/DerivedData
# ** BUILD SUCCEEDED **

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' test \
  -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO \
  -only-testing:CotabbyTests/SuggestionAvailabilityEvaluatorTests \
  -only-testing:CotabbyTests/TerminalAppDetectorTests \
  -only-testing:CotabbyTests/CotabbyPermissionKindTests
# ** TEST SUCCEEDED **  46 tests, 0 failures
```

Not yet verified end-to-end in a live session (needs real TCC permission toggling plus observing inline ghost text). Suggested manual check: with Screen Recording denied, autocomplete should work text-only and Fast Mode should show locked-on; granting it should resume visual context; revoking it mid-session should inject no visual context on the next suggestion (verify in `~/Library/Logs/Cotabby/llm-io.jsonl`).

## Linked issues

Addresses the request to make Screen Recording optional now that Fast Mode skips OCR / screen capture. No matching open issue number was located in the tracker; add `Fixes #N` if one exists.

## Risk / rollout notes

- Behavior change to an existing user flow: Screen Recording is no longer required. Users who already granted it are unaffected (visual context keeps working per their Fast Mode setting). Users who never granted it, or who revoke it, now keep working in text-only Fast Mode instead of being fully disabled.
- `PermissionManager.requiredPermissionsGranted` no longer includes Screen Recording, so the onboarding Continue gate, the post-onboarding permission reminder, the menu-bar permission nag, and the settings attention dot stop flagging it. Onboarding still surfaces it as an optional, skippable card.
- Privacy: on revoke, the visual-context session is cancelled in `handlePermissionChange()` and the excerpt read is re-gated on the live permission, so a cached screenshot excerpt cannot be injected into prompts after the user turns the permission off.
- No schema, settings, or pbxproj migrations. The stored Fast Mode preference is left untouched; it is only force-displayed as on (locked) while the permission is off, and restored when granted.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Screen Recording is demoted from a hard requirement to an optional enhancement — its absence now routes Cotabby into the text-only Fast Mode path rather than blocking autocomplete entirely.

- `SuggestionAvailabilityEvaluator` drops `screenRecordingGranted` from `disabledReason`/`shouldSchedulePrediction` and moves the Screen Recording gate into `shouldCaptureVisualContext` only. `PermissionModels` grows `isOptionalEnhancement` to encode the three-state onboarding model (required / optional / hidden), and `PermissionManager.requiredPermissionsGranted` is narrowed to Accessibility + Input Monitoring only.
- `handlePermissionChange` explicitly cancels the visual context coordinator on revoke (since it no longer trips the prediction-disabled path), and `generateFromCurrentFocus` re-checks the live permission immediately before reading the cached screenshot excerpt to close the 2-second poll window.
- UI surfaces — menu bar, General settings, Permissions pane, and onboarding — consistently show Fast Mode as forced-on and locked while Screen Recording is absent, and restore the stored preference on grant.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the permission demotion is correctly threaded through every code path with no functional regressions introduced.

The core change — removing Screen Recording from the prediction-availability gate and adding it to the visual-context gate — is consistently applied across all call sites: the evaluator, all three coordinator extensions, and the lifecycle settings handler. The double-gating approach (cancel-on-revoke in handlePermissionChange plus the live re-check in generateFromCurrentFocus) correctly closes the 2-second poll window without over-cancelling on grant. UI surfaces are consistently updated and the test suite directly covers the new split behavior. No data-loss, stale-context, or auth-boundary issues were found.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift | handlePermissionChange: explicit visual-context cancel on Screen Recording revoke; Screen Recording removed from shouldSchedulePrediction call. Logic is correct for both grant and revoke paths. |
| Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift | Adds a live permission re-check before reading the cached screenshot excerpt — belt-and-suspenders guard for the 2-second poll window. Correct; no issues. |
| Cotabby/Support/SuggestionAvailabilityEvaluator.swift | screenRecordingGranted removed from disabledReason/shouldSchedulePrediction signatures; moved into shouldCaptureVisualContext. Clean and well-documented split of concerns. |
| Cotabby/Models/PermissionModels.swift | Adds isOptionalEnhancement, correctly independent from isRequiredForAutocomplete, with a clear doc comment explaining the three-state onboarding model. Screen Recording returns false/true respectively. |
| Cotabby/UI/WelcomePermissionStepView.swift | Onboarding split into required/optional card sections. Optional badge added. Button label remains "Allow" for all ungranted permissions. |
| CotabbyTests/SuggestionAvailabilityEvaluatorTests.swift | Old screenRecording-blocks-prediction tests removed; new test_noScreenRecording_suppressesVisualContextButNotPredictions added, correctly verifying the split behavior. |
| CotabbyTests/PermissionAndContextModelTests.swift | Tests updated to assert new isRequiredForAutocomplete and isOptionalEnhancement values per-case. Good coverage of the model change. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cotabby/UI/WelcomePermissionStepView.swift`, line 115-127 ([link](https://github.com/fujacob/cotabby/blob/068d4aae7e5572abce78d09f0c95b65a4cfff9cc/Cotabby/UI/WelcomePermissionStepView.swift#L115-L127)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The onboarding `PermissionCard` always shows "Allow" for ungranted permissions regardless of `isOptional`, while the Permissions settings pane shows "Enable" for the same optional Screen Recording card. Users who skip Screen Recording in onboarding and later find the settings pane will see different button labels for the same action. Consider matching the settings label in the optional card path.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22optional-screen-recording%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22optional-screen-recording%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FWelcomePermissionStepView.swift%0ALine%3A%20115-127%0A%0AComment%3A%0AThe%20onboarding%20%60PermissionCard%60%20always%20shows%20%22Allow%22%20for%20ungranted%20permissions%20regardless%20of%20%60isOptional%60%2C%20while%20the%20Permissions%20settings%20pane%20shows%20%22Enable%22%20for%20the%20same%20optional%20Screen%20Recording%20card.%20Users%20who%20skip%20Screen%20Recording%20in%20onboarding%20and%20later%20find%20the%20settings%20pane%20will%20see%20different%20button%20labels%20for%20the%20same%20action.%20Consider%20matching%20the%20settings%20label%20in%20the%20optional%20card%20path.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20granted%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20PermissionDoneBadge%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Button%28isOptional%20%3F%20%22Enable%22%20%3A%20%22Allow%22%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20permissionGuidanceController.requestAccess%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20for%3A%20permission%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20sourceFrameInScreen%3A%20actionButtonFrame%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.buttonStyle%28.borderedProminent%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.controlSize%28.regular%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.background%28ScreenFrameReader%28frameInScreen%3A%20%24actionButtonFrame%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=633&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FWelcomePermissionStepView.swift%0ALine%3A%20115-127%0A%0AComment%3A%0AThe%20onboarding%20%60PermissionCard%60%20always%20shows%20%22Allow%22%20for%20ungranted%20permissions%20regardless%20of%20%60isOptional%60%2C%20while%20the%20Permissions%20settings%20pane%20shows%20%22Enable%22%20for%20the%20same%20optional%20Screen%20Recording%20card.%20Users%20who%20skip%20Screen%20Recording%20in%20onboarding%20and%20later%20find%20the%20settings%20pane%20will%20see%20different%20button%20labels%20for%20the%20same%20action.%20Consider%20matching%20the%20settings%20label%20in%20the%20optional%20card%20path.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20granted%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20PermissionDoneBadge%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Button%28isOptional%20%3F%20%22Enable%22%20%3A%20%22Allow%22%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20permissionGuidanceController.requestAccess%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20for%3A%20permission%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20sourceFrameInScreen%3A%20actionButtonFrame%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.buttonStyle%28.borderedProminent%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.controlSize%28.regular%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.background%28ScreenFrameReader%28frameInScreen%3A%20%24actionButtonFrame%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=633&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Document that isOptionalEnhancement and ..."](https://github.com/fujacob/cotabby/commit/3a9fd5f8dda96d87e42127309f35545552c3fda5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36101282)</sub>

<!-- /greptile_comment -->