### PR TITLE
Skip ghost text in VS Code / Cursor integrated terminals

### DIFF
--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
@@ -24,6 +24,7 @@ extension SuggestionCoordinator {
             globallyEnabled: settingsSnapshot.isGloballyEnabled,
             disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
             disabledDomains: PerDomainDisableSettings.disabledDomains(),
+            suggestInIntegratedTerminals: settingsSnapshot.suggestInIntegratedTerminals,
             inputMonitoringGranted: permissionManager.inputMonitoringGranted,
             focusSnapshot: focusModel.snapshot
         ) {
@@ -59,6 +60,7 @@ extension SuggestionCoordinator {
                globallyEnabled: settingsSnapshot.isGloballyEnabled,
                disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
                disabledDomains: PerDomainDisableSettings.disabledDomains(),
+               suggestInIntegratedTerminals: settingsSnapshot.suggestInIntegratedTerminals,
                inputMonitoringGranted: permissionManager.inputMonitoringGranted,
                screenRecordingGranted: permissionManager.screenRecordingGranted,
                focusSnapshot: snapshot,
@@ -87,6 +89,7 @@ extension SuggestionCoordinator {
             globallyEnabled: settingsSnapshot.isGloballyEnabled,
             disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
             disabledDomains: PerDomainDisableSettings.disabledDomains(),
+            suggestInIntegratedTerminals: settingsSnapshot.suggestInIntegratedTerminals,
             inputMonitoringGranted: permissionManager.inputMonitoringGranted,
             screenRecordingGranted: permissionManager.screenRecordingGranted,
             focusSnapshot: snapshot,

--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Lifecycle.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Lifecycle.swift
@@ -74,6 +74,7 @@ extension SuggestionCoordinator {
                globallyEnabled: settingsSnapshot.isGloballyEnabled,
                disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
                disabledDomains: PerDomainDisableSettings.disabledDomains(),
+               suggestInIntegratedTerminals: settingsSnapshot.suggestInIntegratedTerminals,
                inputMonitoringGranted: permissionManager.inputMonitoringGranted,
                screenRecordingGranted: permissionManager.screenRecordingGranted,
                focusSnapshot: focusModel.snapshot,
@@ -86,6 +87,7 @@ extension SuggestionCoordinator {
             globallyEnabled: settingsSnapshot.isGloballyEnabled,
             disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
             disabledDomains: PerDomainDisableSettings.disabledDomains(),
+            suggestInIntegratedTerminals: settingsSnapshot.suggestInIntegratedTerminals,
             inputMonitoringGranted: permissionManager.inputMonitoringGranted,
             focusSnapshot: focusModel.snapshot
         ) {

--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
@@ -526,6 +526,7 @@ extension SuggestionCoordinator {
             globallyEnabled: settingsSnapshot.isGloballyEnabled,
             disabledAppBundleIdentifiers: settingsSnapshot.disabledAppBundleIdentifiers,
             disabledDomains: PerDomainDisableSettings.disabledDomains(),
+            suggestInIntegratedTerminals: settingsSnapshot.suggestInIntegratedTerminals,
             inputMonitoringGranted: permissionManager.inputMonitoringGranted,
             focusSnapshot: focusSnapshot
         )

--- a/Cotabby/Models/FocusModels.swift
+++ b/Cotabby/Models/FocusModels.swift
@@ -145,6 +145,14 @@ struct FocusedInputSnapshot: Equatable {
     let selection: NSRange
     let isSecure: Bool
 
+    /// True when the resolved field is an xterm.js integrated-terminal surface (VS Code / Cursor /
+    /// Windsurf terminal, or a browser-hosted web terminal). Set by `FocusSnapshotResolver` from the
+    /// focused element's `AXDOMClassList`. Lets the availability gate suppress ghost text in the
+    /// terminal without disabling the editor or Copilot chat, which share the same bundle id and so
+    /// can't be separated by the app-level terminal blocklist. The initializer default keeps existing
+    /// call sites compiling unchanged.
+    let isIntegratedTerminal: Bool
+
     /// Monotonic counter that increments every time polling observes a focused-input identity
     /// change.
     ///
@@ -189,6 +197,7 @@ struct FocusedInputSnapshot: Equatable {
         trailingText: String,
         selection: NSRange,
         isSecure: Bool,
+        isIntegratedTerminal: Bool = false,
         focusChangeSequence: UInt64 = 0,
         focusedURLString: String? = nil,
         resolvedFieldStyle: ResolvedFieldStyle? = nil
@@ -208,6 +217,7 @@ struct FocusedInputSnapshot: Equatable {
         self.trailingText = trailingText
         self.selection = selection
         self.isSecure = isSecure
+        self.isIntegratedTerminal = isIntegratedTerminal
         self.focusChangeSequence = focusChangeSequence
         self.focusedURLString = focusedURLString
         self.resolvedFieldStyle = resolvedFieldStyle

--- a/Cotabby/Models/SuggestionEngineModels.swift
+++ b/Cotabby/Models/SuggestionEngineModels.swift
@@ -80,6 +80,10 @@ enum AcceptanceGranularity: String, CaseIterable, Codable, Sendable {
 struct SuggestionSettingsSnapshot: Equatable, Sendable {
     let isGloballyEnabled: Bool
     let disabledAppBundleIdentifiers: Set<String>
+    /// When false (the default), ghost text is suppressed in integrated terminals (VS Code / Cursor
+    /// xterm.js surfaces). Power users can opt back in. Travels in the snapshot so the availability
+    /// gate sees the live value alongside the other "where Cotabby runs" rules.
+    let suggestInIntegratedTerminals: Bool
     let selectedEngine: SuggestionEngineKind
     let selectedWordCountPreset: SuggestionWordCountPreset
     /// When true, the generation pipeline uses `customWordCountRange` for the length budget and

--- a/Cotabby/Models/SuggestionSettingsData.swift
+++ b/Cotabby/Models/SuggestionSettingsData.swift
@@ -15,6 +15,10 @@ struct SuggestionSettingsData: Equatable {
     var showIndicator: Bool
     var showAcceptanceHint: Bool
     var disabledAppRules: [DisabledApplicationRule]
+    /// When false (the default), ghost text is suppressed in integrated terminals (VS Code / Cursor
+    /// xterm.js surfaces); a terminal's own completion/history conflicts with autocomplete and ghost
+    /// text overlaps command output. Power users can opt back in.
+    var suggestInIntegratedTerminals: Bool
     var customSuggestionTextColorHex: String?
     var ghostTextOpacity: Double
     var selectedEngine: SuggestionEngineKind

--- a/Cotabby/Models/SuggestionSettingsModel.swift
+++ b/Cotabby/Models/SuggestionSettingsModel.swift
@@ -38,6 +38,10 @@ final class SuggestionSettingsModel: ObservableObject {
     /// Whether the keycap hint (the small pill that teaches the accept key) is drawn after ghost text.
     @Published private(set) var showAcceptanceHint: Bool
     @Published private(set) var disabledAppRules: [DisabledApplicationRule]
+    /// Whether Cotabby should suggest inside integrated terminals (VS Code / Cursor xterm.js
+    /// surfaces). Off by default: a terminal's own completion/history conflicts with ghost text and
+    /// overlaps command output. Power users who want it can opt back in from the Apps settings pane.
+    @Published private(set) var suggestInIntegratedTerminals: Bool
     @Published private(set) var customSuggestionTextColorHex: String?
     @Published private(set) var ghostTextOpacity: Double
     @Published private(set) var selectedEngine: SuggestionEngineKind
@@ -132,6 +136,7 @@ final class SuggestionSettingsModel: ObservableObject {
         showIndicator = data.showIndicator
         showAcceptanceHint = data.showAcceptanceHint
         disabledAppRules = data.disabledAppRules
+        suggestInIntegratedTerminals = data.suggestInIntegratedTerminals
         customSuggestionTextColorHex = data.customSuggestionTextColorHex
         ghostTextOpacity = data.ghostTextOpacity
         selectedEngine = data.selectedEngine
@@ -184,6 +189,7 @@ final class SuggestionSettingsModel: ObservableObject {
         SuggestionSettingsSnapshot(
             isGloballyEnabled: isGloballyEnabled,
             disabledAppBundleIdentifiers: Set(disabledAppRules.map(\.bundleIdentifier)),
+            suggestInIntegratedTerminals: suggestInIntegratedTerminals,
             selectedEngine: selectedEngine,
             selectedWordCountPreset: selectedWordCountPreset,
             isUsingCustomWordCountRange: isUsingCustomWordCountRange,
@@ -469,6 +475,15 @@ final class SuggestionSettingsModel: ObservableObject {
 
         isGloballyEnabled = enabled
         store.saveGloballyEnabled(enabled)
+    }
+
+    func setSuggestInIntegratedTerminals(_ enabled: Bool) {
+        guard suggestInIntegratedTerminals != enabled else {
+            return
+        }
+
+        suggestInIntegratedTerminals = enabled
+        store.saveSuggestInIntegratedTerminals(enabled)
     }
 
     func setApplicationDisabled(
@@ -850,8 +865,15 @@ extension SuggestionSettingsModel: SuggestionSettingsProviding {
             $customWordCountLowWords,
             $customWordCountHighWords
         )
-        return Publishers.CombineLatest4(primary, $acceptanceGranularity, $extendedContext, customRange)
-            .map { primaryTuple, granularity, extendedContext, customRangeTuple in
+        // `extendedContext` shares its outer slot with `suggestInIntegratedTerminals` via a paired
+        // `CombineLatest` so the new toggle costs no extra top-level slot (the outer is at the cap).
+        return Publishers.CombineLatest4(
+            primary,
+            $acceptanceGranularity,
+            Publishers.CombineLatest($extendedContext, $suggestInIntegratedTerminals),
+            customRange
+        )
+            .map { primaryTuple, granularity, extendedContextTuple, customRangeTuple in
                 let (combinedSettings, presentationToggles, profile, timing) = primaryTuple
                 let (globallyEnabled, disabledAppRules, engine, wordCountPreset) = combinedSettings
                 let (clipboardContextEnabled, fastModeEnabled, mirrorPreference, typoToggles) = presentationToggles
@@ -859,9 +881,11 @@ extension SuggestionSettingsModel: SuggestionSettingsProviding {
                 let (userName, customRules, responseLanguages) = profile
                 let (debounce, focusPoll, multiLine, autoAcceptPunctuation) = timing
                 let (isCustomActive, customLow, customHigh) = customRangeTuple
+                let (extendedContext, suggestInIntegratedTerminals) = extendedContextTuple
                 return SuggestionSettingsSnapshot(
                     isGloballyEnabled: globallyEnabled,
                     disabledAppBundleIdentifiers: Set(disabledAppRules.map(\.bundleIdentifier)),
+                    suggestInIntegratedTerminals: suggestInIntegratedTerminals,
                     selectedEngine: engine,
                     selectedWordCountPreset: wordCountPreset,
                     isUsingCustomWordCountRange: isCustomActive,

--- a/Cotabby/Services/Focus/FocusSnapshotResolver.swift
+++ b/Cotabby/Services/Focus/FocusSnapshotResolver.swift
@@ -208,6 +208,17 @@ struct FocusSnapshotResolver {
                 )
             }
         }
+        // Recognize an xterm.js integrated terminal (VS Code / Cursor / web terminal) from the
+        // focused element's DOM classes. The terminal, code editor, and Copilot chat all live in one
+        // process, so this surface-level signal is the only way to suppress ghost text in the
+        // terminal while leaving the editor and chat working. Read on the focused element because
+        // that is exactly where xterm puts the caret (`xterm-helper-textarea`). Computed here — only
+        // once a real editable field has resolved — so idle/non-editable focus polls don't pay for an
+        // extra AXDOMClassList round-trip; native apps don't vend the attribute anyway.
+        let isIntegratedTerminal = TerminalAppDetector.isIntegratedTerminal(
+            domClassList: AXHelper.stringArrayValue(
+                for: "AXDOMClassList" as CFString, on: focusedElement) ?? []
+        )
         let context = FocusedInputSnapshot(
             applicationName: applicationName,
             bundleIdentifier: bundleIdentifier,
@@ -224,6 +235,7 @@ struct FocusSnapshotResolver {
             trailingText: nsValue.substring(from: trailingStart),
             selection: contextWindow.selection,
             isSecure: resolvedCandidate.isSecure,
+            isIntegratedTerminal: isIntegratedTerminal,
             focusChangeSequence: focusChangeSequence,
             focusedURLString: focusedURLString,
             resolvedFieldStyle: resolvedFieldStyle

--- a/Cotabby/Support/AXHelper.swift
+++ b/Cotabby/Support/AXHelper.swift
@@ -97,6 +97,13 @@ enum AXHelper {
         stringValue(for: "AXIdentifier" as CFString, on: element)
     }
 
+    /// Reads an array-of-strings AX attribute. Chromium/Electron exposes a web element's CSS
+    /// classes through `AXDOMClassList` this way; native apps simply don't vend the attribute, so
+    /// this returns nil for them rather than throwing.
+    static func stringArrayValue(for attribute: CFString, on element: AXUIElement) -> [String]? {
+        copyAttributeValue(attribute, on: element) as? [String]
+    }
+
     static func boolValue(for attribute: CFString, on element: AXUIElement) -> Bool? {
         guard let number = copyAttributeValue(attribute, on: element) as? NSNumber else {
             return nil

--- a/Cotabby/Support/SuggestionAvailabilityEvaluator.swift
+++ b/Cotabby/Support/SuggestionAvailabilityEvaluator.swift
@@ -11,6 +11,7 @@ enum SuggestionAvailabilityEvaluator {
         globallyEnabled: Bool = true,
         disabledAppBundleIdentifiers: Set<String> = [],
         disabledDomains: Set<String> = [],
+        suggestInIntegratedTerminals: Bool = false,
         inputMonitoringGranted: Bool,
         focusSnapshot: FocusSnapshot,
         checkCapability: Bool = true
@@ -38,6 +39,14 @@ enum SuggestionAvailabilityEvaluator {
             return "Cotabby is not available in terminal apps."
         }
 
+        // Integrated terminals (VS Code / Cursor xterm.js) share their app's bundle id with the
+        // editor and chat, so they slip past the blocklist above. Suppress them here unless the user
+        // has opted back in, keeping ghost text out of shell prompts and command output while the
+        // editor and Copilot chat in the same window keep suggesting.
+        if !suggestInIntegratedTerminals, focusSnapshot.context?.isIntegratedTerminal == true {
+            return "Cotabby is not available in the integrated terminal."
+        }
+
         guard inputMonitoringGranted else {
             return "Input Monitoring permission is required before Cotabby can react to typing."
         }
@@ -58,6 +67,7 @@ enum SuggestionAvailabilityEvaluator {
         globallyEnabled: Bool = true,
         disabledAppBundleIdentifiers: Set<String> = [],
         disabledDomains: Set<String> = [],
+        suggestInIntegratedTerminals: Bool = false,
         inputMonitoringGranted: Bool,
         focusSnapshot: FocusSnapshot
     ) -> Bool {
@@ -65,6 +75,7 @@ enum SuggestionAvailabilityEvaluator {
             globallyEnabled: globallyEnabled,
             disabledAppBundleIdentifiers: disabledAppBundleIdentifiers,
             disabledDomains: disabledDomains,
+            suggestInIntegratedTerminals: suggestInIntegratedTerminals,
             inputMonitoringGranted: inputMonitoringGranted,
             focusSnapshot: focusSnapshot
         ) == nil
@@ -86,6 +97,7 @@ enum SuggestionAvailabilityEvaluator {
         globallyEnabled: Bool = true,
         disabledAppBundleIdentifiers: Set<String> = [],
         disabledDomains: Set<String> = [],
+        suggestInIntegratedTerminals: Bool = false,
         inputMonitoringGranted: Bool,
         screenRecordingGranted: Bool,
         focusSnapshot: FocusSnapshot,
@@ -103,6 +115,7 @@ enum SuggestionAvailabilityEvaluator {
             globallyEnabled: globallyEnabled,
             disabledAppBundleIdentifiers: disabledAppBundleIdentifiers,
             disabledDomains: disabledDomains,
+            suggestInIntegratedTerminals: suggestInIntegratedTerminals,
             inputMonitoringGranted: inputMonitoringGranted,
             focusSnapshot: focusSnapshot,
             checkCapability: false

--- a/Cotabby/Support/SuggestionSettingsStore.swift
+++ b/Cotabby/Support/SuggestionSettingsStore.swift
@@ -52,6 +52,7 @@ struct SuggestionSettingsStore {
 
     private static let isGloballyEnabledDefaultsKey = "cotabbyGloballyEnabled"
     private static let disabledAppRulesDefaultsKey = "cotabbyDisabledAppRules"
+    private static let suggestInIntegratedTerminalsDefaultsKey = "cotabbySuggestInIntegratedTerminals"
     private static let showCaretIndicatorDefaultsKey = "cotabbyShowCaretIndicator"
     private static let selectedIndicatorModeDefaultsKey = "cotabbySelectedIndicatorMode"
     private static let showAcceptanceHintDefaultsKey = "cotabbyShowAcceptanceHint"
@@ -126,6 +127,10 @@ struct SuggestionSettingsStore {
             userDefaults.object(forKey: Self.showCaretIndicatorDefaultsKey) as? Bool ?? true
         }
         let resolvedShowAcceptanceHint = userDefaults.object(forKey: Self.showAcceptanceHintDefaultsKey) as? Bool ?? true
+        // Defaults to false so ghost text stays out of terminals out of the box, matching how
+        // standalone terminal apps are already skipped. Existing installs (no key) get the same.
+        let resolvedSuggestInIntegratedTerminals =
+            userDefaults.object(forKey: Self.suggestInIntegratedTerminalsDefaultsKey) as? Bool ?? false
         let resolvedCustomSuggestionTextColorHex = Self.normalizedHexString(
             userDefaults.string(forKey: Self.customSuggestionTextColorHexDefaultsKey)
         )
@@ -303,6 +308,7 @@ struct SuggestionSettingsStore {
             showIndicator: resolvedShowIndicator,
             showAcceptanceHint: resolvedShowAcceptanceHint,
             disabledAppRules: resolvedDisabledAppRules,
+            suggestInIntegratedTerminals: resolvedSuggestInIntegratedTerminals,
             customSuggestionTextColorHex: resolvedCustomSuggestionTextColorHex,
             ghostTextOpacity: resolvedGhostTextOpacity,
             selectedEngine: resolvedEngine,
@@ -350,6 +356,7 @@ struct SuggestionSettingsStore {
         // sticky on the next launch. Mirrors the resolution above field-for-field.
         saveGloballyEnabled(data.isGloballyEnabled)
         saveDisabledAppRules(data.disabledAppRules)
+        saveSuggestInIntegratedTerminals(data.suggestInIntegratedTerminals)
         saveShowIndicator(data.showIndicator)
         saveShowAcceptanceHint(data.showAcceptanceHint)
         saveCustomSuggestionTextColorHex(data.customSuggestionTextColorHex)
@@ -410,6 +417,10 @@ struct SuggestionSettingsStore {
 
     func saveGloballyEnabled(_ enabled: Bool) {
         userDefaults.set(enabled, forKey: Self.isGloballyEnabledDefaultsKey)
+    }
+
+    func saveSuggestInIntegratedTerminals(_ enabled: Bool) {
+        userDefaults.set(enabled, forKey: Self.suggestInIntegratedTerminalsDefaultsKey)
     }
 
     func saveDisabledAppRules(_ rules: [DisabledApplicationRule]) {

--- a/Cotabby/Support/TerminalAppDetector.swift
+++ b/Cotabby/Support/TerminalAppDetector.swift
@@ -23,4 +23,21 @@ enum TerminalAppDetector {
         guard let bundleIdentifier else { return false }
         return terminalBundleIdentifiers.contains(bundleIdentifier)
     }
+
+    /// DOM class prefix xterm.js stamps on every node of its terminal subtree — most importantly the
+    /// focusable `xterm-helper-textarea` that receives the caret.
+    private static let integratedTerminalClassPrefix = "xterm"
+
+    /// Whether a focused web element's `AXDOMClassList` marks it as an xterm.js terminal surface.
+    ///
+    /// VS Code, Cursor, Windsurf, and browser-hosted terminals (ttyd, Jupyter) all render their
+    /// terminal through xterm.js, so an `xterm`-prefixed class is a reliable, localization-independent
+    /// signal for "the caret is inside an integrated terminal". This is the piece `isTerminal` can't
+    /// provide: the editor, Copilot chat, and integrated terminal share one process, so the app-level
+    /// bundle blocklist can only ever block or allow all three together. Matching the whole `xterm`
+    /// prefix (not just `xterm-helper-textarea`) keeps detection working if xterm renames its input
+    /// node or focus lands on a sibling like `xterm-screen`.
+    static func isIntegratedTerminal(domClassList: [String]) -> Bool {
+        domClassList.contains { $0.hasPrefix(integratedTerminalClassPrefix) }
+    }
 }

--- a/Cotabby/UI/Settings/Panes/AppsPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/AppsPaneView.swift
@@ -38,6 +38,18 @@ struct AppsPaneView: View {
                 }
             }
 
+            Section("Integrated Terminals") {
+                Toggle(isOn: suggestInIntegratedTerminalsBinding) {
+                    SettingsRowLabel(
+                        title: "Suggest in Integrated Terminals",
+                        description: "Show ghost text in the VS Code and Cursor integrated terminal. "
+                            + "Off by default so suggestions don't overlap shell prompts and command "
+                            + "output — the code editor and Copilot chat in the same window keep "
+                            + "suggesting either way."
+                    )
+                }
+            }
+
             if !filteredRunningAppSuggestions.isEmpty {
                 Section("Suggestions") {
                     Text("Currently running apps you can disable with one click.")
@@ -55,6 +67,13 @@ struct AppsPaneView: View {
         .onAppear {
             runningAppSuggestions = RunningAppSuggestion.collect()
         }
+    }
+
+    private var suggestInIntegratedTerminalsBinding: Binding<Bool> {
+        Binding(
+            get: { suggestionSettings.suggestInIntegratedTerminals },
+            set: { suggestionSettings.setSuggestInIntegratedTerminals($0) }
+        )
     }
 
     /// Hide suggestions that are already in the disabled list so the row never shows a

--- a/CotabbyTests/CotabbyTestFixtures.swift
+++ b/CotabbyTests/CotabbyTestFixtures.swift
@@ -25,6 +25,7 @@ enum CotabbyTestFixtures {
         trailingText: String = "",
         selection: NSRange? = nil,
         isSecure: Bool = false,
+        isIntegratedTerminal: Bool = false,
         focusChangeSequence: UInt64 = 1
     ) -> FocusedInputSnapshot {
         let resolvedSelection = selection
@@ -46,6 +47,7 @@ enum CotabbyTestFixtures {
             trailingText: trailingText,
             selection: resolvedSelection,
             isSecure: isSecure,
+            isIntegratedTerminal: isIntegratedTerminal,
             focusChangeSequence: focusChangeSequence
         )
     }
@@ -214,6 +216,7 @@ enum CotabbyTestFixtures {
     static func settingsSnapshot(
         isGloballyEnabled: Bool = true,
         disabledAppBundleIdentifiers: Set<String> = [],
+        suggestInIntegratedTerminals: Bool = false,
         selectedEngine: SuggestionEngineKind = .llamaOpenSource,
         selectedWordCountPreset: SuggestionWordCountPreset = .sevenToTwelve,
         isUsingCustomWordCountRange: Bool = false,
@@ -236,6 +239,7 @@ enum CotabbyTestFixtures {
         SuggestionSettingsSnapshot(
             isGloballyEnabled: isGloballyEnabled,
             disabledAppBundleIdentifiers: disabledAppBundleIdentifiers,
+            suggestInIntegratedTerminals: suggestInIntegratedTerminals,
             selectedEngine: selectedEngine,
             selectedWordCountPreset: selectedWordCountPreset,
             isUsingCustomWordCountRange: isUsingCustomWordCountRange,

--- a/CotabbyTests/SuggestionAvailabilityEvaluatorTests.swift
+++ b/CotabbyTests/SuggestionAvailabilityEvaluatorTests.swift
@@ -61,6 +61,68 @@ final class SuggestionAvailabilityEvaluatorTests: XCTestCase {
         )
     }
 
+    /// A supported focus snapshot whose field is an xterm.js integrated terminal. Bundle id is a
+    /// non-terminal app (VS Code shares its bundle with the editor/chat), so only the surface-level
+    /// `isIntegratedTerminal` flag distinguishes it.
+    private func makeIntegratedTerminalSnapshot() -> FocusSnapshot {
+        let context = CotabbyTestFixtures.focusedInputSnapshot(
+            applicationName: "Code",
+            bundleIdentifier: "com.microsoft.VSCode",
+            role: "AXTextField",
+            isIntegratedTerminal: true
+        )
+        return FocusSnapshot(
+            applicationName: "Code",
+            bundleIdentifier: "com.microsoft.VSCode",
+            capability: .supported,
+            context: context,
+            inspection: nil
+        )
+    }
+
+    // MARK: - Integrated terminal gating
+
+    func test_disabledReason_integratedTerminal_suppressedByDefault() {
+        let reason = SuggestionAvailabilityEvaluator.disabledReason(
+            globallyEnabled: true,
+            inputMonitoringGranted: true,
+            focusSnapshot: makeIntegratedTerminalSnapshot()
+        )
+
+        XCTAssertEqual(reason, "Cotabby is not available in the integrated terminal.")
+    }
+
+    func test_disabledReason_integratedTerminal_allowedWhenOptedIn() {
+        let reason = SuggestionAvailabilityEvaluator.disabledReason(
+            globallyEnabled: true,
+            suggestInIntegratedTerminals: true,
+            inputMonitoringGranted: true,
+            focusSnapshot: makeIntegratedTerminalSnapshot()
+        )
+
+        XCTAssertNil(reason, "Opting in should let the integrated terminal suggest like any field")
+    }
+
+    func test_shouldSchedulePrediction_integratedTerminal_falseByDefault_trueWhenOptedIn() {
+        let snapshot = makeIntegratedTerminalSnapshot()
+
+        XCTAssertFalse(
+            SuggestionAvailabilityEvaluator.shouldSchedulePrediction(
+                globallyEnabled: true,
+                inputMonitoringGranted: true,
+                focusSnapshot: snapshot
+            )
+        )
+        XCTAssertTrue(
+            SuggestionAvailabilityEvaluator.shouldSchedulePrediction(
+                globallyEnabled: true,
+                suggestInIntegratedTerminals: true,
+                inputMonitoringGranted: true,
+                focusSnapshot: snapshot
+            )
+        )
+    }
+
     // MARK: - disabledReason: exact-string contracts
 
     /// If this string ever changes, the menu-bar status copy will silently

--- a/CotabbyTests/TerminalAppDetectorTests.swift
+++ b/CotabbyTests/TerminalAppDetectorTests.swift
@@ -55,6 +55,32 @@ final class TerminalAppDetectorTests: XCTestCase {
         XCTAssertFalse(TerminalAppDetector.isTerminal(bundleIdentifier: nil))
     }
 
+    // MARK: - Integrated terminal (xterm.js DOM class list)
+
+    func test_isIntegratedTerminal_xtermHelperTextarea() {
+        // The focused input leaf in a VS Code / Cursor terminal — verified live against the real
+        // AX tree (role AXTextField, class "xterm-helper-textarea").
+        XCTAssertTrue(TerminalAppDetector.isIntegratedTerminal(domClassList: ["xterm-helper-textarea"]))
+    }
+
+    func test_isIntegratedTerminal_xtermPrefixedSibling() {
+        // Prefix match so focus landing on another xterm node (or an xterm internal rename) still
+        // counts as a terminal.
+        XCTAssertTrue(TerminalAppDetector.isIntegratedTerminal(domClassList: ["xterm-screen"]))
+    }
+
+    func test_isIntegratedTerminal_monacoEditor_isFalse() {
+        // The VS Code code editor and Copilot chat input — must stay enabled.
+        XCTAssertFalse(TerminalAppDetector.isIntegratedTerminal(domClassList: ["native-edit-context"]))
+        XCTAssertFalse(
+            TerminalAppDetector.isIntegratedTerminal(domClassList: ["monaco-editor", "no-user-select", "mac"])
+        )
+    }
+
+    func test_isIntegratedTerminal_empty_isFalse() {
+        XCTAssertFalse(TerminalAppDetector.isIntegratedTerminal(domClassList: []))
+    }
+
     // MARK: - Evaluator integration
 
     func test_evaluator_blocksTerminalApp() {


### PR DESCRIPTION
## Summary

Cotabby showed ghost text in the VS Code integrated terminal (#647), overlapping shell prompts and interactive command output. The terminal, code editor, and Copilot chat all share one bundle id (`com.microsoft.VSCode`), so the existing app-level terminal blocklist (`TerminalAppDetector.isTerminal`) could only block or allow all three together. This recognizes the integrated terminal at the **surface** level — the focused element's `AXDOMClassList` (xterm.js focuses an `AXTextField` whose class is `xterm-helper-textarea`) — and suppresses suggestions there by default, while the editor and Copilot chat keep working. A new **Suggest in Integrated Terminals** toggle (Apps pane, off by default) lets power users opt back in. Generalizes for free to Cursor/Windsurf and browser-hosted web terminals (all xterm.js).

## Validation

```
xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  -only-testing:CotabbyTests/TerminalAppDetectorTests \
  -only-testing:CotabbyTests/SuggestionAvailabilityEvaluatorTests \
  CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
# ** TEST SUCCEEDED **  43 tests, 0 failures (7 new)

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

swiftlint lint --quiet
# clean (changed files)
```

The detection signal was verified live against VS Code 1.123's real accessibility tree: the focused terminal input is `AXTextField` with `AXDOMClassList = ["xterm-helper-textarea"]` (flagged `AXFocused=true`), while the Monaco editor and Copilot chat inputs are `native-edit-context` inside `monaco-editor` — no `xterm` class. Not yet driven end-to-end in the running app.

## Linked issues

Fixes #647

## Risk / rollout notes

- **New persisted setting** `suggestInIntegratedTerminals` (UserDefaults key `cotabbySuggestInIntegratedTerminals`, default `false`). Existing installs get the default, i.e. the terminal is suppressed — consistent with how standalone terminal apps are already skipped. Threaded through `SuggestionSettingsData` / `SuggestionSettingsStore` / the snapshot publisher.
- **New `FocusedInputSnapshot.isIntegratedTerminal`**, resolved from one extra `AXDOMClassList` read on the focused element. The read is placed after a real editable field has resolved, so idle / non-editable focus polls pay nothing; native apps don't vend the attribute.
- **Behavior change:** users who currently see suggestions in the VS Code / Cursor integrated terminal will stop seeing them by default. The editor and Copilot chat in the same window are unaffected, and the existing per-app rule still disables all of VS Code if wanted.
- No pbxproj / schema migration.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Introduces surface-level detection of xterm.js integrated terminals (VS Code, Cursor, Windsurf) by reading `AXDOMClassList` from the focused AX element, solving the problem that the terminal, editor, and Copilot chat all share one bundle ID and cannot be separated with the existing app-level blocklist. A new `suggestInIntegratedTerminals` UserDefaults flag (default `false`) threads through the entire settings stack and availability evaluator, suppressing ghost text in the terminal while leaving the code editor and Copilot chat unaffected.

- Adds `FocusedInputSnapshot.isIntegratedTerminal` (resolved once per real-editable-field poll via `AXHelper.stringArrayValue`) and `TerminalAppDetector.isIntegratedTerminal(domClassList:)` which matches any class with an `xterm` prefix.
- Plumbs the new `suggestInIntegratedTerminals` setting through `SuggestionSettingsData` → `SuggestionSettingsModel` → `SuggestionSettingsSnapshot` → all five `SuggestionAvailabilityEvaluator` call sites, with a `CombineLatest` pair nested inside the existing `CombineLatest4` to stay within Combine's publisher-count limit.
- Adds a toggle in the Apps settings pane and ships 7 new unit tests covering both the detector and the evaluator gating logic.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change adds a new off-by-default suppression path that is well-isolated and does not alter existing terminal or editor behavior.

The detection heuristic (hasPrefix("xterm")) is intentionally broad for forward-compatibility, but it would also silently suppress ghost text in any VS Code extension panel that happens to use xterm.js for non-terminal output display. This is a known tradeoff documented in comments, not an oversight, but it creates a hidden interaction for future extension authors or power users running xterm.js-based log viewers inside VS Code.

Cotabby/Support/TerminalAppDetector.swift — the prefix-match strategy is the only area worth revisiting if users report suggestions missing in non-terminal xterm.js panels.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/Support/TerminalAppDetector.swift | Adds isIntegratedTerminal(domClassList:) using a broad xterm-prefix match; intentional but could over-suppress in non-terminal xterm.js VS Code extension panels. |
| Cotabby/Services/Focus/FocusSnapshotResolver.swift | Reads AXDOMClassList from the focused element only after a real editable field resolves, keeping the idle-poll fast path free of extra AX round-trips; correctly populates isIntegratedTerminal on the snapshot. |
| Cotabby/Support/SuggestionAvailabilityEvaluator.swift | Integrated-terminal gate is inserted at the right place in the check chain (after app-level terminal blocklist, before permission guards); default false correctly suppresses terminals out of the box. |
| Cotabby/Models/SuggestionSettingsModel.swift | Correctly nests CombineLatest($extendedContext, $suggestInIntegratedTerminals) as the third slot of the outer CombineLatest4 to stay within Combine's 4-publisher cap; snapshot publisher correctly destructures and forwards the new flag. |
| Cotabby/Support/AXHelper.swift | Adds stringArrayValue(for:on:) — thin cast of copyAttributeValue result to [String]?; Swift correctly bridges Chromium's CFArray/NSArray of CFStrings via the conditional cast. |
| Cotabby/Models/FocusModels.swift | Adds isIntegratedTerminal: Bool with a default of false; keeps all existing call sites source-compatible. |
| Cotabby/Support/SuggestionSettingsStore.swift | Persists the new flag under cotabbySuggestInIntegratedTerminals with a false default (via ?? false on missing key); correctly included in saveAll. |
| Cotabby/UI/Settings/Panes/AppsPaneView.swift | Adds the Integrated Terminals section and toggle in the Apps pane with a clear description; binding correctly routes through setSuggestInIntegratedTerminals. |
| CotabbyTests/TerminalAppDetectorTests.swift | Good coverage: verified xterm-helper-textarea, prefix-match sibling, Monaco/non-xterm classes, and empty list; all live-verified class names used. |
| CotabbyTests/SuggestionAvailabilityEvaluatorTests.swift | Three focused tests cover: suppressed-by-default, allowed-when-opted-in, and shouldSchedulePrediction both with and without opt-in. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Focus poll fires] --> B{Real editable\nfield resolved?}
    B -- No --> C[Return nil snapshot]
    B -- Yes --> D[Read AXDOMClassList\nfrom focusedElement]
    D --> E[TerminalAppDetector\n.isIntegratedTerminal]
    E --> F[FocusedInputSnapshot\nisIntegratedTerminal set]
    F --> G[SuggestionAvailabilityEvaluator\n.disabledReason]
    G --> H{isTerminal\nbundle ID?}
    H -- Yes --> I[Block: terminal app]
    H -- No --> J{isIntegratedTerminal\n&& !suggestInTerminals?}
    J -- Yes --> K[Block: integrated terminal]
    J -- No --> L{inputMonitoring\ngranted?}
    L -- No --> M[Block: permission]
    L -- Yes --> N[Suggest ✓]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cotabby/Support/TerminalAppDetector.swift`, line 383-384 ([link](https://github.com/fujacob/cotabby/blob/a0cf966a921a7b9a399846a9629d825bb6c26276/Cotabby/Support/TerminalAppDetector.swift#L383-L384)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`xterm` prefix may suppress suggestions in non-terminal xterm.js panels**

   `hasPrefix("xterm")` will also match any VS Code extension or Electron app that renders output/log viewer panels using xterm.js (e.g., `xterm-viewer`, `xterm-output`). If a user has focus inside such a panel's editable field, suggestions will be suppressed even though it isn't a shell terminal. The current design is intentional (per the doc-comment: "keeps detection working if xterm renames its input node"), but the tradeoff means any future xterm.js-powered non-terminal component inside VS Code silently loses ghost text.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fvscode-integrated-terminal-suggestions%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fvscode-integrated-terminal-suggestions%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FSupport%2FTerminalAppDetector.swift%0ALine%3A%20383-384%0A%0AComment%3A%0A**%60xterm%60%20prefix%20may%20suppress%20suggestions%20in%20non-terminal%20xterm.js%20panels**%0A%0A%60hasPrefix%28%22xterm%22%29%60%20will%20also%20match%20any%20VS%20Code%20extension%20or%20Electron%20app%20that%20renders%20output%2Flog%20viewer%20panels%20using%20xterm.js%20%28e.g.%2C%20%60xterm-viewer%60%2C%20%60xterm-output%60%29.%20If%20a%20user%20has%20focus%20inside%20such%20a%20panel's%20editable%20field%2C%20suggestions%20will%20be%20suppressed%20even%20though%20it%20isn't%20a%20shell%20terminal.%20The%20current%20design%20is%20intentional%20%28per%20the%20doc-comment%3A%20%22keeps%20detection%20working%20if%20xterm%20renames%20its%20input%20node%22%29%2C%20but%20the%20tradeoff%20means%20any%20future%20xterm.js-powered%20non-terminal%20component%20inside%20VS%20Code%20silently%20loses%20ghost%20text.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=656&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FSupport%2FTerminalAppDetector.swift%0ALine%3A%20383-384%0A%0AComment%3A%0A**%60xterm%60%20prefix%20may%20suppress%20suggestions%20in%20non-terminal%20xterm.js%20panels**%0A%0A%60hasPrefix%28%22xterm%22%29%60%20will%20also%20match%20any%20VS%20Code%20extension%20or%20Electron%20app%20that%20renders%20output%2Flog%20viewer%20panels%20using%20xterm.js%20%28e.g.%2C%20%60xterm-viewer%60%2C%20%60xterm-output%60%29.%20If%20a%20user%20has%20focus%20inside%20such%20a%20panel's%20editable%20field%2C%20suggestions%20will%20be%20suppressed%20even%20though%20it%20isn't%20a%20shell%20terminal.%20The%20current%20design%20is%20intentional%20%28per%20the%20doc-comment%3A%20%22keeps%20detection%20working%20if%20xterm%20renames%20its%20input%20node%22%29%2C%20but%20the%20tradeoff%20means%20any%20future%20xterm.js-powered%20non-terminal%20component%20inside%20VS%20Code%20silently%20loses%20ghost%20text.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=656&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fvscode-integrated-terminal-suggestions%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fvscode-integrated-terminal-suggestions%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FSupport%2FTerminalAppDetector.swift%3A383-384%0A**%60xterm%60%20prefix%20may%20suppress%20suggestions%20in%20non-terminal%20xterm.js%20panels**%0A%0A%60hasPrefix%28%22xterm%22%29%60%20will%20also%20match%20any%20VS%20Code%20extension%20or%20Electron%20app%20that%20renders%20output%2Flog%20viewer%20panels%20using%20xterm.js%20%28e.g.%2C%20%60xterm-viewer%60%2C%20%60xterm-output%60%29.%20If%20a%20user%20has%20focus%20inside%20such%20a%20panel's%20editable%20field%2C%20suggestions%20will%20be%20suppressed%20even%20though%20it%20isn't%20a%20shell%20terminal.%20The%20current%20design%20is%20intentional%20%28per%20the%20doc-comment%3A%20%22keeps%20detection%20working%20if%20xterm%20renames%20its%20input%20node%22%29%2C%20but%20the%20tradeoff%20means%20any%20future%20xterm.js-powered%20non-terminal%20component%20inside%20VS%20Code%20silently%20loses%20ghost%20text.%0A%0A&repo=fujacob%2Fcotabby&pr=656&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FSupport%2FTerminalAppDetector.swift%3A383-384%0A**%60xterm%60%20prefix%20may%20suppress%20suggestions%20in%20non-terminal%20xterm.js%20panels**%0A%0A%60hasPrefix%28%22xterm%22%29%60%20will%20also%20match%20any%20VS%20Code%20extension%20or%20Electron%20app%20that%20renders%20output%2Flog%20viewer%20panels%20using%20xterm.js%20%28e.g.%2C%20%60xterm-viewer%60%2C%20%60xterm-output%60%29.%20If%20a%20user%20has%20focus%20inside%20such%20a%20panel's%20editable%20field%2C%20suggestions%20will%20be%20suppressed%20even%20though%20it%20isn't%20a%20shell%20terminal.%20The%20current%20design%20is%20intentional%20%28per%20the%20doc-comment%3A%20%22keeps%20detection%20working%20if%20xterm%20renames%20its%20input%20node%22%29%2C%20but%20the%20tradeoff%20means%20any%20future%20xterm.js-powered%20non-terminal%20component%20inside%20VS%20Code%20silently%20loses%20ghost%20text.%0A%0A&repo=fujacob%2Fcotabby&pr=656&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Skip ghost text in VS Code / Cursor inte..."](https://github.com/fujacob/cotabby/commit/a0cf966a921a7b9a399846a9629d825bb6c26276) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36392304)</sub>

<!-- /greptile_comment -->