### PR TITLE
feat(onboarding): add a Clear button to the setup wizard keybind step

### DIFF
--- a/Cotabby/UI/WelcomeView.swift
+++ b/Cotabby/UI/WelcomeView.swift
@@ -454,7 +454,9 @@ extension WelcomeView {
                                 modifiers: [],
                                 label: SuggestionSettingsModel.defaultAcceptanceKeyLabel
                             )
-                        } : nil
+                        } : nil,
+                        onClear: suggestionSettings.acceptanceKeyCode != SuggestionSettingsModel.disabledKeyCode
+                            ? { suggestionSettings.clearAcceptanceKey() } : nil
                     )
 
                     keybindRow(
@@ -478,12 +480,14 @@ extension WelcomeView {
                                 modifiers: [],
                                 label: SuggestionSettingsModel.defaultFullAcceptanceKeyLabel
                             )
-                        } : nil
+                        } : nil,
+                        onClear: suggestionSettings.fullAcceptanceKeyCode != SuggestionSettingsModel.disabledKeyCode
+                            ? { suggestionSettings.clearFullAcceptanceKey() } : nil
                     )
                 }
 
                 // No `onReset` here: the toggle hotkey is opt-in and has no factory default, so the
-                // only meaningful "reset" is unbind, which the Clear gesture in the recorder covers.
+                // only meaningful "reset" is unbind, which the Clear button already covers.
                 keybindRow(
                     title: "Toggle Cotabby",
                     keyLabel: suggestionSettings.globalToggleKeyLabel,
@@ -496,7 +500,9 @@ extension WelcomeView {
                             label: label
                         )
                     },
-                    onReset: nil
+                    onReset: nil,
+                    onClear: suggestionSettings.globalToggleKeyCode != SuggestionSettingsModel.disabledKeyCode
+                        ? { suggestionSettings.clearGlobalToggleKey() } : nil
                 )
             }
             .frame(maxWidth: 440)
@@ -510,7 +516,8 @@ extension WelcomeView {
         action: ShortcutAction,
         isRecording: Binding<Bool>,
         onKeyRecorded: @escaping (CGKeyCode, ShortcutModifierMask, String) -> Void,
-        onReset: (() -> Void)? = nil
+        onReset: (() -> Void)? = nil,
+        onClear: (() -> Void)? = nil
     ) -> some View {
         HStack(spacing: 10) {
             Text(title)
@@ -553,6 +560,18 @@ extension WelcomeView {
             if let onReset {
                 Button("Reset") {
                     onReset()
+                    isRecording.wrappedValue = false
+                }
+                .controlSize(.small)
+            }
+
+            // Mirror the Settings "Shortcuts" pane, which offers Clear here too: unbinding a shortcut
+            // mid-setup shouldn't force the user to finish onboarding and then dig through Settings to
+            // undo it. Call sites pass nil while the key is already unbound, so the button only appears
+            // when there is a binding to clear (the same gate the settings pane applies).
+            if let onClear {
+                Button("Clear") {
+                    onClear()
                     isRecording.wrappedValue = false
                 }
                 .controlSize(.small)


### PR DESCRIPTION
## Summary

The Settings "Shortcuts" pane lets you unbind a shortcut with a **Clear** button, but the matching keybind step in the first-run setup wizard only offered **Change** and **Reset**. A user who wanted to leave a binding unset during setup (the issue's example: unbinding the `` ` `` key) had to finish onboarding and then open Settings to clear it.

This adds a **Clear** button to all three onboarding keybind rows (Accept Word, Accept Entire Suggestion, Toggle Cotabby), wired to the existing `clearAcceptanceKey()` / `clearFullAcceptanceKey()` / `clearGlobalToggleKey()` model methods that the Settings pane already uses.

The button follows the row's existing `onReset` idiom: the call site passes `nil` for `onClear` while the key is already unbound, so the button only appears when there is a binding to clear, the same visibility rule the Settings pane applies (`keyCode != disabledKeyCode`).

## Validation

```
swiftlint lint --strict --quiet Cotabby/UI/WelcomeView.swift
# exit 0 (matches CI's `swiftlint --strict`)

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby \
  -destination 'platform=macOS' build -derivedDataPath build/DerivedData
# ** BUILD SUCCEEDED **
```

No screenshot attached. The change reuses the same control, styling (`.controlSize(.small)`), and clear-key methods as the existing Settings "Shortcuts" Clear button, gated by the same `keyCode != disabledKeyCode` rule, so it renders like the Reset button already shown beside it. A reviewer can confirm in-app via **Settings > General > "Replay setup walkthrough" > Keybinds**: a Clear button appears next to each bound shortcut and disappears once that shortcut is unbound.

## Linked issues

Fixes #659

## Risk / rollout notes

Onboarding-only, additive UI change. No schema, settings, or `project.yml` migration (no new files; the edited file is auto-discovered). The clear-key methods are already exercised by the Settings pane, so no new model behavior is introduced.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a **Clear** button to each of the three keybind rows in the first-run setup wizard (`WelcomeView`), mirroring the equivalent button already present in the Settings › Shortcuts pane. Previously, users who wanted to leave a binding unset during onboarding had to complete setup and then open Settings manually.

- Extends `keybindRow` with an optional `onClear: (() -> Void)?` parameter (default `nil`) and renders a `.controlSize(.small)` Clear button when it is non-nil, exactly mirroring the existing `onReset` pattern.
- Wires the three call sites (Accept Word, Accept Entire Suggestion, Toggle Cotabby) to the same `clearAcceptanceKey()` / `clearFullAcceptanceKey()` / `clearGlobalToggleKey()` model methods already used by the Settings pane, gated by `keyCode != disabledKeyCode` so the button only appears when there is an active binding to clear.

<h3>Confidence Score: 5/5</h3>

Additive onboarding-only UI change that reuses proven model methods and mirrors an existing UI pattern; no new model behavior, schema changes, or shared-state mutations introduced.

The change is a small, well-contained addition: a new optional parameter on a private helper, three wired call sites, and a conditional button that delegates entirely to model methods already exercised by the Settings pane. The gating condition (keyCode != disabledKeyCode) matches the existing Settings pane rule, and isRecording is correctly reset to false in the Clear handler, consistent with the Reset button's behavior. No regressions to existing flows are expected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/WelcomeView.swift | Adds optional `onClear` parameter to `keybindRow` and wires it to existing clear-key model methods at all three call sites; logic is straightforward and consistent with the Settings pane pattern. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[keybindRow rendered] --> B{isRecording?}
    B -- Yes --> C[KeyRecorderView\nonKeyRecorded / onCancelled]
    B -- No --> D[Button: Change\nsets isRecording = true]

    A --> E{onReset != nil?}
    E -- Yes --> F[Button: Reset\ncalls onReset\nsets isRecording = false]
    E -- No --> G[hidden]

    A --> H{onClear != nil?\nkeyCode != disabledKeyCode}
    H -- Yes --> I["Button: Clear ← NEW\ncalls onClear()\nsets isRecording = false"]
    H -- No --> J[hidden]

    I --> K[clearAcceptanceKey /\nclearFullAcceptanceKey /\nclearGlobalToggleKey]
    K --> L[SuggestionSettingsModel\nupdates persisted binding]
```

<sub>Reviews (1): Last reviewed commit: ["feat(onboarding): add a Clear button to ..."](https://github.com/fujacob/cotabby/commit/ebf8c1ca8a567284f6d5cfca20e98ef2d8a5cca8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36880487)</sub>

<!-- /greptile_comment -->