### PR TITLE
docs(readme): remove the last-commit badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@
   <a href="https://github.com/FuJacob/cotabby/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/FuJacob/cotabby" /></a>
   <a href="https://github.com/FuJacob/cotabby/releases"><img alt="Downloads" src="https://img.shields.io/github/downloads/FuJacob/cotabby/total" /></a>
   <a href="https://github.com/FuJacob/cotabby/stargazers"><img alt="Stars" src="https://img.shields.io/github/stars/FuJacob/cotabby?style=flat" /></a>
-  <a href="https://github.com/FuJacob/cotabby/commits/main"><img alt="Last commit" src="https://img.shields.io/github/last-commit/FuJacob/cotabby" /></a>
   <img alt="Swift" src="https://img.shields.io/badge/Swift-F05138?logo=swift&amp;logoColor=white" />
   <img alt="Platform" src="https://img.shields.io/badge/platform-macOS%2014%2B-lightgrey" />
 </p>


### PR DESCRIPTION
## Summary

Removes the "last commit" shields.io badge from the README badge row.

## Validation

README-only change; no code, build, or project files touched.

## Linked issues

None.

## Risk / rollout notes

Documentation only. The remaining badges (Build, License, Release, Downloads, Stars, Swift, Platform) are unchanged.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the `last-commit` shields.io badge from the README badge row, leaving the remaining seven badges (Build, License, Release, Downloads, Stars, Swift, Platform) intact.

- The deleted line is a single `<a>` element wrapping a `shields.io/github/last-commit` `<img>` tag; no other content is affected.
- No code, build scripts, or project configuration files are touched.

<h3>Confidence Score: 5/5</h3>

Purely a documentation change — one badge link removed, no code or config touched.

The change deletes exactly one line from the README, removing a shields.io last-commit badge. Nothing else is modified, and no downstream behavior is affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Removes the shields.io last-commit badge line; all other badges and content are untouched. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[README.md badge row] --> B[Build badge]
    A --> C[License badge]
    A --> D[Release badge]
    A --> E[Downloads badge]
    A --> F[Stars badge]
    A --> G["~~Last Commit badge~~ (removed)"]
    A --> H[Swift badge]
    A --> I[Platform badge]

    style G stroke-dasharray: 5 5,fill:#ffcccc,color:#999
```

<sub>Reviews (1): Last reviewed commit: ["docs(readme): remove the last-commit bad..."](https://github.com/fujacob/cotabby/commit/9b53c40ebeb3d45040340863744cd3f73caf62fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36105823)</sub>

<!-- /greptile_comment -->