### PR TITLE
feat(onboarding): replace Custom tier card with a "Set up later" button

### DIFF
--- a/Cotabby/Models/OnboardingTemplate.swift
+++ b/Cotabby/Models/OnboardingTemplate.swift
@@ -11,9 +11,11 @@ import Foundation
 /// static value type should not capture. Keeping the data here and the rules in `Support/` keeps the
 /// resolution pure and unit-testable.
 
-/// One of the onboarding starting points the user chooses from. Quick, Everyday, and Powerful are
-/// curated tiers; Custom is the neutral "set it up yourself" option that applies lean defaults so a
-/// user who does not want a curated tier can still get going and configure the rest in Settings.
+/// One of the onboarding starting points. Quick, Everyday, and Powerful are the curated tiers shown
+/// as selectable cards (`curatedTiers`). Custom is the neutral "set it up yourself" option that
+/// applies lean defaults; it is no longer its own card. The template step's "Set up later" button
+/// applies it under the hood so a user who does not want a curated tier can still move forward and
+/// configure the rest in Settings.
 enum OnboardingTemplate: String, CaseIterable, Identifiable, Equatable, Sendable {
     case quick
     case everyday
@@ -21,6 +23,11 @@ enum OnboardingTemplate: String, CaseIterable, Identifiable, Equatable, Sendable
     case custom
 
     var id: String { rawValue }
+
+    /// The curated tiers shown as selectable cards in onboarding, in display order. Excludes
+    /// `.custom`, which is applied implicitly by the "Set up later" button rather than picked from a
+    /// card. Kept distinct from `allCases` so the pure recommender still reasons over every tier.
+    static var curatedTiers: [OnboardingTemplate] { [.quick, .everyday, .powerful] }
 
     var title: String {
         switch self {

--- a/Cotabby/Models/OnboardingTemplate.swift
+++ b/Cotabby/Models/OnboardingTemplate.swift
@@ -27,7 +27,7 @@ enum OnboardingTemplate: String, CaseIterable, Identifiable, Equatable, Sendable
     /// The curated tiers shown as selectable cards in onboarding, in display order. Excludes
     /// `.custom`, which is applied implicitly by the "Set up later" button rather than picked from a
     /// card. Kept distinct from `allCases` so the pure recommender still reasons over every tier.
-    static var curatedTiers: [OnboardingTemplate] { [.quick, .everyday, .powerful] }
+    static let curatedTiers: [OnboardingTemplate] = [.quick, .everyday, .powerful]
 
     var title: String {
         switch self {

--- a/Cotabby/UI/WelcomeTemplateStepView.swift
+++ b/Cotabby/UI/WelcomeTemplateStepView.swift
@@ -34,7 +34,7 @@ struct WelcomeTemplateStepView: View {
             engineSelector
 
             VStack(spacing: 10) {
-                ForEach(OnboardingTemplate.allCases) { template in
+                ForEach(OnboardingTemplate.curatedTiers) { template in
                     let availability = OnboardingTemplateRecommender.availability(
                         for: template,
                         hardware: hardware,

--- a/Cotabby/UI/WelcomeView.swift
+++ b/Cotabby/UI/WelcomeView.swift
@@ -27,9 +27,9 @@ struct WelcomeView: View {
     /// Reports the current step's raw index up to the coordinator so it can persist a resume point.
     /// The wizard is re-shown from this step if the user is pulled out before finishing (see #314).
     let onStepChange: (Int) -> Void
-    /// True when this user has completed a prior onboarding version. Custom keeps the user's existing
-    /// settings instead of overwriting them with template defaults, since they have already tuned
-    /// Cotabby and chose Custom precisely to preserve that.
+    /// True when this user has completed a prior onboarding version. The Custom path keeps the user's
+    /// existing settings instead of overwriting them with template defaults, since they have already
+    /// tuned Cotabby; advancing via "Set up later" preserves that.
     let isReturningUser: Bool
 
     @State private var step: WelcomeStep
@@ -216,9 +216,17 @@ extension WelcomeView {
             WelcomeNavigation(
                 canGoBack: true,
                 canContinue: canContinueFromTemplate,
+                // With no curated tier chosen, the primary button becomes "Set up later" and applies
+                // the neutral Custom path under the hood, so the user is never blocked on a card.
+                continueTitle: selectedTemplate == nil ? "Set up later" : "Continue",
                 disabledHint: templateStepDisabledHint,
                 onBack: { step = .permissions },
-                onContinue: { step = .aboutYou }
+                onContinue: {
+                    if selectedTemplate == nil {
+                        applyTemplate(.custom)
+                    }
+                    step = .aboutYou
+                }
             )
         case .aboutYou:
             WelcomeNavigation(
@@ -663,9 +671,13 @@ extension WelcomeView {
         return modelDownloadManager.state(for: model)
     }
 
+    /// Whether the template step's primary button is enabled. With no tier chosen it is always
+    /// enabled: the button reads "Set up later" and applies the neutral Custom path. With a tier
+    /// chosen, Apple Intelligence is immediately ready, while Open Source waits until that tier's
+    /// model download has at least started (it finishes in the background).
     fileprivate var canContinueFromTemplate: Bool {
         guard let template = selectedTemplate else {
-            return false
+            return true
         }
         let plan = resolvedPlan(for: template)
         switch plan.engine {
@@ -680,17 +692,18 @@ extension WelcomeView {
         }
     }
 
+    /// Tooltip for the disabled primary button. Only reachable once a tier is chosen but its Open
+    /// Source download hasn't started yet — with no tier chosen the button is "Set up later" and
+    /// always enabled, so there is no longer a "pick something" hint.
     fileprivate var templateStepDisabledHint: String {
-        selectedTemplate == nil
-            ? "Choose a starting point to continue."
-            : "Hang on while your model starts downloading."
+        "Hang on while your model starts downloading."
     }
 
     fileprivate func resolvedPlan(for template: OnboardingTemplate) -> ResolvedTemplatePlan {
         let base = OnboardingTemplateRecommender.resolvePlan(for: template, engine: selectedEngine)
-        // Returning users picking Custom on the OSS engine see their currently selected local model
-        // in the footer instead of the static template default, so the card matches the settings
-        // we will actually preserve in applyTemplate.
+        // Returning users on the Custom path with the OSS engine keep their currently selected local
+        // model instead of the static template default, so the done-step status and model activation
+        // reflect the settings applyTemplate actually preserves for them.
         guard
             template == .custom,
             isReturningUser,
@@ -726,12 +739,13 @@ extension WelcomeView {
         }
     }
 
-    /// Applies a template's settings and starts its model download (if any). Selecting a card is the
-    /// user's explicit consent to download, so a multi-gigabyte fetch only ever starts from here.
+    /// Applies a template's settings and starts its model download (if any). Choosing a tier card —
+    /// or taking the "Set up later" path, which applies `.custom` — is the user's explicit consent to
+    /// download, so a multi-gigabyte fetch only ever starts from here.
     fileprivate func applyTemplate(_ template: OnboardingTemplate) {
         selectedTemplate = template
 
-        // Returning users picking Custom keep every setting they previously tuned. Skipping the
+        // Returning users on the Custom path keep every setting they previously tuned. Skipping the
         // writes here (and the model download below) preserves their engine, word count, behavior
         // toggles, and avoids re-triggering a multi-gigabyte fetch they already completed.
         if template == .custom && isReturningUser {
@@ -827,11 +841,13 @@ struct WelcomeButton: View {
     }
 }
 
-/// Continue navigation bar for middle wizard steps.
-/// "Continue" can be disabled with a tooltip hint explaining what's needed.
+/// Continue navigation bar for middle wizard steps. The primary button label defaults to "Continue"
+/// but can be overridden (the template step shows "Set up later" when no tier is chosen). The button
+/// can be disabled with a tooltip hint explaining what's needed.
 struct WelcomeNavigation: View {
     var canGoBack: Bool = false
     var canContinue: Bool = true
+    var continueTitle: String = "Continue"
     var disabledHint: String?
     var onBack: (() -> Void)?
     let onContinue: () -> Void
@@ -847,7 +863,7 @@ struct WelcomeNavigation: View {
 
             Spacer(minLength: 0)
 
-            Button("Continue") {
+            Button(continueTitle) {
                 onContinue()
             }
             .buttonStyle(.borderedProminent)


### PR DESCRIPTION
## Summary

The onboarding "Choose a starting point" step listed **Custom** as a fourth tier card, but for a new user it resolved to the same plan as Everyday; its only real job was "let me move forward without committing to a curated tier." That made it a redundant card that added scrolling and a heavier-feeling choice. This removes the Custom card and folds its behavior into the footer: when no tier is selected, the primary button reads **"Set up later"** and applies the Custom path under the hood before advancing, so it's easier to keep moving through onboarding.

## Validation

```
swiftlint lint --quiet Cotabby/UI/WelcomeView.swift Cotabby/UI/WelcomeTemplateStepView.swift Cotabby/Models/OnboardingTemplate.swift
# exit 0

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build -derivedDataPath build/DerivedData
# ** BUILD SUCCEEDED **

xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' -derivedDataPath build/DerivedData \
  -only-testing:CotabbyTests/OnboardingTemplateRecommenderTests \
  -only-testing:CotabbyTests/OnboardingTemplateFeatureListTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
# ** TEST SUCCEEDED **  16 tests, 0 failures
```

Not screenshotted end-to-end: reaching the template step at runtime requires granting real macOS permissions on the prior step, which isn't practical in this environment. Manual repro for a reviewer: reset onboarding, advance to **Step 2 of 4**, and confirm (1) only Quick / Everyday / Powerful cards render, (2) with nothing selected the footer button says **"Set up later"** and is enabled, and (3) selecting a tier flips it back to **"Continue"** with the existing download gating.

## Linked issues

None.

## Risk / rollout notes

- **Touches the first-run onboarding flow.** Behavior changes:
  - No tier selected + **"Set up later"** now applies `.custom` and advances, instead of leaving "Continue" disabled. This is the same settings bundle the old Custom card produced (lean defaults; on the Open Source engine it downloads the balanced default model in the background, exactly as the Custom card did).
  - Returning users are unchanged: the `.custom` path still early-returns and preserves their tuned engine/model/behavior settings.
- The `OnboardingTemplate.custom` enum case is intentionally retained (now applied implicitly, not shown as a card), so `OnboardingTemplateRecommender` and its tests keep full coverage over every tier.
- No schema, settings, or pbxproj migrations. Only files under `Cotabby/` (auto-discovered), so no `project.yml` / XcodeGen change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the Custom tier card from the onboarding template step and replaces its role with a "Set up later" footer button. When no curated tier is selected the primary button shows "Set up later" and is always enabled; tapping it applies the `.custom` path under the hood before advancing — a new user on the Open Source engine gets the same balanced default model download the Custom card used to trigger, and a returning user's existing settings are preserved unchanged.

- `OnboardingTemplate.curatedTiers` is added as a `static let` containing only the three shown cards; `.custom` is intentionally kept in `allCases`/`CaseIterable` so the recommender and its tests continue to cover every tier.
- `canContinueFromTemplate` now returns `true` when `selectedTemplate == nil`, `WelcomeNavigation` gains a `continueTitle` defaulting to `"Continue"`, and the `onContinue` closure calls `applyTemplate(.custom)` only when nothing was selected before stepping forward.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change only touches first-run onboarding UI and applies the pre-existing Custom path implicitly.

All three paths through the template step (new user on Apple Intelligence, new user on Open Source, returning user) are handled correctly. The `applyTemplate(.custom)` call for a new Open Source user starts the same model download the old Custom card triggered; the returning-user early-return in `applyTemplate` preserves existing settings unchanged. `curatedTiers` is correctly a `static let` excluding `.custom`, while `allCases`/`CaseIterable` still cover the full enum for recommender tests. No schema, settings, or migration changes are involved.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/Models/OnboardingTemplate.swift | Adds `curatedTiers` as a `static let` listing only Quick/Everyday/Powerful; `.custom` is retained in `allCases` for recommender coverage. Updated doc comment accurately describes the new UX contract. |
| Cotabby/UI/WelcomeTemplateStepView.swift | Single-line change: `allCases` → `curatedTiers` in the `ForEach` that renders tier cards, correctly hiding the Custom card while keeping all other card logic unchanged. |
| Cotabby/UI/WelcomeView.swift | Core logic changes: `canContinueFromTemplate` returns `true` for the nil-template case, `continueTitle` toggles between "Set up later" and "Continue", and `onContinue` calls `applyTemplate(.custom)` before advancing when nothing was selected. Returning-user early-return in `applyTemplate` keeps preservation behavior intact. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cotabby/UI/WelcomeTemplateStepView.swift`, line 28-29 ([link](https://github.com/fujacob/cotabby/blob/f7f8a4242d61876fef43c9ece084fe13bbf1a01c/Cotabby/UI/WelcomeTemplateStepView.swift#L28-L29)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Subtitle copy still implies selection is mandatory**

   `"Pick one to get set up."` now contradicts the new UX — the footer button actively invites users to skip choosing a card. A first-run user will read this subtitle, feel obligated to pick, then be confused by the "Set up later" option. Something like `"Pick one, or tap \"Set up later\" to configure in Settings."` or simply dropping the imperative would align copy with intent.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fonboarding-set-up-later%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fonboarding-set-up-later%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FWelcomeTemplateStepView.swift%0ALine%3A%2028-29%0A%0AComment%3A%0A**Subtitle%20copy%20still%20implies%20selection%20is%20mandatory**%0A%0A%60%22Pick%20one%20to%20get%20set%20up.%22%60%20now%20contradicts%20the%20new%20UX%20%E2%80%94%20the%20footer%20button%20actively%20invites%20users%20to%20skip%20choosing%20a%20card.%20A%20first-run%20user%20will%20read%20this%20subtitle%2C%20feel%20obligated%20to%20pick%2C%20then%20be%20confused%20by%20the%20%22Set%20up%20later%22%20option.%20Something%20like%20%60%22Pick%20one%2C%20or%20tap%20%5C%22Set%20up%20later%5C%22%20to%20configure%20in%20Settings.%22%60%20or%20simply%20dropping%20the%20imperative%20would%20align%20copy%20with%20intent.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=650&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FWelcomeTemplateStepView.swift%0ALine%3A%2028-29%0A%0AComment%3A%0A**Subtitle%20copy%20still%20implies%20selection%20is%20mandatory**%0A%0A%60%22Pick%20one%20to%20get%20set%20up.%22%60%20now%20contradicts%20the%20new%20UX%20%E2%80%94%20the%20footer%20button%20actively%20invites%20users%20to%20skip%20choosing%20a%20card.%20A%20first-run%20user%20will%20read%20this%20subtitle%2C%20feel%20obligated%20to%20pick%2C%20then%20be%20confused%20by%20the%20%22Set%20up%20later%22%20option.%20Something%20like%20%60%22Pick%20one%2C%20or%20tap%20%5C%22Set%20up%20later%5C%22%20to%20configure%20in%20Settings.%22%60%20or%20simply%20dropping%20the%20imperative%20would%20align%20copy%20with%20intent.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=650&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["refactor(onboarding): make curatedTiers ..."](https://github.com/fujacob/cotabby/commit/625bb1e22f89ea0a5cc6113c28a7b3cb78922bfd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36388569)</sub>

<!-- /greptile_comment -->