### PR TITLE
Cut inference and AX hot-path waste: P-core threads, gated logprob, halved KV, geometry cache

### DIFF
--- a/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
+++ b/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
@@ -381,6 +381,14 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
                         // Seed for the reuse path is sampled at the end of this decodePrompt; apply
                         // the word-continuation constraint to it just like the fresh path does.
                         engine.setForceWordContinuation(autocompleteSequenceID, options.forceWordContinuation)
+                        // Per-token log-probabilities cost two O(vocab) passes each in the engine;
+                        // only compute them when the confidence gate would actually read them.
+                        // Re-assert per request: the floor is not part of the sampling fingerprint,
+                        // so a reused sequence must not carry a stale flag.
+                        engine.setComputeLogprob(
+                            autocompleteSequenceID,
+                            options.confidenceFloor > -.infinity
+                        )
                         var mutableRemaining = remaining
                         let status = engine.decodePrompt(
                             autocompleteSequenceID,
@@ -420,6 +428,10 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
         // The engine samples the first (seed) token at the end of decodePrompt, so set the
         // word-continuation constraint here, before decoding.
         engine.setForceWordContinuation(seqID, options.forceWordContinuation)
+        // Skip the engine's per-token log-probability work (two O(vocab) passes per token)
+        // whenever confidence suppression is disabled — the shipping default — since the value
+        // would be summed and then discarded.
+        engine.setComputeLogprob(seqID, options.confidenceFloor > -.infinity)
 
         var tokens = promptTokens
         let status = engine.decodePrompt(seqID, &tokens, Int32(tokens.count), 0)

--- a/Cotabby/Support/AXHelper.swift
+++ b/Cotabby/Support/AXHelper.swift
@@ -774,8 +774,33 @@ enum AXHelper {
         return flipped
     }
 
+    /// Cached display list. Display configuration changes are rare (plug/unplug, resolution or
+    /// arrangement changes), but `cocoaRect`/`validatedCocoaTextRect` run for every AX rect at the
+    /// focus-poll cadence — rebuilding `NSScreen.screens` + `CGDisplayBounds` per conversion
+    /// multiplied AppKit/CoreGraphics traffic by the resolve rate for identical results. All AX
+    /// geometry work happens on the main thread, so unsynchronized statics are safe here.
+    private static var cachedDisplayGeometries: [DisplayGeometry]?
+
+    /// Invalidation hook for the cache above. macOS posts `didChangeScreenParameters` for every
+    /// event that can alter the display list (connect/disconnect, resolution, arrangement, Dock
+    /// and menu-bar resizes affecting `visibleFrame`). Lazily installed via the first
+    /// `displayGeometries()` call, so the observer always exists before a cached value could go
+    /// stale.
+    private static let displayChangeObserver: NSObjectProtocol = NotificationCenter.default.addObserver(
+        forName: NSApplication.didChangeScreenParametersNotification,
+        object: nil,
+        queue: .main
+    ) { _ in
+        cachedDisplayGeometries = nil
+    }
+
     private static func displayGeometries() -> [DisplayGeometry] {
-        NSScreen.screens.compactMap { screen in
+        _ = displayChangeObserver
+        if let cachedDisplayGeometries {
+            return cachedDisplayGeometries
+        }
+
+        let geometries = NSScreen.screens.compactMap { screen -> DisplayGeometry? in
             guard let number = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")]
                 as? NSNumber
             else {
@@ -790,6 +815,8 @@ enum AXHelper {
                 backingScaleFactor: screen.backingScaleFactor
             )
         }
+        cachedDisplayGeometries = geometries
+        return geometries
     }
 
     /// Last-resort fallback for unusual virtual displays where AppKit cannot expose a display ID.

--- a/Cotabby/Support/SuggestionTextNormalizer.swift
+++ b/Cotabby/Support/SuggestionTextNormalizer.swift
@@ -188,6 +188,13 @@ enum SuggestionTextNormalizer {
     /// Removes `<think>…</think>` reasoning blocks: complete blocks first, then any dangling open
     /// tag left when generation hit the token limit before the block was closed.
     private static func stripThinkBlocks(_ text: String) -> String {
+        // Both patterns below require a literal `<think>`, so this cheap scan lets the common case
+        // (no reasoning block — the vast majority of completions) skip regex work entirely.
+        // `String.range(of:options:.regularExpression)` compiles its pattern on every call, and
+        // this runs on the per-prediction critical path.
+        guard text.contains("<think>") else {
+            return text
+        }
         var result = text
         if let complete = result.range(of: "<think>[\\s\\S]*?</think>", options: .regularExpression) {
             result.replaceSubrange(complete, with: "")
@@ -269,12 +276,16 @@ enum SuggestionTextNormalizer {
         "App:"
     ]
 
+    /// `scaffoldingLabels` ordered longest-first, computed once. The ordering is what makes
+    /// "Text before the caret:" win over a shorter sibling; sorting on every call repeated that
+    /// work on the per-prediction critical path for an identical result.
+    private static let labelsByLengthDescending: [String] = scaffoldingLabels.sorted { $0.count > $1.count }
+
     /// Removes a leading run of known prompt-scaffolding labels (see `scaffoldingLabels`), whether
     /// each sits on its own line or inline before the continuation. Only labels at the very start
     /// are stripped; a label appearing later in the text is left alone because by then it is far
     /// more likely to be real user content than echoed scaffolding.
     private static func stripLeadingScaffoldingLabels(_ text: String) -> String {
-        let labelsByLengthDescending = scaffoldingLabels.sorted { $0.count > $1.count }
         var working = text
 
         while true {


### PR DESCRIPTION
## Summary

High-confidence performance work for #661: cuts per-token CPU, decode-thread oversubscription, resident KV RAM, and hot-path rebuild work, with no behavior or UX change in the shipping configuration. Pairs with engine commit `6e1a9ba` on cotabbyinference main ("Cut idle inference costs: P-core threads, gated logprob, right-sized KV").

Engine side (cotabbyinference, already on main):
- Decode threads now match the performance-core count (`hw.perflevel0.physicalcpu`, physical-core fallback on Intel) instead of all logical cores. Barriered matmul threads on E-cores stall every layer; with full Metal offload the CPU threads only orchestrate, so logical-core oversubscription was wasted wakeups.
- `SampleResult.logprob` (two O(vocab) passes + a vocab-wide `exp()` per generated token) is now computed only when the sequence opts in via the new `setComputeLogprob`. Engine default stays ON, so existing callers are untouched.
- `MAX_SEQUENCES` 4 -> 2 halves the shared KV allocation (`n_ctx = window * MAX_SEQUENCES`). The app holds at most one live sequence (destroy-before-create everywhere); 2 keeps a spare slot for tests/evals. Per-sequence window unchanged.

App side (this PR):
- `LlamaRuntimeCore` disables the engine's per-token logprob whenever `confidenceFloor == -infinity` — the shipping default, where `ConfidenceSuppressionPolicy.shouldSuppress` returns before ever reading the value. In the default config every generated token was paying ~2x vocab-size float ops plus a vocab-wide exp() to produce a number that was summed and discarded. Byte-identical suggestions; the confidence-suppression feature stays fully wired for anyone who raises the floor.
- `AXHelper.displayGeometries()` is now cached and invalidated on `didChangeScreenParameters`. It was rebuilding `NSScreen.screens` + `CGDisplayBounds` for every AX rect conversion — many per focus resolve at the poll cadence — for identical results between display changes.
- `SuggestionTextNormalizer`: `<think>`-block stripping now short-circuits with a `contains` check before any regex work (both patterns require the literal tag; most completions have none), and the scaffolding-label list is length-sorted once instead of per call.

Considered and deliberately excluded (uncertain benefit or behavior tradeoffs): OCR result dedupe (the capture band contains the blinking caret, so "identical" content rarely produces identical pixels), debounce/interval tuning, OCR `.accurate` -> `.fast`, greedy sampling at low temp, menu-bar observation split, InputMonitor allocation tweaks.

## Validation

Engine (cotabbyinference @ 6e1a9ba):
```
COTABBY_TEST_MODEL_PATH=.../Qwen3-0.6B-Q4_K_M.gguf swift test
# 22 tests, 0 failures — includes the two-concurrent-sequence path under MAX_SEQUENCES=2,
# the default-on logprob assertion, and a new test that setComputeLogprob(false) zeroes logprob.
```

App (this branch, resolved against engine 6e1a9ba):
```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build
# ** BUILD SUCCEEDED **

xcodebuild ... -only-testing:CotabbyTests/SuggestionTextNormalizerTests \
  -only-testing:CotabbyTests/DisplayCoordinateConverterTests \
  -only-testing:CotabbyTests/AXTextGeometryResolverTests \
  -only-testing:CotabbyTests/LlamaSuggestionEngineCancellationTests \
  CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO test
# ** TEST SUCCEEDED ** — 38 tests, 0 failures (3 pre-existing environment-gated skips)

swiftlint lint --quiet <changed files>
# exit 0
```

## Linked issues

Refs #661.

## Risk / rollout notes

- **Engine dependency.** The Swift plumbing requires cotabbyinference main at or after `6e1a9ba`. The package is pinned `branch: main` with an untracked `Package.resolved`, so CI and fresh checkouts resolve it automatically; locally, re-resolve packages (or delete `Package.resolved`) to pick it up.
- **Engine main is backward-compatible for other branches**: `setComputeLogprob` is additive (a setter, not a `SamplingConfig` field, precisely so existing memberwise initializers keep compiling), logprob defaults to ON engine-side, and the sequence-count reduction is invisible to an app that holds one sequence.
- **Thread-count change is the one non-byte-identical item**: decode threads drop from all logical cores (12 on M3 Max) to P-cores only. With Metal offload (`gpu_layers = -1`, the shipping config) CPU threads only orchestrate/sample, so throughput is unaffected; in a CPU-bound fallback, P-cores-only is llama.cpp's own Apple Silicon guidance (E-core stragglers stall every layer barrier). Validated end-to-end generation in the engine suite on this machine.
- KV reduction halves resident inference RAM at load time; per-sequence context window is unchanged, so no prompt that fit before can stop fitting.
- No schema, settings, or pbxproj changes; no new files, so no `xcodegen generate`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR applies focused hot-path optimizations across three files: gating per-token logprob computation in `LlamaRuntimeCore` behind the `confidenceFloor` check, caching display geometries in `AXHelper` with `didChangeScreenParameters` invalidation, and short-circuiting `<think>`-block stripping and sorting `scaffoldingLabels` once at startup in `SuggestionTextNormalizer`.

- **LlamaRuntimeCore.swift**: Calls `engine.setComputeLogprob(seqID, options.confidenceFloor > -.infinity)` on both the fresh-sequence and KV-reuse paths, skipping two O(vocab) passes per generated token in the default (suppression-off) configuration.
- **AXHelper.swift**: Adds `cachedDisplayGeometries` (a static optional) populated on first call and cleared by a lazily-registered `NSApplication.didChangeScreenParametersNotification` observer, eliminating repeated `NSScreen.screens` + `CGDisplayBounds` work per AX rect conversion at the focus-poll cadence.
- **SuggestionTextNormalizer.swift**: Guards `stripThinkBlocks` with a `contains(\"<think>\")` fast-path and promotes `scaffoldingLabels.sorted` from per-call to a `static let`, both on the per-prediction critical path.

<h3>Confidence Score: 4/5</h3>

Safe to merge. All three changes are tightly scoped optimisations with no behaviour change in the default configuration.

The logprob-gating and normalizer changes are straightforward and correct. The display-geometry cache is well-structured with documented main-thread assumptions and a notification-based invalidation path. The one item worth a second look is the `setComputeLogprob` call on the KV-reuse path: the comment says the flag must be re-asserted per request regardless of incremental decoding, but the call is nested inside `if !remaining.isEmpty`, making that re-assertion conditional. Under current `reusableTokenCount` semantics `remaining` is never empty, so this is harmless today, but it contradicts the stated invariant.

Cotabby/Services/Runtime/LlamaRuntimeCore.swift — specifically the placement of `setComputeLogprob` on the KV-reuse path.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/Services/Runtime/LlamaRuntimeCore.swift | Adds setComputeLogprob gating on both fresh and reuse paths; correct for all current inputs, but the re-assertion on the reuse path is nested inside an `if !remaining.isEmpty` guard that is unreachable in practice — a future change to reusableTokenCount semantics could silently skip it. |
| Cotabby/Support/AXHelper.swift | Adds a lazily-initialized display-geometry cache with correct notification-based invalidation; main-thread assumption is documented and upheld by existing callers. |
| Cotabby/Support/SuggestionTextNormalizer.swift | Guards stripThinkBlocks with contains() fast-path and hoists scaffolding label sort to a static let; both correct. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as LlamaRuntimeCore
    participant E as LlamaEngine
    participant AX as AXHelper
    participant NS as NSScreen/CGDisplay

    Note over C,E: Per-request path (fresh sequence)
    C->>E: setForceWordContinuation(seqID, ...)
    C->>E: "setComputeLogprob(seqID, floor > -inf)"
    C->>E: decodePrompt(seqID, tokens)
    loop sampleNext
        C->>E: sampleNext(seqID)
        E-->>C: SampleResult
    end

    Note over C,E: Per-request path (KV reuse)
    C->>E: trimKV(seqID, reusableCount)
    C->>E: "setComputeLogprob(seqID, floor > -inf)"
    C->>E: decodePrompt(seqID, remaining)

    Note over AX,NS: Display geometry cache
    AX->>AX: "_ = displayChangeObserver (lazy init)"
    alt cache hit
        AX-->>AX: return cachedDisplayGeometries
    else cache miss
        AX->>NS: NSScreen.screens + CGDisplayBounds
        NS-->>AX: raw geometries
        AX->>AX: "cachedDisplayGeometries = geometries"
    end
    Note over AX: Invalidated by didChangeScreenParameters
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cotabby/Services/Runtime/LlamaRuntimeCore.swift`, line 376-392 ([link](https://github.com/fujacob/cotabby/blob/0469a14a227f7f0800d36952baa7859312293546/Cotabby/Services/Runtime/LlamaRuntimeCore.swift#L376-L392)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `setComputeLogprob` re-assertion belongs outside the `if !remaining.isEmpty` guard. If `remaining` were ever empty (full KV hit), the sequence would carry its previous flag value into the next generation, silently enabling the O(vocab) work for a request that expects it off. Moving the call up matches the stated design intent ("re-assert per request") without changing current behaviour.

   

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22perf-inference-hot-paths%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22perf-inference-hot-paths%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%0ALine%3A%20376-392%0A%0AComment%3A%0AThe%20%60setComputeLogprob%60%20re-assertion%20belongs%20outside%20the%20%60if%20!remaining.isEmpty%60%20guard.%20If%20%60remaining%60%20were%20ever%20empty%20%28full%20KV%20hit%29%2C%20the%20sequence%20would%20carry%20its%20previous%20flag%20value%20into%20the%20next%20generation%2C%20silently%20enabling%20the%20O%28vocab%29%20work%20for%20a%20request%20that%20expects%20it%20off.%20Moving%20the%20call%20up%20matches%20the%20stated%20design%20intent%20%28%22re-assert%20per%20request%22%29%20without%20changing%20current%20behaviour.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20reusableTokenCount%20%3E%200%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20engine.trimKV%28autocompleteSequenceID%2C%20Int32%28reusableTokenCount%29%29%20%7B%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20let%20remaining%20%3D%20Array%28promptTokens%5BreusableTokenCount...%5D%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Re-assert%20per%20request%3A%20the%20floor%20is%20not%20part%20of%20the%20sampling%20fingerprint%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20so%20a%20reused%20sequence%20must%20not%20carry%20a%20stale%20flag%20regardless%20of%20whether%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20an%20incremental%20decode%20is%20needed.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20engine.setComputeLogprob%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20autocompleteSequenceID%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20options.confidenceFloor%20%3E%20-.infinity%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20!remaining.isEmpty%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Seed%20for%20the%20reuse%20path%20is%20sampled%20at%20the%20end%20of%20this%20decodePrompt%3B%20apply%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20the%20word-continuation%20constraint%20to%20it%20just%20like%20the%20fresh%20path%20does.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20engine.setForceWordContinuation%28autocompleteSequenceID%2C%20options.forceWordContinuation%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20var%20mutableRemaining%20%3D%20remaining%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=667&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%0ALine%3A%20376-392%0A%0AComment%3A%0AThe%20%60setComputeLogprob%60%20re-assertion%20belongs%20outside%20the%20%60if%20!remaining.isEmpty%60%20guard.%20If%20%60remaining%60%20were%20ever%20empty%20%28full%20KV%20hit%29%2C%20the%20sequence%20would%20carry%20its%20previous%20flag%20value%20into%20the%20next%20generation%2C%20silently%20enabling%20the%20O%28vocab%29%20work%20for%20a%20request%20that%20expects%20it%20off.%20Moving%20the%20call%20up%20matches%20the%20stated%20design%20intent%20%28%22re-assert%20per%20request%22%29%20without%20changing%20current%20behaviour.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20reusableTokenCount%20%3E%200%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20engine.trimKV%28autocompleteSequenceID%2C%20Int32%28reusableTokenCount%29%29%20%7B%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20let%20remaining%20%3D%20Array%28promptTokens%5BreusableTokenCount...%5D%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Re-assert%20per%20request%3A%20the%20floor%20is%20not%20part%20of%20the%20sampling%20fingerprint%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20so%20a%20reused%20sequence%20must%20not%20carry%20a%20stale%20flag%20regardless%20of%20whether%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20an%20incremental%20decode%20is%20needed.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20engine.setComputeLogprob%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20autocompleteSequenceID%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20options.confidenceFloor%20%3E%20-.infinity%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20!remaining.isEmpty%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Seed%20for%20the%20reuse%20path%20is%20sampled%20at%20the%20end%20of%20this%20decodePrompt%3B%20apply%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20the%20word-continuation%20constraint%20to%20it%20just%20like%20the%20fresh%20path%20does.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20engine.setForceWordContinuation%28autocompleteSequenceID%2C%20options.forceWordContinuation%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20var%20mutableRemaining%20%3D%20remaining%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=667&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22perf-inference-hot-paths%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22perf-inference-hot-paths%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%3A376-392%0AThe%20%60setComputeLogprob%60%20re-assertion%20belongs%20outside%20the%20%60if%20!remaining.isEmpty%60%20guard.%20If%20%60remaining%60%20were%20ever%20empty%20%28full%20KV%20hit%29%2C%20the%20sequence%20would%20carry%20its%20previous%20flag%20value%20into%20the%20next%20generation%2C%20silently%20enabling%20the%20O%28vocab%29%20work%20for%20a%20request%20that%20expects%20it%20off.%20Moving%20the%20call%20up%20matches%20the%20stated%20design%20intent%20%28%22re-assert%20per%20request%22%29%20without%20changing%20current%20behaviour.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20reusableTokenCount%20%3E%200%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20engine.trimKV%28autocompleteSequenceID%2C%20Int32%28reusableTokenCount%29%29%20%7B%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20let%20remaining%20%3D%20Array%28promptTokens%5BreusableTokenCount...%5D%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Re-assert%20per%20request%3A%20the%20floor%20is%20not%20part%20of%20the%20sampling%20fingerprint%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20so%20a%20reused%20sequence%20must%20not%20carry%20a%20stale%20flag%20regardless%20of%20whether%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20an%20incremental%20decode%20is%20needed.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20engine.setComputeLogprob%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20autocompleteSequenceID%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20options.confidenceFloor%20%3E%20-.infinity%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20!remaining.isEmpty%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Seed%20for%20the%20reuse%20path%20is%20sampled%20at%20the%20end%20of%20this%20decodePrompt%3B%20apply%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20the%20word-continuation%20constraint%20to%20it%20just%20like%20the%20fresh%20path%20does.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20engine.setForceWordContinuation%28autocompleteSequenceID%2C%20options.forceWordContinuation%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20var%20mutableRemaining%20%3D%20remaining%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=667&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%3A376-392%0AThe%20%60setComputeLogprob%60%20re-assertion%20belongs%20outside%20the%20%60if%20!remaining.isEmpty%60%20guard.%20If%20%60remaining%60%20were%20ever%20empty%20%28full%20KV%20hit%29%2C%20the%20sequence%20would%20carry%20its%20previous%20flag%20value%20into%20the%20next%20generation%2C%20silently%20enabling%20the%20O%28vocab%29%20work%20for%20a%20request%20that%20expects%20it%20off.%20Moving%20the%20call%20up%20matches%20the%20stated%20design%20intent%20%28%22re-assert%20per%20request%22%29%20without%20changing%20current%20behaviour.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20reusableTokenCount%20%3E%200%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20engine.trimKV%28autocompleteSequenceID%2C%20Int32%28reusableTokenCount%29%29%20%7B%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20let%20remaining%20%3D%20Array%28promptTokens%5BreusableTokenCount...%5D%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Re-assert%20per%20request%3A%20the%20floor%20is%20not%20part%20of%20the%20sampling%20fingerprint%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20so%20a%20reused%20sequence%20must%20not%20carry%20a%20stale%20flag%20regardless%20of%20whether%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20an%20incremental%20decode%20is%20needed.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20engine.setComputeLogprob%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20autocompleteSequenceID%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20options.confidenceFloor%20%3E%20-.infinity%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20!remaining.isEmpty%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Seed%20for%20the%20reuse%20path%20is%20sampled%20at%20the%20end%20of%20this%20decodePrompt%3B%20apply%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20the%20word-continuation%20constraint%20to%20it%20just%20like%20the%20fresh%20path%20does.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20engine.setForceWordContinuation%28autocompleteSequenceID%2C%20options.forceWordContinuation%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20var%20mutableRemaining%20%3D%20remaining%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=667&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Skip discarded per-token logprob, cache ..."](https://github.com/fujacob/cotabby/commit/0469a14a227f7f0800d36952baa7859312293546) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36892011)</sub>

<!-- /greptile_comment -->