### PR TITLE
Show Screen Recording as an optional permission, not an "enable" toggle

### DIFF
--- a/Cotabby/Models/PermissionModels.swift
+++ b/Cotabby/Models/PermissionModels.swift
@@ -39,6 +39,15 @@ enum CotabbyPermissionKind: String, CaseIterable, Identifiable, Sendable {
         }
     }
 
+    /// Title for the compact permission rows (menu-bar panel, Settings list), with an "(Optional)"
+    /// qualifier appended for enhancement permissions. Those rows reuse the required rows' styling so
+    /// the permission reads as a real, grantable permission rather than a separate feature toggle, and
+    /// this suffix is the only thing that marks it optional there. Card surfaces (onboarding, the
+    /// reminder window) carry their own "Optional" capsule instead, so they keep using `title`.
+    var compactRowTitle: String {
+        isOptionalEnhancement ? "\(title) (Optional)" : title
+    }
+
     var systemImageName: String {
         switch self {
         case .accessibility:

--- a/Cotabby/Services/Permission/PermissionManager.swift
+++ b/Cotabby/Services/Permission/PermissionManager.swift
@@ -111,6 +111,15 @@ final class PermissionManager: ObservableObject {
             .allSatisfy(isGranted(_:))
     }
 
+    /// Whether every permission Cotabby can use (required ones plus the optional Screen Recording
+    /// enhancement) is granted. Surfaces that list all permissions (the menu-bar Permissions card)
+    /// use this so they keep showing the still-missing optional permission instead of vanishing as
+    /// soon as the required ones are satisfied. Does not gate autocomplete; that stays on
+    /// `requiredPermissionsGranted`.
+    var allPermissionsGranted: Bool {
+        CotabbyPermissionKind.allCases.allSatisfy(isGranted(_:))
+    }
+
     /// Shared opener used by onboarding and the menu-bar shortcuts.
     func openSettings(for permission: CotabbyPermissionKind) {
         NSWorkspace.shared.open(permission.settingsURL)

--- a/Cotabby/UI/MenuBarView.swift
+++ b/Cotabby/UI/MenuBarView.swift
@@ -233,8 +233,12 @@ struct MenuBarView: View {
 
     // MARK: - Permissions (conditional)
 
-    /// Only appears when at least one permission is missing. Once all are granted, this
-    /// section vanishes — no wasted space on resolved state.
+    /// Lists every permission Cotabby can use and appears whenever at least one is missing, including
+    /// the optional Screen Recording enhancement. Each row carries its own grant state, so the card
+    /// keeps showing the still-missing permission until nothing is left to grant, then vanishes.
+    /// Screen Recording is surfaced as a normal "(Optional)" permission row rather than hidden or
+    /// shown as a feature toggle, but it never blocks autocomplete (see
+    /// `CotabbyPermissionKind.isRequiredForAutocomplete`).
     @ViewBuilder
     private var permissionsCard: some View {
         if !allPermissionsGranted {
@@ -243,9 +247,9 @@ struct MenuBarView: View {
                     .font(.subheadline.weight(.medium))
                     .padding(.bottom, 2)
 
-                ForEach(CotabbyPermissionKind.allCases.filter(\.isRequiredForAutocomplete)) { permission in
+                ForEach(CotabbyPermissionKind.allCases) { permission in
                     PermissionRow(
-                        title: permission.title,
+                        title: permission.compactRowTitle,
                         granted: permissionManager.isGranted(permission),
                         action: { sourceFrameInScreen in
                             permissionGuidanceController.requestAccess(
@@ -446,7 +450,7 @@ struct MenuBarView: View {
     // MARK: - Derived state
 
     private var allPermissionsGranted: Bool {
-        permissionManager.requiredPermissionsGranted
+        permissionManager.allPermissionsGranted
     }
 
     /// Fast Mode is forced on and locked while Screen Recording is unavailable, since visual context

--- a/Cotabby/UI/PermissionReminderView.swift
+++ b/Cotabby/UI/PermissionReminderView.swift
@@ -120,9 +120,10 @@ private struct ReminderPermissionCard: View {
                 }
                 .foregroundStyle(.green)
             } else if isOptional {
-                // Lower-emphasis bordered button so the optional row never competes visually with the
-                // required Allow buttons above it.
-                Button("Enable") {
+                // Same "Allow" verb as the required rows (never a "feature toggle" like Enable), but a
+                // lower-emphasis bordered button so the optional row never competes visually with the
+                // required Allow buttons above it in this "Permissions needed" modal.
+                Button("Allow") {
                     permissionGuidanceController.requestAccess(
                         for: permission,
                         sourceFrameInScreen: actionButtonFrame

--- a/Cotabby/UI/Settings/Panes/PermissionsPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/PermissionsPaneView.swift
@@ -41,7 +41,6 @@ struct PermissionsPaneView: View {
                         "context. Without it, Cotabby runs in Fast Mode using only the text you've typed.",
                     systemImage: "camera.viewfinder",
                     granted: permissionManager.screenRecordingGranted,
-                    isOptional: true,
                     permissionGuidanceController: permissionGuidanceController
                 )
             }
@@ -79,23 +78,25 @@ private struct SettingsPermissionRow: View {
     let description: String
     let systemImage: String
     let granted: Bool
-    var isOptional: Bool = false
     let permissionGuidanceController: PermissionGuidanceController
 
     @State private var actionButtonFrame: CGRect = .zero
 
     var body: some View {
         HStack(spacing: 10) {
-            SettingsRowLabel(title: permission.title, description: description, systemImage: systemImage)
+            SettingsRowLabel(title: permission.compactRowTitle, description: description, systemImage: systemImage)
             Spacer(minLength: 0)
-            // An ungranted optional permission reads as a neutral "Off" rather than the orange
-            // "Needs Access" used for required ones, so it never looks like a broken setup.
-            Text(granted ? "Granted" : (isOptional ? "Off" : "Needs Access"))
+            // Optional permissions reuse the required rows' styling and read as real permissions; the
+            // "(Optional)" suffix in `compactRowTitle` is what marks them optional, not a separate
+            // neutral "Off" state or "Enable" verb. The pane-level warning callout still fires for
+            // required permissions only, so nothing here claims autocomplete is broken when just
+            // Screen Recording is missing.
+            Text(granted ? "Granted" : "Needs Access")
                 .font(.caption.weight(.medium))
-                .foregroundStyle(granted ? .green : (isOptional ? .secondary : .orange))
+                .foregroundStyle(granted ? .green : .orange)
 
             if !granted {
-                Button(isOptional ? "Enable" : "Grant Access") {
+                Button("Grant Access") {
                     permissionGuidanceController.requestAccess(
                         for: permission,
                         sourceFrameInScreen: actionButtonFrame


### PR DESCRIPTION
## Summary

Screen Recording was presented inconsistently: the menu-bar Permissions card filtered it out entirely (required-only), while Settings and the permission-reminder window framed it as a feature to "Enable" / turn "Off". It read like a toggle, not a permission. This makes it look like the other permissions everywhere it appears, while keeping it strictly non-blocking and clearly labeled optional.

## Validation

```
swiftlint lint --quiet <5 changed files>
# exit 0, no violations

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -configuration Debug \
  -destination 'platform=macOS' build -derivedDataPath build/DerivedData \
  -disableAutomaticPackageResolution
# ** BUILD SUCCEEDED **
```

Verified by build + reading. I did not capture the popover visually: the menu Permissions card only renders while a permission is missing, and forcing that state on a machine where permissions are already granted is awkward. Happy to run it and attach a screenshot if you want eyes on the exact layout.

## Linked issues

None.

## Risk / rollout notes

- **Visible behavior change in the menu popup.** The Permissions card now stays visible until *every* permission is granted, including the optional Screen Recording. Users who have granted the two required permissions but deliberately skip Screen Recording will now keep seeing the card (two checked rows + the `Screen Recording (Optional)` row) instead of it vanishing. This is the intended "still show the missing permission" behavior, but it is the main thing to confirm you want.
- **Settings styling reversed deliberately.** The optional row previously rendered a neutral "Off" / "Enable" so it "never looks like a broken setup"; it now uses the same orange "Needs Access" + "Grant Access" as the required rows, with an `(Optional)` title suffix. The pane-level warning callout still fires for required permissions only, so nothing claims autocomplete is broken when only Screen Recording is missing.
- **Autocomplete gating is untouched.** `isRequiredForAutocomplete` and `requiredPermissionsGranted` still cover only Accessibility + Input Monitoring, so the app keeps working without Screen Recording (Fast Mode / text-only), exactly as before.
- No schema, settings, or pbxproj changes. Onboarding already used "Allow" + an "Optional" tag and is unchanged.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR unifies how Screen Recording permission is presented across all Cotabby UI surfaces — menu bar card, Settings pane, and reminder modal — so it reads as a real (but optional) permission rather than a feature toggle. The menu bar card now remains visible until every permission (including optional Screen Recording) is granted, and the Settings row drops its separate "Off"/"Enable" treatment in favor of the same orange "Needs Access"/"Grant Access" styling used by required permissions, with the only opt-in signal being the `(Optional)` suffix in the title.

- **`PermissionModels.swift` / `PermissionManager.swift`**: adds `compactRowTitle` (appends `(Optional)` for enhancement permissions) and `allPermissionsGranted` (covers all `CotabbyPermissionKind.allCases`, not just required ones).
- **`MenuBarView.swift`**: permissions card iterates all cases and guards on `allPermissionsGranted` so it stays visible when only Screen Recording is ungranted; `PermissionReminderView.swift` changes the optional button label from "Enable" → "Allow".
- **`PermissionsPaneView.swift`**: removes the `isOptional` branch from `SettingsPermissionRow`, so the optional row renders the same orange badge and "Grant Access" button as required rows.

<h3>Confidence Score: 4/5</h3>

Safe to merge. The autocomplete gating logic is untouched; only the presentation layer for Screen Recording permission changes.

All five files make narrow, well-scoped UI changes. The new `compactRowTitle` and `allPermissionsGranted` additions are straightforward and correctly separated from the autocomplete-gating path. The one design trade-off — the menu bar card staying visible and showing already-granted required permissions when only Screen Recording is missing — is explicitly called out in the PR description and is the intended behavior, not a defect. A single stale doc-comment is the only thing that needs updating.

No files require special attention. The `MenuBarView.swift` behavior change (card stays visible with all-granted required rows when Screen Recording is ungranted) is worth a quick UX confirmation, but it is a deliberate product decision rather than a code problem.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/Models/PermissionModels.swift | Adds `compactRowTitle` computed property that appends `(Optional)` for enhancement permissions; logic is straightforward and consistent with existing `isOptionalEnhancement` flag. |
| Cotabby/Services/Permission/PermissionManager.swift | Adds `allPermissionsGranted` that checks all `CotabbyPermissionKind.allCases`; correctly documented as not gating autocomplete, which remains on `requiredPermissionsGranted`. |
| Cotabby/UI/MenuBarView.swift | Permissions card now iterates all cases and uses `allPermissionsGranted` for visibility; notably, granted-but-required rows still appear in the card while an optional permission is ungranted — a minor UX awkwardness documented in the PR. |
| Cotabby/UI/PermissionReminderView.swift | Optional button label changed from "Enable" to "Allow" for consistency; `ungrantedTint` for optional cards remains secondary (not orange), matching the existing intent to keep the reminder modal low-pressure for optional permissions. |
| Cotabby/UI/Settings/Panes/PermissionsPaneView.swift | Removes `isOptional` parameter from `SettingsPermissionRow`; Screen Recording now shows orange "Needs Access"/"Grant Access" identical to required permissions. Pane-level callout still guards on `requiredPermissionsGranted` only, so the warning never fires for missing Screen Recording alone. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    PM[PermissionManager] -->|requiredPermissionsGranted| A[Autocomplete gating\nAccessibility + Input Monitoring only]
    PM -->|allPermissionsGranted| B[Menu bar Permissions card visibility\nAll 3 permissions]

    subgraph Menu Bar Card
        B -->|false - any missing| C[Show all CotabbyPermissionKind.allCases rows]
        C --> D[PermissionRow: compactRowTitle\ne.g. 'Screen Recording Optional']
        B -->|true - all granted| E[Card hidden]
    end

    subgraph Settings Pane
        PM --> F[SettingsPermissionRow]
        F -->|compactRowTitle| G[Orange 'Needs Access' + 'Grant Access'\nfor all ungranted permissions]
        F -->|granted| H[Green 'Granted']
    end

    subgraph Reminder Modal
        PM -->|requiredPermissionsGranted| I[Done / I'll do this later button]
        PM --> J[Required cards - borderedProminent 'Allow']
        PM --> K[Optional cards - bordered 'Allow'\nneutral tint, no orange]
    end

    PM -->|isRequiredForAutocomplete| A
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `Cotabby/UI/Settings/Panes/PermissionsPaneView.swift`, line 73-75 ([link](https://github.com/fujacob/cotabby/blob/77ebf35866dc799ca59575fed0772440b7f57a1f/Cotabby/UI/Settings/Panes/PermissionsPaneView.swift#L73-L75)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The doc-comment on `SettingsPermissionRow` still says "Enable button", but this PR renamed that button to "Grant Access". The stale wording undermines the consistency goal of the change.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fscreen-recording-permission-row%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fscreen-recording-permission-row%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FSettings%2FPanes%2FPermissionsPaneView.swift%0ALine%3A%2073-75%0A%0AComment%3A%0AThe%20doc-comment%20on%20%60SettingsPermissionRow%60%20still%20says%20%22Enable%20button%22%2C%20but%20this%20PR%20renamed%20that%20button%20to%20%22Grant%20Access%22.%20The%20stale%20wording%20undermines%20the%20consistency%20goal%20of%20the%20change.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20One%20permission%20row%20in%20the%20Settings%20pane.%20Tracks%20its%20own%20button%20frame%20so%20the%20shared%0A%2F%2F%2F%20%60PermissionGuidanceController%60%20can%20anchor%20its%20drag-helper%20overlay%20near%20the%20Grant%20Access%20button%0A%2F%2F%2F%20%28mirroring%20the%20onboarding%20flow%29%20instead%20of%20dumping%20the%20user%20into%20System%20Settings%20cold.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=666&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FSettings%2FPanes%2FPermissionsPaneView.swift%0ALine%3A%2073-75%0A%0AComment%3A%0AThe%20doc-comment%20on%20%60SettingsPermissionRow%60%20still%20says%20%22Enable%20button%22%2C%20but%20this%20PR%20renamed%20that%20button%20to%20%22Grant%20Access%22.%20The%20stale%20wording%20undermines%20the%20consistency%20goal%20of%20the%20change.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20One%20permission%20row%20in%20the%20Settings%20pane.%20Tracks%20its%20own%20button%20frame%20so%20the%20shared%0A%2F%2F%2F%20%60PermissionGuidanceController%60%20can%20anchor%20its%20drag-helper%20overlay%20near%20the%20Grant%20Access%20button%0A%2F%2F%2F%20%28mirroring%20the%20onboarding%20flow%29%20instead%20of%20dumping%20the%20user%20into%20System%20Settings%20cold.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=666&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>


2. `Cotabby/UI/MenuBarView.swift`, line 244-267 ([link](https://github.com/fujacob/cotabby/blob/77ebf35866dc799ca59575fed0772440b7f57a1f/Cotabby/UI/MenuBarView.swift#L244-L267)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Granted required rows remain visible while only Screen Recording is ungranted**

   The permissions card now stays open (`!allPermissionsGranted`) and renders all three rows. For a user who has already granted Accessibility and Input Monitoring and is only missing Screen Recording, the card will show two green checkmark rows alongside the `Screen Recording (Optional)` row. The PR description acknowledges this is the intended behavior, but it is worth confirming that "required permissions are already granted but I'm seeing a permissions card again" won't read as confusing or alarming to users, since the card's header text is simply "Permissions" with no indication that only the optional row is pending.

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fscreen-recording-permission-row%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fscreen-recording-permission-row%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FMenuBarView.swift%0ALine%3A%20244-267%0A%0AComment%3A%0A**Granted%20required%20rows%20remain%20visible%20while%20only%20Screen%20Recording%20is%20ungranted**%0A%0AThe%20permissions%20card%20now%20stays%20open%20%28%60!allPermissionsGranted%60%29%20and%20renders%20all%20three%20rows.%20For%20a%20user%20who%20has%20already%20granted%20Accessibility%20and%20Input%20Monitoring%20and%20is%20only%20missing%20Screen%20Recording%2C%20the%20card%20will%20show%20two%20green%20checkmark%20rows%20alongside%20the%20%60Screen%20Recording%20%28Optional%29%60%20row.%20The%20PR%20description%20acknowledges%20this%20is%20the%20intended%20behavior%2C%20but%20it%20is%20worth%20confirming%20that%20%22required%20permissions%20are%20already%20granted%20but%20I'm%20seeing%20a%20permissions%20card%20again%22%20won't%20read%20as%20confusing%20or%20alarming%20to%20users%2C%20since%20the%20card's%20header%20text%20is%20simply%20%22Permissions%22%20with%20no%20indication%20that%20only%20the%20optional%20row%20is%20pending.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=666&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FMenuBarView.swift%0ALine%3A%20244-267%0A%0AComment%3A%0A**Granted%20required%20rows%20remain%20visible%20while%20only%20Screen%20Recording%20is%20ungranted**%0A%0AThe%20permissions%20card%20now%20stays%20open%20%28%60!allPermissionsGranted%60%29%20and%20renders%20all%20three%20rows.%20For%20a%20user%20who%20has%20already%20granted%20Accessibility%20and%20Input%20Monitoring%20and%20is%20only%20missing%20Screen%20Recording%2C%20the%20card%20will%20show%20two%20green%20checkmark%20rows%20alongside%20the%20%60Screen%20Recording%20%28Optional%29%60%20row.%20The%20PR%20description%20acknowledges%20this%20is%20the%20intended%20behavior%2C%20but%20it%20is%20worth%20confirming%20that%20%22required%20permissions%20are%20already%20granted%20but%20I'm%20seeing%20a%20permissions%20card%20again%22%20won't%20read%20as%20confusing%20or%20alarming%20to%20users%2C%20since%20the%20card's%20header%20text%20is%20simply%20%22Permissions%22%20with%20no%20indication%20that%20only%20the%20optional%20row%20is%20pending.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=666&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fscreen-recording-permission-row%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fscreen-recording-permission-row%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FSettings%2FPanes%2FPermissionsPaneView.swift%3A73-75%0AThe%20doc-comment%20on%20%60SettingsPermissionRow%60%20still%20says%20%22Enable%20button%22%2C%20but%20this%20PR%20renamed%20that%20button%20to%20%22Grant%20Access%22.%20The%20stale%20wording%20undermines%20the%20consistency%20goal%20of%20the%20change.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20One%20permission%20row%20in%20the%20Settings%20pane.%20Tracks%20its%20own%20button%20frame%20so%20the%20shared%0A%2F%2F%2F%20%60PermissionGuidanceController%60%20can%20anchor%20its%20drag-helper%20overlay%20near%20the%20Grant%20Access%20button%0A%2F%2F%2F%20%28mirroring%20the%20onboarding%20flow%29%20instead%20of%20dumping%20the%20user%20into%20System%20Settings%20cold.%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FUI%2FMenuBarView.swift%3A244-267%0A**Granted%20required%20rows%20remain%20visible%20while%20only%20Screen%20Recording%20is%20ungranted**%0A%0AThe%20permissions%20card%20now%20stays%20open%20%28%60!allPermissionsGranted%60%29%20and%20renders%20all%20three%20rows.%20For%20a%20user%20who%20has%20already%20granted%20Accessibility%20and%20Input%20Monitoring%20and%20is%20only%20missing%20Screen%20Recording%2C%20the%20card%20will%20show%20two%20green%20checkmark%20rows%20alongside%20the%20%60Screen%20Recording%20%28Optional%29%60%20row.%20The%20PR%20description%20acknowledges%20this%20is%20the%20intended%20behavior%2C%20but%20it%20is%20worth%20confirming%20that%20%22required%20permissions%20are%20already%20granted%20but%20I'm%20seeing%20a%20permissions%20card%20again%22%20won't%20read%20as%20confusing%20or%20alarming%20to%20users%2C%20since%20the%20card's%20header%20text%20is%20simply%20%22Permissions%22%20with%20no%20indication%20that%20only%20the%20optional%20row%20is%20pending.%0A%0A&repo=fujacob%2Fcotabby&pr=666&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FSettings%2FPanes%2FPermissionsPaneView.swift%3A73-75%0AThe%20doc-comment%20on%20%60SettingsPermissionRow%60%20still%20says%20%22Enable%20button%22%2C%20but%20this%20PR%20renamed%20that%20button%20to%20%22Grant%20Access%22.%20The%20stale%20wording%20undermines%20the%20consistency%20goal%20of%20the%20change.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20One%20permission%20row%20in%20the%20Settings%20pane.%20Tracks%20its%20own%20button%20frame%20so%20the%20shared%0A%2F%2F%2F%20%60PermissionGuidanceController%60%20can%20anchor%20its%20drag-helper%20overlay%20near%20the%20Grant%20Access%20button%0A%2F%2F%2F%20%28mirroring%20the%20onboarding%20flow%29%20instead%20of%20dumping%20the%20user%20into%20System%20Settings%20cold.%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FUI%2FMenuBarView.swift%3A244-267%0A**Granted%20required%20rows%20remain%20visible%20while%20only%20Screen%20Recording%20is%20ungranted**%0A%0AThe%20permissions%20card%20now%20stays%20open%20%28%60!allPermissionsGranted%60%29%20and%20renders%20all%20three%20rows.%20For%20a%20user%20who%20has%20already%20granted%20Accessibility%20and%20Input%20Monitoring%20and%20is%20only%20missing%20Screen%20Recording%2C%20the%20card%20will%20show%20two%20green%20checkmark%20rows%20alongside%20the%20%60Screen%20Recording%20%28Optional%29%60%20row.%20The%20PR%20description%20acknowledges%20this%20is%20the%20intended%20behavior%2C%20but%20it%20is%20worth%20confirming%20that%20%22required%20permissions%20are%20already%20granted%20but%20I'm%20seeing%20a%20permissions%20card%20again%22%20won't%20read%20as%20confusing%20or%20alarming%20to%20users%2C%20since%20the%20card's%20header%20text%20is%20simply%20%22Permissions%22%20with%20no%20indication%20that%20only%20the%20optional%20row%20is%20pending.%0A%0A&repo=fujacob%2Fcotabby&pr=666&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Show Screen Recording as an optional per..."](https://github.com/fujacob/cotabby/commit/77ebf35866dc799ca59575fed0772440b7f57a1f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36891010)</sub>

<!-- /greptile_comment -->