### PR TITLE
Keep ghost text perfectly still through word accepts (TextEdit jitter)

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -305,6 +305,7 @@
 		709F365A846B908D953FA92D /* FoundationModelPromptRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE7BF162A12703249726F20A /* FoundationModelPromptRenderer.swift */; };
 		70D6F9480DA4104AD5669569 /* WelcomePermissionStepView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D6C2318E405AA717D1C256 /* WelcomePermissionStepView.swift */; };
 		7179FB0EC6411166CCD79F6B /* CompositionInputModeClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F283E5B403F9FEBFB4BA04A /* CompositionInputModeClassifier.swift */; };
+		7324B18578C646B1ADFF0C3F /* InsertedTextAdvanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C46024A6D18B1AD9D04B3BD /* InsertedTextAdvanceTests.swift */; };
 		735C2E64CA51F58098B30A0D /* it.txt in Resources */ = {isa = PBXBuildFile; fileRef = 0397F1DACB094A0F6A66BC0E /* it.txt */; };
 		74422BB837D6A319D12BF981 /* BaseCompletionPromptRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85EF79E6144D6C6AD062B569 /* BaseCompletionPromptRenderer.swift */; };
 		744B06C2488156B178675615 /* PermissionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85BF316556FDA64CB8AD07B6 /* PermissionManager.swift */; };
@@ -523,6 +524,7 @@
 		CF2EADEEEF5AA63FB9B9EA8E /* SuggestionInserter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3D1125B962CBE0269EEDDB /* SuggestionInserter.swift */; };
 		CF39EB76C3ECF8F764C1B4FB /* DeviceInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29ED42C4BDD0C521101AF95E /* DeviceInfo.swift */; };
 		CF4205B85D881B8176590D25 /* FocusSnapshotResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04E25414C307A20B6F9F20EC /* FocusSnapshotResolver.swift */; };
+		CFDB42AB7DC7F9663450BC7F /* InsertedTextAdvance.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1267FF524A170ACC144E919 /* InsertedTextAdvance.swift */; };
 		D0D4C0E28F5CD99669A49414 /* FoundationModelAvailabilityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8724ECA8FABBC82B0A2B943B /* FoundationModelAvailabilityService.swift */; };
 		D1D7D50E5C620042CEA3A77E /* LaunchAtLogin in Frameworks */ = {isa = PBXBuildFile; productRef = E0AA9F90B83B823132880E6F /* LaunchAtLogin */; };
 		D21EBD25BCB37E69B633BC00 /* CotabbyDebugOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93AF1246C1C2E296A1162E63 /* CotabbyDebugOptionsTests.swift */; };
@@ -549,6 +551,7 @@
 		DA23422A2CF77CFD3B1283C8 /* OnboardingTemplateFeatureListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D814BBA41CF29E8DD9954651 /* OnboardingTemplateFeatureListTests.swift */; };
 		DAD77998F793468D4D64B705 /* DateMacroEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F671FE53CDEAE9091EFBCE45 /* DateMacroEvaluator.swift */; };
 		DB1310FF3576ACA6472C4DB1 /* TrailingDuplicationFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19A5B462891263BDFB56607 /* TrailingDuplicationFilterTests.swift */; };
+		DB7BE0A914BF75654D9EA6FF /* InsertedTextAdvance.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1267FF524A170ACC144E919 /* InsertedTextAdvance.swift */; };
 		DC0394C83D334B92A512A775 /* NOTICE.md in Resources */ = {isa = PBXBuildFile; fileRef = 66CF2A70D4699421AC9BD849 /* NOTICE.md */; };
 		DC84D6A6A2F9A1060CD20ABB /* TokenCountEstimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BA30E71C21C77BB6EA4C166 /* TokenCountEstimator.swift */; };
 		DCABB8D2B391C7820D6CA5FF /* InsertionSafetyGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D472F9F396672E57873303B /* InsertionSafetyGate.swift */; };
@@ -811,6 +814,7 @@
 		78E280F4F39A9D86840800D2 /* SuggestionCoordinator+Lifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SuggestionCoordinator+Lifecycle.swift"; sourceTree = "<group>"; };
 		78E49BDA7F3A42455C4C5350 /* HuggingFaceModelBrowserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceModelBrowserView.swift; sourceTree = "<group>"; };
 		7C0FCC5CCF6AE528E3C4DDA7 /* PerformanceMetricsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceMetricsStoreTests.swift; sourceTree = "<group>"; };
+		7C46024A6D18B1AD9D04B3BD /* InsertedTextAdvanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsertedTextAdvanceTests.swift; sourceTree = "<group>"; };
 		7C9BB65FA5FC42B89766B037 /* he-100k.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "he-100k.txt"; sourceTree = "<group>"; };
 		7D472F9F396672E57873303B /* InsertionSafetyGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsertionSafetyGate.swift; sourceTree = "<group>"; };
 		7E44E393DD58B978B1EAB6CF /* GhostTextColorPreset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostTextColorPreset.swift; sourceTree = "<group>"; };
@@ -866,6 +870,7 @@
 		9E5F074ED7E340E9B9E4C5E0 /* EmojiPickerModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiPickerModels.swift; sourceTree = "<group>"; };
 		9E6439213F2A273702A6E26B /* GhostFontMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostFontMetrics.swift; sourceTree = "<group>"; };
 		9E72A3972E15749337539C2D /* EmojiRecents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiRecents.swift; sourceTree = "<group>"; };
+		A1267FF524A170ACC144E919 /* InsertedTextAdvance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsertedTextAdvance.swift; sourceTree = "<group>"; };
 		A168A7B6A7AD11559B60C56B /* ApplicationBundleMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationBundleMetadataTests.swift; sourceTree = "<group>"; };
 		A28B4A4368DB33C25E3AB5F3 /* EmojiPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiPaneView.swift; sourceTree = "<group>"; };
 		A3E8E86A14090BC7BD13BA76 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -1366,6 +1371,7 @@
 				D0AF9479EF020071CA64CCC1 /* HuggingFaceModelsTests.swift */,
 				BAC01317B0B68E3C4125E421 /* InputMonitorTests.swift */,
 				01F583E92B0A78212B330E6E /* InputSuppressionControllerTests.swift */,
+				7C46024A6D18B1AD9D04B3BD /* InsertedTextAdvanceTests.swift */,
 				43D627C4A55359EAF4676FF7 /* InsertionSafetyGateTests.swift */,
 				2960080A726E51198225147A /* InsertionStrategySelectorTests.swift */,
 				2930EC34057319130393696B /* KeyCodeLabelsTests.swift */,
@@ -1596,6 +1602,7 @@
 				043E8AA850F930222DD112C0 /* GhostSuggestionLayout.swift */,
 				7E44E393DD58B978B1EAB6CF /* GhostTextColorPreset.swift */,
 				41BBD5A4BA08CABE77860886 /* HardwareCapabilityProbe.swift */,
+				A1267FF524A170ACC144E919 /* InsertedTextAdvance.swift */,
 				7D472F9F396672E57873303B /* InsertionSafetyGate.swift */,
 				E0D2FEEA4304C86324BAADAB /* InsertionStrategySelector.swift */,
 				EAAE6B395FAB604DF059280A /* KeyCodeLabels.swift */,
@@ -1932,6 +1939,7 @@
 				266DB36F6BD7AD1038F13E39 /* InputModels.swift in Sources */,
 				5ADAA8600CE1A5ED570F889E /* InputMonitor.swift in Sources */,
 				3AC2F7F221F7C59242B06DFC /* InputSuppressionController.swift in Sources */,
+				CFDB42AB7DC7F9663450BC7F /* InsertedTextAdvance.swift in Sources */,
 				FC0C0C43EEC80325FE699B5A /* InsertionSafetyGate.swift in Sources */,
 				ADBCB725707ED11B19C7F08D /* InsertionStrategySelector.swift in Sources */,
 				1C267B67EA61527B74C9D051 /* KeyCodeLabels.swift in Sources */,
@@ -2156,6 +2164,7 @@
 				5F019E5A0679FFB52F129798 /* InputModels.swift in Sources */,
 				2DF5A3826AAB99C279EBB8DE /* InputMonitor.swift in Sources */,
 				6955C3A4D7AB3EEF7FA7C469 /* InputSuppressionController.swift in Sources */,
+				DB7BE0A914BF75654D9EA6FF /* InsertedTextAdvance.swift in Sources */,
 				DCABB8D2B391C7820D6CA5FF /* InsertionSafetyGate.swift in Sources */,
 				9D0F4829D11BCD4DB1290410 /* InsertionStrategySelector.swift in Sources */,
 				F78F594F77C26C233377E71F /* KeyCodeLabels.swift in Sources */,
@@ -2342,6 +2351,7 @@
 				663D37E35292F38666D807A7 /* HuggingFaceModelsTests.swift in Sources */,
 				07D046D406411ED85AC5758A /* InputMonitorTests.swift in Sources */,
 				0FCBF2250722780E46A92EE6 /* InputSuppressionControllerTests.swift in Sources */,
+				7324B18578C646B1ADFF0C3F /* InsertedTextAdvanceTests.swift in Sources */,
 				83EC3543DC45B1601F119BF9 /* InsertionSafetyGateTests.swift in Sources */,
 				FC255241A3B34A5717F09B36 /* InsertionStrategySelectorTests.swift in Sources */,
 				F66F0D982EBAF5A3E99C5342 /* KeyCodeLabelsTests.swift in Sources */,

--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
@@ -240,7 +240,7 @@ extension SuggestionCoordinator {
         insertionChunk: String,
         liveContext: FocusedInputContext
     ) {
-        if overlayController.advanceInline(to: remainingText) {
+        if overlayController.advanceInline(to: remainingText, insertedText: insertionChunk) {
             return
         }
 
@@ -250,6 +250,7 @@ extension SuggestionCoordinator {
             oldCaretRect: liveContext.caretRect,
             caretQuality: liveContext.caretQuality,
             observedCharWidth: liveContext.observedCharWidth,
+            fieldStyle: liveContext.resolvedFieldStyle,
             isRightToLeft: isRTL
         )
         presentOverlay(
@@ -492,9 +493,9 @@ extension SuggestionCoordinator {
         }
 
         state = .ready(text: advancedSession.remainingText, latency: advancedSession.latency)
-        // Same exact-width slide as Tab acceptance; the user typed the next characters, so the tail
-        // shrank by them. Fall back to the (session-start) caret anchor only if the slide can't apply.
-        if !overlayController.advanceInline(to: advancedSession.remainingText) {
+        // Same slide as Tab acceptance; the user typed the next characters, so the caret traveled
+        // by exactly them. Fall back to the (session-start) caret anchor only if the slide can't apply.
+        if !overlayController.advanceInline(to: advancedSession.remainingText, insertedText: typedCharacters) {
             presentOverlay(
                 text: advancedSession.remainingText,
                 at: session.baseContext.caretRect,
@@ -578,17 +579,21 @@ extension SuggestionCoordinator {
     /// Estimates the caret rect after inserting a chunk by shifting the old caret in the text
     /// direction. LTR shifts right; RTL shifts left.
     /// When `observedCharWidth` is available (measured from real AX child frames), we use it
-    /// directly — this matches the target app's actual font. Falls back to NSFont measurement.
+    /// directly — this matches the target app's actual font. Otherwise the field's resolved font
+    /// measures the chunk (the host's true caret travel), and only a host with no usable style
+    /// falls back to a system-font approximation.
     static func predictedCaretRect(
         after insertedChunk: String,
         oldCaretRect: CGRect,
         caretQuality: CaretGeometryQuality,
         observedCharWidth: CGFloat?,
+        fieldStyle: ResolvedFieldStyle? = nil,
         isRightToLeft: Bool = false
     ) -> CGRect {
         let measuredWidth = predictedChunkWidth(
             insertedChunk: insertedChunk,
-            observedCharWidth: observedCharWidth
+            observedCharWidth: observedCharWidth,
+            fieldStyle: fieldStyle
         )
         let chunkWidth: CGFloat
 
@@ -628,10 +633,18 @@ extension SuggestionCoordinator {
 
     private static func predictedChunkWidth(
         insertedChunk: String,
-        observedCharWidth: CGFloat?
+        observedCharWidth: CGFloat?,
+        fieldStyle: ResolvedFieldStyle? = nil
     ) -> CGFloat {
         if let observed = observedCharWidth {
             return observed * CGFloat(insertedChunk.count)
+        }
+
+        // The field's own font is the host's true caret travel; the system-14 fallback measured
+        // TextEdit's Helvetica 12 a quarter too wide, and the resulting overshoot surfaced as a
+        // corrective snap once AX published the real caret.
+        if let hostAdvance = InsertedTextAdvance.width(of: insertedChunk, style: fieldStyle) {
+            return hostAdvance
         }
 
         let attrs: [NSAttributedString.Key: Any] = [
@@ -641,7 +654,7 @@ extension SuggestionCoordinator {
     }
 
     /// Gives the host app ~30ms to process the synthetic keystroke, then forces an AX snapshot
-    /// so the overlay snaps to the real caret position without waiting for the 250ms poll.
+    /// so the overlay snaps to the real caret position without waiting for the 80ms poll.
     func schedulePostInsertionRefresh() {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.03) { [weak self] in
             guard let self else { return }

--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift
@@ -698,7 +698,10 @@ extension SuggestionCoordinator {
             newText: reconciledSession.remainingText,
             newCaretRect: liveContext.caretRect,
             newInputFrameRect: liveContext.inputFrameRect,
-            newFocusChangeSequence: liveContext.focusChangeSequence
+            newFocusChangeSequence: liveContext.focusChangeSequence,
+            // While the host has not published our own synthetic insert, this snapshot's caret is
+            // the pre-insertion one; re-anchoring to it is the left-then-right accept jitter.
+            isAwaitingPostInsertionSync: interactionState.isAwaitingPostInsertionSync
         ) {
             presentOverlay(
                 text: reconciledSession.remainingText,

--- a/Cotabby/Models/SuggestionSubsystemContracts.swift
+++ b/Cotabby/Models/SuggestionSubsystemContracts.swift
@@ -226,18 +226,19 @@ protocol SuggestionOverlayControlling: AnyObject {
     func showSuggestion(_ text: String, geometry: SuggestionOverlayGeometry)
     func hide(reason: String)
 
-    /// Advances a visible single-line inline ghost to `remainingText` by sliding the panel by the
-    /// exact rendered width of the text just handed off, keeping the remaining glyphs on the same
-    /// pixels (no caret re-read, no jitter). Returns `false` when the controller cannot safely slide
-    /// (hidden, mirror mode, RTL, multi-line, or nothing rendered to measure against); callers then
-    /// fall back to a caret-anchored present.
-    func advanceInline(to remainingText: String) -> Bool
+    /// Advances a visible single-line inline ghost to `remainingText` by sliding the panel right
+    /// by the caret's travel for `insertedText` (the text that just landed in the host, whether
+    /// Cotabby typed it or the user did). The slide reads the held overlay state, never a fresh AX
+    /// caret, so it cannot jitter against AX noise. Returns `false` when the controller cannot
+    /// safely slide (hidden, mirror mode, RTL, multi-line, or nothing rendered to measure
+    /// against); callers then fall back to a caret-anchored present.
+    func advanceInline(to remainingText: String, insertedText: String) -> Bool
 }
 
 extension SuggestionOverlayControlling {
     /// Default: not supported, so conformers that do not render an inline panel (e.g. test doubles)
     /// transparently fall back to the caret-anchored present path.
-    func advanceInline(to remainingText: String) -> Bool { false }
+    func advanceInline(to remainingText: String, insertedText: String) -> Bool { false }
 }
 
 @MainActor

--- a/Cotabby/Services/UI/OverlayController.swift
+++ b/Cotabby/Services/UI/OverlayController.swift
@@ -225,12 +225,12 @@ final class OverlayController: SuggestionOverlayControlling {
     }
 
     /// Advances a visible single-line inline ghost to `remainingText` by sliding the panel right by
-    /// the exact rendered width of the text just handed off, so the remaining glyphs stay on the same
-    /// pixels. This is the "perfectly still" path for word-by-word acceptance and type-through: it
-    /// reads the held overlay state (not a fresh AX caret), so it cannot jitter against AX noise.
+    /// the caret's travel for `insertedText`. This is the "perfectly still" path for word-by-word
+    /// acceptance and type-through: it reads the held overlay state (not a fresh AX caret), so it
+    /// cannot jitter against AX noise.
     /// Returns `false` when the held overlay is not a single-line, LTR, inline ghost this can safely
     /// slide; the caller then falls back to a caret-anchored present.
-    func advanceInline(to remainingText: String) -> Bool {
+    func advanceInline(to remainingText: String, insertedText: String) -> Bool {
         guard case let .visible(beforeText, geometry, mode) = state,
               case .inline = mode,
               !geometry.isRightToLeft,
@@ -242,8 +242,24 @@ final class OverlayController: SuggestionOverlayControlling {
         }
 
         let renderFont = lastInlineRenderFont ?? NSFont.systemFont(ofSize: fontSize)
-        let shift = GhostSuggestionLayout.renderedWidth(of: beforeText, font: renderFont)
-            - GhostSuggestionLayout.renderedWidth(of: remainingText, font: renderFont)
+        // Trusted-geometry hosts get the slide measured in the field's own font: that is the
+        // caret's true travel, so the anchor stays aligned with the post-publish AX caret and the
+        // stability gate never has to issue a delayed corrective nudge. The ghost render font is
+        // floored at 14pt for legibility, so its width of the same text overshoots a 12pt host by
+        // ~15% per accepted word; that error used to accumulate in the anchor until the gate
+        // snapped the tail sideways with no input in flight. The cost is a few points of tail
+        // shift at the accept keystroke itself (the ghost glyphs are wider than the host's), which
+        // lands exactly when the text visibly changes anyway. Untrusted/web geometry keeps the
+        // pixel-identical ghost-width slide: its anchors are approximate either way, and observed
+        // char-width hosts already correct through their own machinery.
+        let shift: CGFloat
+        if geometry.caretQuality == .exact,
+           let hostAdvance = InsertedTextAdvance.width(of: insertedText, style: geometry.resolvedFieldStyle) {
+            shift = hostAdvance
+        } else {
+            shift = GhostSuggestionLayout.renderedWidth(of: beforeText, font: renderFont)
+                - GhostSuggestionLayout.renderedWidth(of: remainingText, font: renderFont)
+        }
         // A non-positive or non-finite shift means the tail did not shrink as expected; re-anchor.
         guard shift.isFinite, shift > 0 else {
             return false

--- a/Cotabby/Support/InsertedTextAdvance.swift
+++ b/Cotabby/Support/InsertedTextAdvance.swift
@@ -1,0 +1,36 @@
+import AppKit
+
+/// File overview:
+/// Measures how far a host field's caret travels when text is inserted, using the field's own
+/// resolved font.
+///
+/// The accept-time overlay slide and the predicted-caret fallback both need the caret's true
+/// travel, not the ghost render font's width of the same text. The ghost is deliberately floored
+/// at 14pt for legibility while hosts commonly render smaller (TextEdit's Helvetica 12, plain-text
+/// Menlo 11), so a ghost-font measurement overshoots the real caret advance by 5-11pt per accepted
+/// word. That error lands in the overlay's anchor bookkeeping, accumulates past the stability
+/// gate's drift tolerance, and surfaces as a sideways nudge tens of milliseconds after the accept,
+/// when no input is happening and any motion reads as jitter. Measuring with the field's own font
+/// keeps the anchor aligned with where AX will report the caret once the host publishes the
+/// insert, so post-accept reconciles have nothing to correct.
+nonisolated enum InsertedTextAdvance {
+    /// Width of `text` in the field's resolved font, or nil when the style does not carry a
+    /// usable font (callers keep their previous approximation).
+    ///
+    /// Whitespace is measured as-is: a leading boundary space is real caret travel, so this
+    /// deliberately does not share `GhostSuggestionLayout`'s display normalization. A style whose
+    /// face name fails to resolve still uses the host's point size with the system face; the size
+    /// dominates the width error the ghost-font fallback suffers from.
+    static func width(of text: String, style: ResolvedFieldStyle?) -> CGFloat? {
+        guard !text.isEmpty, let style, let pointSize = style.fontPointSize, pointSize > 0 else {
+            return nil
+        }
+        let font = style.fontName.flatMap { NSFont(name: $0, size: pointSize) }
+            ?? NSFont.systemFont(ofSize: pointSize)
+        let width = (text as NSString).size(withAttributes: [.font: font]).width
+        guard width.isFinite, width > 0 else {
+            return nil
+        }
+        return width
+    }
+}

--- a/Cotabby/Support/SuggestionOverlayStabilityGate.swift
+++ b/Cotabby/Support/SuggestionOverlayStabilityGate.swift
@@ -41,12 +41,22 @@ enum SuggestionOverlayStabilityGate {
     ///   - The caret moved beyond `caretDriftTolerance` from where the overlay is currently anchored
     ///     (a genuine caret move, or accumulated advance drift that needs correcting).
     ///   - The host editor's frame moved on screen (window drag, sheet appear, etc.).
+    ///
+    /// `isAwaitingPostInsertionSync` short-circuits the geometry checks entirely: between a
+    /// synthesized insert and the host publishing it back through AX, the snapshot's caret is the
+    /// PRE-insertion one, a full accepted-word-width left of where the overlay correctly sits. The
+    /// drift tolerance cannot tell that stale rect from a genuine caret move, so the +30ms
+    /// post-insertion refresh used to re-anchor the ghost onto the just-accepted word and the next
+    /// poll tick snapped it back: the left-then-right accept jitter. While the field and text are
+    /// unchanged, stale geometry is never worth re-anchoring to; the hold lasts at most one or two
+    /// poll ticks because the sentinel clears the moment AX catches up.
     static func shouldRePresent(
         currentOverlay: OverlayState,
         newText: String,
         newCaretRect: CGRect,
         newInputFrameRect: CGRect?,
-        newFocusChangeSequence: UInt64
+        newFocusChangeSequence: UInt64,
+        isAwaitingPostInsertionSync: Bool = false
     ) -> Bool {
         // Render mode is the third associated value; it is not part of the stability decision, so
         // we ignore it. A mode change still re-anchors because text or geometry will also differ.
@@ -58,6 +68,11 @@ enum SuggestionOverlayStabilityGate {
         }
         if currentText != newText {
             return true
+        }
+        // Same field, same text, host has not published our own insert yet: every geometric field
+        // of this snapshot describes the pre-insertion state and must not move the overlay.
+        if isAwaitingPostInsertionSync {
+            return false
         }
         // Hold small caret deltas (post-insertion AX noise and exact-advance residual); re-anchor on
         // genuine moves and on accumulated drift past the tolerance. Compared against the held

--- a/CotabbyTests/InsertedTextAdvanceTests.swift
+++ b/CotabbyTests/InsertedTextAdvanceTests.swift
@@ -1,0 +1,99 @@
+import AppKit
+import XCTest
+@testable import Cotabby
+
+/// Locks the host-font caret-travel measurement that keeps the accept-time overlay slide aligned
+/// with where AX will report the caret once the host publishes the insert. The numbers here
+/// document the bug being prevented: the ghost render font is floored at 14pt, so measuring the
+/// accepted chunk with it overshoots a 12pt host by more than the stability gate's 6pt drift
+/// tolerance within one or two accepts, surfacing as a sideways nudge with no input in flight.
+final class InsertedTextAdvanceTests: XCTestCase {
+    func test_width_usesTheFieldsOwnFaceAndSize() throws {
+        let helvetica12 = ResolvedFieldStyle(fontName: "Helvetica", fontPointSize: 12, colorHex: nil)
+        let width = try XCTUnwrap(InsertedTextAdvance.width(of: " world", style: helvetica12))
+
+        let expected = (" world" as NSString).size(withAttributes: [
+            .font: try XCTUnwrap(NSFont(name: "Helvetica", size: 12))
+        ]).width
+        XCTAssertEqual(width, expected, accuracy: 0.01)
+    }
+
+    func test_width_atHostSizeIsSmallerThanTheGhostFloorMeasurement() throws {
+        // The exact regression scenario: TextEdit renders Helvetica 12, the ghost renders the
+        // same face at the 14pt legibility floor. The per-word delta must be visible to this
+        // test the same way it was visible on screen.
+        let host = try XCTUnwrap(
+            InsertedTextAdvance.width(
+                of: " world",
+                style: ResolvedFieldStyle(fontName: "Helvetica", fontPointSize: 12, colorHex: nil)
+            )
+        )
+        let ghostFloor = try XCTUnwrap(
+            InsertedTextAdvance.width(
+                of: " world",
+                style: ResolvedFieldStyle(fontName: "Helvetica", fontPointSize: 14, colorHex: nil)
+            )
+        )
+        XCTAssertGreaterThan(ghostFloor - host, 3, "The 12pt vs 14pt mismatch is points per word, not noise")
+    }
+
+    func test_width_countsLeadingWhitespaceAsRealCaretTravel() throws {
+        let style = ResolvedFieldStyle(fontName: "Helvetica", fontPointSize: 12, colorHex: nil)
+        let bare = try XCTUnwrap(InsertedTextAdvance.width(of: "world", style: style))
+        let spaced = try XCTUnwrap(InsertedTextAdvance.width(of: " world", style: style))
+        XCTAssertGreaterThan(spaced, bare, "A boundary space moves the caret and must be measured")
+    }
+
+    func test_width_unknownFaceFallsBackToSystemAtTheHostsSize() throws {
+        let style = ResolvedFieldStyle(fontName: "NoSuchFaceEver", fontPointSize: 12, colorHex: nil)
+        let width = try XCTUnwrap(InsertedTextAdvance.width(of: " world", style: style))
+
+        let expected = (" world" as NSString).size(withAttributes: [
+            .font: NSFont.systemFont(ofSize: 12)
+        ]).width
+        XCTAssertEqual(width, expected, accuracy: 0.01)
+    }
+
+    @MainActor
+    func test_predictedCaretRect_prefersTheHostFontOverTheSystemFallback() {
+        let oldCaret = CGRect(x: 100, y: 20, width: 2, height: 18)
+        let withHostFont = SuggestionCoordinator.predictedCaretRect(
+            after: " world",
+            oldCaretRect: oldCaret,
+            caretQuality: .exact,
+            observedCharWidth: nil,
+            fieldStyle: ResolvedFieldStyle(fontName: "Helvetica", fontPointSize: 12, colorHex: nil)
+        )
+        let withSystemFallback = SuggestionCoordinator.predictedCaretRect(
+            after: " world",
+            oldCaretRect: oldCaret,
+            caretQuality: .exact,
+            observedCharWidth: nil
+        )
+
+        XCTAssertLessThan(
+            withHostFont.origin.x,
+            withSystemFallback.origin.x,
+            "Helvetica 12 advances less than system 14; the prediction must track the host"
+        )
+        XCTAssertGreaterThan(withHostFont.origin.x, oldCaret.origin.x)
+    }
+
+    func test_width_refusesUnusableInputs() {
+        XCTAssertNil(InsertedTextAdvance.width(of: "", style: ResolvedFieldStyle(fontName: "Helvetica", fontPointSize: 12, colorHex: nil)))
+        XCTAssertNil(InsertedTextAdvance.width(of: " world", style: nil))
+        XCTAssertNil(
+            InsertedTextAdvance.width(
+                of: " world",
+                style: ResolvedFieldStyle(fontName: "Helvetica", fontPointSize: nil, colorHex: nil)
+            ),
+            "A style without a point size cannot describe caret travel"
+        )
+        XCTAssertNil(
+            InsertedTextAdvance.width(
+                of: " world",
+                style: ResolvedFieldStyle(fontName: "Helvetica", fontPointSize: 0, colorHex: nil)
+            )
+        )
+    }
+}

--- a/CotabbyTests/SuggestionCoordinatorPredictionTests.swift
+++ b/CotabbyTests/SuggestionCoordinatorPredictionTests.swift
@@ -336,6 +336,57 @@ final class SuggestionCoordinatorPredictionTests: XCTestCase {
         XCTAssertFalse(rig.coordinator.overlayState.isVisible)
     }
 
+    // MARK: - Post-insertion stillness
+
+    func test_reconcileDuringPostInsertionSyncWindow_neverReAnchorsTheOverlay() {
+        // The TextEdit accept jitter: Tab inserts " world" and the overlay advances immediately,
+        // but the +30ms refresh can read AX BEFORE the host publishes the insert. That snapshot's
+        // caret is the pre-insertion one, a full word left of the overlay; re-presenting there
+        // jumped the ghost left, and the post-publish poll snapped it back right. While the
+        // session is awaiting the publish, reconciles must hold the overlay exactly where it is.
+        let rig = retained(makeCoordinatorRig())
+        let context = FocusedInputContext(snapshot: rig.focusProvider.snapshot.context!, generation: 1)
+        _ = rig.interactionState.startSession(fullText: " world again", liveContext: context, latency: 0.05)
+        rig.overlayController.showSuggestion(" world again", geometry: CotabbyTestFixtures.overlayGeometry())
+
+        XCTAssertTrue(rig.coordinator.acceptCurrentSuggestion())
+        XCTAssertEqual(rig.inserter.insertedChunks, [" world"])
+        XCTAssertTrue(
+            rig.interactionState.isAwaitingPostInsertionSync,
+            "An accept must arm the publish sentinel before any reconcile can fire"
+        )
+        let presentsAfterAccept = rig.overlayController.shownTexts
+
+        // The +30ms refresh racing the publish: the field still shows the PRE-insertion text and
+        // caret. The reconciler tolerates the lag; presentation must not re-anchor.
+        rig.coordinator.reconcileActiveSession(with: rig.focusProvider.snapshot)
+
+        XCTAssertEqual(
+            rig.overlayController.shownTexts,
+            presentsAfterAccept,
+            "A pre-publish reconcile re-presented the overlay at the stale caret"
+        )
+        XCTAssertTrue(rig.interactionState.isAwaitingPostInsertionSync, "The sentinel survives the tolerated tick")
+        XCTAssertNotNil(rig.interactionState.activeSession)
+
+        // The host publishes: the same reconcile path clears the sentinel and may settle normally.
+        let publishedSnapshot = CotabbyTestFixtures.focusedInputSnapshot(precedingText: "Hello world")
+        rig.focusProvider.snapshot = FocusSnapshot(
+            applicationName: publishedSnapshot.applicationName,
+            bundleIdentifier: publishedSnapshot.bundleIdentifier,
+            capability: .supported,
+            context: publishedSnapshot,
+            inspection: nil
+        )
+        rig.coordinator.reconcileActiveSession(with: rig.focusProvider.snapshot)
+
+        XCTAssertFalse(
+            rig.interactionState.isAwaitingPostInsertionSync,
+            "The publish must lift the hold so genuine caret moves re-anchor again"
+        )
+        XCTAssertNotNil(rig.interactionState.activeSession, "The session survives the publish settle")
+    }
+
     // MARK: - Cache reset barrier
 
     func test_resetCachedGenerationContext_barrierRunsTheEngineResetExactlyOnce() async {

--- a/CotabbyTests/SuggestionOverlayStabilityGateTests.swift
+++ b/CotabbyTests/SuggestionOverlayStabilityGateTests.swift
@@ -253,4 +253,81 @@ final class SuggestionOverlayStabilityGateTests: XCTestCase {
             )
         )
     }
+
+    // MARK: - Post-insertion sync window
+
+    func test_awaitingPostInsertionSync_holdsEvenAcrossAWordWidthOfCaretDrift() {
+        // The +30ms refresh racing the host publish reads the PRE-insertion caret, a full accepted
+        // word left of where the overlay correctly sits. The drift tolerance cannot tell that from
+        // a genuine caret move; only the awaiting flag can, and it must win. This is the TextEdit
+        // left-then-right accept jitter.
+        let current: OverlayState = .visible(
+            text: " again",
+            geometry: Self.geometry(caretRect: CGRect(x: 180, y: 210, width: 2, height: 18)),
+            mode: .inline
+        )
+
+        XCTAssertFalse(
+            SuggestionOverlayStabilityGate.shouldRePresent(
+                currentOverlay: current,
+                newText: " again",
+                newCaretRect: Self.caretRect,
+                newInputFrameRect: Self.inputFrame,
+                newFocusChangeSequence: 7,
+                isAwaitingPostInsertionSync: true
+            )
+        )
+    }
+
+    func test_awaitingPostInsertionSync_stillReAnchorsOnFieldOrTextChange() {
+        // The hold only covers stale geometry for the same field and text: a real field switch or
+        // a text change mid-window must keep re-anchoring.
+        let current: OverlayState = .visible(
+            text: " again",
+            geometry: Self.geometry(),
+            mode: .inline
+        )
+
+        XCTAssertTrue(
+            SuggestionOverlayStabilityGate.shouldRePresent(
+                currentOverlay: current,
+                newText: " again",
+                newCaretRect: Self.caretRect,
+                newInputFrameRect: Self.inputFrame,
+                newFocusChangeSequence: 8,
+                isAwaitingPostInsertionSync: true
+            )
+        )
+        XCTAssertTrue(
+            SuggestionOverlayStabilityGate.shouldRePresent(
+                currentOverlay: current,
+                newText: " different tail",
+                newCaretRect: Self.caretRect,
+                newInputFrameRect: Self.inputFrame,
+                newFocusChangeSequence: 7,
+                isAwaitingPostInsertionSync: true
+            )
+        )
+    }
+
+    func test_syncCleared_wordWidthDriftReAnchorsAgain() {
+        // Once the host publishes (the sentinel clears), the same drift must re-anchor: that is
+        // the legitimate settle onto the real caret.
+        let current: OverlayState = .visible(
+            text: " again",
+            geometry: Self.geometry(caretRect: CGRect(x: 180, y: 210, width: 2, height: 18)),
+            mode: .inline
+        )
+
+        XCTAssertTrue(
+            SuggestionOverlayStabilityGate.shouldRePresent(
+                currentOverlay: current,
+                newText: " again",
+                newCaretRect: Self.caretRect,
+                newInputFrameRect: Self.inputFrame,
+                newFocusChangeSequence: 7,
+                isAwaitingPostInsertionSync: false
+            )
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Accepting a word in TextEdit sometimes jumped the remaining ghost text LEFT by roughly the accepted word's width, then snapped it back RIGHT a few dozen milliseconds later. A four-way investigation (full pipeline trace, overlay-layer audit, reconcile/prediction math with measured font widths, and structured-log mining) converged on two motion sources:

1. **The big bounce (intermittent):** the +30ms post-insertion refresh races the host's processing of the synthetic keystroke. When TextEdit loses the race, the snapshot carries the PRE-insertion caret. The session reconciler correctly tolerates the lag, but presentation discarded that fact and ran `SuggestionOverlayStabilityGate` against the stale caret: a full word of "drift" blows past the 6pt tolerance, so the gate re-anchored the ghost onto the just-accepted text (left), and the next 80ms poll re-anchored it onto the published caret (right). The gate never consulted `isAwaitingPostInsertionSync`, the precise signal that the geometry is suspect.
2. **The residual nudge (systematic):** the accept-time slide measured the consumed text in the ghost render font, which is floored at 14pt for legibility, while TextEdit renders Helvetica 12 (rich text) or Menlo 11 (plain text). Measured on this machine, that overshoots the real caret travel by 5.3pt (Helvetica) to 10.9pt (Menlo) per accepted word; the error accumulates in the anchor until the gate fires a sideways correction with no input in flight (every second accept for Helvetica, every accept for Menlo). The slide-fallback path was worse, measuring with a fixed system-14 font (+23% vs Helvetica 12).

The fix addresses each at its source:
- `SuggestionOverlayStabilityGate.shouldRePresent` gains `isAwaitingPostInsertionSync` and holds geometry outright while the host has not published the insert (same field, same text). The hold lifts on the exact reconcile tick that observes the publish, because the interaction state clears the sentinel before presentation reads it. Field switches and text changes still re-anchor mid-window.
- New pure `InsertedTextAdvance` measures the caret's true travel for inserted text using the field's own resolved font. `advanceInline` uses it for trusted `.exact` geometry (web/derived hosts keep the existing pixel-identical ghost-width slide and their `observedCharWidth` machinery), and `predictedCaretRect`'s fallback prefers it over the system-14 approximation. With the anchor matching the published caret within kerning noise, post-accept reconciles have nothing left to correct: any residual few-point tail shift now happens at the accept keystroke itself, where the text is visibly changing anyway, and nothing moves afterward.

## Validation

```
xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  -skip-testing:CotabbyTests/FoundationModelDriftEvalTests \
  CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
# ** TEST SUCCEEDED ** 1466 tests, 0 failures, 0 crashes

swiftlint lint --quiet
# 0 findings on the files this PR touches
```

New regression locks:
- Gate: a word-width caret drift during the sync window holds; the same drift after the publish re-anchors (the legitimate settle); field/text changes re-anchor even mid-window.
- Coordinator (recording rig): a full accept followed by a pre-publish reconcile produces zero re-presents, the sentinel survives the tolerated tick, and the publish lifts the hold.
- `InsertedTextAdvance`: host-face/size measurement, the documented 12pt-vs-14pt per-word delta (>3pt), leading-space travel, unknown-face fallback at the host's size, and unusable-input refusals.
- `predictedCaretRect` prefers the host font over the system-14 fallback.

Not verified live in a TextEdit typing session (the logs show TextEdit has never run under `-cotabby-debug` on this machine); the mechanism is pinned by code-level tracing with measured font arithmetic, and both motion sources are locked by differential tests that fail on the previous behavior.

## Linked issues

None filed; reported directly ("fragile... jitters left then jitters back to the right after accepting a word" in TextEdit).

## Risk / rollout notes

- The gate hold is scoped tightly: it requires an unpublished synthetic insert AND unchanged field AND unchanged text, and lasts at most one or two poll ticks (the sentinel clears the moment AX catches up). A window drag inside that sub-100ms window settles one tick later than before.
- Host-font slide math is gated to `.exact` caret quality, so Gmail/Outlook-class derived hosts keep today's slide behavior bit-for-bit.
- `advanceInline` gained an `insertedText` parameter (protocol + default); the only behavioral callers are word-accept and type-through advancement.
- If a host swallows the insert entirely, the sentinel-driven hold ends the same way it does today: the session invalidates through the normal divergence rules.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR eliminates two sources of ghost-text jitter that triggered when accepting a word in TextEdit (and similar apps): a timing-race where the +30ms post-insertion AX refresh reads the pre-insertion caret and re-anchors the overlay left, and a systematic font-size mismatch where the ghost render font (floored at 14pt) measured accepted text wider than the host's 12pt Helvetica, accumulating anchor error past the stability gate's tolerance.

- `SuggestionOverlayStabilityGate.shouldRePresent` gains an `isAwaitingPostInsertionSync` short-circuit that holds geometry for the same field and text while the host has not yet published the synthetic insert; field switches and text changes still re-anchor immediately through checks that remain ahead of the new guard.
- New `InsertedTextAdvance` utility measures the host field's true caret travel using its AX-resolved font; `advanceInline` uses it for `.exact`-quality geometry (the pixel-correct slide), and `predictedCaretRect`'s fallback prefers it over the previous system-14 approximation.
- Web/derived hosts and `observedCharWidth` hosts are explicitly kept on their existing paths, so only the targeted TextEdit-class scenario changes behavior.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the changes are tightly scoped, well-tested, and fallback paths keep existing host types on their previous behavior.

Both motion sources are addressed at their actual root cause, test coverage is thorough across unit and integration levels, and the behavioral gating correctly limits the new code to the intended case. The only gaps are that the integration test exercises the ghost-font fallback rather than the new host-font slide, and a width > 0 guard is dead code — neither affects correctness.

CotabbyTests/SuggestionCoordinatorPredictionTests.swift — the integration test would be more complete with a resolvedFieldStyle-bearing overlay geometry so the host-font slide path is exercised end-to-end.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/Support/InsertedTextAdvance.swift | New utility measuring host-font caret advance for accepted text; clean, well-documented, and guarded against nil/zero/infinite widths. |
| Cotabby/Support/SuggestionOverlayStabilityGate.swift | Adds isAwaitingPostInsertionSync guard after field-switch and text-change checks, correctly ordering the short-circuit so field switches and text changes still re-anchor even during the sync window. |
| Cotabby/Services/UI/OverlayController.swift | advanceInline now takes insertedText and uses host-font width for .exact-quality geometry, falling back to ghost-font diff for web/derived hosts; logic is sound. |
| Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift | Passes insertedText and fieldStyle through the acceptance and type-through paths; fieldStyle is now included in predictedCaretRect for the non-slide fallback, improving accuracy. |
| Cotabby/App/Coordinators/SuggestionCoordinator+Prediction.swift | Threads isAwaitingPostInsertionSync from interactionState into the stability gate call; minimal, correctly placed change. |
| CotabbyTests/InsertedTextAdvanceTests.swift | Thorough unit tests for InsertedTextAdvance: host-font measurement, 12pt vs 14pt delta, leading-space travel, unknown-face fallback, nil/zero point-size refusals, and predictedCaretRect host-font preference. |
| CotabbyTests/SuggestionOverlayStabilityGateTests.swift | Adds three gate tests covering the sync-window hold under word-width drift, the re-anchor on field/text changes even while awaiting, and the post-publish re-anchor restoration. |
| CotabbyTests/SuggestionCoordinatorPredictionTests.swift | New integration test verifies the full accept → pre-publish reconcile → publish cycle; uses overlayGeometry() without resolvedFieldStyle so advanceInline exercises the ghost-font fallback path rather than the new host-font slide. |
| Cotabby/Models/SuggestionSubsystemContracts.swift | Protocol and default updated to require insertedText; default still returns false so test doubles transparently fall back to caret-anchored present without changes. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User (Tab accept)
    participant SC as SuggestionCoordinator
    participant IS as InteractionState
    participant OC as OverlayController
    participant ITA as InsertedTextAdvance
    participant SOSG as StabilityGate
    participant AX as Accessibility (AX)

    U->>SC: acceptCurrentSuggestion()
    SC->>IS: "arm isAwaitingPostInsertionSync = true"
    SC->>OC: advanceInline(to: ' again', insertedText: ' world')
    OC->>ITA: width(of: ' world', style: resolvedFieldStyle)
    ITA-->>OC: host-font advance (e.g. 34pt for Helvetica 12)
    OC->>OC: "shift = hostAdvance (not ghost-font diff)"
    OC->>OC: slide panel right by shift, update state
    Note over SC,AX: +30ms post-insertion refresh (AX may not have published insert yet)
    SC->>AX: snapshot()
    AX-->>SC: pre-insertion caret (left of correct position)
    SC->>SOSG: shouldRePresent(..., isAwaitingPostInsertionSync: true)
    SOSG-->>SC: false (hold - same field, same text, sentinel armed)
    Note over OC: overlay stays perfectly still
    Note over SC,AX: Next poll - AX publishes the insert
    SC->>AX: snapshot()
    AX-->>SC: post-insertion caret (correct position)
    SC->>IS: reconcile clears isAwaitingPostInsertionSync
    SC->>SOSG: shouldRePresent(..., isAwaitingPostInsertionSync: false)
    SOSG-->>SC: "false if drift < 6pt, true only if genuine drift"
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `CotabbyTests/SuggestionCoordinatorPredictionTests.swift`, line 475 ([link](https://github.com/fujacob/cotabby/blob/4df7cae5ec47e3e828e68a6ffd4f98ae8e21e06c/CotabbyTests/SuggestionCoordinatorPredictionTests.swift#L475)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Integration test exercises the ghost-font fallback, not the new host-font slide**

   `CotabbyTestFixtures.overlayGeometry()` sets `caretQuality: .exact` but leaves `resolvedFieldStyle: nil` (it has no parameter for it). In `advanceInline`, the new host-font branch requires both `geometry.caretQuality == .exact` AND a non-nil `InsertedTextAdvance.width`, which itself requires a non-nil `style`. With `style == nil`, `InsertedTextAdvance.width` returns `nil`, so the slide falls back to the ghost-font diff path — the old behavior rather than the new fix.

   The test still correctly validates the stability-gate hold (no re-present during the sync window), but it doesn't exercise the `InsertedTextAdvance`-driven slide that is the core of fix #2. The `InsertedTextAdvanceTests` cover the measurement path in isolation, and `test_predictedCaretRect_prefersTheHostFontOverTheSystemFallback` covers the prediction fallback, so coverage is ultimately adequate — but an `overlayGeometry(resolvedFieldStyle: ...)` variant here would lock the full new slide path end-to-end.

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Ftextedit-accept-jitter%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Ftextedit-accept-jitter%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20CotabbyTests%2FSuggestionCoordinatorPredictionTests.swift%0ALine%3A%20475%0A%0AComment%3A%0A**Integration%20test%20exercises%20the%20ghost-font%20fallback%2C%20not%20the%20new%20host-font%20slide**%0A%0A%60CotabbyTestFixtures.overlayGeometry%28%29%60%20sets%20%60caretQuality%3A%20.exact%60%20but%20leaves%20%60resolvedFieldStyle%3A%20nil%60%20%28it%20has%20no%20parameter%20for%20it%29.%20In%20%60advanceInline%60%2C%20the%20new%20host-font%20branch%20requires%20both%20%60geometry.caretQuality%20%3D%3D%20.exact%60%20AND%20a%20non-nil%20%60InsertedTextAdvance.width%60%2C%20which%20itself%20requires%20a%20non-nil%20%60style%60.%20With%20%60style%20%3D%3D%20nil%60%2C%20%60InsertedTextAdvance.width%60%20returns%20%60nil%60%2C%20so%20the%20slide%20falls%20back%20to%20the%20ghost-font%20diff%20path%20%E2%80%94%20the%20old%20behavior%20rather%20than%20the%20new%20fix.%0A%0AThe%20test%20still%20correctly%20validates%20the%20stability-gate%20hold%20%28no%20re-present%20during%20the%20sync%20window%29%2C%20but%20it%20doesn't%20exercise%20the%20%60InsertedTextAdvance%60-driven%20slide%20that%20is%20the%20core%20of%20fix%20%232.%20The%20%60InsertedTextAdvanceTests%60%20cover%20the%20measurement%20path%20in%20isolation%2C%20and%20%60test_predictedCaretRect_prefersTheHostFontOverTheSystemFallback%60%20covers%20the%20prediction%20fallback%2C%20so%20coverage%20is%20ultimately%20adequate%20%E2%80%94%20but%20an%20%60overlayGeometry%28resolvedFieldStyle%3A%20...%29%60%20variant%20here%20would%20lock%20the%20full%20new%20slide%20path%20end-to-end.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=690&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20CotabbyTests%2FSuggestionCoordinatorPredictionTests.swift%0ALine%3A%20475%0A%0AComment%3A%0A**Integration%20test%20exercises%20the%20ghost-font%20fallback%2C%20not%20the%20new%20host-font%20slide**%0A%0A%60CotabbyTestFixtures.overlayGeometry%28%29%60%20sets%20%60caretQuality%3A%20.exact%60%20but%20leaves%20%60resolvedFieldStyle%3A%20nil%60%20%28it%20has%20no%20parameter%20for%20it%29.%20In%20%60advanceInline%60%2C%20the%20new%20host-font%20branch%20requires%20both%20%60geometry.caretQuality%20%3D%3D%20.exact%60%20AND%20a%20non-nil%20%60InsertedTextAdvance.width%60%2C%20which%20itself%20requires%20a%20non-nil%20%60style%60.%20With%20%60style%20%3D%3D%20nil%60%2C%20%60InsertedTextAdvance.width%60%20returns%20%60nil%60%2C%20so%20the%20slide%20falls%20back%20to%20the%20ghost-font%20diff%20path%20%E2%80%94%20the%20old%20behavior%20rather%20than%20the%20new%20fix.%0A%0AThe%20test%20still%20correctly%20validates%20the%20stability-gate%20hold%20%28no%20re-present%20during%20the%20sync%20window%29%2C%20but%20it%20doesn't%20exercise%20the%20%60InsertedTextAdvance%60-driven%20slide%20that%20is%20the%20core%20of%20fix%20%232.%20The%20%60InsertedTextAdvanceTests%60%20cover%20the%20measurement%20path%20in%20isolation%2C%20and%20%60test_predictedCaretRect_prefersTheHostFontOverTheSystemFallback%60%20covers%20the%20prediction%20fallback%2C%20so%20coverage%20is%20ultimately%20adequate%20%E2%80%94%20but%20an%20%60overlayGeometry%28resolvedFieldStyle%3A%20...%29%60%20variant%20here%20would%20lock%20the%20full%20new%20slide%20path%20end-to-end.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=690&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Ftextedit-accept-jitter%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Ftextedit-accept-jitter%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabbyTests%2FSuggestionCoordinatorPredictionTests.swift%3A475%0A**Integration%20test%20exercises%20the%20ghost-font%20fallback%2C%20not%20the%20new%20host-font%20slide**%0A%0A%60CotabbyTestFixtures.overlayGeometry%28%29%60%20sets%20%60caretQuality%3A%20.exact%60%20but%20leaves%20%60resolvedFieldStyle%3A%20nil%60%20%28it%20has%20no%20parameter%20for%20it%29.%20In%20%60advanceInline%60%2C%20the%20new%20host-font%20branch%20requires%20both%20%60geometry.caretQuality%20%3D%3D%20.exact%60%20AND%20a%20non-nil%20%60InsertedTextAdvance.width%60%2C%20which%20itself%20requires%20a%20non-nil%20%60style%60.%20With%20%60style%20%3D%3D%20nil%60%2C%20%60InsertedTextAdvance.width%60%20returns%20%60nil%60%2C%20so%20the%20slide%20falls%20back%20to%20the%20ghost-font%20diff%20path%20%E2%80%94%20the%20old%20behavior%20rather%20than%20the%20new%20fix.%0A%0AThe%20test%20still%20correctly%20validates%20the%20stability-gate%20hold%20%28no%20re-present%20during%20the%20sync%20window%29%2C%20but%20it%20doesn't%20exercise%20the%20%60InsertedTextAdvance%60-driven%20slide%20that%20is%20the%20core%20of%20fix%20%232.%20The%20%60InsertedTextAdvanceTests%60%20cover%20the%20measurement%20path%20in%20isolation%2C%20and%20%60test_predictedCaretRect_prefersTheHostFontOverTheSystemFallback%60%20covers%20the%20prediction%20fallback%2C%20so%20coverage%20is%20ultimately%20adequate%20%E2%80%94%20but%20an%20%60overlayGeometry%28resolvedFieldStyle%3A%20...%29%60%20variant%20here%20would%20lock%20the%20full%20new%20slide%20path%20end-to-end.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FSupport%2FInsertedTextAdvance.swift%3A31-32%0A**%60width%20%3E%200%60%20guard%20is%20redundant%20given%20%60NSString.size%60%20advance-width%20semantics**%0A%0A%60NSString.size%28withAttributes%3A%29%60%20returns%20the%20typographic%20advance%20width%20of%20the%20string%2C%20which%20is%20positive%20for%20any%20non-empty%20string%20including%20pure%20whitespace%20%28confirmed%3A%20a%20single%20space%20returns%20its%20glyph%20advance%2C%20not%200%29.%20The%20guard%20%60width%20%3E%200%60%20cannot%20fire%20for%20any%20input%20that%20passed%20the%20%60!text.isEmpty%60%20check%2C%20so%20it%20is%20dead%20code%20in%20practice.%20Removing%20it%20would%20make%20the%20boundary%20condition%20explicit%20in%20the%20guard%20above%20%28%60!text.isEmpty%60%29%20and%20remove%20a%20subtle%20implication%20that%20whitespace%20might%20somehow%20return%20zero.%20Separately%2C%20the%20%60width.isFinite%60%20check%20is%20still%20useful%20for%20pathological%20custom%20fonts.%0A%0A&repo=fujacob%2Fcotabby&pr=690&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabbyTests%2FSuggestionCoordinatorPredictionTests.swift%3A475%0A**Integration%20test%20exercises%20the%20ghost-font%20fallback%2C%20not%20the%20new%20host-font%20slide**%0A%0A%60CotabbyTestFixtures.overlayGeometry%28%29%60%20sets%20%60caretQuality%3A%20.exact%60%20but%20leaves%20%60resolvedFieldStyle%3A%20nil%60%20%28it%20has%20no%20parameter%20for%20it%29.%20In%20%60advanceInline%60%2C%20the%20new%20host-font%20branch%20requires%20both%20%60geometry.caretQuality%20%3D%3D%20.exact%60%20AND%20a%20non-nil%20%60InsertedTextAdvance.width%60%2C%20which%20itself%20requires%20a%20non-nil%20%60style%60.%20With%20%60style%20%3D%3D%20nil%60%2C%20%60InsertedTextAdvance.width%60%20returns%20%60nil%60%2C%20so%20the%20slide%20falls%20back%20to%20the%20ghost-font%20diff%20path%20%E2%80%94%20the%20old%20behavior%20rather%20than%20the%20new%20fix.%0A%0AThe%20test%20still%20correctly%20validates%20the%20stability-gate%20hold%20%28no%20re-present%20during%20the%20sync%20window%29%2C%20but%20it%20doesn't%20exercise%20the%20%60InsertedTextAdvance%60-driven%20slide%20that%20is%20the%20core%20of%20fix%20%232.%20The%20%60InsertedTextAdvanceTests%60%20cover%20the%20measurement%20path%20in%20isolation%2C%20and%20%60test_predictedCaretRect_prefersTheHostFontOverTheSystemFallback%60%20covers%20the%20prediction%20fallback%2C%20so%20coverage%20is%20ultimately%20adequate%20%E2%80%94%20but%20an%20%60overlayGeometry%28resolvedFieldStyle%3A%20...%29%60%20variant%20here%20would%20lock%20the%20full%20new%20slide%20path%20end-to-end.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FSupport%2FInsertedTextAdvance.swift%3A31-32%0A**%60width%20%3E%200%60%20guard%20is%20redundant%20given%20%60NSString.size%60%20advance-width%20semantics**%0A%0A%60NSString.size%28withAttributes%3A%29%60%20returns%20the%20typographic%20advance%20width%20of%20the%20string%2C%20which%20is%20positive%20for%20any%20non-empty%20string%20including%20pure%20whitespace%20%28confirmed%3A%20a%20single%20space%20returns%20its%20glyph%20advance%2C%20not%200%29.%20The%20guard%20%60width%20%3E%200%60%20cannot%20fire%20for%20any%20input%20that%20passed%20the%20%60!text.isEmpty%60%20check%2C%20so%20it%20is%20dead%20code%20in%20practice.%20Removing%20it%20would%20make%20the%20boundary%20condition%20explicit%20in%20the%20guard%20above%20%28%60!text.isEmpty%60%29%20and%20remove%20a%20subtle%20implication%20that%20whitespace%20might%20somehow%20return%20zero.%20Separately%2C%20the%20%60width.isFinite%60%20check%20is%20still%20useful%20for%20pathological%20custom%20fonts.%0A%0A&repo=fujacob%2Fcotabby&pr=690&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(overlay): keep ghost text perfectly ..."](https://github.com/fujacob/cotabby/commit/4df7cae5ec47e3e828e68a6ffd4f98ae8e21e06c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37146810)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->