### PR TITLE
docs: rewrite README for a non-technical audience

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <h1 align="center">Cotabby [beta]</h1>
 
-<p align="center"><em>Open-source, local AI autocomplete for macOS - an AI-native productivity layer for everything you type.</em></p>
+<p align="center"><em>Open-source, on-device AI autocomplete for macOS — it finishes your sentences in almost any text field, with nothing sent to the cloud.</em></p>
 
 <p align="center">
   <a href="https://cotabby.app">
@@ -34,18 +34,18 @@
 </p>
 
 <p align="center">
-  <sub>Cotabby is free and open-source - maintained by two students. If it's useful to you, please consider supporting Cotabby's future.</sub>
+  <sub>Cotabby is free and open-source — maintained by two students. If it's useful to you, please consider supporting Cotabby's future.</sub>
 </p>
 
 ---
 
 ## What It Does
 
-Cotabby shows AI suggestions as ghost text in any macOS text field. Press `Tab` to accept, or keep typing to ignore.
+Cotabby adds AI autocomplete to almost any text field on your Mac. As you type, a gray suggestion appears inline next to your cursor — press `Tab` to accept it a word at a time, or just keep typing to ignore it.
 
-It also does inline `:emoji:` autocomplete, `/` macros (math, unit and currency conversion, dates), and autocorrect that fixes typos with one keystroke.
+It also does inline `:emoji:` autocomplete, `/` macros (quick math, unit and currency conversion, dates), and one-key autocorrect for typos.
 
-Everything runs on-device. No hosted API, no cloud round-trip.
+Everything runs on your Mac. No account, no cloud, no telemetry.
 
 ## Demo
 
@@ -64,37 +64,65 @@ Everything runs on-device. No hosted API, no cloud round-trip.
 
 ## Features
 
-- **Ghost-text autocomplete** -- Inline AI suggestions in any macOS text field; `Tab` to accept
-- **Emoji autocomplete** -- Type `:emoji:` and insert without leaving the field
-- **Inline macros** -- `/` for math, unit and currency conversion, dates, and random values
-- **Autocorrect** -- One-key fixes for likely typos
-- **Two engines** -- Apple Intelligence or local models via llama.cpp
-- **Personalize** -- Name, languages, length, and per-app control
-- **100% local** -- Everything runs on-device
-- **Visual context** -- Optional screenshot OCR for on-screen awareness
+- **Ghost-text autocomplete** — AI suggestions inline in almost any macOS text field; `Tab` accepts a word at a time
+- **Emoji autocomplete** — type `:rocket:` and accept it without leaving the field
+- **Inline macros** — type `/` for quick math, unit and currency conversion, dates, and random values
+- **One-key autocorrect** — fix a likely typo with a single keystroke
+- **Two engines** — Apple Intelligence, or a small model you download and run locally
+- **Make it yours** — set your name, languages, and suggestion length, and turn Cotabby off per app
+- **Screen-aware (optional)** — can read the area around your cursor so suggestions fit what's on screen
+- **100% on-device** — no account, no cloud, no telemetry
+
+## Privacy
+
+Privacy is the whole point — everything that produces a suggestion happens on your Mac:
+
+- All AI runs on-device. There's no hosted API and no cloud round-trip.
+- No analytics, no telemetry, no crash reporting.
+- A normal install never writes what you type to disk.
+- The network is used only to download a model you pick and to check for updates — never to send your text, your screen, or your suggestions anywhere.
 
 ## Engines
 
-**Apple Intelligence**: uses Apple's on-device `FoundationModels` runtime on macOS 26 or later, no download required.
+Cotabby generates suggestions one of two ways. You choose which in Settings → Engine:
 
-**Open Source**: runs local GGUF *base* models in-process through llama.cpp via `CotabbyInference`. Rather than instructing an instruction-tuned model, Cotabby treats the model as a pure text continuer and conditions it on your persona, style, language, and on-screen context. Cotabby ships with four built-in downloadable models:
+- **Apple Intelligence** — Apple's model, built into macOS 26 or later on supported Macs. Nothing to download.
+- **Open Source** — a small AI model you download that runs entirely on your Mac. Works on any supported Mac (macOS 14+), with or without Apple Intelligence.
 
-| Model          | File                             | Size    | Source                                                                                                  |
-| -------------- | -------------------------------- | ------- | ------------------------------------------------------------------------------------------------------- |
-| `tabby-2-nano` | `Qwen3.5-0.8B-Base.i1-Q6_K.gguf` | ~0.8 GB | [Link](https://huggingface.co/mradermacher/Qwen3.5-0.8B-Base-i1-GGUF) |
-| `tabby-2-mini` | `Qwen3.5-2B-Base.i1-Q4_K_M.gguf` | ~1.4 GB | [Link](https://huggingface.co/mradermacher/Qwen3.5-2B-Base-i1-GGUF)     |
-| `tabby-2-base` | `gemma-4-E2B.i1-Q6_K.gguf`       | ~4.5 GB | [Link](https://huggingface.co/mradermacher/gemma-4-E2B-i1-GGUF)             |
-| `tabby-2-pro`  | `gemma-4-E4B.i1-Q4_K_M.gguf`     | ~5.0 GB | [Link](https://huggingface.co/mradermacher/gemma-4-E4B-i1-GGUF)             |
+If your Mac supports Apple Intelligence, that's the easiest place to start. Otherwise, use the Open Source engine and pick one of the built-in models:
 
-### Bring your own model
+| Model          | Size    | Good for                          |
+| -------------- | ------- | --------------------------------- |
+| `tabby-2-nano` | ~0.8 GB | Older or low-memory Macs; fastest |
+| `tabby-2-mini` | ~1.4 GB | A solid everyday balance          |
+| `tabby-2-base` | ~4.5 GB | Higher-quality suggestions        |
+| `tabby-2-pro`  | ~5.0 GB | Best quality                      |
 
-Any GGUF small enough to run on-device works. Drop a `.gguf` file into Cotabby's models folder and refresh the model list from the menu bar.
+Download any of them straight from Cotabby's menu bar.
 
-Browse the [unsloth GGUF collection on Hugging Face](https://huggingface.co/unsloth) for more variants. Smaller quants (`Q3_K_M`, `Q4_K_S`) trade quality for size; larger models give better completions at the cost of memory and per-token latency.
+<details>
+<summary><strong>Advanced:</strong> model files, custom models, and how generation works</summary>
+
+<br />
+
+Under the hood, the Open Source engine runs local GGUF *base* models in-process through [llama.cpp](https://github.com/ggerganov/llama.cpp) (via [CotabbyInference](https://github.com/FuJacob/cotabbyinference)). Instead of prompting an instruction-tuned chat model, Cotabby treats the model as a pure text continuer and conditions it on your name, writing style, language, and on-screen context.
+
+| Model          | File                             | Size    | Source                                                                       |
+| -------------- | -------------------------------- | ------- | ---------------------------------------------------------------------------- |
+| `tabby-2-nano` | `Qwen3.5-0.8B-Base.i1-Q6_K.gguf` | ~0.8 GB | [Hugging Face](https://huggingface.co/mradermacher/Qwen3.5-0.8B-Base-i1-GGUF) |
+| `tabby-2-mini` | `Qwen3.5-2B-Base.i1-Q4_K_M.gguf` | ~1.4 GB | [Hugging Face](https://huggingface.co/mradermacher/Qwen3.5-2B-Base-i1-GGUF)   |
+| `tabby-2-base` | `gemma-4-E2B.i1-Q6_K.gguf`       | ~4.5 GB | [Hugging Face](https://huggingface.co/mradermacher/gemma-4-E2B-i1-GGUF)       |
+| `tabby-2-pro`  | `gemma-4-E4B.i1-Q4_K_M.gguf`     | ~5.0 GB | [Hugging Face](https://huggingface.co/mradermacher/gemma-4-E4B-i1-GGUF)       |
+
+**Bring your own model.** Any GGUF small enough to run on-device works. Drop a `.gguf` file into Cotabby's models folder and refresh the model list from the menu bar. Browse the [unsloth GGUF collection](https://huggingface.co/unsloth) for more variants — smaller quants (`Q3_K_M`, `Q4_K_S`) trade quality for size; larger models give better completions at the cost of memory and per-token latency.
+
+For the full suggestion pipeline, see [ARCHITECTURE.md](ARCHITECTURE.md).
+
+</details>
 
 ## Install
 
-**Compatibility:** Requires macOS 14.0 or later. Apple Intelligence suggestions require macOS 26 or later; on earlier supported systems, use the Open Source engine.
+**Compatibility:** macOS 14.0 or later. The Apple Intelligence engine needs macOS 26 or later on a supported Mac; on older systems, use the Open Source engine.
 
 ### Homebrew
 
@@ -103,17 +131,31 @@ brew tap FuJacob/cotabby
 brew install --cask cotabby
 ```
 
-Upgrade later with `brew upgrade --cask cotabby`. The tap repo is [FuJacob/homebrew-cotabby](https://github.com/FuJacob/homebrew-cotabby).
+Upgrade later with `brew upgrade --cask cotabby`. The tap lives at [FuJacob/homebrew-cotabby](https://github.com/FuJacob/homebrew-cotabby).
 
 ### Manual download
 
-Download and install the latest release from [cotabby.app](https://cotabby.app).
+Grab the latest release from [cotabby.app](https://cotabby.app) and drag Cotabby into your Applications folder.
 
-### Why those permissions?
+## Using Cotabby
 
-- **Accessibility**: read the focused text field's value and caret position.
-- **Input Monitoring**: detect global `Tab` presses, acceptance shortcuts, and inline emoji triggers.
-- **Screen Recording**: capture a screenshot around the focused field for visual context (OCR).
+Start typing in almost any text field. When a gray suggestion appears:
+
+- **`Tab`** — accept the next word. (Prefer whole phrases? Switch this in Settings → Acceptance Mode.)
+- **`` ` `` (backtick)** — accept the entire suggestion at once.
+- **`Esc`**, or just keep typing — dismiss it.
+
+Every shortcut is rebindable under Settings → Shortcuts.
+
+## Permissions
+
+Cotabby works inside other apps, so macOS asks for a few permissions. Each one maps to a specific feature, and Cotabby walks you through them on first launch:
+
+- **Accessibility** — read the text and cursor position in the field you're typing in, and insert what you accept.
+- **Input Monitoring** — notice your typing so it knows when to suggest, and detect the accept keys.
+- **Screen Recording** *(optional)* — capture the area around your cursor for visual context. Leave it off and everything else still works.
+
+Cotabby never reads password or other secure fields.
 
 ## Local Development
 


### PR DESCRIPTION
## What & why

Feedback we got: the README reads as too technical. The primary audience on this page is the 6000+ people deciding whether to install — not contributors. This pass keeps the layout, badges, and CTAs (download + support stay up top) and rewrites the prose to be user-first.

## Changes

- **Engines section de-jargoned.** Leads with the plain choice — *Apple Intelligence* vs *Open Source* — plus a model table with a "Good for" column. GGUF/llama.cpp internals, raw model filenames, quant notes, and bring-your-own are moved into a collapsed `<details>` for power users. Engine labels still match the in-app Settings wording.
- **Keyboard model fixed (correctness).** The old copy implied `Tab` accepts the whole suggestion. It accepts the *next word*; backtick accepts the whole thing; `Esc` dismisses. Added a short **Using Cotabby** section spelling this out.
- **New Privacy section** — on-device, no telemetry, no disk writes, network only for model downloads + update checks.
- **Features de-jargoned** — dropped "via llama.cpp", "OCR", "on-screen awareness".
- **Permissions** — noted Screen Recording is optional (#633) and that secure fields are never read.
- **Typography** — spaced hyphens / `--` → em-dashes.

## Open question

- The Ko-fi link here is `ko-fi.com/I2F22066MI`; the landing site uses `ko-fi.com/cotabby`. Left as-is to avoid touching a payment link — worth unifying if they're the same account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR rewrites `README.md` to prioritize the non-technical installer audience: it de-jargons the Engines section, adds Privacy and Using Cotabby sections, collapses GGUF/llama.cpp internals behind a `<details>` block, and corrects the keyboard model (Tab → next word, backtick → whole suggestion).

- The keyboard shortcut correction (Tab accepts a word, not the whole suggestion) is a genuine accuracy fix that matches the `acceptCurrentSuggestion()` implementation.
- Two Settings navigation paths in the new prose point to panel names that don't match the app's sidebar: `Settings → Engine` (actual label: **Engine & Model**) and `Settings → Acceptance Mode` (a picker inside **Shortcuts**, not its own pane).

<h3>Confidence Score: 3/5</h3>

The README rewrite is largely accurate and well-structured, but two navigation instructions direct users to Settings panel names that don't match the app UI.

The prose and keyboard model corrections are solid. However, two user-facing navigation paths ("Settings → Engine" and "Settings → Acceptance Mode") reference labels that don't exist in the Settings sidebar — the actual panels are "Engine & Model" and "Shortcuts" respectively. Users who follow these instructions verbatim will be confused when they don't find the named panel.

README.md — specifically the "Engines" and "Using Cotabby" sections where Settings navigation paths are specified.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Non-technical rewrite of the README: de-jargoned engines section with a collapsed advanced details block, new Privacy and Using Cotabby sections, corrected Tab/backtick keyboard model. Two Settings navigation paths reference incorrect panel names ("Engine" vs "Engine & Model"; "Acceptance Mode" instead of "Shortcuts"). |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User opens Settings] --> B{Engine choice}
    B -->|macOS 26+ / Apple Silicon| C[Apple Intelligence]
    B -->|macOS 14+, any Mac| D[Open Source Engine]
    D --> E{Pick a model}
    E --> F[tabby-2-nano ~0.8 GB]
    E --> G[tabby-2-mini ~1.4 GB]
    E --> H[tabby-2-base ~4.5 GB]
    E --> I[tabby-2-pro ~5.0 GB]
    E --> J[Bring Your Own GGUF]

    subgraph Suggestion Flow
        K[User types] --> L{Suggestion appears?}
        L -->|Yes| M[Tab: accept next word]
        L -->|Yes| N[Backtick: accept whole suggestion]
        L -->|Yes| O[Esc / keep typing: dismiss]
        L -->|No| K
    end
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22docs%2Freadme-clarity%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Freadme-clarity%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0AREADME.md%3A87%0AThe%20Settings%20sidebar%20label%20for%20the%20engine%20pane%20is%20**%22Engine%20%26%20Model%22**%20%28see%20%60SettingsCategory.engineAndModel%60%20%E2%86%92%20%60%22Engine%20%26%20Model%22%60%20in%20%60SettingsCategory.swift%60%29%2C%20not%20just%20%22Engine%22.%20A%20user%20following%20this%20navigation%20path%20will%20scan%20the%20sidebar%20for%20a%20pane%20called%20%22Engine%22%20and%20may%20not%20find%20it%20immediately.%0A%0A%60%60%60suggestion%0ACotabby%20generates%20suggestions%20one%20of%20two%20ways.%20You%20choose%20which%20in%20Settings%20%E2%86%92%20Engine%20%26%20Model%3A%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0AREADME.md%3A144%0A%22Acceptance%20Mode%22%20is%20not%20a%20top-level%20Settings%20pane%20%E2%80%94%20it's%20a%20picker%20control%20inside%20the%20**%22Shortcuts%22**%20pane%20%28%60AcceptanceModePickerView%60%20is%20rendered%20by%20%60ShortcutsPaneView%60%29.%20Users%20following%20%22Settings%20%E2%86%92%20Acceptance%20Mode%22%20will%20look%20for%20a%20sidebar%20entry%20that%20doesn't%20exist.%20The%20correct%20navigation%20is%20%22Settings%20%E2%86%92%20Shortcuts%22.%0A%0A%60%60%60suggestion%0A-%20**%60Tab%60**%20%E2%80%94%20accept%20the%20next%20word.%20%28Prefer%20whole%20phrases%3F%20Switch%20this%20in%20Settings%20%E2%86%92%20Shortcuts.%29%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=638&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0AREADME.md%3A87%0AThe%20Settings%20sidebar%20label%20for%20the%20engine%20pane%20is%20**%22Engine%20%26%20Model%22**%20%28see%20%60SettingsCategory.engineAndModel%60%20%E2%86%92%20%60%22Engine%20%26%20Model%22%60%20in%20%60SettingsCategory.swift%60%29%2C%20not%20just%20%22Engine%22.%20A%20user%20following%20this%20navigation%20path%20will%20scan%20the%20sidebar%20for%20a%20pane%20called%20%22Engine%22%20and%20may%20not%20find%20it%20immediately.%0A%0A%60%60%60suggestion%0ACotabby%20generates%20suggestions%20one%20of%20two%20ways.%20You%20choose%20which%20in%20Settings%20%E2%86%92%20Engine%20%26%20Model%3A%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0AREADME.md%3A144%0A%22Acceptance%20Mode%22%20is%20not%20a%20top-level%20Settings%20pane%20%E2%80%94%20it's%20a%20picker%20control%20inside%20the%20**%22Shortcuts%22**%20pane%20%28%60AcceptanceModePickerView%60%20is%20rendered%20by%20%60ShortcutsPaneView%60%29.%20Users%20following%20%22Settings%20%E2%86%92%20Acceptance%20Mode%22%20will%20look%20for%20a%20sidebar%20entry%20that%20doesn't%20exist.%20The%20correct%20navigation%20is%20%22Settings%20%E2%86%92%20Shortcuts%22.%0A%0A%60%60%60suggestion%0A-%20**%60Tab%60**%20%E2%80%94%20accept%20the%20next%20word.%20%28Prefer%20whole%20phrases%3F%20Switch%20this%20in%20Settings%20%E2%86%92%20Shortcuts.%29%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=638&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs: rewrite README for a non-technical..."](https://github.com/fujacob/cotabby/commit/7dcc0010a1196e1beb3a75c7509bbe5ae2fc3010) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36105319)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->