### PR TITLE
perf(accept): hop acceptance bookkeeping off the consuming tap callback

### DIFF
--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
@@ -114,7 +114,9 @@ extension SuggestionCoordinator {
             return false
         }
 
-        recordAcceptedWords(from: acceptedChunk)
+        deferAcceptanceBookkeeping { [weak self] in
+            self?.recordAcceptedWords(from: acceptedChunk)
+        }
 
         cancelPredictionWork()
 
@@ -133,13 +135,16 @@ extension SuggestionCoordinator {
             // a regeneration that only re-proposes the same tail before the host publishes the insert
             // (see the `schedulePredictionAfterHostPublishDelay` rationale below).
             lastAcceptedTail = AcceptedSuggestionTail(text: acceptedChunk, precedingText: liveContext.precedingText)
-            logStage(
-                "\(keyName)-accepted-final-chunk",
-                workID: currentWorkID,
-                generation: liveContext.generation,
-                message: "Inserted the final suggestion chunk and queued a refresh.",
-                normalizedOutput: acceptedChunk
-            )
+            let workID = currentWorkID
+            deferAcceptanceBookkeeping { [weak self] in
+                self?.logStage(
+                    "\(keyName)-accepted-final-chunk",
+                    workID: workID,
+                    generation: liveContext.generation,
+                    message: "Inserted the final suggestion chunk and queued a refresh.",
+                    normalizedOutput: acceptedChunk
+                )
+            }
             // Keep owning Tab while the continuation regenerates so a fast follow-up press is
             // swallowed and queued instead of leaking into the host app as a real Tab. Must run
             // *after* the `hideOverlay` above, which routes through `onStateChange(.hidden)` and
@@ -157,22 +162,45 @@ extension SuggestionCoordinator {
 
         case let .advanced(advancedSession, _):
             latestGenerationNumber = liveContext.generation
-            applySessionDiagnostics(advancedSession, acceptanceAction: "Accepted next chunk with \(keyName).")
             state = .ready(text: advancedSession.remainingText, latency: advancedSession.latency)
+            // The overlay slide stays synchronous on purpose: acceptance validation compares the
+            // visible overlay text against the session tail, so a deferred slide could make a
+            // rapid follow-up Tab read a stale overlay and pass through to the host.
             presentAdvancedOverlay(
                 remainingText: advancedSession.remainingText,
                 insertionChunk: insertionChunk,
                 liveContext: liveContext
             )
             schedulePostInsertionRefresh()
-            logStage(
-                "\(keyName)-accepted-chunk",
-                workID: currentWorkID,
-                generation: liveContext.generation,
-                message: "Inserted the next suggestion chunk and kept the remaining tail active.",
-                normalizedOutput: acceptedChunk
-            )
+            let workID = currentWorkID
+            deferAcceptanceBookkeeping { [weak self] in
+                self?.applySessionDiagnostics(
+                    advancedSession,
+                    acceptanceAction: "Accepted next chunk with \(keyName)."
+                )
+                self?.logStage(
+                    "\(keyName)-accepted-chunk",
+                    workID: workID,
+                    generation: liveContext.generation,
+                    message: "Inserted the next suggestion chunk and kept the remaining tail active.",
+                    normalizedOutput: acceptedChunk
+                )
+            }
             return true
+        }
+    }
+
+    /// Runs acceptance bookkeeping one runloop hop after the consuming tap callback returns.
+    ///
+    /// While ghost text is visible the accept tap gates every keyDown system-wide, and the whole
+    /// acceptance executes inside that callback before the original key is released. Work that
+    /// neither decides consumption nor upholds the overlay/session invariant (counter persistence,
+    /// stage logging, diagnostics publishes) does not belong on that synchronous path; a
+    /// `UserDefaults` write in particular can stall on the preferences daemon at the worst moment.
+    /// Captured values keep the deferred log lines describing the accept that scheduled them.
+    private func deferAcceptanceBookkeeping(_ work: @escaping @MainActor () -> Void) {
+        DispatchQueue.main.async {
+            work()
         }
     }
 
@@ -279,20 +307,23 @@ extension SuggestionCoordinator {
             return false
         }
 
-        recordAcceptedWords(from: replacement.replacementText)
         cancelPredictionWork()
         latestGenerationNumber = session.baseContext.generation
         clearSuggestion(clearDiagnostics: false)
         hideOverlay(reason: "Overlay hidden because \(keyName) accepted a typo correction.")
-        latestAcceptanceAction = "Accepted typo correction with \(keyName)."
         state = .idle
-        logStage(
-            "\(keyName)-accepted-correction",
-            workID: currentWorkID,
-            generation: session.baseContext.generation,
-            message: "Replaced the user's last word with the corrected version.",
-            normalizedOutput: replacement.replacementText
-        )
+        let workID = currentWorkID
+        deferAcceptanceBookkeeping { [weak self] in
+            self?.recordAcceptedWords(from: replacement.replacementText)
+            self?.latestAcceptanceAction = "Accepted typo correction with \(keyName)."
+            self?.logStage(
+                "\(keyName)-accepted-correction",
+                workID: workID,
+                generation: session.baseContext.generation,
+                message: "Replaced the user's last word with the corrected version.",
+                normalizedOutput: replacement.replacementText
+            )
+        }
         // Re-arm prediction so the next keystroke can produce a fresh continuation now that the typo
         // is gone — the user usually keeps typing right after accepting.
         schedulePrediction()
@@ -310,12 +341,15 @@ extension SuggestionCoordinator {
         clearSuggestion(clearDiagnostics: true)
         hideOverlay(reason: reason)
         state = .idle
-        logStage(
-            "tab-passed-through",
-            workID: currentWorkID,
-            generation: generation,
-            message: reason
-        )
+        let workID = currentWorkID
+        deferAcceptanceBookkeeping { [weak self] in
+            self?.logStage(
+                "tab-passed-through",
+                workID: workID,
+                generation: generation,
+                message: reason
+            )
+        }
         return false
     }
 

--- a/CotabbyTests/SuggestionCoordinatorAcceptanceTests.swift
+++ b/CotabbyTests/SuggestionCoordinatorAcceptanceTests.swift
@@ -19,7 +19,7 @@ final class SuggestionCoordinatorAcceptanceTests: XCTestCase {
     }
 
     func test_acceptCurrentSuggestionAllowsVisibleSessionWhileDebugStateIsDebouncing() {
-        runOnMainActor {
+        let coordinator: SuggestionCoordinator = runOnMainActor {
             let snapshot = CotabbyTestFixtures.focusedInputSnapshot(precedingText: "Hello")
             let context = FocusedInputContext(snapshot: snapshot, generation: 7)
             let interactionState = SuggestionInteractionState()
@@ -51,12 +51,23 @@ final class SuggestionCoordinatorAcceptanceTests: XCTestCase {
             XCTAssertTrue(coordinator.acceptCurrentSuggestion())
 
             XCTAssertEqual(inserter.insertedChunks, [" world"])
-            XCTAssertEqual(coordinator.latestAcceptanceAction, "Accepted next chunk with Tab.")
-            guard case let .ready(remainingText, _) = coordinator.state else {
+            if case let .ready(remainingText, _) = coordinator.state {
+                XCTAssertEqual(remainingText, " again")
+            } else {
                 XCTFail("Partial acceptance should leave the remaining suggestion ready.")
-                return
             }
-            XCTAssertEqual(remainingText, " again")
+            return coordinator
+        }
+
+        // Acceptance bookkeeping (diagnostics publishes, counters, stage logs) lands one runloop
+        // hop after the gating tap callback returns (`deferAcceptanceBookkeeping`); drain that hop
+        // before asserting on it. The session math and overlay state above are still synchronous.
+        let bookkeepingDrained = expectation(description: "acceptance bookkeeping hop")
+        DispatchQueue.main.async { bookkeepingDrained.fulfill() }
+        wait(for: [bookkeepingDrained], timeout: 1.0)
+
+        runOnMainActor {
+            XCTAssertEqual(coordinator.latestAcceptanceAction, "Accepted next chunk with Tab.")
         }
     }
 


### PR DESCRIPTION
## Summary

The consuming accept tap runs on the main run loop and intercepts every keyDown system-wide while ghost text is visible, and the entire acceptance executed synchronously inside its callback before the original Tab was released. Any stall there delays both the accept and bystander typing. This PR hops the bookkeeping that neither decides consumption nor upholds the overlay/session invariant one runloop turn later via `deferAcceptanceBookkeeping`:

- the `UserDefaults` word-counter write (`recordAcceptedWords`), which can stall on the preferences daemon at exactly the wrong moment
- `logStage` calls on the chunk-accept, final-chunk, correction-accept, and pass-through paths (values captured at accept time, so the lines still describe the accept that scheduled them)
- the pure-diagnostics publishes (`applySessionDiagnostics`, `latestAcceptanceAction`)

What deliberately stays synchronous: session validation and math, the insertion itself (its failure decides whether the key is consumed), `state`, `lastAcceptedTail`/`latestGenerationNumber` (consumed by the apply-time echo guards), and the overlay slide. The slide must stay synchronous because acceptance validation compares the visible overlay text against the session tail; a deferred slide could make a rapid follow-up Tab read a stale overlay and pass through to the host.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build-for-testing \
  -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
# ** TEST BUILD SUCCEEDED **

xcodebuild ... test-without-building \
  -only-testing:CotabbyTests/SuggestionCoordinatorAcceptanceTests \
  -only-testing:CotabbyTests/InputMonitorTests \
  -only-testing:CotabbyTests/SuggestionSessionReconcilerTests
# 20 tests, 0 failures (plus the reconciler suite green)

swiftlint lint --quiet
# exit 0
```

One acceptance test was updated to drain the bookkeeping hop before asserting on `latestAcceptanceAction`; its synchronous assertions (inserted chunk, session state) are unchanged, which documents exactly what moved and what did not.

## Linked issues

Refs #661

## Risk / rollout notes

- Deferred log lines for one accept can now interleave after a subsequent event's synchronous lines in rare bursts; each line still carries the captured work id, generation, and request id, so `jq` joins are unaffected.
- The word counter publishes one runloop hop later; the menu bar label visually updates a frame later at most.
- Rapid-Tab behavior is intentionally unchanged: everything the burst path validates against remains synchronous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves acceptance bookkeeping that is neither on the consumption decision path nor required to uphold session/overlay invariants — `UserDefaults` word-counter writes, `logStage` calls, and `applySessionDiagnostics` publishes — one main-run-loop hop later via a new `deferAcceptanceBookkeeping` helper. The tap callback's synchronous path is kept to the minimum needed to decide key consumption and maintain the overlay/state invariants that rapid-Tab burst behavior relies on.

- **What stays synchronous:** insertion, `state`, `lastAcceptedTail`/`latestGenerationNumber` (used by echo guards), and the overlay slide (prevents stale overlay reads on rapid Tab).
- **What is deferred:** `recordAcceptedWords` (UserDefaults write), all `logStage` calls on acceptance paths, and `applySessionDiagnostics` on the chunk-advance path — one test was updated to drain the hop before asserting on `latestAcceptanceAction`.
- **Rapid-Tab safety preserved:** all values the burst validation path reads remain synchronous; deferred lines may interleave in logs across back-to-back accepts, but each carries a captured `workID`/`generation` for unambiguous `jq` joins."

<h3>Confidence Score: 4/5</h3>

Safe to merge. The synchronous invariants (insertion result, state machine, echo-guard fields, overlay slide) are untouched; only fire-and-forget diagnostics are deferred.

The deferred helper calls `work()` — a `@MainActor`-annotated closure — from inside a plain `DispatchQueue.main.async { }` block that carries no `@MainActor` isolation in Swift's type system. This works today but would require `MainActor.assumeIsolated` under Swift 6 strict concurrency. Everything else is well-bounded: captured values are immutable at call time, `[weak self]` prevents retention cycles, and the one test that asserts on a deferred value correctly drains the hop first.

Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift — specifically the `deferAcceptanceBookkeeping` implementation, which will need `MainActor.assumeIsolated { work() }` when strict concurrency is enabled.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift | Moves non-critical bookkeeping (UserDefaults write, logStage, applySessionDiagnostics) one run-loop hop off the consuming tap callback via DispatchQueue.main.async. Synchronous invariants (state, lastAcceptedTail, overlay slide) are correctly preserved. The @MainActor closure parameter is called from a non-isolated DispatchQueue.main.async block, which requires MainActor.assumeIsolated in Swift 6 strict concurrency mode. |
| CotabbyTests/SuggestionCoordinatorAcceptanceTests.swift | Updates the partial-acceptance test to drain the deferred bookkeeping hop before asserting on latestAcceptanceAction; synchronous assertions (inserted chunk, session state) are unchanged. Drain technique (enqueue a sentinel async block, wait for it) is correct and the expectation timeout is reasonable. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Tap as CGEvent Tap
    participant AC as acceptSuggestion()
    participant Ins as SuggestionInserter
    participant Main as DispatchQueue.main (next hop)

    Tap->>AC: keyDown (Tab)
    AC->>AC: validateSession / prepareAcceptance
    AC->>Ins: insert(insertionChunk) — sync
    AC->>AC: commitAcceptedChunk → .advanced or .exhausted — sync
    AC->>AC: "state = .ready / .idle — sync"
    AC->>AC: presentAdvancedOverlay / hideOverlay — sync
    AC->>AC: lastAcceptedTail / latestGenerationNumber — sync
    AC->>Main: "deferAcceptanceBookkeeping { recordAcceptedWords } — async"
    AC->>Main: "deferAcceptanceBookkeeping { applySessionDiagnostics + logStage } — async"
    AC-->>Tap: return true (key consumed)
    Note over Tap: original key released
    Main->>Main: recordAcceptedWords (UserDefaults write)
    Main->>Main: applySessionDiagnostics (latestAcceptanceAction, previews)
    Main->>Main: logStage (structured JSONL emit)
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22perf%2Faccept-tap-defer%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22perf%2Faccept-tap-defer%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BAcceptance.swift%3A201-205%0A**%60%40MainActor%60%20closure%20called%20from%20non-isolated%20context**%0A%0A%60work%60%20is%20declared%20%60%40escaping%20%40MainActor%20%28%29%20-%3E%20Void%60%2C%20but%20it%20is%20invoked%20directly%20inside%20%60DispatchQueue.main.async%20%7B%20%7D%60.%20That%20outer%20block%20has%20no%20%60%40MainActor%60%20isolation%20from%20Swift's%20type-system%20perspective%2C%20so%20calling%20a%20%60%40MainActor%60-annotated%20closure%20there%20is%20technically%20a%20strict-concurrency%20violation.%20This%20compiles%20today%20because%20strict-concurrency%20checking%20is%20off%2C%20but%20it%20will%20need%20%60MainActor.assumeIsolated%20%7B%20work%28%29%20%7D%60%20when%20the%20project%20moves%20to%20Swift%206%20complete%20concurrency.%20A%20safe%20drop-in%20for%20the%20body%20today%3A%20%60DispatchQueue.main.async%20%7B%20MainActor.assumeIsolated%20%7B%20work%28%29%20%7D%20%7D%60%0A%0A&repo=fujacob%2Fcotabby&pr=680&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BAcceptance.swift%3A201-205%0A**%60%40MainActor%60%20closure%20called%20from%20non-isolated%20context**%0A%0A%60work%60%20is%20declared%20%60%40escaping%20%40MainActor%20%28%29%20-%3E%20Void%60%2C%20but%20it%20is%20invoked%20directly%20inside%20%60DispatchQueue.main.async%20%7B%20%7D%60.%20That%20outer%20block%20has%20no%20%60%40MainActor%60%20isolation%20from%20Swift's%20type-system%20perspective%2C%20so%20calling%20a%20%60%40MainActor%60-annotated%20closure%20there%20is%20technically%20a%20strict-concurrency%20violation.%20This%20compiles%20today%20because%20strict-concurrency%20checking%20is%20off%2C%20but%20it%20will%20need%20%60MainActor.assumeIsolated%20%7B%20work%28%29%20%7D%60%20when%20the%20project%20moves%20to%20Swift%206%20complete%20concurrency.%20A%20safe%20drop-in%20for%20the%20body%20today%3A%20%60DispatchQueue.main.async%20%7B%20MainActor.assumeIsolated%20%7B%20work%28%29%20%7D%20%7D%60%0A%0A&repo=fujacob%2Fcotabby&pr=680&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["perf(accept): hop acceptance bookkeeping..."](https://github.com/fujacob/cotabby/commit/f96f3a9ad467d79ae5886c1dc28f6903d7e4cd9e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37127149)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->