### PR TITLE
Back off idle timers so the menu-bar app stops waking the main thread when idle

### DIFF
--- a/Cotabby/Services/Focus/FocusTracker.swift
+++ b/Cotabby/Services/Focus/FocusTracker.swift
@@ -38,6 +38,9 @@ final class FocusTracker {
     private let snapshotResolver: FocusSnapshotResolver
 
     private var timer: Timer?
+    /// The interval the running `timer` was created with, so idle-backoff transitions can re-arm it
+    /// only when the effective interval actually changes (no per-keystroke timer churn while active).
+    private var scheduledInterval: TimeInterval?
     private var pollSequence = 0
     private var focusChangeSequence: UInt64 = 0
     private var lastFocusedInputSignature: FocusedInputPollingSignature?
@@ -92,9 +95,35 @@ final class FocusTracker {
         }
 
         CotabbyLogger.focus.info("Focus polling started at \(Int(self.pollInterval * 1000))ms interval")
+        // Capture once immediately (this also resets idle backoff), then arm the timer at the
+        // resulting effective interval.
         refreshNow()
+        scheduleTimer()
+    }
 
-        let timer = Timer(timeInterval: pollInterval, repeats: true) { [weak self] _ in
+    /// Stops polling while leaving the most recent snapshot available to callers.
+    func stop() {
+        CotabbyLogger.focus.info("Focus polling stopped")
+        timer?.invalidate()
+        timer = nil
+        scheduledInterval = nil
+    }
+
+    /// The interval the poll timer should currently run at: the base interval stretched by idle
+    /// backoff. While the user is active the stride is 1, so this is just `pollInterval`.
+    private func effectiveInterval() -> TimeInterval {
+        pollInterval * Double(backoff.captureStride)
+    }
+
+    /// Creates (or replaces) the poll timer at the current effective interval. Each fire performs
+    /// exactly one capture, so an idle machine wakes the main thread every `base * stride` instead of
+    /// every base tick. The capture cadence is identical to the previous tick-skipping design; only
+    /// the no-op wakeups are removed.
+    private func scheduleTimer() {
+        timer?.invalidate()
+        let interval = effectiveInterval()
+        scheduledInterval = interval
+        let timer = Timer(timeInterval: interval, repeats: true) { [weak self] _ in
             Task { @MainActor [weak self] in
                 self?.handleTimerTick()
             }
@@ -103,11 +132,13 @@ final class FocusTracker {
         RunLoop.main.add(timer, forMode: .common)
     }
 
-    /// Stops polling while leaving the most recent snapshot available to callers.
-    func stop() {
-        CotabbyLogger.focus.info("Focus polling stopped")
-        timer?.invalidate()
-        timer = nil
+    /// Re-arms the timer only when idle backoff has moved it to a new effective interval. During
+    /// active use the stride stays at 1, so this is a no-op and avoids per-keystroke timer churn.
+    private func rescheduleTimerIfIntervalChanged() {
+        guard timer != nil, effectiveInterval() != scheduledInterval else {
+            return
+        }
+        scheduleTimer()
     }
 
     /// Restarts the polling timer with a new interval. No-op if the interval hasn't changed.
@@ -137,18 +168,19 @@ final class FocusTracker {
     func refreshNow() {
         backoff.reset()
         performCaptureAndPublish()
+        rescheduleTimerIfIntervalChanged()
     }
 
-    /// Timer entry point that applies idle backoff before the expensive Accessibility walk.
+    /// Timer entry point: capture once, fold the result into idle backoff, then re-arm the timer at
+    /// the backoff-derived interval.
     ///
     /// While captures keep producing changes (typing, focus churn) the stride stays at 1 and the
-    /// poll runs at full cadence. Once captures stop changing, the stride grows so an idle machine
-    /// isn't paying for ~12.5 full Chrome AX tree walks per second — the dominant idle cost in #280.
+    /// timer stays at the base interval. Once captures stop changing, the stride grows and the timer
+    /// is re-armed to a longer interval, so an idle machine stops waking ~12.5x/second only to skip
+    /// the walk it would not run anyway. That wasteful wake was the dominant idle cost in #280.
     private func handleTimerTick() {
-        guard backoff.shouldCaptureOnTick() else {
-            return
-        }
         backoff.recordCapture(didChange: performCaptureAndPublish())
+        rescheduleTimerIfIntervalChanged()
     }
 
     /// Captures the current snapshot, publishes any change, and reports whether anything changed.

--- a/Cotabby/Services/Permission/PermissionManager.swift
+++ b/Cotabby/Services/Permission/PermissionManager.swift
@@ -34,7 +34,14 @@ final class PermissionManager: ObservableObject {
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            self?.refresh()
+            // The observer closure is not formally actor-isolated even though `queue: .main`
+            // guarantees main-thread delivery. `assumeIsolated` makes the hop explicit for strict
+            // concurrency checking (and keeps the refresh synchronous with activation, so surfaces
+            // reading permission state on this same turn see fresh values). Same pattern as
+            // `SystemMetricsStore`'s main-queue timer.
+            MainActor.assumeIsolated {
+                self?.refresh()
+            }
         }
         // `refresh()` also (re)configures polling for the current grant state, so a process that
         // launches with every permission already granted never arms the timer at all.

--- a/Cotabby/Services/Permission/PermissionManager.swift
+++ b/Cotabby/Services/Permission/PermissionManager.swift
@@ -17,22 +17,35 @@ final class PermissionManager: ObservableObject {
     @Published private(set) var screenRecordingGranted = false
 
     private var pollTimer: Timer?
+    private var activationObserver: NSObjectProtocol?
 
-    /// Polling keeps UI state aligned with system settings changes performed outside the app.
+    /// Keeps UI state aligned with permission changes the user makes in System Settings.
+    ///
+    /// A permission can only change while the user is in System Settings, i.e. while Cotabby is
+    /// backgrounded; returning to the app fires `didBecomeActive`, and the menu/settings surfaces
+    /// already call `refresh()` when they appear. So instead of a forever-running 2s poll (a 0.5 Hz
+    /// main-thread wake for the whole session, long after every grant is already in place), we
+    /// refresh on activation and keep the short catch-up poll alive ONLY while a required permission
+    /// is still missing — the onboarding window where snappy feedback matters. Once the required set
+    /// is granted the timer is torn down, so an established user pays zero idle wakeups here.
     init() {
-        refresh()
-        let pollTimer = Timer(timeInterval: 2.0, repeats: true) { [weak self] _ in
-            DispatchQueue.main.async { self?.refresh() }
+        activationObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.refresh()
         }
-        // Menu panels and drag sessions can move the main run loop out of its default mode.
-        // Common modes keep the permission cache from freezing during exactly the flows that
-        // change permissions.
-        RunLoop.main.add(pollTimer, forMode: .common)
-        self.pollTimer = pollTimer
+        // `refresh()` also (re)configures polling for the current grant state, so a process that
+        // launches with every permission already granted never arms the timer at all.
+        refresh()
     }
 
     deinit {
         pollTimer?.invalidate()
+        if let activationObserver {
+            NotificationCenter.default.removeObserver(activationObserver)
+        }
     }
 
     /// Re-reads the current system permission state and republishes any changes to observers.
@@ -57,6 +70,38 @@ final class PermissionManager: ObservableObject {
             CotabbyLogger.app.info("Screen Recording permission changed: \(latestScreenRecordingGranted)")
             screenRecordingGranted = latestScreenRecordingGranted
         }
+
+        updatePollingForCurrentState()
+    }
+
+    /// Arms the 2-second catch-up poll only while a required permission is still missing, and stops
+    /// it once the required set is granted. Permission changes after that are rare and deliberate,
+    /// and every one is followed by the user returning to the app (`didBecomeActive`) or opening a
+    /// Cotabby surface that already calls `refresh()`, so the standing timer buys nothing but idle
+    /// main-thread wakeups.
+    private func updatePollingForCurrentState() {
+        if requiredPermissionsGranted {
+            stopPolling()
+        } else {
+            startPollingIfNeeded()
+        }
+    }
+
+    private func startPollingIfNeeded() {
+        guard pollTimer == nil else { return }
+        let pollTimer = Timer(timeInterval: 2.0, repeats: true) { [weak self] _ in
+            DispatchQueue.main.async { self?.refresh() }
+        }
+        // Menu panels and drag sessions can move the main run loop out of its default mode. Common
+        // modes keep the permission cache from freezing during exactly the flows that change
+        // permissions.
+        RunLoop.main.add(pollTimer, forMode: .common)
+        self.pollTimer = pollTimer
+    }
+
+    private func stopPolling() {
+        pollTimer?.invalidate()
+        pollTimer = nil
     }
 
     /// Asks macOS to register or prompt for the current process before showing manual guidance.

--- a/Cotabby/Support/FocusPollBackoff.swift
+++ b/Cotabby/Support/FocusPollBackoff.swift
@@ -9,18 +9,18 @@ import Foundation
 struct FocusPollBackoff {
     /// Consecutive captures that produced no change. Drives the stride.
     private(set) var idleCaptureCount = 0
-    /// Base timer ticks elapsed since the last expensive capture.
-    private var ticksSinceCapture = 0
 
     /// Cap on `idleCaptureCount` so a long idle period can't overflow; the stride is already maxed
     /// well before this is reached.
     static let idleCaptureCountCap = 60
 
-    /// How many base poll ticks to wait between expensive captures, given how many consecutive
-    /// captures have produced no change.
+    /// Poll-interval multiplier for the given idle level. The focus timer runs at
+    /// `baseInterval * captureStride`, so this is how much an idle machine stretches the gap between
+    /// expensive Accessibility walks.
     ///
-    /// The first few idle captures stay at full cadence so a brief pause doesn't make the field feel
-    /// laggy; sustained idleness ramps toward ~800ms (at the 80ms base) before the next AX walk.
+    /// The first few idle captures stay at full cadence (stride 1) so a brief pause doesn't make the
+    /// field feel laggy; sustained idleness ramps toward 10x (e.g. ~500ms at the 50ms base) before
+    /// the next AX walk.
     static func captureStride(idleCaptureCount: Int) -> Int {
         switch idleCaptureCount {
         case ..<5:
@@ -34,17 +34,15 @@ struct FocusPollBackoff {
         }
     }
 
-    /// Advances one timer tick. Returns `true` when the caller should run the expensive capture now.
-    mutating func shouldCaptureOnTick() -> Bool {
-        ticksSinceCapture += 1
-        guard ticksSinceCapture >= Self.captureStride(idleCaptureCount: idleCaptureCount) else {
-            return false
-        }
-        ticksSinceCapture = 0
-        return true
+    /// The current poll-interval multiplier. `FocusTracker` multiplies its base interval by this to
+    /// get the interval the timer actually runs at, so an idle machine wakes the main thread every
+    /// `base * stride` instead of waking every base tick only to skip the work.
+    var captureStride: Int {
+        Self.captureStride(idleCaptureCount: idleCaptureCount)
     }
 
-    /// Records a completed capture: a change returns the loop to full cadence, no change grows the stride.
+    /// Records a completed capture: a change returns the loop to full cadence, no change grows the
+    /// stride.
     mutating func recordCapture(didChange: Bool) {
         idleCaptureCount = didChange ? 0 : min(idleCaptureCount + 1, Self.idleCaptureCountCap)
     }
@@ -52,6 +50,5 @@ struct FocusPollBackoff {
     /// An explicit refresh (real activity, e.g. a keystroke) returns the loop to full cadence.
     mutating func reset() {
         idleCaptureCount = 0
-        ticksSinceCapture = 0
     }
 }

--- a/CotabbyTests/FocusPollBackoffTests.swift
+++ b/CotabbyTests/FocusPollBackoffTests.swift
@@ -1,15 +1,15 @@
 import XCTest
 @testable import Cotabby
 
-/// Verifies the focus-poll idle backoff (`FocusPollBackoff`). This is the #280 fix: the poll stays
-/// responsive right after activity, then stretches the interval between the expensive Accessibility
-/// walks once the focused state stops changing — so an idle machine isn't paying for ~12.5 Chrome AX
-/// tree walks per second.
+/// Verifies the focus-poll idle backoff (`FocusPollBackoff`). This is the #280 fix plus its energy
+/// follow-up: the poll stays responsive right after activity, then stretches the interval between the
+/// expensive Accessibility walks once the focused state stops changing, so an idle machine isn't
+/// waking the main thread ~12.5x/second for a walk it would only skip.
 final class FocusPollBackoffTests: XCTestCase {
-    /// Drives `count` timer ticks, recording every capture as "no change", and returns the result.
-    private func idledBackoff(ticks count: Int) -> FocusPollBackoff {
+    /// Returns a backoff that has recorded `count` consecutive no-change captures (i.e. gone idle).
+    private func idledBackoff(captures count: Int) -> FocusPollBackoff {
         var backoff = FocusPollBackoff()
-        for _ in 0..<count where backoff.shouldCaptureOnTick() {
+        for _ in 0..<count {
             backoff.recordCapture(didChange: false)
         }
         return backoff
@@ -47,46 +47,44 @@ final class FocusPollBackoffTests: XCTestCase {
 
     // MARK: - State machine
 
-    func test_capturesEveryTickWhileChanging() {
+    func test_instanceStrideMatchesSchedule() {
+        XCTAssertEqual(FocusPollBackoff().captureStride, 1)
+        XCTAssertEqual(idledBackoff(captures: 5).captureStride, 3)
+        XCTAssertEqual(idledBackoff(captures: 12).captureStride, 6)
+        XCTAssertEqual(idledBackoff(captures: 30).captureStride, 10)
+    }
+
+    func test_capturesWhileChangingStayAtFullCadence() {
         var backoff = FocusPollBackoff()
         for _ in 0..<10 {
-            XCTAssertTrue(backoff.shouldCaptureOnTick())
             backoff.recordCapture(didChange: true)
         }
         XCTAssertEqual(backoff.idleCaptureCount, 0)
+        XCTAssertEqual(backoff.captureStride, 1)
     }
 
-    func test_sustainedIdleStretchesStrideSoMostTicksSkip() {
-        var backoff = FocusPollBackoff()
-        var captures = 0
-        for _ in 0..<400 where backoff.shouldCaptureOnTick() {
-            backoff.recordCapture(didChange: false)
-            captures += 1
-        }
-        XCTAssertGreaterThanOrEqual(backoff.idleCaptureCount, 30)
-        XCTAssertLessThanOrEqual(backoff.idleCaptureCount, FocusPollBackoff.idleCaptureCountCap)
-        // With the stride ramping to 10, 400 ticks should yield far fewer than 400 captures.
-        XCTAssertLessThan(captures, 100)
+    func test_sustainedIdleGrowsStrideAndCaps() {
+        let backoff = idledBackoff(captures: 400)
+        XCTAssertEqual(backoff.idleCaptureCount, FocusPollBackoff.idleCaptureCountCap)
+        XCTAssertEqual(backoff.captureStride, 10)
     }
 
     /// The invariant Greptile flagged: a change after a long idle period must snap back to full
-    /// cadence, not stay permanently backed off. (A dropped reset here would leave stride at 10.)
+    /// cadence, not stay permanently backed off. (A dropped reset here would leave the stride at 10.)
     func test_changeAfterIdleResetsToFullCadence() {
-        var backoff = idledBackoff(ticks: 400)
-        XCTAssertGreaterThan(FocusPollBackoff.captureStride(idleCaptureCount: backoff.idleCaptureCount), 1)
+        var backoff = idledBackoff(captures: 400)
+        XCTAssertGreaterThan(backoff.captureStride, 1)
 
-        while !backoff.shouldCaptureOnTick() {}
         backoff.recordCapture(didChange: true)
 
         XCTAssertEqual(backoff.idleCaptureCount, 0)
-        XCTAssertEqual(FocusPollBackoff.captureStride(idleCaptureCount: backoff.idleCaptureCount), 1)
-        XCTAssertTrue(backoff.shouldCaptureOnTick(), "the tick after a change should capture immediately")
+        XCTAssertEqual(backoff.captureStride, 1)
     }
 
     func test_resetReturnsToFullCadence() {
-        var backoff = idledBackoff(ticks: 400)
+        var backoff = idledBackoff(captures: 400)
         backoff.reset()
         XCTAssertEqual(backoff.idleCaptureCount, 0)
-        XCTAssertTrue(backoff.shouldCaptureOnTick(), "the tick after an explicit refresh should capture immediately")
+        XCTAssertEqual(backoff.captureStride, 1)
     }
 }


### PR DESCRIPTION
## Summary

Two always-on timers woke the main thread continuously regardless of whether the user was typing. On Apple Silicon, idle package power is dominated by wake *frequency* rather than per-wake work, so these are a real idle-energy floor (Tier C of the #661 energy audit).

- **PermissionManager** polled `AXIsProcessTrusted` + two `CGPreflight*` calls every 2s for the entire session, even after every permission was already granted (the steady state for any established user). It now refreshes on `NSApplication.didBecomeActive` and keeps the 2s catch-up poll alive only while a *required* permission is still missing (onboarding). Once the required set is granted, the timer is torn down: zero idle wakeups thereafter.
- **FocusTracker** ran a fixed 50ms (20Hz) timer and used `FocusPollBackoff` to *skip* the expensive AX walk when idle, but the timer still fired 20x/s and hopped to the main actor only to no-op. The backoff now drives the timer *interval* itself (`base * stride`), so an idle machine wakes ~2x/s instead of 20x/s.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  -derivedDataPath build/DerivedData -onlyUsePackageVersionsFromResolvedFile \
  -only-testing:CotabbyTests/FocusPollBackoffTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO test
# ** TEST SUCCEEDED **  Executed 9 tests, with 0 failures

swiftlint lint --quiet <changed files>
# exit 0
```

Built the full app + test target. Not yet exercised at runtime; behavior to confirm on next launch: with permissions already granted, no permission poll timer arms (and revoking a permission in System Settings is still reflected after returning to the app); focus tracking still follows the caret while typing and snaps back to fast cadence after an idle pause.

## Linked issues

Refs #661 (Tier C: idle timers).

## Risk / rollout notes

- **Permission revocation latency.** After the required set is granted there is no standing poll, so a revocation made in System Settings is reflected when the user next returns to the app (`didBecomeActive`) or opens any Cotabby surface (the menu, Settings, the Permissions pane, and onboarding all already call `refresh()` on appear). The app cannot function without those permissions anyway, and AX calls begin failing immediately on revocation, so the cache cannot drive harmful behavior in the gap. During onboarding (required not yet granted) the 2s poll still runs for snappy feedback.
- **Focus capture cadence is unchanged.** The timer now fires every `base * stride` and captures on every fire, which is the exact same spacing between AX walks as the previous "fire every base, skip to every stride" design. Only the no-op in-between wakes are removed. The timer is re-armed only when the stride actually changes, so active typing (stride 1) adds zero timer churn, and `refreshNow()` (called per keystroke) still resets to the base interval instantly.
- **API change.** `FocusPollBackoff.shouldCaptureOnTick()` is replaced by a `captureStride` multiplier. The only caller was `FocusTracker`; the unit tests are updated to assert the stride schedule and state machine directly (9 tests, all passing).
- No schema, settings, or pbxproj migration. No new files, so no `xcodegen generate` needed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reduces idle main-thread wakeups in two subsystems: `PermissionManager` now refreshes on `NSApplication.didBecomeActive` and only polls while a required permission is still missing (zero standing wakeups for established users), and `FocusTracker` drives its timer interval directly from the idle-backoff stride so the main thread wakes every `base × stride` instead of every `base` tick.

- **`FocusPollBackoff`** drops `ticksSinceCapture` / `shouldCaptureOnTick()` in favour of a `captureStride` property; `FocusTracker` multiplies the base interval by this stride and re-arms the timer only when the stride actually changes, keeping active typing at full cadence with zero timer churn.
- **`PermissionManager`** wires up a `didBecomeActive` observer, tears down the 2-second poll once `requiredPermissionsGranted` is true, and addresses the prior review's `@MainActor` isolation concern with `MainActor.assumeIsolated` in the activation callback.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the idle-backoff and permission-polling changes are well-scoped, `@MainActor` isolation is consistent throughout both modified actors, and the state machines are directly exercised by 9 passing unit tests.

Both behavioural changes preserve the original capture cadence (active users see no difference) and handle edge cases explicitly: permission revocation is reflected on the next activation or UI surface appear; timer re-arming is guarded by an interval-equality check so active typing causes zero timer churn. The one remaining inconsistency is a style/concurrency-annotation gap with no runtime consequence under current Swift settings.

All files look solid; `PermissionManager.swift` has the minor `DispatchQueue.main.async` inconsistency noted in the inline comment.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/Services/Focus/FocusTracker.swift | Replaces tick-skipping backoff with timer-interval backoff: adds `scheduledInterval` tracking, `scheduleTimer()`, and `rescheduleTimerIfIntervalChanged()`. Logic is sound — `@MainActor` isolation prevents races and `stop()` keeps `timer`/`scheduledInterval` in sync. |
| Cotabby/Services/Permission/PermissionManager.swift | Adds activation-based refresh and conditional polling — correct design. One minor inconsistency: the activation observer uses `MainActor.assumeIsolated` but the preserved timer callback in `startPollingIfNeeded` still uses `DispatchQueue.main.async`. |
| Cotabby/Support/FocusPollBackoff.swift | Simplifies the struct by removing `ticksSinceCapture` and replacing `shouldCaptureOnTick()` with a `captureStride` computed property. Logic and state machine are unchanged. |
| CotabbyTests/FocusPollBackoffTests.swift | Tests updated to match the new stride-based API; coverage is thorough — stride schedule, monotonicity, snap-back after idle, and reset all tested directly. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cotabby/Services/Focus/FocusTracker.swift`, line 91-95 ([link](https://github.com/fujacob/cotabby/blob/46da6cecf9e040d27dcb4e08abbf7978d20ca774/Cotabby/Services/Focus/FocusTracker.swift#L91-L95)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Undocumented behavior change in `start()`: calling it while the timer is already running previously was a no-op; it now calls `refreshNow()`, which resets idle backoff (snap back to stride 1) and performs an immediate AX tree walk. If any callsite invokes `start()` while polling is already active — e.g. as a "ensure tracking is on" guard — this introduces an unintended backoff reset and an extra synchronous AX read that can briefly spike CPU. Consider documenting the new "restart capture and reset backoff" semantic in the method's doc comment.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22energy-idle-timers%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22energy-idle-timers%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FServices%2FFocus%2FFocusTracker.swift%0ALine%3A%2091-95%0A%0AComment%3A%0AUndocumented%20behavior%20change%20in%20%60start%28%29%60%3A%20calling%20it%20while%20the%20timer%20is%20already%20running%20previously%20was%20a%20no-op%3B%20it%20now%20calls%20%60refreshNow%28%29%60%2C%20which%20resets%20idle%20backoff%20%28snap%20back%20to%20stride%201%29%20and%20performs%20an%20immediate%20AX%20tree%20walk.%20If%20any%20callsite%20invokes%20%60start%28%29%60%20while%20polling%20is%20already%20active%20%E2%80%94%20e.g.%20as%20a%20%22ensure%20tracking%20is%20on%22%20guard%20%E2%80%94%20this%20introduces%20an%20unintended%20backoff%20reset%20and%20an%20extra%20synchronous%20AX%20read%20that%20can%20briefly%20spike%20CPU.%20Consider%20documenting%20the%20new%20%22restart%20capture%20and%20reset%20backoff%22%20semantic%20in%20the%20method's%20doc%20comment.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=665&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FServices%2FFocus%2FFocusTracker.swift%0ALine%3A%2091-95%0A%0AComment%3A%0AUndocumented%20behavior%20change%20in%20%60start%28%29%60%3A%20calling%20it%20while%20the%20timer%20is%20already%20running%20previously%20was%20a%20no-op%3B%20it%20now%20calls%20%60refreshNow%28%29%60%2C%20which%20resets%20idle%20backoff%20%28snap%20back%20to%20stride%201%29%20and%20performs%20an%20immediate%20AX%20tree%20walk.%20If%20any%20callsite%20invokes%20%60start%28%29%60%20while%20polling%20is%20already%20active%20%E2%80%94%20e.g.%20as%20a%20%22ensure%20tracking%20is%20on%22%20guard%20%E2%80%94%20this%20introduces%20an%20unintended%20backoff%20reset%20and%20an%20extra%20synchronous%20AX%20read%20that%20can%20briefly%20spike%20CPU.%20Consider%20documenting%20the%20new%20%22restart%20capture%20and%20reset%20backoff%22%20semantic%20in%20the%20method's%20doc%20comment.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=665&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22energy-idle-timers%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22energy-idle-timers%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FServices%2FPermission%2FPermissionManager.swift%3A99-101%0AThe%20%60activationObserver%60%20callback%20in%20%60init%60%20was%20just%20changed%20to%20use%20%60MainActor.assumeIsolated%60%20%28addressing%20the%20previous%20review%20thread%29%2C%20but%20the%20timer%20callback%20in%20%60startPollingIfNeeded%60%20still%20dispatches%20via%20%60DispatchQueue.main.async%20%7B%20self%3F.refresh%28%29%20%7D%60.%20The%20timer%20is%20added%20to%20%60RunLoop.main%60%2C%20so%20it%20already%20fires%20on%20the%20main%20thread%3B%20the%20inner%20async%20dispatch%20is%20redundant%2C%20and%20calling%20the%20%60%40MainActor%60-isolated%20%60refresh%28%29%60%20from%20a%20non-isolated%20%60DispatchQueue.main.async%60%20closure%20has%20the%20same%20strict-concurrency%20concern%20the%20PR%20just%20fixed%20elsewhere%20in%20this%20file.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20pollTimer%20%3D%20Timer%28timeInterval%3A%202.0%2C%20repeats%3A%20true%29%20%7B%20%5Bweak%20self%5D%20_%20in%0A%20%20%20%20%20%20%20%20%20%20%20%20MainActor.assumeIsolated%20%7B%20self%3F.refresh%28%29%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=665&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FServices%2FPermission%2FPermissionManager.swift%3A99-101%0AThe%20%60activationObserver%60%20callback%20in%20%60init%60%20was%20just%20changed%20to%20use%20%60MainActor.assumeIsolated%60%20%28addressing%20the%20previous%20review%20thread%29%2C%20but%20the%20timer%20callback%20in%20%60startPollingIfNeeded%60%20still%20dispatches%20via%20%60DispatchQueue.main.async%20%7B%20self%3F.refresh%28%29%20%7D%60.%20The%20timer%20is%20added%20to%20%60RunLoop.main%60%2C%20so%20it%20already%20fires%20on%20the%20main%20thread%3B%20the%20inner%20async%20dispatch%20is%20redundant%2C%20and%20calling%20the%20%60%40MainActor%60-isolated%20%60refresh%28%29%60%20from%20a%20non-isolated%20%60DispatchQueue.main.async%60%20closure%20has%20the%20same%20strict-concurrency%20concern%20the%20PR%20just%20fixed%20elsewhere%20in%20this%20file.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20pollTimer%20%3D%20Timer%28timeInterval%3A%202.0%2C%20repeats%3A%20true%29%20%7B%20%5Bweak%20self%5D%20_%20in%0A%20%20%20%20%20%20%20%20%20%20%20%20MainActor.assumeIsolated%20%7B%20self%3F.refresh%28%29%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=665&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Make the activation observer&#39;s main-acto..."](https://github.com/fujacob/cotabby/commit/ac3cbfbb3af6539e4dc5d04a5129dda6a560b66a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36888777)</sub>

<!-- /greptile_comment -->