### PR TITLE
perf(schedule): cut ~25-50ms of fixed per-suggestion overhead on the keystroke path

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -247,6 +247,7 @@
 		5C119807B84F84B0B1B1C2D5 /* MarkerSelectionSynthesizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A863F41C0C03D7B4AC5DC002 /* MarkerSelectionSynthesizer.swift */; };
 		5C5A2751F848F8A11DCF64B2 /* it-100k.txt in Resources */ = {isa = PBXBuildFile; fileRef = 2D8AA55C2B730110E8598F91 /* it-100k.txt */; };
 		5C6B59C2E56A3C4260591095 /* TypoCaseTransferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D0FE44138BCA8B2EE05AFE /* TypoCaseTransferTests.swift */; };
+		5CED06E89FBEF557DCD6C684 /* SuggestionFocusFreshnessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A896811745673061AF3612 /* SuggestionFocusFreshnessTests.swift */; };
 		5CF34E01F13FB242817057E2 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 6F134BAB5BC7015B9B2354AF /* Sparkle */; };
 		5D083F544CF36CF6DFA34CB1 /* GhostTextColorPreset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E44E393DD58B978B1EAB6CF /* GhostTextColorPreset.swift */; };
 		5DF31F465A3A1233260BD3A4 /* EngineAndModelPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC9ECD5408B0F5708149B5C0 /* EngineAndModelPaneView.swift */; };
@@ -680,6 +681,7 @@
 		43E37A7E835D3BDE6265843C /* TerminalAppDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAppDetectorTests.swift; sourceTree = "<group>"; };
 		4451D6673112575DF24C4A48 /* OnboardingTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTemplate.swift; sourceTree = "<group>"; };
 		44595B534DD7323F0AD60825 /* MenuBarPopoverDismisser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarPopoverDismisser.swift; sourceTree = "<group>"; };
+		45A896811745673061AF3612 /* SuggestionFocusFreshnessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionFocusFreshnessTests.swift; sourceTree = "<group>"; };
 		4638C74239D1DE2DC4D87975 /* MacroController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacroController.swift; sourceTree = "<group>"; };
 		4696A84D17890B154533A08F /* PromptPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptPolicyTests.swift; sourceTree = "<group>"; };
 		474560E524C1D74BAB1570DA /* SecureFieldDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureFieldDetectorTests.swift; sourceTree = "<group>"; };
@@ -1295,6 +1297,7 @@
 				C05B0439348261163B37C508 /* SuggestionAvailabilityEvaluatorTests.swift */,
 				EC04832FBD5311352F35241B /* SuggestionCaretLayoutRepairTests.swift */,
 				C375227649689775275AA4B3 /* SuggestionCoordinatorAcceptanceTests.swift */,
+				45A896811745673061AF3612 /* SuggestionFocusFreshnessTests.swift */,
 				CDB25ABC4FFB0E63477CDCB0 /* SuggestionOverlayStabilityGateTests.swift */,
 				EE94342B888A5A2CCF66BC93 /* SuggestionRequestFactoryTests.swift */,
 				9C8F07AC52C7A482F5FE34C5 /* SuggestionSessionReconcilerTests.swift */,
@@ -2223,6 +2226,7 @@
 				88BCD795A14E1C9308F7BB31 /* SuggestionAvailabilityEvaluatorTests.swift in Sources */,
 				EB9B5E5F7326AB72E0E44C70 /* SuggestionCaretLayoutRepairTests.swift in Sources */,
 				5B404450B412A6102F514250 /* SuggestionCoordinatorAcceptanceTests.swift in Sources */,
+				5CED06E89FBEF557DCD6C684 /* SuggestionFocusFreshnessTests.swift in Sources */,
 				4C6D8ED0A7B45D2EADF06DA5 /* SuggestionOverlayStabilityGateTests.swift in Sources */,
 				B93AB7E845086F6FBB068369 /* SuggestionRequestFactoryTests.swift in Sources */,
 				7E9413CE7C999C4612348248 /* SuggestionSessionReconcilerTests.swift in Sources */,

--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
@@ -794,7 +794,11 @@ extension SuggestionCoordinator {
         rawOutput: String? = nil,
         normalizedOutput: String? = nil
     ) {
-        latestStageMessage = message
+        // Repeated keystrokes produce identical stage messages; republishing the same string
+        // would still fire `objectWillChange` and re-render every coordinator observer.
+        if latestStageMessage != message {
+            latestStageMessage = message
+        }
         logger.logStage(
             stage,
             workID: workID,
@@ -809,6 +813,12 @@ extension SuggestionCoordinator {
         // touching one suggestion via `request_id`. `latestRequestID` is set when `+Prediction`
         // builds the request and cleared between sessions; logs outside an active request still
         // carry a placeholder so the field shape is stable for `jq`.
+        // Level-gate before building the metadata dictionary: stages fire per keystroke, and at
+        // the default `.info` floor the line is dropped anyway, so the allocations would be waste.
+        guard CotabbyLogger.suggestion.logLevel <= .debug else {
+            return
+        }
+
         var metadata: Logger.Metadata = [
             "stage": .string(stage),
             "work_id": .stringConvertible(workID),

--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
@@ -183,10 +183,14 @@ extension SuggestionCoordinator {
         }
 
         if event.shouldClearSuggestion {
+            // Always kill pending work: a stale host-publish chain or debounce from the previous
+            // keystroke must not fire a prediction this event meant to cancel.
             cancelPredictionWork()
-            clearSuggestion(clearDiagnostics: true)
-            hideOverlay(reason: SuggestionSessionReconciler.overlayHideReason(for: event))
-            if !event.shouldSchedulePrediction {
+            if hasSuggestionArtifactsToClear {
+                clearSuggestion(clearDiagnostics: true)
+                hideOverlay(reason: SuggestionSessionReconciler.overlayHideReason(for: event))
+            }
+            if !event.shouldSchedulePrediction, state != .idle {
                 state = .idle
             }
         }
@@ -237,6 +241,12 @@ extension SuggestionCoordinator {
         hostPublishPollGeneration &+= 1
         let pollGeneration = hostPublishPollGeneration
         let baseline = focusModel.snapshot.context
+        // Anchor for folding the publish wait into the debounce: `schedulePrediction` subtracts
+        // the wall time already spent waiting for AX from the configured debounce, so the debounce
+        // window starts at the keystroke instead of stacking on top of the publish delay. Measured
+        // from real uptime rather than the scheduled poll intervals because each poll's AX capture
+        // adds milliseconds the schedule does not account for.
+        let keystrokeUptimeNanoseconds = DispatchTime.now().uptimeNanoseconds
 
         // The event tap fires before the host processes the key, so an immediate `refreshNow()`
         // almost always reads the pre-keystroke value while still paying the full AX cost. Start at
@@ -246,22 +256,32 @@ extension SuggestionCoordinator {
             deadline: .now() + .milliseconds(Self.hostPublishFirstPollIntervalMs)
         ) { [weak self] in
             self?.pollForHostPublish(
-                baselineText: baseline?.precedingText,
-                baselineElementID: baseline?.elementIdentifier,
-                baselineSelectionLocation: baseline?.selection.location,
+                baseline: HostPublishBaseline(
+                    precedingText: baseline?.precedingText,
+                    elementIdentifier: baseline?.elementIdentifier,
+                    selectionLocation: baseline?.selection.location,
+                    keystrokeUptimeNanoseconds: keystrokeUptimeNanoseconds
+                ),
                 pollGeneration: pollGeneration,
                 elapsedMs: Self.hostPublishFirstPollIntervalMs
             )
         }
     }
 
+    /// The AX state captured at keystroke time, against which the host-publish poll detects "the
+    /// host has processed the key", plus the uptime anchor for folding the wait into the debounce.
+    private struct HostPublishBaseline {
+        let precedingText: String?
+        let elementIdentifier: String?
+        let selectionLocation: Int?
+        let keystrokeUptimeNanoseconds: UInt64
+    }
+
     /// Drives the snapshot-changed gate. Reads the live focus snapshot, fires `schedulePrediction`
     /// as soon as any of the captured baseline fields move on, and otherwise tail-calls itself
     /// after `hostPublishPollIntervalMs` until the ceiling is hit.
     private func pollForHostPublish(
-        baselineText: String?,
-        baselineElementID: String?,
-        baselineSelectionLocation: Int?,
+        baseline: HostPublishBaseline,
         pollGeneration: UInt64,
         elapsedMs: Int
     ) {
@@ -278,11 +298,13 @@ extension SuggestionCoordinator {
 
         // No focus context at all means the user moved away from any editable field — let
         // `schedulePrediction` and its downstream guards handle the disabled / unsupported state.
-        let textChanged = currentContext?.precedingText != baselineText
-        let elementChanged = currentContext?.elementIdentifier != baselineElementID
-        let selectionChanged = currentContext?.selection.location != baselineSelectionLocation
+        let textChanged = currentContext?.precedingText != baseline.precedingText
+        let elementChanged = currentContext?.elementIdentifier != baseline.elementIdentifier
+        let selectionChanged = currentContext?.selection.location != baseline.selectionLocation
         if textChanged || elementChanged || selectionChanged {
-            schedulePrediction()
+            schedulePrediction(
+                consumedDelayMilliseconds: Self.elapsedMilliseconds(since: baseline.keystrokeUptimeNanoseconds)
+            )
             return
         }
 
@@ -294,19 +316,23 @@ extension SuggestionCoordinator {
         let interval = Self.hostPublishPollIntervalMs
         let nextElapsed = elapsedMs + interval
         guard nextElapsed < Self.hostPublishWaitCeilingMs else {
-            schedulePrediction()
+            schedulePrediction(
+                consumedDelayMilliseconds: Self.elapsedMilliseconds(since: baseline.keystrokeUptimeNanoseconds)
+            )
             return
         }
 
         DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(interval)) { [weak self] in
             self?.pollForHostPublish(
-                baselineText: baselineText,
-                baselineElementID: baselineElementID,
-                baselineSelectionLocation: baselineSelectionLocation,
+                baseline: baseline,
                 pollGeneration: pollGeneration,
                 elapsedMs: nextElapsed
             )
         }
+    }
+
+    private static func elapsedMilliseconds(since uptimeNanoseconds: UInt64) -> Int {
+        Int((DispatchTime.now().uptimeNanoseconds &- uptimeNanoseconds) / 1_000_000)
     }
 
     func handleSuppressedSyntheticInput() {

--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
@@ -7,22 +7,43 @@ import Logging
 extension SuggestionCoordinator {
     // MARK: - Prediction Pipeline
 
-    func schedulePrediction() {
+    /// How recent a focus capture must be for the pipeline to trust it instead of paying another
+    /// synchronous AX walk. Chosen to cover the debounce window plus scheduling jitter: a capture
+    /// younger than this was taken after the keystroke that scheduled the current work, so a fresh
+    /// read cannot observe a different editing context without the downstream generation guards
+    /// also tripping.
+    static let freshSnapshotReuseWindowMilliseconds = 30
+
+    func schedulePrediction(consumedDelayMilliseconds: Int = 0) {
         if let disabledReason = currentDisabledReason(focusSnapshot: focusModel.snapshot) {
             disablePredictions(reason: disabledReason)
             return
         }
 
+        // The debounce clock starts at the keystroke, not here. The host-publish poll has already
+        // consumed real wall time waiting for the host to publish the keystroke to AX, and that
+        // wait collapses bursts just as well as sleeping does. Stacking the full debounce on top
+        // of the publish wait was pure added latency, so only the unconsumed remainder is slept.
+        let remainingDelay = max(0, settingsSnapshot.debounceMilliseconds - consumedDelayMilliseconds)
+
         // Task cancellation in Swift is cooperative, so we also use an explicit work id.
         // That gives us strict "latest request wins" semantics even if an old task wakes up late.
         let workID = workController.replaceDebouncedWork(
-            delayMilliseconds: settingsSnapshot.debounceMilliseconds
+            delayMilliseconds: remainingDelay
         ) { [weak self] workID in
             await self?.generateFromCurrentFocus(workID: workID)
         }
 
-        state = .debouncing
-        logStage("debouncing", workID: workID, message: "Waiting \(settingsSnapshot.debounceMilliseconds)ms before generating.")
+        // Equality guards keep repeated keystrokes from republishing identical state: every
+        // @Published write re-renders every coordinator observer (menu bar label included).
+        if state != .debouncing {
+            state = .debouncing
+        }
+        logStage(
+            "debouncing",
+            workID: workID,
+            message: "Debouncing (\(settingsSnapshot.debounceMilliseconds)ms window) before generating."
+        )
     }
 
     /// Refreshes focus after debounce, materializes a stable context, and starts generation.
@@ -38,7 +59,9 @@ extension SuggestionCoordinator {
 
         // We intentionally re-read the latest focus snapshot here instead of trusting the earlier
         // key event, because the user may have switched apps or fields during the debounce window.
-        focusModel.refreshNow()
+        // The host-publish poll usually captured one milliseconds ago, though, so a fresh-enough
+        // capture is reused instead of paying another synchronous AX walk back to back.
+        focusModel.refreshIfStale(maxAgeMilliseconds: Self.freshSnapshotReuseWindowMilliseconds)
         let snapshot = focusModel.snapshot
 
         if let disabledReason = currentDisabledReason(focusSnapshot: snapshot) {
@@ -323,7 +346,11 @@ extension SuggestionCoordinator {
             return
         }
 
-        focusModel.refreshNow()
+        // The free-running focus poll keeps capturing while the engine generates, so a fresh
+        // capture often already exists here; only pay a synchronous AX walk when it does not.
+        // Any keystroke during generation bumped the work id (checked above), and non-keyboard
+        // edits are caught by the generation guard below on the materialized context.
+        focusModel.refreshIfStale(maxAgeMilliseconds: Self.freshSnapshotReuseWindowMilliseconds)
         let snapshot = focusModel.snapshot
 
         if let disabledReason = currentDisabledReason(focusSnapshot: snapshot) {
@@ -634,6 +661,14 @@ extension SuggestionCoordinator {
 
     /// Fully disables prediction, clears cached context, and updates UI messaging with the cause.
     func disablePredictions(reason: String) {
+        // In a field that stays blocked (capability, per-app, per-domain), every keystroke routes
+        // here. Once the pipeline is already torn down for this exact reason there is nothing
+        // left to cancel or hide; re-running the teardown only spawns a redundant engine-reset
+        // task and republishes identical UI state on each key.
+        if isAlreadyDisabled(for: reason) {
+            return
+        }
+
         CotabbyLogger.suggestion.debug("Predictions disabled: \(reason)")
         cancelPredictionWork()
         resetCachedGenerationContext()
@@ -652,6 +687,10 @@ extension SuggestionCoordinator {
     /// session is field-scoped and outlives individual prediction cycles; destroying it here would
     /// force a redundant re-capture when the user starts typing again.
     func disablePredictionsPreservingVisualContext(reason: String) {
+        if isAlreadyDisabled(for: reason) {
+            return
+        }
+
         cancelPredictionWork()
         resetCachedGenerationContext()
         interactionState.resetAll()
@@ -659,6 +698,37 @@ extension SuggestionCoordinator {
         hideOverlay(reason: reason)
         state = .disabled(reason)
         latestStageMessage = "Disabled: \(reason)"
+    }
+
+    /// True when a previous teardown already disabled the pipeline for this exact reason and
+    /// nothing visible or session-shaped has appeared since. The overlay and session checks are
+    /// defensive: any path that shows ghost text or starts a session also moves `state` away from
+    /// `.disabled`, but re-running the teardown is cheap insurance if that invariant ever slips.
+    private func isAlreadyDisabled(for reason: String) -> Bool {
+        guard case .disabled(let currentReason) = state, currentReason == reason else {
+            return false
+        }
+
+        return !overlayState.isVisible && interactionState.activeSession == nil
+    }
+
+    /// True when the no-session clear path still has anything to tear down. With no active
+    /// session, most keystrokes arrive with the overlay already hidden and the published
+    /// suggestion state already nil; assigning nil to an already-nil `@Published` property still
+    /// fires `objectWillChange`, so skipping the redundant clear avoids re-rendering every
+    /// coordinator observer on every key. `.disabled` counts as nothing-to-clear because entering
+    /// it already ran the full teardown.
+    var hasSuggestionArtifactsToClear: Bool {
+        if overlayState.isVisible || latestSuggestionPreview != nil || latestPromptPreview != nil {
+            return true
+        }
+
+        switch state {
+        case .idle, .disabled:
+            return false
+        default:
+            return true
+        }
     }
 
     /// Clears the active suggestion and optionally preserves or drops diagnostic breadcrumbs.

--- a/Cotabby/Models/FocusTrackingModel.swift
+++ b/Cotabby/Models/FocusTrackingModel.swift
@@ -93,4 +93,8 @@ extension FocusTrackingModel: SuggestionFocusProviding {
     var snapshotPublisher: AnyPublisher<FocusSnapshot, Never> {
         $snapshot.eraseToAnyPublisher()
     }
+
+    var millisecondsSinceLastCapture: Int? {
+        tracker.millisecondsSinceLastCapture
+    }
 }

--- a/Cotabby/Models/SuggestionSubsystemContracts.swift
+++ b/Cotabby/Models/SuggestionSubsystemContracts.swift
@@ -26,8 +26,30 @@ protocol SuggestionPermissionProviding: AnyObject {
 protocol SuggestionFocusProviding: AnyObject {
     var snapshot: FocusSnapshot { get }
     var snapshotPublisher: AnyPublisher<FocusSnapshot, Never> { get }
+    /// Milliseconds since the provider last completed a full AX capture, or `nil` when unknown.
+    /// Each capture is a synchronous multi-IPC Accessibility walk, so hot-path consumers use this
+    /// to skip a redundant capture that another caller performed moments earlier.
+    var millisecondsSinceLastCapture: Int? { get }
 
     func refreshNow()
+}
+
+extension SuggestionFocusProviding {
+    /// Conservative default: age unknown, so `refreshIfStale` always refreshes. Production
+    /// providers report a real age; test fakes can ignore freshness entirely.
+    var millisecondsSinceLastCapture: Int? { nil }
+
+    /// Refreshes only when the last capture is older than `maxAgeMilliseconds`. The suggestion
+    /// pipeline performs several captures per keystroke (host-publish poll, post-debounce check,
+    /// result apply); when two of those land within one debounce window the second read cannot
+    /// observe anything the first missed, so paying another synchronous AX walk buys nothing.
+    func refreshIfStale(maxAgeMilliseconds: Int) {
+        if let age = millisecondsSinceLastCapture, age <= maxAgeMilliseconds {
+            return
+        }
+
+        refreshNow()
+    }
 }
 
 @MainActor

--- a/Cotabby/Services/Focus/FocusTracker.swift
+++ b/Cotabby/Services/Focus/FocusTracker.swift
@@ -183,6 +183,22 @@ final class FocusTracker {
         rescheduleTimerIfIntervalChanged()
     }
 
+    /// Uptime stamp of the most recent completed capture (timer tick or explicit refresh).
+    /// Backs `millisecondsSinceLastCapture` so pipeline consumers can skip a synchronous AX walk
+    /// when another caller just performed one. Uses uptime (monotonic) so wall-clock adjustments
+    /// cannot fake freshness.
+    private var lastCaptureUptimeNanoseconds: UInt64?
+
+    /// Age of the last capture in milliseconds, or `nil` before the first capture.
+    var millisecondsSinceLastCapture: Int? {
+        guard let lastCaptureUptimeNanoseconds else {
+            return nil
+        }
+
+        let elapsed = DispatchTime.now().uptimeNanoseconds &- lastCaptureUptimeNanoseconds
+        return Int(elapsed / 1_000_000)
+    }
+
     /// Captures the current snapshot, publishes any change, and reports whether anything changed.
     /// Returns `true` when the published snapshot or the focused-input identity changed; idle
     /// backoff uses this to decide whether to stay fast or stretch the poll stride.
@@ -190,6 +206,7 @@ final class FocusTracker {
     private func performCaptureAndPublish() -> Bool {
         pollSequence += 1
         let capture = captureSnapshot()
+        lastCaptureUptimeNanoseconds = DispatchTime.now().uptimeNanoseconds
 
         let snapshotChanged = capture.snapshot != snapshot
         if snapshotChanged {

--- a/Cotabby/Support/PerDomainDisableSettings.swift
+++ b/Cotabby/Support/PerDomainDisableSettings.swift
@@ -18,9 +18,15 @@ enum PerDomainDisableSettings {
         defaults.bool(forKey: enabledKey)
     }
 
-    /// The configured disabled-domain entries, or an empty set when unset. An empty set leaves the
-    /// per-site gate inert regardless of the flag.
+    /// The configured disabled-domain entries while the feature flag is on, or an empty set
+    /// otherwise. The flag gate lives here (not only in the evaluator) because this is read on
+    /// every keystroke's availability check; with the default-off flag, paying a defaults array
+    /// read plus `Set` construction per key would be pure waste, and the gate is inert anyway
+    /// since focus capture only reads page URLs while the flag is on.
     static func disabledDomains(_ defaults: UserDefaults = .standard) -> Set<String> {
+        guard isEnabled(defaults) else {
+            return []
+        }
         guard let entries = defaults.stringArray(forKey: disabledDomainsKey) else {
             return []
         }

--- a/CotabbyTests/PerDomainDisableSettingsTests.swift
+++ b/CotabbyTests/PerDomainDisableSettingsTests.swift
@@ -34,8 +34,18 @@ final class PerDomainDisableSettingsTests: XCTestCase {
         XCTAssertEqual(PerDomainDisableSettings.disabledDomains(defaults), [])
     }
 
-    func test_disabledDomains_readsStoredArrayAsSet() {
+    func test_disabledDomains_readsStoredArrayAsSet_whenEnabled() {
+        defaults.set(true, forKey: PerDomainDisableSettings.enabledKey)
         defaults.set(["bank.com", "example.org", "bank.com"], forKey: PerDomainDisableSettings.disabledDomainsKey)
         XCTAssertEqual(PerDomainDisableSettings.disabledDomains(defaults), ["bank.com", "example.org"])
+    }
+
+    /// The reader is consulted on every keystroke's availability check, so with the default-off
+    /// flag it must short-circuit to empty without touching the stored array. Behaviorally this is
+    /// identical to the old contract: with the flag off, focus capture never reads page URLs, so
+    /// the per-site gate could never match anyway.
+    func test_disabledDomains_emptyWhileFlagOff_evenWithStoredEntries() {
+        defaults.set(["bank.com"], forKey: PerDomainDisableSettings.disabledDomainsKey)
+        XCTAssertEqual(PerDomainDisableSettings.disabledDomains(defaults), [])
     }
 }

--- a/CotabbyTests/SuggestionFocusFreshnessTests.swift
+++ b/CotabbyTests/SuggestionFocusFreshnessTests.swift
@@ -1,0 +1,75 @@
+import Combine
+import XCTest
+@testable import Cotabby
+
+/// Tests for `SuggestionFocusProviding.refreshIfStale`, the guard that lets the prediction
+/// pipeline reuse a capture another caller performed moments earlier instead of paying a second
+/// synchronous AX walk back to back.
+@MainActor
+final class SuggestionFocusFreshnessTests: XCTestCase {
+    func test_refreshIfStale_refreshesWhenAgeUnknown() {
+        let provider = RecordingFocusProvider(millisecondsSinceLastCapture: nil)
+        provider.refreshIfStale(maxAgeMilliseconds: 30)
+        XCTAssertEqual(provider.refreshCount, 1)
+    }
+
+    func test_refreshIfStale_refreshesWhenCaptureOlderThanWindow() {
+        let provider = RecordingFocusProvider(millisecondsSinceLastCapture: 31)
+        provider.refreshIfStale(maxAgeMilliseconds: 30)
+        XCTAssertEqual(provider.refreshCount, 1)
+    }
+
+    func test_refreshIfStale_skipsWhenCaptureFresh() {
+        let provider = RecordingFocusProvider(millisecondsSinceLastCapture: 10)
+        provider.refreshIfStale(maxAgeMilliseconds: 30)
+        XCTAssertEqual(provider.refreshCount, 0)
+    }
+
+    func test_refreshIfStale_boundaryAgeCountsAsFresh() {
+        let provider = RecordingFocusProvider(millisecondsSinceLastCapture: 30)
+        provider.refreshIfStale(maxAgeMilliseconds: 30)
+        XCTAssertEqual(provider.refreshCount, 0)
+    }
+
+    /// Fakes that do not implement the age accessor must keep today's always-refresh behavior, so
+    /// adding freshness can never silently weaken a test double's refresh expectations.
+    func test_defaultConformance_reportsUnknownAge() {
+        let provider = MinimalFocusProvider()
+        XCTAssertNil(provider.millisecondsSinceLastCapture)
+        provider.refreshIfStale(maxAgeMilliseconds: 1000)
+        XCTAssertEqual(provider.refreshCount, 1)
+    }
+}
+
+@MainActor
+private final class RecordingFocusProvider: SuggestionFocusProviding {
+    let snapshot = FocusSnapshot.inactive
+    var snapshotPublisher: AnyPublisher<FocusSnapshot, Never> {
+        Empty().eraseToAnyPublisher()
+    }
+
+    let millisecondsSinceLastCapture: Int?
+    private(set) var refreshCount = 0
+
+    init(millisecondsSinceLastCapture: Int?) {
+        self.millisecondsSinceLastCapture = millisecondsSinceLastCapture
+    }
+
+    func refreshNow() {
+        refreshCount += 1
+    }
+}
+
+@MainActor
+private final class MinimalFocusProvider: SuggestionFocusProviding {
+    let snapshot = FocusSnapshot.inactive
+    var snapshotPublisher: AnyPublisher<FocusSnapshot, Never> {
+        Empty().eraseToAnyPublisher()
+    }
+
+    private(set) var refreshCount = 0
+
+    func refreshNow() {
+        refreshCount += 1
+    }
+}


### PR DESCRIPTION
## Summary

Every suggestion currently pays a serial chain of fixed waits and redundant work around the engine call: the host-publish AX wait and the 20ms debounce run back to back, the pipeline performs up to three full synchronous AX captures per suggestion (host-publish poll, post-debounce, result apply) even when one happened milliseconds earlier, and per-keystroke gates rebuild state for default-off or already-torn-down paths. This PR removes the redundant portion without changing any pipeline semantics:

- The debounce clock now starts at the keystroke: `schedulePrediction` subtracts the wall time the host-publish poll already consumed, so the publish wait and the debounce overlap instead of stacking (~10-20ms saved per suggestion).
- `generateFromCurrentFocus` and `apply` reuse a focus capture younger than 30ms (`refreshIfStale` on `SuggestionFocusProviding`, backed by a monotonic capture stamp in `FocusTracker`) instead of paying another 5-15ms synchronous AX walk; all downstream stale-result guards are unchanged.
- `PerDomainDisableSettings.disabledDomains()` short-circuits to empty while its default-off flag is off, instead of doing a defaults array read plus `Set` construction on every keystroke's availability check.
- `disablePredictions` no-ops when the pipeline is already disabled for the same reason, so keystrokes in a blocked field stop re-spawning an engine-reset task and republishing identical UI state.
- The no-session clear path skips `clearSuggestion` + `hideOverlay` when the overlay is already hidden and the published state already nil (assigning nil to a nil `@Published` still fires `objectWillChange` and re-renders every coordinator observer, menu bar label included). Pending-work cancellation still runs unconditionally.
- `logStage` deduplicates the published stage message and only builds its JSONL metadata dictionary when the log level would actually emit it, matching the #663 philosophy.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build-for-testing \
  -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
# ** TEST BUILD SUCCEEDED **

xcodebuild ... test-without-building -only-testing:CotabbyTests/PerDomainDisableSettingsTests \
  -only-testing:CotabbyTests/SuggestionFocusFreshnessTests \
  -only-testing:CotabbyTests/SuggestionCoordinatorAcceptanceTests \
  -only-testing:CotabbyTests/InputMonitorTests \
  -only-testing:CotabbyTests/EmojiPickerControllerTests \
  -only-testing:CotabbyTests/FocusPollBackoffTests
# Test Suite 'Selected tests' passed; 0 failures

swiftlint lint --quiet
# exit 0
```

New tests: `SuggestionFocusFreshnessTests` (refresh-if-stale contract incl. the default conformance used by fakes), plus `PerDomainDisableSettingsTests` coverage for the flag gate.

## Linked issues

Refs #661

## Risk / rollout notes

- The freshness window (30ms) covers the debounce plus scheduling jitter; a capture younger than that was taken after the keystroke that scheduled the work, and the generation-number guard at apply still drops results when the materialized context moved on. Non-keyboard edits (e.g. mouse paste) during that window are caught by the same guard one poll tick later, exactly as today.
- `disabledDomains()` now returns empty while the per-domain flag is off even if entries exist in defaults. Behaviorally identical: with the flag off, focus capture never reads page URLs, so the gate could never match. The test documenting the old shape was updated.
- The debounce fold can start a generation up to ~20ms earlier during very fast typing; superseded generations are cancelled exactly as before (workID semantics untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes a chain of serial overhead on the keystroke → suggestion path: the host-publish AX poll wait now overlaps with the debounce instead of stacking on top of it, synchronous AX captures within one debounce window are reused instead of duplicated, and several per-keystroke no-op paths (already-disabled field, already-hidden overlay, already-nil suggestion state) skip their redundant work.

- **Debounce folding**: `schedulePrediction` now receives `consumedDelayMilliseconds` from the host-publish poll and subtracts it from the configured debounce, so only the remaining sleep is scheduled rather than the full window after an already-consumed wait.
- **Snapshot freshness reuse**: `refreshIfStale(maxAgeMilliseconds: 30)` replaces three unconditional `refreshNow()` calls (post-debounce, apply-result, and host-publish poll stages), backed by a new monotonic `lastCaptureUptimeNanoseconds` stamp in `FocusTracker`.
- **Short-circuit guards**: `disablePredictions` and `disablePredictionsPreservingVisualContext` skip their full teardown if `isAlreadyDisabled` for the same reason; `PerDomainDisableSettings.disabledDomains()` returns empty without reading UserDefaults when the feature flag is off; `clearSuggestion`/`hideOverlay` are skipped when `hasSuggestionArtifactsToClear` is false.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all mutated state is guarded by the existing work-ID and generation-number cancel path, so the debounce-folding and snapshot-reuse changes cannot produce wrong suggestions — only early or skipped ones, which the downstream guards already handle.

The changes are well-decomposed and individually small. The two observations worth tracking are: `isAlreadyDisabled` is shared between the two disable variants without encoding which one last ran (could silently skip `visualContextCoordinator.cancel` in edge cases), and `freshSnapshotReuseWindowMilliseconds = 30` is independent of the configured debounce (assumes debounce ≥ 30ms). Neither causes incorrect suggestions today, and the new tests cover the freshness contract thoroughly.

`SuggestionCoordinator+Prediction.swift` — the `isAlreadyDisabled` guard and the hardcoded 30ms freshness window both warrant a second read.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift | Core scheduling changes: debounce folding, `refreshIfStale` replacements, `isAlreadyDisabled` guard, and `hasSuggestionArtifactsToClear` helper. Logic is well-reasoned; see comment on `isAlreadyDisabled` bypassing `visualContextCoordinator.cancel` for one cross-path edge case. |
| Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift | Refactors host-publish polling to pass a typed `HostPublishBaseline` struct including the keystroke uptime anchor; adds `elapsedMilliseconds(since:)` helper; calls `schedulePrediction(consumedDelayMilliseconds:)`. Guards `state = .idle` with `state != .idle`. Clean and correct. |
| Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift | Adds `@Published` deduplication on `latestStageMessage` and level-gates the JSONL metadata dictionary build behind `logLevel <= .debug`. Both optimizations are correct: the guard matches swift-log's own emission semantics. |
| Cotabby/Services/Focus/FocusTracker.swift | Adds `lastCaptureUptimeNanoseconds` stamped after each `performCaptureAndPublish` call and exposes `millisecondsSinceLastCapture`. Uses wrapping subtraction (`&-`) on a monotonic uptime value — correct and safe. |
| Cotabby/Models/SuggestionSubsystemContracts.swift | Adds `millisecondsSinceLastCapture` to `SuggestionFocusProviding` with a safe `nil`-returning default extension, and adds `refreshIfStale` as a default-extension method. The default returning `nil` ensures test fakes keep always-refresh behavior without code changes — good protocol design. |
| Cotabby/Models/FocusTrackingModel.swift | Bridges `FocusTracker.millisecondsSinceLastCapture` through `SuggestionFocusProviding`. Trivial forwarding; no issues. |
| Cotabby/Support/PerDomainDisableSettings.swift | Adds a feature-flag short-circuit to `disabledDomains()`: returns empty immediately when the flag is off, avoiding a UserDefaults array read + `Set` construction per keystroke. Behaviorally equivalent since the URL read in focus capture is also gated on the same flag. |
| CotabbyTests/SuggestionFocusFreshnessTests.swift | New tests covering all four boundary conditions of `refreshIfStale` (nil age, older-than-window, fresh, exact-boundary) plus the default-conformance nil-age guarantee. Coverage is thorough for the contract surface. |
| CotabbyTests/PerDomainDisableSettingsTests.swift | Renames existing test to require the flag to be on and adds a complementary test verifying the flag-off short-circuit. Tests correctly document the new behavior. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant K as Keystroke (CGEvent tap)
    participant I as SuggestionCoordinator+Input
    participant P as +Prediction (schedulePrediction)
    participant FT as FocusTracker
    participant G as generateFromCurrentFocus
    participant A as apply(result:)

    K->>I: handleInputEvent
    I->>I: Record keystrokeUptimeNanoseconds
    I->>FT: asyncAfter(10ms) → pollForHostPublish
    Note over FT: AX walk (5-15ms)
    FT-->>I: snapshot changed OR ceiling hit
    I->>P: schedulePrediction(consumedDelayMilliseconds: elapsed)
    P->>P: "remainingDelay = max(0, debounce - consumed)"
    P->>P: replaceDebouncedWork(delay: remainingDelay)
    Note over P: State → .debouncing

    Note over G: After remainingDelay ms…
    P->>G: generateFromCurrentFocus(workID)
    G->>FT: refreshIfStale(maxAge: 30ms)
    alt "capture < 30ms old"
        FT-->>G: reuse existing snapshot (skip AX walk)
    else "capture >= 30ms old"
        FT->>FT: refreshNow() (AX walk)
        FT-->>G: fresh snapshot
    end
    G->>G: build request, call engine
    G->>A: apply(result:, workID:)
    A->>FT: refreshIfStale(maxAge: 30ms)
    alt "capture < 30ms old"
        FT-->>A: reuse snapshot
    else
        FT->>FT: refreshNow()
    end
    A->>A: promote to .ready if workID current
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22perf%2Fscheduling-overhead%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22perf%2Fscheduling-overhead%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BPrediction.swift%3A707-712%0A**%60isAlreadyDisabled%60%20shared%20by%20two%20functionally%20distinct%20disable%20paths**%0A%0A%60disablePredictions%60%20%28which%20cancels%20%60visualContextCoordinator%60%29%20and%20%60disablePredictionsPreservingVisualContext%60%20%28which%20intentionally%20does%20not%29%20both%20use%20the%20same%20%60isAlreadyDisabled%60%20guard%20keyed%20only%20on%20%60reason%60%20and%20overlay%2Fsession%20presence.%20Because%20%60handleFocusSnapshot%60%20always%20calls%20the%20*preserving*%20variant%2C%20any%20subsequent%20call%20to%20%60disablePredictions%60%20with%20the%20same%20reason%20string%20%E2%80%94%20from%20%60schedulePrediction%60%20or%20%60handleInputEvent%60%20%E2%80%94%20hits%20the%20early%20return%20before%20reaching%20%60visualContextCoordinator.cancel%28resetState%3A%20true%29%60.%0A%0AIn%20practice%20the%20impact%20is%20limited%3A%20hard-disable%20conditions%20%28per-app%2C%20global%29%20block%20%60shouldCaptureVisualContext%60%20before%20a%20session%20ever%20starts%2C%20and%20the%20lifecycle's%20settings-change%20handler%20calls%20%60visualContextCoordinator.cancel%60%20unconditionally.%20However%2C%20the%20guard%20does%20not%20encode%20the%20*which%20variant%20ran%20first*%20distinction%2C%20so%20callers%20that%20expect%20%60disablePredictions%60%20to%20always%20cancel%20the%20visual%20context%20would%20be%20surprised.%20A%20note%20in%20%60isAlreadyDisabled%60's%20doc-comment%20%E2%80%94%20or%20checking%20that%20the%20state%20was%20set%20by%20the%20full-cancel%20path%20%E2%80%94%20would%20make%20the%20shared%20guard's%20scope%20explicit.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BPrediction.swift%3A15%0A**Freshness%20window%20is%20independent%20of%20the%20configured%20debounce**%0A%0A%60freshSnapshotReuseWindowMilliseconds%20%3D%2030%60%20is%20a%20hardcoded%20constant%2C%20but%20%60settingsSnapshot.debounceMilliseconds%60%20is%20user-configurable.%20The%20PR%20description%20says%20the%20window%20%22covers%20the%20debounce%20window%20plus%20scheduling%20jitter%2C%22%20which%20holds%20for%20the%20default%20debounce%20%28%E2%89%A5%2020ms%29%2C%20but%20if%20a%20user%20or%20test%20configures%20a%20debounce%20shorter%20than%2030ms%20the%20constant%20exceeds%20the%20debounce%20and%20%60generateFromCurrentFocus%60%20could%20reuse%20a%20snapshot%20older%20than%20the%20entire%20debounce%20period.%20The%20downstream%20work-ID%20and%20generation%20guards%20still%20catch%20stale%20results%2C%20so%20correctness%20is%20preserved%3B%20but%20the%20reuse%20rationale%20%28%22cannot%20observe%20anything%20the%20first%20missed%22%29%20weakens%20when%20the%20window%20exceeds%20the%20configured%20debounce.%20Documenting%20the%20minimum-debounce%20assumption%20would%20make%20the%20invariant%20explicit.%0A%0A&repo=fujacob%2Fcotabby&pr=677&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BPrediction.swift%3A707-712%0A**%60isAlreadyDisabled%60%20shared%20by%20two%20functionally%20distinct%20disable%20paths**%0A%0A%60disablePredictions%60%20%28which%20cancels%20%60visualContextCoordinator%60%29%20and%20%60disablePredictionsPreservingVisualContext%60%20%28which%20intentionally%20does%20not%29%20both%20use%20the%20same%20%60isAlreadyDisabled%60%20guard%20keyed%20only%20on%20%60reason%60%20and%20overlay%2Fsession%20presence.%20Because%20%60handleFocusSnapshot%60%20always%20calls%20the%20*preserving*%20variant%2C%20any%20subsequent%20call%20to%20%60disablePredictions%60%20with%20the%20same%20reason%20string%20%E2%80%94%20from%20%60schedulePrediction%60%20or%20%60handleInputEvent%60%20%E2%80%94%20hits%20the%20early%20return%20before%20reaching%20%60visualContextCoordinator.cancel%28resetState%3A%20true%29%60.%0A%0AIn%20practice%20the%20impact%20is%20limited%3A%20hard-disable%20conditions%20%28per-app%2C%20global%29%20block%20%60shouldCaptureVisualContext%60%20before%20a%20session%20ever%20starts%2C%20and%20the%20lifecycle's%20settings-change%20handler%20calls%20%60visualContextCoordinator.cancel%60%20unconditionally.%20However%2C%20the%20guard%20does%20not%20encode%20the%20*which%20variant%20ran%20first*%20distinction%2C%20so%20callers%20that%20expect%20%60disablePredictions%60%20to%20always%20cancel%20the%20visual%20context%20would%20be%20surprised.%20A%20note%20in%20%60isAlreadyDisabled%60's%20doc-comment%20%E2%80%94%20or%20checking%20that%20the%20state%20was%20set%20by%20the%20full-cancel%20path%20%E2%80%94%20would%20make%20the%20shared%20guard's%20scope%20explicit.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BPrediction.swift%3A15%0A**Freshness%20window%20is%20independent%20of%20the%20configured%20debounce**%0A%0A%60freshSnapshotReuseWindowMilliseconds%20%3D%2030%60%20is%20a%20hardcoded%20constant%2C%20but%20%60settingsSnapshot.debounceMilliseconds%60%20is%20user-configurable.%20The%20PR%20description%20says%20the%20window%20%22covers%20the%20debounce%20window%20plus%20scheduling%20jitter%2C%22%20which%20holds%20for%20the%20default%20debounce%20%28%E2%89%A5%2020ms%29%2C%20but%20if%20a%20user%20or%20test%20configures%20a%20debounce%20shorter%20than%2030ms%20the%20constant%20exceeds%20the%20debounce%20and%20%60generateFromCurrentFocus%60%20could%20reuse%20a%20snapshot%20older%20than%20the%20entire%20debounce%20period.%20The%20downstream%20work-ID%20and%20generation%20guards%20still%20catch%20stale%20results%2C%20so%20correctness%20is%20preserved%3B%20but%20the%20reuse%20rationale%20%28%22cannot%20observe%20anything%20the%20first%20missed%22%29%20weakens%20when%20the%20window%20exceeds%20the%20configured%20debounce.%20Documenting%20the%20minimum-debounce%20assumption%20would%20make%20the%20invariant%20explicit.%0A%0A&repo=fujacob%2Fcotabby&pr=677&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["perf(schedule): cut fixed per-suggestion..."](https://github.com/fujacob/cotabby/commit/63bc818b4844eda404e8344afac7ec8d99d7c309) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37120768)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->