### PR TITLE
docs: use ko-fi.com/cotabby and trim the tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <h1 align="center">Cotabby [beta]</h1>
 
-<p align="center"><em>Open-source, on-device AI autocomplete for macOS — it finishes your sentences in almost any text field, with nothing sent to the cloud.</em></p>
+<p align="center"><em>Open-source, on-device AI autocomplete for macOS.</em></p>
 
 <p align="center">
   <a href="https://cotabby.app">
@@ -18,7 +18,7 @@
 <img width="200" alt="download" src="https://github.com/user-attachments/assets/d5cb4454-d2ab-41d3-9d36-171d44ebfc52" /></a>
 
 
-<a href="https://ko-fi.com/I2F22066MI" target="_blank">
+<a href="https://ko-fi.com/cotabby" target="_blank">
 <img width="200" alt="support" src=".github/assets/readme/support-cotabby.png" />
 </a></p>
 


### PR DESCRIPTION
Follow-up to #638, which merged before these two edits had landed on the branch. Net change is two lines:

- Switch the Ko-fi link to `ko-fi.com/cotabby`.
- Trim the tagline to "Open-source, on-device AI autocomplete for macOS."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes two minor copy edits to `README.md` as a follow-up to #638.

- Replaces the Ko-fi donation link (`ko-fi.com/I2F22066MI`) with the canonical project page (`ko-fi.com/cotabby`), making the URL easier to remember and verify.
- Shortens the tagline from the full two-clause sentence to just "Open-source, on-device AI autocomplete for macOS."

<h3>Confidence Score: 5/5</h3>

Two-line documentation change — safe to merge.

Both edits are cosmetic README copy changes. The Ko-fi URL swap points to the canonical project page and the tagline trim removes the redundant second clause. No code, logic, or configuration is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Updates Ko-fi donation link from a personal hash URL to the canonical ko-fi.com/cotabby page, and trims the tagline to its first clause. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[README.md] --> B[Tagline]
    A --> C[Ko-fi donation link]
    B --> B1["Before: full two-clause sentence"]
    B --> B2["After: 'Open-source, on-device AI autocomplete for macOS.'"]
    C --> C1["Before: ko-fi.com/I2F22066MI"]
    C --> C2["After: ko-fi.com/cotabby"]
```

<sub>Reviews (1): Last reviewed commit: ["docs: use ko-fi.com/cotabby and trim the..."](https://github.com/fujacob/cotabby/commit/e57dfcbe852837bdc462d7f561546b3dd1dd45ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36105770)</sub>

<!-- /greptile_comment -->