### PR TITLE
Trust native AX caret geometry; scope the layout-estimate override to web content

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -330,6 +330,7 @@
 		84A4CA05AF6885AE4FA4C13A /* SettingsAttentionEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A02336442BB735EE2E8D064 /* SettingsAttentionEvaluator.swift */; };
 		862146ABDADC022A3BE74E00 /* CurrencyEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0537986794554F5FABE6EFF3 /* CurrencyEvaluator.swift */; };
 		865C569A9BC95B08F440D199 /* SystemResourceSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A5D63F390E9B7A7FE343FE /* SystemResourceSampler.swift */; };
+		86AC625B4DD14EF807002FA2 /* WebContentFieldDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3A35FAA742408D002B75920 /* WebContentFieldDetector.swift */; };
 		87806DE08881D11F2608A13D /* MarkerSelectionSynthesizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52BAFA2F989C3C4F7FB892B5 /* MarkerSelectionSynthesizerTests.swift */; };
 		8865B95FE84198D70390DF80 /* ClipboardContentDistillerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFD89799BB82AF7A92559AEB /* ClipboardContentDistillerTests.swift */; };
 		88BCD795A14E1C9308F7BB31 /* SuggestionAvailabilityEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05B0439348261163B37C508 /* SuggestionAvailabilityEvaluatorTests.swift */; };
@@ -501,6 +502,7 @@
 		D603EC842D9D7A1A81899050 /* PermissionModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D82FFC568527700EC17C07D /* PermissionModels.swift */; };
 		D648DD70AD847F67B77CE052 /* OnboardingTemplateRecommenderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B72736E416910878E8E493 /* OnboardingTemplateRecommenderTests.swift */; };
 		D6AD25168F108DA8D60E76EF /* SpellingDictionaryPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF3A73EB848780061FC162C0 /* SpellingDictionaryPicker.swift */; };
+		D75626719A38F535D475C675 /* WebContentFieldDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3A35FAA742408D002B75920 /* WebContentFieldDetector.swift */; };
 		D800277BE3296DE2FB8198A8 /* ChromiumAccessibilityEnabler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8896D976C7F116EBA0F3969F /* ChromiumAccessibilityEnabler.swift */; };
 		D80D98F6C7B86AAF8C831865 /* he-100k.txt in Resources */ = {isa = PBXBuildFile; fileRef = 7C9BB65FA5FC42B89766B037 /* he-100k.txt */; };
 		D81AC2294A64E7A95B29E081 /* fr.txt in Resources */ = {isa = PBXBuildFile; fileRef = 5DCA3E46621815A19300365F /* fr.txt */; };
@@ -531,6 +533,7 @@
 		E46F50AEDA8FE13B02E3FA8D /* AXHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC70775535A3428991025AB8 /* AXHelper.swift */; };
 		E51FA12B690428CA431328FC /* WritingPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D48B95B6665109B6C6A63B42 /* WritingPaneView.swift */; };
 		E54F5F03E16859D5A1E3437A /* MacroController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4638C74239D1DE2DC4D87975 /* MacroController.swift */; };
+		E5CB34ED76BAE87E8A858112 /* WebContentFieldDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210F9AD332273FE2EB3A9A01 /* WebContentFieldDetectorTests.swift */; };
 		E6EE3C13FA31F261CD734C69 /* DownloadOutcomeClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DE1975F3B5F4A70478DBF41 /* DownloadOutcomeClassifier.swift */; };
 		E853B9C7AF93FA595DC417B2 /* EmojiVariantResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A8414BEB7E34F57607E37FE /* EmojiVariantResolver.swift */; };
 		E912D4617AE1376061DF1F00 /* LanguageSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4793D4EA5D36D7E5CC216C27 /* LanguageSupportTests.swift */; };
@@ -640,6 +643,7 @@
 		1ED1EA9282E0AC7592E60889 /* SuggestionCoordinator+Prediction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SuggestionCoordinator+Prediction.swift"; sourceTree = "<group>"; };
 		1F761083EA5465023D82B5F4 /* BrowserDomainTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDomainTests.swift; sourceTree = "<group>"; };
 		1F7ED2D9D71CFAD9A30977E9 /* ArithmeticEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArithmeticEvaluator.swift; sourceTree = "<group>"; };
+		210F9AD332273FE2EB3A9A01 /* WebContentFieldDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebContentFieldDetectorTests.swift; sourceTree = "<group>"; };
 		21CB3008986BE7FD2A4D9132 /* WelcomeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeCoordinator.swift; sourceTree = "<group>"; };
 		224438039A86E5619294EAF7 /* EmojiUsageStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiUsageStoreTests.swift; sourceTree = "<group>"; };
 		22544F4B756E3E4144497D17 /* SuggestionCoordinator+Input.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SuggestionCoordinator+Input.swift"; sourceTree = "<group>"; };
@@ -847,6 +851,7 @@
 		C1C5DE0F3FF63545000E2453 /* DisplayCoordinateConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayCoordinateConverterTests.swift; sourceTree = "<group>"; };
 		C375227649689775275AA4B3 /* SuggestionCoordinatorAcceptanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionCoordinatorAcceptanceTests.swift; sourceTree = "<group>"; };
 		C379D77029D6E88C8C1B9AF7 /* emoji.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = emoji.json; sourceTree = "<group>"; };
+		C3A35FAA742408D002B75920 /* WebContentFieldDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebContentFieldDetector.swift; sourceTree = "<group>"; };
 		C648EBB10D7F8E0B904DEC91 /* de.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = de.txt; sourceTree = "<group>"; };
 		C71031E8DB171047318B92FC /* SyntheticReplacePlannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntheticReplacePlannerTests.swift; sourceTree = "<group>"; };
 		C727BF6FF8ACAAED30B0329F /* TypoGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypoGateTests.swift; sourceTree = "<group>"; };
@@ -1312,6 +1317,7 @@
 				D2D0FE44138BCA8B2EE05AFE /* TypoCaseTransferTests.swift */,
 				C727BF6FF8ACAAED30B0329F /* TypoGateTests.swift */,
 				050D929E13BE52E6282B64D2 /* VisualContextStartCoalescerTests.swift */,
+				210F9AD332273FE2EB3A9A01 /* WebContentFieldDetectorTests.swift */,
 				1E0513E3B23937B099A3CFF2 /* WordCountFormatterTests.swift */,
 			);
 			path = CotabbyTests;
@@ -1506,6 +1512,7 @@
 				08CE63B8725EBD71A4C024E1 /* TypoCaseTransfer.swift */,
 				B8412FE2BAC406421248A03B /* TypoGate.swift */,
 				2F01FAC4F57EB08471521196 /* VisualContextStartCoalescer.swift */,
+				C3A35FAA742408D002B75920 /* WebContentFieldDetector.swift */,
 				815F2ABAF6AB75DA3AFBBCEF /* WordCountFormatter.swift */,
 			);
 			path = Support;
@@ -1911,6 +1918,7 @@
 				0A15FAD03A93D57372D267E0 /* VisualContextCoordinator.swift in Sources */,
 				F77DB394E9D6C6C482131BF9 /* VisualContextModels.swift in Sources */,
 				641A9FAF3009A3E2AA06D74B /* VisualContextStartCoalescer.swift in Sources */,
+				86AC625B4DD14EF807002FA2 /* WebContentFieldDetector.swift in Sources */,
 				3AB45217DFC86AFC98C374D6 /* WelcomeCoordinator.swift in Sources */,
 				70D6F9480DA4104AD5669569 /* WelcomePermissionStepView.swift in Sources */,
 				4FEA3AC7ABB1982063BC0041 /* WelcomeTemplateStepView.swift in Sources */,
@@ -2131,6 +2139,7 @@
 				E9E4CC657771DF9F4C56183C /* VisualContextCoordinator.swift in Sources */,
 				4190F8A76196B16ED94D0A55 /* VisualContextModels.swift in Sources */,
 				19CB55B62977376E9AE8D428 /* VisualContextStartCoalescer.swift in Sources */,
+				D75626719A38F535D475C675 /* WebContentFieldDetector.swift in Sources */,
 				4AC255BE2D0CCC67B8882C7A /* WelcomeCoordinator.swift in Sources */,
 				344B9BF352C97CFA830853D6 /* WelcomePermissionStepView.swift in Sources */,
 				286B7022E2A2774275004447 /* WelcomeTemplateStepView.swift in Sources */,
@@ -2240,6 +2249,7 @@
 				5C6B59C2E56A3C4260591095 /* TypoCaseTransferTests.swift in Sources */,
 				BE688EC1957B4AE004063EFE /* TypoGateTests.swift in Sources */,
 				D5CAF3B590E5EC2AFC72E57A /* VisualContextStartCoalescerTests.swift in Sources */,
+				E5CB34ED76BAE87E8A858112 /* WebContentFieldDetectorTests.swift in Sources */,
 				6AE0B46FB52D189D94E1F79A /* WordCountFormatterTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
@@ -629,14 +629,21 @@ extension SuggestionCoordinator {
 
     /// Repairs untrustworthy caret anchors with a hidden-text-layout estimate before presentation.
     ///
-    /// Two repair modes, by resolver quality:
+    /// The repair's authority is scoped by where the AX geometry came from, not just its quality:
     ///   - `.estimated` (AXFrame-only hosts): the AX guess has no real position at all, so a
-    ///     passing estimate always replaces it.
+    ///     passing estimate always replaces it. Applies to web and native hosts alike, because
+    ///     there is no real measurement to protect.
+    ///   - `.derived` in a native host: never repaired, the estimator does not run. Native AX
+    ///     per-character bounds come from the app's real layout manager and reflect rendering the
+    ///     uniform hidden layout cannot model (Notes renders a 23pt title line above 16pt body
+    ///     lines, plus paragraph spacing, so the layout "disagrees" within a few lines while AX is
+    ///     exactly right). A vertical mismatch there indicts the estimate, not AX.
     ///   - `.derived` with measured run frames (Gmail/Outlook child-run hosts): the rect's Y is a
     ///     real rendered line, so it is always kept and the estimator does not run at all; the
     ///     layout estimate cannot beat measurement (and is blind to blank lines those hosts
     ///     collapse out of the AX text).
-    ///   - `.derived` without run frames (previous-character bounds): the estimate (calibrated
+    ///   - `.derived` web content without run frames (previous-character bounds through a web
+    ///     engine's AX bridge, which has known wrong-line pathologies): the estimate (calibrated
     ///     with whatever the host revealed) only overrides the AX rect when the two disagree
     ///     vertically by more than `verticallyAgrees` tolerates; on agreement the AX rect is kept.
     ///
@@ -659,19 +666,34 @@ extension SuggestionCoordinator {
     ) -> LayoutRepairedAnchor {
         let quality = context.caretQuality
         guard quality == .estimated || quality == .derived else {
-            return LayoutRepairedAnchor(rect: fallbackRect, quality: quality, outcome: nil)
+            return LayoutRepairedAnchor(rect: fallbackRect, quality: quality, outcome: nil, skipReason: nil)
         }
 
-        // Run-measured derived rects are kept unconditionally — run frames carry the host's real
-        // line positions, including blank lines some hosts omit from the AX text — so skip the
-        // estimator entirely instead of computing a diagnostic it can never act on. This path runs
+        // Derived rects carry a real AX measurement, so whether the estimate may second-guess
+        // them depends on who produced the measurement. Both bypasses skip the estimator
+        // entirely rather than computing a diagnostic they can never act on: this path runs
         // inside the accept keystroke's handling window, where every spent millisecond of layout
         // work on a large flat prefix is pure risk during a rapid Tab burst.
-        if quality == .derived, context.observedContentEdges != nil {
-            return LayoutRepairedAnchor(rect: fallbackRect, quality: .derived, outcome: nil)
+        if quality == .derived {
+            // Native hosts: per-character bounds come from the app's own layout manager and are
+            // ground truth, while the uniform hidden layout cannot model rich text (Notes' taller
+            // title line and paragraph spacing put it a line off within a few paragraphs). Only
+            // web engines' AX bridges have the wrong-line pathologies the override exists for.
+            if !context.isWebContentField {
+                return LayoutRepairedAnchor(
+                    rect: fallbackRect, quality: .derived, outcome: nil, skipReason: .nativeHostGeometry
+                )
+            }
+            // Run-measured derived rects are kept unconditionally: run frames carry the host's
+            // real line positions, including blank lines some hosts omit from the AX text.
+            if context.observedContentEdges != nil {
+                return LayoutRepairedAnchor(
+                    rect: fallbackRect, quality: .derived, outcome: nil, skipReason: .runMeasuredGeometry
+                )
+            }
         }
 
-        // A `.derived` rect's height is a real rendered line box (child-run frame height); the
+        // A `.derived` rect's height is a real rendered line box (previous-character bounds); the
         // `.estimated` AXFrame fallback's height is the whole field, which the estimator's
         // sanitizer would discard anyway — pass it for derived geometry only.
         let observedLineHeight: CGFloat? = quality == .derived ? context.caretRect.height : nil
@@ -694,11 +716,13 @@ extension SuggestionCoordinator {
         case .estimate(let estimate):
             if quality == .derived, verticallyAgrees(estimate: estimate, axRect: fallbackRect) {
                 // Same line: keep the AX rect, whose X carries the host's real glyph positions.
-                return LayoutRepairedAnchor(rect: fallbackRect, quality: .derived, outcome: outcome)
+                return LayoutRepairedAnchor(rect: fallbackRect, quality: .derived, outcome: outcome, skipReason: nil)
             }
-            return LayoutRepairedAnchor(rect: estimate.caretRect, quality: .layoutEstimated, outcome: outcome)
+            return LayoutRepairedAnchor(
+                rect: estimate.caretRect, quality: .layoutEstimated, outcome: outcome, skipReason: nil
+            )
         case .rejected:
-            return LayoutRepairedAnchor(rect: fallbackRect, quality: quality, outcome: outcome)
+            return LayoutRepairedAnchor(rect: fallbackRect, quality: quality, outcome: outcome, skipReason: nil)
         }
     }
 
@@ -720,6 +744,20 @@ extension SuggestionCoordinator {
         let rect: CGRect
         let quality: CaretGeometryQuality
         let outcome: TextLayoutCaretEstimator.Outcome?
+        /// Why a derived rect bypassed the estimator without running it (nil when the estimator
+        /// ran, or when repair was out of scope for the quality entirely). Logged so "the caret
+        /// came from trusted AX and repair stood down" is distinguishable from "this field never
+        /// triggered repair" when diagnosing a misplaced overlay from the JSONL stream.
+        let skipReason: LayoutRepairSkipReason?
+    }
+
+    /// Why `layoutRepairedAnchor` kept a derived AX rect without running the estimator at all.
+    /// Raw values feed the structured log stream.
+    enum LayoutRepairSkipReason: String {
+        /// Native (non-web) host: AX-derived geometry is ground truth for the trust policy.
+        case nativeHostGeometry = "native_host_geometry"
+        /// The rect was measured from child text-run frames, which outrank any estimate.
+        case runMeasuredGeometry = "run_measured_geometry"
     }
 
     /// Mirrors the repair outcome into the structured JSONL stream so a misplaced overlay can be
@@ -734,7 +772,9 @@ extension SuggestionCoordinator {
         fallbackRect: CGRect,
         context: FocusedInputContext
     ) {
-        guard let outcome = anchor.outcome else {
+        // Exact/layout-estimated presentations never reach repair and carry nothing to log; bail
+        // before building metadata so the common path pays nothing per present.
+        guard anchor.outcome != nil || anchor.skipReason != nil else {
             return
         }
         var metadata: Logger.Metadata = [
@@ -750,13 +790,24 @@ extension SuggestionCoordinator {
         if let fieldFrame = context.inputFrameRect {
             metadata["field_top_y"] = .stringConvertible(Double(fieldFrame.maxY))
         }
+        guard let outcome = anchor.outcome else {
+            // A trusted-AX bypass stood the estimator down without running it. Logged (unlike the
+            // qualities repair never applies to) so the stream can distinguish "repair deferred to
+            // trusted AX" from "this presentation never reached repair".
+            if let skipReason = anchor.skipReason {
+                metadata["repair_outcome"] = .string("skipped")
+                metadata["skip_reason"] = .string(skipReason.rawValue)
+                CotabbyLogger.suggestion.debug(
+                    "Kept the AX caret; its geometry source outranks the layout estimate.",
+                    metadata: metadata
+                )
+            }
+            return
+        }
         switch outcome {
         case .estimate(let estimate):
             let substituted = anchor.quality == .layoutEstimated
-            let keptReason = context.observedContentEdges != nil
-                ? "kept_ax_run_measured"
-                : "kept_ax_agreement"
-            metadata["repair_outcome"] = .string(substituted ? "substituted" : keptReason)
+            metadata["repair_outcome"] = .string(substituted ? "substituted" : "kept_ax_agreement")
             metadata["line_index"] = .stringConvertible(estimate.lineIndex)
             metadata["multi_line_field"] = .stringConvertible(estimate.isMultiLineField)
             metadata["ax_mid_y_delta"] = .stringConvertible(

--- a/Cotabby/Models/FocusModels.swift
+++ b/Cotabby/Models/FocusModels.swift
@@ -178,6 +178,13 @@ struct FocusedInputSnapshot: Equatable {
     /// call sites compiling unchanged.
     let isIntegratedTerminal: Bool
 
+    /// True when the resolved field's text is rendered by a web engine rather than a native text
+    /// view (see `WebContentFieldDetector`). The caret layout repair keys its trust policy on
+    /// this: web-engine caret bounds have known wrong-line pathologies the hidden-layout estimate
+    /// may repair, while native AX bounds are ground truth the estimate must never override.
+    /// The initializer default keeps existing call sites compiling unchanged.
+    let isWebContentField: Bool
+
     /// Monotonic counter that increments every time polling observes a focused-input identity
     /// change.
     ///
@@ -224,6 +231,7 @@ struct FocusedInputSnapshot: Equatable {
         selection: NSRange,
         isSecure: Bool,
         isIntegratedTerminal: Bool = false,
+        isWebContentField: Bool = false,
         focusChangeSequence: UInt64 = 0,
         focusedURLString: String? = nil,
         resolvedFieldStyle: ResolvedFieldStyle? = nil
@@ -245,6 +253,7 @@ struct FocusedInputSnapshot: Equatable {
         self.selection = selection
         self.isSecure = isSecure
         self.isIntegratedTerminal = isIntegratedTerminal
+        self.isWebContentField = isWebContentField
         self.focusChangeSequence = focusChangeSequence
         self.focusedURLString = focusedURLString
         self.resolvedFieldStyle = resolvedFieldStyle

--- a/Cotabby/Models/SuggestionModels.swift
+++ b/Cotabby/Models/SuggestionModels.swift
@@ -204,6 +204,10 @@ struct FocusedInputContext: Equatable, Sendable {
     let trailingText: String
     let selection: NSRange
     let isSecure: Bool
+    /// Whether the field's text is rendered by a web engine (see `WebContentFieldDetector`),
+    /// carried through so the presentation-time caret repair can scope estimator authority to
+    /// hosts whose AX caret geometry actually needs repairing.
+    let isWebContentField: Bool
     /// The host field's own text font/color, carried through so the overlay can match it.
     let resolvedFieldStyle: ResolvedFieldStyle?
     /// Carries the immutable focus-observation identity across debounce/generation boundaries.
@@ -229,6 +233,7 @@ struct FocusedInputContext: Equatable, Sendable {
         trailingText = snapshot.trailingText
         selection = snapshot.selection
         isSecure = snapshot.isSecure
+        isWebContentField = snapshot.isWebContentField
         resolvedFieldStyle = snapshot.resolvedFieldStyle
         focusChangeSequence = snapshot.focusChangeSequence
         self.generation = generation

--- a/Cotabby/Services/Focus/FocusSnapshotResolver.swift
+++ b/Cotabby/Services/Focus/FocusSnapshotResolver.swift
@@ -226,6 +226,13 @@ struct FocusSnapshotResolver {
             domClassList: AXHelper.stringArrayValue(
                 for: "AXDOMClassList" as CFString, on: focusedElement) ?? []
         )
+        // Web-vs-native classification for the caret-geometry trust policy. The DOM-attribute
+        // signal was computed in `candidateSnapshot` from the attribute list it already fetched,
+        // so this adds no AX round-trip to the focus poll.
+        let isWebContentField = WebContentFieldDetector.isWebContentField(
+            bundleIdentifier: bundleIdentifier,
+            vendsDOMAttributes: resolvedCandidate.vendsDOMAttributes
+        )
         let context = FocusedInputSnapshot(
             applicationName: applicationName,
             bundleIdentifier: bundleIdentifier,
@@ -244,6 +251,7 @@ struct FocusSnapshotResolver {
             selection: contextWindow.selection,
             isSecure: resolvedCandidate.isSecure,
             isIntegratedTerminal: isIntegratedTerminal,
+            isWebContentField: isWebContentField,
             focusChangeSequence: focusChangeSequence,
             focusedURLString: focusedURLString,
             resolvedFieldStyle: resolvedFieldStyle
@@ -710,6 +718,9 @@ struct FocusSnapshotResolver {
         let caretRect = caretResult?.rect
         let caretQuality = caretResult?.quality
         let isSecure = isSecureElement(element: element, role: role, subrole: subrole)
+        // Recorded from the already-fetched attribute list (no extra AX call) so snapshot
+        // assembly can classify the field as web-rendered without touching the element again.
+        let vendsDOMAttributes = WebContentFieldDetector.vendsDOMAttributes(supportedAttributes)
         let elementIdentifier = AXHelper.elementIdentifier(
             for: element, bundleIdentifier: bundleIdentifier)
         let resolverCandidate = FocusCapabilityCandidate(
@@ -739,6 +750,7 @@ struct FocusSnapshotResolver {
             caretSourceDetail: caretResult?.sourceDetail,
             inputFrameRect: inputFrameRect,
             isSecure: isSecure,
+            vendsDOMAttributes: vendsDOMAttributes,
             resolverCandidate: resolverCandidate
         )
     }
@@ -873,5 +885,8 @@ private struct AXFocusCandidate {
     let caretSourceDetail: String?
     let inputFrameRect: CGRect?
     let isSecure: Bool
+    /// Whether the element advertises DOM-reflection attributes, marking it as web-engine
+    /// content (see `WebContentFieldDetector`).
+    let vendsDOMAttributes: Bool
     let resolverCandidate: FocusCapabilityCandidate
 }

--- a/Cotabby/Support/WebContentFieldDetector.swift
+++ b/Cotabby/Support/WebContentFieldDetector.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// File overview:
+/// Classifies whether a focused text field's content is rendered by a web engine
+/// (Chromium/WebKit/Gecko) rather than a native macOS text view. The caret layout repair uses
+/// this to decide how much authority the hidden-text-layout estimate has over AX-measured
+/// geometry: web engines have known wrong-line caret-bounds pathologies the estimate exists to
+/// repair, while native AX bounds come from the app's real layout manager and outrank any
+/// re-layout Cotabby could compute.
+///
+/// Why this distinction is trustworthy: probing real hosts showed both sides concretely.
+/// Apple Notes (native TextKit) answers per-character `AXBoundsForRange` with rects that match
+/// its rendered lines exactly, including the taller title line (23pt) above 16pt body lines,
+/// which a uniform hidden layout cannot model; its geometry must win. Gmail in Chrome answers
+/// the same queries through the renderer's lossy AX bridge, which maps carets into neighboring
+/// visual lines around blank lines; there the estimate must be allowed to override.
+///
+/// Two independent signals, either of which marks a field as web content:
+///   - The element vends DOM-reflection attributes (`AXDOMIdentifier`/`AXDOMClassList`).
+///     Chromium and WebKit attach these to web-content nodes only; native AppKit elements never
+///     vend them. This catches web fields in apps no bundle list could anticipate (opaque
+///     Electron bundle ids like Cursor's `com.todesktop.*`, or a WKWebView embedded in a native
+///     app).
+///   - The host bundle is a known browser or Electron editor (`BrowserAppDetector`). This covers
+///     browser-chrome fields (e.g. the omnibox) that are not DOM-backed but still speak the
+///     browser toolkit's AX dialect rather than AppKit's, and engines whose DOM reflection is
+///     absent (Gecko).
+///
+/// Defaulting unknown hosts to "native" is deliberate: the failure mode for a misclassified
+/// native field is keeping pre-repair behavior (never worse than before the estimator existed),
+/// while misclassifying a web field merely forgoes a repair.
+enum WebContentFieldDetector {
+    /// Attribute names only web-engine accessibility nodes vend. Checked against the element's
+    /// advertised attribute list, which the focus resolver already fetches, so this costs no
+    /// extra AX round-trip.
+    private static let domReflectionAttributes: Set<String> = [
+        "AXDOMIdentifier",
+        "AXDOMClassList"
+    ]
+
+    /// Whether the element's advertised attribute names mark it as a web-content node.
+    static func vendsDOMAttributes(_ attributeNames: Set<String>) -> Bool {
+        !domReflectionAttributes.isDisjoint(with: attributeNames)
+    }
+
+    /// Whether the focused field should be treated as web-rendered content for caret-geometry
+    /// trust decisions.
+    static func isWebContentField(
+        bundleIdentifier: String?,
+        vendsDOMAttributes: Bool
+    ) -> Bool {
+        if vendsDOMAttributes {
+            return true
+        }
+        return BrowserAppDetector.isBrowser(bundleIdentifier: bundleIdentifier)
+            || BrowserAppDetector.isElectronEditor(bundleIdentifier: bundleIdentifier)
+    }
+}

--- a/CotabbyTests/CotabbyTestFixtures.swift
+++ b/CotabbyTests/CotabbyTestFixtures.swift
@@ -27,6 +27,7 @@ enum CotabbyTestFixtures {
         selection: NSRange? = nil,
         isSecure: Bool = false,
         isIntegratedTerminal: Bool = false,
+        isWebContentField: Bool = false,
         focusChangeSequence: UInt64 = 1
     ) -> FocusedInputSnapshot {
         let resolvedSelection = selection
@@ -50,6 +51,7 @@ enum CotabbyTestFixtures {
             selection: resolvedSelection,
             isSecure: isSecure,
             isIntegratedTerminal: isIntegratedTerminal,
+            isWebContentField: isWebContentField,
             focusChangeSequence: focusChangeSequence
         )
     }
@@ -68,6 +70,7 @@ enum CotabbyTestFixtures {
         trailingText: String = "",
         selection: NSRange? = nil,
         isSecure: Bool = false,
+        isWebContentField: Bool = false,
         focusChangeSequence: UInt64 = 1,
         generation: UInt64 = 1
     ) -> FocusedInputContext {
@@ -86,6 +89,7 @@ enum CotabbyTestFixtures {
                 trailingText: trailingText,
                 selection: selection,
                 isSecure: isSecure,
+                isWebContentField: isWebContentField,
                 focusChangeSequence: focusChangeSequence
             ),
             generation: generation

--- a/CotabbyTests/SuggestionCaretLayoutRepairTests.swift
+++ b/CotabbyTests/SuggestionCaretLayoutRepairTests.swift
@@ -6,6 +6,12 @@ import XCTest
 /// resolver quality is `.estimated`, the overlay anchor is recomputed from the hidden text layout
 /// and the geometry quality upgraded to `.layoutEstimated`. Every rejection must keep today's
 /// behavior bit-for-bit (the passed rect and `.estimated` survive untouched).
+///
+/// For `.derived` geometry the rule is additionally scoped by provenance: only web-content hosts
+/// (whose AX caret bounds have known wrong-line pathologies) expose their derived rects to the
+/// estimate's line-mismatch override. Native hosts' derived rects are AX ground truth and bypass
+/// the estimator entirely; the `.estimated` substitution stays provenance-independent because
+/// there is no real measurement to protect.
 @MainActor
 final class SuggestionCaretLayoutRepairTests: XCTestCase {
     /// Deliberately far outside any field frame so a substitution is unmistakable.
@@ -95,7 +101,7 @@ final class SuggestionCaretLayoutRepairTests: XCTestCase {
         XCTAssertEqual(anchor.outcome, .rejected(.prefixTruncated))
     }
 
-    // MARK: - Derived geometry (line-mismatch gate)
+    // MARK: - Derived geometry (web hosts: line-mismatch gate)
 
     func test_layoutRepair_derivedAgreementKeepsAXRect() {
         // The estimate and the AX rect land on the same line: AX wins, because its X carries the
@@ -106,7 +112,8 @@ final class SuggestionCaretLayoutRepairTests: XCTestCase {
             caretRect: axRect,
             inputFrameRect: frame,
             caretQuality: .derived,
-            precedingText: "Hello"
+            precedingText: "Hello",
+            isWebContentField: true
         )
 
         let anchor = SuggestionCoordinator.layoutRepairedAnchor(
@@ -123,16 +130,18 @@ final class SuggestionCaretLayoutRepairTests: XCTestCase {
         }
     }
 
-    func test_layoutRepair_derivedLineMismatchSubstitutesEstimate() {
+    func test_layoutRepair_derivedLineMismatchSubstitutesEstimateForWebContent() {
         // The AX rect sits three line boxes below where the text layout puts the caret — the
-        // Gmail-class blank-line drift this gate exists for.
+        // Gmail-class blank-line drift this gate exists for. Web content only: the host's AX
+        // bridge, not its layout, is the suspect there.
         let frame = CGRect(x: 0, y: 0, width: 300, height: 120)
         let axRect = CGRect(x: 50, y: 52, width: 2, height: 16)
         let context = CotabbyTestFixtures.focusedInputContext(
             caretRect: axRect,
             inputFrameRect: frame,
             caretQuality: .derived,
-            precedingText: "Hello"
+            precedingText: "Hello",
+            isWebContentField: true
         )
 
         let anchor = SuggestionCoordinator.layoutRepairedAnchor(
@@ -150,6 +159,62 @@ final class SuggestionCaretLayoutRepairTests: XCTestCase {
         XCTAssertEqual(anchor.rect.height, axRect.height, accuracy: 0.01)
     }
 
+    // MARK: - Derived geometry (native hosts: AX is ground truth)
+
+    func test_layoutRepair_nativeDerivedLineMismatchKeepsAXRect() {
+        // Identical geometry to the web mismatch test, but the field is native. Native rich-text
+        // views render what a uniform hidden layout cannot model (Apple Notes draws a 23pt title
+        // line above 16pt body lines, plus paragraph spacing), so a vertical disagreement there
+        // means the estimate is wrong while the AX prev-character bounds are exactly right.
+        // Substituting here was the post-#670 Notes regression: ghost text drifted off the real
+        // caret line. The estimator must not even run (nil outcome): it would burn a TextKit
+        // layout inside the accept keystroke's handling window to compute nothing actionable.
+        let frame = CGRect(x: 0, y: 0, width: 300, height: 120)
+        let axRect = CGRect(x: 50, y: 52, width: 2, height: 16)
+        let context = CotabbyTestFixtures.focusedInputContext(
+            caretRect: axRect,
+            inputFrameRect: frame,
+            caretQuality: .derived,
+            precedingText: "Hello",
+            isWebContentField: false
+        )
+
+        let anchor = SuggestionCoordinator.layoutRepairedAnchor(
+            for: context,
+            fallbackRect: axRect,
+            pendingInsertion: "",
+            isRightToLeft: false
+        )
+
+        XCTAssertEqual(anchor.quality, .derived)
+        XCTAssertEqual(anchor.rect, axRect)
+        XCTAssertNil(anchor.outcome)
+        XCTAssertEqual(anchor.skipReason, .nativeHostGeometry)
+    }
+
+    func test_layoutRepair_nativeEstimatedStillSubstitutes() {
+        // `.estimated` means AX offered no real caret position at all (only the field frame), so
+        // there is no native measurement for the trust policy to protect: the layout estimate
+        // applies regardless of provenance.
+        let frame = CGRect(x: 0, y: 0, width: 240, height: 32)
+        let context = CotabbyTestFixtures.focusedInputContext(
+            inputFrameRect: frame,
+            caretQuality: .estimated,
+            precedingText: "Hello",
+            isWebContentField: false
+        )
+
+        let anchor = SuggestionCoordinator.layoutRepairedAnchor(
+            for: context,
+            fallbackRect: fallbackRect,
+            pendingInsertion: "",
+            isRightToLeft: false
+        )
+
+        XCTAssertEqual(anchor.quality, .layoutEstimated)
+        XCTAssertTrue(frame.insetBy(dx: -1, dy: -1).contains(anchor.rect))
+    }
+
     func test_layoutRepair_runMeasuredDerivedKeepsAXEvenOnLineMismatch() {
         // Same wrong-looking vertical gap as the mismatch test, but this rect came from measured
         // child-run frames (content edges present). Run frames carry the host's real line
@@ -164,7 +229,8 @@ final class SuggestionCaretLayoutRepairTests: XCTestCase {
             inputFrameRect: frame,
             caretQuality: .derived,
             observedContentEdges: ObservedContentEdges(leftX: 4, topY: 116),
-            precedingText: "Hello"
+            precedingText: "Hello",
+            isWebContentField: true
         )
 
         let anchor = SuggestionCoordinator.layoutRepairedAnchor(
@@ -177,6 +243,7 @@ final class SuggestionCaretLayoutRepairTests: XCTestCase {
         XCTAssertEqual(anchor.quality, .derived)
         XCTAssertEqual(anchor.rect, axRect)
         XCTAssertNil(anchor.outcome)
+        XCTAssertEqual(anchor.skipReason, .runMeasuredGeometry)
     }
 
     func test_layoutRepair_derivedKeepsAXRectWhenEstimatorRejects() {
@@ -184,7 +251,8 @@ final class SuggestionCaretLayoutRepairTests: XCTestCase {
         let context = CotabbyTestFixtures.focusedInputContext(
             caretRect: axRect,
             caretQuality: .derived,
-            precedingText: "column\tvalue"
+            precedingText: "column\tvalue",
+            isWebContentField: true
         )
 
         let anchor = SuggestionCoordinator.layoutRepairedAnchor(

--- a/CotabbyTests/WebContentFieldDetectorTests.swift
+++ b/CotabbyTests/WebContentFieldDetectorTests.swift
@@ -1,0 +1,110 @@
+import XCTest
+@testable import Cotabby
+
+/// Locks the web-vs-native field classification the caret-geometry trust policy depends on.
+/// A false negative here merely forgoes a repair (pre-estimator behavior); a false positive
+/// exposes trustworthy native AX geometry to estimator overrides, which is the Notes-class
+/// regression the detector exists to prevent.
+final class WebContentFieldDetectorTests: XCTestCase {
+    // MARK: - DOM-attribute signal
+
+    func test_domIdentifierMarksElementAsWebContent() {
+        XCTAssertTrue(WebContentFieldDetector.vendsDOMAttributes(["AXRole", "AXDOMIdentifier"]))
+    }
+
+    func test_domClassListMarksElementAsWebContent() {
+        XCTAssertTrue(WebContentFieldDetector.vendsDOMAttributes(["AXDOMClassList"]))
+    }
+
+    func test_nativeAttributeSetDoesNotMarkElementAsWebContent() {
+        // The attribute surface Apple Notes' body text area actually advertises (probed live):
+        // a rich native text element, no DOM reflection.
+        XCTAssertFalse(
+            WebContentFieldDetector.vendsDOMAttributes(
+                ["AXRole", "AXValue", "AXSelectedTextRange", "AXFrame", "AXNumberOfCharacters"]
+            )
+        )
+    }
+
+    // MARK: - Combined classification
+
+    func test_unknownElectronBundleWithDOMAttributesIsWebContent() {
+        // Cursor ships under opaque per-build `com.todesktop.*` bundle ids no allowlist can
+        // track; the element-level DOM signal is what catches it.
+        XCTAssertTrue(
+            WebContentFieldDetector.isWebContentField(
+                bundleIdentifier: "com.todesktop.230313mzl4w4u92",
+                vendsDOMAttributes: true
+            )
+        )
+    }
+
+    func test_browserChromeFieldWithoutDOMAttributesIsWebContent() {
+        // The omnibox is not DOM-backed but still speaks the browser toolkit's AX dialect, not
+        // AppKit's, so it stays inside the estimator's jurisdiction.
+        XCTAssertTrue(
+            WebContentFieldDetector.isWebContentField(
+                bundleIdentifier: "com.google.Chrome",
+                vendsDOMAttributes: false
+            )
+        )
+    }
+
+    func test_safariIsWebContentByBundle() {
+        XCTAssertTrue(
+            WebContentFieldDetector.isWebContentField(
+                bundleIdentifier: "com.apple.Safari",
+                vendsDOMAttributes: false
+            )
+        )
+    }
+
+    func test_electronEditorBundleIsWebContent() {
+        XCTAssertTrue(
+            WebContentFieldDetector.isWebContentField(
+                bundleIdentifier: "com.microsoft.VSCode",
+                vendsDOMAttributes: false
+            )
+        )
+    }
+
+    func test_nativeAppIsNotWebContent() {
+        XCTAssertFalse(
+            WebContentFieldDetector.isWebContentField(
+                bundleIdentifier: "com.apple.Notes",
+                vendsDOMAttributes: false
+            )
+        )
+    }
+
+    func test_unknownBundleDefaultsToNative() {
+        // Unknown hosts default to the conservative side: keeping pre-repair behavior can never
+        // be worse than before the estimator existed.
+        XCTAssertFalse(
+            WebContentFieldDetector.isWebContentField(
+                bundleIdentifier: "com.example.SomeNativeApp",
+                vendsDOMAttributes: false
+            )
+        )
+    }
+
+    func test_nilBundleDefaultsToNative() {
+        XCTAssertFalse(
+            WebContentFieldDetector.isWebContentField(
+                bundleIdentifier: nil,
+                vendsDOMAttributes: false
+            )
+        )
+    }
+
+    func test_embeddedWebViewInNativeAppIsWebContent() {
+        // A WKWebView-hosted field inside a non-browser app: the bundle says native, the element
+        // says web. The element wins, because the text is rendered by the web engine.
+        XCTAssertTrue(
+            WebContentFieldDetector.isWebContentField(
+                bundleIdentifier: "com.example.SomeNativeApp",
+                vendsDOMAttributes: true
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary

#670's caret repair gave the hidden-text-layout estimate authority to override a `.derived` AX rect whenever the two disagreed vertically by more than 0.75 line, on the theory that a mismatch means the host mapped the caret into the wrong visual line. That theory is correct for web engines' AX bridges (the Gmail drift it was built for) and wrong for native apps: Notes answers previous-character `AXBoundsForRange` from its real layout (a 23pt title line above 16pt body lines, plus paragraph spacing), which a uniform hidden layout cannot model, so within a few lines the layout "disagrees" while AX is exactly right, and the override moved ghost text a full line off the caret. This PR scopes estimator authority by geometry provenance: a new `WebContentFieldDetector` classifies the focused field as web-rendered (DOM-reflection attributes on the resolved element, or a known browser/Electron bundle), `.derived` geometry in native hosts now bypasses the estimator unconditionally (restoring pre-#670 anchoring there), and `.estimated` substitution stays universal because AXFrame-only hosts have no real measurement to protect.

Detection adds no AX traffic (the resolver already fetches the attribute-name list it keys on), unknown hosts default to native (worst case is pre-#670 behavior, never a new failure), and the bypass now logs a `skipped` outcome with a `skip_reason`, which also closes the silent run-measured path flagged in #670's review.

## Validation

Live AX probe of Notes on this machine (macOS 26), which pinned the regression mechanically before the fix was designed:

- The body `AXTextArea` vends no DOM-reflection attributes and exposes no static-text child runs, so it resolves through previous-character bounds: `.derived` without run frames, exactly the mode #670's override applies to.
- Per-line `AXBoundsForRange` shows mixed line boxes (title 23pt, separator 17pt, body 16pt) that the estimator's pinned uniform line height cannot reproduce; the cumulative error crosses the 0.75-line override threshold within about three lines.
- Zero-length `AXBoundsForRange` in Notes is systematically one visual line high as well as zero-width, so Branch 1's empty-rect rejection is load-bearing and was deliberately left untouched.

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build \
  -derivedDataPath build/DerivedData
# ** BUILD SUCCEEDED **

xcodebuild test ... -skip-testing:CotabbyTests/FoundationModelDriftEvalTests \
  CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
# ** TEST SUCCEEDED ** full suite, 1062 tests, 0 failures
# (SuggestionCaretLayoutRepairTests: 11 tests, including the new native-derived
#  keep-AX lock and the native-estimated still-substitutes lock;
#  WebContentFieldDetectorTests: 11 tests covering the DOM-attribute/bundle matrix)

swiftlint lint --quiet
# 0 findings on the files this PR touches
```

The repair stage now emits `repair_outcome: "skipped"` with `skip_reason: "native_host_geometry" | "run_measured_geometry"`, so the trust decision is auditable per `request_id` under `-cotabby-debug`.

Not yet verified end-to-end in a live Notes typing session; the evidence is the probe-derived geometry plus the unit locks above.

## Linked issues

Refs #670. The Notes-class regression was reported directly after #670 merged and has no separate issue filed.

## Risk / rollout notes

- The behavior change is confined to `.derived` geometry in non-web hosts: they return to pre-#670 anchoring (the AX rect, rendered inline as before). Web hosts (DOM-attribute elements, browser bundles, Electron editors) keep the #670 override and the run-measured bypass bit-for-bit, so the Gmail/Outlook wins are unchanged.
- Misclassification is asymmetric by design: an unrecognized web host merely degrades to pre-#670 behavior, while a native host can only be exposed to the override if it vends DOM-reflection attributes, which native AppKit elements never do.
- Browser-chrome fields that are not DOM-backed (e.g. the omnibox) stay estimator-eligible via the bundle signal; these are single-line fields where the vertical-agreement test short-circuits, and their toolkit's AX is browser-grade rather than AppKit-grade anyway.
- `FocusedInputSnapshot`/`FocusedInputContext` gain one immutable Bool; equality-based polling dedupe is unaffected because the flag is constant for a given focused field.
- `project.pbxproj` regenerated by XcodeGen (additions only).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR scopes the `#670` caret-layout-repair estimator to web-rendered fields only, fixing a regression where native apps like Apple Notes (which use their own layout manager for rich-text geometry) had ghost text shifted off the real caret line. A new `WebContentFieldDetector` classifies each focused field as web or native using two independent signals: DOM-reflection attributes already present in the fetched AX attribute list (no extra round-trip), and a bundle-identifier check via `BrowserAppDetector`.

- **New `WebContentFieldDetector`** classifies fields as web vs. native, with unknown hosts defaulting conservatively to native (worst case: pre-#670 behavior, never a new failure mode).
- **`layoutRepairedAnchor` gating** now bypasses the estimator for all `.derived` geometry in native hosts; web hosts retain the prior line-mismatch override path; `.estimated` geometry (no real measurement exists) still substitutes regardless of host type.
- **Structured logging** adds `repair_outcome: \"skipped\"` with a `skip_reason` enum, closing the previously silent run-measured and native-host bypass paths that were unreachable from the log stream.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the behavioral change is isolated to `.derived` geometry in non-web hosts, which revert to pre-#670 anchoring. Web hosts are unchanged bit-for-bit.

The fix is well-scoped and mechanically verified against the Notes regression with live AX probes. The two style notes are non-blocking: a redundant nil-guard in the logging path and the reuse of `BrowserAppDetector.isBrowser` (a tone-hint utility) to drive the trust policy, which is correct today but creates a latent coupling risk if that prefix list is extended for unrelated reasons in the future.

`WebContentFieldDetector.swift` and its use of `BrowserAppDetector.isBrowser` are worth a second look to confirm the coupling is acceptable long-term; all other files are straightforward propagation or test additions.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/Support/WebContentFieldDetector.swift | New enum with two static classification signals (DOM-reflection attributes + bundle identifier). Logic is clean and well-documented; the minor concern is that `isWebContentField` delegates to `BrowserAppDetector.isBrowser`, which was designed for a different purpose and could silently widen the trust policy if its prefix list is extended for tone-hint reasons. |
| Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift | Core fix: native `.derived` geometry now bypasses the estimator unconditionally, web `.derived` geometry retains the prior line-mismatch gate, `.estimated` path is unchanged. The `logLayoutRepairDiagnostic` update has a redundant `if let skipReason` check that's always non-nil at that branch. Removal of `kept_ax_run_measured` log value is correct (that path was previously unreachable). |
| Cotabby/Services/Focus/FocusSnapshotResolver.swift | Correctly wires `vendsDOMAttributes` through `AXFocusCandidate` to snapshot assembly without adding any new AX round-trips; the attribute name list is already fetched earlier in the same candidate probe. |
| Cotabby/Models/FocusModels.swift | Adds `isWebContentField: Bool` with a `false` default that keeps all existing call sites compiling unchanged; participates in `Equatable` synthesis harmlessly since the flag is constant for a given focused element. |
| Cotabby/Models/SuggestionModels.swift | Propagates `isWebContentField` from `FocusedInputSnapshot` into `FocusedInputContext` correctly. |
| CotabbyTests/WebContentFieldDetectorTests.swift | New test file covering DOM-attribute signal, bundle-only signal (Chrome, Safari, VS Code, Firefox omnibox path), nil-bundle default, embedded WKWebView in native app, and the unknown-bundle-defaults-to-native invariant. Good coverage of the classification matrix. |
| CotabbyTests/SuggestionCaretLayoutRepairTests.swift | Adds `isWebContentField: true` to existing derived-geometry tests (preserving their intent) and new native-host tests locking the Notes-class regression and the native-estimated-still-substitutes invariant. |
| CotabbyTests/CotabbyTestFixtures.swift | Adds `isWebContentField: Bool = false` to both fixture builders; default value preserves existing test behavior. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[layoutRepairedAnchor called] --> B{quality == .estimated or .derived?}
    B -- No --> C[Return: rect as-is, outcome: nil]
    B -- Yes --> D{quality == .derived?}
    D -- No .estimated --> E[Run layout estimator]
    D -- Yes --> F{isWebContentField?}
    F -- No native host --> G[Return: AX rect, skipReason: nativeHostGeometry]
    F -- Yes web host --> H{observedContentEdges != nil?}
    H -- Yes --> I[Return: AX rect, skipReason: runMeasuredGeometry]
    H -- No --> E
    E --> J{Estimator result}
    J -- .rejected --> K[Return: fallback rect]
    J -- .estimate --> L{verticallyAgrees?}
    L -- Yes --> M[Return: AX rect, log: kept_ax_agreement]
    L -- No --> N[Return: estimate rect, quality: .layoutEstimated]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift`, line 809-822 ([link](https://github.com/fujacob/cotabby/blob/e64c663f38905377b4a8386023f2fc91073ab079/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift#L809-L822)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Redundant nil-check on `skipReason`**

   The outer `guard anchor.outcome != nil || anchor.skipReason != nil else { return }` ensures that when execution reaches this inner `guard let outcome` else-branch (i.e., `outcome == nil`), `skipReason` is guaranteed non-nil. The `if let skipReason` nested inside will always bind, which can mislead a future reader into thinking there is a reachable code path where `skipReason` could be `nil` at that point. A force-unwrap with a comment, or restructuring as `let skipReason = anchor.skipReason!`, would make the invariant explicit.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix-regression%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix-regression%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BAcceptance.swift%0ALine%3A%20809-822%0A%0AComment%3A%0A**Redundant%20nil-check%20on%20%60skipReason%60**%0A%0AThe%20outer%20%60guard%20anchor.outcome%20!%3D%20nil%20%7C%7C%20anchor.skipReason%20!%3D%20nil%20else%20%7B%20return%20%7D%60%20ensures%20that%20when%20execution%20reaches%20this%20inner%20%60guard%20let%20outcome%60%20else-branch%20%28i.e.%2C%20%60outcome%20%3D%3D%20nil%60%29%2C%20%60skipReason%60%20is%20guaranteed%20non-nil.%20The%20%60if%20let%20skipReason%60%20nested%20inside%20will%20always%20bind%2C%20which%20can%20mislead%20a%20future%20reader%20into%20thinking%20there%20is%20a%20reachable%20code%20path%20where%20%60skipReason%60%20could%20be%20%60nil%60%20at%20that%20point.%20A%20force-unwrap%20with%20a%20comment%2C%20or%20restructuring%20as%20%60let%20skipReason%20%3D%20anchor.skipReason!%60%2C%20would%20make%20the%20invariant%20explicit.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=676&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BAcceptance.swift%0ALine%3A%20809-822%0A%0AComment%3A%0A**Redundant%20nil-check%20on%20%60skipReason%60**%0A%0AThe%20outer%20%60guard%20anchor.outcome%20!%3D%20nil%20%7C%7C%20anchor.skipReason%20!%3D%20nil%20else%20%7B%20return%20%7D%60%20ensures%20that%20when%20execution%20reaches%20this%20inner%20%60guard%20let%20outcome%60%20else-branch%20%28i.e.%2C%20%60outcome%20%3D%3D%20nil%60%29%2C%20%60skipReason%60%20is%20guaranteed%20non-nil.%20The%20%60if%20let%20skipReason%60%20nested%20inside%20will%20always%20bind%2C%20which%20can%20mislead%20a%20future%20reader%20into%20thinking%20there%20is%20a%20reachable%20code%20path%20where%20%60skipReason%60%20could%20be%20%60nil%60%20at%20that%20point.%20A%20force-unwrap%20with%20a%20comment%2C%20or%20restructuring%20as%20%60let%20skipReason%20%3D%20anchor.skipReason!%60%2C%20would%20make%20the%20invariant%20explicit.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=676&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>


2. `Cotabby/Support/WebContentFieldDetector.swift`, line 397-406 ([link](https://github.com/fujacob/cotabby/blob/e64c663f38905377b4a8386023f2fc91073ab079/Cotabby/Support/WebContentFieldDetector.swift#L397-L406)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`isBrowser` repurposed outside its documented scope**

   `BrowserAppDetector.isBrowser` is documented as the "broad 'is the user typing in a web browser' tone hint," and its prefix list is maintained with that purpose in mind. `WebContentFieldDetector` now gives it a second role: deciding whether AX-derived geometry may be overridden by the layout estimator. If a future contributor adds a non-web-engine bundle prefix to `browserBundlePrefixes` for tone-hint breadth (e.g. an Electron email client that shouldn't expose its AX geometry to the estimator), the trust policy would silently widen. A narrowly scoped `isWebEngine(bundleIdentifier:)` method on `BrowserAppDetector`, or a shared private constant the two detectors both reference, would make the coupling explicit and enforce the distinction at the call-site.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix-regression%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix-regression%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FSupport%2FWebContentFieldDetector.swift%0ALine%3A%20397-406%0A%0AComment%3A%0A**%60isBrowser%60%20repurposed%20outside%20its%20documented%20scope**%0A%0A%60BrowserAppDetector.isBrowser%60%20is%20documented%20as%20the%20%22broad%20'is%20the%20user%20typing%20in%20a%20web%20browser'%20tone%20hint%2C%22%20and%20its%20prefix%20list%20is%20maintained%20with%20that%20purpose%20in%20mind.%20%60WebContentFieldDetector%60%20now%20gives%20it%20a%20second%20role%3A%20deciding%20whether%20AX-derived%20geometry%20may%20be%20overridden%20by%20the%20layout%20estimator.%20If%20a%20future%20contributor%20adds%20a%20non-web-engine%20bundle%20prefix%20to%20%60browserBundlePrefixes%60%20for%20tone-hint%20breadth%20%28e.g.%20an%20Electron%20email%20client%20that%20shouldn't%20expose%20its%20AX%20geometry%20to%20the%20estimator%29%2C%20the%20trust%20policy%20would%20silently%20widen.%20A%20narrowly%20scoped%20%60isWebEngine%28bundleIdentifier%3A%29%60%20method%20on%20%60BrowserAppDetector%60%2C%20or%20a%20shared%20private%20constant%20the%20two%20detectors%20both%20reference%2C%20would%20make%20the%20coupling%20explicit%20and%20enforce%20the%20distinction%20at%20the%20call-site.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=676&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FSupport%2FWebContentFieldDetector.swift%0ALine%3A%20397-406%0A%0AComment%3A%0A**%60isBrowser%60%20repurposed%20outside%20its%20documented%20scope**%0A%0A%60BrowserAppDetector.isBrowser%60%20is%20documented%20as%20the%20%22broad%20'is%20the%20user%20typing%20in%20a%20web%20browser'%20tone%20hint%2C%22%20and%20its%20prefix%20list%20is%20maintained%20with%20that%20purpose%20in%20mind.%20%60WebContentFieldDetector%60%20now%20gives%20it%20a%20second%20role%3A%20deciding%20whether%20AX-derived%20geometry%20may%20be%20overridden%20by%20the%20layout%20estimator.%20If%20a%20future%20contributor%20adds%20a%20non-web-engine%20bundle%20prefix%20to%20%60browserBundlePrefixes%60%20for%20tone-hint%20breadth%20%28e.g.%20an%20Electron%20email%20client%20that%20shouldn't%20expose%20its%20AX%20geometry%20to%20the%20estimator%29%2C%20the%20trust%20policy%20would%20silently%20widen.%20A%20narrowly%20scoped%20%60isWebEngine%28bundleIdentifier%3A%29%60%20method%20on%20%60BrowserAppDetector%60%2C%20or%20a%20shared%20private%20constant%20the%20two%20detectors%20both%20reference%2C%20would%20make%20the%20coupling%20explicit%20and%20enforce%20the%20distinction%20at%20the%20call-site.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=676&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix-regression%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix-regression%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BAcceptance.swift%3A809-822%0A**Redundant%20nil-check%20on%20%60skipReason%60**%0A%0AThe%20outer%20%60guard%20anchor.outcome%20!%3D%20nil%20%7C%7C%20anchor.skipReason%20!%3D%20nil%20else%20%7B%20return%20%7D%60%20ensures%20that%20when%20execution%20reaches%20this%20inner%20%60guard%20let%20outcome%60%20else-branch%20%28i.e.%2C%20%60outcome%20%3D%3D%20nil%60%29%2C%20%60skipReason%60%20is%20guaranteed%20non-nil.%20The%20%60if%20let%20skipReason%60%20nested%20inside%20will%20always%20bind%2C%20which%20can%20mislead%20a%20future%20reader%20into%20thinking%20there%20is%20a%20reachable%20code%20path%20where%20%60skipReason%60%20could%20be%20%60nil%60%20at%20that%20point.%20A%20force-unwrap%20with%20a%20comment%2C%20or%20restructuring%20as%20%60let%20skipReason%20%3D%20anchor.skipReason!%60%2C%20would%20make%20the%20invariant%20explicit.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FSupport%2FWebContentFieldDetector.swift%3A397-406%0A**%60isBrowser%60%20repurposed%20outside%20its%20documented%20scope**%0A%0A%60BrowserAppDetector.isBrowser%60%20is%20documented%20as%20the%20%22broad%20'is%20the%20user%20typing%20in%20a%20web%20browser'%20tone%20hint%2C%22%20and%20its%20prefix%20list%20is%20maintained%20with%20that%20purpose%20in%20mind.%20%60WebContentFieldDetector%60%20now%20gives%20it%20a%20second%20role%3A%20deciding%20whether%20AX-derived%20geometry%20may%20be%20overridden%20by%20the%20layout%20estimator.%20If%20a%20future%20contributor%20adds%20a%20non-web-engine%20bundle%20prefix%20to%20%60browserBundlePrefixes%60%20for%20tone-hint%20breadth%20%28e.g.%20an%20Electron%20email%20client%20that%20shouldn't%20expose%20its%20AX%20geometry%20to%20the%20estimator%29%2C%20the%20trust%20policy%20would%20silently%20widen.%20A%20narrowly%20scoped%20%60isWebEngine%28bundleIdentifier%3A%29%60%20method%20on%20%60BrowserAppDetector%60%2C%20or%20a%20shared%20private%20constant%20the%20two%20detectors%20both%20reference%2C%20would%20make%20the%20coupling%20explicit%20and%20enforce%20the%20distinction%20at%20the%20call-site.%0A%0A&repo=fujacob%2Fcotabby&pr=676&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BAcceptance.swift%3A809-822%0A**Redundant%20nil-check%20on%20%60skipReason%60**%0A%0AThe%20outer%20%60guard%20anchor.outcome%20!%3D%20nil%20%7C%7C%20anchor.skipReason%20!%3D%20nil%20else%20%7B%20return%20%7D%60%20ensures%20that%20when%20execution%20reaches%20this%20inner%20%60guard%20let%20outcome%60%20else-branch%20%28i.e.%2C%20%60outcome%20%3D%3D%20nil%60%29%2C%20%60skipReason%60%20is%20guaranteed%20non-nil.%20The%20%60if%20let%20skipReason%60%20nested%20inside%20will%20always%20bind%2C%20which%20can%20mislead%20a%20future%20reader%20into%20thinking%20there%20is%20a%20reachable%20code%20path%20where%20%60skipReason%60%20could%20be%20%60nil%60%20at%20that%20point.%20A%20force-unwrap%20with%20a%20comment%2C%20or%20restructuring%20as%20%60let%20skipReason%20%3D%20anchor.skipReason!%60%2C%20would%20make%20the%20invariant%20explicit.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FSupport%2FWebContentFieldDetector.swift%3A397-406%0A**%60isBrowser%60%20repurposed%20outside%20its%20documented%20scope**%0A%0A%60BrowserAppDetector.isBrowser%60%20is%20documented%20as%20the%20%22broad%20'is%20the%20user%20typing%20in%20a%20web%20browser'%20tone%20hint%2C%22%20and%20its%20prefix%20list%20is%20maintained%20with%20that%20purpose%20in%20mind.%20%60WebContentFieldDetector%60%20now%20gives%20it%20a%20second%20role%3A%20deciding%20whether%20AX-derived%20geometry%20may%20be%20overridden%20by%20the%20layout%20estimator.%20If%20a%20future%20contributor%20adds%20a%20non-web-engine%20bundle%20prefix%20to%20%60browserBundlePrefixes%60%20for%20tone-hint%20breadth%20%28e.g.%20an%20Electron%20email%20client%20that%20shouldn't%20expose%20its%20AX%20geometry%20to%20the%20estimator%29%2C%20the%20trust%20policy%20would%20silently%20widen.%20A%20narrowly%20scoped%20%60isWebEngine%28bundleIdentifier%3A%29%60%20method%20on%20%60BrowserAppDetector%60%2C%20or%20a%20shared%20private%20constant%20the%20two%20detectors%20both%20reference%2C%20would%20make%20the%20coupling%20explicit%20and%20enforce%20the%20distinction%20at%20the%20call-site.%0A%0A&repo=fujacob%2Fcotabby&pr=676&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(caret): only let the layout estimate..."](https://github.com/fujacob/cotabby/commit/e64c663f38905377b4a8386023f2fc91073ab079) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37108647)</sub>

<!-- /greptile_comment -->