### PR TITLE
docs(readme): trim What It Does and Features

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,7 @@
 
 ## What It Does
 
-Cotabby adds AI autocomplete to almost any text field on your Mac. As you type, a gray suggestion appears inline next to your cursor — press `Tab` to accept it a word at a time, or just keep typing to ignore it.
-
-It also does inline `:emoji:` autocomplete, `/` macros (quick math, unit and currency conversion, dates), and one-key autocorrect for typos.
+Cotabby adds AI autocomplete to almost any text field on your Mac. As you type, a gray suggestion appears inline next to your cursor. Press `Tab` to accept it a word at a time, or keep typing to ignore it.
 
 Everything runs on your Mac. No account, no cloud, no telemetry.
 
@@ -67,10 +65,6 @@ Everything runs on your Mac. No account, no cloud, no telemetry.
 - **Emoji autocomplete** — type `:rocket:` and accept it without leaving the field
 - **Inline macros** — type `/` for quick math, unit and currency conversion, dates, and random values
 - **One-key autocorrect** — fix a likely typo with a single keystroke
-- **Two engines** — Apple Intelligence, or a small model you download and run locally
-- **Make it yours** — set your name, languages, and suggestion length, and turn Cotabby off per app
-- **Screen-aware (optional)** — can read the area around your cursor so suggestions fit what's on screen
-- **100% on-device** — no account, no cloud, no telemetry
 
 ## Privacy
 


### PR DESCRIPTION
## Summary

The What It Does section repeated the feature bullets in a separate paragraph, and the Features list had grown to eight items mixing user-facing actions with implementation details (Two engines), value props (100% on-device, already covered in Privacy), and a settings dump (Make it yours). Cut both back to what isn't already said elsewhere on the page.

## Validation

Docs-only change. Rendered the README locally; the four remaining Features bullets line up with the four demo gifs directly above the section.

## Linked issues

None.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR trims `README.md` in two places: the "What It Does" section loses its second paragraph (which duplicated the Features list), and the Features list shrinks from eight bullets to four by removing items already covered elsewhere on the page (engines, settings, screen-awareness, on-device privacy).

- The condensed "What It Does" paragraph now reads as a single coherent description instead of repeating what appears just below in Features.
- The four remaining Features bullets (`Ghost-text autocomplete`, `Emoji autocomplete`, `Inline macros`, `One-key autocorrect`) correspond directly to the four demo GIFs immediately above, which tightens the visual flow of the page.

<h3>Confidence Score: 5/5</h3>

Documentation-only change with no code, logic, or configuration touched — safe to merge as-is.

Every removed line is duplicated content that already appears in another section of the same file (Features, Privacy, Engines, Permissions). The trimming reduces noise and creates a clean 1-to-1 mapping between the four demo GIFs and the four remaining Feature bullets, which is exactly what the PR description claims.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Docs-only trimming: removed a duplicate second paragraph in "What It Does" and four redundant Feature bullets; no functional or structural issues |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[README.md] --> B[What It Does]
    A --> C[Demo — 4 GIFs]
    A --> D[Features — 4 bullets]
    A --> E[Privacy]
    A --> F[Engines]

    B -->|Before| B1["Intro paragraph\n+ duplicate feature paragraph\n+ privacy line"]
    B -->|After| B2["Intro paragraph\n+ privacy line"]

    D -->|Before| D1["8 bullets\n(features + engines + settings + privacy)"]
    D -->|After| D2["4 bullets aligned with 4 demo GIFs"]

    C -.->|now matches 1-to-1| D2
```

<sub>Reviews (1): Last reviewed commit: ["docs(readme): trim What It Does and Feat..."](https://github.com/fujacob/cotabby/commit/ce241f2f4b6c59bb6e7d8e91c240166482ea607e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36108447)</sub>

<!-- /greptile_comment -->