### PR TITLE
Remove the visitors badge from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@
   <a href="https://github.com/FuJacob/cotabby/commits/main"><img alt="Last commit" src="https://img.shields.io/github/last-commit/FuJacob/cotabby" /></a>
   <img alt="Swift" src="https://img.shields.io/badge/Swift-F05138?logo=swift&amp;logoColor=white" />
   <img alt="Platform" src="https://img.shields.io/badge/platform-macOS%2014%2B-lightgrey" />
-  <img alt="Visitors" src="https://visitor-badge.laobi.icu/badge?page_id=FuJacob.tabby" />
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

Remove the laobi.icu visitor-counter badge from the README header row.

## Validation

- README markup only; the badge row now ends at the Platform badge.
- No code change.

## Linked issues

None.

## Risk / rollout notes

- Pure README change. The counter's server-side tally (keyed to `page_id=FuJacob.tabby`) still exists if it is ever re-added later.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the `visitor-badge.laobi.icu` badge from the README header badge row. No code, logic, or configuration is affected.

- The single-line deletion removes the `<img>` tag pointing to `https://visitor-badge.laobi.icu/badge?page_id=FuJacob.tabby`, leaving the badge row with only the commit-history, Swift, and platform badges.
- The server-side visit counter (keyed to `FuJacob.tabby`) is unaffected and can be re-added in the future if desired.

<h3>Confidence Score: 5/5</h3>

This is a one-line markup deletion with no functional impact — safe to merge as-is.

The change removes a single <img> tag from a README badge row. Nothing else is touched; no code, tests, configuration, or logic is affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Removes the laobi.icu visitor-counter badge <img> tag from the badge row; no other content is changed. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[README.md badge row] --> B[Last Commit badge]
    A --> C[Swift badge]
    A --> D[Platform badge]
    A -. removed .-> E[Visitors badge\nlaobi.icu]
    style E stroke-dasharray: 5 5,fill:#f9f9f9,color:#999
```

<sub>Reviews (1): Last reviewed commit: ["Remove the visitors badge from the READM..."](https://github.com/fujacob/cotabby/commit/a6062ffd91c00b7a377cef0ae617a34a2a54a101) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36102386)</sub>

<!-- /greptile_comment -->