### PR TITLE
Eliminate all 68 Swift 6 forward-compat build warnings

### DIFF
--- a/Cotabby/Models/EmojiPickerModels.swift
+++ b/Cotabby/Models/EmojiPickerModels.swift
@@ -12,7 +12,7 @@ import Foundation
 ///
 /// `aliases` are the canonical `:name:` tokens a user types (for example `grinning`, `+1`), while
 /// `keywords` are looser synonyms used only to widen search recall.
-struct EmojiEntry: Equatable, Decodable {
+nonisolated struct EmojiEntry: Equatable, Decodable {
     let glyph: String
     let name: String
     let aliases: [String]
@@ -25,7 +25,7 @@ struct EmojiEntry: Equatable, Decodable {
 ///
 /// `id` is the glyph because the bundled dataset has one record per glyph, which keeps SwiftUI list
 /// identity stable as the query narrows.
-struct EmojiMatch: Equatable, Identifiable {
+nonisolated struct EmojiMatch: Equatable, Identifiable {
     let entry: EmojiEntry
 
     /// The glyph to display and insert. Defaults to `entry.glyph`; the variant resolver overrides it
@@ -117,14 +117,14 @@ struct EmojiVariantPreferences: Equatable, Sendable {
 // MARK: - Trigger state machine vocabulary
 
 /// Direction for moving the highlighted row while the picker is open.
-enum EmojiSelectionMove: Equatable {
+nonisolated enum EmojiSelectionMove: Equatable {
     case up
     case down
 }
 
 /// How a capture was committed. `.key` is a consumed Tab/Return; `.closingColon` is the
 /// passed-through second `:` of `:query:` (EMOJI.md Mode B).
-enum EmojiCommitMode: Equatable {
+nonisolated enum EmojiCommitMode: Equatable {
     case key
     case closingColon
 }
@@ -143,7 +143,7 @@ enum EmojiTriggerInput: Equatable {
 
 /// Side effects the controller performs after a transition. The machine itself stays pure; it only
 /// describes what should happen.
-enum EmojiTriggerAction: Equatable {
+nonisolated enum EmojiTriggerAction: Equatable {
     case open(query: String)
     case updateQuery(String)
     case moveSelection(EmojiSelectionMove)
@@ -153,7 +153,7 @@ enum EmojiTriggerAction: Equatable {
 
 /// The two lifecycle states. `idle` remembers the previously typed character so the trigger can
 /// require a word boundary (start of field or after whitespace) before opening a capture.
-enum EmojiTriggerState: Equatable {
+nonisolated enum EmojiTriggerState: Equatable {
     case idle(previousCharacter: Character?)
     case capturing(query: String)
 }

--- a/Cotabby/Models/EmojiUsageModels.swift
+++ b/Cotabby/Models/EmojiUsageModels.swift
@@ -8,7 +8,7 @@ import Foundation
 /// Usage is keyed by an emoji's primary alias (e.g. `joy`), not its glyph, so a concept's signal is
 /// stable across skin-tone and gender variants: using 👍🏽 still boosts the 👍 concept, and recents
 /// render in the user's current variant preference at display time.
-struct EmojiUsageSnapshot: Equatable, Sendable {
+nonisolated struct EmojiUsageSnapshot: Equatable, Sendable {
     /// Primary aliases of recently committed emoji, most recent first, de-duplicated.
     let recentAliases: [String]
     /// Primary alias -> number of times committed.

--- a/Cotabby/Models/FocusModels.swift
+++ b/Cotabby/Models/FocusModels.swift
@@ -10,7 +10,7 @@ import Foundation
 /// `elementIdentifier` is still useful because it describes the AX node we resolved, but it is not
 /// globally unique over time: macOS can recycle `CFHash` values after AX elements are destroyed.
 /// Pairing it with `focusChangeSequence` gives async consumers a stable "same focus event" key.
-struct FocusedInputIdentity: Equatable, Sendable {
+nonisolated struct FocusedInputIdentity: Equatable, Sendable {
     let elementIdentifier: String
     let focusChangeSequence: UInt64
 }

--- a/Cotabby/Models/HuggingFaceModels.swift
+++ b/Cotabby/Models/HuggingFaceModels.swift
@@ -4,7 +4,7 @@ import Foundation
 /// These are pure value types with no business logic beyond URL construction.
 
 /// One result from `GET /api/models?filter=gguf&search=...&sort=downloads`.
-struct HFModelSearchResult: Codable, Identifiable, Equatable {
+nonisolated struct HFModelSearchResult: Codable, Identifiable, Equatable {
     let id: String
     let modelId: String
     let downloads: Int

--- a/Cotabby/Models/SuggestionEngineModels.swift
+++ b/Cotabby/Models/SuggestionEngineModels.swift
@@ -58,7 +58,7 @@ enum PowerProfile: Equatable, Hashable {
 /// The bundle identifier is the durable identity used by the suggestion pipeline. The display name
 /// is saved only so Settings can show a readable list without having to resolve installed
 /// applications again on every launch.
-struct DisabledApplicationRule: Codable, Equatable, Identifiable, Sendable {
+nonisolated struct DisabledApplicationRule: Codable, Equatable, Identifiable, Sendable {
     let bundleIdentifier: String
     let displayName: String
 

--- a/Cotabby/Models/SystemMetricsStore.swift
+++ b/Cotabby/Models/SystemMetricsStore.swift
@@ -22,7 +22,7 @@ final class SystemMetricsStore: ObservableObject {
     /// Number of samples retained. At the default one-second cadence this is a rolling 60-second
     /// window, which is enough to watch a generation spike rise and fall without unbounded growth.
     static let maximumSamples = 60
-    static let defaultInterval: TimeInterval = 1.0
+    nonisolated static let defaultInterval: TimeInterval = 1.0
 
     @Published private(set) var samples: [SystemMetricSample] = []
 

--- a/Cotabby/Models/VisualContextModels.swift
+++ b/Cotabby/Models/VisualContextModels.swift
@@ -10,7 +10,7 @@ import Foundation
 /// Tunables for converting a focused-input screenshot into OCR text for prompt injection.
 /// These values are intentionally separate from `SuggestionConfiguration` because they govern
 /// screenshot capture and OCR, not normal text completion behavior.
-struct VisualContextConfiguration: Equatable, Sendable {
+nonisolated struct VisualContextConfiguration: Equatable, Sendable {
     let snapshotDimension: Int
     let maxImageDimension: Int
     let minRecognizedCharacterCount: Int

--- a/Cotabby/Services/Input/KeyboardInputSourceMonitor.swift
+++ b/Cotabby/Services/Input/KeyboardInputSourceMonitor.swift
@@ -34,7 +34,10 @@ final class KeyboardInputSourceMonitor {
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            self?.handleInputSourceChanged()
+            // Same main-queue delivery contract as above; assumeIsolated makes it checkable.
+            MainActor.assumeIsolated {
+                self?.handleInputSourceChanged()
+            }
         }
     }
 

--- a/Cotabby/Services/Power/PowerSourceMonitor.swift
+++ b/Cotabby/Services/Power/PowerSourceMonitor.swift
@@ -26,7 +26,11 @@ final class PowerSourceMonitor: ObservableObject {
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            self?.refreshPowerState()
+            // Delivered on the main queue (see `queue:` above), so entering the main actor is an
+            // assertion, not a hop; a queue change would trap here rather than corrupt state.
+            MainActor.assumeIsolated {
+                self?.refreshPowerState()
+            }
         }
     }
 

--- a/Cotabby/Support/ConfidenceSuppressionPolicy.swift
+++ b/Cotabby/Support/ConfidenceSuppressionPolicy.swift
@@ -10,7 +10,7 @@ import Foundation
 /// instead of showing a confident-looking guess. The policy is pure and isolated so the threshold
 /// is easy to test and tune. A floor of negative infinity (the default) disables suppression, so
 /// this is a no-op until a caller opts in by raising the floor.
-enum ConfidenceSuppressionPolicy {
+nonisolated enum ConfidenceSuppressionPolicy {
     /// Suppress when the completion's average per-token log-probability is below `floor`.
     static func shouldSuppress(averageLogprob: Double, floor: Double) -> Bool {
         guard floor > -.infinity else {

--- a/Cotabby/Support/CotabbyDebugOptions.swift
+++ b/Cotabby/Support/CotabbyDebugOptions.swift
@@ -9,7 +9,7 @@ import os
 /// privacy-sensitive diagnostic path has one obvious gate. Passing `-cotabby-debug` means the
 /// developer intentionally opted into local debugging artifacts such as overlays, detailed service
 /// logs, and screenshot/OCR captures.
-enum CotabbyDebugOptions {
+nonisolated enum CotabbyDebugOptions {
     static let launchArgument = "-cotabby-debug"
 
     static var isEnabled: Bool {
@@ -61,7 +61,7 @@ enum CotabbyDebugOptions {
 /// subsystem as a filterable column. When the `-cotabby-debug` launch argument is set we
 /// additionally fan out to `FileLogHandler`, which writes JSONL to
 /// `~/Library/Logs/Cotabby/cotabby.jsonl` for AI-assisted debugging without copy-paste.
-enum CotabbyLogger {
+nonisolated enum CotabbyLogger {
     /// Reserved label that routes only to the dedicated LLM I/O sink, never to OSLog or the main
     /// JSONL file. Kept out of OSLog because full prompts/completions can be many KB per request
     /// and would dominate Console.app; kept out of `cotabby.jsonl` because it would drown the

--- a/Cotabby/Support/DecodeStopPolicy.swift
+++ b/Cotabby/Support/DecodeStopPolicy.swift
@@ -11,7 +11,7 @@ import Foundation
 /// A short minimum-token guard avoids degenerate instant stops (for example, the model's first token
 /// being a lone period). `SentenceBoundaryClassifier` already rejects decimals, abbreviations, and
 /// list markers, so this never truncates "e.g.", "3.14", or a numbered "1." mid-thought.
-enum DecodeStopPolicy {
+nonisolated enum DecodeStopPolicy {
     static func shouldStop(
         accumulated: String,
         tokensGenerated: Int,

--- a/Cotabby/Support/EmojiCatalog.swift
+++ b/Cotabby/Support/EmojiCatalog.swift
@@ -14,7 +14,7 @@ import Logging
 /// `Resources/Emoji/emoji.json` is generated from GitHub's gemoji dataset (MIT licensed). To refresh
 /// it, transform the upstream `db/emoji.json` into this file's `{glyph,name,aliases,keywords,group,
 /// unicodeVersion}` shape.
-struct EmojiCatalog {
+nonisolated struct EmojiCatalog {
     /// An entry paired with its lowercased searchable tokens, computed once at load time.
     struct IndexedEntry: Equatable {
         let entry: EmojiEntry

--- a/Cotabby/Support/EmojiMatcher.swift
+++ b/Cotabby/Support/EmojiMatcher.swift
@@ -17,7 +17,7 @@ import Foundation
 /// matched token (so `smile` beats `smiley`), then the curated popularity prior, then catalog order.
 /// Favorites and popularity only break ties inside a tier, so relevance is never sacrificed to make
 /// a popular or frequently-used emoji jump ahead of a genuinely better match.
-struct EmojiMatcher {
+nonisolated struct EmojiMatcher {
     let catalog: EmojiCatalog
 
     /// Default number of rows the panel shows. Bounded so a one-character query does not build a

--- a/Cotabby/Support/EmojiPopularity.swift
+++ b/Cotabby/Support/EmojiPopularity.swift
@@ -13,7 +13,7 @@ import Foundation
 /// order is roughly age-based, not usage-based. A curated list is the cheapest way to encode "what
 /// people reach for" until per-user history (see `EmojiUsageStore`) takes over. Aliases that are not
 /// present in the active catalog simply never rank or resolve, so a stale entry here is harmless.
-enum EmojiPopularity {
+nonisolated enum EmojiPopularity {
     /// Ranked aliases, most popular first. The index is the rank, so order is the contract; keep the
     /// highest-traffic reactions at the top. Grouped only for readability.
     static let ordered: [String] = [

--- a/Cotabby/Support/EmojiRecents.swift
+++ b/Cotabby/Support/EmojiRecents.swift
@@ -8,7 +8,7 @@ import Foundation
 /// This is what makes the very first `:` useful instead of empty. A brand-new user with no history
 /// sees popular emoji; a returning user sees what they actually reach for. Variant resolution (skin
 /// tone / gender) is applied by the caller, the same way it is for query results.
-enum EmojiRecents {
+nonisolated enum EmojiRecents {
     /// Recents-first, popularity-padded suggestions for an empty query, capped at `limit`.
     static func suggestions(
         usage: EmojiUsageSnapshot,

--- a/Cotabby/Support/EmojiSynonymCatalog.swift
+++ b/Cotabby/Support/EmojiSynonymCatalog.swift
@@ -14,7 +14,7 @@ import Foundation
 /// The matcher consumes this through `boostedAliases(for:)`: an exact key match boosts its aliases to
 /// the alias-prefix tier, and a prefix key match boosts to the keyword tier, so intent ranks high
 /// without ever overriding a literal exact-alias match the user typed.
-enum EmojiSynonymCatalog {
+nonisolated enum EmojiSynonymCatalog {
     /// Lowercased query word -> canonical aliases to boost, in rough preference order (final ordering
     /// among equally-boosted aliases is decided by the matcher's popularity tiebreak).
     static let map: [String: [String]] = [

--- a/Cotabby/Support/EmojiTriggerStateMachine.swift
+++ b/Cotabby/Support/EmojiTriggerStateMachine.swift
@@ -12,7 +12,7 @@ import Foundation
 /// commit time. This keeps the active, gating event tap out of the ordinary-typing path (the
 /// issue #328 invariant that the base branch fixed) while still consuming navigation, commit, and
 /// Escape keys so the picker can be driven without the foreground app seeing them.
-struct EmojiTriggerStateMachine {
+nonisolated struct EmojiTriggerStateMachine {
     private(set) var state: EmojiTriggerState = .idle(previousCharacter: nil)
 
     var isCapturing: Bool {

--- a/Cotabby/Support/FileLogHandler.swift
+++ b/Cotabby/Support/FileLogHandler.swift
@@ -18,7 +18,7 @@ import Logging
 ///
 /// `@unchecked Sendable`: the only mutable state is `handle` and `currentByteOffset`,
 /// both guarded by `lock`. FileHandle itself is not Sendable so we cannot mark it cleanly.
-final class FileLogWriter: @unchecked Sendable {
+nonisolated final class FileLogWriter: @unchecked Sendable {
     static let shared = FileLogWriter()
 
     /// Default cap of 10 MB. Large enough for hours of debug output without ballooning disk.

--- a/Cotabby/Support/FocusCapabilityFlickerGate.swift
+++ b/Cotabby/Support/FocusCapabilityFlickerGate.swift
@@ -27,7 +27,7 @@ struct FocusCapabilityFlickerGate {
     static let requiredConsecutiveBlockedReads = 2
 
     /// Outcome the caller acts on.
-    enum Decision: Equatable {
+    nonisolated enum Decision: Equatable {
         /// Apply this snapshot as-is.
         case apply
         /// Treat as a transient flicker: pretend the previous Supported snapshot is still current.

--- a/Cotabby/Support/InsertionStrategySelector.swift
+++ b/Cotabby/Support/InsertionStrategySelector.swift
@@ -5,7 +5,7 @@ import Foundation
 /// keystrokes are reliable and clipboard-free for the common short, single-line completion, but some
 /// apps mishandle a long or multi-line synthetic string; pasting is steadier there. Keeping the
 /// decision here (separate from the side-effectful inserter) makes the policy trivially testable.
-enum InsertionStrategy: Equatable {
+nonisolated enum InsertionStrategy: Equatable {
     /// Synthesize the text as a Unicode keyboard event (the default, clipboard-free path).
     case keystroke
     /// Place the text on the pasteboard and synthesize Cmd-V. Only used when paste insertion is

--- a/Cotabby/Support/LLMIOFileHandler.swift
+++ b/Cotabby/Support/LLMIOFileHandler.swift
@@ -13,7 +13,7 @@ import Logging
 ///
 /// Like `FileLogHandler`, this handler is only installed when `-cotabby-debug` is set, so a release
 /// build never touches the user's disk with prompt or completion text.
-final class LLMIOFileWriter: @unchecked Sendable {
+nonisolated final class LLMIOFileWriter: @unchecked Sendable {
     static let shared = LLMIOFileWriter()
 
     /// Same 10 MB cap as the main log. LLM I/O records are larger per line, so this corresponds to

--- a/Cotabby/Support/MacroTriggerStateMachine.swift
+++ b/Cotabby/Support/MacroTriggerStateMachine.swift
@@ -10,7 +10,7 @@ import Foundation
 /// sigil, `/` does not overlap the emoji picker's `:`, so there is no deferred hand-off and no
 /// shared-key race: one keystroke, one open. That directness is deliberate, it is what makes the
 /// preview reliably appear instead of intermittently losing the second colon to the emoji feature.
-struct MacroTriggerStateMachine {
+nonisolated struct MacroTriggerStateMachine {
     private(set) var state: MacroTriggerState = .idle(previousCharacter: nil)
 
     var isCapturing: Bool {
@@ -124,7 +124,7 @@ enum MacroTriggerInput: Equatable {
 
 /// Side effects the controller performs after a transition. The machine stays pure; it only
 /// describes what should happen.
-enum MacroTriggerAction: Equatable {
+nonisolated enum MacroTriggerAction: Equatable {
     case open
     case updateQuery(String)
     case commit
@@ -133,7 +133,7 @@ enum MacroTriggerAction: Equatable {
 
 /// The two lifecycle states. `idle` remembers the previously typed character so the trigger can
 /// require a word boundary; `capturing` holds the live query typed after the `/`.
-enum MacroTriggerState: Equatable {
+nonisolated enum MacroTriggerState: Equatable {
     case idle(previousCharacter: Character?)
     case capturing(query: String)
 }
@@ -142,7 +142,7 @@ enum MacroTriggerState: Equatable {
 /// lists use `,`, conversions use `->`, and `/` is division (the leading `/` is the sigil, any later
 /// `/` is an operator). Only the rendered output is localized, which avoids the comma-decimal
 /// ambiguity a localized input grammar would create.
-enum MacroQueryGrammar {
+nonisolated enum MacroQueryGrammar {
     static func extends(_ character: Character) -> Bool {
         if character.isLetter || character.isNumber {
             return true

--- a/Cotabby/Support/OCRTextHygiene.swift
+++ b/Cotabby/Support/OCRTextHygiene.swift
@@ -14,7 +14,7 @@ import Foundation
 /// in isolation, and so the orchestrating service (`ScreenTextExtractor` / `ScreenshotContextGenerator`)
 /// stays free of OCR-noise heuristics. There is no I/O, no logging, and no dependency beyond
 /// `Foundation`; the same input always yields the same output.
-enum OCRTextHygiene {
+nonisolated enum OCRTextHygiene {
 
     /// A single recognized OCR line paired with the recognizer's confidence for that line.
     ///

--- a/Cotabby/Support/OnboardingTemplateFeatureList.swift
+++ b/Cotabby/Support/OnboardingTemplateFeatureList.swift
@@ -10,7 +10,7 @@ import Foundation
 /// `OnboardingTemplate`. If a template gains a new behavior flag, the row order here is the only
 /// place to extend — the UI walks whatever rows this returns.
 
-enum OnboardingTemplateFeatureValue: Equatable, Sendable {
+nonisolated enum OnboardingTemplateFeatureValue: Equatable, Sendable {
     /// Toggled on by the template. UI renders a positive affordance (e.g., a check).
     case enabled
     /// Explicitly off under the template. UI renders a neutral/negative affordance (e.g., a dash).

--- a/Cotabby/Support/SentenceBoundaryClassifier.swift
+++ b/Cotabby/Support/SentenceBoundaryClassifier.swift
@@ -9,7 +9,7 @@ import Foundation
 /// "e.g.", and a numbered "1." mid-tail. A purely structural scanner cannot resolve every case, but
 /// it can resolve the frequent ones with a few local rules. `!` and `?` are always terminal and do
 /// not need this; only the period is ambiguous.
-enum SentenceBoundaryClassifier {
+nonisolated enum SentenceBoundaryClassifier {
     /// Lowercased abbreviations whose trailing period is part of the word, not a sentence end.
     private static let abbreviations: Set<String> = [
         "mr", "mrs", "ms", "dr", "st", "vs", "eg", "ie", "etc", "no", "fig", "approx", "inc", "ltd"
@@ -101,7 +101,7 @@ enum SentenceBoundaryClassifier {
     }
 }
 
-private extension Character {
+nonisolated private extension Character {
     /// Closing punctuation that may follow a sentence terminator: straight and curly quotes,
     /// parentheses, square brackets, and braces, plus the shared CJK closer set (see
     /// `Character.isCJKClosingPunctuation`). `endsSentence` walks back past a run of these to find

--- a/Cotabby/Support/SuggestionSessionReconciler.swift
+++ b/Cotabby/Support/SuggestionSessionReconciler.swift
@@ -586,7 +586,7 @@ private extension String {
 /// The CJK punctuation primitives, internal because they are the single source of truth shared by
 /// this file's acceptance policy and `SentenceBoundaryClassifier`'s sentence-end detection. Adding a
 /// codepoint here updates phrase boundaries, chunk binding, and the generation stop in one edit.
-extension Character {
+nonisolated extension Character {
     /// The CJK sentence terminators: ideographic full stop `。`, fullwidth `！` `？`, and the halfwidth
     /// ideographic stop `｡`. Unlike the ASCII period these are unambiguous (they never mark decimals,
     /// list numbers, or abbreviations), so every consumer treats them as terminal without classifier
@@ -605,7 +605,7 @@ extension Character {
     }
 }
 
-private extension Character {
+nonisolated private extension Character {
     /// True when the character begins a word of a space-less script (Han, Hiragana, Katakana, Hangul,
     /// Thai, Lao, Khmer, Myanmar, ...). These scripts write words without separating spaces, so the
     /// whitespace-run acceptance rule would over-accept a whole run; `nextAcceptanceChunk` switches to

--- a/Cotabby/Support/SystemResourceSampler.swift
+++ b/Cotabby/Support/SystemResourceSampler.swift
@@ -20,7 +20,7 @@ struct SystemResourceSample: Equatable {
     let footprintBytes: UInt64
 }
 
-enum SystemResourceSampler {
+nonisolated enum SystemResourceSampler {
     static func sample() -> SystemResourceSample {
         SystemResourceSample(
             cpuPercent: currentCPUPercent(),

--- a/Cotabby/Support/TokenCountEstimator.swift
+++ b/Cotabby/Support/TokenCountEstimator.swift
@@ -10,7 +10,7 @@ import Foundation
 /// global chars-per-token ratio — especially for code or short function words — while staying
 /// allocation-light and deterministic for tests. It is not exact, so it is used only for relative
 /// budgeting decisions, never to assert a hard token limit.
-enum TokenCountEstimator {
+nonisolated enum TokenCountEstimator {
     static func estimate(_ text: String) -> Int {
         // Split on punctuation as well as whitespace: real subword tokenizers break "can't", "end.",
         // and "func()" into multiple tokens, so gluing punctuation to a word would systematically

--- a/Cotabby/Support/TypoGate.swift
+++ b/Cotabby/Support/TypoGate.swift
@@ -5,7 +5,7 @@ import Foundation
 /// `SuggestionCoordinator` so the "suppress vs correct vs proceed" logic is unit-testable without
 /// `NSSpellChecker` or a live AX snapshot: the coordinator passes the spell-check behaviors in as
 /// closures, and tests pass deterministic stubs.
-enum TypoGateDecision: Equatable {
+nonisolated enum TypoGateDecision: Equatable {
     /// No actionable typo on the current word. Proceed with a normal continuation.
     case proceed
     /// The current word looks misspelled and corrections are off (or none was available). Hide the


### PR DESCRIPTION
## Summary

A clean build of latest main emits 68 project warnings, and every one is the same class of problem: the target's `SWIFT_DEFAULT_ACTOR_ISOLATION: MainActor` makes pure value types, statics, and `Character` extensions main-actor-isolated, and nonisolated contexts reference them (the llama runtime task logging through `CotabbyLogger`, sort comparators, timer closures, conformances used from plain XCTest classes). Each carries the compiler's "this is an error in the Swift 6 language mode" rider, so the whole set is a queued-up future build break.

The fix follows the pattern the codebase already established for `CaretGeometryQuality` and `ObservedContentEdges`: annotate pure helper enums (`CotabbyLogger`, `TypoGate`'s decision, `DecodeStopPolicy`, `OCRTextHygiene`, the emoji catalog/popularity/synonym tables, and friends), value-type models (`EmojiEntry`, `HFModelSearchResult`, `DisabledApplicationRule`, `FocusedInputIdentity`, the trigger state machines), and the lock-guarded `@unchecked Sendable` log writers as `nonisolated`. None of these have main-actor state; isolation on them was an accident of the build setting.

The two notification-callback warnings (`PowerSourceMonitor`, `KeyboardInputSourceMonitor`) are real isolation decisions rather than annotations: both observers register with `queue: .main`, so the callbacks now enter the actor via `MainActor.assumeIsolated`, which documents the main-queue delivery contract as a checkable assertion instead of paying a re-dispatch hop.

## Validation

```
rm -rf build/DerivedData
xcodebuild build-for-testing -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
# Before: 68 project warnings on a clean build
# After:  0 project warnings on a clean build (the two appintentsmetadataprocessor
#         notices are toolchain noise about a framework the app does not link)

xcodebuild test ... -skip-testing:CotabbyTests/FoundationModelDriftEvalTests \
  CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
# ** TEST SUCCEEDED ** 1436 tests, 0 failures, 0 crashes

swiftlint lint --quiet
# 0 findings on the files this PR touches
```

## Linked issues

None filed; this came out of a "build latest main and fix every warning" sweep.

## Risk / rollout notes

- `nonisolated` on pure value types and statics only widens where they may be used; no call site changes behavior. The diff is +48/-41 across 30 files, almost entirely one-word annotations.
- The two `MainActor.assumeIsolated` sites trap if the delivery queue ever stops being `.main`. That is intentional: a queue change there should be loud, not a silent data race on actor state.
- `FileLogWriter`/`LLMIOFileWriter` becoming explicitly `nonisolated` matches what their `@unchecked Sendable` + internal `NSLock` already promised; their `nonisolated deinit` (from #678) is now redundant but harmless and kept for clarity.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR eliminates all 68 Swift 6 forward-compatibility build warnings generated by the `SWIFT_DEFAULT_ACTOR_ISOLATION: MainActor` project setting, which was accidentally isolating pure value types, static-only namespaces, and `Character` extensions to the main actor. The fixes follow the two patterns already established in the codebase.

- **`nonisolated` on value types and static-only enums** (26 types across 28 files): pure structs and caseless enums (`CotabbyLogger`, `DecodeStopPolicy`, `OCRTextHygiene`, state-machine types, emoji catalogs, log writers, etc.) that carry no main-actor state are explicitly annotated, widening where they may be used without changing any behavior.
- **`MainActor.assumeIsolated` in main-queue callbacks** (`PowerSourceMonitor`, `KeyboardInputSourceMonitor`): instead of relying on the implicit isolation that the build setting provided, both `NSWorkspace`/`DistributedNotificationCenter` observers registered with `queue: .main` now explicitly assert main-actor execution, converting a silent assumption into a checkable runtime precondition.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all changes are additive isolation annotations with no behavioral impact on app logic, and the two MainActor.assumeIsolated sites correctly document an existing queue contract.

The diff is almost entirely one-word nonisolated additions to pure value types and static namespaces that genuinely have no main-actor state. The only non-trivial changes are the two MainActor.assumeIsolated wraps in notification callbacks that were already delivered on the main queue. One minor inconsistency: MacroTriggerInput and EmojiTriggerInput are left unannotated in files where all their sibling enums received nonisolated; this doesn't cause any current warning but leaves those two types subject to accidental re-isolation if members are added later.

MacroTriggerStateMachine.swift and EmojiPickerModels.swift — both leave their respective TriggerInput enum unannotated while annotating every other state-machine type in the same file.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/Services/Power/PowerSourceMonitor.swift | Adds MainActor.assumeIsolated to the NSWorkspace wake-observer closure (already present for the IOKit run-loop callback); correct because queue:.main delivers on main thread |
| Cotabby/Services/Input/KeyboardInputSourceMonitor.swift | Wraps the DistributedNotificationCenter callback (queue:.main) in MainActor.assumeIsolated; mirrors the PowerSourceMonitor pattern correctly |
| Cotabby/Support/FileLogHandler.swift | Adds nonisolated to FileLogWriter class; correct because the class is @unchecked Sendable and already has NSLock-guarded state, matching what nonisolated promises |
| Cotabby/Support/LLMIOFileHandler.swift | Adds nonisolated to LLMIOFileWriter class; same NSLock-backed pattern as FileLogWriter; annotation matches the implementation contract |
| Cotabby/Support/SuggestionSessionReconciler.swift | Two Character extensions (one internal, one private) get nonisolated; members are pure computed properties on a value type with no actor-state concerns |
| Cotabby/Support/SentenceBoundaryClassifier.swift | Adds nonisolated to the enum and to a private Character extension; pure static/instance logic with no shared mutable state |
| Cotabby/Support/MacroTriggerStateMachine.swift | Annotates MacroTriggerStateMachine, MacroTriggerAction, MacroTriggerState, and MacroQueryGrammar as nonisolated but leaves MacroTriggerInput unannotated—minor inconsistency within the file |
| Cotabby/Models/EmojiPickerModels.swift | Annotates EmojiEntry, EmojiMatch, EmojiSelectionMove, EmojiCommitMode, EmojiTriggerAction, EmojiTriggerState as nonisolated but leaves EmojiTriggerInput unannotated—same pattern as MacroTriggerInput |
| Cotabby/Support/CotabbyDebugOptions.swift | Adds nonisolated to CotabbyDebugOptions and CotabbyLogger enums; both are static-only namespaces with no main-actor-specific state |
| Cotabby/Models/SystemMetricsStore.swift | Makes the static constant defaultInterval nonisolated; a simple TimeInterval literal that doesn't belong on the main actor |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SWIFT_DEFAULT_ACTOR_ISOLATION: MainActor] -->|Before PR| B[All types implicitly @MainActor]
    B --> C{Type has no actor state?}
    C -->|Yes - pure enum/struct| D[Warning: nonisolated context references @MainActor member - error in Swift 6 mode]
    C -->|No - @MainActor class| E[OK]
    A -->|After PR| F{Classification}
    F -->|Pure value types / static namespaces| G[nonisolated annotation]
    F -->|Lock-guarded writers| H[nonisolated final class]
    F -->|Character extensions| I[nonisolated extension Character]
    F -->|Main-queue callbacks| J[MainActor.assumeIsolated]
    G --> K[0 warnings, usable from any context]
    H --> K
    I --> K
    J --> K
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cotabby/Support/MacroTriggerStateMachine.swift`, line 115-123 ([link](https://github.com/fujacob/cotabby/blob/5702d712ad9fd0f1c560803d80c2263ee9566977/Cotabby/Support/MacroTriggerStateMachine.swift#L115-L123)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Unannotated input enum amid nonisolated siblings**

   `MacroTriggerInput` is the only enum in this file that wasn't given `nonisolated`; its siblings `MacroTriggerAction`, `MacroTriggerState`, and `MacroQueryGrammar` all were. The same pattern appears in `EmojiPickerModels.swift` where `EmojiTriggerInput` is left unannotated while every other state-machine enum in the file gets the annotation.

   The current 0-warning result makes sense: both `*TriggerInput` enums contain only cases with no methods or stored properties, so the compiler has nothing main-actor-isolated to warn about on them. If either enum gains a static helper (e.g. a factory or description property) in a future change, it will silently re-inherit `@MainActor` from the build setting and the new member will be isolated while its callers in the now-`nonisolated` state machines are not. Adding `nonisolated` here (and on `EmojiTriggerInput`) would make the isolation intent explicit and keep the file internally consistent.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix-build-warnings%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix-build-warnings%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FSupport%2FMacroTriggerStateMachine.swift%0ALine%3A%20115-123%0A%0AComment%3A%0A**Unannotated%20input%20enum%20amid%20nonisolated%20siblings**%0A%0A%60MacroTriggerInput%60%20is%20the%20only%20enum%20in%20this%20file%20that%20wasn't%20given%20%60nonisolated%60%3B%20its%20siblings%20%60MacroTriggerAction%60%2C%20%60MacroTriggerState%60%2C%20and%20%60MacroQueryGrammar%60%20all%20were.%20The%20same%20pattern%20appears%20in%20%60EmojiPickerModels.swift%60%20where%20%60EmojiTriggerInput%60%20is%20left%20unannotated%20while%20every%20other%20state-machine%20enum%20in%20the%20file%20gets%20the%20annotation.%0A%0AThe%20current%200-warning%20result%20makes%20sense%3A%20both%20%60*TriggerInput%60%20enums%20contain%20only%20cases%20with%20no%20methods%20or%20stored%20properties%2C%20so%20the%20compiler%20has%20nothing%20main-actor-isolated%20to%20warn%20about%20on%20them.%20If%20either%20enum%20gains%20a%20static%20helper%20%28e.g.%20a%20factory%20or%20description%20property%29%20in%20a%20future%20change%2C%20it%20will%20silently%20re-inherit%20%60%40MainActor%60%20from%20the%20build%20setting%20and%20the%20new%20member%20will%20be%20isolated%20while%20its%20callers%20in%20the%20now-%60nonisolated%60%20state%20machines%20are%20not.%20Adding%20%60nonisolated%60%20here%20%28and%20on%20%60EmojiTriggerInput%60%29%20would%20make%20the%20isolation%20intent%20explicit%20and%20keep%20the%20file%20internally%20consistent.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=684&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FSupport%2FMacroTriggerStateMachine.swift%0ALine%3A%20115-123%0A%0AComment%3A%0A**Unannotated%20input%20enum%20amid%20nonisolated%20siblings**%0A%0A%60MacroTriggerInput%60%20is%20the%20only%20enum%20in%20this%20file%20that%20wasn't%20given%20%60nonisolated%60%3B%20its%20siblings%20%60MacroTriggerAction%60%2C%20%60MacroTriggerState%60%2C%20and%20%60MacroQueryGrammar%60%20all%20were.%20The%20same%20pattern%20appears%20in%20%60EmojiPickerModels.swift%60%20where%20%60EmojiTriggerInput%60%20is%20left%20unannotated%20while%20every%20other%20state-machine%20enum%20in%20the%20file%20gets%20the%20annotation.%0A%0AThe%20current%200-warning%20result%20makes%20sense%3A%20both%20%60*TriggerInput%60%20enums%20contain%20only%20cases%20with%20no%20methods%20or%20stored%20properties%2C%20so%20the%20compiler%20has%20nothing%20main-actor-isolated%20to%20warn%20about%20on%20them.%20If%20either%20enum%20gains%20a%20static%20helper%20%28e.g.%20a%20factory%20or%20description%20property%29%20in%20a%20future%20change%2C%20it%20will%20silently%20re-inherit%20%60%40MainActor%60%20from%20the%20build%20setting%20and%20the%20new%20member%20will%20be%20isolated%20while%20its%20callers%20in%20the%20now-%60nonisolated%60%20state%20machines%20are%20not.%20Adding%20%60nonisolated%60%20here%20%28and%20on%20%60EmojiTriggerInput%60%29%20would%20make%20the%20isolation%20intent%20explicit%20and%20keep%20the%20file%20internally%20consistent.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=684&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix-build-warnings%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix-build-warnings%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FSupport%2FMacroTriggerStateMachine.swift%3A115-123%0A**Unannotated%20input%20enum%20amid%20nonisolated%20siblings**%0A%0A%60MacroTriggerInput%60%20is%20the%20only%20enum%20in%20this%20file%20that%20wasn't%20given%20%60nonisolated%60%3B%20its%20siblings%20%60MacroTriggerAction%60%2C%20%60MacroTriggerState%60%2C%20and%20%60MacroQueryGrammar%60%20all%20were.%20The%20same%20pattern%20appears%20in%20%60EmojiPickerModels.swift%60%20where%20%60EmojiTriggerInput%60%20is%20left%20unannotated%20while%20every%20other%20state-machine%20enum%20in%20the%20file%20gets%20the%20annotation.%0A%0AThe%20current%200-warning%20result%20makes%20sense%3A%20both%20%60*TriggerInput%60%20enums%20contain%20only%20cases%20with%20no%20methods%20or%20stored%20properties%2C%20so%20the%20compiler%20has%20nothing%20main-actor-isolated%20to%20warn%20about%20on%20them.%20If%20either%20enum%20gains%20a%20static%20helper%20%28e.g.%20a%20factory%20or%20description%20property%29%20in%20a%20future%20change%2C%20it%20will%20silently%20re-inherit%20%60%40MainActor%60%20from%20the%20build%20setting%20and%20the%20new%20member%20will%20be%20isolated%20while%20its%20callers%20in%20the%20now-%60nonisolated%60%20state%20machines%20are%20not.%20Adding%20%60nonisolated%60%20here%20%28and%20on%20%60EmojiTriggerInput%60%29%20would%20make%20the%20isolation%20intent%20explicit%20and%20keep%20the%20file%20internally%20consistent.%0A%0A&repo=fujacob%2Fcotabby&pr=684&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FSupport%2FMacroTriggerStateMachine.swift%3A115-123%0A**Unannotated%20input%20enum%20amid%20nonisolated%20siblings**%0A%0A%60MacroTriggerInput%60%20is%20the%20only%20enum%20in%20this%20file%20that%20wasn't%20given%20%60nonisolated%60%3B%20its%20siblings%20%60MacroTriggerAction%60%2C%20%60MacroTriggerState%60%2C%20and%20%60MacroQueryGrammar%60%20all%20were.%20The%20same%20pattern%20appears%20in%20%60EmojiPickerModels.swift%60%20where%20%60EmojiTriggerInput%60%20is%20left%20unannotated%20while%20every%20other%20state-machine%20enum%20in%20the%20file%20gets%20the%20annotation.%0A%0AThe%20current%200-warning%20result%20makes%20sense%3A%20both%20%60*TriggerInput%60%20enums%20contain%20only%20cases%20with%20no%20methods%20or%20stored%20properties%2C%20so%20the%20compiler%20has%20nothing%20main-actor-isolated%20to%20warn%20about%20on%20them.%20If%20either%20enum%20gains%20a%20static%20helper%20%28e.g.%20a%20factory%20or%20description%20property%29%20in%20a%20future%20change%2C%20it%20will%20silently%20re-inherit%20%60%40MainActor%60%20from%20the%20build%20setting%20and%20the%20new%20member%20will%20be%20isolated%20while%20its%20callers%20in%20the%20now-%60nonisolated%60%20state%20machines%20are%20not.%20Adding%20%60nonisolated%60%20here%20%28and%20on%20%60EmojiTriggerInput%60%29%20would%20make%20the%20isolation%20intent%20explicit%20and%20keep%20the%20file%20internally%20consistent.%0A%0A&repo=fujacob%2Fcotabby&pr=684&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(concurrency): eliminate all 68 Swift..."](https://github.com/fujacob/cotabby/commit/5702d712ad9fd0f1c560803d80c2263ee9566977) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37133253)</sub>

<!-- /greptile_comment -->