### PR TITLE
perf(visual): skip re-OCR of unchanged pixels, right-size the OCR input, pin the clipboard preface

### DIFF
--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
@@ -96,21 +96,7 @@ extension SuggestionCoordinator {
         let visualContextSummary = permissionManager.screenRecordingGranted
             ? visualContextCoordinator.excerpt(for: context)
             : nil
-        let rawClipboard = settingsSnapshot.isClipboardContextEnabled
-            ? clipboardContextProvider.currentContext()
-            : nil
-        // Same bounded window the downstream distiller sees, so the relevance gate and the
-        // per-line filter can't disagree about what "shares tokens with the prefix" means.
-        let truncatedPrefix = SuggestionRequestFactory.truncatedPromptPrefix(
-            from: rawContext.precedingText,
-            configuration: configuration,
-            engine: settingsSnapshot.selectedEngine
-        )
-        let clipboardContext = clipboardRelevanceFilter.filter(
-            clipboard: rawClipboard,
-            pasteboardChangeCount: clipboardContextProvider.currentChangeCount,
-            precedingText: truncatedPrefix
-        )
+        let clipboardContext = pinnedClipboardContext(rawContext: rawContext)
         let requestBuildResult = SuggestionRequestFactory.buildRequest(
             context: context,
             settings: settingsSnapshot,
@@ -162,6 +148,45 @@ extension SuggestionCoordinator {
                 await applyFailure(error.localizedDescription, workID: workID)
             }
         }
+    }
+
+    /// Resolves the clipboard prompt section under the pinning policy documented on
+    /// `clipboardPrefaceMemo`: an accepted (non-nil) verdict is reused for the rest of the field
+    /// session so the prompt head stays stable and the engine's KV common prefix survives; a nil
+    /// verdict re-evaluates per request because it adds nothing to the prompt and the clipboard
+    /// may only become relevant once more text is typed. A new copy or a field switch always
+    /// re-evaluates.
+    private func pinnedClipboardContext(rawContext: FocusedInputSnapshot) -> String? {
+        guard settingsSnapshot.isClipboardContextEnabled else {
+            return nil
+        }
+
+        let changeCount = clipboardContextProvider.currentChangeCount
+        if let memo = clipboardPrefaceMemo,
+           memo.focusSequence == rawContext.focusChangeSequence,
+           memo.changeCount == changeCount,
+           memo.value != nil {
+            return memo.value
+        }
+
+        // Same bounded window the downstream distiller sees, so the relevance gate and the
+        // per-line filter can't disagree about what "shares tokens with the prefix" means.
+        let truncatedPrefix = SuggestionRequestFactory.truncatedPromptPrefix(
+            from: rawContext.precedingText,
+            configuration: configuration,
+            engine: settingsSnapshot.selectedEngine
+        )
+        let value = clipboardRelevanceFilter.filter(
+            clipboard: clipboardContextProvider.currentContext(),
+            pasteboardChangeCount: changeCount,
+            precedingText: truncatedPrefix
+        )
+        clipboardPrefaceMemo = ClipboardPrefaceMemo(
+            focusSequence: rawContext.focusChangeSequence,
+            changeCount: changeCount,
+            value: value
+        )
+        return value
     }
 
     /// Runs the typo gate for the current word. Returns `true` when it handled the cycle by suppressing,

--- a/Cotabby/App/Coordinators/SuggestionCoordinator.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator.swift
@@ -78,6 +78,21 @@ final class SuggestionCoordinator: ObservableObject {
     // barrier task that the next generation must cross before it can ask the runtime for output.
     var cacheResetSequence: UInt64 = 0
     var pendingCacheReset: (sequence: UInt64, task: Task<Void, Never>)?
+    /// One accepted clipboard-relevance verdict per (field session, pasteboard state). The verdict
+    /// used to be re-evaluated against the live prefix on every request, and because the clipboard
+    /// section precedes the typed prefix in the prompt, every flip rewrote the prompt HEAD and
+    /// collapsed the engine's reusable common prefix back to zero (a full re-prefill). A pinned
+    /// non-nil verdict keeps the prompt head stable for the field session; a nil verdict keeps
+    /// re-evaluating because adding nothing to the prompt cannot destabilize the head, and the
+    /// clipboard may only become relevant once more text is typed. A new copy (change count) or a
+    /// field switch (focus sequence) always re-evaluates. See `pinnedClipboardContext`.
+    struct ClipboardPrefaceMemo {
+        let focusSequence: UInt64
+        let changeCount: Int
+        let value: String?
+    }
+
+    var clipboardPrefaceMemo: ClipboardPrefaceMemo?
     /// Monotonic cancellation token for the "wait until the host publishes typed text to AX" loop.
     ///
     /// Keystrokes can arrive faster than Chromium publishes contenteditable updates. Without this

--- a/Cotabby/Models/VisualContextModels.swift
+++ b/Cotabby/Models/VisualContextModels.swift
@@ -20,8 +20,12 @@ struct VisualContextConfiguration: Equatable, Sendable {
     static let `default` = VisualContextConfiguration(
         // Capture a wider field-centered area so OCR can see nearby labels and conversation turns.
         snapshotDimension: 700,
-        // Vision's accurate mode benefits from more pixels, especially on dense document UIs.
-        maxImageDimension: 1600,
+        // Vision's accurate mode benefits from more pixels, but OCR cost scales with pixel area
+        // and a Retina capture of the 700pt strip arrives well above this cap either way. 1200
+        // keeps typical 11-13pt UI text comfortably above Vision's recognition floor (the strip
+        // is ~1000pt wide, so this is ~1.2 px/pt) while cutting the Vision workload ~44% versus
+        // the previous 1600 cap.
+        maxImageDimension: 1200,
         minRecognizedCharacterCount: 12,
         // The summarizer needs enough raw OCR to recover task, filenames, and nearby messages.
         maxRecognizedCharacters: 5000,

--- a/Cotabby/Services/Visual/ScreenshotContextGenerator.swift
+++ b/Cotabby/Services/Visual/ScreenshotContextGenerator.swift
@@ -34,6 +34,14 @@ final class ScreenshotContextGenerator {
     private let textExtractor: any ScreenTextExtracting
     private let configuration: VisualContextConfiguration
 
+    /// Recent OCR extractions keyed by a pixel hash of the captured crop, so refocusing a window
+    /// whose content has not changed skips the Vision pass (the dominant cost of this pipeline).
+    /// Only the raw extraction is cached: hygiene and bounding still rerun against the live field
+    /// text below, so a cache hit stays byte-identical to re-OCRing identical pixels. Bounded to a
+    /// few entries so alt-tabbing between two or three windows keeps hitting.
+    private var extractionCache: [(hash: UInt64, extracted: ExtractedScreenText)] = []
+    private static let extractionCacheLimit = 4
+
     init(
         screenshotService: (any WindowScreenshotCapturing)? = nil,
         textExtractor: (any ScreenTextExtracting)? = nil,
@@ -59,6 +67,11 @@ final class ScreenshotContextGenerator {
         let screenshot = try await captureScreenshot(for: context, onStatusChange: onStatusChange)
 
         await onStatusChange?(.extractingText)
+
+        let pixelHash = Self.pixelHash(of: screenshot.image)
+        if let pixelHash, let cached = cachedExtraction(for: pixelHash) {
+            return try finishedExcerpt(from: cached, context: context, image: screenshot.image)
+        }
 
         let extracted: ExtractedScreenText
         do {
@@ -89,6 +102,19 @@ final class ScreenshotContextGenerator {
             throw ScreenshotContextGenerationError.failed(error.localizedDescription)
         }
 
+        storeExtraction(extracted, for: pixelHash)
+        return try finishedExcerpt(from: extracted, context: context, image: screenshot.image)
+    }
+
+    /// Hygiene, normalization, bounding, and the meaningful-signal gate, shared by the fresh and
+    /// cache-hit paths so a hit stays byte-identical to re-OCRing the same pixels. The field-text
+    /// stripping in particular must rerun per call: the cached extraction may have been taken when
+    /// the user's own typed text differed.
+    private func finishedExcerpt(
+        from extracted: ExtractedScreenText,
+        context: FocusedInputSnapshot,
+        image: CGImage
+    ) throws -> VisualContextExcerpt {
         // Filter OCR corruption (garbled / symbol-noise / digit-substituted lines) and strip any
         // line that merely echoes the user's own field text, then sanitize for prompt-injection
         // safety. No model summarization: a base model conditions fine on cleaned raw context, and
@@ -102,7 +128,7 @@ final class ScreenshotContextGenerator {
 
         if CotabbyDebugOptions.isEnabled {
             saveDebugScreenshot(
-                screenshot.image,
+                image,
                 text: extracted.text,
                 name: sanitizedDebugName(from: context.applicationName)
             )
@@ -120,6 +146,48 @@ final class ScreenshotContextGenerator {
         )
 
         return VisualContextExcerpt(text: finalContextText)
+    }
+
+    // MARK: - Extraction cache
+
+    /// FNV-1a over a strided sample of the image bytes, mixed with the dimensions. Sampling every
+    /// 16th byte keeps the hash sub-millisecond on Retina crops while still touching every row;
+    /// any real content change moves enough antialiased pixels that a stride collision is
+    /// vanishingly unlikely, and the worst case of one is reusing OCR text for a window whose
+    /// pixels barely changed. `nil` (no readable backing data) simply disables caching.
+    private static func pixelHash(of image: CGImage) -> UInt64? {
+        guard let data = image.dataProvider?.data,
+              let bytes = CFDataGetBytePtr(data) else {
+            return nil
+        }
+
+        let length = CFDataGetLength(data)
+        let prime: UInt64 = 0x0000_0100_0000_01B3
+        var hash: UInt64 = 0xcbf2_9ce4_8422_2325
+        var index = 0
+        while index < length {
+            hash = (hash ^ UInt64(bytes[index])) &* prime
+            index += 16
+        }
+        hash = (hash ^ UInt64(image.width)) &* prime
+        hash = (hash ^ UInt64(image.height)) &* prime
+        return hash
+    }
+
+    private func cachedExtraction(for hash: UInt64) -> ExtractedScreenText? {
+        extractionCache.first(where: { $0.hash == hash })?.extracted
+    }
+
+    private func storeExtraction(_ extracted: ExtractedScreenText, for hash: UInt64?) {
+        guard let hash else {
+            return
+        }
+
+        extractionCache.removeAll { $0.hash == hash }
+        extractionCache.append((hash, extracted))
+        if extractionCache.count > Self.extractionCacheLimit {
+            extractionCache.removeFirst(extractionCache.count - Self.extractionCacheLimit)
+        }
     }
 
     private func captureScreenshot(

--- a/Cotabby/Services/Visual/ScreenshotContextGenerator.swift
+++ b/Cotabby/Services/Visual/ScreenshotContextGenerator.swift
@@ -165,9 +165,12 @@ final class ScreenshotContextGenerator {
         let prime: UInt64 = 0x0000_0100_0000_01B3
         var hash: UInt64 = 0xcbf2_9ce4_8422_2325
         var index = 0
+        // 17, not 16: with 4-byte pixels a multiple-of-4 stride lands on the same color channel
+        // forever, so a chroma-only change (e.g. a theme toggle with unchanged luminance) could
+        // hash identically. A stride coprime with the pixel size cycles through all four channels.
         while index < length {
             hash = (hash ^ UInt64(bytes[index])) &* prime
-            index += 16
+            index += 17
         }
         hash = (hash ^ UInt64(image.width)) &* prime
         hash = (hash ^ UInt64(image.height)) &* prime

--- a/CotabbyTests/PermissionAndContextModelTests.swift
+++ b/CotabbyTests/PermissionAndContextModelTests.swift
@@ -101,7 +101,8 @@ final class VisualContextModelTests: XCTestCase {
     func test_defaultConfiguration_hasExpectedValues() {
         let config = VisualContextConfiguration.default
         XCTAssertEqual(config.snapshotDimension, 700)
-        XCTAssertEqual(config.maxImageDimension, 1600)
+        // 1200 is the measured-tradeoff OCR input cap; see the rationale on the default config.
+        XCTAssertEqual(config.maxImageDimension, 1200)
         XCTAssertEqual(config.minRecognizedCharacterCount, 12)
         XCTAssertEqual(config.maxRecognizedCharacters, 5000)
         XCTAssertEqual(config.maxSummaryCharacters, 1500)

--- a/CotabbyTests/ScreenshotContextGeneratorTests.swift
+++ b/CotabbyTests/ScreenshotContextGeneratorTests.swift
@@ -80,6 +80,34 @@ final class ScreenshotContextGeneratorTests: XCTestCase {
         )
     }
 
+    func test_generateContext_reusesExtractionForIdenticalPixels() async throws {
+        let line = "GeneralPaneView.swift should say Screen Recording is required for autocomplete context"
+        let extractor = CountingTextExtractor(
+            extracted: ExtractedScreenText(
+                text: line,
+                lineCount: 1,
+                lines: [OCRTextHygiene.OCRLine(text: line, confidence: 0.9)]
+            )
+        )
+        let generator = ScreenshotContextGenerator(
+            screenshotService: StubScreenshotCapture(
+                screenshot: CapturedWindowScreenshot(image: makeImage(), windowTitle: nil)
+            ),
+            textExtractor: extractor,
+            configuration: .default
+        )
+
+        let first = try await generator.generateContext(for: makeSnapshot())
+        let second = try await generator.generateContext(for: makeSnapshot())
+
+        XCTAssertEqual(
+            extractor.extractionCount,
+            1,
+            "Re-capturing pixel-identical content must reuse the extraction instead of re-running Vision."
+        )
+        XCTAssertEqual(first.text, second.text, "A cache hit must produce the same excerpt as a fresh OCR.")
+    }
+
     func test_generateContext_dropsLowConfidenceOCRLines() async throws {
         // A clean, plausible sentence at low confidence must be dropped even though no other hygiene
         // filter would catch it, proving real per-line Vision confidence now reaches the hygiene pass.
@@ -149,6 +177,22 @@ private struct StubScreenshotCapture: WindowScreenshotCapturing {
         snapshotDimension: Int
     ) async throws -> CapturedWindowScreenshot {
         screenshot
+    }
+}
+
+/// Counts Vision-pass invocations so the pixel-hash extraction cache can be asserted on.
+@MainActor
+private final class CountingTextExtractor: ScreenTextExtracting {
+    private let extracted: ExtractedScreenText
+    private(set) var extractionCount = 0
+
+    init(extracted: ExtractedScreenText) {
+        self.extracted = extracted
+    }
+
+    func extractText(from image: CGImage) async throws -> ExtractedScreenText {
+        extractionCount += 1
+        return extracted
     }
 }
 


### PR DESCRIPTION
## Summary

Three efficiency cuts in the visual-context pipeline, sized from the energy-audit follow-up (the OCR lane was the one remaining tier-B lever):

- **Pixel-hash extraction cache.** Refocusing a window re-ran the full Vision pass even when the captured pixels were identical (alt-tab away and back is the common case). A small bounded cache keyed by an FNV-1a stride hash of the capture now reuses the raw extraction; hygiene, normalization, and the field-text stripping still rerun against the live field text, so a hit stays byte-identical to re-OCRing the same pixels.
- **Downscale cap 1600 to 1200.** The Retina capture of the 700pt strip arrives above both caps, so this only changes how much gets handed to Vision: ~44% fewer pixels per accurate-mode pass while typical 11-13pt UI text stays comfortably above the recognition floor (~1.2 px/pt on the strip). The recognition level itself intentionally stays `.accurate`: measured data puts `.fast` at only ~1.6x on Apple Silicon with a real recall cost.
- **Clipboard preface pinning.** The clipboard relevance verdict was re-evaluated against the live prefix on every request, and the clipboard section precedes the typed prefix in the prompt, so every verdict flip rewrote the prompt head and collapsed the llama engine's reusable KV common prefix into a full re-prefill. An accepted verdict is now pinned per (field session, pasteboard change count); a nil verdict keeps re-evaluating because it adds nothing to the prompt (head-stable) and the clipboard may only become relevant as more text is typed.

## Validation

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build-for-testing \
  -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
# ** TEST BUILD SUCCEEDED **

xcodebuild ... test-without-building \
  -only-testing:CotabbyTests/ScreenshotContextGeneratorTests \
  -only-testing:CotabbyTests/VisualContextStartCoalescerTests \
  -only-testing:CotabbyTests/SuggestionCoordinatorAcceptanceTests
# 0 failures (wall time inflated by an unrelated local disk-pressure incident during the run)

swiftlint lint --quiet
# exit 0
```

New test: `test_generateContext_reusesExtractionForIdenticalPixels` (counting extractor proves the Vision pass is skipped and the excerpt is identical).

## Linked issues

Refs #661

## Risk / rollout notes

- A stride-hash collision would reuse OCR text for a window whose pixels changed; the stride still touches every row and any text change moves antialiased pixels broadly, so this is vanishingly unlikely, and the blast radius is one stale excerpt for one field session.
- The 1200px cap is a measured-tradeoff default, not a hard floor; if small-text recall regresses in practice the constant is one line.
- Pinning changes when clipboard context can ENTER a session's prompts (it always could before via flips); it cannot change what the relevance filter accepts. A new copy re-evaluates immediately.
- Follow-up candidates deliberately not in this PR: battery-aware capture policy via the existing power-profile machinery, and raising `minimumTextHeight` with measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Three targeted efficiency improvements to the visual-context pipeline: a bounded FNV-1a pixel-hash cache that skips re-OCR when captured pixels are unchanged, a downscale cap reduction from 1600 → 1200 px (≈44% fewer pixels per Vision pass), and clipboard-relevance pinning that stabilises the prompt head so the engine's KV common prefix survives across keystrokes.

- **Pixel-hash cache** (`ScreenshotContextGenerator`): stride-17 FNV-1a hash gates the Vision pass; `finishedExcerpt` is refactored into a shared helper so hygiene and field-text stripping rerun on every call regardless of cache hit. The `noRecognizedText`/windowTitle fallback path does not populate the cache (noted in a previous review thread).
- **1200 px OCR cap** (`VisualContextModels`): measured-tradeoff constant with inline rationale; one-line revert if small-text recall regresses.
- **Clipboard preface pinning** (`SuggestionCoordinator+Prediction`): non-nil verdicts are pinned per `(focusChangeSequence, changeCount)`; nil verdicts keep re-evaluating. `handleSuggestionSettingsChange` does not clear the memo, so a pinned verdict from one engine can survive an engine switch within the same field session.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all three optimizations are narrowly scoped, each with a documented worst-case blast radius of one stale value for one field session.

Changes are well-contained: the pixel-hash cache degrades gracefully (nil hash disables it, stride-17 was corrected in the follow-up commit), the 1200 px cap is a single constant, and the clipboard memo self-heals on focus change or clipboard change. The only gap is that the memo is not invalidated on engine/settings change, which could leave a stale relevance verdict for the remainder of a field session — a minor behavioural edge case with no data-loss or security implications.

Cotabby/App/Coordinators/SuggestionCoordinator+Lifecycle.swift — handleSuggestionSettingsChange does not clear clipboardPrefaceMemo.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/Services/Visual/ScreenshotContextGenerator.swift | Adds FNV-1a pixel-hash extraction cache (stride 17 to sample all channels) and refactors finishedExcerpt into a shared helper; noRecognizedText/windowTitle path skips storeExtraction so that branch never warms the cache. |
| Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift | Extracts clipboard resolution into pinnedClipboardContext with correct (focusSequence, changeCount) keying; nil verdicts keep re-evaluating, non-nil are pinned. Memo is not cleared on settings change. |
| Cotabby/App/Coordinators/SuggestionCoordinator.swift | Adds ClipboardPrefaceMemo struct and clipboardPrefaceMemo property; straightforward data model change with clear documentation. |
| Cotabby/Models/VisualContextModels.swift | Lowers maxImageDimension default from 1600 to 1200; well-documented tradeoff with measured rationale in comments. |
| CotabbyTests/ScreenshotContextGeneratorTests.swift | Adds test_generateContext_reusesExtractionForIdenticalPixels with a CountingTextExtractor stub; correctly validates Vision-pass is skipped and output is byte-identical on cache hit. |
| CotabbyTests/PermissionAndContextModelTests.swift | Updates maxImageDimension expectation to 1200 with explanatory comment; trivial alignment change. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[generateContext called] --> B[captureScreenshot]
    B --> C[pixelHash of image]
    C --> D{hash in cache?}
    D -- yes --> E[finishedExcerpt\nhygiene + field-text strip]
    D -- no --> F[textExtractor.extractText\nVision OCR pass]
    F --> G{noRecognizedText?}
    G -- yes, windowTitle exists --> H[return title excerpt\ncache NOT populated]
    G -- no --> I[storeExtraction in cache]
    I --> E
    E --> J[VisualContextExcerpt]

    K[pinnedClipboardContext] --> L{settings enabled?}
    L -- no --> M[return nil]
    L -- yes --> N{memo hit?\nfocusSeq + changeCount match\nvalue != nil}
    N -- yes --> O[return pinned value]
    N -- no --> P[truncatedPromptPrefix\nclipboardRelevanceFilter]
    P --> Q[store ClipboardPrefaceMemo]
    Q --> R[return value]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cotabby/Services/Visual/ScreenshotContextGenerator.swift`, line 79-98 ([link](https://github.com/fujacob/cotabby/blob/184d9669ebdcc61d43a5a2b7b8ce36551c237de3/Cotabby/Services/Visual/ScreenshotContextGenerator.swift#L79-L98)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`noRecognizedText` branch never populates the cache**

   When Vision finds no text but a valid `windowTitle` is present, the function returns early at line 98 without calling `storeExtraction`. The `pixelHash` was computed, but the cache is never populated for this path. On the next call with identical pixels — the exact alt-tab scenario the PR targets — the cache check misses and Vision runs again. Applications like Figma or image-heavy UIs that commonly land in this branch get no benefit from the pixel-hash cache.

   A lightweight fix would be to store a sentinel `ExtractedScreenText` (e.g., empty lines) before the early return so the key is recorded; alternatively, the windowTitle path could be cached separately.

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22perf%2Fvisual-context-efficiency%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22perf%2Fvisual-context-efficiency%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FServices%2FVisual%2FScreenshotContextGenerator.swift%0ALine%3A%2079-98%0A%0AComment%3A%0A**%60noRecognizedText%60%20branch%20never%20populates%20the%20cache**%0A%0AWhen%20Vision%20finds%20no%20text%20but%20a%20valid%20%60windowTitle%60%20is%20present%2C%20the%20function%20returns%20early%20at%20line%2098%20without%20calling%20%60storeExtraction%60.%20The%20%60pixelHash%60%20was%20computed%2C%20but%20the%20cache%20is%20never%20populated%20for%20this%20path.%20On%20the%20next%20call%20with%20identical%20pixels%20%E2%80%94%20the%20exact%20alt-tab%20scenario%20the%20PR%20targets%20%E2%80%94%20the%20cache%20check%20misses%20and%20Vision%20runs%20again.%20Applications%20like%20Figma%20or%20image-heavy%20UIs%20that%20commonly%20land%20in%20this%20branch%20get%20no%20benefit%20from%20the%20pixel-hash%20cache.%0A%0AA%20lightweight%20fix%20would%20be%20to%20store%20a%20sentinel%20%60ExtractedScreenText%60%20%28e.g.%2C%20empty%20lines%29%20before%20the%20early%20return%20so%20the%20key%20is%20recorded%3B%20alternatively%2C%20the%20windowTitle%20path%20could%20be%20cached%20separately.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=685&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FServices%2FVisual%2FScreenshotContextGenerator.swift%0ALine%3A%2079-98%0A%0AComment%3A%0A**%60noRecognizedText%60%20branch%20never%20populates%20the%20cache**%0A%0AWhen%20Vision%20finds%20no%20text%20but%20a%20valid%20%60windowTitle%60%20is%20present%2C%20the%20function%20returns%20early%20at%20line%2098%20without%20calling%20%60storeExtraction%60.%20The%20%60pixelHash%60%20was%20computed%2C%20but%20the%20cache%20is%20never%20populated%20for%20this%20path.%20On%20the%20next%20call%20with%20identical%20pixels%20%E2%80%94%20the%20exact%20alt-tab%20scenario%20the%20PR%20targets%20%E2%80%94%20the%20cache%20check%20misses%20and%20Vision%20runs%20again.%20Applications%20like%20Figma%20or%20image-heavy%20UIs%20that%20commonly%20land%20in%20this%20branch%20get%20no%20benefit%20from%20the%20pixel-hash%20cache.%0A%0AA%20lightweight%20fix%20would%20be%20to%20store%20a%20sentinel%20%60ExtractedScreenText%60%20%28e.g.%2C%20empty%20lines%29%20before%20the%20early%20return%20so%20the%20key%20is%20recorded%3B%20alternatively%2C%20the%20windowTitle%20path%20could%20be%20cached%20separately.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=685&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22perf%2Fvisual-context-efficiency%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22perf%2Fvisual-context-efficiency%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BLifecycle.swift%3A48-96%0A**Stale%20clipboard%20verdict%20after%20engine%20or%20settings%20change**%0A%0A%60handleSuggestionSettingsChange%60%20cancels%20work%2C%20resets%20the%20generation%20context%2C%20and%20clears%20the%20suggestion%2C%20but%20never%20sets%20%60clipboardPrefaceMemo%20%3D%20nil%60.%20If%20the%20user%20switches%20engines%20while%20in%20the%20same%20field%20%28same%20%60focusChangeSequence%60%29%20without%20touching%20the%20clipboard%20%28same%20%60changeCount%60%29%20and%20a%20non-nil%20verdict%20was%20already%20pinned%2C%20%60pinnedClipboardContext%60%20returns%20the%20old%20verdict%20immediately%20without%20re-evaluating.%20The%20pinned%20verdict%20was%20computed%20using%20the%20old%20engine's%20%60truncatedPromptPrefix%60%20window%2C%20so%20if%20the%20new%20engine%20has%20a%20materially%20different%20context-window%20size%20the%20relevance%20signal%20fed%20to%20the%20prompt%20may%20be%20wrong%20until%20the%20user%20switches%20focus%20or%20changes%20the%20clipboard.%0A%0A&repo=fujacob%2Fcotabby&pr=685&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BLifecycle.swift%3A48-96%0A**Stale%20clipboard%20verdict%20after%20engine%20or%20settings%20change**%0A%0A%60handleSuggestionSettingsChange%60%20cancels%20work%2C%20resets%20the%20generation%20context%2C%20and%20clears%20the%20suggestion%2C%20but%20never%20sets%20%60clipboardPrefaceMemo%20%3D%20nil%60.%20If%20the%20user%20switches%20engines%20while%20in%20the%20same%20field%20%28same%20%60focusChangeSequence%60%29%20without%20touching%20the%20clipboard%20%28same%20%60changeCount%60%29%20and%20a%20non-nil%20verdict%20was%20already%20pinned%2C%20%60pinnedClipboardContext%60%20returns%20the%20old%20verdict%20immediately%20without%20re-evaluating.%20The%20pinned%20verdict%20was%20computed%20using%20the%20old%20engine's%20%60truncatedPromptPrefix%60%20window%2C%20so%20if%20the%20new%20engine%20has%20a%20materially%20different%20context-window%20size%20the%20relevance%20signal%20fed%20to%20the%20prompt%20may%20be%20wrong%20until%20the%20user%20switches%20focus%20or%20changes%20the%20clipboard.%0A%0A&repo=fujacob%2Fcotabby&pr=685&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["review: stride the pixel hash coprime wi..."](https://github.com/fujacob/cotabby/commit/de46342342a6f76538c2ef6339b28e96591011c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37135718)</sub>

<!-- /greptile_comment -->