### PR TITLE
Llama suggestion eval harness + decode-time scaffolding stop + caret-seam guard

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -170,6 +170,8 @@
 		3C561CD717064F9250200667 /* PromptSectionBudget.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCFCCCB69C29A86E726B10A /* PromptSectionBudget.swift */; };
 		3CBBC3BFAC0DC8952EE24EF7 /* BundledRuntimeLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA33F5FFAC5B99384E15CE3E /* BundledRuntimeLocator.swift */; };
 		3CF1A4E39F24917DF0470A7D /* PromptPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4696A84D17890B154533A08F /* PromptPolicyTests.swift */; };
+		3D56E9B3AA378400E2C081E3 /* LlamaEvalScoringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D4C1EF008B9DFA753D561D3 /* LlamaEvalScoringTests.swift */; };
+		3D82280EFF7F7E9F3FFF45ED /* LlamaEvalScoring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 906011A6C9D66EEBAF3B5CC0 /* LlamaEvalScoring.swift */; };
 		3E1DBB2ABCB2404B59173534 /* SettingsIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34EF2406E7A384F3325AAF9A /* SettingsIndex.swift */; };
 		3E28FFB8F7D91D3B39968E73 /* SuggestionSubsystemContracts.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB16474A67CE1D210B944C9 /* SuggestionSubsystemContracts.swift */; };
 		3E78D03ABA7141D344AB8285 /* he.txt in Resources */ = {isa = PBXBuildFile; fileRef = C9C000E46A1E404932F89C81 /* he.txt */; };
@@ -281,6 +283,7 @@
 		644EEF959D07D54CC779BBF6 /* SettingsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3350EDE01ED5125520C79D53 /* SettingsCoordinator.swift */; };
 		64599CD334AAD79266224689 /* CurrentWordExtractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C4751DFE9DA372FBC40BA30 /* CurrentWordExtractorTests.swift */; };
 		64A36D1EE1BF29AF5B58906A /* TrailingDuplicationFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D408D647412C59F3E692C42B /* TrailingDuplicationFilter.swift */; };
+		64C76BE489BD6E7D1DB94A85 /* CompletionSeamGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306A36888B5F2CA8FEF9C806 /* CompletionSeamGuard.swift */; };
 		64DA031AEAC20AC6C852A24A /* OnboardingTemplateFeatureList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F613F0E2F7046E6532A09C /* OnboardingTemplateFeatureList.swift */; };
 		6503E1585D0CDE8CD852144B /* MacroTriggerStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C201A65A6B040F90C528A3B /* MacroTriggerStateMachine.swift */; };
 		65478B0DABF5460C32D4C458 /* ModelFileValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A829F28F01FAE76CA7244BBC /* ModelFileValidatorTests.swift */; };
@@ -342,9 +345,11 @@
 		7EEE6AEBFBD419FFE7C544BA /* SuggestionSettingsData.swift in Sources */ = {isa = PBXBuildFile; fileRef = D93563FDA25DFC0038E5F887 /* SuggestionSettingsData.swift */; };
 		7FC103944F4EF39DB965F469 /* InMemoryLogging in Frameworks */ = {isa = PBXBuildFile; productRef = 88921938DC814625ED57D605 /* InMemoryLogging */; };
 		814E348C663B697537594F0C /* EmojiRecentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 671689F289D45A124639C9C6 /* EmojiRecentsTests.swift */; };
+		8284A20D24B64503F138E946 /* CompletionSeamGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306A36888B5F2CA8FEF9C806 /* CompletionSeamGuard.swift */; };
 		82D4ADEAF05337ABDE4C586C /* RuntimeBootstrapModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60629DFE309C1A4BD8A7FB3B /* RuntimeBootstrapModel.swift */; };
 		82DAFCA8CC3AE3E2FBFDBD76 /* RequestID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DC693E00430F46E41CB56E6 /* RequestID.swift */; };
 		831B8DF92AAC8D0B99C5A262 /* AcceptanceModePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5DAF68AEBFE334F68A65E82 /* AcceptanceModePickerView.swift */; };
+		8320BEF361D8EA55E5CC7D95 /* llama-eval-cases.json in Resources */ = {isa = PBXBuildFile; fileRef = AB84C175EA5B59E118F58C49 /* llama-eval-cases.json */; };
 		8369356B8E7E7E61787E828D /* AXHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66B53214C3842F78B202D498 /* AXHelperTests.swift */; };
 		83B25F54B74EE35787D5DBD4 /* de-100k.txt in Resources */ = {isa = PBXBuildFile; fileRef = 4B8665A5495891F9E3DDA48B /* de-100k.txt */; };
 		83EC3543DC45B1601F119BF9 /* InsertionSafetyGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43D627C4A55359EAF4676FF7 /* InsertionSafetyGateTests.swift */; };
@@ -359,6 +364,7 @@
 		8865B95FE84198D70390DF80 /* ClipboardContentDistillerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFD89799BB82AF7A92559AEB /* ClipboardContentDistillerTests.swift */; };
 		88BCD795A14E1C9308F7BB31 /* SuggestionAvailabilityEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05B0439348261163B37C508 /* SuggestionAvailabilityEvaluatorTests.swift */; };
 		89329024F050602EFBC7CC6B /* FocusTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C9FDF029F7828CAF3FE8850 /* FocusTracker.swift */; };
+		8A47597B097058832453C2FF /* LlamaSuggestionEvalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A691EB51A7B93D1FAC38657F /* LlamaSuggestionEvalTests.swift */; };
 		8B26F7B26358438D6EB88C2E /* PerformanceMetricsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C0FCC5CCF6AE528E3C4DDA7 /* PerformanceMetricsStoreTests.swift */; };
 		8B2DFC860803C0A7C4D34A36 /* ContextBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54EF3C7F5D9D6F3FA50FD51C /* ContextBuffer.swift */; };
 		8D0F66DD1E6C988368A4545D /* DownloadFileRescuer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B4A2E2DD6733658EC05BD8 /* DownloadFileRescuer.swift */; };
@@ -616,6 +622,7 @@
 		FBEDA005ECD53CD645CD4C64 /* EmojiPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3384FD33776960103D6E22A9 /* EmojiPickerView.swift */; };
 		FC0C0C43EEC80325FE699B5A /* InsertionSafetyGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D472F9F396672E57873303B /* InsertionSafetyGate.swift */; };
 		FC255241A3B34A5717F09B36 /* InsertionStrategySelectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2960080A726E51198225147A /* InsertionStrategySelectorTests.swift */; };
+		FC51AE2C3F21263B11CA06B6 /* CompletionSeamGuardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D36DB66629CF22C1783945 /* CompletionSeamGuardTests.swift */; };
 		FC6B0524B774F20C18BD6889 /* OnboardingTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4451D6673112575DF24C4A48 /* OnboardingTemplate.swift */; };
 		FCC571EC239846F06007BFCA /* CotabbyAppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 711293EA57808B9428C7B908 /* CotabbyAppEnvironment.swift */; };
 		FDBD858EDABA08FBBE0C7ED3 /* InlineCommandCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D77C99769239E4B33D6B2C9 /* InlineCommandCoordinator.swift */; };
@@ -717,6 +724,7 @@
 		2D7360A6D4261989A66658ED /* SentenceBoundaryClassifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentenceBoundaryClassifierTests.swift; sourceTree = "<group>"; };
 		2D8AA55C2B730110E8598F91 /* it-100k.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "it-100k.txt"; sourceTree = "<group>"; };
 		2F01FAC4F57EB08471521196 /* VisualContextStartCoalescer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualContextStartCoalescer.swift; sourceTree = "<group>"; };
+		306A36888B5F2CA8FEF9C806 /* CompletionSeamGuard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionSeamGuard.swift; sourceTree = "<group>"; };
 		312C7306D916963F519CE0D9 /* EmojiTriggerStateMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiTriggerStateMachine.swift; sourceTree = "<group>"; };
 		313EDBA60565836F32CEEC10 /* DateMacroEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateMacroEvaluatorTests.swift; sourceTree = "<group>"; };
 		328847A0F494360033366791 /* TextDirectionDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextDirectionDetector.swift; sourceTree = "<group>"; };
@@ -790,6 +798,7 @@
 		6A44BEC8C23FF227731DD0CD /* FocusCapabilityFlickerGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusCapabilityFlickerGate.swift; sourceTree = "<group>"; };
 		6B2D97BAA3618A7D0357AC44 /* SuggestionWorkController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionWorkController.swift; sourceTree = "<group>"; };
 		6CF1FBAABEF545B620AF8D78 /* ru-100k.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "ru-100k.txt"; sourceTree = "<group>"; };
+		6D4C1EF008B9DFA753D561D3 /* LlamaEvalScoringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LlamaEvalScoringTests.swift; sourceTree = "<group>"; };
 		6DB982BF30B3601F57277776 /* fr-100k.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "fr-100k.txt"; sourceTree = "<group>"; };
 		6DC693E00430F46E41CB56E6 /* RequestID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestID.swift; sourceTree = "<group>"; };
 		6E3B1232C4BE8072A5183F9C /* SymSpell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymSpell.swift; sourceTree = "<group>"; };
@@ -836,6 +845,7 @@
 		8F426127917FCB1096134732 /* HuggingFaceSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceSearchService.swift; sourceTree = "<group>"; };
 		8F961F5DF2A392F6F5F94F8A /* SuggestionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionCoordinator.swift; sourceTree = "<group>"; };
 		9030FAAB468119A0236284A6 /* LLMIOFileHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMIOFileHandlerTests.swift; sourceTree = "<group>"; };
+		906011A6C9D66EEBAF3B5CC0 /* LlamaEvalScoring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LlamaEvalScoring.swift; sourceTree = "<group>"; };
 		907549CB913B40C28B953A5D /* SettingsRowLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRowLabel.swift; sourceTree = "<group>"; };
 		90B0D133AB77A2503FB08827 /* ClipboardRelevanceFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardRelevanceFilterTests.swift; sourceTree = "<group>"; };
 		9255CBCDE66253F521EE0F08 /* SystemResourceSamplerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemResourceSamplerTests.swift; sourceTree = "<group>"; };
@@ -873,6 +883,7 @@
 		A520809E71697E3BB9A8139C /* HuggingFaceModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceModels.swift; sourceTree = "<group>"; };
 		A52D0B550E00EF173A5D157E /* LlamaRuntimeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LlamaRuntimeManager.swift; sourceTree = "<group>"; };
 		A594D02B0EF3C2DD62EFE69A /* GhostTextPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostTextPreview.swift; sourceTree = "<group>"; };
+		A691EB51A7B93D1FAC38657F /* LlamaSuggestionEvalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LlamaSuggestionEvalTests.swift; sourceTree = "<group>"; };
 		A804F4DB6FD9BC8C27B2B65F /* LlamaRuntimeModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LlamaRuntimeModels.swift; sourceTree = "<group>"; };
 		A829F28F01FAE76CA7244BBC /* ModelFileValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelFileValidatorTests.swift; sourceTree = "<group>"; };
 		A854CAFB1F557BC4CAED8819 /* VisualContextCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualContextCoordinator.swift; sourceTree = "<group>"; };
@@ -881,6 +892,7 @@
 		AA33F5FFAC5B99384E15CE3E /* BundledRuntimeLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledRuntimeLocator.swift; sourceTree = "<group>"; };
 		AABCC3FD99B1824A81E665F3 /* LlamaSuggestionEngineCancellationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LlamaSuggestionEngineCancellationTests.swift; sourceTree = "<group>"; };
 		AAEFF8BAEC9168CADEDD4757 /* InlinePreviewPanelController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlinePreviewPanelController.swift; sourceTree = "<group>"; };
+		AB84C175EA5B59E118F58C49 /* llama-eval-cases.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "llama-eval-cases.json"; sourceTree = "<group>"; };
 		AC70775535A3428991025AB8 /* AXHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AXHelper.swift; sourceTree = "<group>"; };
 		AD752451330486FE270018B0 /* CustomRulesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomRulesTests.swift; sourceTree = "<group>"; };
 		AD8025E4A296845FC53E660D /* BrowserDomain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDomain.swift; sourceTree = "<group>"; };
@@ -902,6 +914,7 @@
 		B424E2AC97C99D335B0D5751 /* SuggestionTextNormalizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionTextNormalizer.swift; sourceTree = "<group>"; };
 		B4B4A2E2DD6733658EC05BD8 /* DownloadFileRescuer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadFileRescuer.swift; sourceTree = "<group>"; };
 		B6ACCB12E4DB32D2F2BEA567 /* PermissionHostApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionHostApp.swift; sourceTree = "<group>"; };
+		B6D36DB66629CF22C1783945 /* CompletionSeamGuardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionSeamGuardTests.swift; sourceTree = "<group>"; };
 		B6D42CD456B4B3C988B148A6 /* FocusTrackingModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusTrackingModel.swift; sourceTree = "<group>"; };
 		B78AA11B52A6588119ABF76F /* TokenCountEstimatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenCountEstimatorTests.swift; sourceTree = "<group>"; };
 		B7B185BA246A526CBA85E581 /* EmojiPickerPanelLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiPickerPanelLayoutTests.swift; sourceTree = "<group>"; };
@@ -1304,9 +1317,18 @@
 			path = Onboarding;
 			sourceTree = "<group>";
 		};
+		A3C1F7BD86257CF93639327C /* Fixtures */ = {
+			isa = PBXGroup;
+			children = (
+				AB84C175EA5B59E118F58C49 /* llama-eval-cases.json */,
+			);
+			path = Fixtures;
+			sourceTree = "<group>";
+		};
 		A8A141E1F2137943476D0C82 /* CotabbyTests */ = {
 			isa = PBXGroup;
 			children = (
+				A3C1F7BD86257CF93639327C /* Fixtures */,
 				A168A7B6A7AD11559B60C56B /* ApplicationBundleMetadataTests.swift */,
 				78AFA4586C82E92D7FBF381B /* ArithmeticEvaluatorTests.swift */,
 				66B53214C3842F78B202D498 /* AXHelperTests.swift */,
@@ -1321,6 +1343,7 @@
 				EFD89799BB82AF7A92559AEB /* ClipboardContentDistillerTests.swift */,
 				90B0D133AB77A2503FB08827 /* ClipboardRelevanceFilterTests.swift */,
 				D504BEB224E0C176F5FCFF6E /* CompletionRenderModePolicyTests.swift */,
+				B6D36DB66629CF22C1783945 /* CompletionSeamGuardTests.swift */,
 				EC4A3C4BC38793EB11F484F1 /* CompositionInputModeClassifierTests.swift */,
 				06FF2B0A3094A952A8EBA9B5 /* ConfidenceSuppressionPolicyTests.swift */,
 				22707E26E2106DF0E826D32D /* ControlTokenMarkersTests.swift */,
@@ -1370,10 +1393,13 @@
 				2960080A726E51198225147A /* InsertionStrategySelectorTests.swift */,
 				2930EC34057319130393696B /* KeyCodeLabelsTests.swift */,
 				4793D4EA5D36D7E5CC216C27 /* LanguageSupportTests.swift */,
+				906011A6C9D66EEBAF3B5CC0 /* LlamaEvalScoring.swift */,
+				6D4C1EF008B9DFA753D561D3 /* LlamaEvalScoringTests.swift */,
 				0CA88BB29BC8727878C99E95 /* LlamaPromptCacheHintTrackerTests.swift */,
 				AABCC3FD99B1824A81E665F3 /* LlamaSuggestionEngineCancellationTests.swift */,
 				26EF16C7439BEB156BD9FB03 /* LlamaSuggestionEnginePrewarmTests.swift */,
 				DDC034BBCBAC5E7989D4C85B /* LlamaSuggestionEngineStreamingTests.swift */,
+				A691EB51A7B93D1FAC38657F /* LlamaSuggestionEvalTests.swift */,
 				9030FAAB468119A0236284A6 /* LLMIOFileHandlerTests.swift */,
 				D8083D44ABCDCFA68A4CD497 /* MacroEngineTests.swift */,
 				22BE47D1DBF6C23151458836 /* MacroTriggerStateMachineTests.swift */,
@@ -1569,6 +1595,7 @@
 				96495E4147D828C0B1B22765 /* ClipboardContentDistiller.swift */,
 				D3A2AC525DC664DB540D4F19 /* ClipboardRelevanceFilter.swift */,
 				53CF416511099C6818110F01 /* CompletionRenderModePolicy.swift */,
+				306A36888B5F2CA8FEF9C806 /* CompletionSeamGuard.swift */,
 				4F283E5B403F9FEBFB4BA04A /* CompositionInputModeClassifier.swift */,
 				1BD71ECC2AE4821B643E0935 /* ConfidenceSuppressionPolicy.swift */,
 				9CC2D6472ACD377FD73A5801 /* ControlTokenMarkers.swift */,
@@ -1710,6 +1737,7 @@
 			buildConfigurationList = 9C6ABE77CA274E68D1A4EC68 /* Build configuration list for PBXNativeTarget "CotabbyTests" */;
 			buildPhases = (
 				CDEA6591B84C41B81A6E780E /* Sources */,
+				80415AE1337927B5CFEADEC4 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -1801,6 +1829,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		80415AE1337927B5CFEADEC4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8320BEF361D8EA55E5CC7D95 /* llama-eval-cases.json in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		89FA0B011090823F93FF340E /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1860,6 +1896,7 @@
 				2314C82FAAA81EB58BFE204D /* ClipboardRelevanceFilter.swift in Sources */,
 				47EBA122ABE99932326D9E4A /* CompletionRenderMode.swift in Sources */,
 				53AA9A9D3555A67F8F31DC65 /* CompletionRenderModePolicy.swift in Sources */,
+				8284A20D24B64503F138E946 /* CompletionSeamGuard.swift in Sources */,
 				7179FB0EC6411166CCD79F6B /* CompositionInputModeClassifier.swift in Sources */,
 				6BE0C8F9D054A2C0D9018001 /* ConfidenceSuppressionPolicy.swift in Sources */,
 				A29594647EA5450A54B36228 /* ContextBuffer.swift in Sources */,
@@ -2084,6 +2121,7 @@
 				157A55EB796BEB7819B90D5D /* ClipboardRelevanceFilter.swift in Sources */,
 				7C94725B4837DEC9ECF1BC54 /* CompletionRenderMode.swift in Sources */,
 				3985F0F2B3178DBB945B1064 /* CompletionRenderModePolicy.swift in Sources */,
+				64C76BE489BD6E7D1DB94A85 /* CompletionSeamGuard.swift in Sources */,
 				B6346C2A6D8EB02A5BD0E49B /* CompositionInputModeClassifier.swift in Sources */,
 				429CE592897D8A952F2916C3 /* ConfidenceSuppressionPolicy.swift in Sources */,
 				8B2DFC860803C0A7C4D34A36 /* ContextBuffer.swift in Sources */,
@@ -2297,6 +2335,7 @@
 				8865B95FE84198D70390DF80 /* ClipboardContentDistillerTests.swift in Sources */,
 				BFCA7FAFDAEBF586AB615567 /* ClipboardRelevanceFilterTests.swift in Sources */,
 				25F91CEF38400FD1ADB6B1AF /* CompletionRenderModePolicyTests.swift in Sources */,
+				FC51AE2C3F21263B11CA06B6 /* CompletionSeamGuardTests.swift in Sources */,
 				2A53558D66C96E963B23CA11 /* CompositionInputModeClassifierTests.swift in Sources */,
 				91D8189EFCD1BA992EA6F038 /* ConfidenceSuppressionPolicyTests.swift in Sources */,
 				5009AF59DE8D40A45C0A5C2F /* ControlTokenMarkersTests.swift in Sources */,
@@ -2347,10 +2386,13 @@
 				F66F0D982EBAF5A3E99C5342 /* KeyCodeLabelsTests.swift in Sources */,
 				475FB7450EEC3C1B16E66CC4 /* LLMIOFileHandlerTests.swift in Sources */,
 				E912D4617AE1376061DF1F00 /* LanguageSupportTests.swift in Sources */,
+				3D82280EFF7F7E9F3FFF45ED /* LlamaEvalScoring.swift in Sources */,
+				3D56E9B3AA378400E2C081E3 /* LlamaEvalScoringTests.swift in Sources */,
 				E38801433B99E65BD7E45A0E /* LlamaPromptCacheHintTrackerTests.swift in Sources */,
 				BE3CB85508055D159C35020A /* LlamaSuggestionEngineCancellationTests.swift in Sources */,
 				E64AE96DF2A80A368FDE522D /* LlamaSuggestionEnginePrewarmTests.swift in Sources */,
 				3F87586426B5EF16B41CE62F /* LlamaSuggestionEngineStreamingTests.swift in Sources */,
+				8A47597B097058832453C2FF /* LlamaSuggestionEvalTests.swift in Sources */,
 				8429B116328C392DCA018D95 /* MacroEngineTests.swift in Sources */,
 				3F8CBCBCC45E377DF9ADB216 /* MacroTriggerStateMachineTests.swift in Sources */,
 				87806DE08881D11F2608A13D /* MarkerSelectionSynthesizerTests.swift in Sources */,

--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
@@ -259,6 +259,16 @@ extension SuggestionCoordinator {
             return
         }
 
+        // Streaming half of the seam guard: the pure junk-run rule only. The spell-lookup half
+        // is an XPC and partials drain at token cadence, so it stays on the final apply, which
+        // authoritatively replaces or suppresses whatever streamed.
+        guard CompletionSeamGuard.allowsStreamedPartial(
+            precedingText: liveContext.precedingText,
+            completion: partial.text
+        ) else {
+            return
+        }
+
         _ = interactionState.startSession(
             fullText: partial.text,
             liveContext: liveContext,

--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
@@ -554,6 +554,29 @@ extension SuggestionCoordinator {
             return
         }
 
+        // Last line of defense before display: junk punctuation runs and mid-word splices that
+        // misspell the word being typed read as glitches, so showing nothing beats showing them.
+        // The spell lookup runs at most once per generation and only in the mid-word case.
+        let seamVerdict = CompletionSeamGuard.verdict(
+            precedingText: liveContext.precedingText,
+            completion: result.text,
+            isKnownWord: { !spellChecker.isTypo($0) }
+        )
+        if seamVerdict != .allow {
+            clearSuggestion()
+            hideOverlay(reason: "Overlay hidden because the completion failed the seam guard.")
+            state = .idle
+            logStage(
+                "seam-suppressed",
+                workID: workID,
+                generation: result.generation,
+                message: "Suppressed completion at the caret seam: \(seamVerdict).",
+                rawOutput: result.rawText,
+                normalizedOutput: result.text
+            )
+            return
+        }
+
         latestLatencyMilliseconds = Int(result.latency * 1000)
         latestGenerationNumber = liveContext.generation
         let session = interactionState.startSession(

--- a/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
+++ b/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
@@ -401,17 +401,19 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
             // semantics make late or reordered deliveries harmless downstream.
             onPartialRawText?(generatedText)
 
-            // Stop at the first natural sentence boundary instead of running the full token budget.
-            // This keeps completions tight and is latency-positive (fewer tokens), and it adds no
-            // per-token vocabulary work: it only inspects the text already accumulated. The
-            // classifier ignores decimals, abbreviations, and list markers, so it will not truncate
-            // "e.g." or "3.14" mid-thought.
-            if DecodeStopPolicy.shouldStop(
+            // Stop at the first natural sentence boundary, or as soon as the text contains a
+            // chat-template stop marker, instead of running the full token budget. Both are
+            // latency-positive (fewer tokens) and add no per-token vocabulary work: they only
+            // inspect the text already accumulated. The boundary classifier ignores decimals,
+            // abbreviations, and list markers, so it will not truncate "e.g." or "3.14"
+            // mid-thought; the marker stop produces identical visible text because the
+            // normalizer truncates at the first marker anyway.
+            if let earlyStop = DecodeStopPolicy.verdict(
                 accumulated: generatedText,
                 tokensGenerated: tokensGenerated,
                 minimumTokens: options.sentenceStopMinimumTokens
             ) {
-                stopReason = "sentence_boundary"
+                stopReason = earlyStop.rawValue
                 break
             }
         }

--- a/Cotabby/Support/CompletionSeamGuard.swift
+++ b/Cotabby/Support/CompletionSeamGuard.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+/// Post-generation guard for the two classic visible failures at the caret seam: junk punctuation
+/// runs ("....", "$$$$") and mid-word splices that turn the word being typed into a misspelling
+/// ("gre" + "atful"). Showing nothing beats showing either, and both checks are pure string work
+/// on a single short completion, so the guard costs microseconds once per generation.
+///
+/// Both rules are deliberately narrow so they fire rarely:
+///
+/// - **Junk run**: a run of four or more identical punctuation/symbol characters inside the
+///   completion, unless the run merely extends an identical run the user already has at the caret
+///   (continuing an existing `----` divider is legitimate).
+/// - **Seam misspelling**: only in the mid-word case (caret inside a word, completion starts with
+///   word characters), the joined word formed across the seam must be known to the spell checker.
+///   Skipped for capitalized words (names and brands are routinely out-of-dictionary), for short
+///   joins (under four letters), for words with digits, and for CJK text (no space-delimited word
+///   boundaries, and the dictionaries do not cover it).
+nonisolated enum CompletionSeamGuard {
+    enum Verdict: Equatable {
+        case allow
+        case junkPunctuationRun
+        case seamMisspelling(word: String)
+    }
+
+    /// Identical punctuation/symbol characters in a row that count as junk when freshly introduced.
+    private static let junkRunLength = 4
+
+    /// Joined seam words shorter than this are too ambiguous to judge ("a" + "t").
+    private static let minimumSeamWordLength = 4
+
+    /// `isKnownWord` is injected so the pure rule stays testable and the caller picks the spell
+    /// checking backend; it is only invoked when the mid-word rule actually applies.
+    static func verdict(
+        precedingText: String,
+        completion: String,
+        isKnownWord: (String) -> Bool
+    ) -> Verdict {
+        if introducesJunkPunctuationRun(precedingText: precedingText, completion: completion) {
+            return .junkPunctuationRun
+        }
+
+        if let seamWord = misspellingCandidateSeamWord(
+            precedingText: precedingText,
+            completion: completion
+        ), !isKnownWord(seamWord) {
+            return .seamMisspelling(word: seamWord)
+        }
+
+        return .allow
+    }
+
+    // MARK: - Junk punctuation runs
+
+    private static func introducesJunkPunctuationRun(
+        precedingText: String,
+        completion: String
+    ) -> Bool {
+        var runCharacter: Character?
+        var runLength = 0
+        var runStartsAtCompletionStart = false
+        var index = 0
+
+        for character in completion {
+            if character == runCharacter {
+                runLength += 1
+            } else {
+                runCharacter = character
+                runLength = 1
+                runStartsAtCompletionStart = index == 0
+            }
+            index += 1
+
+            guard runLength >= junkRunLength,
+                  let current = runCharacter,
+                  current.isPunctuation || current.isSymbol
+            else { continue }
+
+            // A run flush against the seam that continues the same character the user already
+            // typed is an existing divider being extended, not fresh junk.
+            if runStartsAtCompletionStart, precedingText.last == current {
+                continue
+            }
+            return true
+        }
+        return false
+    }
+
+    // MARK: - Seam misspellings
+
+    /// The joined word across the caret seam when the mid-word rule applies, or nil when any of
+    /// the narrowing conditions exempt it.
+    private static func misspellingCandidateSeamWord(
+        precedingText: String,
+        completion: String
+    ) -> String? {
+        guard let lastBefore = precedingText.last, lastBefore.isLetter,
+              let firstAfter = completion.first, firstAfter.isLetter
+        else { return nil }
+
+        let head = trailingLetterRun(of: precedingText)
+        let tail = leadingLetterRun(of: completion)
+        let seamWord = head + tail
+
+        guard seamWord.count >= minimumSeamWordLength else { return nil }
+        // Capitalized joins are usually names or brands the dictionary cannot know.
+        guard let firstCharacter = seamWord.first, firstCharacter.isLowercase else { return nil }
+        guard !containsCJK(seamWord) else { return nil }
+        return seamWord
+    }
+
+    private static func trailingLetterRun(of text: String) -> String {
+        String(text.reversed().prefix(while: { $0.isLetter }).reversed())
+    }
+
+    private static func leadingLetterRun(of text: String) -> String {
+        String(text.prefix(while: { $0.isLetter }))
+    }
+
+    /// Han, kana, and Hangul ranges; CJK has no space-delimited words, so a "seam word" is not a
+    /// meaningful unit there and the spelling dictionaries do not cover these scripts.
+    private static func containsCJK(_ text: String) -> Bool {
+        text.unicodeScalars.contains { scalar in
+            switch scalar.value {
+            case 0x2E80...0x9FFF, 0x3040...0x30FF, 0xAC00...0xD7AF, 0xF900...0xFAFF, 0xFF65...0xFF9F:
+                return true
+            default:
+                return false
+            }
+        }
+    }
+}

--- a/Cotabby/Support/CompletionSeamGuard.swift
+++ b/Cotabby/Support/CompletionSeamGuard.swift
@@ -28,6 +28,13 @@ nonisolated enum CompletionSeamGuard {
     /// Joined seam words shorter than this are too ambiguous to judge ("a" + "t").
     private static let minimumSeamWordLength = 4
 
+    /// Streaming-path variant: only the pure junk-run rule. Partials drain at token cadence, so
+    /// the spell-lookup half of the guard (an XPC round trip) stays off that path; the full
+    /// verdict still gates the final result, which authoritatively replaces whatever streamed.
+    static func allowsStreamedPartial(precedingText: String, completion: String) -> Bool {
+        !introducesJunkPunctuationRun(precedingText: precedingText, completion: completion)
+    }
+
     /// `isKnownWord` is injected so the pure rule stays testable and the caller picks the spell
     /// checking backend; it is only invoked when the mid-word rule actually applies.
     static func verdict(
@@ -75,9 +82,11 @@ nonisolated enum CompletionSeamGuard {
                   current.isPunctuation || current.isSymbol
             else { continue }
 
-            // A run flush against the seam that continues the same character the user already
-            // typed is an existing divider being extended, not fresh junk.
-            if runStartsAtCompletionStart, precedingText.last == current {
+            // A run flush against the seam that continues a run of the same character the user
+            // already has at the caret is an existing divider being extended, not fresh junk.
+            // It must be a real preceding run (two or more): a sentence that merely ends in "."
+            // must not exempt "...." from the completion.
+            if runStartsAtCompletionStart, trailingRunLength(of: precedingText, character: current) >= 2 {
                 continue
             }
             return true
@@ -108,6 +117,10 @@ nonisolated enum CompletionSeamGuard {
         return seamWord
     }
 
+    private static func trailingRunLength(of text: String, character: Character) -> Int {
+        text.reversed().prefix(while: { $0 == character }).count
+    }
+
     private static func trailingLetterRun(of text: String) -> String {
         String(text.reversed().prefix(while: { $0.isLetter }).reversed())
     }
@@ -117,11 +130,12 @@ nonisolated enum CompletionSeamGuard {
     }
 
     /// Han, kana, and Hangul ranges; CJK has no space-delimited words, so a "seam word" is not a
-    /// meaningful unit there and the spelling dictionaries do not cover these scripts.
+    /// meaningful unit there and the spelling dictionaries do not cover these scripts. The
+    /// 0x2E80-0x9FFF block already spans the kana ranges, so they are not listed separately.
     private static func containsCJK(_ text: String) -> Bool {
         text.unicodeScalars.contains { scalar in
             switch scalar.value {
-            case 0x2E80...0x9FFF, 0x3040...0x30FF, 0xAC00...0xD7AF, 0xF900...0xFAFF, 0xFF65...0xFF9F:
+            case 0x2E80...0x9FFF, 0xAC00...0xD7AF, 0xF900...0xFAFF, 0xFF65...0xFF9F:
                 return true
             default:
                 return false

--- a/Cotabby/Support/DecodeStopPolicy.swift
+++ b/Cotabby/Support/DecodeStopPolicy.swift
@@ -1,26 +1,63 @@
 import Foundation
 
-/// Decides, during decoding, whether the completion accumulated so far already ends at a natural
-/// sentence boundary so generation can stop early.
+/// Decides, during decoding, whether the completion accumulated so far should stop generation
+/// early, and why.
 ///
 /// The shipping decoder otherwise samples up to a fixed token budget and trims afterward, which lets
-/// the model ramble past the point a suggestion is useful. Stopping at the first real sentence end
-/// keeps completions tight and is latency-positive: it generates fewer tokens. The check inspects
-/// only the already-accumulated string, so it adds no per-token vocabulary work in the decode loop.
+/// the model ramble past the point a suggestion is useful. Two early stops apply:
 ///
-/// A short minimum-token guard avoids degenerate instant stops (for example, the model's first token
-/// being a lone period). `SentenceBoundaryClassifier` already rejects decimals, abbreviations, and
-/// list markers, so this never truncates "e.g.", "3.14", or a numbered "1." mid-thought.
+/// - **Sentence boundary**: the accumulated text ends at a natural sentence end. A short
+///   minimum-token guard avoids degenerate instant stops (for example, the model's first token being
+///   a lone period). `SentenceBoundaryClassifier` already rejects decimals, abbreviations, and list
+///   markers, so this never truncates "e.g.", "3.14", or a numbered "1." mid-thought.
+/// - **Scaffolding marker**: the accumulated text contains a chat-template stop marker
+///   (`<|im_end|>` and friends). The normalizer already truncates the visible text at the first such
+///   marker, so everything generated past it is guaranteed-discarded work; stopping at decode time
+///   produces the identical suggestion while skipping the rest of the token budget, exactly in the
+///   worst case where the model has drifted into template scaffolding. No minimum-token guard: a
+///   marker means the model believes the turn is over, no matter how early it appears.
+///
+/// Both checks inspect only the already-accumulated string (at most a few hundred characters), so
+/// they add no per-token vocabulary work in the decode loop.
 nonisolated enum DecodeStopPolicy {
+    /// Why decoding stopped early. Raw values feed the decode log's `stop_reason` field.
+    enum StopReason: String {
+        case sentenceBoundary = "sentence_boundary"
+        case scaffoldingMarker = "scaffolding_marker"
+    }
+
+    static func verdict(
+        accumulated: String,
+        tokensGenerated: Int,
+        minimumTokens: Int = 2
+    ) -> StopReason? {
+        if containsScaffoldingStopMarker(accumulated) {
+            return .scaffoldingMarker
+        }
+
+        guard tokensGenerated >= minimumTokens else {
+            return nil
+        }
+
+        return SentenceBoundaryClassifier.endsSentence(accumulated) ? .sentenceBoundary : nil
+    }
+
     static func shouldStop(
         accumulated: String,
         tokensGenerated: Int,
         minimumTokens: Int = 2
     ) -> Bool {
-        guard tokensGenerated >= minimumTokens else {
-            return false
-        }
+        verdict(
+            accumulated: accumulated,
+            tokensGenerated: tokensGenerated,
+            minimumTokens: minimumTokens
+        ) != nil
+    }
 
-        return SentenceBoundaryClassifier.endsSentence(accumulated)
+    private static func containsScaffoldingStopMarker(_ text: String) -> Bool {
+        // Cheap pre-filter: every stop marker starts with "<", so most prose never reaches the
+        // per-marker scan.
+        guard text.contains("<") else { return false }
+        return ControlTokenMarkers.stopMarkers.contains { text.contains($0) }
     }
 }

--- a/CotabbyTests/CompletionSeamGuardTests.swift
+++ b/CotabbyTests/CompletionSeamGuardTests.swift
@@ -50,6 +50,30 @@ final class CompletionSeamGuardTests: XCTestCase {
         )
     }
 
+    func testSingleTrailingCharacterDoesNotExemptAJunkRun() {
+        // "Hello." ends with one period; that must not license "...." from the completion. Only
+        // a real preceding run (two or more) reads as a divider being extended.
+        XCTAssertEqual(
+            CompletionSeamGuard.verdict(
+                precedingText: "Hello.",
+                completion: "....",
+                isKnownWord: knowsEverything
+            ),
+            .junkPunctuationRun
+        )
+    }
+
+    func testStreamedPartialVariantAppliesOnlyTheJunkRule() {
+        XCTAssertFalse(
+            CompletionSeamGuard.allowsStreamedPartial(precedingText: "Wait", completion: " what....")
+        )
+        // A mid-word splice passes the streamed check; the spell half runs only on the final
+        // apply, which replaces or suppresses whatever streamed.
+        XCTAssertTrue(
+            CompletionSeamGuard.allowsStreamedPartial(precedingText: "gre", completion: "atful and kind")
+        )
+    }
+
     func testContinuingAnExistingDividerIsAllowed() {
         // The user already has a dash run at the caret; extending it is intentional.
         XCTAssertEqual(

--- a/CotabbyTests/CompletionSeamGuardTests.swift
+++ b/CotabbyTests/CompletionSeamGuardTests.swift
@@ -1,0 +1,180 @@
+import XCTest
+@testable import Cotabby
+
+/// Locks in that the seam guard fires only on the two failure shapes it exists for (fresh junk
+/// punctuation runs, mid-word splices that misspell the joined word) and never on the ordinary
+/// continuations that surround them. Every guard must fire rarely; most of these tests are
+/// allow-cases for exactly that reason.
+final class CompletionSeamGuardTests: XCTestCase {
+    /// A stub dictionary: the listed words are known, everything else is a misspelling.
+    private func knowing(_ words: Set<String>) -> (String) -> Bool {
+        { words.contains($0.lowercased()) }
+    }
+
+    private let knowsEverything: (String) -> Bool = { _ in true }
+    private let knowsNothing: (String) -> Bool = { _ in false }
+
+    // MARK: - Junk punctuation runs
+
+    func testFreshPunctuationRunIsSuppressed() {
+        XCTAssertEqual(
+            CompletionSeamGuard.verdict(
+                precedingText: "Wait",
+                completion: " what....",
+                isKnownWord: knowsEverything
+            ),
+            .junkPunctuationRun
+        )
+    }
+
+    func testSymbolRunIsSuppressed() {
+        XCTAssertEqual(
+            CompletionSeamGuard.verdict(
+                precedingText: "Price: ",
+                completion: "$$$$",
+                isKnownWord: knowsEverything
+            ),
+            .junkPunctuationRun
+        )
+    }
+
+    func testThreeCharacterRunIsAllowed() {
+        // Ellipsis-length runs are ordinary prose.
+        XCTAssertEqual(
+            CompletionSeamGuard.verdict(
+                precedingText: "Well",
+                completion: "... maybe",
+                isKnownWord: knowsEverything
+            ),
+            .allow
+        )
+    }
+
+    func testContinuingAnExistingDividerIsAllowed() {
+        // The user already has a dash run at the caret; extending it is intentional.
+        XCTAssertEqual(
+            CompletionSeamGuard.verdict(
+                precedingText: "----",
+                completion: "------",
+                isKnownWord: knowsEverything
+            ),
+            .allow
+        )
+    }
+
+    func testFreshDividerAwayFromSeamIsSuppressed() {
+        XCTAssertEqual(
+            CompletionSeamGuard.verdict(
+                precedingText: "----",
+                completion: " section ======",
+                isKnownWord: knowsEverything
+            ),
+            .junkPunctuationRun
+        )
+    }
+
+    func testRepeatedLettersAreNotJunk() {
+        XCTAssertEqual(
+            CompletionSeamGuard.verdict(
+                precedingText: "That is so",
+                completion: " coooool",
+                isKnownWord: knowsEverything
+            ),
+            .allow
+        )
+    }
+
+    // MARK: - Seam misspellings
+
+    func testMisspelledSeamWordIsSuppressed() {
+        XCTAssertEqual(
+            CompletionSeamGuard.verdict(
+                precedingText: "I am so gre",
+                completion: "atful for this",
+                isKnownWord: knowing(["great", "grateful"])
+            ),
+            .seamMisspelling(word: "greatful")
+        )
+    }
+
+    func testKnownSeamWordIsAllowed() {
+        XCTAssertEqual(
+            CompletionSeamGuard.verdict(
+                precedingText: "I am so gre",
+                completion: "at to hear it",
+                isKnownWord: knowing(["great"])
+            ),
+            .allow
+        )
+    }
+
+    func testSeamRuleOnlyAppliesMidWord() {
+        // Caret after a space: no seam word exists, so nothing to judge.
+        XCTAssertEqual(
+            CompletionSeamGuard.verdict(
+                precedingText: "I am so ",
+                completion: "greatful",
+                isKnownWord: knowsNothing
+            ),
+            .allow
+        )
+    }
+
+    func testCapitalizedSeamWordIsAllowed() {
+        // Names and brands are routinely out-of-dictionary; never block them.
+        XCTAssertEqual(
+            CompletionSeamGuard.verdict(
+                precedingText: "Ask Cota",
+                completion: "bby about it",
+                isKnownWord: knowsNothing
+            ),
+            .allow
+        )
+    }
+
+    func testShortSeamWordIsAllowed() {
+        XCTAssertEqual(
+            CompletionSeamGuard.verdict(
+                precedingText: "a",
+                completion: "t the office",
+                isKnownWord: knowsNothing
+            ),
+            .allow
+        )
+    }
+
+    func testDigitAdjacentSeamIsAllowed() {
+        // The letter-run join is "vbeta"? No: digits break the letter run, so the head is empty
+        // and the mid-word precondition (letter on both sides) fails.
+        XCTAssertEqual(
+            CompletionSeamGuard.verdict(
+                precedingText: "version 2",
+                completion: "024 release",
+                isKnownWord: knowsNothing
+            ),
+            .allow
+        )
+    }
+
+    func testCJKSeamIsAllowed() {
+        XCTAssertEqual(
+            CompletionSeamGuard.verdict(
+                precedingText: "これはとても良",
+                completion: "い天気ですね",
+                isKnownWord: knowsNothing
+            ),
+            .allow
+        )
+    }
+
+    func testOrdinaryContinuationIsAllowed() {
+        XCTAssertEqual(
+            CompletionSeamGuard.verdict(
+                precedingText: "Thanks again for your help",
+                completion: " with the move last weekend.",
+                isKnownWord: knowing(["with"])
+            ),
+            .allow
+        )
+    }
+}

--- a/CotabbyTests/DecodeStopPolicyTests.swift
+++ b/CotabbyTests/DecodeStopPolicyTests.swift
@@ -50,4 +50,41 @@ final class DecodeStopPolicyTests: XCTestCase {
             DecodeStopPolicy.shouldStop(accumulated: "Hi.", tokensGenerated: 3, minimumTokens: 3)
         )
     }
+
+    func testStopsWhenScaffoldingStopMarkerAppears() {
+        XCTAssertEqual(
+            DecodeStopPolicy.verdict(accumulated: "Sounds good<|im_end|>", tokensGenerated: 4),
+            .scaffoldingMarker
+        )
+    }
+
+    func testScaffoldingMarkerStopsEvenBelowMinimumTokens() {
+        // A stop marker means the model believes the turn is over; the minimum-token guard only
+        // protects the sentence-boundary heuristic, never delays a marker stop.
+        XCTAssertEqual(
+            DecodeStopPolicy.verdict(accumulated: "<end_of_turn>", tokensGenerated: 1, minimumTokens: 3),
+            .scaffoldingMarker
+        )
+    }
+
+    func testStopsWhenMarkerCompletesAcrossPieces() {
+        // The marker can arrive split across token pieces; only the accumulated text matters.
+        XCTAssertNil(DecodeStopPolicy.verdict(accumulated: "Done<|im_", tokensGenerated: 3))
+        XCTAssertEqual(
+            DecodeStopPolicy.verdict(accumulated: "Done<|im_end|>", tokensGenerated: 4),
+            .scaffoldingMarker
+        )
+    }
+
+    func testDoesNotStopOnHTMLStrikethroughClose() {
+        // `</s>` is deliberately not a stop marker (it is the closing HTML strikethrough tag).
+        XCTAssertNil(DecodeStopPolicy.verdict(accumulated: "<s>old</s> new", tokensGenerated: 5))
+    }
+
+    func testSentenceBoundaryVerdictReasonIsReported() {
+        XCTAssertEqual(
+            DecodeStopPolicy.verdict(accumulated: "Hello there.", tokensGenerated: 3),
+            .sentenceBoundary
+        )
+    }
 }

--- a/CotabbyTests/Fixtures/llama-eval-cases.json
+++ b/CotabbyTests/Fixtures/llama-eval-cases.json
@@ -1,0 +1,2622 @@
+[
+ {
+  "id": "email-followup-01",
+  "tags": [
+   "email",
+   "en"
+  ],
+  "applicationName": "Mail",
+  "bundleIdentifier": "com.apple.mail",
+  "precedingText": "Hi Sarah,\n\nThanks again for taking the time to meet yesterday. I'll send over the ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "revised proposal",
+    "updated proposal",
+    "notes",
+    "documents",
+    "details",
+    "updated draft",
+    "slides",
+    "deck",
+    "agenda",
+    "summary",
+    "report",
+    "files",
+    "final",
+    "new",
+    "contract",
+    "presentation",
+    "meeting notes",
+    "next steps",
+    "information"
+   ]
+  }
+ },
+ {
+  "id": "email-followup-02",
+  "tags": [
+   "email",
+   "en"
+  ],
+  "applicationName": "Mail",
+  "bundleIdentifier": "com.apple.mail",
+  "precedingText": "Dear Mr. Alvarez,\n\nI hope this email finds you well. I am writing to follow up on ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "our conversation",
+    "the status",
+    "our meeting",
+    "my previous email",
+    "the invoice",
+    "our discussion",
+    "the proposal",
+    "your request",
+    "our last",
+    "the email",
+    "my application",
+    "our call",
+    "the matter",
+    "your inquiry"
+   ]
+  }
+ },
+ {
+  "id": "email-scheduling-03",
+  "tags": [
+   "email",
+   "en"
+  ],
+  "applicationName": "Mail",
+  "bundleIdentifier": "com.apple.mail",
+  "precedingText": "Would Tuesday at 2pm work for you? If not, I'm also free on ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Monday",
+    "Tuesday"
+   ]
+  }
+ },
+ {
+  "id": "email-signoff-04",
+  "tags": [
+   "email",
+   "en"
+  ],
+  "applicationName": "Mail",
+  "bundleIdentifier": "com.apple.mail",
+  "precedingText": "Let me know if you have any questions.\n\nBest ",
+  "expectation": {
+   "kind": "positive",
+   "mustShow": true,
+   "acceptable": [
+    "regards",
+    "wishes"
+   ]
+  }
+ },
+ {
+  "id": "email-apology-05",
+  "tags": [
+   "email",
+   "en"
+  ],
+  "applicationName": "Mail",
+  "bundleIdentifier": "com.apple.mail",
+  "precedingText": "I apologize for the delay in getting back to you. I was ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "out of",
+    "traveling",
+    "on vacation",
+    "away",
+    "tied up",
+    "busy",
+    "out sick",
+    "dealing with",
+    "swamped",
+    "caught up",
+    "unable"
+   ]
+  }
+ },
+ {
+  "id": "email-intro-06",
+  "tags": [
+   "email",
+   "en"
+  ],
+  "applicationName": "Mail",
+  "bundleIdentifier": "com.apple.mail",
+  "precedingText": "Hi team,\n\nI wanted to give everyone a quick update on the ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "project",
+    "launch",
+    "progress",
+    "status",
+    "timeline",
+    "budget",
+    "migration",
+    "release",
+    "roadmap",
+    "situation",
+    "upcoming",
+    "latest",
+    "new",
+    "current",
+    "recent"
+   ]
+  }
+ },
+ {
+  "id": "email-request-07",
+  "tags": [
+   "email",
+   "en"
+  ],
+  "applicationName": "Mail",
+  "bundleIdentifier": "com.apple.mail",
+  "precedingText": "Could you please review the attached document and ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "let me know",
+    "provide feedback",
+    "share your",
+    "send me",
+    "get back",
+    "confirm",
+    "sign",
+    "return",
+    "provide your",
+    "give me"
+   ]
+  }
+ },
+ {
+  "id": "email-thanks-08",
+  "tags": [
+   "email",
+   "en"
+  ],
+  "applicationName": "Mail",
+  "bundleIdentifier": "com.apple.mail",
+  "precedingText": "Thank you so much for your help with the move last weekend. I really ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "appreciate it",
+    "appreciate your",
+    "appreciate all",
+    "couldn't have",
+    "owe you",
+    "am grateful"
+   ]
+  }
+ },
+ {
+  "id": "email-decline-09",
+  "tags": [
+   "email",
+   "en"
+  ],
+  "applicationName": "Mail",
+  "bundleIdentifier": "com.apple.mail",
+  "precedingText": "Unfortunately, I won't be able to make it to the offsite next week due to a ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "prior commitment",
+    "scheduling conflict",
+    "family",
+    "conflict",
+    "previous",
+    "personal",
+    "doctor's",
+    "last-minute",
+    "prior engagement"
+   ]
+  }
+ },
+ {
+  "id": "email-deadline-10",
+  "tags": [
+   "email",
+   "en"
+  ],
+  "applicationName": "Mail",
+  "bundleIdentifier": "com.apple.mail",
+  "precedingText": "Just a friendly reminder that the quarterly reports are due by ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "Friday",
+    "the end",
+    "end of",
+    "Monday",
+    "tomorrow",
+    "next",
+    "EOD",
+    "close of",
+    "5pm",
+    "December",
+    "January",
+    "March",
+    "the 15th"
+   ]
+  }
+ },
+ {
+  "id": "email-recap-11",
+  "tags": [
+   "email",
+   "en"
+  ],
+  "applicationName": "Mail",
+  "bundleIdentifier": "com.apple.mail",
+  "precedingText": "Here's a quick recap of what we agreed on during today's call:\n\n1. Marketing will draft the announcement\n2. Engineering will ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "finalize",
+    "ship",
+    "handle",
+    "deploy",
+    "fix",
+    "review",
+    "deliver",
+    "complete",
+    "prepare",
+    "update",
+    "work on",
+    "build",
+    "focus on",
+    "start",
+    "implement",
+    "release",
+    "test",
+    "draft"
+   ]
+  }
+ },
+ {
+  "id": "email-newhire-12",
+  "tags": [
+   "email",
+   "en"
+  ],
+  "applicationName": "Mail",
+  "bundleIdentifier": "com.apple.mail",
+  "precedingText": "Please join me in welcoming Dana to the team! She'll be working on ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "the",
+    "our",
+    "marketing",
+    "design",
+    "product",
+    "engineering",
+    "customer",
+    "sales",
+    "data",
+    "growth",
+    "a"
+   ]
+  }
+ },
+ {
+  "id": "email-invoice-13",
+  "tags": [
+   "email",
+   "en"
+  ],
+  "applicationName": "Mail",
+  "bundleIdentifier": "com.apple.mail",
+  "precedingText": "I've attached the invoice for last month's work. Payment is due within ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "30 days",
+    "thirty days",
+    "14 days",
+    "two weeks",
+    "15 days",
+    "60 days",
+    "net",
+    "10 days",
+    "7 days",
+    "a week",
+    "one week",
+    "45 days",
+    "the next"
+   ]
+  }
+ },
+ {
+  "id": "email-ooo-14",
+  "tags": [
+   "email",
+   "en"
+  ],
+  "applicationName": "Mail",
+  "bundleIdentifier": "com.apple.mail",
+  "precedingText": "I will be out of the office from June 17 through June 21 with limited access to ",
+  "expectation": {
+   "kind": "positive",
+   "mustShow": true,
+   "acceptable": [
+    "email",
+    "my email",
+    "the internet",
+    "phone",
+    "my phone",
+    "messages"
+   ]
+  }
+ },
+ {
+  "id": "email-feedback-15",
+  "tags": [
+   "email",
+   "en"
+  ],
+  "applicationName": "Mail",
+  "bundleIdentifier": "com.apple.mail",
+  "precedingText": "Overall the draft looks great. My only suggestion would be to ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "add",
+    "shorten",
+    "tighten",
+    "clarify",
+    "expand",
+    "include",
+    "remove",
+    "simplify",
+    "reorder",
+    "rework",
+    "make",
+    "tweak",
+    "consider",
+    "change",
+    "revise",
+    "move",
+    "cut",
+    "trim",
+    "double-check",
+    "rephrase"
+   ]
+  }
+ },
+ {
+  "id": "email-confirm-16",
+  "tags": [
+   "email",
+   "en"
+  ],
+  "applicationName": "Mail",
+  "bundleIdentifier": "com.apple.mail",
+  "precedingText": "This is to confirm that your appointment has been scheduled for ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "June",
+    "July",
+    "tomorrow",
+    "next",
+    "10am",
+    "9am",
+    "2pm",
+    "3pm",
+    "the"
+   ]
+  }
+ },
+ {
+  "id": "email-jobapp-17",
+  "tags": [
+   "email",
+   "en"
+  ],
+  "applicationName": "Mail",
+  "bundleIdentifier": "com.apple.mail",
+  "precedingText": "I am excited to apply for the Senior Designer position at your company. With over eight years of ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "experience",
+    "design experience",
+    "professional experience",
+    "industry experience",
+    "hands-on"
+   ]
+  }
+ },
+ {
+  "id": "email-postmortem-18",
+  "tags": [
+   "email",
+   "en"
+  ],
+  "applicationName": "Mail",
+  "bundleIdentifier": "com.apple.mail",
+  "precedingText": "The outage lasted 43 minutes. The root cause was a misconfigured ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "load balancer",
+    "DNS",
+    "firewall",
+    "database",
+    "server",
+    "deployment",
+    "environment",
+    "certificate",
+    "cache",
+    "router",
+    "config",
+    "setting",
+    "feature flag",
+    "proxy",
+    "cron"
+   ]
+  }
+ },
+ {
+  "id": "email-travel-19",
+  "tags": [
+   "email",
+   "en"
+  ],
+  "applicationName": "Mail",
+  "bundleIdentifier": "com.apple.mail",
+  "precedingText": "My flight lands at 4:30pm, so I should be at the hotel by ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "6",
+    "5",
+    "6pm",
+    "5pm",
+    "5:30",
+    "6:30",
+    "7",
+    "7pm",
+    "evening",
+    "dinner",
+    "5:30pm",
+    "6:00",
+    "5:45"
+   ]
+  }
+ },
+ {
+  "id": "email-renewal-20",
+  "tags": [
+   "email",
+   "en"
+  ],
+  "applicationName": "Mail",
+  "bundleIdentifier": "com.apple.mail",
+  "precedingText": "Your subscription is set to renew on July 1. If you'd like to cancel or make changes, please ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "visit",
+    "log in",
+    "log into",
+    "contact",
+    "reach out",
+    "go to",
+    "click",
+    "let us",
+    "reply",
+    "call",
+    "email",
+    "do so",
+    "sign in",
+    "head to",
+    "manage"
+   ]
+  }
+ },
+ {
+  "id": "chat-lunch-01",
+  "tags": [
+   "chat",
+   "en"
+  ],
+  "applicationName": "Slack",
+  "bundleIdentifier": "com.tinyspeck.slackmacgap",
+  "isMultiLineEnabled": false,
+  "precedingText": "want to grab lunch at ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "noon",
+    "12",
+    "1",
+    "the",
+    "that"
+   ]
+  }
+ },
+ {
+  "id": "chat-eta-02",
+  "tags": [
+   "chat",
+   "en"
+  ],
+  "applicationName": "Slack",
+  "bundleIdentifier": "com.tinyspeck.slackmacgap",
+  "isMultiLineEnabled": false,
+  "precedingText": "running a few minutes late, be there in ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "10",
+    "5",
+    "15",
+    "ten",
+    "five",
+    "fifteen",
+    "20",
+    "a few",
+    "a bit",
+    "twenty"
+   ]
+  }
+ },
+ {
+  "id": "chat-standup-03",
+  "tags": [
+   "chat",
+   "en"
+  ],
+  "applicationName": "Slack",
+  "bundleIdentifier": "com.tinyspeck.slackmacgap",
+  "isMultiLineEnabled": false,
+  "precedingText": "yesterday I finished the login flow, today I'm working on ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "the",
+    "tests",
+    "the signup",
+    "error handling",
+    "the onboarding",
+    "fixing",
+    "the password",
+    "the settings",
+    "polish",
+    "cleanup",
+    "reviews",
+    "the API",
+    "bug fixes",
+    "documentation",
+    "a"
+   ]
+  }
+ },
+ {
+  "id": "chat-thanks-04",
+  "tags": [
+   "chat",
+   "en"
+  ],
+  "applicationName": "Discord",
+  "bundleIdentifier": "com.hnc.discord",
+  "isMultiLineEnabled": false,
+  "precedingText": "omg thank you so much, you're a ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "lifesaver",
+    "legend",
+    "star",
+    "hero",
+    "genius",
+    "gem",
+    "real one",
+    "godsend",
+    "life saver"
+   ]
+  }
+ },
+ {
+  "id": "chat-plans-05",
+  "tags": [
+   "chat",
+   "en"
+  ],
+  "applicationName": "Discord",
+  "bundleIdentifier": "com.hnc.discord",
+  "isMultiLineEnabled": false,
+  "precedingText": "anyone up for a movie this ",
+  "expectation": {
+   "kind": "positive",
+   "mustShow": true,
+   "acceptable": [
+    "weekend",
+    "Friday",
+    "Saturday",
+    "evening",
+    "week",
+    "afternoon",
+    "Sunday"
+   ]
+  }
+ },
+ {
+  "id": "chat-review-06",
+  "tags": [
+   "chat",
+   "en"
+  ],
+  "applicationName": "Slack",
+  "bundleIdentifier": "com.tinyspeck.slackmacgap",
+  "isMultiLineEnabled": false,
+  "precedingText": "hey, when you get a chance could you take a look at ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "the PR",
+    "my PR",
+    "this",
+    "the doc",
+    "the design",
+    "the ticket",
+    "my branch",
+    "the latest",
+    "the new",
+    "that",
+    "my"
+   ]
+  }
+ },
+ {
+  "id": "chat-deploy-07",
+  "tags": [
+   "chat",
+   "en"
+  ],
+  "applicationName": "Slack",
+  "bundleIdentifier": "com.tinyspeck.slackmacgap",
+  "isMultiLineEnabled": false,
+  "precedingText": "heads up, deploying the fix to production in ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "10",
+    "5",
+    "a few",
+    "15",
+    "ten",
+    "five",
+    "30",
+    "about",
+    "an hour",
+    "the next",
+    "two",
+    "20"
+   ]
+  }
+ },
+ {
+  "id": "chat-congrats-08",
+  "tags": [
+   "chat",
+   "en"
+  ],
+  "applicationName": "Slack",
+  "bundleIdentifier": "com.tinyspeck.slackmacgap",
+  "isMultiLineEnabled": false,
+  "precedingText": "huge congrats on the launch, the new site looks ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "amazing",
+    "great",
+    "incredible",
+    "fantastic",
+    "awesome",
+    "so good",
+    "really good",
+    "stunning",
+    "beautiful",
+    "sharp",
+    "clean",
+    "slick"
+   ]
+  }
+ },
+ {
+  "id": "chat-help-09",
+  "tags": [
+   "chat",
+   "en"
+  ],
+  "applicationName": "Discord",
+  "bundleIdentifier": "com.hnc.discord",
+  "isMultiLineEnabled": false,
+  "precedingText": "my build keeps failing with a weird linker error, has anyone ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "seen",
+    "run into",
+    "hit",
+    "encountered",
+    "had",
+    "experienced",
+    "dealt with",
+    "else"
+   ]
+  }
+ },
+ {
+  "id": "chat-food-10",
+  "tags": [
+   "chat",
+   "en"
+  ],
+  "applicationName": "Discord",
+  "bundleIdentifier": "com.hnc.discord",
+  "isMultiLineEnabled": false,
+  "precedingText": "we could do pizza, sushi, or that new ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "thai",
+    "ramen",
+    "taco",
+    "burger",
+    "italian",
+    "mexican",
+    "korean",
+    "indian",
+    "bbq",
+    "place",
+    "spot",
+    "restaurant",
+    "noodle",
+    "sandwich",
+    "chinese",
+    "vietnamese"
+   ]
+  }
+ },
+ {
+  "id": "chat-meeting-11",
+  "tags": [
+   "chat",
+   "en"
+  ],
+  "applicationName": "Slack",
+  "bundleIdentifier": "com.tinyspeck.slackmacgap",
+  "isMultiLineEnabled": false,
+  "precedingText": "can we push our 1:1 to tomorrow? something came ",
+  "expectation": {
+   "kind": "positive",
+   "mustShow": true,
+   "acceptable": [
+    "up"
+   ]
+  }
+ },
+ {
+  "id": "chat-weekend-12",
+  "tags": [
+   "chat",
+   "en"
+  ],
+  "applicationName": "Discord",
+  "bundleIdentifier": "com.hnc.discord",
+  "isMultiLineEnabled": false,
+  "precedingText": "the hike was amazing, we should do it again ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "soon",
+    "next",
+    "sometime",
+    "this",
+    "some time"
+   ]
+  }
+ },
+ {
+  "id": "chat-bug-13",
+  "tags": [
+   "chat",
+   "en"
+  ],
+  "applicationName": "Slack",
+  "bundleIdentifier": "com.tinyspeck.slackmacgap",
+  "isMultiLineEnabled": false,
+  "precedingText": "found the bug, it was a race condition in the ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "cache",
+    "init",
+    "startup",
+    "login",
+    "auth",
+    "queue",
+    "scheduler",
+    "database",
+    "sync",
+    "session",
+    "worker",
+    "event",
+    "handler",
+    "loading",
+    "network",
+    "request",
+    "timer",
+    "thread",
+    "background",
+    "async",
+    "callback",
+    "listener",
+    "state"
+   ]
+  }
+ },
+ {
+  "id": "chat-remote-14",
+  "tags": [
+   "chat",
+   "en"
+  ],
+  "applicationName": "Slack",
+  "bundleIdentifier": "com.tinyspeck.slackmacgap",
+  "isMultiLineEnabled": false,
+  "precedingText": "working from home today, my internet was out all ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "morning",
+    "night",
+    "day",
+    "weekend",
+    "yesterday",
+    "afternoon",
+    "evening",
+    "week"
+   ]
+  }
+ },
+ {
+  "id": "chat-gg-15",
+  "tags": [
+   "chat",
+   "en"
+  ],
+  "applicationName": "Discord",
+  "bundleIdentifier": "com.hnc.discord",
+  "isMultiLineEnabled": false,
+  "precedingText": "gg everyone, that last round was so ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "close",
+    "intense",
+    "fun",
+    "good",
+    "crazy",
+    "wild",
+    "clutch",
+    "sweaty",
+    "chaotic",
+    "epic",
+    "much fun"
+   ]
+  }
+ },
+ {
+  "id": "chat-onboarding-16",
+  "tags": [
+   "chat",
+   "en"
+  ],
+  "applicationName": "Slack",
+  "bundleIdentifier": "com.tinyspeck.slackmacgap",
+  "isMultiLineEnabled": false,
+  "precedingText": "welcome aboard! the team docs are pinned in this channel, and feel free to ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "ask",
+    "reach out",
+    "ping",
+    "message",
+    "DM",
+    "drop",
+    "post"
+   ]
+  }
+ },
+ {
+  "id": "chat-retro-17",
+  "tags": [
+   "chat",
+   "en"
+  ],
+  "applicationName": "Slack",
+  "bundleIdentifier": "com.tinyspeck.slackmacgap",
+  "isMultiLineEnabled": false,
+  "precedingText": "one thing that went really well this sprint was the ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "new",
+    "pairing",
+    "planning",
+    "communication",
+    "collaboration",
+    "testing",
+    "release",
+    "deploy",
+    "handoff",
+    "teamwork",
+    "demo",
+    "documentation",
+    "code review",
+    "launch",
+    "process",
+    "improved",
+    "speed",
+    "way",
+    "team",
+    "fact that"
+   ]
+  }
+ },
+ {
+  "id": "chat-pet-18",
+  "tags": [
+   "chat",
+   "en"
+  ],
+  "applicationName": "Discord",
+  "bundleIdentifier": "com.hnc.discord",
+  "isMultiLineEnabled": false,
+  "precedingText": "sorry I missed the call, had to take my dog to the ",
+  "expectation": {
+   "kind": "positive",
+   "mustShow": true,
+   "acceptable": [
+    "vet",
+    "groomer",
+    "park"
+   ]
+  }
+ },
+ {
+  "id": "prose-essay-01",
+  "tags": [
+   "prose",
+   "en"
+  ],
+  "applicationName": "Pages",
+  "bundleIdentifier": "com.apple.iWork.Pages",
+  "precedingText": "The industrial revolution transformed not only how goods were produced, but also how people ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "lived",
+    "worked",
+    "lived and worked",
+    "traveled",
+    "thought",
+    "organized",
+    "spent",
+    "related",
+    "communicated",
+    "moved",
+    "saw",
+    "understood",
+    "experienced",
+    "interacted"
+   ]
+  }
+ },
+ {
+  "id": "prose-journal-02",
+  "tags": [
+   "prose",
+   "en"
+  ],
+  "applicationName": "Notes",
+  "bundleIdentifier": "com.apple.Notes",
+  "precedingText": "Today was one of those days where everything seemed to go ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "wrong",
+    "right",
+    "smoothly",
+    "sideways",
+    "perfectly",
+    "my way",
+    "well",
+    "downhill",
+    "off"
+   ]
+  }
+ },
+ {
+  "id": "prose-recipe-03",
+  "tags": [
+   "prose",
+   "en"
+  ],
+  "applicationName": "Notes",
+  "bundleIdentifier": "com.apple.Notes",
+  "precedingText": "Preheat the oven to 375 degrees. In a large bowl, mix the flour, sugar, and ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "salt",
+    "baking powder",
+    "baking soda",
+    "butter",
+    "eggs",
+    "cinnamon",
+    "vanilla",
+    "cocoa",
+    "yeast",
+    "milk"
+   ]
+  }
+ },
+ {
+  "id": "prose-blog-04",
+  "tags": [
+   "prose",
+   "en"
+  ],
+  "applicationName": "Google Chrome",
+  "bundleIdentifier": "com.google.Chrome",
+  "precedingText": "After six months of working remotely from a tiny coastal town, I've learned that the most important thing is ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "routine",
+    "a routine",
+    "having",
+    "to have",
+    "community",
+    "structure",
+    "boundaries",
+    "connection",
+    "discipline",
+    "balance",
+    "not",
+    "finding",
+    "keeping",
+    "staying",
+    "making",
+    "setting"
+   ]
+  }
+ },
+ {
+  "id": "prose-review-05",
+  "tags": [
+   "prose",
+   "en"
+  ],
+  "applicationName": "Google Chrome",
+  "bundleIdentifier": "com.google.Chrome",
+  "precedingText": "The food was excellent and the service was friendly, but the wait time was ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "a bit",
+    "way too",
+    "too long",
+    "far too",
+    "ridiculous",
+    "unacceptable",
+    "over an",
+    "really long",
+    "absurd",
+    "quite",
+    "very long",
+    "long",
+    "terrible",
+    "awful",
+    "almost"
+   ]
+  }
+ },
+ {
+  "id": "prose-history-06",
+  "tags": [
+   "prose",
+   "en"
+  ],
+  "applicationName": "Pages",
+  "bundleIdentifier": "com.apple.iWork.Pages",
+  "precedingText": "The Roman Empire reached its greatest territorial extent under the emperor ",
+  "expectation": {
+   "kind": "positive",
+   "mustShow": true,
+   "acceptable": [
+    "Trajan",
+    "Hadrian"
+   ]
+  }
+ },
+ {
+  "id": "prose-fiction-07",
+  "tags": [
+   "prose",
+   "en"
+  ],
+  "applicationName": "Pages",
+  "bundleIdentifier": "com.apple.iWork.Pages",
+  "precedingText": "She opened the old wooden door slowly, and the smell of ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "dust",
+    "old books",
+    "mildew",
+    "mold",
+    "lavender",
+    "fresh bread",
+    "smoke",
+    "damp",
+    "cedar",
+    "rain",
+    "musty",
+    "age",
+    "stale",
+    "pine",
+    "something",
+    "decay",
+    "earth",
+    "wood"
+   ]
+  }
+ },
+ {
+  "id": "prose-notes-08",
+  "tags": [
+   "prose",
+   "en"
+  ],
+  "applicationName": "Notes",
+  "bundleIdentifier": "com.apple.Notes",
+  "precedingText": "Grocery list for the week: eggs, milk, bread, ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "butter",
+    "cheese",
+    "apples",
+    "bananas",
+    "chicken",
+    "coffee",
+    "rice",
+    "pasta",
+    "tomatoes",
+    "onions",
+    "yogurt",
+    "spinach",
+    "flour",
+    "sugar",
+    "and"
+   ]
+  }
+ },
+ {
+  "id": "prose-essay-09",
+  "tags": [
+   "prose",
+   "en"
+  ],
+  "applicationName": "Pages",
+  "bundleIdentifier": "com.apple.iWork.Pages",
+  "precedingText": "Climate change poses three major risks to coastal cities: rising sea levels, stronger storms, and ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "flooding",
+    "erosion",
+    "coastal erosion",
+    "saltwater",
+    "increased",
+    "more frequent",
+    "higher",
+    "extreme",
+    "infrastructure",
+    "frequent"
+   ]
+  }
+ },
+ {
+  "id": "prose-travel-10",
+  "tags": [
+   "prose",
+   "en"
+  ],
+  "applicationName": "Notes",
+  "bundleIdentifier": "com.apple.Notes",
+  "precedingText": "Day 3 in Kyoto: visited the bamboo grove in the morning, then spent the afternoon exploring ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "temples",
+    "the temples",
+    "the old",
+    "shrines",
+    "the markets",
+    "downtown",
+    "the gion",
+    "gion",
+    "the city",
+    "the streets",
+    "the historic",
+    "local",
+    "the nearby",
+    "arashiyama",
+    "nishiki"
+   ]
+  }
+ },
+ {
+  "id": "prose-memo-11",
+  "tags": [
+   "prose",
+   "docs",
+   "en"
+  ],
+  "applicationName": "Google Chrome",
+  "bundleIdentifier": "com.google.Chrome",
+  "precedingText": "Decision: we will migrate the billing service to the new platform in Q3. The main reasons are ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "cost",
+    "performance",
+    "scalability",
+    "reliability",
+    "maintainability",
+    "the",
+    "reduced",
+    "lower",
+    "better",
+    "improved",
+    "simpler",
+    "twofold",
+    "as follows",
+    "that"
+   ]
+  }
+ },
+ {
+  "id": "prose-bio-12",
+  "tags": [
+   "prose",
+   "en"
+  ],
+  "applicationName": "Google Chrome",
+  "bundleIdentifier": "com.google.Chrome",
+  "precedingText": "Maya is a product designer based in Toronto with a passion for ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "accessible",
+    "accessibility",
+    "user",
+    "inclusive",
+    "sustainable",
+    "design",
+    "creating",
+    "building",
+    "crafting",
+    "human",
+    "digital",
+    "typography",
+    "simple",
+    "clean",
+    "thoughtful",
+    "minimal"
+   ]
+  }
+ },
+ {
+  "id": "prose-summary-13",
+  "tags": [
+   "prose",
+   "docs",
+   "en"
+  ],
+  "applicationName": "Google Chrome",
+  "bundleIdentifier": "com.google.Chrome",
+  "precedingText": "In summary, the study found that participants who slept fewer than six hours performed significantly ",
+  "expectation": {
+   "kind": "positive",
+   "mustShow": true,
+   "acceptable": [
+    "worse",
+    "more poorly",
+    "below",
+    "lower"
+   ]
+  }
+ },
+ {
+  "id": "prose-event-14",
+  "tags": [
+   "prose",
+   "en"
+  ],
+  "applicationName": "Notes",
+  "bundleIdentifier": "com.apple.Notes",
+  "precedingText": "Birthday party planning: venue booked, cake ordered, still need to send out the ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "invitations",
+    "invites",
+    "evites",
+    "guest list",
+    "thank-you"
+   ]
+  }
+ },
+ {
+  "id": "prose-essay-15",
+  "tags": [
+   "prose",
+   "en"
+  ],
+  "applicationName": "Pages",
+  "bundleIdentifier": "com.apple.iWork.Pages",
+  "precedingText": "Photosynthesis is the process by which plants convert sunlight, water, and carbon dioxide into ",
+  "expectation": {
+   "kind": "positive",
+   "mustShow": true,
+   "acceptable": [
+    "glucose",
+    "oxygen",
+    "energy",
+    "sugar",
+    "glucose and oxygen",
+    "food",
+    "oxygen and glucose",
+    "chemical energy"
+   ]
+  }
+ },
+ {
+  "id": "prose-minutes-16",
+  "tags": [
+   "prose",
+   "docs",
+   "en"
+  ],
+  "applicationName": "Google Chrome",
+  "bundleIdentifier": "com.google.Chrome",
+  "precedingText": "Action items from the meeting: Alex will update the roadmap, Priya will schedule the ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "follow-up",
+    "next",
+    "kickoff",
+    "demo",
+    "review",
+    "user",
+    "customer",
+    "interviews",
+    "workshop",
+    "meeting",
+    "call",
+    "session",
+    "retro",
+    "planning",
+    "design",
+    "sync",
+    "stakeholder"
+   ]
+  }
+ },
+ {
+  "id": "prose-letter-17",
+  "tags": [
+   "prose",
+   "en"
+  ],
+  "applicationName": "Pages",
+  "bundleIdentifier": "com.apple.iWork.Pages",
+  "precedingText": "To whom it may concern,\n\nI am writing to express my strong support for Lena's application. I have known her for ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "five years",
+    "three years",
+    "over",
+    "more than",
+    "several years",
+    "many years",
+    "ten years",
+    "four years",
+    "two years",
+    "six years",
+    "seven years",
+    "eight years",
+    "a decade",
+    "nearly",
+    "almost",
+    "the past"
+   ]
+  }
+ },
+ {
+  "id": "prose-howto-18",
+  "tags": [
+   "prose",
+   "docs",
+   "en"
+  ],
+  "applicationName": "Google Chrome",
+  "bundleIdentifier": "com.google.Chrome",
+  "precedingText": "To reset your password, click the link in the email and enter a new password. If you don't receive the email within five minutes, check your ",
+  "expectation": {
+   "kind": "positive",
+   "mustShow": true,
+   "acceptable": [
+    "spam",
+    "junk",
+    "spam folder",
+    "spam or junk"
+   ]
+  }
+ },
+ {
+  "id": "prose-nature-19",
+  "tags": [
+   "prose",
+   "en"
+  ],
+  "applicationName": "Pages",
+  "bundleIdentifier": "com.apple.iWork.Pages",
+  "precedingText": "Monarch butterflies migrate thousands of miles each year, traveling from Canada all the way to ",
+  "expectation": {
+   "kind": "positive",
+   "mustShow": true,
+   "acceptable": [
+    "Mexico",
+    "central Mexico"
+   ]
+  }
+ },
+ {
+  "id": "prose-pitch-20",
+  "tags": [
+   "prose",
+   "docs",
+   "en"
+  ],
+  "applicationName": "Google Chrome",
+  "bundleIdentifier": "com.google.Chrome",
+  "precedingText": "Our app helps busy parents plan healthy meals in under ten minutes a week. Unlike existing meal planners, we ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "use",
+    "automatically",
+    "personalize",
+    "focus",
+    "learn",
+    "generate",
+    "build",
+    "tailor",
+    "adapt",
+    "combine",
+    "integrate",
+    "offer",
+    "don't",
+    "take",
+    "make",
+    "do"
+   ]
+  }
+ },
+ {
+  "id": "prose-condolence-21",
+  "tags": [
+   "prose",
+   "en"
+  ],
+  "applicationName": "Mail",
+  "bundleIdentifier": "com.apple.mail",
+  "precedingText": "I was so sorry to hear about your grandmother. Please know that my thoughts are ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "with you",
+    "with you and your family"
+   ]
+  }
+ },
+ {
+  "id": "prose-announce-22",
+  "tags": [
+   "prose",
+   "en"
+  ],
+  "applicationName": "Google Chrome",
+  "bundleIdentifier": "com.google.Chrome",
+  "precedingText": "We're thrilled to announce that after two years of development, our game is finally ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "here",
+    "out",
+    "available",
+    "launching",
+    "ready",
+    "released",
+    "live",
+    "coming",
+    "done",
+    "complete",
+    "shipping"
+   ]
+  }
+ },
+ {
+  "id": "code-comment-01",
+  "tags": [
+   "code",
+   "en"
+  ],
+  "applicationName": "Xcode",
+  "bundleIdentifier": "com.apple.dt.Xcode",
+  "precedingText": "// Returns the number of days between two dates, ignoring the time ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "component",
+    "of day",
+    "zone",
+    "portion",
+    "components",
+    "part",
+    "fields",
+    "information"
+   ]
+  }
+ },
+ {
+  "id": "code-comment-02",
+  "tags": [
+   "code",
+   "en"
+  ],
+  "applicationName": "Xcode",
+  "bundleIdentifier": "com.apple.dt.Xcode",
+  "precedingText": "// TODO: remove this workaround once the upstream bug is ",
+  "expectation": {
+   "kind": "positive",
+   "mustShow": true,
+   "acceptable": [
+    "fixed",
+    "resolved",
+    "patched",
+    "closed",
+    "addressed"
+   ]
+  }
+ },
+ {
+  "id": "code-swift-03",
+  "tags": [
+   "code",
+   "en"
+  ],
+  "applicationName": "Xcode",
+  "bundleIdentifier": "com.apple.dt.Xcode",
+  "precedingText": "guard let user = currentUser else {\n    return ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "nil",
+    "false",
+    "[]",
+    "nil\n}",
+    ".none",
+    "0",
+    "nothing"
+   ]
+  }
+ },
+ {
+  "id": "code-python-04",
+  "tags": [
+   "code",
+   "en"
+  ],
+  "applicationName": "Visual Studio Code",
+  "bundleIdentifier": "com.microsoft.VSCode",
+  "precedingText": "def fibonacci(n):\n    if n <= 1:\n        return ",
+  "expectation": {
+   "kind": "positive",
+   "mustShow": true,
+   "acceptable": [
+    "n",
+    "1",
+    "n\n"
+   ]
+  }
+ },
+ {
+  "id": "code-log-05",
+  "tags": [
+   "code",
+   "en"
+  ],
+  "applicationName": "Visual Studio Code",
+  "bundleIdentifier": "com.microsoft.VSCode",
+  "precedingText": "logger.error(\"Failed to connect to the ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "database",
+    "server",
+    "API",
+    "remote",
+    "service",
+    "host",
+    "endpoint",
+    "socket",
+    "network",
+    "redis",
+    "db",
+    "backend",
+    "broker",
+    "client",
+    "cluster",
+    "instance",
+    "upstream"
+   ]
+  }
+ },
+ {
+  "id": "code-readme-06",
+  "tags": [
+   "code",
+   "docs",
+   "en"
+  ],
+  "applicationName": "Visual Studio Code",
+  "bundleIdentifier": "com.microsoft.VSCode",
+  "precedingText": "## Installation\n\nClone the repository and run ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "npm install",
+    "npm",
+    "the",
+    "yarn",
+    "make",
+    "pip install",
+    "cargo",
+    "the following",
+    "the install",
+    "the setup",
+    "this",
+    "install"
+   ]
+  }
+ },
+ {
+  "id": "code-sql-07",
+  "tags": [
+   "code",
+   "en"
+  ],
+  "applicationName": "Visual Studio Code",
+  "bundleIdentifier": "com.microsoft.VSCode",
+  "precedingText": "SELECT name, email FROM users WHERE created_at > '2026-01-01' ORDER BY ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "created_at",
+    "name",
+    "email",
+    "id",
+    "date"
+   ]
+  }
+ },
+ {
+  "id": "code-css-08",
+  "tags": [
+   "code",
+   "en"
+  ],
+  "applicationName": "Visual Studio Code",
+  "bundleIdentifier": "com.microsoft.VSCode",
+  "precedingText": ".header {\n    display: flex;\n    justify-content: ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "center",
+    "space-between",
+    "flex-start",
+    "flex-end",
+    "space-around",
+    "space-evenly",
+    "start",
+    "left"
+   ]
+  }
+ },
+ {
+  "id": "cjk-ja-weather-01",
+  "tags": [
+   "cjk",
+   "ja"
+  ],
+  "applicationName": "Notes",
+  "bundleIdentifier": "com.apple.Notes",
+  "precedingText": "今日はとても天気が良いので、",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "散歩",
+    "公園",
+    "外に",
+    "外で",
+    "お出かけ",
+    "出かけ",
+    "ピクニック",
+    "洗濯",
+    "外出",
+    "お散歩"
+   ]
+  }
+ },
+ {
+  "id": "cjk-ja-email-02",
+  "tags": [
+   "cjk",
+   "ja",
+   "email"
+  ],
+  "applicationName": "Mail",
+  "bundleIdentifier": "com.apple.mail",
+  "precedingText": "お世話になっております。先日の打ち合わせの件につきまして、",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "ご確認",
+    "資料を",
+    "改めて",
+    "下記の",
+    "以下の",
+    "ご連絡",
+    "ご報告",
+    "ご相談",
+    "添付の",
+    "御礼",
+    "お礼"
+   ]
+  }
+ },
+ {
+  "id": "cjk-ja-thanks-03",
+  "tags": [
+   "cjk",
+   "ja"
+  ],
+  "applicationName": "Slack",
+  "bundleIdentifier": "com.tinyspeck.slackmacgap",
+  "isMultiLineEnabled": false,
+  "precedingText": "昨日はありがとうございました。とても",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "楽しかった",
+    "勉強に",
+    "助かりました",
+    "嬉しかった",
+    "有意義",
+    "参考に",
+    "良い",
+    "楽し"
+   ]
+  }
+ },
+ {
+  "id": "cjk-ja-plan-04",
+  "tags": [
+   "cjk",
+   "ja"
+  ],
+  "applicationName": "Notes",
+  "bundleIdentifier": "com.apple.Notes",
+  "precedingText": "明日の予定:朝9時に駅で集合して、それから",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "電車",
+    "バス",
+    "みんなで",
+    "一緒に",
+    "会場",
+    "カフェ",
+    "朝食",
+    "新幹線",
+    "歩いて",
+    "車で",
+    "昼食",
+    "移動"
+   ]
+  }
+ },
+ {
+  "id": "cjk-ja-review-05",
+  "tags": [
+   "cjk",
+   "ja"
+  ],
+  "applicationName": "Google Chrome",
+  "bundleIdentifier": "com.google.Chrome",
+  "precedingText": "このレストランは雰囲気も良く、料理も",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "美味しかった",
+    "美味しい",
+    "とても",
+    "最高",
+    "絶品",
+    "素晴らしい",
+    "どれも",
+    "美味し"
+   ]
+  }
+ },
+ {
+  "id": "cjk-ja-apology-06",
+  "tags": [
+   "cjk",
+   "ja",
+   "email"
+  ],
+  "applicationName": "Mail",
+  "bundleIdentifier": "com.apple.mail",
+  "precedingText": "ご返信が遅くなり、大変申し訳",
+  "expectation": {
+   "kind": "positive",
+   "mustShow": true,
+   "acceptable": [
+    "ありません",
+    "ございません"
+   ]
+  }
+ },
+ {
+  "id": "cjk-ja-intro-07",
+  "tags": [
+   "cjk",
+   "ja"
+  ],
+  "applicationName": "Notes",
+  "bundleIdentifier": "com.apple.Notes",
+  "precedingText": "はじめまして。東京でエンジニアをして",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "います",
+    "おります",
+    "いる"
+   ]
+  }
+ },
+ {
+  "id": "cjk-ja-travel-08",
+  "tags": [
+   "cjk",
+   "ja"
+  ],
+  "applicationName": "Notes",
+  "bundleIdentifier": "com.apple.Notes",
+  "precedingText": "京都旅行のメモ:一日目は清水寺と金閣寺を見て、夜は",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "祇園",
+    "懐石",
+    "京料理",
+    "ホテル",
+    "旅館",
+    "居酒屋",
+    "夜景",
+    "川床",
+    "鴨川",
+    "先斗町",
+    "温泉",
+    "美味しい"
+   ]
+  }
+ },
+ {
+  "id": "cjk-zh-greeting-09",
+  "tags": [
+   "cjk",
+   "zh"
+  ],
+  "applicationName": "Notes",
+  "bundleIdentifier": "com.apple.Notes",
+  "precedingText": "今天天气很好,我们一起去",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "公园",
+    "散步",
+    "爬山",
+    "郊游",
+    "野餐",
+    "海边",
+    "玩",
+    "逛街",
+    "骑车",
+    "外面"
+   ]
+  }
+ },
+ {
+  "id": "cjk-zh-thanks-10",
+  "tags": [
+   "cjk",
+   "zh"
+  ],
+  "applicationName": "Notes",
+  "bundleIdentifier": "com.apple.Notes",
+  "precedingText": "非常感谢你的帮助,这个项目",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "终于",
+    "顺利",
+    "才能",
+    "能够",
+    "进展",
+    "已经",
+    "完成",
+    "成功"
+   ]
+  }
+ },
+ {
+  "id": "cjk-ja-deadline-11",
+  "tags": [
+   "cjk",
+   "ja",
+   "email"
+  ],
+  "applicationName": "Mail",
+  "bundleIdentifier": "com.apple.mail",
+  "precedingText": "資料の提出期限は金曜日までと",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "なって",
+    "なります",
+    "させて",
+    "のこと",
+    "いたします",
+    "なっております",
+    "記載"
+   ]
+  }
+ },
+ {
+  "id": "cjk-ja-recipe-12",
+  "tags": [
+   "cjk",
+   "ja"
+  ],
+  "applicationName": "Notes",
+  "bundleIdentifier": "com.apple.Notes",
+  "precedingText": "カレーの作り方:まず玉ねぎを炒めて、次に",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "肉",
+    "じゃがいも",
+    "にんじん",
+    "お肉",
+    "野菜",
+    "鶏肉",
+    "豚肉",
+    "牛肉",
+    "水",
+    "トマト"
+   ]
+  }
+ },
+ {
+  "id": "midword-forward-01",
+  "tags": [
+   "midword",
+   "en"
+  ],
+  "applicationName": "Mail",
+  "bundleIdentifier": "com.apple.mail",
+  "precedingText": "I'm really looking forw",
+  "expectation": {
+   "kind": "positive",
+   "mustShow": false,
+   "acceptable": [
+    "ard to",
+    "ard"
+   ]
+  }
+ },
+ {
+  "id": "midword-appreciate-02",
+  "tags": [
+   "midword",
+   "en"
+  ],
+  "applicationName": "Mail",
+  "bundleIdentifier": "com.apple.mail",
+  "precedingText": "Thanks so much, I really apprec",
+  "expectation": {
+   "kind": "positive",
+   "mustShow": false,
+   "acceptable": [
+    "iate it",
+    "iate"
+   ]
+  }
+ },
+ {
+  "id": "midword-definitely-03",
+  "tags": [
+   "midword",
+   "en"
+  ],
+  "applicationName": "Slack",
+  "bundleIdentifier": "com.tinyspeck.slackmacgap",
+  "isMultiLineEnabled": false,
+  "precedingText": "sounds good, I'll defin",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "itely"
+   ]
+  }
+ },
+ {
+  "id": "midword-tomorrow-04",
+  "tags": [
+   "midword",
+   "en"
+  ],
+  "applicationName": "Slack",
+  "bundleIdentifier": "com.tinyspeck.slackmacgap",
+  "isMultiLineEnabled": false,
+  "precedingText": "let's sync up tomor",
+  "expectation": {
+   "kind": "positive",
+   "mustShow": false,
+   "acceptable": [
+    "row"
+   ]
+  }
+ },
+ {
+  "id": "midword-schedule-05",
+  "tags": [
+   "midword",
+   "en"
+  ],
+  "applicationName": "Mail",
+  "bundleIdentifier": "com.apple.mail",
+  "precedingText": "Happy to resched",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "ule"
+   ]
+  }
+ },
+ {
+  "id": "midword-congrat-06",
+  "tags": [
+   "midword",
+   "en"
+  ],
+  "applicationName": "Discord",
+  "bundleIdentifier": "com.hnc.discord",
+  "isMultiLineEnabled": false,
+  "precedingText": "congratul",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "ations"
+   ]
+  }
+ },
+ {
+  "id": "midword-unfortunately-07",
+  "tags": [
+   "midword",
+   "en"
+  ],
+  "applicationName": "Mail",
+  "bundleIdentifier": "com.apple.mail",
+  "precedingText": "Unfortun",
+  "expectation": {
+   "kind": "positive",
+   "mustShow": false,
+   "acceptable": [
+    "ately"
+   ]
+  }
+ },
+ {
+  "id": "midword-experience-08",
+  "tags": [
+   "midword",
+   "en"
+  ],
+  "applicationName": "Google Chrome",
+  "bundleIdentifier": "com.google.Chrome",
+  "precedingText": "With over ten years of exper",
+  "expectation": {
+   "kind": "positive",
+   "mustShow": false,
+   "acceptable": [
+    "ience"
+   ]
+  }
+ },
+ {
+  "id": "midword-immediately-09",
+  "tags": [
+   "midword",
+   "en"
+  ],
+  "applicationName": "Mail",
+  "bundleIdentifier": "com.apple.mail",
+  "precedingText": "Please contact us immed",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "iately"
+   ]
+  }
+ },
+ {
+  "id": "midword-available-10",
+  "tags": [
+   "midword",
+   "en"
+  ],
+  "applicationName": "Mail",
+  "bundleIdentifier": "com.apple.mail",
+  "precedingText": "I'm avail",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "able"
+   ]
+  }
+ },
+ {
+  "id": "midword-environment-11",
+  "tags": [
+   "midword",
+   "code",
+   "en"
+  ],
+  "applicationName": "Visual Studio Code",
+  "bundleIdentifier": "com.microsoft.VSCode",
+  "precedingText": "// Make sure to set the environ",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "ment"
+   ]
+  }
+ },
+ {
+  "id": "midword-recommendation-12",
+  "tags": [
+   "midword",
+   "en"
+  ],
+  "applicationName": "Pages",
+  "bundleIdentifier": "com.apple.iWork.Pages",
+  "precedingText": "I am pleased to write this letter of recommend",
+  "expectation": {
+   "kind": "positive",
+   "mustShow": false,
+   "acceptable": [
+    "ation"
+   ]
+  }
+ },
+ {
+  "id": "midword-beautiful-13",
+  "tags": [
+   "midword",
+   "en"
+  ],
+  "applicationName": "Notes",
+  "bundleIdentifier": "com.apple.Notes",
+  "precedingText": "The sunset tonight was absolutely beauti",
+  "expectation": {
+   "kind": "positive",
+   "acceptable": [
+    "ful"
+   ]
+  }
+ },
+ {
+  "id": "midword-understand-14",
+  "tags": [
+   "midword",
+   "en"
+  ],
+  "applicationName": "Mail",
+  "bundleIdentifier": "com.apple.mail",
+  "precedingText": "I completely underst",
+  "expectation": {
+   "kind": "positive",
+   "mustShow": false,
+   "acceptable": [
+    "and"
+   ]
+  }
+ },
+ {
+  "id": "neg-dup-tight-01",
+  "tags": [
+   "negative",
+   "dup-trailing",
+   "en"
+  ],
+  "applicationName": "Mail",
+  "bundleIdentifier": "com.apple.mail",
+  "precedingText": "The meeting is at 3",
+  "trailingText": ":30 tomorrow afternoon in the main conference room.",
+  "expectation": {
+   "kind": "negative",
+   "reason": "Caret is tight against a continuation that already exists; any insertion duplicates or corrupts it."
+  }
+ },
+ {
+  "id": "neg-dup-tight-02",
+  "tags": [
+   "negative",
+   "dup-trailing",
+   "en"
+  ],
+  "applicationName": "Mail",
+  "bundleIdentifier": "com.apple.mail",
+  "precedingText": "Please send the report to jane",
+  "trailingText": "@example.com before the end of the day.",
+  "expectation": {
+   "kind": "negative",
+   "reason": "Mid-email-address caret; the address already continues after the cursor."
+  }
+ },
+ {
+  "id": "neg-dup-word-03",
+  "tags": [
+   "negative",
+   "dup-trailing",
+   "en"
+  ],
+  "applicationName": "Pages",
+  "bundleIdentifier": "com.apple.iWork.Pages",
+  "precedingText": "We are committed to deliv",
+  "trailingText": "ering the best possible experience for every customer.",
+  "expectation": {
+   "kind": "negative",
+   "reason": "The word is already completed after the caret; inserting a completion duplicates it."
+  }
+ },
+ {
+  "id": "neg-dup-word-04",
+  "tags": [
+   "negative",
+   "dup-trailing",
+   "en"
+  ],
+  "applicationName": "Notes",
+  "bundleIdentifier": "com.apple.Notes",
+  "precedingText": "Don't forget to water the ",
+  "trailingText": "plants before leaving for the airport.",
+  "expectation": {
+   "kind": "negative",
+   "reason": "The obvious continuation is already present after the caret."
+  }
+ },
+ {
+  "id": "neg-dup-sentence-05",
+  "tags": [
+   "negative",
+   "dup-trailing",
+   "en"
+  ],
+  "applicationName": "Mail",
+  "bundleIdentifier": "com.apple.mail",
+  "precedingText": "Thanks for your patience",
+  "trailingText": " while we sorted this out. The refund has been processed.",
+  "expectation": {
+   "kind": "negative",
+   "reason": "The sentence already continues immediately after the caret with no gap."
+  }
+ },
+ {
+  "id": "neg-dup-code-06",
+  "tags": [
+   "negative",
+   "dup-trailing",
+   "code"
+  ],
+  "applicationName": "Visual Studio Code",
+  "bundleIdentifier": "com.microsoft.VSCode",
+  "precedingText": "const total = items.red",
+  "trailingText": "uce((sum, item) => sum + item.price, 0);",
+  "expectation": {
+   "kind": "negative",
+   "reason": "Identifier already completed after the caret."
+  }
+ },
+ {
+  "id": "neg-dup-list-07",
+  "tags": [
+   "negative",
+   "dup-trailing",
+   "en"
+  ],
+  "applicationName": "Notes",
+  "bundleIdentifier": "com.apple.Notes",
+  "precedingText": "Packing list: passport, charger, head",
+  "trailingText": "phones, sunscreen, and a good book.",
+  "expectation": {
+   "kind": "negative",
+   "reason": "List item already completed after the caret."
+  }
+ },
+ {
+  "id": "neg-dup-tight-08",
+  "tags": [
+   "negative",
+   "dup-trailing",
+   "en"
+  ],
+  "applicationName": "Google Chrome",
+  "bundleIdentifier": "com.google.Chrome",
+  "precedingText": "Our office is located at 41",
+  "trailingText": "5 Mission Street, San Francisco.",
+  "expectation": {
+   "kind": "negative",
+   "reason": "Mid-number caret with the rest of the address after the cursor."
+  }
+ },
+ {
+  "id": "neg-gibberish-01",
+  "tags": [
+   "negative",
+   "gibberish"
+  ],
+  "applicationName": "Notes",
+  "bundleIdentifier": "com.apple.Notes",
+  "precedingText": "asdkfj qwpeoriu zxmcnv ",
+  "expectation": {
+   "kind": "negative",
+   "reason": "Keyboard mash; no meaningful continuation exists."
+  }
+ },
+ {
+  "id": "neg-gibberish-02",
+  "tags": [
+   "negative",
+   "gibberish"
+  ],
+  "applicationName": "Notes",
+  "bundleIdentifier": "com.apple.Notes",
+  "precedingText": "jjjjjj kkkkk hhhhhh ",
+  "expectation": {
+   "kind": "negative",
+   "reason": "Key-repeat garbage; nothing sensible follows."
+  }
+ },
+ {
+  "id": "neg-gibberish-03",
+  "tags": [
+   "negative",
+   "gibberish"
+  ],
+  "applicationName": "Google Chrome",
+  "bundleIdentifier": "com.google.Chrome",
+  "precedingText": "xq vbnz pleorty ",
+  "expectation": {
+   "kind": "negative",
+   "reason": "Random characters; suppression is the only good answer."
+  }
+ },
+ {
+  "id": "neg-gibberish-04",
+  "tags": [
+   "negative",
+   "gibberish"
+  ],
+  "applicationName": "Slack",
+  "bundleIdentifier": "com.tinyspeck.slackmacgap",
+  "isMultiLineEnabled": false,
+  "precedingText": "wfhqk zzrtp ",
+  "expectation": {
+   "kind": "negative",
+   "reason": "Random characters in a chat field."
+  }
+ },
+ {
+  "id": "neg-blank-05",
+  "tags": [
+   "negative",
+   "blank"
+  ],
+  "applicationName": "Notes",
+  "bundleIdentifier": "com.apple.Notes",
+  "precedingText": "   ",
+  "expectation": {
+   "kind": "negative",
+   "reason": "Whitespace-only field; generation should not even be attempted."
+  }
+ },
+ {
+  "id": "neg-blank-06",
+  "tags": [
+   "negative",
+   "blank"
+  ],
+  "applicationName": "Mail",
+  "bundleIdentifier": "com.apple.mail",
+  "precedingText": "\n\n",
+  "expectation": {
+   "kind": "negative",
+   "reason": "Newlines only; generation should not even be attempted."
+  }
+ },
+ {
+  "id": "forbid-scaffold-01",
+  "tags": [
+   "scaffolding",
+   "en"
+  ],
+  "applicationName": "Notes",
+  "bundleIdentifier": "com.apple.Notes",
+  "precedingText": "Pasted transcript:\n<|im_start|>user\nHow do I reset my router?<|im_end|>\n<|im_start|>assistant\nUnplug it for ten seconds.\nMy notes: the trick that worked was ",
+  "expectation": {
+   "kind": "forbidden",
+   "forbidden": [
+    "<|im_start|>",
+    "<|im_end|>",
+    "<|endoftext|>"
+   ]
+  }
+ },
+ {
+  "id": "forbid-scaffold-02",
+  "tags": [
+   "scaffolding",
+   "en"
+  ],
+  "applicationName": "Notes",
+  "bundleIdentifier": "com.apple.Notes",
+  "precedingText": "<start_of_turn>user\nWhat's a good pasta recipe?<end_of_turn>\n<start_of_turn>model\nStart with good tomatoes and ",
+  "expectation": {
+   "kind": "forbidden",
+   "forbidden": [
+    "<start_of_turn>",
+    "<end_of_turn>",
+    "<|im_end|>"
+   ]
+  }
+ },
+ {
+  "id": "forbid-scaffold-03",
+  "tags": [
+   "scaffolding",
+   "en"
+  ],
+  "applicationName": "Google Chrome",
+  "bundleIdentifier": "com.google.Chrome",
+  "precedingText": "Notes on prompt formats: ChatML wraps each turn in im_start markers. For example, after the assistant answers you usually see ",
+  "expectation": {
+   "kind": "forbidden",
+   "forbidden": [
+    "<|im_start|>",
+    "<|im_end|>"
+   ]
+  }
+ },
+ {
+  "id": "forbid-scaffold-04",
+  "tags": [
+   "scaffolding",
+   "en"
+  ],
+  "applicationName": "Visual Studio Code",
+  "bundleIdentifier": "com.microsoft.VSCode",
+  "precedingText": "# Conversation log\n[INST] How do I exit vim? [/INST] Press escape, then type ",
+  "expectation": {
+   "kind": "forbidden",
+   "forbidden": [
+    "[INST]",
+    "[/INST]",
+    "<|endoftext|>"
+   ]
+  }
+ },
+ {
+  "id": "forbid-role-05",
+  "tags": [
+   "scaffolding",
+   "en"
+  ],
+  "applicationName": "Notes",
+  "bundleIdentifier": "com.apple.Notes",
+  "precedingText": "Saved chat:\n<|user|>\nBest hiking trails near Seattle?\n<|assistant|>\nTry Rattlesnake Ledge for a ",
+  "expectation": {
+   "kind": "forbidden",
+   "forbidden": [
+    "<|user|>",
+    "<|assistant|>",
+    "<|end|>"
+   ]
+  }
+ },
+ {
+  "id": "forbid-header-06",
+  "tags": [
+   "scaffolding",
+   "en"
+  ],
+  "applicationName": "Notes",
+  "bundleIdentifier": "com.apple.Notes",
+  "precedingText": "Debug dump: <|start_header_id|>assistant<|end_header_id|> The cache expires after ",
+  "expectation": {
+   "kind": "forbidden",
+   "forbidden": [
+    "<|start_header_id|>",
+    "<|end_header_id|>",
+    "<|eot_id|>"
+   ]
+  }
+ }
+]

--- a/CotabbyTests/LlamaEvalScoring.swift
+++ b/CotabbyTests/LlamaEvalScoring.swift
@@ -291,7 +291,10 @@ struct LlamaEvalReport {
             "positiveCoverage": positiveCoverage,
             "wrongShowRate": wrongShowRate,
             "latencyP50Ms": latencyPercentile(0.5) * 1000,
-            "latencyP95Ms": latencyPercentile(0.95) * 1000
+            "latencyP95Ms": latencyPercentile(0.95) * 1000,
+            // The printed report includes max; the artifact must too, or the worst-case decode
+            // tail (exactly what the scaffolding-marker stop targets) is invisible in run diffs.
+            "latencyMaxMs": latencyPercentile(1.0) * 1000
         ]
         payload["cases"] = results.map { result -> [String: Any] in
             [

--- a/CotabbyTests/LlamaEvalScoring.swift
+++ b/CotabbyTests/LlamaEvalScoring.swift
@@ -1,0 +1,308 @@
+import Foundation
+
+/// Pure scoring layer for the llama suggestion eval: the case schema, the shown-vs-acceptable
+/// matcher, the outcome taxonomy, and report aggregation.
+///
+/// Lives in the test target (it is measurement tooling, not product code) but contains no XCTest
+/// so the CI-run `LlamaEvalScoringTests` can exercise every rule without a model.
+///
+/// Scoring is deliberately non-negative with suppression scored per expectation kind, so neither
+/// "show everything" nor "suppress everything" can win the aggregate: wrong text scores 0 where
+/// suppression would have scored 0.3 or 1.0, and suppression on a must-show positive scores 0
+/// where a correct insert would have scored 1.0.
+enum LlamaEvalExpectationKind: String, Decodable {
+    /// A continuation is wanted; `acceptable` lists reference continuations.
+    case positive
+    /// Showing anything is wrong (duplicate-of-trailing, gibberish); suppression is correct.
+    case negative
+    /// Showing is fine unless the text contains one of `forbidden`; suppression also correct.
+    case forbidden
+}
+
+struct LlamaEvalExpectation: Decodable, Equatable {
+    let kind: LlamaEvalExpectationKind
+    /// Positive only: suppressing scores 0 instead of the acceptable-suppression 0.3.
+    var mustShow: Bool = false
+    /// Positive only: reference continuations the shown text is matched against.
+    var acceptable: [String] = []
+    /// Forbidden only: substrings that must never appear in shown text (case-insensitive).
+    var forbidden: [String] = []
+    /// Negative only: documentation of why showing anything is wrong.
+    var reason: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case kind, mustShow, acceptable, forbidden, reason
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        kind = try container.decode(LlamaEvalExpectationKind.self, forKey: .kind)
+        mustShow = try container.decodeIfPresent(Bool.self, forKey: .mustShow) ?? false
+        acceptable = try container.decodeIfPresent([String].self, forKey: .acceptable) ?? []
+        forbidden = try container.decodeIfPresent([String].self, forKey: .forbidden) ?? []
+        reason = try container.decodeIfPresent(String.self, forKey: .reason)
+    }
+
+    init(
+        kind: LlamaEvalExpectationKind,
+        mustShow: Bool = false,
+        acceptable: [String] = [],
+        forbidden: [String] = [],
+        reason: String? = nil
+    ) {
+        self.kind = kind
+        self.mustShow = mustShow
+        self.acceptable = acceptable
+        self.forbidden = forbidden
+        self.reason = reason
+    }
+}
+
+struct LlamaEvalCase: Decodable, Equatable {
+    let id: String
+    let tags: [String]
+    var applicationName: String = "TestApp"
+    var bundleIdentifier: String = "com.example.TestApp"
+    let precedingText: String
+    var trailingText: String = ""
+    var isMultiLineEnabled: Bool = true
+    let expectation: LlamaEvalExpectation
+
+    private enum CodingKeys: String, CodingKey {
+        case id, tags, applicationName, bundleIdentifier
+        case precedingText, trailingText, isMultiLineEnabled, expectation
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        tags = try container.decode([String].self, forKey: .tags)
+        applicationName = try container.decodeIfPresent(String.self, forKey: .applicationName) ?? "TestApp"
+        bundleIdentifier = try container.decodeIfPresent(String.self, forKey: .bundleIdentifier)
+            ?? "com.example.TestApp"
+        precedingText = try container.decode(String.self, forKey: .precedingText)
+        trailingText = try container.decodeIfPresent(String.self, forKey: .trailingText) ?? ""
+        isMultiLineEnabled = try container.decodeIfPresent(Bool.self, forKey: .isMultiLineEnabled) ?? true
+        expectation = try container.decode(LlamaEvalExpectation.self, forKey: .expectation)
+    }
+
+    init(
+        id: String,
+        tags: [String],
+        applicationName: String = "TestApp",
+        bundleIdentifier: String = "com.example.TestApp",
+        precedingText: String,
+        trailingText: String = "",
+        isMultiLineEnabled: Bool = true,
+        expectation: LlamaEvalExpectation
+    ) {
+        self.id = id
+        self.tags = tags
+        self.applicationName = applicationName
+        self.bundleIdentifier = bundleIdentifier
+        self.precedingText = precedingText
+        self.trailingText = trailingText
+        self.isMultiLineEnabled = isMultiLineEnabled
+        self.expectation = expectation
+    }
+
+    static func loadDataset(from url: URL) throws -> [LlamaEvalCase] {
+        let data = try Data(contentsOf: url)
+        return try JSONDecoder().decode([LlamaEvalCase].self, from: data)
+    }
+}
+
+enum LlamaEvalOutcome: String, CaseIterable {
+    case correctInsert
+    case correctSuppression
+    case acceptableSuppression
+    case wrongShown
+    case missedShow
+
+    var score: Double {
+        switch self {
+        case .correctInsert, .correctSuppression: return 1.0
+        case .acceptableSuppression: return 0.3
+        case .wrongShown, .missedShow: return 0.0
+        }
+    }
+}
+
+enum LlamaEvalScorer {
+    /// `shownText` is the final visible suggestion after the full production pipeline, or nil when
+    /// it was suppressed anywhere along it.
+    static func outcome(shownText: String?, for evalCase: LlamaEvalCase) -> LlamaEvalOutcome {
+        switch evalCase.expectation.kind {
+        case .positive:
+            guard let shown = shownText, !shown.isEmpty else {
+                return evalCase.expectation.mustShow ? .missedShow : .acceptableSuppression
+            }
+            return matches(shown: shown, acceptable: evalCase.expectation.acceptable)
+                ? .correctInsert
+                : .wrongShown
+        case .negative:
+            return shownText == nil ? .correctSuppression : .wrongShown
+        case .forbidden:
+            guard let shown = shownText else { return .correctSuppression }
+            let lowered = shown.lowercased()
+            let violates = evalCase.expectation.forbidden.contains { lowered.contains($0.lowercased()) }
+            return violates ? .wrongShown : .correctInsert
+        }
+    }
+
+    /// Word-boundary prefix match in either direction: the shown text may extend a reference
+    /// continuation or stop early inside one, but the words it does show must be the reference's
+    /// words. Case-folded; punctuation folded out of each word; whitespace collapsed. When both
+    /// sides collapse to a single folded "word" (single English words, or space-free scripts like
+    /// CJK where the whole clause is one run), single ASCII words must match exactly and CJK runs
+    /// match on a character prefix.
+    static func matches(shown: String, acceptable: [String]) -> Bool {
+        acceptable.contains { reference in
+            let shownWords = foldedWords(shown)
+            let referenceWords = foldedWords(reference)
+            guard let firstShown = shownWords.first, let firstReference = referenceWords.first else {
+                return false
+            }
+
+            if shownWords.count == 1, referenceWords.count == 1 {
+                let bothASCII = firstShown.allSatisfy(\.isASCII) && firstReference.allSatisfy(\.isASCII)
+                return bothASCII ? firstShown == firstReference : characterPrefixMatch(shown, reference)
+            }
+
+            let overlap = min(shownWords.count, referenceWords.count)
+            return Array(shownWords.prefix(overlap)) == Array(referenceWords.prefix(overlap))
+        }
+    }
+
+    private static func foldedWords(_ text: String) -> [String] {
+        text.lowercased()
+            .split(whereSeparator: { $0.isWhitespace })
+            .map { word in String(word.filter { $0.isLetter || $0.isNumber }) }
+            .filter { !$0.isEmpty }
+    }
+
+    private static func foldedCharacters(_ text: String) -> [Character] {
+        Array(text.lowercased().filter { !$0.isWhitespace })
+    }
+
+    private static func characterPrefixMatch(_ first: String, _ second: String) -> Bool {
+        let firstFolded = foldedCharacters(first)
+        let secondFolded = foldedCharacters(second)
+        let overlap = min(firstFolded.count, secondFolded.count)
+        guard overlap >= 2 else { return false }
+        return Array(firstFolded.prefix(overlap)) == Array(secondFolded.prefix(overlap))
+    }
+}
+
+/// One executed case, ready for aggregation.
+struct LlamaEvalCaseResult {
+    let evalCase: LlamaEvalCase
+    let shownText: String?
+    let rawText: String
+    let outcome: LlamaEvalOutcome
+    let suppressionStage: String?
+    let latencySeconds: Double
+}
+
+struct LlamaEvalReport {
+    let modelLabel: String
+    let results: [LlamaEvalCaseResult]
+
+    var qualityScore: Double {
+        guard !results.isEmpty else { return 0 }
+        return results.map(\.outcome.score).reduce(0, +) / Double(results.count)
+    }
+
+    var shownCount: Int { results.filter { $0.shownText != nil }.count }
+
+    var precisionWhenShown: Double {
+        let shown = results.filter { $0.shownText != nil }
+        guard !shown.isEmpty else { return 0 }
+        let correct = shown.filter { $0.outcome == .correctInsert }.count
+        return Double(correct) / Double(shown.count)
+    }
+
+    var wrongShowRate: Double {
+        guard !results.isEmpty else { return 0 }
+        return Double(results.filter { $0.outcome == .wrongShown }.count) / Double(results.count)
+    }
+
+    var positiveCoverage: Double {
+        let positives = results.filter { $0.evalCase.expectation.kind == .positive }
+        guard !positives.isEmpty else { return 0 }
+        let shown = positives.filter { $0.shownText != nil }.count
+        return Double(shown) / Double(positives.count)
+    }
+
+    func latencyPercentile(_ percentile: Double) -> Double {
+        let sorted = results.map(\.latencySeconds).sorted()
+        guard !sorted.isEmpty else { return 0 }
+        let rank = Int((Double(sorted.count - 1) * percentile).rounded())
+        return sorted[rank]
+    }
+
+    func rendered() -> String {
+        var lines: [String] = []
+        lines.append("=== Llama suggestion eval: \(modelLabel) — \(results.count) cases ===")
+        lines.append(String(
+            format: "qualityScore %.3f | precisionWhenShown %.3f | positiveCoverage %.3f | wrongShowRate %.3f | shown %d/%d",
+            qualityScore, precisionWhenShown, positiveCoverage, wrongShowRate, shownCount, results.count
+        ))
+        lines.append(String(
+            format: "latency p50 %.0fms p95 %.0fms max %.0fms",
+            latencyPercentile(0.5) * 1000, latencyPercentile(0.95) * 1000, latencyPercentile(1.0) * 1000
+        ))
+
+        var outcomeCounts: [LlamaEvalOutcome: Int] = [:]
+        for result in results { outcomeCounts[result.outcome, default: 0] += 1 }
+        let outcomeSummary = LlamaEvalOutcome.allCases
+            .compactMap { outcome -> String? in
+                guard let count = outcomeCounts[outcome] else { return nil }
+                return "\(outcome.rawValue) \(count)"
+            }
+            .joined(separator: " | ")
+        lines.append("outcomes: \(outcomeSummary)")
+
+        let allTags = Set(results.flatMap { $0.evalCase.tags }).sorted()
+        for tag in allTags {
+            let tagged = results.filter { $0.evalCase.tags.contains(tag) }
+            let score = tagged.map(\.outcome.score).reduce(0, +) / Double(tagged.count)
+            let wrong = tagged.filter { $0.outcome == .wrongShown }.count
+            lines.append(String(
+                format: "  [%@] n=%d score %.3f wrongShown %d",
+                tag, tagged.count, score, wrong
+            ))
+        }
+
+        for result in results where result.outcome == .wrongShown || result.outcome == .missedShow {
+            let shownPreview = (result.shownText ?? "<suppressed>").prefix(80)
+            lines.append("  !! \(result.outcome.rawValue) \(result.evalCase.id): \"\(shownPreview)\"")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    /// Machine-readable artifact for diffing runs across branches.
+    func jsonArtifact() throws -> Data {
+        var payload: [String: Any] = [
+            "model": modelLabel,
+            "caseCount": results.count,
+            "qualityScore": qualityScore,
+            "precisionWhenShown": precisionWhenShown,
+            "positiveCoverage": positiveCoverage,
+            "wrongShowRate": wrongShowRate,
+            "latencyP50Ms": latencyPercentile(0.5) * 1000,
+            "latencyP95Ms": latencyPercentile(0.95) * 1000
+        ]
+        payload["cases"] = results.map { result -> [String: Any] in
+            [
+                "id": result.evalCase.id,
+                "outcome": result.outcome.rawValue,
+                "shown": result.shownText ?? NSNull(),
+                "raw": result.rawText,
+                "suppressionStage": result.suppressionStage ?? NSNull(),
+                "latencyMs": result.latencySeconds * 1000
+            ]
+        }
+        return try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
+    }
+}

--- a/CotabbyTests/LlamaEvalScoringTests.swift
+++ b/CotabbyTests/LlamaEvalScoringTests.swift
@@ -1,0 +1,179 @@
+import XCTest
+@testable import Cotabby
+
+/// CI-runnable coverage for the eval's pure scoring layer (no model needed): the matcher rules,
+/// the outcome taxonomy, and the dataset's structural invariants. Loading the dataset here also
+/// proves the JSON resource actually ships in the test bundle, so the gated model run cannot
+/// silently skip because of a packaging regression.
+final class LlamaEvalScoringTests: XCTestCase {
+    // MARK: - Matcher
+
+    func testShownExtendingReferenceMatches() {
+        XCTAssertTrue(LlamaEvalScorer.matches(shown: "revised proposal by Friday", acceptable: ["revised proposal"]))
+    }
+
+    func testShownStoppingEarlyInsideReferenceMatches() {
+        XCTAssertTrue(LlamaEvalScorer.matches(shown: "revised", acceptable: ["revised proposal"]))
+    }
+
+    func testDifferentFirstWordDoesNotMatch() {
+        XCTAssertFalse(LlamaEvalScorer.matches(shown: "the proposal", acceptable: ["revised proposal"]))
+    }
+
+    func testCaseAndPunctuationAreFolded() {
+        XCTAssertTrue(LlamaEvalScorer.matches(shown: "Revised Proposal.", acceptable: ["revised proposal"]))
+    }
+
+    func testWhitespaceIsCollapsed() {
+        XCTAssertTrue(LlamaEvalScorer.matches(shown: "revised   proposal", acceptable: ["revised proposal"]))
+    }
+
+    func testSingleASCIIWordsRequireExactEquality() {
+        XCTAssertTrue(LlamaEvalScorer.matches(shown: "regards", acceptable: ["regards"]))
+        XCTAssertFalse(LlamaEvalScorer.matches(shown: "regard", acceptable: ["regards"]))
+    }
+
+    func testCJKMatchesOnCharacterPrefix() {
+        XCTAssertTrue(LlamaEvalScorer.matches(shown: "散歩に行きたい", acceptable: ["散歩"]))
+        XCTAssertFalse(LlamaEvalScorer.matches(shown: "映画を見たい", acceptable: ["散歩"]))
+    }
+
+    func testAnyAcceptableCanMatch() {
+        XCTAssertTrue(LlamaEvalScorer.matches(shown: "Thursday works", acceptable: ["Wednesday", "Thursday"]))
+    }
+
+    func testEmptyShownNeverMatches() {
+        XCTAssertFalse(LlamaEvalScorer.matches(shown: "  ", acceptable: ["anything"]))
+    }
+
+    // MARK: - Outcomes
+
+    private func positiveCase(mustShow: Bool = false, acceptable: [String] = ["next steps"]) -> LlamaEvalCase {
+        LlamaEvalCase(
+            id: "p", tags: ["t"], precedingText: "send the ",
+            expectation: .init(kind: .positive, mustShow: mustShow, acceptable: acceptable)
+        )
+    }
+
+    func testPositiveShownMatchingIsCorrectInsert() {
+        XCTAssertEqual(
+            LlamaEvalScorer.outcome(shownText: "next steps soon", for: positiveCase()),
+            .correctInsert
+        )
+    }
+
+    func testPositiveShownMismatchIsWrongShown() {
+        XCTAssertEqual(
+            LlamaEvalScorer.outcome(shownText: "elephants dancing", for: positiveCase()),
+            .wrongShown
+        )
+    }
+
+    func testPositiveSuppressedIsAcceptableSuppression() {
+        XCTAssertEqual(LlamaEvalScorer.outcome(shownText: nil, for: positiveCase()), .acceptableSuppression)
+    }
+
+    func testMustShowSuppressedIsMissedShow() {
+        XCTAssertEqual(
+            LlamaEvalScorer.outcome(shownText: nil, for: positiveCase(mustShow: true)),
+            .missedShow
+        )
+    }
+
+    func testNegativeSuppressedIsCorrectSuppression() {
+        let negative = LlamaEvalCase(
+            id: "n", tags: ["t"], precedingText: "asdf ",
+            expectation: .init(kind: .negative, reason: "gibberish")
+        )
+        XCTAssertEqual(LlamaEvalScorer.outcome(shownText: nil, for: negative), .correctSuppression)
+        XCTAssertEqual(LlamaEvalScorer.outcome(shownText: "anything", for: negative), .wrongShown)
+    }
+
+    func testForbiddenJudgesOnlyTheForbiddenSubstrings() {
+        let forbidden = LlamaEvalCase(
+            id: "f", tags: ["t"], precedingText: "notes ",
+            expectation: .init(kind: .forbidden, forbidden: ["<|im_end|>"])
+        )
+        XCTAssertEqual(LlamaEvalScorer.outcome(shownText: "ten seconds", for: forbidden), .correctInsert)
+        XCTAssertEqual(LlamaEvalScorer.outcome(shownText: "ok<|im_end|>", for: forbidden), .wrongShown)
+        XCTAssertEqual(LlamaEvalScorer.outcome(shownText: nil, for: forbidden), .correctSuppression)
+    }
+
+    func testScoresMatchTheNonNegativeTaxonomy() {
+        XCTAssertEqual(LlamaEvalOutcome.correctInsert.score, 1.0)
+        XCTAssertEqual(LlamaEvalOutcome.correctSuppression.score, 1.0)
+        XCTAssertEqual(LlamaEvalOutcome.acceptableSuppression.score, 0.3)
+        XCTAssertEqual(LlamaEvalOutcome.wrongShown.score, 0.0)
+        XCTAssertEqual(LlamaEvalOutcome.missedShow.score, 0.0)
+    }
+
+    // MARK: - Dataset invariants
+
+    private func loadDataset() throws -> [LlamaEvalCase] {
+        let url = try XCTUnwrap(
+            Bundle(for: LlamaEvalScoringTests.self)
+                .url(forResource: "llama-eval-cases", withExtension: "json"),
+            "llama-eval-cases.json must ship in the test bundle"
+        )
+        return try LlamaEvalCase.loadDataset(from: url)
+    }
+
+    func testDatasetLoadsAndHasUniqueIDs() throws {
+        let cases = try loadDataset()
+        XCTAssertGreaterThanOrEqual(cases.count, 100)
+        XCTAssertEqual(Set(cases.map(\.id)).count, cases.count, "case ids must be unique")
+    }
+
+    func testDatasetExpectationsAreWellFormed() throws {
+        for evalCase in try loadDataset() {
+            XCTAssertFalse(evalCase.tags.isEmpty, "\(evalCase.id) has no tags")
+            switch evalCase.expectation.kind {
+            case .positive:
+                XCTAssertFalse(
+                    evalCase.expectation.acceptable.isEmpty,
+                    "\(evalCase.id) is positive but lists no acceptable continuations"
+                )
+            case .negative:
+                XCTAssertNotNil(evalCase.expectation.reason, "\(evalCase.id) negative needs a reason")
+            case .forbidden:
+                XCTAssertFalse(
+                    evalCase.expectation.forbidden.isEmpty,
+                    "\(evalCase.id) is forbidden-kind but lists no forbidden substrings"
+                )
+            }
+        }
+    }
+
+    func testDatasetCoversTheCoreTags() throws {
+        let tags = Set(try loadDataset().flatMap(\.tags))
+        for required in ["email", "chat", "prose", "code", "cjk", "midword", "negative", "scaffolding"] {
+            XCTAssertTrue(tags.contains(required), "dataset lost its \(required) coverage")
+        }
+    }
+
+    // MARK: - Report aggregation
+
+    func testReportMetrics() {
+        let shown = LlamaEvalCaseResult(
+            evalCase: positiveCase(), shownText: "next steps", rawText: "next steps",
+            outcome: .correctInsert, suppressionStage: nil, latencySeconds: 0.1
+        )
+        let wrong = LlamaEvalCaseResult(
+            evalCase: positiveCase(), shownText: "garbage", rawText: "garbage",
+            outcome: .wrongShown, suppressionStage: nil, latencySeconds: 0.3
+        )
+        let suppressed = LlamaEvalCaseResult(
+            evalCase: positiveCase(), shownText: nil, rawText: "",
+            outcome: .acceptableSuppression, suppressionStage: "normalizer", latencySeconds: 0.2
+        )
+        let report = LlamaEvalReport(modelLabel: "test", results: [shown, wrong, suppressed])
+
+        XCTAssertEqual(report.shownCount, 2)
+        XCTAssertEqual(report.precisionWhenShown, 0.5, accuracy: 0.0001)
+        XCTAssertEqual(report.wrongShowRate, 1.0 / 3.0, accuracy: 0.0001)
+        XCTAssertEqual(report.positiveCoverage, 2.0 / 3.0, accuracy: 0.0001)
+        XCTAssertEqual(report.qualityScore, (1.0 + 0.0 + 0.3) / 3.0, accuracy: 0.0001)
+        XCTAssertEqual(report.latencyPercentile(0.5), 0.2, accuracy: 0.0001)
+        XCTAssertFalse(report.rendered().isEmpty)
+    }
+}

--- a/CotabbyTests/LlamaSuggestionEvalTests.swift
+++ b/CotabbyTests/LlamaSuggestionEvalTests.swift
@@ -1,0 +1,175 @@
+import XCTest
+@testable import Cotabby
+
+/// Dataset-driven eval for the llama suggestion path. Runs the production pipeline per case —
+/// request factory → base prompt renderer → llama engine (real model) → normalizer → display
+/// guards — and scores the FINAL visible suggestion, so prompt, decode, filter, and suppression
+/// changes are measured by what the user would actually see.
+///
+/// Local-only by design (mirrors `FoundationModelDriftEvalTests`): xcodebuild does not forward
+/// shell environment variables into the macOS test host, so the switch is a compile flag, and the
+/// model is a multi-GB local download. Run with:
+///
+///   xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
+///     -only-testing:CotabbyTests/LlamaSuggestionEvalTests \
+///     SWIFT_ACTIVE_COMPILATION_CONDITIONS='$(inherited) RUN_LLAMA_EVAL' \
+///     CODE_SIGNING_ALLOWED=NO -derivedDataPath build/DerivedData
+///
+/// Add `-configuration Release ENABLE_TESTABILITY=YES` when quoting latency numbers: Debug
+/// inflates the Swift-side per-token work by an order of magnitude and is only meaningful for
+/// correctness (testability must be forced on because Release builds disable it, and this file
+/// `@testable import`s the app).
+///
+/// The model comes from the app's own runtime directory (`~/Library/Application Support/Cotabby/
+/// LlamaRuntime/`, resolved through `BundledRuntimeLocator` because the test host IS Cotabby.app),
+/// so whichever catalog model the app would load is what gets measured. The suite skips with a
+/// hint when no model is downloaded.
+///
+/// Scoring is non-negative (correct suppression scores like a correct insert) so "suppress
+/// everything" cannot win, and `precisionWhenShown` is a relative metric: the acceptable lists
+/// are not exhaustive, so absolute values matter less than deltas across branches on this fixed
+/// dataset. A JSON artifact is written to `build/eval/` (gitignored) for diffing runs.
+@MainActor
+final class LlamaSuggestionEvalTests: XCTestCase {
+    func test_reportEvalSuite() async throws {
+        #if RUN_LLAMA_EVAL
+        let manager = LlamaRuntimeManager()
+        do {
+            try await manager.prepare()
+        } catch {
+            throw XCTSkip(
+                "No llama runtime available (\(error)). Download a model in the app first; " +
+                "the eval loads it from ~/Library/Application Support/Cotabby/LlamaRuntime/."
+            )
+        }
+        let engine = LlamaSuggestionEngine(runtimeManager: manager)
+        let spellChecker = CurrentWordSpellChecker()
+        let cases = try Self.loadCases()
+
+        var results: [LlamaEvalCaseResult] = []
+        for evalCase in cases {
+            let result = try await Self.runCase(
+                evalCase,
+                engine: engine,
+                spellChecker: spellChecker
+            )
+            results.append(result)
+        }
+
+        let report = LlamaEvalReport(modelLabel: Self.modelLabel(), results: results)
+        print(report.rendered())
+        try Self.writeArtifact(report)
+
+        XCTAssertFalse(results.isEmpty)
+        #else
+        throw XCTSkip(
+            "Llama eval is disabled. Pass SWIFT_ACTIVE_COMPILATION_CONDITIONS='$(inherited) RUN_LLAMA_EVAL'."
+        )
+        #endif
+    }
+
+    #if RUN_LLAMA_EVAL
+    /// One case through the production pipeline. `shownText` is nil wherever the pipeline would
+    /// have shown nothing: the pre-generation gate, the normalizer (empty result), the
+    /// trailing-duplication check inside the normalizer, or the display-time seam guard.
+    private static func runCase(
+        _ evalCase: LlamaEvalCase,
+        engine: LlamaSuggestionEngine,
+        spellChecker: CurrentWordSpellChecker
+    ) async throws -> LlamaEvalCaseResult {
+        // Mirrors the coordinator's pre-generation gate.
+        guard SuggestionRequestFactory.shouldGenerateSuggestion(for: evalCase.precedingText) else {
+            return LlamaEvalCaseResult(
+                evalCase: evalCase,
+                shownText: nil,
+                rawText: "",
+                outcome: LlamaEvalScorer.outcome(shownText: nil, for: evalCase),
+                suppressionStage: "pre-generation-gate",
+                latencySeconds: 0
+            )
+        }
+
+        let context = CotabbyTestFixtures.focusedInputContext(
+            applicationName: evalCase.applicationName,
+            bundleIdentifier: evalCase.bundleIdentifier,
+            precedingText: evalCase.precedingText,
+            trailingText: evalCase.trailingText
+        )
+        let settings = CotabbyTestFixtures.settingsSnapshot(
+            selectedEngine: .llamaOpenSource,
+            selectedWordCountPreset: .twelveToTwenty,
+            isClipboardContextEnabled: false,
+            isMultiLineEnabled: evalCase.isMultiLineEnabled
+        )
+        let request = SuggestionRequestFactory.buildRequest(
+            context: context,
+            settings: settings,
+            configuration: .standard
+        ).request
+
+        let start = Date()
+        let result = try await engine.generateSuggestion(for: request)
+        let latency = Date().timeIntervalSince(start)
+
+        var shownText: String? = result.text.isEmpty ? nil : result.text
+        var suppressionStage: String? = result.text.isEmpty ? "normalizer" : nil
+
+        // Mirrors the coordinator's display-time seam guard.
+        if let candidate = shownText {
+            let verdict = CompletionSeamGuard.verdict(
+                precedingText: evalCase.precedingText,
+                completion: candidate,
+                isKnownWord: { !spellChecker.isTypo($0) }
+            )
+            if verdict != .allow {
+                shownText = nil
+                suppressionStage = "seam-guard"
+            }
+        }
+
+        return LlamaEvalCaseResult(
+            evalCase: evalCase,
+            shownText: shownText,
+            rawText: result.rawText,
+            outcome: LlamaEvalScorer.outcome(shownText: shownText, for: evalCase),
+            suppressionStage: suppressionStage,
+            latencySeconds: latency
+        )
+    }
+
+    private static func loadCases() throws -> [LlamaEvalCase] {
+        guard let url = Bundle(for: LlamaSuggestionEvalTests.self)
+            .url(forResource: "llama-eval-cases", withExtension: "json") else {
+            throw XCTSkip("llama-eval-cases.json missing from the test bundle")
+        }
+        return try LlamaEvalCase.loadDataset(from: url)
+    }
+
+    /// The model file the runtime locator would pick, for the report header. Mirrors the
+    /// preferred-name-first resolution without reaching into the manager's internals.
+    private static func modelLabel() -> String {
+        let directory = BundledRuntimeLocator.userRuntimeDirectoryURL()
+        let discovered = BundledRuntimeLocator.discoverGGUFModelURLs(in: directory)
+            .map(\.lastPathComponent)
+        for preferred in LlamaRuntimeConfiguration.default.preferredModelNames
+        where discovered.contains(preferred) {
+            return preferred
+        }
+        return discovered.first ?? "unknown-model"
+    }
+
+    /// Repo-relative artifact path derived from this source file so the output lands in the
+    /// gitignored build/ directory regardless of the test process working directory.
+    private static func writeArtifact(_ report: LlamaEvalReport) throws {
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let directory = repoRoot.appendingPathComponent("build/eval", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let stem = report.modelLabel.replacingOccurrences(of: ".gguf", with: "")
+        let url = directory.appendingPathComponent("llama-eval-\(stem).json")
+        try report.jsonArtifact().write(to: url)
+        print("Eval artifact written to \(url.path)")
+    }
+    #endif
+}


### PR DESCRIPTION
## Summary

Three quality foundations for the llama suggestion path, shipped together so the measurement loop and the first guards it validates land with before/after numbers in one place:

1. **Eval harness** (`LlamaSuggestionEvalTests`, local-only): 114 hand-authored cases (email, chat, prose, code, Japanese/Chinese, mid-word, plus negative and scaffolding-bait kinds) run through the production pipeline end to end (request factory → base prompt renderer → real llama engine → normalizer → display guards) and score the **final visible suggestion** with non-negative scoring, so neither show-everything nor suppress-everything can win. Compile-flag gated (`RUN_LLAMA_EVAL`) like the FM drift eval; the pure scoring layer (`LlamaEvalScoringTests`, 20 tests) runs in CI without a model and proves the dataset ships in the test bundle. A JSON artifact lands in gitignored `build/eval/` for diffing runs across branches.
2. **Decode-time scaffolding stop**: `DecodeStopPolicy` now also stops the moment the accumulated text contains a chat-template stop marker (`<|im_end|>` etc., single-sourced from `ControlTokenMarkers`). The normalizer already truncates at the first marker, so visible text is identical; the win is skipping the rest of the token budget exactly when the model has drifted into scaffolding (worst-case latency tail).
3. **Caret-seam guard** (`CompletionSeamGuard`, display-time): suppresses fresh junk punctuation runs (`....`, `$$$$`) and mid-word splices whose joined word the spell checker does not know ("gre" + "atful"). Narrow by design: capitalized joins (names/brands), short joins, digits, and CJK are exempt, and extending a divider the user already typed is allowed.

## Validation

```
xcodebuild build-for-testing -scheme Cotabby -destination 'platform=macOS' \
  -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
# ** TEST BUILD SUCCEEDED ** (no new warnings)

xcodebuild test-without-building \
  -only-testing:CotabbyTests/DecodeStopPolicyTests \
  -only-testing:CotabbyTests/CompletionSeamGuardTests \
  -only-testing:CotabbyTests/LlamaEvalScoringTests \
  -only-testing:CotabbyTests/SuggestionTextNormalizerTests ...
# Executed 72 tests, with 0 failures

swiftlint lint --quiet <changed files>   # exit 0
xcodegen generate                        # pbxproj diff is additions only (new file refs)
```

**Eval baseline on this branch** (Gemma E2B Q6_K, Release config + ENABLE_TESTABILITY, fixed seed; quality metrics identical in Debug, confirming end-to-end determinism):

```
qualityScore 0.742 | precisionWhenShown 0.786 | positiveCoverage 0.872 | wrongShowRate 0.184
latency p50 171ms | p95 1041ms | max 1377ms   (114 cases, shown 98)
```

The seam guard converted 12 of 14 mid-word cases from visible misspelled splices ("definately", "tomorow", "availble", "experince") into suppressions, with zero false positives across the other 100 cases. Weakest tags are gibberish-prefix (0.00) and duplicate-after-caret (0.25): those are decode-confidence problems this eval now measures, addressed in follow-up work. Acceptable-continuation lists were calibrated once against a first scoring pass before freezing the baseline; `precisionWhenShown` is a relative metric for diffing branches on this fixed dataset, not absolute truth.

## Linked issues

Refs #546, #660 (gives suggestion-quality reports a measurable harness).

## Risk / rollout notes

- The eval suite is skip-by-default everywhere (compile flag + model presence check); CI never runs the model.
- The decode stop changes no visible text by construction (normalizer already truncated at markers); only the `stop_reason` log value can newly read `scaffolding_marker`.
- The seam guard is the one behavior change: it suppresses (shows nothing) where the app previously showed junk or a misspelling-splice. Both rules log `seam-suppressed` with the verdict, so any false positive is directly diagnosable from the JSONL stream. Spell lookup runs at most once per generation, main-actor, microseconds (NSSpellChecker-backed, same checker the typo feature uses).
- New files only need the regenerated pbxproj (committed); no project.yml change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ships three quality foundations for the llama suggestion path: a 114-case eval harness (compile-flag-gated, local-only), a decode-time scaffolding-marker stop in `DecodeStopPolicy`, and a new `CompletionSeamGuard` that suppresses junk punctuation runs and mid-word misspelled splices at display time.

- **Eval harness** (`LlamaEvalScoring`, `LlamaSuggestionEvalTests`): runs the full production pipeline end-to-end per case and scores the final visible suggestion with non-negative scoring; the pure scoring layer runs in CI without a model, and a JSON artifact lands in `build/eval/` for branch-to-branch diffing.
- **Scaffolding-marker stop** (`DecodeStopPolicy.verdict`): stops decode the moment a chat-template stop token appears in the accumulated text, bypassing the minimum-token guard; produces identical visible output since the normalizer already truncates at the first marker, but skips the wasted tail of the token budget.
- **Caret-seam guard** (`CompletionSeamGuard`): suppresses fresh junk punctuation runs (≥4 identical punct/symbol chars) and mid-word splices whose joined word is unknown to the spell checker; wired into both the streaming-partial path (junk-run rule only) and the final display path (full verdict with spell lookup).

<h3>Confidence Score: 5/5</h3>

Safe to merge; the scaffolding stop changes no visible output and the seam guard's only behavior change (suppression of junk/misspelled completions) is directly diagnosable from the JSONL log.

All three changes are narrowly scoped: the decode stop produces identical visible text by construction, the seam guard is guarded by well-tested exemption rules and logs every suppression, and the eval harness is compile-flag-gated and never runs in CI. The one correctness note (single-char CJK scoring in the eval layer) affects measurement accuracy only, not product behavior.

LlamaEvalScoring.swift — the characterPrefixMatch overlap guard silently misevaluates single-character CJK exact matches.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/CompletionSeamGuard.swift | New display-time guard suppressing junk punctuation runs (≥4 identical punct/symbol chars) and mid-word seam misspellings; exemptions for capitalized joins, short joins, digits, and CJK are correctly implemented. The run-extension exemption now requires a preceding run of ≥2 chars, addressing the single-char loophole from earlier review. |
| Cotabby/Support/DecodeStopPolicy.swift | Refactored from a bool-returning shouldStop to a verdict-returning enum; adds scaffolding-marker stop (checked before the minimum-token guard) and preserves the sentence-boundary stop. Backward-compat shouldStop wrapper delegates to verdict correctly. |
| Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift | Wires CompletionSeamGuard into both the streaming-partial path (junk-run rule only, no spell XPC) and the final display path (full verdict). Silent early-return on streaming suppression is intentional — the final authoritative verdict clears or suppresses whatever streamed. |
| CotabbyTests/LlamaEvalScoring.swift | Pure scoring layer (no XCTest, no model). latencyMaxMs is present in the JSON artifact. One subtle issue: characterPrefixMatch returns false for single-character exact CJK matches due to the overlap >= 2 guard. |
| CotabbyTests/LlamaSuggestionEvalTests.swift | Compile-flag-gated eval harness; mirrors coordinator pre-generation gate and display-time seam guard faithfully. XCTSkip paths prevent CI breakage when model is absent or flag is not set. |
| CotabbyTests/LlamaEvalScoringTests.swift | 20 CI-runnable tests covering matcher rules, outcome taxonomy, dataset structural invariants, and report aggregation. Dataset loading proves JSON resource ships in the test bundle. |
| CotabbyTests/CompletionSeamGuardTests.swift | Comprehensive allow/suppress test matrix for both junk-run and seam-misspelling rules; covers single-char divider non-exemption, CJK, capitalized joins, digit adjacency, and streaming-partial variant. |
| CotabbyTests/DecodeStopPolicyTests.swift | Tests for sentence-boundary stop, scaffolding-marker stop (including below-minimum-token behaviour), split-token marker accumulation, and HTML false-positive avoidance. All existing sentence-boundary tests still pass through the shouldStop wrapper. |
| CotabbyTests/Fixtures/llama-eval-cases.json | 114 hand-authored eval cases spanning email, chat, prose, code, CJK, mid-word, negative, and scaffolding-bait categories; unique IDs and structural invariants verified by LlamaEvalScoringTests in CI. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Token decoded] --> B[Append to accumulated text]
    B --> C{DecodeStopPolicy.verdict}
    C -->|containsScaffoldingStopMarker| D[stop_reason: scaffolding_marker]
    C -->|tokensGenerated < minimumTokens| E[Continue decoding]
    C -->|endsSentence| F[stop_reason: sentence_boundary]
    C -->|else| E
    D --> G[Normalizer / ControlTokenMarkers.sanitize]
    F --> G
    G --> H[SuggestionCoordinator: streaming partial]
    H --> I{CompletionSeamGuard.allowsStreamedPartial}
    I -->|junk run detected| J[return — no session update]
    I -->|pass| K[interactionState.startSession — show partial]
    G --> L[SuggestionCoordinator: final result]
    L --> M{CompletionSeamGuard.verdict}
    M -->|junkPunctuationRun or seamMisspelling| N[clearSuggestion + log seam-suppressed]
    M -->|allow| O[Show suggestion overlay]
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22quality%2Feval-and-output-hygiene%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22quality%2Feval-and-output-hygiene%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabbyTests%2FLlamaEvalScoring.swift%3A188-194%0A**Single-char%20CJK%20match%20always%20returns%20false**%0A%0A%60guard%20overlap%20%3E%3D%202%20else%20%7B%20return%20false%20%7D%60%20means%20a%20model%20suggestion%20of%20exactly%20one%20CJK%20character%20%28e.g.%20%60%22%E7%9A%84%22%60%29%20against%20an%20acceptable%20reference%20of%20the%20same%20character%20will%20return%20%60false%60%2C%20scoring%20the%20case%20as%20%60wrongShown%60%20instead%20of%20%60correctInsert%60.%20CJK%20eval%20cases%20where%20the%20natural%20completion%20is%20a%20single%20character%20%28conjunctions%2C%20particles%2C%20classifiers%29%20will%20be%20permanently%20misscored%20against%20any%20single-character%20reference.%20A%20direct%20equality%20check%20when%20%60overlap%20%3D%3D%201%60%20avoids%20this%20without%20loosening%20the%20multi-character%20prefix%20requirement.%0A%0A&repo=fujacob%2Fcotabby&pr=683&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabbyTests%2FLlamaEvalScoring.swift%3A188-194%0A**Single-char%20CJK%20match%20always%20returns%20false**%0A%0A%60guard%20overlap%20%3E%3D%202%20else%20%7B%20return%20false%20%7D%60%20means%20a%20model%20suggestion%20of%20exactly%20one%20CJK%20character%20%28e.g.%20%60%22%E7%9A%84%22%60%29%20against%20an%20acceptable%20reference%20of%20the%20same%20character%20will%20return%20%60false%60%2C%20scoring%20the%20case%20as%20%60wrongShown%60%20instead%20of%20%60correctInsert%60.%20CJK%20eval%20cases%20where%20the%20natural%20completion%20is%20a%20single%20character%20%28conjunctions%2C%20particles%2C%20classifiers%29%20will%20be%20permanently%20misscored%20against%20any%20single-character%20reference.%20A%20direct%20equality%20check%20when%20%60overlap%20%3D%3D%201%60%20avoids%20this%20without%20loosening%20the%20multi-character%20prefix%20requirement.%0A%0A&repo=fujacob%2Fcotabby&pr=683&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["review: require a real preceding run for..."](https://github.com/fujacob/cotabby/commit/f06caebf0bef7697bb84c0ce0cbbd2b411d18c37) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37132529)</sub>

<!-- /greptile_comment -->