### PR TITLE
perf(ram): lazy SymSpell and emoji catalog, bounded emoji frequency map

### DIFF
--- a/Cotabby/App/Coordinators/EmojiPickerController.swift
+++ b/Cotabby/App/Coordinators/EmojiPickerController.swift
@@ -18,7 +18,19 @@ import Logging
 @MainActor
 final class EmojiPickerController {
     private var machine = EmojiTriggerStateMachine()
-    private let matcher: EmojiMatcher
+    /// Built on first use rather than injected ready-made: the bundled catalog decode plus index
+    /// costs a few MB of resident strings, and most sessions never open the picker. The one-time
+    /// build lands on the first `:` capture's first match request, which is user-paced.
+    private let matcherProvider: @MainActor () -> EmojiMatcher
+    private var cachedMatcher: EmojiMatcher?
+    private var matcher: EmojiMatcher {
+        if let cachedMatcher {
+            return cachedMatcher
+        }
+        let built = matcherProvider()
+        cachedMatcher = built
+        return built
+    }
     private let panel: any EmojiPickerPanelPresenting
     private let focusModel: any SuggestionFocusProviding
     private let inputMonitor: any EmojiInputIntercepting
@@ -66,7 +78,7 @@ final class EmojiPickerController {
     private static let longPauseNanoseconds: UInt64 = 8_000_000_000
 
     init(
-        matcher: EmojiMatcher,
+        matcherProvider: @MainActor @escaping () -> EmojiMatcher,
         panel: any EmojiPickerPanelPresenting,
         focusModel: any SuggestionFocusProviding,
         inputMonitor: any EmojiInputIntercepting,
@@ -77,7 +89,7 @@ final class EmojiPickerController {
         emojiUsage: @MainActor @escaping () -> EmojiUsageSnapshot,
         recordEmojiUsage: @MainActor @escaping (String) -> Void
     ) {
-        self.matcher = matcher
+        self.matcherProvider = matcherProvider
         self.panel = panel
         self.focusModel = focusModel
         self.inputMonitor = inputMonitor

--- a/Cotabby/App/Core/CotabbyAppEnvironment.swift
+++ b/Cotabby/App/Core/CotabbyAppEnvironment.swift
@@ -188,16 +188,14 @@ final class CotabbyAppEnvironment {
         // Constructed once at app scope so the underlying `NSSpellChecker` document tag survives
         // across coordinator state transitions instead of churning per keystroke.
         let spellChecker = CurrentWordSpellChecker()
-        let enabledSpellingLanguages = SpellingDictionaryCatalog.languages(
-            for: suggestionSettings.enabledSpellingDictionaryCodes
-        )
-        // Preserve the existing warm English path when it is enabled. A sole non-English choice is
-        // also preloaded; broader multilingual sets stay lazy so app launch never builds every index.
-        let preloadSpellingLanguage = enabledSpellingLanguages.count == 1
-            ? enabledSpellingLanguages.first
-            : enabledSpellingLanguages.first(where: { $0 == .english })
+        // No launch-time preload: a fully built index costs tens of MB resident for a feature that
+        // is only consulted once the typo gate actually finds a misspelling, and the first
+        // consultation triggers the same background build (`cachedIndexOrRequestLoad`) with the
+        // designed NSSpellChecker fallback ranking corrections until it lands. The only cost of
+        // staying cold is that the first correction or two after launch rank via the system
+        // checker instead of corpus frequency.
         let symSpellCorrector = SymSpellCorrector(
-            preloadLanguage: preloadSpellingLanguage
+            preloadLanguage: nil
         )
         let suggestionCoordinator = SuggestionCoordinator(
             permissionManager: permissionManager,
@@ -221,7 +219,9 @@ final class CotabbyAppEnvironment {
         // The emoji picker is a sibling to the suggestion coordinator. It reuses the input monitor,
         // focus model, and inserter, but owns its own trigger state machine and floating panel.
         let emojiPickerController = EmojiPickerController(
-            matcher: EmojiMatcher(catalog: EmojiCatalog.bundled()),
+            // Deferred: decoding and indexing the bundled emoji catalog costs a few MB of resident
+            // strings that most sessions never use; the picker builds it on first `:` capture.
+            matcherProvider: { EmojiMatcher(catalog: EmojiCatalog.bundled()) },
             panel: EmojiPickerPanelController(),
             focusModel: focusModel,
             inputMonitor: inputMonitor,

--- a/Cotabby/Models/EmojiUsageStore.swift
+++ b/Cotabby/Models/EmojiUsageStore.swift
@@ -35,6 +35,12 @@ final class EmojiUsageStore {
     /// Cap on stored recents: ample for the panel (which shows ~24) while keeping the persisted blob
     /// small. Older aliases fall off the end as new emoji are committed.
     private static let recentsCap = 50
+    /// Bounds for the frequency map, which previously grew one entry per unique emoji forever.
+    /// Frequency only breaks ties inside a relevance tier, so trimming the rarest entries cannot
+    /// change which emoji match a query. Trimming triggers above `frequencyCap` and cuts down to
+    /// `frequencyTrimTarget` so steady use does not re-sort the map on every commit.
+    private static let frequencyCap = 300
+    private static let frequencyTrimTarget = 200
     private static let storageKey = "cotabbyEmojiUsage"
 
     private struct Persisted: Codable {
@@ -68,7 +74,25 @@ final class EmojiUsageStore {
             recents.removeLast(recents.count - Self.recentsCap)
         }
         frequency[alias, default: 0] += 1
+        trimFrequencyIfNeeded()
         persist()
+    }
+
+    /// Drops the least-used aliases once the map outgrows its cap, keeping current recents so a
+    /// just-used emoji can never lose its favorite ranking to the trim.
+    private func trimFrequencyIfNeeded() {
+        guard frequency.count > Self.frequencyCap else {
+            return
+        }
+
+        let keepAlways = Set(recents)
+        let removable = frequency
+            .filter { !keepAlways.contains($0.key) }
+            .sorted { $0.value < $1.value }
+        let overflow = frequency.count - Self.frequencyTrimTarget
+        for (alias, _) in removable.prefix(overflow) {
+            frequency.removeValue(forKey: alias)
+        }
     }
 
     /// Immutable snapshot for the pure ranker and recents helper.

--- a/Cotabby/Models/EmojiUsageStore.swift
+++ b/Cotabby/Models/EmojiUsageStore.swift
@@ -89,7 +89,11 @@ final class EmojiUsageStore {
         let removable = frequency
             .filter { !keepAlways.contains($0.key) }
             .sorted { $0.value < $1.value }
-        let overflow = frequency.count - Self.frequencyTrimTarget
+        // The effective floor is the larger of the trim target and the protected recents, so the
+        // bound holds by construction even if `recentsCap` is ever raised past
+        // `frequencyTrimTarget` instead of silently under-trimming.
+        let effectiveTarget = max(Self.frequencyTrimTarget, keepAlways.count)
+        let overflow = frequency.count - effectiveTarget
         for (alias, _) in removable.prefix(overflow) {
             frequency.removeValue(forKey: alias)
         }

--- a/CotabbyTests/EmojiPickerControllerTests.swift
+++ b/CotabbyTests/EmojiPickerControllerTests.swift
@@ -127,7 +127,7 @@ final class EmojiPickerControllerTests: XCTestCase {
             let usageRecorder = UsageRecorder()
             usage = usageRecorder
             controller = EmojiPickerController(
-                matcher: EmojiMatcher(catalog: catalog),
+                matcherProvider: { EmojiMatcher(catalog: catalog) },
                 panel: panel,
                 focusModel: focus,
                 inputMonitor: monitor,

--- a/CotabbyTests/EmojiUsageStoreTests.swift
+++ b/CotabbyTests/EmojiUsageStoreTests.swift
@@ -56,6 +56,32 @@ final class EmojiUsageStoreTests: XCTestCase {
         }
     }
 
+    func test_frequencyIsBoundedAndKeepsHeavyHitters() {
+        runOnMainActor {
+            let sut = EmojiUsageStore(defaults: InMemoryDefaults())
+            // A heavy favorite that must survive trimming even after it falls out of recents.
+            for _ in 0..<10 {
+                sut.record(alias: "joy")
+            }
+            // Flood with one-shot unique aliases to push the map past its cap several times over.
+            for index in 0..<320 {
+                sut.record(alias: "flood\(index)")
+            }
+
+            let snapshot = sut.snapshot()
+            XCTAssertLessThanOrEqual(
+                snapshot.frequency.count,
+                300,
+                "The frequency map must stay bounded instead of growing one entry per unique emoji forever."
+            )
+            XCTAssertEqual(
+                snapshot.frequency["joy"],
+                10,
+                "Trimming removes the rarest entries; heavy hitters keep their counts."
+            )
+        }
+    }
+
     func test_clearForgetsEverything() {
         runOnMainActor {
             let sut = EmojiUsageStore(defaults: InMemoryDefaults())

--- a/CotabbyTests/EmojiUsageStoreTests.swift
+++ b/CotabbyTests/EmojiUsageStoreTests.swift
@@ -69,10 +69,13 @@ final class EmojiUsageStoreTests: XCTestCase {
             }
 
             let snapshot = sut.snapshot()
-            XCTAssertLessThanOrEqual(
+            // Exactly 220: the 301st unique alias trips the cap and trims down to the 200 target,
+            // and the remaining 20 flood inserts land afterwards. An exact bound catches both a
+            // trim that never fires and one that removes fewer entries than the target demands.
+            XCTAssertEqual(
                 snapshot.frequency.count,
-                300,
-                "The frequency map must stay bounded instead of growing one entry per unique emoji forever."
+                220,
+                "The frequency map must trim to its target instead of growing one entry per unique emoji forever."
             )
             XCTAssertEqual(
                 snapshot.frequency["joy"],


### PR DESCRIPTION
## Summary

Three idle-footprint cuts, none of which change steady-state behavior:

- **SymSpell loads on first need, not at launch.** The corrector already lazy-loads every language with an LRU of two and falls back to `NSSpellChecker` while an index builds; the only eager part was the launch-time preload. A built index is an `[Int: [Int32]]` delete-variant map over ~83-100k words (order tens of MB resident), paid by every session for a feature consulted only when the typo gate actually finds a misspelling. The first consultation now triggers the same background build through `cachedIndexOrRequestLoad`. Cost of staying cold: the first correction or two after launch rank via the system spell checker instead of corpus frequency, exactly the designed fallback.
- **Emoji catalog builds on first `:` capture.** `EmojiPickerController` now takes a `matcherProvider` and builds the matcher (bundle JSON decode + lowercased index, a few MB) on the first match request instead of at app construction. One-time ~tens-of-ms build on first picker use, user-paced.
- **Bounded emoji frequency map.** `EmojiUsageStore.frequency` grew one entry per unique emoji forever. It now trims above 300 entries down to 200, preserving current recents and (by construction, since trimming removes the rarest first) heavy hitters. Frequency only breaks ties within a relevance tier, so trimming cannot change which emoji match a query.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build-for-testing \
  -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
# ** TEST BUILD SUCCEEDED **

xcodebuild ... test-without-building \
  -only-testing:CotabbyTests/EmojiUsageStoreTests \
  -only-testing:CotabbyTests/EmojiPickerControllerTests \
  -only-testing:CotabbyTests/SymSpellCorrectorTests \
  -only-testing:CotabbyTests/EmojiMatcherTests
# 19 tests, 0 failures

swiftlint lint --quiet
# exit 0
```

New test: `test_frequencyIsBoundedAndKeepsHeavyHitters` floods the store with 320 unique aliases and asserts the bound plus survivor counts.

## Linked issues

Refs #661

## Risk / rollout notes

- The launch-preload removal reverses an explicit earlier choice ("preserve the warm English path"). The tradeoff is documented at the construction site: tens of MB resident in every session versus system-checker ranking for the first correction after launch.
- First emoji picker open pays a one-time catalog build on the main actor (small, user-initiated). If it ever shows up in practice it can move behind the capture-open hop.
- Existing persisted frequency blobs above the cap trim on the next emoji commit, not at migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reduces idle memory footprint across three subsystems without changing steady-state behavior: SymSpell index load is deferred until the first correction, the emoji catalog is built on the first picker interaction, and the emoji frequency map is capped at 300 entries (trimming to 200 on overflow).

- **Lazy SymSpell & emoji catalog**: Both expensive initializations (tens of MB for SymSpell, a few MB for emoji indexing) are now deferred behind a `nil` preload and a `matcherProvider` closure, respectively. The SymSpell fallback (`NSSpellChecker`) covers the cold path; the emoji catalog builds on first `:` capture, which is user-paced.
- **Bounded frequency map**: `trimFrequencyIfNeeded()` fires above 300 entries and cuts to 200, protecting the current recents set and using `effectiveTarget = max(frequencyTrimTarget, keepAlways.count)` to stay correct if `recentsCap` is ever raised above `frequencyTrimTarget`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three deferred-load changes preserve existing runtime behavior, previous review concerns about under-trim and loose test assertions are both resolved.

The lazy SymSpell path is a deliberate, documented tradeoff with a safe fallback (NSSpellChecker). The emoji matcher lazy-init is correct and main-actor-isolated. The trim logic is sound: overflow ≤ removable.count is guaranteed by the effectiveTarget = max(frequencyTrimTarget, keepAlways.count) construction, and the new test uses an exact count assertion that would catch both a missing trim and an under-trim.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Models/EmojiUsageStore.swift | Adds frequencyCap/frequencyTrimTarget constants and a trimFrequencyIfNeeded() method. Overflow calculation is safe: effectiveTarget = max(target, keepAlways.count) ensures prefix(overflow) never exceeds removable.count even if recentsCap grows beyond frequencyTrimTarget. |
| Cotabby/App/Coordinators/EmojiPickerController.swift | Replaces the injected EmojiMatcher with a @MainActor matcherProvider closure and a hand-rolled lazy var pattern. Correct and thread-safe since the class is @MainActor; cachedMatcher is set exactly once on first access. |
| Cotabby/App/Core/CotabbyAppEnvironment.swift | Removes the SymSpell preload logic (preloadLanguage: nil) and wraps EmojiMatcher construction in a deferred closure; both are clean one-liners with thorough inline rationale. |
| CotabbyTests/EmojiUsageStoreTests.swift | New test floods the store with 320 unique aliases and asserts an exact count of 220 — tight enough to catch both a missing trim and an under-trim that removes fewer entries than the target demands. Joy survival assertion validates heavy-hitter protection. |
| CotabbyTests/EmojiPickerControllerTests.swift | Minimal mechanical update to match the new matcherProvider: closure API; all existing test logic is preserved. |

</details>

<sub>Reviews (2): Last reviewed commit: ["review: clamp the frequency trim floor t..."](https://github.com/fujacob/cotabby/commit/6333758f437d9e91c14b1d0bc783759ad2850126) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37131294)</sub>

<!-- /greptile_comment -->