### PR TITLE
fix(permissions): show optional Screen Recording in the permission reminder

### DIFF
--- a/Cotabby/UI/PermissionReminderView.swift
+++ b/Cotabby/UI/PermissionReminderView.swift
@@ -37,6 +37,18 @@ struct PermissionReminderView: View {
                         permissionGuidanceController: permissionGuidanceController
                     )
                 }
+
+                // Optional enhancements (Screen Recording) render after the required cards, tagged so
+                // they read as a discoverable extra rather than a blocker. The "I'll do this later" /
+                // "Done" button is gated on required permissions only, so these never hold it up.
+                ForEach(CotabbyPermissionKind.allCases.filter(\.isOptionalEnhancement)) { permission in
+                    ReminderPermissionCard(
+                        permission: permission,
+                        granted: permissionManager.isGranted(permission),
+                        isOptional: true,
+                        permissionGuidanceController: permissionGuidanceController
+                    )
+                }
             }
 
             WelcomeButton(title: permissionManager.requiredPermissionsGranted ? "Done" : "I'll do this later") {
@@ -54,25 +66,43 @@ struct PermissionReminderView: View {
 private struct ReminderPermissionCard: View {
     let permission: CotabbyPermissionKind
     let granted: Bool
+    var isOptional = false
     let permissionGuidanceController: PermissionGuidanceController
 
     @State private var actionButtonFrame = CGRect.zero
+
+    /// Tint for the ungranted state. Optional permissions stay neutral so they never look like the
+    /// broken/required state the orange treatment signals in this "Permissions needed" window.
+    private var ungrantedTint: Color {
+        isOptional ? .secondary : .orange
+    }
 
     var body: some View {
         HStack(spacing: 14) {
             ZStack {
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(granted ? Color.green.opacity(0.12) : Color.orange.opacity(0.12))
+                    .fill(granted ? Color.green.opacity(0.12) : ungrantedTint.opacity(0.12))
 
                 Image(systemName: permission.systemImageName)
                     .font(.system(size: 15, weight: .medium))
-                    .foregroundStyle(granted ? .green : .orange)
+                    .foregroundStyle(granted ? .green : ungrantedTint)
             }
             .frame(width: 32, height: 32)
 
             VStack(alignment: .leading, spacing: 2) {
-                Text(permission.title)
-                    .font(.system(size: 14, weight: .medium))
+                HStack(spacing: 6) {
+                    Text(permission.title)
+                        .font(.system(size: 14, weight: .medium))
+
+                    if isOptional {
+                        Text("Optional")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 1)
+                            .background(.quaternary, in: Capsule())
+                    }
+                }
 
                 Text(permission.onboardingSubtitle)
                     .font(.system(size: 12))
@@ -89,6 +119,18 @@ private struct ReminderPermissionCard: View {
                         .font(.system(size: 12, weight: .medium))
                 }
                 .foregroundStyle(.green)
+            } else if isOptional {
+                // Lower-emphasis bordered button so the optional row never competes visually with the
+                // required Allow buttons above it.
+                Button("Enable") {
+                    permissionGuidanceController.requestAccess(
+                        for: permission,
+                        sourceFrameInScreen: actionButtonFrame
+                    )
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.regular)
+                .background(ScreenFrameReader(frameInScreen: $actionButtonFrame))
             } else {
                 Button("Allow") {
                     permissionGuidanceController.requestAccess(


### PR DESCRIPTION
## Summary

The post-onboarding "Permissions needed" window (`PermissionReminderView`) filtered to required permissions only, so the optional Screen Recording card never appeared there. It now renders after the required cards, with an "Optional" tag, neutral (non-orange) styling, and an "Enable" button. The dismiss button stays gated on required permissions, so the optional card never blocks it.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **
```

## Linked issues

(none)

## Risk / rollout notes

- UI-only change to the reminder window; required-permission gating of the dismiss button is unchanged.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the optional Screen Recording permission visible in the post-onboarding `PermissionReminderView`, which previously only showed required permissions. The dismiss-button gating on `requiredPermissionsGranted` is untouched, so the new card cannot block the user from leaving the window.

- Adds a second `ForEach` filtered by `isOptionalEnhancement`, rendering Screen Recording cards after required ones with `isOptional: true`.
- Introduces an `ungrantedTint` computed property on `ReminderPermissionCard` that falls back to `.secondary` (instead of orange) for optional cards, and shows an \"Optional\" capsule badge alongside the title and a bordered \"Enable\" button rather than the filled \"Allow\" button used for required permissions.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is UI-only and the critical dismiss-button gating on required permissions is untouched.

The logic is straightforward and well-scoped: a second ForEach renders only optional permissions, the tint/button style correctly distinguish them from required cards, and the dismiss path is unaffected. The one thing worth a second look is that the window's header subtitle still reads as if every listed permission is required, which could momentarily confuse a user who sees the Screen Recording row before noticing the Optional badge.

Only PermissionReminderView.swift changed; no other files require attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/UI/PermissionReminderView.swift | Adds optional Screen Recording card to PermissionReminderView using a second ForEach, introduces isOptional flag to ReminderPermissionCard with neutral tint and bordered Enable button. Logic is clean; dismiss-button gating on requiredPermissionsGranted is unchanged. Minor: header subtitle copy implies all listed permissions are required. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PermissionReminderView loads] --> B[ForEach: isRequiredForAutocomplete]
    B --> C[ReminderPermissionCard isOptional: false]
    C --> D{granted?}
    D -- yes --> E[Show Done]
    D -- no --> F[Show Allow button borderedProminent / orange tint]
    A --> G[ForEach: isOptionalEnhancement]
    G --> H[ReminderPermissionCard isOptional: true]
    H --> I{granted?}
    I -- yes --> J[Show Done]
    I -- no --> K[Show Enable button bordered / secondary tint + Optional badge]
    A --> L{requiredPermissionsGranted?}
    L -- yes --> M[WelcomeButton: Done]
    L -- no --> N[WelcomeButton: I'll do this later]
    M --> O[onDismiss]
    N --> O
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cotabby/UI/PermissionReminderView.swift`, line 26-29 ([link](https://github.com/fujacob/cotabby/blob/c92da0c30a1ef5975dc389d58effee5e44bf3dec/Cotabby/UI/PermissionReminderView.swift#L26-L29)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Header copy still implies all cards are required**

   The subtitle "Cotabby needs these permissions to work. Grant them in System Settings, then come back here." now applies to a view that also shows an optional Screen Recording card. A user who reads the header before spotting the "Optional" badge may think Screen Recording is blocking something. The "Optional" badge does mitigate this, but even a small copy tweak like "Cotabby needs some of these permissions to work." or splitting the subtitle to acknowledge the optional row would remove the ambiguity entirely.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Freminder-optional-screen-recording%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Freminder-optional-screen-recording%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FPermissionReminderView.swift%0ALine%3A%2026-29%0A%0AComment%3A%0A**Header%20copy%20still%20implies%20all%20cards%20are%20required**%0A%0AThe%20subtitle%20%22Cotabby%20needs%20these%20permissions%20to%20work.%20Grant%20them%20in%20System%20Settings%2C%20then%20come%20back%20here.%22%20now%20applies%20to%20a%20view%20that%20also%20shows%20an%20optional%20Screen%20Recording%20card.%20A%20user%20who%20reads%20the%20header%20before%20spotting%20the%20%22Optional%22%20badge%20may%20think%20Screen%20Recording%20is%20blocking%20something.%20The%20%22Optional%22%20badge%20does%20mitigate%20this%2C%20but%20even%20a%20small%20copy%20tweak%20like%20%22Cotabby%20needs%20some%20of%20these%20permissions%20to%20work.%22%20or%20splitting%20the%20subtitle%20to%20acknowledge%20the%20optional%20row%20would%20remove%20the%20ambiguity%20entirely.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=645&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FPermissionReminderView.swift%0ALine%3A%2026-29%0A%0AComment%3A%0A**Header%20copy%20still%20implies%20all%20cards%20are%20required**%0A%0AThe%20subtitle%20%22Cotabby%20needs%20these%20permissions%20to%20work.%20Grant%20them%20in%20System%20Settings%2C%20then%20come%20back%20here.%22%20now%20applies%20to%20a%20view%20that%20also%20shows%20an%20optional%20Screen%20Recording%20card.%20A%20user%20who%20reads%20the%20header%20before%20spotting%20the%20%22Optional%22%20badge%20may%20think%20Screen%20Recording%20is%20blocking%20something.%20The%20%22Optional%22%20badge%20does%20mitigate%20this%2C%20but%20even%20a%20small%20copy%20tweak%20like%20%22Cotabby%20needs%20some%20of%20these%20permissions%20to%20work.%22%20or%20splitting%20the%20subtitle%20to%20acknowledge%20the%20optional%20row%20would%20remove%20the%20ambiguity%20entirely.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=645&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Freminder-optional-screen-recording%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Freminder-optional-screen-recording%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FPermissionReminderView.swift%3A26-29%0A**Header%20copy%20still%20implies%20all%20cards%20are%20required**%0A%0AThe%20subtitle%20%22Cotabby%20needs%20these%20permissions%20to%20work.%20Grant%20them%20in%20System%20Settings%2C%20then%20come%20back%20here.%22%20now%20applies%20to%20a%20view%20that%20also%20shows%20an%20optional%20Screen%20Recording%20card.%20A%20user%20who%20reads%20the%20header%20before%20spotting%20the%20%22Optional%22%20badge%20may%20think%20Screen%20Recording%20is%20blocking%20something.%20The%20%22Optional%22%20badge%20does%20mitigate%20this%2C%20but%20even%20a%20small%20copy%20tweak%20like%20%22Cotabby%20needs%20some%20of%20these%20permissions%20to%20work.%22%20or%20splitting%20the%20subtitle%20to%20acknowledge%20the%20optional%20row%20would%20remove%20the%20ambiguity%20entirely.%0A%0A&repo=fujacob%2Fcotabby&pr=645&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FPermissionReminderView.swift%3A26-29%0A**Header%20copy%20still%20implies%20all%20cards%20are%20required**%0A%0AThe%20subtitle%20%22Cotabby%20needs%20these%20permissions%20to%20work.%20Grant%20them%20in%20System%20Settings%2C%20then%20come%20back%20here.%22%20now%20applies%20to%20a%20view%20that%20also%20shows%20an%20optional%20Screen%20Recording%20card.%20A%20user%20who%20reads%20the%20header%20before%20spotting%20the%20%22Optional%22%20badge%20may%20think%20Screen%20Recording%20is%20blocking%20something.%20The%20%22Optional%22%20badge%20does%20mitigate%20this%2C%20but%20even%20a%20small%20copy%20tweak%20like%20%22Cotabby%20needs%20some%20of%20these%20permissions%20to%20work.%22%20or%20splitting%20the%20subtitle%20to%20acknowledge%20the%20optional%20row%20would%20remove%20the%20ambiguity%20entirely.%0A%0A&repo=fujacob%2Fcotabby&pr=645&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(permissions): show optional Screen R..."](https://github.com/fujacob/cotabby/commit/c92da0c30a1ef5975dc389d58effee5e44bf3dec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36109495)</sub>

<!-- /greptile_comment -->