### PR TITLE
fix(power): popup edits update active power profile; disable redundant model picker

### DIFF
--- a/Cotabby/App/Core/AppDelegate.swift
+++ b/Cotabby/App/Core/AppDelegate.swift
@@ -24,6 +24,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let permissionGuidanceController: PermissionGuidanceController
     let suggestionSettings: SuggestionSettingsModel
     let foundationModelAvailabilityService: FoundationModelAvailabilityService
+    let powerSourceMonitor: PowerSourceMonitor
     let suggestionCoordinator: SuggestionCoordinator
     let inlineCommandCoordinator: InlineCommandCoordinator
     let welcomeCoordinator: WelcomeCoordinator
@@ -55,6 +56,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         permissionGuidanceController = environment.permissionGuidanceController
         suggestionSettings = environment.suggestionSettings
         foundationModelAvailabilityService = environment.foundationModelAvailabilityService
+        powerSourceMonitor = environment.powerSourceMonitor
         suggestionCoordinator = environment.suggestionCoordinator
         inlineCommandCoordinator = environment.inlineCommandCoordinator
         welcomeCoordinator = environment.welcomeCoordinator

--- a/Cotabby/App/Core/CotabbyApp.swift
+++ b/Cotabby/App/Core/CotabbyApp.swift
@@ -21,6 +21,7 @@ struct CotabbyApp: App {
                 permissionGuidanceController: appDelegate.permissionGuidanceController,
                 suggestionSettings: appDelegate.suggestionSettings,
                 foundationModelAvailabilityService: appDelegate.foundationModelAvailabilityService,
+                powerSourceMonitor: appDelegate.powerSourceMonitor,
                 appUpdateManager: appDelegate.appUpdateManager,
                 onOpenSettings: {
                     appDelegate.settingsCoordinator.showSettings()

--- a/Cotabby/UI/MenuBarView.swift
+++ b/Cotabby/UI/MenuBarView.swift
@@ -20,6 +20,7 @@ struct MenuBarView: View {
     let permissionGuidanceController: PermissionGuidanceController
     @ObservedObject var suggestionSettings: SuggestionSettingsModel
     @ObservedObject var foundationModelAvailabilityService: FoundationModelAvailabilityService
+    @ObservedObject var powerSourceMonitor: PowerSourceMonitor
     let appUpdateManager: AppUpdateManager
     let onOpenSettings: () -> Void
     let onReportFeedback: () -> Void
@@ -338,7 +339,19 @@ struct MenuBarView: View {
         Binding(
             get: { suggestionSettings.selectedEngine },
             set: { engine in
-                suggestionSettings.selectEngine(engine)
+                // With power-based switching on, the active engine is owned by the current power
+                // source's profile. Editing it here writes that profile (battery vs. plugged-in)
+                // instead of `selectedEngine`, which the switcher would otherwise revert. The profile
+                // carries engine + model, so an Apple Intelligence pick drops the model and an Open
+                // Source pick keeps the currently selected one.
+                guard suggestionSettings.isPowerBasedModelSwitchingEnabled else {
+                    suggestionSettings.selectEngine(engine)
+                    return
+                }
+                let profile: PowerProfile = engine == .appleIntelligence
+                    ? .appleIntelligence
+                    : .llama(filename: runtimeModel.selectedModelFilename ?? "")
+                applyProfileForCurrentPowerSource(profile)
             }
         )
     }
@@ -394,11 +407,31 @@ struct MenuBarView: View {
                     ?? ""
             },
             set: { filename in
-                Task {
-                    await runtimeModel.selectModel(filename)
+                // With power-based switching on, write the model into the current power source's
+                // profile so it sticks for that source (and the other source keeps its own model).
+                // Calling `selectModel` directly would be reverted by the power switcher on its next
+                // evaluation, which read as "the popup just resets my choice".
+                guard suggestionSettings.isPowerBasedModelSwitchingEnabled else {
+                    Task {
+                        await runtimeModel.selectModel(filename)
+                    }
+                    return
                 }
+                applyProfileForCurrentPowerSource(.llama(filename: filename))
             }
         )
+    }
+
+    /// Writes a profile into whichever per-power-source slot is currently active, so a menu-bar edit
+    /// updates the battery profile while on battery and the plugged-in profile while charging. The
+    /// power-source observer then applies it to the runtime, so no direct `selectModel`/`selectEngine`
+    /// call is needed here.
+    private func applyProfileForCurrentPowerSource(_ profile: PowerProfile) {
+        if powerSourceMonitor.isPluggedIn {
+            suggestionSettings.setPluggedInProfile(profile)
+        } else {
+            suggestionSettings.setBatteryProfile(profile)
+        }
     }
 
     private var runtimePickerDisabled: Bool {

--- a/Cotabby/UI/Settings/Panes/EngineAndModelPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/EngineAndModelPaneView.swift
@@ -218,11 +218,18 @@ struct EngineAndModelPaneView: View {
                 } label: {
                     SettingsRowLabel(
                         title: "Selected Model",
-                        description: "Which downloaded model file generates suggestions. " +
-                            "Larger models are slower but write better.",
+                        description: suggestionSettings.isPowerBasedModelSwitchingEnabled
+                            ? "Set automatically by power source. Use the On Battery / Plugged In " +
+                                "pickers in the Power section, or turn off power-based switching."
+                            : "Which downloaded model file generates suggestions. " +
+                                "Larger models are slower but write better.",
                         systemImage: "shippingbox"
                     )
                 }
+                // Redundant while power-based switching owns the active model: the Power section's
+                // per-source profile pickers are the source of truth, and any pick here would be
+                // reverted on the next power evaluation.
+                .disabled(suggestionSettings.isPowerBasedModelSwitchingEnabled)
             }
 
             DownloadableModelCatalogView(

--- a/Cotabby/UI/Settings/Panes/WritingPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/WritingPaneView.swift
@@ -33,25 +33,13 @@ struct WritingPaneView: View {
                             value: customLowBinding,
                             in: SuggestionWordRange.minimumWord...SuggestionWordRange.maximumWord
                         ) {
-                            HStack(spacing: 4) {
-                                Text("Min:")
-                                TextField("", value: customLowBinding, format: .number)
-                                    .textFieldStyle(.plain)
-                                    .frame(width: 32)
-                                    .multilineTextAlignment(.trailing)
-                            }
+                            Text("Min: \(suggestionSettings.customWordCountLowWords)")
                         }
                         Stepper(
                             value: customHighBinding,
                             in: SuggestionWordRange.minimumWord...SuggestionWordRange.maximumWord
                         ) {
-                            HStack(spacing: 4) {
-                                Text("Max:")
-                                TextField("", value: customHighBinding, format: .number)
-                                    .textFieldStyle(.plain)
-                                    .frame(width: 32)
-                                    .multilineTextAlignment(.trailing)
-                            }
+                            Text("Max: \(suggestionSettings.customWordCountHighWords)")
                         }
                     }
                     Text("Token budget scales by your selected language. Multiple languages or a " +

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,173 @@
+# Cotabby FAQ
+
+Frequently asked questions about Cotabby, the free, open-source, on-device AI
+autocomplete for macOS.
+
+## 1. What is Cotabby and how does it work?
+
+Cotabby is a free, open-source macOS menu bar app that adds AI autocomplete to
+almost any text field on your Mac. As you type, it shows a gray "ghost text"
+suggestion inline next to your cursor. Press `Tab` to accept it, or just keep
+typing to ignore it.
+
+Under the hood, Cotabby notices which text field you are focused on, reads what
+you have typed (and optionally the surrounding on-screen context), generates a
+short continuation with a local AI model, and inserts the text you accept right
+where your cursor is.
+
+Beyond sentence completion, Cotabby also includes:
+
+- Inline emoji autocomplete (type `:smile` and accept).
+- Slash macros for quick math, unit and currency conversion, dates, and more
+  (type `/`).
+- Autocorrect that fixes typos with a single keystroke.
+
+Cotabby is currently in beta.
+
+## 2. Is Cotabby free?
+
+Yes. Cotabby is completely free and open source, released under the GNU Affero
+General Public License v3.0 (AGPL-3.0). There is no subscription, no account, and
+no paid tier. You are free to read, modify, and redistribute the source under the
+terms of that license. The code lives at
+[github.com/FuJacob/cotabby](https://github.com/FuJacob/cotabby).
+
+The downloadable AI models are free too, and Apple Intelligence is built into
+macOS, so there are no usage costs of any kind.
+
+## 3. Is my data private? Does Cotabby send what I type to the cloud?
+
+Privacy is the core design principle. Everything that produces a suggestion runs
+on your Mac:
+
+- All AI text generation happens on-device, using either Apple Intelligence
+  (built into macOS) or a local model running directly on your machine. There is
+  no hosted API and no cloud round-trip.
+- When screen context is used, the screenshot is captured and read entirely
+  on-device with Apple's built-in text recognition. No images or recognized text
+  are ever uploaded.
+- Cotabby contains no analytics, no telemetry, and no crash reporting.
+
+The only times Cotabby uses the network are to download an AI model when you
+choose to, to let you search for models in the optional in-app model browser, and
+to check for app updates. None of these carry the text you type, your
+suggestions, or anything from your screen.
+
+For the technically curious: a normal install never writes your typed text to
+disk. Only special developer debug builds write local diagnostic logs, and even
+those stay on your Mac and are never transmitted.
+
+## 4. What are the system requirements?
+
+- macOS 14 (Sonoma) or later.
+- Apple Silicon (M-series) is strongly recommended for good local-model
+  performance.
+- Free disk space for any local models you download (from under 1 GB to around
+  5 GB each, depending on the model you pick).
+- To use the Apple Intelligence engine specifically, you need macOS 26 or later
+  on a Mac that supports Apple Intelligence, with Apple Intelligence turned on in
+  System Settings. On older Macs, use the built-in Open Source engine instead.
+
+## 5. How do I install Cotabby?
+
+There are three ways:
+
+- **Homebrew (recommended):**
+  ```sh
+  brew tap FuJacob/cotabby
+  brew install --cask cotabby
+  ```
+  Update later with `brew upgrade --cask cotabby`.
+- **Direct download:** get the latest release from
+  [cotabby.app](https://cotabby.app) (or the GitHub Releases page) and drag
+  Cotabby into your Applications folder.
+- **Build from source:** clone
+  [github.com/FuJacob/cotabby](https://github.com/FuJacob/cotabby) and open the
+  project in Xcode.
+
+After launching, Cotabby lives in your menu bar and walks you through a short
+setup. It checks for and installs updates automatically when new versions ship.
+
+## 6. Why does Cotabby need Accessibility, Input Monitoring, and Screen Recording permissions?
+
+Cotabby works inside other apps, so macOS requires you to grant three
+permissions. Each one maps to a specific feature:
+
+- **Accessibility:** to read the text and cursor position in the field you are
+  typing in, and to insert the text you accept.
+- **Input Monitoring:** to notice your typing so it knows when to suggest, and to
+  recognize the accept key (`Tab`).
+- **Screen Recording:** to capture the area around your cursor for visual
+  context, which makes suggestions more relevant.
+
+Cotabby guides you through granting each one during setup and shows a reminder if
+a permission is later turned off. You can change them anytime in System Settings
+under Privacy & Security. Cotabby never operates in password or other secure
+fields.
+
+## 7. How do I use Cotabby, and how do I accept or dismiss a suggestion?
+
+Start typing in any supported text field. When a suggestion appears as ghost
+text:
+
+- Press `Tab` to accept it. By default `Tab` accepts one word (or a full phrase,
+  depending on your Acceptance Mode setting).
+- Press the accept-entire-suggestion key (backtick `` ` `` by default) to take
+  the whole suggestion at once.
+- Keep typing to ignore the suggestion, or press `Esc` to dismiss it.
+
+All of these keys are rebindable in Settings, under Shortcuts, so you can pick
+whatever feels natural.
+
+## 8. Which apps does Cotabby work in?
+
+Cotabby works system-wide in almost any standard, editable text field, including
+native Mac apps and most web and Electron apps (such as Chrome).
+
+For your safety and privacy, it deliberately stays out of:
+
+- Password and other secure or sensitive fields (passcodes, card numbers,
+  one-time codes, and the like).
+- Terminal apps (Terminal, iTerm2, and others).
+
+Some browser and Electron editors expose their contents to macOS a little
+differently, so Cotabby includes special handling for them. If a particular
+field does not expose what Cotabby needs, it simply stays quiet there.
+
+## 9. Which AI model does Cotabby use, and does it work offline?
+
+Cotabby gives you two engines, and you choose which one to use:
+
+- **Apple Intelligence:** Apple's on-device model built into macOS (requires
+  macOS 26 or later on a supported Mac). Nothing to download.
+- **Open Source:** a local model that runs directly on your Mac. You can pick
+  from several tiers, from a lightweight model (under 1 GB) up to a larger,
+  higher-quality one (around 5 GB). Larger models write better but run slower.
+  You can also import your own GGUF model or browse Hugging Face from inside the
+  app.
+
+Both engines run entirely on your Mac. Once a model is downloaded (or Apple
+Intelligence is set up), suggestions work fully offline, with no internet
+required.
+
+## 10. How do I customize Cotabby or turn it off?
+
+Open Settings from the menu bar icon. A few of the things you can adjust:
+
+- Suggestion length, multi-line suggestions, and Fast Mode (which skips screen
+  context for faster results).
+- Ghost text color and opacity, and whether suggestions appear inline or as a
+  popup.
+- Engine and model selection, emoji style, slash macros, and your keyboard
+  shortcuts.
+
+To pause Cotabby:
+
+- Turn off "Enable Globally" in the menu or General settings to disable it
+  everywhere without quitting.
+- Add specific apps to the Disabled Apps list (or toggle it off for the app you
+  are currently in) to silence it just there.
+- Set a global toggle shortcut in Settings, under Shortcuts, to flip it on and
+  off from the keyboard.
+
+To quit entirely, choose Quit from the menu bar.


### PR DESCRIPTION
## Summary

Two fixes to power-based model switching. (1) In the menu bar popup, changing Engine/Model while switching is on now writes the *current* power source's profile (battery vs. plugged-in) instead of calling `selectEngine`/`selectModel` directly, which the power switcher reverted on its next evaluation, making the popup appear to reset the user's choice. (2) The Settings > Models "Selected Model" picker is disabled while switching is on, since the Power section's per-source pickers are the source of truth.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **
```

## Linked issues

(none)

## Risk / rollout notes

- Plumbs `PowerSourceMonitor` through `AppDelegate` -> `CotabbyApp` -> `MenuBarView` so the popup knows the current power source.
- Behavior only changes when power-based switching is enabled; default-off path is unchanged.
- Also carries in-progress `WritingPaneView` edits and adds `FAQ.md`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes two related bugs in power-source-driven model switching: menu-bar engine/model edits now write through the active power-source profile instead of bypassing it, and the Settings › Models "Selected Model" picker is disabled while power switching is on. The PR also ships a FAQ document and simplifies the custom word-count stepper labels in `WritingPaneView`.

- **MenuBarView**: `selectedEngineBinding` and `selectedModelBinding` now route edits through `applyProfileForCurrentPowerSource`, which writes the battery or plugged-in profile so the power-switcher observer picks up the change rather than reverting it.
- **EngineAndModelPaneView**: The Selected Model picker gains a `.disabled(isPowerBasedModelSwitchingEnabled)` guard and context-sensitive description, consistent with how the Power section's per-source pickers own the active model.

<h3>Confidence Score: 3/5</h3>

The menu-bar fix is correct and well-reasoned, but a parallel gap in the Settings pane means the Engine picker there can still be silently overridden.

The `selectedEngineBinding` in `EngineAndModelPaneView` still calls `selectEngine` directly, so a user who changes the engine from the Settings pane while power-based switching is on will see their choice quietly reverted the next time any profile trigger fires — the exact class of bug the PR fixes in the menu bar, left unaddressed in the Settings view.

Cotabby/UI/Settings/Panes/EngineAndModelPaneView.swift — the Engine picker's binding needs the same treatment (disabled with explanation, or routed through the profile) as the Model picker directly below it.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/App/Core/AppDelegate.swift | Exposes `powerSourceMonitor` as a stored property on AppDelegate, mirroring the pattern used for other services; straightforward plumbing change. |
| Cotabby/App/Core/CotabbyApp.swift | Threads `powerSourceMonitor` from AppDelegate into MenuBarView; a one-line addition to an existing argument list, no issues. |
| Cotabby/UI/MenuBarView.swift | Engine and model bindings now write through the active power-source profile instead of calling selectEngine/selectModel directly; the new `applyProfileForCurrentPowerSource` helper is correct. |
| Cotabby/UI/Settings/Panes/EngineAndModelPaneView.swift | The Selected Model picker is correctly disabled with updated helper text. However, the Engine picker at the top of the pane still calls `selectEngine` directly and is not disabled, which leads to silent reverts when power-based switching is on. |
| Cotabby/UI/Settings/Panes/WritingPaneView.swift | Replaces inline TextField labels on custom word count steppers with display-only Text; removes direct numeric input, making large value changes tedious. |
| FAQ.md | New FAQ document covering install, privacy, permissions, and usage; content aligns with observed app behavior. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant MenuBarView
    participant PowerSourceMonitor
    participant SuggestionSettingsModel
    participant CotabbyAppEnvironment

    Note over MenuBarView: isPowerBasedModelSwitchingEnabled = true

    User->>MenuBarView: Change Engine or Model picker
    MenuBarView->>PowerSourceMonitor: isPluggedIn?
    alt Plugged in
        MenuBarView->>SuggestionSettingsModel: setPluggedInProfile(profile)
    else On battery
        MenuBarView->>SuggestionSettingsModel: setBatteryProfile(profile)
    end
    SuggestionSettingsModel-->>CotabbyAppEnvironment: "@Published batteryEngine/pluggedInEngine fires"
    CotabbyAppEnvironment->>SuggestionSettingsModel: selectEngine(profile.engine)
    CotabbyAppEnvironment->>RuntimeBootstrapModel: selectModel(profile.filename)

    Note over MenuBarView: isPowerBasedModelSwitchingEnabled = false

    User->>MenuBarView: Change Engine or Model picker
    MenuBarView->>SuggestionSettingsModel: selectEngine(engine) / selectModel(filename) directly
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cotabby/UI/Settings/Panes/EngineAndModelPaneView.swift`, line 344-349 ([link](https://github.com/fujacob/cotabby/blob/cdf1741fe7a2dde6e1b76762ea2a078e9e2fac9a/Cotabby/UI/Settings/Panes/EngineAndModelPaneView.swift#L344-L349)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Engine picker not disabled/guarded when power-based switching is on**

   `selectedEngineBinding` in `EngineAndModelPaneView` still calls `suggestionSettings.selectEngine` directly. This is the same pattern the PR fixes in the menu bar: when power-based switching is enabled, `selectedEngine` will be silently overwritten by `applyPowerProfile` the next time any profile trigger fires (power source change, model-list refresh, etc.). Meanwhile the Model picker right below it is correctly disabled with an explanation — leaving the Engine picker editable creates a confusing inconsistency where the change *appears* to stick in the UI but is quietly reverted later.

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fpower-source-popup-and-disable%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpower-source-popup-and-disable%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FSettings%2FPanes%2FEngineAndModelPaneView.swift%0ALine%3A%20344-349%0A%0AComment%3A%0A**Engine%20picker%20not%20disabled%2Fguarded%20when%20power-based%20switching%20is%20on**%0A%0A%60selectedEngineBinding%60%20in%20%60EngineAndModelPaneView%60%20still%20calls%20%60suggestionSettings.selectEngine%60%20directly.%20This%20is%20the%20same%20pattern%20the%20PR%20fixes%20in%20the%20menu%20bar%3A%20when%20power-based%20switching%20is%20enabled%2C%20%60selectedEngine%60%20will%20be%20silently%20overwritten%20by%20%60applyPowerProfile%60%20the%20next%20time%20any%20profile%20trigger%20fires%20%28power%20source%20change%2C%20model-list%20refresh%2C%20etc.%29.%20Meanwhile%20the%20Model%20picker%20right%20below%20it%20is%20correctly%20disabled%20with%20an%20explanation%20%E2%80%94%20leaving%20the%20Engine%20picker%20editable%20creates%20a%20confusing%20inconsistency%20where%20the%20change%20*appears*%20to%20stick%20in%20the%20UI%20but%20is%20quietly%20reverted%20later.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=644&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FSettings%2FPanes%2FEngineAndModelPaneView.swift%0ALine%3A%20344-349%0A%0AComment%3A%0A**Engine%20picker%20not%20disabled%2Fguarded%20when%20power-based%20switching%20is%20on**%0A%0A%60selectedEngineBinding%60%20in%20%60EngineAndModelPaneView%60%20still%20calls%20%60suggestionSettings.selectEngine%60%20directly.%20This%20is%20the%20same%20pattern%20the%20PR%20fixes%20in%20the%20menu%20bar%3A%20when%20power-based%20switching%20is%20enabled%2C%20%60selectedEngine%60%20will%20be%20silently%20overwritten%20by%20%60applyPowerProfile%60%20the%20next%20time%20any%20profile%20trigger%20fires%20%28power%20source%20change%2C%20model-list%20refresh%2C%20etc.%29.%20Meanwhile%20the%20Model%20picker%20right%20below%20it%20is%20correctly%20disabled%20with%20an%20explanation%20%E2%80%94%20leaving%20the%20Engine%20picker%20editable%20creates%20a%20confusing%20inconsistency%20where%20the%20change%20*appears*%20to%20stick%20in%20the%20UI%20but%20is%20quietly%20reverted%20later.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=644&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fpower-source-popup-and-disable%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpower-source-popup-and-disable%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FSettings%2FPanes%2FEngineAndModelPaneView.swift%3A344-349%0A**Engine%20picker%20not%20disabled%2Fguarded%20when%20power-based%20switching%20is%20on**%0A%0A%60selectedEngineBinding%60%20in%20%60EngineAndModelPaneView%60%20still%20calls%20%60suggestionSettings.selectEngine%60%20directly.%20This%20is%20the%20same%20pattern%20the%20PR%20fixes%20in%20the%20menu%20bar%3A%20when%20power-based%20switching%20is%20enabled%2C%20%60selectedEngine%60%20will%20be%20silently%20overwritten%20by%20%60applyPowerProfile%60%20the%20next%20time%20any%20profile%20trigger%20fires%20%28power%20source%20change%2C%20model-list%20refresh%2C%20etc.%29.%20Meanwhile%20the%20Model%20picker%20right%20below%20it%20is%20correctly%20disabled%20with%20an%20explanation%20%E2%80%94%20leaving%20the%20Engine%20picker%20editable%20creates%20a%20confusing%20inconsistency%20where%20the%20change%20*appears*%20to%20stick%20in%20the%20UI%20but%20is%20quietly%20reverted%20later.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FUI%2FSettings%2FPanes%2FWritingPaneView.swift%3A36-43%0A**Direct%20numeric%20input%20removed%20from%20custom%20word%20count%20steppers**%0A%0AReplacing%20the%20labeled%20%60TextField%60%20with%20a%20display-only%20%60Text%60%20means%20users%20can%20no%20longer%20type%20a%20value%20directly%3B%20they%20must%20click%20the%20stepper%20arrow%20once%20per%20word%2C%20which%20is%20impractical%20when%20jumping%20from%2C%20say%2C%205%20to%2050.%20The%20old%20%60TextField%28%E2%80%A6%2C%20format%3A%20.number%29%60%20approach%20provided%20instant%20entry%20at%20no%20extra%20complexity%20cost.%20Worth%20confirming%20this%20simplification%20is%20intentional%20before%20shipping.%0A%0A&repo=fujacob%2Fcotabby&pr=644&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FSettings%2FPanes%2FEngineAndModelPaneView.swift%3A344-349%0A**Engine%20picker%20not%20disabled%2Fguarded%20when%20power-based%20switching%20is%20on**%0A%0A%60selectedEngineBinding%60%20in%20%60EngineAndModelPaneView%60%20still%20calls%20%60suggestionSettings.selectEngine%60%20directly.%20This%20is%20the%20same%20pattern%20the%20PR%20fixes%20in%20the%20menu%20bar%3A%20when%20power-based%20switching%20is%20enabled%2C%20%60selectedEngine%60%20will%20be%20silently%20overwritten%20by%20%60applyPowerProfile%60%20the%20next%20time%20any%20profile%20trigger%20fires%20%28power%20source%20change%2C%20model-list%20refresh%2C%20etc.%29.%20Meanwhile%20the%20Model%20picker%20right%20below%20it%20is%20correctly%20disabled%20with%20an%20explanation%20%E2%80%94%20leaving%20the%20Engine%20picker%20editable%20creates%20a%20confusing%20inconsistency%20where%20the%20change%20*appears*%20to%20stick%20in%20the%20UI%20but%20is%20quietly%20reverted%20later.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FUI%2FSettings%2FPanes%2FWritingPaneView.swift%3A36-43%0A**Direct%20numeric%20input%20removed%20from%20custom%20word%20count%20steppers**%0A%0AReplacing%20the%20labeled%20%60TextField%60%20with%20a%20display-only%20%60Text%60%20means%20users%20can%20no%20longer%20type%20a%20value%20directly%3B%20they%20must%20click%20the%20stepper%20arrow%20once%20per%20word%2C%20which%20is%20impractical%20when%20jumping%20from%2C%20say%2C%205%20to%2050.%20The%20old%20%60TextField%28%E2%80%A6%2C%20format%3A%20.number%29%60%20approach%20provided%20instant%20entry%20at%20no%20extra%20complexity%20cost.%20Worth%20confirming%20this%20simplification%20is%20intentional%20before%20shipping.%0A%0A&repo=fujacob%2Fcotabby&pr=644&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(power): popup edits update active po..."](https://github.com/fujacob/cotabby/commit/cdf1741fe7a2dde6e1b76762ea2a078e9e2fac9a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36109204)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->