### PR TITLE
Add build, last-commit, and Swift badges to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,13 @@
 </a></p>
 
 <p align="center">
+  <a href="https://github.com/FuJacob/cotabby/actions/workflows/build.yml"><img alt="Build" src="https://img.shields.io/github/actions/workflow/status/FuJacob/cotabby/build.yml?branch=main" /></a>
   <a href="LICENSE"><img alt="License: AGPL v3" src="https://img.shields.io/badge/license-AGPL--3.0-blue.svg" /></a>
   <a href="https://github.com/FuJacob/cotabby/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/FuJacob/cotabby" /></a>
   <a href="https://github.com/FuJacob/cotabby/releases"><img alt="Downloads" src="https://img.shields.io/github/downloads/FuJacob/cotabby/total" /></a>
   <a href="https://github.com/FuJacob/cotabby/stargazers"><img alt="Stars" src="https://img.shields.io/github/stars/FuJacob/cotabby?style=flat" /></a>
+  <a href="https://github.com/FuJacob/cotabby/commits/main"><img alt="Last commit" src="https://img.shields.io/github/last-commit/FuJacob/cotabby" /></a>
+  <img alt="Swift" src="https://img.shields.io/badge/Swift-F05138?logo=swift&amp;logoColor=white" />
   <img alt="Platform" src="https://img.shields.io/badge/platform-macOS%2014%2B-lightgrey" />
   <img alt="Visitors" src="https://visitor-badge.laobi.icu/badge?page_id=FuJacob.tabby" />
 </p>


### PR DESCRIPTION
## Summary

Add three badges to the README header row: **Build** (GitHub Actions), **Last commit**, and **Swift**. `build.yml` was already wired to run on push-to-main specifically so a badge could reflect main health (per its own comment); this surfaces it, alongside a recent-activity signal and the tech stack.

## Validation

- Verified each shields endpoint resolves: `build.yml?branch=main` -> `passing`, `last-commit` -> `today`, and the Swift logo badge renders (SVG `aria-label="Swift"`).
- Left the visitors badge's `page_id` (`FuJacob.tabby`) untouched so its accumulated count is not reset to zero.
- No code change; README markup only.

## Linked issues

None.

## Risk / rollout notes

- Pure README change, no code or behavior change.
- The build badge tracks `main`; it will read `failing` if a push to main ever breaks the build gate, which is the intended signal.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Surfaces three new badges in the README header: a GitHub Actions build-status badge (already supported by `build.yml`'s push-to-main trigger), a last-commit activity badge, and a static Swift language badge.

- **Build badge** links to `build.yml?branch=main` and reflects main health; `build.yml` was explicitly wired for this use case per its own inline comment.
- **Last-commit badge** links to `commits/main` and provides a recent-activity signal; the `github/last-commit` shields endpoint defaults to the repository's default branch when no branch parameter is given.
- **Swift badge** is a static tech-stack indicator with no external link, consistent with the existing Platform badge style.

<h3>Confidence Score: 5/5</h3>

Pure README change adding three informational badges; no code, config, or behavior is modified.

All three badge URLs are well-formed, the build badge correctly targets ?branch=main, the build.yml workflow was already explicitly designed to support a badge (per its own comment), and the static Swift badge uses correct HTML entity encoding. No logic, data, or runtime behavior is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Adds three new shields.io badges (Build, Last commit, Swift) to the badge row; no code changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph README["README badge row"]
        B1["Build badge"]
        B2["Last commit badge"]
        B3["Swift badge"]
    end

    subgraph Sources["Data sources"]
        GHA["GitHub Actions\nbuild.yml @ main"]
        GC["GitHub Commits API\n(default branch = main)"]
        STATIC["Static shields.io\n(no external data)"]
    end

    B1 -->|"shields.io/github/actions/workflow/status\n?branch=main"| GHA
    B2 -->|"shields.io/github/last-commit"| GC
    B3 -->|"shields.io/badge/Swift-F05138"| STATIC
```

<sub>Reviews (1): Last reviewed commit: ["Add build, last-commit, and Swift badges..."](https://github.com/fujacob/cotabby/commit/3cf0f62600328bed3708a53c360cae4038fc5e89) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36102296)</sub>

<!-- /greptile_comment -->