### PR TITLE
Default log floor to .info so debug log lines aren't built unless opted in

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -105,6 +105,13 @@ Cotabby ships a structured logging system built for AI-assisted debugging. Durin
 the app is launched with `-cotabby-debug`, which enables on-disk JSONL sinks in addition to
 the always-on Console.app stream.
 
+**Verbosity floor.** Every handler's level comes from `CotabbyDebugOptions.minimumLogLevel`. The
+default is `.info`, which lets swift-log skip per-keystroke `.debug`/`.trace` calls before they
+allocate, so they cost nothing in release and do not distort energy measurements. `-cotabby-debug`
+raises the floor to `.trace`. `COTABBY_LOG_LEVEL=<trace|debug|info|...>` overrides it explicitly,
+e.g. to get Console `.debug` output without the heavier file/screenshot artifacts. A
+`Logging initialized` line at startup records the active `debug_mode`, `min_log_level`, and sink paths.
+
 **Log file locations** (only populated when `-cotabby-debug` is set):
 
 - `~/Library/Logs/Cotabby/cotabby.jsonl` — main event stream. One JSON object per line. All
@@ -158,6 +165,11 @@ jq 'select(.category == "runtime")' ~/Library/Logs/Cotabby/cotabby.jsonl
 log show --predicate 'subsystem == "com.cotabby.app"' --last 10m
 log stream --predicate 'subsystem == "com.cotabby.app"' --level debug
 ```
+
+Note the default verbosity floor is `.info`, so Cotabby's `.debug`/`.trace` lines are not emitted
+unless the app was launched with `-cotabby-debug` or `COTABBY_LOG_LEVEL=debug`. The `--level debug`
+flag above controls what `log` *displays*, not what Cotabby *emits*. The `.info`, warning, and error
+lines (including model-load config and permission transitions) always stream.
 
 **Rule of thumb.** When a user reports a bug, first `tail` / `jq` the relevant file with the
 symptom → category map. Do not ask the user to re-explain symptoms before checking the logs.

--- a/Cotabby/Support/CotabbyDebugOptions.swift
+++ b/Cotabby/Support/CotabbyDebugOptions.swift
@@ -16,6 +16,31 @@ enum CotabbyDebugOptions {
         ProcessInfo.processInfo.arguments.contains(launchArgument)
     }
 
+    /// The swift-log floor applied to the always-on `OSLogHandler` and the debug-only file sinks.
+    ///
+    /// swift-log only skips evaluating a log call's `@autoclosure` message (and building its
+    /// metadata) when the handler's `logLevel` is strictly greater than the call's level. The
+    /// handlers previously hardcoded `.trace`, so *every* `.debug`/`.trace` call on the hot path
+    /// (one per keystroke: focus snapshots, routing, generation boundaries) still built its message
+    /// string and metadata dictionary even in release builds where nothing consumed it. That is
+    /// wasted CPU and energy, and it quietly inflates any on-device energy measurement. Defaulting
+    /// the floor to `.info` makes those hot-path calls genuinely free unless verbose logging is
+    /// explicitly requested.
+    ///
+    /// Precedence, highest first:
+    /// 1. `COTABBY_LOG_LEVEL=<trace|debug|info|notice|warning|error|critical>` — explicit override,
+    ///    e.g. to get Console `.debug` output without the heavier `-cotabby-debug` file/screenshot
+    ///    artifacts. An unrecognized value is ignored.
+    /// 2. `-cotabby-debug` — full `.trace` capture to Console and the JSONL sinks.
+    /// 3. Default — `.info`.
+    static var minimumLogLevel: Logging.Logger.Level {
+        if let raw = ProcessInfo.processInfo.environment["COTABBY_LOG_LEVEL"]?.lowercased(),
+           let level = Logging.Logger.Level(rawValue: raw) {
+            return level
+        }
+        return isEnabled ? .trace : .info
+    }
+
     /// Writes a diagnostic line only when the explicit debug launch argument is present.
     ///
     /// Keep this for metadata, not raw user content. Full prompts, OCR text, and screenshots are
@@ -58,11 +83,36 @@ enum CotabbyLogger {
             guard installFileHandler else { return osHandler }
             return MultiplexLogHandler([osHandler, FileLogHandler(label: label)])
         }
+        announceConfiguration(fileSinksInstalled: installFileHandler)
     }()
 
     /// Call once at app startup (e.g. in AppDelegate.init) before any logger is used.
     static func bootstrap() {
         _ = bootstrapOnce
+    }
+
+    /// Emits a single startup line recording the active logging configuration: whether debug mode
+    /// is on, the effective verbosity floor, and where the JSONL sinks live. Logged at `.info` so it
+    /// survives even the default quiet configuration — it is the first thing a developer (or an AI
+    /// debugging agent reading the logs) needs before interpreting anything else, and it makes a
+    /// misconfigured verbosity obvious instead of looking like "nothing is being logged".
+    private static func announceConfiguration(fileSinksInstalled: Bool) {
+        var metadata: Logging.Logger.Metadata = [
+            "debug_mode": .stringConvertible(CotabbyDebugOptions.isEnabled),
+            "min_log_level": .string(CotabbyDebugOptions.minimumLogLevel.rawValue),
+            "file_sinks": .stringConvertible(fileSinksInstalled)
+        ]
+        // Only touch the file writers when sinks are actually installed: referencing `.shared` opens
+        // the on-disk handle, which must never happen in the default (no-sink) configuration.
+        if fileSinksInstalled {
+            if let path = FileLogWriter.shared.fileURL?.path {
+                metadata["event_log"] = .string(path)
+            }
+            if let path = LLMIOFileWriter.shared.fileURL?.path {
+                metadata["llm_io_log"] = .string(path)
+            }
+        }
+        app.info("Logging initialized", metadata: metadata)
     }
 
     static let app = Logger(label: "com.cotabby.app")
@@ -81,7 +131,7 @@ enum CotabbyLogger {
 /// with the correct subsystem, category, and native log level.
 struct OSLogHandler: LogHandler {
     var metadata: Logging.Logger.Metadata = [:]
-    var logLevel: Logging.Logger.Level = .trace
+    var logLevel: Logging.Logger.Level
 
     private let osLogger: os.Logger
 
@@ -90,7 +140,11 @@ struct OSLogHandler: LogHandler {
     /// with one subsystem while still distinguishing components by category.
     private static let subsystem = "com.cotabby.app"
 
-    init(label: String) {
+    /// `logLevel` defaults to `CotabbyDebugOptions.minimumLogLevel` so the always-on Console sink is
+    /// quiet (`.info`) in normal runs and fully verbose (`.trace`) under `-cotabby-debug`. The floor
+    /// is what lets swift-log skip per-keystroke `.debug`/`.trace` calls before they allocate.
+    init(label: String, logLevel: Logging.Logger.Level = CotabbyDebugOptions.minimumLogLevel) {
+        self.logLevel = logLevel
         let parts = label.split(separator: ".", maxSplits: 2)
         let category = parts.count > 2 ? String(parts[2]) : label
         osLogger = os.Logger(subsystem: Self.subsystem, category: category)

--- a/Cotabby/Support/FileLogHandler.swift
+++ b/Cotabby/Support/FileLogHandler.swift
@@ -147,14 +147,23 @@ final class FileLogWriter: @unchecked Sendable {
 /// top-level keys so they can be filtered with `jq` without unpacking strings.
 struct FileLogHandler: LogHandler {
     var metadata: Logging.Logger.Metadata = [:]
-    var logLevel: Logging.Logger.Level = .trace
+    var logLevel: Logging.Logger.Level
 
     private let label: String
     private let writer: FileLogWriter
 
-    init(label: String, writer: FileLogWriter = .shared) {
+    /// `logLevel` defaults to `CotabbyDebugOptions.minimumLogLevel`. This sink is only installed
+    /// under `-cotabby-debug`, where the floor is `.trace`, so it captures everything by default —
+    /// but sourcing the level from the same place keeps it honest if the floor is overridden via
+    /// `COTABBY_LOG_LEVEL`.
+    init(
+        label: String,
+        writer: FileLogWriter = .shared,
+        logLevel: Logging.Logger.Level = CotabbyDebugOptions.minimumLogLevel
+    ) {
         self.label = label
         self.writer = writer
+        self.logLevel = logLevel
     }
 
     subscript(metadataKey key: String) -> Logging.Logger.Metadata.Value? {


### PR DESCRIPTION
## Summary

Mechanical change: the swift-log level floor now defaults to `.info` instead of being hardcoded to `.trace`, so `.debug`/`.trace` log calls short-circuit (their message string and metadata dictionary are never built) unless verbose logging is explicitly turned on.

**This is not a privacy or security fix, and nothing dangerous was being logged.** No prompt text, OCR, screenshots, or JSONL were ever written in release builds: those sinks are gated on `-cotabby-debug` and stay gated. The only thing that ran in release was the CPU and allocation cost of *formatting* debug log lines that nothing consumes.

Why that happened: swift-log only skips evaluating a log call's `@autoclosure` when the handler's level is strictly above the call's level. Every handler hardcoded `.trace` (the lowest level), so no `.debug`/`.trace` call was ever skipped, in any build. The always-on `OSLogHandler` is installed in release too, so on the hot path (focus snapshots, engine routing, generation boundaries) release builds still built each debug line's string + metadata and handed it to `os_log` per keystroke. Under `-cotabby-debug` the same un-gated floor additionally meant ISO8601 + `JSONSerialization` + a locked disk write per keystroke, which inflates the energy numbers used to investigate #661.

Behavior after this change:
- Default floor `.info`: `.debug`/`.trace` calls are skipped before they allocate.
- `-cotabby-debug` raises the floor to `.trace` (full Console + JSONL capture, unchanged).
- `COTABBY_LOG_LEVEL=<trace|debug|info|...>` overrides it explicitly, e.g. Console `.debug` without the heavier file/screenshot artifacts.
- New one-time `Logging initialized` line records `debug_mode`, `min_log_level`, and the JSONL sink paths.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build \
  -derivedDataPath build/DerivedData -onlyUsePackageVersionsFromResolvedFile
# ** BUILD SUCCEEDED **

swiftlint lint --quiet Cotabby/Support/CotabbyDebugOptions.swift Cotabby/Support/FileLogHandler.swift
# exit 0
```

Not yet exercised end-to-end at runtime. To confirm on next launch:
- No flags: one `Logging initialized` line with `min_log_level=info`, and no per-keystroke `.debug` lines in `log stream`.
- `-cotabby-debug`: `min_log_level=trace`, `cotabby.jsonl` / `llm-io.jsonl` populate, and `event_log` / `llm_io_log` paths appear in the startup line.

## Linked issues

Refs #661. This is measurement-hygiene groundwork: it removes per-keystroke logging overhead so energy profiling is accurate. It is not by itself a steady-state energy fix; the larger levers (inference frequency, OCR defaults, idle timers) are separate follow-ups.

## Risk / rollout notes

- Not a privacy or security change. Release builds never wrote prompt, OCR, screenshot, or JSONL data, before or after this PR; those file sinks remain gated on `-cotabby-debug`. The only change is that debug-level log lines are no longer formatted in the default configuration.
- Behavior change: `.debug`/`.trace` are no longer emitted to OSLog by default, so `log show/stream ... --level debug` will not show them without `-cotabby-debug` or `COTABBY_LOG_LEVEL=debug`. `.info` and above (model-load config, permission transitions, routing fallbacks, warnings, errors) still stream. CLAUDE.md debugging docs updated to match.
- The dedicated llm-io sink is unchanged (still `.trace`, debug-only install), so counting generations per minute from `llm-io.jsonl` is unaffected.
- No schema, settings, or pbxproj migration. No new files, so no `xcodegen generate` needed.
- `COTABBY_LOG_LEVEL` accepts swift-log level names; an unrecognized value is ignored and falls back to the flag/default.
