### PR TITLE
feat(runtime): per-power-source engine + model profiles

### DIFF
--- a/Cotabby/App/Core/CotabbyAppEnvironment.swift
+++ b/Cotabby/App/Core/CotabbyAppEnvironment.swift
@@ -288,54 +288,79 @@ final class CotabbyAppEnvironment {
             }
             .store(in: &cancellables)
 
-        observePowerSourceModelSwitching(
-            powerSourceMonitor: powerSourceMonitor,
-            runtimeModel: runtimeModel,
-            suggestionSettings: suggestionSettings
-        )
+        observePowerSourceProfileSwitching()
     }
 
-    /// Switches the runtime model when the power source changes, if the user opted into power-based
-    /// switching. The guards bail early when the feature is off, the target model is unset or no
-    /// longer installed, or it is already selected, so the only side effect is a deliberate reload on
-    /// a genuine power transition. Extracted from `init` to keep the initializer's complexity bounded.
-    private func observePowerSourceModelSwitching(
-        powerSourceMonitor: PowerSourceMonitor,
-        runtimeModel: RuntimeBootstrapModel,
-        suggestionSettings: SuggestionSettingsModel
-    ) {
-        powerSourceMonitor.$isPluggedIn
-            .removeDuplicates()
-            .sink { [weak runtimeModel, weak suggestionSettings] isPluggedIn in
-                guard let runtimeModel,
-                      let suggestionSettings else {
+    /// Applies the user's per-power-source profile (engine + model) whenever anything that could
+    /// change the right answer changes: the power source, the feature toggle, either profile, or the
+    /// installed-model list (so a profile referencing a still-loading model is honored once it
+    /// appears). The apply step is idempotent (`selectEngine`/`selectModel` no-op when already
+    /// current), so the redundant values `@Published` replays on subscription are harmless.
+    /// Extracted from `init` to keep the initializer's complexity bounded.
+    private func observePowerSourceProfileSwitching() {
+        let triggers: [AnyPublisher<Void, Never>] = [
+            powerSourceMonitor.$isPluggedIn.map { _ in () }.eraseToAnyPublisher(),
+            suggestionSettings.$isPowerBasedModelSwitchingEnabled.map { _ in () }.eraseToAnyPublisher(),
+            suggestionSettings.$batteryEngine.map { _ in () }.eraseToAnyPublisher(),
+            suggestionSettings.$batteryModelFilename.map { _ in () }.eraseToAnyPublisher(),
+            suggestionSettings.$pluggedInEngine.map { _ in () }.eraseToAnyPublisher(),
+            suggestionSettings.$pluggedInModelFilename.map { _ in () }.eraseToAnyPublisher(),
+            runtimeModel.$availableModels.map { _ in () }.eraseToAnyPublisher()
+        ]
+
+        Publishers.MergeMany(triggers)
+            .sink { [weak self] _ in
+                guard let self else {
                     return
                 }
 
-                guard suggestionSettings.isPowerBasedModelSwitchingEnabled else {
-                    return
-                }
-
-                let filename = isPluggedIn
-                    ? suggestionSettings.pluggedInModelFilename
-                    : suggestionSettings.batteryModelFilename
-
-                guard !filename.isEmpty else {
-                    return
-                }
-
-                guard runtimeModel.availableModels.contains(where: { $0.filename == filename }) else {
-                    return
-                }
-
-                guard runtimeModel.selectedModelFilename != filename else {
-                    return
-                }
-
-                Task {
-                    await runtimeModel.selectModel(filename)
-                }
+                Self.applyPowerProfile(
+                    isPluggedIn: self.powerSourceMonitor.isPluggedIn,
+                    runtimeModel: self.runtimeModel,
+                    suggestionSettings: self.suggestionSettings,
+                    availability: self.foundationModelAvailabilityService
+                )
             }
             .store(in: &cancellables)
+    }
+
+    /// Switches the active engine (and, for Open Source, the model) to the profile configured for the
+    /// current power source. Does nothing when the feature is off. Apple Intelligence is applied only
+    /// when actually available, so a configured-but-unavailable profile never strands the user on a
+    /// dead engine; the Open Source branch reloads the model only when it is installed and not already
+    /// selected, so the sole side effect is a deliberate reload on a real change.
+    private static func applyPowerProfile(
+        isPluggedIn: Bool,
+        runtimeModel: RuntimeBootstrapModel,
+        suggestionSettings: SuggestionSettingsModel,
+        availability: FoundationModelAvailabilityService
+    ) {
+        guard suggestionSettings.isPowerBasedModelSwitchingEnabled else {
+            return
+        }
+
+        let profile = isPluggedIn ? suggestionSettings.pluggedInProfile : suggestionSettings.batteryProfile
+
+        switch profile {
+        case .appleIntelligence:
+            guard availability.isAvailable else {
+                return
+            }
+
+            suggestionSettings.selectEngine(.appleIntelligence)
+
+        case .llama(let filename):
+            suggestionSettings.selectEngine(.llamaOpenSource)
+
+            guard !filename.isEmpty,
+                  runtimeModel.availableModels.contains(where: { $0.filename == filename }),
+                  runtimeModel.selectedModelFilename != filename else {
+                return
+            }
+
+            Task {
+                await runtimeModel.selectModel(filename)
+            }
+        }
     }
 }

--- a/Cotabby/Models/SuggestionEngineModels.swift
+++ b/Cotabby/Models/SuggestionEngineModels.swift
@@ -33,6 +33,26 @@ enum SuggestionEngineKind: String, CaseIterable, Equatable, Hashable, Sendable, 
 
 }
 
+/// A per-power-source suggestion configuration: which engine to use and, for the local llama engine,
+/// which downloaded model file. Apple Intelligence carries no model file because the OS owns the
+/// model. Used by the power-based switching feature to pick an engine + model per power state, and as
+/// the single selection tag for the per-state pickers in Settings.
+enum PowerProfile: Equatable, Hashable {
+    case appleIntelligence
+    case llama(filename: String)
+
+    /// The engine this profile selects. Settings persists engine + filename separately, so this is
+    /// the bridge from those two stored fields to a single picker selection (and back).
+    var engine: SuggestionEngineKind {
+        switch self {
+        case .appleIntelligence:
+            return .appleIntelligence
+        case .llama:
+            return .llamaOpenSource
+        }
+    }
+}
+
 /// A user-authored app blocklist entry.
 ///
 /// The bundle identifier is the durable identity used by the suggestion pipeline. The display name

--- a/Cotabby/Models/SuggestionSettingsData.swift
+++ b/Cotabby/Models/SuggestionSettingsData.swift
@@ -59,6 +59,8 @@ struct SuggestionSettingsData: Equatable {
     var globalToggleKeyLabel: String
     var acceptanceGranularity: AcceptanceGranularity
     var isPowerBasedModelSwitchingEnabled: Bool
+    var batteryEngine: SuggestionEngineKind
     var batteryModelFilename: String
+    var pluggedInEngine: SuggestionEngineKind
     var pluggedInModelFilename: String
 }

--- a/Cotabby/Models/SuggestionSettingsModel.swift
+++ b/Cotabby/Models/SuggestionSettingsModel.swift
@@ -97,7 +97,9 @@ final class SuggestionSettingsModel: ObservableObject {
     @Published private(set) var globalToggleKeyLabel: String
     @Published private(set) var acceptanceGranularity: AcceptanceGranularity
     @Published private(set) var isPowerBasedModelSwitchingEnabled: Bool
+    @Published private(set) var batteryEngine: SuggestionEngineKind
     @Published private(set) var batteryModelFilename: String
+    @Published private(set) var pluggedInEngine: SuggestionEngineKind
     @Published private(set) var pluggedInModelFilename: String
 
     /// Owns the on-disk keys, defaults, migrations, and per-field writes. The facade holds one and
@@ -167,7 +169,9 @@ final class SuggestionSettingsModel: ObservableObject {
         globalToggleKeyLabel = data.globalToggleKeyLabel
         acceptanceGranularity = data.acceptanceGranularity
         isPowerBasedModelSwitchingEnabled = data.isPowerBasedModelSwitchingEnabled
+        batteryEngine = data.batteryEngine
         batteryModelFilename = data.batteryModelFilename
+        pluggedInEngine = data.pluggedInEngine
         pluggedInModelFilename = data.pluggedInModelFilename
     }
 
@@ -222,6 +226,15 @@ final class SuggestionSettingsModel: ObservableObject {
         store.savePowerBasedModelSwitchingEnabled(enabled)
     }
 
+    func setBatteryEngine(_ engine: SuggestionEngineKind) {
+        guard batteryEngine != engine else {
+            return
+        }
+
+        batteryEngine = engine
+        store.saveBatteryEngine(engine)
+    }
+
     func setBatteryModelFilename(_ filename: String) {
         guard batteryModelFilename != filename else {
             return
@@ -229,6 +242,15 @@ final class SuggestionSettingsModel: ObservableObject {
 
         batteryModelFilename = filename
         store.saveBatteryModelFilename(filename)
+    }
+
+    func setPluggedInEngine(_ engine: SuggestionEngineKind) {
+        guard pluggedInEngine != engine else {
+            return
+        }
+
+        pluggedInEngine = engine
+        store.savePluggedInEngine(engine)
     }
 
     func setPluggedInModelFilename(_ filename: String) {
@@ -240,21 +262,47 @@ final class SuggestionSettingsModel: ObservableObject {
         store.savePluggedInModelFilename(filename)
     }
 
-    /// Seeds the per-power-source model selections from the active model the first time the feature
-    /// is configured, so both pickers default to something valid instead of an empty selection.
-    func initializePowerModelSelections(currentModelFilename: String?) {
-        guard let currentModelFilename else {
-            return
+    /// The profile applied while on battery, assembled from the stored engine + model filename.
+    var batteryProfile: PowerProfile {
+        batteryEngine == .appleIntelligence ? .appleIntelligence : .llama(filename: batteryModelFilename)
+    }
+
+    /// The profile applied while plugged in, assembled from the stored engine + model filename.
+    var pluggedInProfile: PowerProfile {
+        pluggedInEngine == .appleIntelligence ? .appleIntelligence : .llama(filename: pluggedInModelFilename)
+    }
+
+    func setBatteryProfile(_ profile: PowerProfile) {
+        setBatteryEngine(profile.engine)
+        if case .llama(let filename) = profile {
+            setBatteryModelFilename(filename)
+        }
+    }
+
+    func setPluggedInProfile(_ profile: PowerProfile) {
+        setPluggedInEngine(profile.engine)
+        if case .llama(let filename) = profile {
+            setPluggedInModelFilename(filename)
+        }
+    }
+
+    /// Seeds each per-power-source profile from the active engine + model the first time the feature
+    /// is configured, so the pickers default to something valid instead of an empty selection. Only
+    /// seeds a profile still at its pristine default (Open Source with no model chosen), so an
+    /// explicit Apple Intelligence or model choice is never overwritten on a later appearance.
+    func initializePowerProfiles(currentEngine: SuggestionEngineKind, currentModelFilename: String?) {
+        if batteryEngine == .llamaOpenSource, batteryModelFilename.isEmpty {
+            setBatteryEngine(currentEngine)
+            if let currentModelFilename {
+                setBatteryModelFilename(currentModelFilename)
+            }
         }
 
-        if batteryModelFilename.isEmpty {
-            batteryModelFilename = currentModelFilename
-            store.saveBatteryModelFilename(currentModelFilename)
-        }
-
-        if pluggedInModelFilename.isEmpty {
-            pluggedInModelFilename = currentModelFilename
-            store.savePluggedInModelFilename(currentModelFilename)
+        if pluggedInEngine == .llamaOpenSource, pluggedInModelFilename.isEmpty {
+            setPluggedInEngine(currentEngine)
+            if let currentModelFilename {
+                setPluggedInModelFilename(currentModelFilename)
+            }
         }
     }
 

--- a/Cotabby/Services/Power/PowerSourceMonitor.swift
+++ b/Cotabby/Services/Power/PowerSourceMonitor.swift
@@ -4,21 +4,24 @@ import Foundation
 import IOKit.ps
 
 /// Tracks whether the Mac is currently drawing AC power and publishes changes for power-aware
-/// features (such as switching the local model on battery vs. plugged in).
+/// features (such as switching the engine/model on battery vs. plugged in).
 ///
-/// Lives on the main actor because `@Published` feeds SwiftUI and the wake observer is delivered on
-/// the main queue. State is refreshed at launch and on wake from sleep; live charger plug/unplug
-/// during an active session is not yet observed.
+/// Lives on the main actor because `@Published` feeds SwiftUI and both the IOKit run-loop callback
+/// and the wake observer are delivered on the main run loop / queue. Live charger plug/unplug is
+/// detected via an `IOPSNotificationCreateRunLoopSource`; the wake observer is a safety net for
+/// power changes that happen while the machine is asleep.
 @MainActor
 final class PowerSourceMonitor: ObservableObject {
     @Published private(set) var isPluggedIn = true
 
-    private var observer: NSObjectProtocol?
+    private var wakeObserver: NSObjectProtocol?
+    private var runLoopSource: CFRunLoopSource?
 
     init() {
         refreshPowerState()
+        startObservingPowerSourceChanges()
 
-        observer = NSWorkspace.shared.notificationCenter.addObserver(
+        wakeObserver = NSWorkspace.shared.notificationCenter.addObserver(
             forName: NSWorkspace.didWakeNotification,
             object: nil,
             queue: .main
@@ -28,9 +31,37 @@ final class PowerSourceMonitor: ObservableObject {
     }
 
     deinit {
-        if let observer {
-            NSWorkspace.shared.notificationCenter.removeObserver(observer)
+        if let wakeObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(wakeObserver)
         }
+
+        if let runLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), runLoopSource, .defaultMode)
+        }
+    }
+
+    /// Registers an IOKit run-loop source that fires whenever the providing power source changes, so
+    /// charger plug/unplug is picked up live during an active session rather than only at launch and
+    /// on wake. The C callback cannot capture context, so `self` is threaded through the opaque
+    /// pointer; the source is added to the main run loop, so the callback runs on the main actor.
+    private func startObservingPowerSourceChanges() {
+        let context = Unmanaged.passUnretained(self).toOpaque()
+
+        guard let source = IOPSNotificationCreateRunLoopSource({ rawContext in
+            guard let rawContext else {
+                return
+            }
+
+            let monitor = Unmanaged<PowerSourceMonitor>.fromOpaque(rawContext).takeUnretainedValue()
+            MainActor.assumeIsolated {
+                monitor.refreshPowerState()
+            }
+        }, context)?.takeRetainedValue() else {
+            return
+        }
+
+        runLoopSource = source
+        CFRunLoopAddSource(CFRunLoopGetMain(), source, .defaultMode)
     }
 
     func refreshPowerState() {

--- a/Cotabby/Support/SuggestionSettingsStore.swift
+++ b/Cotabby/Support/SuggestionSettingsStore.swift
@@ -103,7 +103,9 @@ struct SuggestionSettingsStore {
     private static let acceptanceGranularityDefaultsKey = "cotabbyAcceptanceGranularity"
 
     private static let powerModelSwitchingEnabledDefaultsKey = "cotabbyPowerBasedModelSwitchingEnabled"
+    private static let batteryEngineDefaultsKey = "cotabbyBatteryEngine"
     private static let batteryModelFilenameDefaultsKey = "cotabbyBatteryModelFilename"
+    private static let pluggedInEngineDefaultsKey = "cotabbyPluggedInEngine"
     private static let pluggedInModelFilenameDefaultsKey = "cotabbyPluggedInModelFilename"
 
     // MARK: - Load
@@ -289,7 +291,11 @@ struct SuggestionSettingsStore {
 
         let resolvedPowerBasedModelSwitchingEnabled =
             userDefaults.object(forKey: Self.powerModelSwitchingEnabledDefaultsKey) as? Bool ?? false
+        let resolvedBatteryEngine = userDefaults.string(forKey: Self.batteryEngineDefaultsKey)
+            .flatMap(SuggestionEngineKind.init(rawValue:)) ?? .llamaOpenSource
         let resolvedBatteryModelFilename = userDefaults.string(forKey: Self.batteryModelFilenameDefaultsKey) ?? ""
+        let resolvedPluggedInEngine = userDefaults.string(forKey: Self.pluggedInEngineDefaultsKey)
+            .flatMap(SuggestionEngineKind.init(rawValue:)) ?? .llamaOpenSource
         let resolvedPluggedInModelFilename = userDefaults.string(forKey: Self.pluggedInModelFilenameDefaultsKey) ?? ""
 
         let data = SuggestionSettingsData(
@@ -334,7 +340,9 @@ struct SuggestionSettingsStore {
             globalToggleKeyLabel: resolvedGlobalToggleKeyLabel,
             acceptanceGranularity: resolvedAcceptanceGranularity,
             isPowerBasedModelSwitchingEnabled: resolvedPowerBasedModelSwitchingEnabled,
+            batteryEngine: resolvedBatteryEngine,
             batteryModelFilename: resolvedBatteryModelFilename,
+            pluggedInEngine: resolvedPluggedInEngine,
             pluggedInModelFilename: resolvedPluggedInModelFilename
         )
 
@@ -386,7 +394,9 @@ struct SuggestionSettingsStore {
         )
         saveAcceptanceGranularity(data.acceptanceGranularity)
         savePowerBasedModelSwitchingEnabled(data.isPowerBasedModelSwitchingEnabled)
+        saveBatteryEngine(data.batteryEngine)
         saveBatteryModelFilename(data.batteryModelFilename)
+        savePluggedInEngine(data.pluggedInEngine)
         savePluggedInModelFilename(data.pluggedInModelFilename)
 
         // The custom indicator icon feature was removed; scrub any previously-persisted PNG so
@@ -443,8 +453,16 @@ struct SuggestionSettingsStore {
         userDefaults.set(enabled, forKey: Self.powerModelSwitchingEnabledDefaultsKey)
     }
 
+    func saveBatteryEngine(_ engine: SuggestionEngineKind) {
+        userDefaults.set(engine.rawValue, forKey: Self.batteryEngineDefaultsKey)
+    }
+
     func saveBatteryModelFilename(_ filename: String) {
         userDefaults.set(filename, forKey: Self.batteryModelFilenameDefaultsKey)
+    }
+
+    func savePluggedInEngine(_ engine: SuggestionEngineKind) {
+        userDefaults.set(engine.rawValue, forKey: Self.pluggedInEngineDefaultsKey)
     }
 
     func savePluggedInModelFilename(_ filename: String) {

--- a/Cotabby/UI/Settings/Panes/EngineAndModelPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/EngineAndModelPaneView.swift
@@ -41,6 +41,8 @@ struct EngineAndModelPaneView: View {
                 .pickerStyle(.menu)
             }
 
+            powerSection
+
             switch suggestionSettings.selectedEngine {
             case .appleIntelligence:
                 appleIntelligenceSections
@@ -51,7 +53,8 @@ struct EngineAndModelPaneView: View {
         .onAppear {
             foundationModelAvailabilityService.refresh()
 
-            suggestionSettings.initializePowerModelSelections(
+            suggestionSettings.initializePowerProfiles(
+                currentEngine: suggestionSettings.selectedEngine,
                 currentModelFilename: runtimeModel.selectedModelFilename
             )
 
@@ -74,6 +77,95 @@ struct EngineAndModelPaneView: View {
         } message: { model in
             Text("Remove \(model.displayName) from Cotabby's local models folder?")
         }
+    }
+
+    // MARK: - Power
+
+    /// Engine-level section (shown for any engine) that lets the user pick a different profile,
+    /// Apple Intelligence or a specific local model, for battery vs. plugged-in power. Apple
+    /// Intelligence is offered only when it is actually available on this Mac.
+    @ViewBuilder
+    private var powerSection: some View {
+        Section("Power") {
+            Toggle(
+                isOn: Binding(
+                    get: { suggestionSettings.isPowerBasedModelSwitchingEnabled },
+                    set: { suggestionSettings.setPowerBasedModelSwitchingEnabled($0) }
+                )
+            ) {
+                SettingsRowLabel(
+                    title: "Switch based on power source",
+                    description: "Use a different engine or model on battery vs. while plugged in. " +
+                        "For example, Apple Intelligence on battery to save power and a larger local " +
+                        "model while charging.",
+                    systemImage: "battery.100.bolt"
+                )
+            }
+
+            if suggestionSettings.isPowerBasedModelSwitchingEnabled {
+                powerProfilePicker(
+                    title: "On Battery",
+                    systemImage: "battery.25",
+                    selection: batteryProfileBinding
+                )
+
+                powerProfilePicker(
+                    title: "Plugged In",
+                    systemImage: "powerplug",
+                    selection: pluggedInProfileBinding
+                )
+            }
+        }
+    }
+
+    /// One per-power-source profile picker. Lists Apple Intelligence (only when available) plus every
+    /// installed local model, tagged by `PowerProfile` so a single selection carries engine + model.
+    @ViewBuilder
+    private func powerProfilePicker(
+        title: String,
+        systemImage: String,
+        selection: Binding<PowerProfile>
+    ) -> some View {
+        Picker(selection: selection) {
+            if foundationModelAvailabilityService.isAvailable {
+                Text("Apple Intelligence").tag(PowerProfile.appleIntelligence)
+            }
+
+            ForEach(runtimeModel.availableModels) { model in
+                Text(model.displayName).tag(PowerProfile.llama(filename: model.filename))
+            }
+        } label: {
+            SettingsRowLabel(
+                title: title,
+                description: "Engine and model to use while on this power source.",
+                systemImage: systemImage
+            )
+        }
+        .pickerStyle(.menu)
+    }
+
+    private var batteryProfileBinding: Binding<PowerProfile> {
+        Binding(
+            get: { powerProfileForDisplay(suggestionSettings.batteryProfile) },
+            set: { suggestionSettings.setBatteryProfile($0) }
+        )
+    }
+
+    private var pluggedInProfileBinding: Binding<PowerProfile> {
+        Binding(
+            get: { powerProfileForDisplay(suggestionSettings.pluggedInProfile) },
+            set: { suggestionSettings.setPluggedInProfile($0) }
+        )
+    }
+
+    /// Falls a not-yet-chosen local profile back to the currently selected model so the picker shows
+    /// a concrete row instead of an empty selection, mirroring the primary model picker's fallback.
+    private func powerProfileForDisplay(_ profile: PowerProfile) -> PowerProfile {
+        if case .llama(let filename) = profile, filename.isEmpty {
+            return .llama(filename: runtimeModel.selectedModelFilename ?? "")
+        }
+
+        return profile
     }
 
     // MARK: - Apple Intelligence
@@ -130,55 +222,6 @@ struct EngineAndModelPaneView: View {
                             "Larger models are slower but write better.",
                         systemImage: "shippingbox"
                     )
-                }
-            }
-
-            Toggle(
-                isOn: Binding(
-                    get: { suggestionSettings.isPowerBasedModelSwitchingEnabled },
-                    set: { suggestionSettings.setPowerBasedModelSwitchingEnabled($0) }
-                )
-            ) {
-                SettingsRowLabel(
-                    title: "Switch models based on power source",
-                    description: "Use different models when running on battery or while plugged in.",
-                    systemImage: "battery.100"
-                )
-            }
-
-            if suggestionSettings.isPowerBasedModelSwitchingEnabled {
-                Picker(
-                    "Battery Model",
-                    selection: Binding(
-                        get: {
-                            suggestionSettings.batteryModelFilename.isEmpty
-                                ? (runtimeModel.selectedModelFilename ?? "")
-                                : suggestionSettings.batteryModelFilename
-                        },
-                        set: { suggestionSettings.setBatteryModelFilename($0) }
-                    )
-                ) {
-                    ForEach(runtimeModel.availableModels) { model in
-                        Text(model.displayName)
-                            .tag(model.filename)
-                    }
-                }
-
-                Picker(
-                    "Plugged-in Model",
-                    selection: Binding(
-                        get: {
-                            suggestionSettings.pluggedInModelFilename.isEmpty
-                                ? (runtimeModel.selectedModelFilename ?? "")
-                                : suggestionSettings.pluggedInModelFilename
-                        },
-                        set: { suggestionSettings.setPluggedInModelFilename($0) }
-                    )
-                ) {
-                    ForEach(runtimeModel.availableModels) { model in
-                        Text(model.displayName)
-                            .tag(model.filename)
-                    }
                 }
             }
 

--- a/CotabbyTests/SuggestionSettingsStoreTests.swift
+++ b/CotabbyTests/SuggestionSettingsStoreTests.swift
@@ -182,6 +182,49 @@ final class SuggestionSettingsStoreTests: XCTestCase {
         XCTAssertEqual(data.ghostTextOpacity, SuggestionSettingsStore.minimumGhostTextOpacity, accuracy: 0.0001)
     }
 
+    // MARK: - Power-based switching profiles
+
+    func test_load_powerProfileEnginesDefaultToOpenSourceWhenAbsent() async {
+        let defaults = makeIsolatedDefaults()
+
+        let data = SuggestionSettingsStore(userDefaults: defaults).load(configuration: .standard)
+
+        // A fresh install has no per-power-source engine stored: both default to Open Source so the
+        // pre-engine behavior (local model switching only) is preserved.
+        XCTAssertEqual(data.batteryEngine, .llamaOpenSource)
+        XCTAssertEqual(data.pluggedInEngine, .llamaOpenSource)
+    }
+
+    func test_saveThenLoad_roundTripsPowerProfileEngines() async {
+        let defaults = makeIsolatedDefaults()
+        let store = SuggestionSettingsStore(userDefaults: defaults)
+
+        store.saveBatteryEngine(.appleIntelligence)
+        store.savePluggedInEngine(.llamaOpenSource)
+        store.savePluggedInModelFilename("big-model.gguf")
+
+        let data = store.load(configuration: .standard)
+
+        XCTAssertEqual(data.batteryEngine, .appleIntelligence)
+        XCTAssertEqual(data.pluggedInEngine, .llamaOpenSource)
+        XCTAssertEqual(data.pluggedInModelFilename, "big-model.gguf")
+    }
+
+    func test_load_legacyModelOnlyProfilePreservedWithOpenSourceEngine() async {
+        let defaults = makeIsolatedDefaults()
+        // A user upgrading from the model-only release has filenames but no engine keys. The model
+        // selections must survive and the engine must resolve to Open Source so their setup is intact.
+        defaults.set("small-model.gguf", forKey: "cotabbyBatteryModelFilename")
+        defaults.set("big-model.gguf", forKey: "cotabbyPluggedInModelFilename")
+
+        let data = SuggestionSettingsStore(userDefaults: defaults).load(configuration: .standard)
+
+        XCTAssertEqual(data.batteryEngine, .llamaOpenSource)
+        XCTAssertEqual(data.batteryModelFilename, "small-model.gguf")
+        XCTAssertEqual(data.pluggedInEngine, .llamaOpenSource)
+        XCTAssertEqual(data.pluggedInModelFilename, "big-model.gguf")
+    }
+
     // MARK: - helpers
 
     /// Each store test gets its own isolated UserDefaults so state cannot leak between cases.


### PR DESCRIPTION
## Summary

Extends power-based switching (#630) so each power source selects a full profile (engine + model) instead of only a local model file. Users can run Apple Intelligence on battery to save power and a larger local model while plugged in, and charger plug/unplug is now detected live during a session.

## Validation

Built, linted, and tested locally on macOS (repo-scoped DerivedData):

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  build -derivedDataPath build/DerivedData
# ** BUILD SUCCEEDED **

swiftlint lint --strict --quiet
# exit 0, 0 violations

xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  -only-testing:CotabbyTests/SuggestionSettingsStoreTests \
  CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
# ** TEST SUCCEEDED **  17 tests, 0 failures (incl. 3 new power-profile cases)
```

Not verified end-to-end yet: live AC/battery transitions on hardware (no easy way to script charger plug/unplug). The IOKit notification path is wired but unobserved in a real session, so it is worth a manual QA pass.

## Linked issues

Refs #619. Builds on #630.

## Risk / rollout notes

- Settings persistence: adds two keys (`cotabbyBatteryEngine`, `cotabbyPluggedInEngine`). Both resolve to Open Source when absent, so existing users from #630 keep their model-only switching unchanged (covered by a new backward-compat test).
- Behavior change: when the feature is enabled, the active engine + model is driven by the current power source, so the primary Engine / Selected Model pickers reflect that active selection and can change as power changes. With the feature off, nothing changes.
- Apple Intelligence is offered in the per-state pickers and applied only when `FoundationModelAvailabilityService` reports it available, so a configured-but-unavailable profile never strands the user on a dead engine.
- Local model switches still reload the runtime (multi-second), as in #630; switching to or from Apple Intelligence is effectively free. Per the "not mid-completion" note in #619, a local reload can still land mid-session on a power transition, but choosing Apple Intelligence on battery avoids the reload entirely.
- No `project.yml` / pbxproj changes (no new files added).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends power-based switching so each power source selects a full profile (engine + model) rather than just a local model file, and adds live charger plug/unplug detection via an IOKit run-loop source.

- **`PowerSourceMonitor`** gains an `IOPSNotificationCreateRunLoopSource` callback wired to the main run loop; the `Unmanaged.passUnretained` pattern is safe because `deinit` removes the source before deallocation and both paths serialize on the main actor.
- **`applyPowerProfile`** re-evaluates the active engine + model on any of seven triggers, but `selectEngine(.llamaOpenSource)` is called before the filename and model-availability guards, so an empty or uninstalled llama profile can switch the engine away from Apple Intelligence with no model to fall back to.
- **`SuggestionSettingsStore`** adds two new UserDefaults keys with `llamaOpenSource` as the absent-key default, preserving existing behavior for users upgrading from #630.

<h3>Confidence Score: 3/5</h3>

The core power-profile wiring and persistence are solid, but the ordering of engine switching vs. model guards in `applyPowerProfile` can silently move an Apple Intelligence user to a non-functional Open Source engine state.

The `selectEngine(.llamaOpenSource)` call happens unconditionally before the filename and model-availability guards. When the llama profile has an empty filename or the model is uninstalled, the engine is persisted to Open Source with no model loaded, leaving a user who had Apple Intelligence active on a dead engine until another trigger fires. The fix is a one-line reordering. The rest of the change is well-structured.

Cotabby/App/Core/CotabbyAppEnvironment.swift — specifically the `applyPowerProfile` static method and the trigger list in `observePowerSourceProfileSwitching`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/App/Core/CotabbyAppEnvironment.swift | Replaces a simple `powerSourceMonitor.$isPluggedIn` sink with a MergeMany of seven triggers and extracts `applyPowerProfile` as a static helper. Engine switching is called before the filename/model-availability guards in the `.llama` branch, which can silently change the active engine to Open Source with no model loaded. |
| Cotabby/Services/Power/PowerSourceMonitor.swift | Adds live charger plug/unplug detection via `IOPSNotificationCreateRunLoopSource`. The `Unmanaged.passUnretained` pattern is safe because `deinit` removes the run-loop source before deallocation and both paths serialize on the main actor. |
| Cotabby/Models/SuggestionSettingsModel.swift | Adds `batteryEngine`/`pluggedInEngine` published properties, derived profile computed vars, and `setBatteryProfile`/`setPluggedInProfile` convenience mutators. Logic is clear and idempotent. |
| Cotabby/Support/SuggestionSettingsStore.swift | Adds two new UserDefaults keys with `llamaOpenSource` as the absent-key default for backward compatibility. Persistence round-trip confirmed by new tests. |
| Cotabby/UI/Settings/Panes/EngineAndModelPaneView.swift | Moves power toggle into a top-level `powerSection`, replaces raw filename pickers with `powerProfilePicker` using `PowerProfile` tags. The `powerProfileForDisplay` fallback can produce `.llama(filename: "")` when no models are installed, yielding an unmatched picker selection. |
| CotabbyTests/SuggestionSettingsStoreTests.swift | Adds three tests covering defaults, round-trip persistence, and backward compatibility with the model-only release. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Trigger fires] --> B[MergeMany 7 publishers]
    B --> C{isPowerBasedModelSwitchingEnabled?}
    C -- No --> Z[No-op return]
    C -- Yes --> D{isPluggedIn?}
    D -- Yes --> E[pluggedInProfile]
    D -- No --> F[batteryProfile]
    E --> G{profile case}
    F --> G
    G -- appleIntelligence --> H{isAvailable?}
    H -- No --> Z
    H -- Yes --> I[selectEngine appleIntelligence]
    G -- llama filename --> J[selectEngine llamaOpenSource called before guards]
    J --> K{filename empty or model not installed?}
    K -- Yes --> Z
    K -- No --> L{already selected?}
    L -- Yes --> Z
    L -- No --> M[Task: runtimeModel.selectModel]
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fpower-aware-engine-profiles%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fpower-aware-engine-profiles%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0ACotabby%2FApp%2FCore%2FCotabbyAppEnvironment.swift%3A352-363%0A%60selectEngine%28.llamaOpenSource%29%60%20is%20called%20unconditionally%20before%20the%20filename%20and%20model-availability%20guards.%20If%20the%20llama%20profile%20has%20an%20empty%20filename%20%28e.g.%2C%20all%20local%20models%20were%20uninstalled%2C%20or%20the%20profile%20was%20never%20fully%20seeded%29%20the%20engine%20still%20switches%20to%20%60llamaOpenSource%60%20and%20the%20change%20is%20persisted%20via%20%60store.saveSelectedEngine%60.%20The%20subsequent%20%60return%60%20only%20prevents%20the%20model%20load%2C%20leaving%20the%20engine%20changed%20but%20no%20model%20loaded%20%E2%80%94%20so%20a%20user%20who%20was%20on%20Apple%20Intelligence%20gets%20silently%20stranded%20on%20a%20non-functional%20Open%20Source%20engine%20until%20another%20trigger%20fires%20and%20a%20model%20becomes%20available.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20case%20.llama%28let%20filename%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20guard%20!filename.isEmpty%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20runtimeModel.availableModels.contains%28where%3A%20%7B%20%240.filename%20%3D%3D%20filename%20%7D%29%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20suggestionSettings.selectEngine%28.llamaOpenSource%29%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20guard%20runtimeModel.selectedModelFilename%20!%3D%20filename%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20Task%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20await%20runtimeModel.selectModel%28filename%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0ACotabby%2FApp%2FCore%2FCotabbyAppEnvironment.swift%3A302-312%0A%60FoundationModelAvailabilityService%60%20availability%20is%20not%20observed%20as%20a%20trigger.%20If%20%60refresh%28%29%60%20%28called%20in%20%60onAppear%60%29%20completes%20asynchronously%20and%20updates%20%60isAvailable%60%20to%20%60true%60%20after%20the%20initial%20subscription%20fires%2C%20%60applyPowerProfile%60%20won't%20be%20re-evaluated%20until%20another%20trigger%20fires%20%E2%80%94%20meaning%20a%20user%20with%20Apple%20Intelligence%20configured%20as%20their%20active%20power-source%20profile%20won't%20have%20it%20applied%20until%20they%20plug%20or%20unplug%20the%20charger.%20Adding%20%60foundationModelAvailabilityService.%24isAvailable.map%20%7B%20_%20in%20%28%29%20%7D.eraseToAnyPublisher%28%29%60%20to%20the%20%60triggers%60%20array%20would%20ensure%20the%20profile%20is%20re-applied%20immediately%20when%20availability%20is%20resolved.%0A%0A%23%23%23%20Issue%203%20of%203%0ACotabby%2FUI%2FSettings%2FPanes%2FEngineAndModelPaneView.swift%3A161-167%0AIf%20%60runtimeModel.selectedModelFilename%60%20is%20%60nil%60%20%28no%20models%20installed%29%20and%20%60batteryModelFilename%60%20is%20empty%2C%20%60powerProfileForDisplay%60%20returns%20%60.llama%28filename%3A%20%22%22%29%60.%20The%20picker's%20%60ForEach%60%20only%20produces%20rows%20for%20items%20in%20%60availableModels%60%20and%20none%20will%20have%20an%20empty%20filename%2C%20so%20the%20%60Binding.get%60%20value%20matches%20no%20picker%20row.%20SwiftUI%20renders%20the%20picker%20with%20a%20blank%20or%20stale%20selection%2C%20which%20is%20confusing.%20Consider%20returning%20%60.appleIntelligence%60%20as%20the%20fallback%20when%20no%20local%20model%20is%20available%2C%20or%20hiding%20the%20per-state%20pickers%20until%20at%20least%20one%20model%20%28or%20AI%29%20is%20usable.%0A%0A&repo=fujacob%2Fcotabby&pr=637&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0ACotabby%2FApp%2FCore%2FCotabbyAppEnvironment.swift%3A352-363%0A%60selectEngine%28.llamaOpenSource%29%60%20is%20called%20unconditionally%20before%20the%20filename%20and%20model-availability%20guards.%20If%20the%20llama%20profile%20has%20an%20empty%20filename%20%28e.g.%2C%20all%20local%20models%20were%20uninstalled%2C%20or%20the%20profile%20was%20never%20fully%20seeded%29%20the%20engine%20still%20switches%20to%20%60llamaOpenSource%60%20and%20the%20change%20is%20persisted%20via%20%60store.saveSelectedEngine%60.%20The%20subsequent%20%60return%60%20only%20prevents%20the%20model%20load%2C%20leaving%20the%20engine%20changed%20but%20no%20model%20loaded%20%E2%80%94%20so%20a%20user%20who%20was%20on%20Apple%20Intelligence%20gets%20silently%20stranded%20on%20a%20non-functional%20Open%20Source%20engine%20until%20another%20trigger%20fires%20and%20a%20model%20becomes%20available.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20case%20.llama%28let%20filename%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20guard%20!filename.isEmpty%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20runtimeModel.availableModels.contains%28where%3A%20%7B%20%240.filename%20%3D%3D%20filename%20%7D%29%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20suggestionSettings.selectEngine%28.llamaOpenSource%29%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20guard%20runtimeModel.selectedModelFilename%20!%3D%20filename%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20Task%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20await%20runtimeModel.selectModel%28filename%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0ACotabby%2FApp%2FCore%2FCotabbyAppEnvironment.swift%3A302-312%0A%60FoundationModelAvailabilityService%60%20availability%20is%20not%20observed%20as%20a%20trigger.%20If%20%60refresh%28%29%60%20%28called%20in%20%60onAppear%60%29%20completes%20asynchronously%20and%20updates%20%60isAvailable%60%20to%20%60true%60%20after%20the%20initial%20subscription%20fires%2C%20%60applyPowerProfile%60%20won't%20be%20re-evaluated%20until%20another%20trigger%20fires%20%E2%80%94%20meaning%20a%20user%20with%20Apple%20Intelligence%20configured%20as%20their%20active%20power-source%20profile%20won't%20have%20it%20applied%20until%20they%20plug%20or%20unplug%20the%20charger.%20Adding%20%60foundationModelAvailabilityService.%24isAvailable.map%20%7B%20_%20in%20%28%29%20%7D.eraseToAnyPublisher%28%29%60%20to%20the%20%60triggers%60%20array%20would%20ensure%20the%20profile%20is%20re-applied%20immediately%20when%20availability%20is%20resolved.%0A%0A%23%23%23%20Issue%203%20of%203%0ACotabby%2FUI%2FSettings%2FPanes%2FEngineAndModelPaneView.swift%3A161-167%0AIf%20%60runtimeModel.selectedModelFilename%60%20is%20%60nil%60%20%28no%20models%20installed%29%20and%20%60batteryModelFilename%60%20is%20empty%2C%20%60powerProfileForDisplay%60%20returns%20%60.llama%28filename%3A%20%22%22%29%60.%20The%20picker's%20%60ForEach%60%20only%20produces%20rows%20for%20items%20in%20%60availableModels%60%20and%20none%20will%20have%20an%20empty%20filename%2C%20so%20the%20%60Binding.get%60%20value%20matches%20no%20picker%20row.%20SwiftUI%20renders%20the%20picker%20with%20a%20blank%20or%20stale%20selection%2C%20which%20is%20confusing.%20Consider%20returning%20%60.appleIntelligence%60%20as%20the%20fallback%20when%20no%20local%20model%20is%20available%2C%20or%20hiding%20the%20per-state%20pickers%20until%20at%20least%20one%20model%20%28or%20AI%29%20is%20usable.%0A%0A&repo=fujacob%2Fcotabby&pr=637&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(runtime): per-power-source engine +..."](https://github.com/fujacob/cotabby/commit/2328d584e19bcfd460aa826049ab1823363da90a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36104849)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->