### PR TITLE
fix(focus): prime VS Code's Electron AX tree so suggestions work

### DIFF
--- a/Cotabby/Services/Focus/ChromiumAccessibilityEnabler.swift
+++ b/Cotabby/Services/Focus/ChromiumAccessibilityEnabler.swift
@@ -27,17 +27,37 @@ final class ChromiumAccessibilityEnabler {
     /// not advertise it). Recorded so we stop retrying a doomed call every tick.
     private var unsupportedPIDs: Set<pid_t> = []
 
+    /// The frontmost PID seen on the previous poll tick, used to detect activation edges. Updated on
+    /// every call (including for apps we never prime) so a switch away and back is always an edge.
+    private var lastFrontmostPID: pid_t?
+
     /// Primes the application if it is a Chromium/Electron surface we cover and has not been primed
     /// (or marked unsupported) yet. Safe to call every poll tick.
+    ///
+    /// Electron editors are additionally re-primed on every activation edge (each time the app
+    /// becomes frontmost), not just once per PID. Observed on VS Code: the first
+    /// `AXManualAccessibility` write returns success while the app is long-running, yet the web-AX
+    /// tree stays dormant for minutes; a later re-assert wakes it promptly. One extra AX write per
+    /// app switch is negligible, and Chromium browsers keep the once-per-PID behavior that already
+    /// works for them.
     func primeIfNeeded(application: NSRunningApplication) {
+        let pid = application.processIdentifier
+        let isActivationEdge = pid != lastFrontmostPID
+        lastFrontmostPID = pid
+
         guard BrowserAppDetector.needsWebAccessibilityPriming(
             bundleIdentifier: application.bundleIdentifier)
         else {
             return
         }
 
-        let pid = application.processIdentifier
-        guard pid > 0, !primedPIDs.contains(pid), !unsupportedPIDs.contains(pid) else {
+        guard pid > 0, !unsupportedPIDs.contains(pid) else {
+            return
+        }
+
+        let reassertForElectronEditor = isActivationEdge
+            && BrowserAppDetector.isElectronEditor(bundleIdentifier: application.bundleIdentifier)
+        guard !primedPIDs.contains(pid) || reassertForElectronEditor else {
             return
         }
 

--- a/Cotabby/Support/BrowserAppDetector.swift
+++ b/Cotabby/Support/BrowserAppDetector.swift
@@ -39,8 +39,21 @@ enum BrowserAppDetector {
     /// Electron apps (Chromium under the hood) that ship editors worth covering. This is an
     /// intentional named allowlist, not a blanket Electron opt-in: most Electron apps are not
     /// text-editing surfaces, and priming them wholesale risks unexpected behavior.
+    ///
+    /// Entries are lowercased and matched case-insensitively (see `isElectronEditor`). VS Code's real
+    /// bundle id is the mixed-case `com.microsoft.VSCode`, so an exact match would silently miss it
+    /// and leave the editor's entire Electron AX tree dormant: no focused field resolves for the
+    /// editor, the Copilot chat, or the integrated terminal, so no suggestions appear anywhere in the
+    /// app even though screenshot-based OCR keeps working.
+    ///
+    /// Cursor is intentionally absent: it ships under opaque ToDesktop bundle ids
+    /// (`com.todesktop.<hash>`) that change between builds, so there is no stable id to allowlist
+    /// here without a broad `com.todesktop.` prefix that would also prime unrelated ToDesktop apps.
     private static let electronEditorBundleIdentifiers: Set<String> = [
-        "com.clickup.desktop-app"
+        "com.clickup.desktop-app",
+        "com.microsoft.vscode",          // Visual Studio Code
+        "com.microsoft.vscodeinsiders",  // VS Code - Insiders
+        "com.vscodium"                   // VSCodium (FOSS VS Code build)
     ]
 
     /// Broad check: is the user typing inside any web browser? Used for prompt tone hints.
@@ -53,10 +66,12 @@ enum BrowserAppDetector {
         hasMatchingPrefix(bundleIdentifier, in: chromiumBundlePrefixes)
     }
 
-    /// Is this a named Electron editor we intentionally cover?
+    /// Is this a named Electron editor we intentionally cover? Case-insensitive because macOS bundle
+    /// ids are case-insensitive in practice and VS Code's is mixed-case (`com.microsoft.VSCode`); a
+    /// case-sensitive exact match here was the reason VS Code resolved no focus and got no suggestions.
     static func isElectronEditor(bundleIdentifier: String?) -> Bool {
-        guard let bundleIdentifier else { return false }
-        return electronEditorBundleIdentifiers.contains(bundleIdentifier)
+        guard let lowered = bundleIdentifier?.lowercased() else { return false }
+        return electronEditorBundleIdentifiers.contains(lowered)
     }
 
     /// Gate for the Chromium/Electron-specific AX recovery paths (renderer priming, cursor

--- a/CotabbyTests/BrowserAppDetectorTests.swift
+++ b/CotabbyTests/BrowserAppDetectorTests.swift
@@ -32,6 +32,12 @@ final class BrowserAppDetectorTests: XCTestCase {
 
     func testElectronEditorAllowlist() {
         XCTAssertTrue(BrowserAppDetector.isElectronEditor(bundleIdentifier: "com.clickup.desktop-app"))
+        // VS Code ships under the mixed-case `com.microsoft.VSCode`; matching must be case-insensitive
+        // or its entire Electron AX tree stays dormant and no suggestions ever resolve.
+        XCTAssertTrue(BrowserAppDetector.isElectronEditor(bundleIdentifier: "com.microsoft.VSCode"))
+        XCTAssertTrue(BrowserAppDetector.isElectronEditor(bundleIdentifier: "com.microsoft.VSCodeInsiders"))
+        XCTAssertTrue(BrowserAppDetector.isElectronEditor(bundleIdentifier: "com.vscodium"))
+        // Electron, but not a text-editing surface we cover: must stay out of the priming allowlist.
         XCTAssertFalse(BrowserAppDetector.isElectronEditor(bundleIdentifier: "com.hnc.Discord"))
         XCTAssertFalse(BrowserAppDetector.isElectronEditor(bundleIdentifier: nil))
     }
@@ -41,6 +47,8 @@ final class BrowserAppDetectorTests: XCTestCase {
             BrowserAppDetector.needsWebAccessibilityPriming(bundleIdentifier: "com.google.Chrome"))
         XCTAssertTrue(
             BrowserAppDetector.needsWebAccessibilityPriming(bundleIdentifier: "com.clickup.desktop-app"))
+        XCTAssertTrue(
+            BrowserAppDetector.needsWebAccessibilityPriming(bundleIdentifier: "com.microsoft.VSCode"))
         XCTAssertFalse(
             BrowserAppDetector.needsWebAccessibilityPriming(bundleIdentifier: "com.apple.Safari"))
         XCTAssertFalse(


### PR DESCRIPTION
## Summary

VS Code produced **no suggestions anywhere** (editor, chat, integrated terminal), even with the integrated-terminal setting on, while OCR kept working. Root cause: the Electron AX-priming allowlist (`BrowserAppDetector.electronEditorBundleIdentifiers`) only contained ClickUp, so Cotabby never set `AXManualAccessibility` on VS Code and its lazily-built web accessibility tree stayed dormant — no focused text element ever resolved.

Two changes:
1. Add the VS Code family (Code, Insiders, VSCodium) to the priming allowlist, and make `isElectronEditor` case-insensitive (VS Code's real bundle id is the mixed-case `com.microsoft.VSCode`, which the prior exact `Set.contains` would have missed).
2. Re-assert the prime for Electron editors on every activation edge. Observed live: on a long-running VS Code the first `AXManualAccessibility` write returns success but the tree stays dormant for minutes; a re-assert on app switch wakes it promptly. Chromium browsers keep the existing once-per-PID behavior.

## Validation

Verified live on a macOS 26 machine with the dev build (`Cotabby Dev`, `-cotabby-debug`), driving real VS Code:

- Prime fires: `CHROME-PRIME enabled web accessibility for Code` (never present in any pre-fix log).
- Focus resolves: `Resolve timing: app=Code …` up to `capability=Supported`; terminal caret `derived primary`, chat caret `exact primary`.
- **Setting gates correctly, both directions**, typing in the integrated terminal (`xterm-helper-textarea` focused, confirmed via direct AX query):
  - `cotabbySuggestInIntegratedTerminals=1` → no terminal suppression; prediction pipeline proceeds.
  - `=0` → `Predictions disabled: Cotabby is not available in the integrated terminal.`
- Hardened build: prime + `capability=Supported` within ~200 ms of launch against an already-frontmost VS Code.

```
swiftlint lint --quiet   # exit 0
xcodebuild test … BrowserAppDetectorTests + TerminalAppDetectorTests
# ** TEST SUCCEEDED **  25 tests, 0 failures
```

## Linked issues

Refs the "no suggestions in VS Code" report.

## Risk / rollout notes

- **Scope honesty:** this PR makes VS Code *resolvable* and fully fixes the **integrated terminal** path. The **editor and Copilot chat** use VS Code's `native-edit-context`, whose `AXValue` stays empty (and the editor's focus proxy has a zero-width frame), so those surfaces resolve but cannot produce content-aware suggestions yet — that needs a native-edit-context text source (follow-up; related to the TextKit caret work).
- New behavior: one extra `AXManualAccessibility` write per activation of a named Electron editor; Chromium browsers unchanged.
- Integrated-terminal ghost text still respects `suggestInIntegratedTerminals` (off by default).
- Cursor/Windsurf remain uncovered (opaque ToDesktop / unverified bundle ids); follow-up candidates.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes VS Code (and VSCodium / VS Code Insiders) receiving no suggestions by adding them to the Electron AX-priming allowlist and making the `isElectronEditor` check case-insensitive — VS Code's real bundle id is the mixed-case `com.microsoft.VSCode`, which the prior case-sensitive `Set.contains` silently missed.

- **`BrowserAppDetector.swift`**: Adds `com.microsoft.vscode`, `com.microsoft.vscodeinsiders`, and `com.vscodium` to `electronEditorBundleIdentifiers` (all lowercased) and lowercases the input in `isElectronEditor` before the Set lookup.
- **`ChromiumAccessibilityEnabler.swift`**: Introduces `lastFrontmostPID` to track activation edges; Electron editors are re-primed on every app-switch back, working around VS Code's observed behaviour of ignoring the first `AXManualAccessibility` write.
- **`BrowserAppDetectorTests.swift`**: New assertions cover VS Code's mixed-case bundle id, Insiders, VSCodium, and the Discord negative case, with a `needsWebAccessibilityPriming` smoke test for the mixed-case id.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change wakes VS Code's AX tree the same way Chrome and ClickUp have been primed all along, using no new mechanism.

The core fix (lowercasing before the Set lookup and adding the VS Code bundle ids) is straightforward and well-tested. The activation-edge re-priming in ChromiumAccessibilityEnabler is narrowly scoped to isElectronEditor apps and incurs at most one extra AX write per app switch. Chromium browsers retain the existing once-per-PID path untouched. The lastFrontmostPID update is placed before the needsWebAccessibilityPriming guard, so it correctly tracks activation edges even for apps that are not primed. No data is persisted, no new IPC is introduced, and the change is fully reversible.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/BrowserAppDetector.swift | Adds VS Code, VS Code Insiders, and VSCodium (all lowercased) to the Electron editor allowlist and makes isElectronEditor case-insensitive by lowercasing the input before the Set lookup. |
| Cotabby/Services/Focus/ChromiumAccessibilityEnabler.swift | Introduces lastFrontmostPID to detect app-activation edges; Electron editors are re-primed on each such edge, working around VS Code's observed behaviour of ignoring the first AXManualAccessibility write while long-running. |
| CotabbyTests/BrowserAppDetectorTests.swift | Extends the existing test to assert VS Code (mixed-case bundle id), Insiders, and VSCodium are treated as Electron editors, Discord stays excluded, and needsWebAccessibilityPriming returns true for the mixed-case VS Code id. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(focus): re-assert Electron editor pr..."](https://github.com/fujacob/cotabby/commit/4a7706decb9111dff559d4117ec4377861cdbe95) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36905301)</sub>

<!-- /greptile_comment -->