### PR TITLE
Hold TextKit-mirror caret anchors perfectly still through word accepts

### DIFF
--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift
@@ -240,7 +240,21 @@ extension SuggestionCoordinator {
         insertionChunk: String,
         liveContext: FocusedInputContext
     ) {
-        if overlayController.advanceInline(to: remainingText, insertedText: insertionChunk) {
+        // A layout-estimated anchor lives in the hidden text layout's coordinate system, and the
+        // estimator models the accepted chunk's true advance (soft wrap included) better than any
+        // width shift can: that re-anchor, fed with the pending insertion below, is exactly what
+        // the caret repair was built for on these hosts. Sliding instead leaves the anchor a
+        // ghost-vs-host font error away from the next estimate and the settle showed up as a
+        // post-accept jerk. Skip the slide so the estimator places the tail where the
+        // post-publish estimate will also land; nothing moves afterwards.
+        let heldOverlayQuality: CaretGeometryQuality?
+        if case let .visible(_, geometry, _) = overlayState {
+            heldOverlayQuality = geometry.caretQuality
+        } else {
+            heldOverlayQuality = nil
+        }
+        if heldOverlayQuality != .layoutEstimated,
+           overlayController.advanceInline(to: remainingText, insertedText: insertionChunk) {
             return
         }
 

--- a/Cotabby/Support/BrowserAppDetector.swift
+++ b/Cotabby/Support/BrowserAppDetector.swift
@@ -15,7 +15,7 @@ import Foundation
 ///
 /// Matching is by case-insensitive bundle-identifier prefix to tolerate channel suffixes
 /// (`com.google.Chrome.canary`, `com.google.Chrome.beta`, etc.).
-enum BrowserAppDetector {
+nonisolated enum BrowserAppDetector {
     /// Every browser family, used for the broad "typing in a browser" tone hint.
     private static let browserBundlePrefixes: [String] = [
         "com.apple.safari",

--- a/Cotabby/Support/ControlTokenMarkers.swift
+++ b/Cotabby/Support/ControlTokenMarkers.swift
@@ -20,7 +20,7 @@ import Foundation
 /// into a text field expecting a completion, so removing them cannot eat legitimate prose or code.
 /// `<think>…</think>` reasoning blocks are intentionally not listed here: they are handled separately
 /// so the text around them survives.
-enum ControlTokenMarkers {
+nonisolated enum ControlTokenMarkers {
     /// A Llama-3 role-header block, e.g. `<|start_header_id|>assistant<|end_header_id|>`. The role
     /// name sits *between* the markers, so removing the markers individually would leak the role word
     /// into the ghost text; this strips the whole block. `|` is escaped because it is a regex

--- a/Cotabby/Support/SuggestionOverlayStabilityGate.swift
+++ b/Cotabby/Support/SuggestionOverlayStabilityGate.swift
@@ -74,12 +74,22 @@ enum SuggestionOverlayStabilityGate {
         if isAwaitingPostInsertionSync {
             return false
         }
-        // Hold small caret deltas (post-insertion AX noise and exact-advance residual); re-anchor on
-        // genuine moves and on accumulated drift past the tolerance. Compared against the held
-        // (already-advanced) caret, not a per-tick previous value, so slow drift still gets corrected.
-        if abs(currentGeometry.caretRect.origin.x - newCaretRect.origin.x) > caretDriftTolerance
-            || abs(currentGeometry.caretRect.origin.y - newCaretRect.origin.y) > caretDriftTolerance {
-            return true
+        // A layout-estimated anchor was computed by the hidden text layout from (text, field
+        // frame, style), not from the resolver's caret. Fresh snapshots still carry the RAW
+        // resolver rect (an AXFrame proportional guess, or a derived rect the repair overrode),
+        // which lives in a different trust system and routinely sits a word or more away from the
+        // estimate; treating that gap as caret drift re-presented (and re-estimated) on every
+        // reconcile tick. With text and field unchanged the estimate is pure-function stable, so
+        // only the frame check below can demand a re-anchor for these overlays.
+        if currentGeometry.caretQuality != .layoutEstimated {
+            // Hold small caret deltas (post-insertion AX noise and exact-advance residual); re-anchor
+            // on genuine moves and on accumulated drift past the tolerance. Compared against the held
+            // (already-advanced) caret, not a per-tick previous value, so slow drift still gets
+            // corrected.
+            if abs(currentGeometry.caretRect.origin.x - newCaretRect.origin.x) > caretDriftTolerance
+                || abs(currentGeometry.caretRect.origin.y - newCaretRect.origin.y) > caretDriftTolerance {
+                return true
+            }
         }
         // `observedCharWidth` is intentionally NOT compared here. Drift in that value also affects
         // `GhostSuggestionLayout.singleLineFits` (and therefore the panel-origin branch), so during

--- a/Cotabby/Support/TerminalAppDetector.swift
+++ b/Cotabby/Support/TerminalAppDetector.swift
@@ -5,7 +5,7 @@ import Foundation
 /// Terminal apps have their own completion, history, and shell integrations that conflict with
 /// ghost-text autocomplete. Cotabby stays out of the way automatically so the user doesn't have to
 /// manually disable each terminal they use.
-enum TerminalAppDetector {
+nonisolated enum TerminalAppDetector {
     /// Bundle identifiers of well-known macOS terminal emulators.
     private static let terminalBundleIdentifiers: Set<String> = [
         "com.apple.Terminal",

--- a/CotabbyTests/SuggestionCoordinatorPredictionTests.swift
+++ b/CotabbyTests/SuggestionCoordinatorPredictionTests.swift
@@ -338,6 +338,42 @@ final class SuggestionCoordinatorPredictionTests: XCTestCase {
 
     // MARK: - Post-insertion stillness
 
+    func test_accept_layoutEstimatedOverlaySkipsTheSlideAndReAnchorsViaTheEstimator() {
+        // TextKit-mirror hosts: the overlay anchor came from the hidden layout estimate, so a
+        // width-based slide leaves it a ghost-vs-host font error away from the next estimate and
+        // the settle reads as a post-accept jerk. The accept must skip the slide and go through
+        // the presenting path, where the layout repair (fed the pending insertion) re-anchors at
+        // exactly the position the post-publish estimate will reproduce.
+        let rig = retained(makeCoordinatorRig())
+        let context = FocusedInputContext(snapshot: rig.focusProvider.snapshot.context!, generation: 1)
+        _ = rig.interactionState.startSession(fullText: " world again", liveContext: context, latency: 0.05)
+        rig.overlayController.showSuggestion(
+            " world again",
+            geometry: CotabbyTestFixtures.overlayGeometry(caretQuality: .layoutEstimated)
+        )
+
+        XCTAssertTrue(rig.coordinator.acceptCurrentSuggestion())
+
+        XCTAssertTrue(
+            rig.overlayController.advanceInlineCalls.isEmpty,
+            "A layout-estimated overlay must never width-slide on accept"
+        )
+        XCTAssertEqual(rig.overlayController.shownTexts.last, " again", "The estimator path re-presented the tail")
+    }
+
+    func test_accept_trustedGeometryStillAttemptsTheSlideFirst() {
+        let rig = retained(makeCoordinatorRig())
+        let context = FocusedInputContext(snapshot: rig.focusProvider.snapshot.context!, generation: 1)
+        _ = rig.interactionState.startSession(fullText: " world again", liveContext: context, latency: 0.05)
+        rig.overlayController.showSuggestion(" world again", geometry: CotabbyTestFixtures.overlayGeometry())
+
+        XCTAssertTrue(rig.coordinator.acceptCurrentSuggestion())
+
+        XCTAssertEqual(rig.overlayController.advanceInlineCalls.count, 1)
+        XCTAssertEqual(rig.overlayController.advanceInlineCalls.first?.remaining, " again")
+        XCTAssertEqual(rig.overlayController.advanceInlineCalls.first?.inserted, " world")
+    }
+
     func test_reconcileDuringPostInsertionSyncWindow_neverReAnchorsTheOverlay() {
         // The TextEdit accept jitter: Tab inserts " world" and the overlay advances immediately,
         // but the +30ms refresh can read AX BEFORE the host publishes the insert. That snapshot's

--- a/CotabbyTests/SuggestionCoordinatorTestSupport.swift
+++ b/CotabbyTests/SuggestionCoordinatorTestSupport.swift
@@ -64,9 +64,17 @@ final class RigOverlayController: SuggestionOverlayControlling {
     var onStateChange: ((OverlayState) -> Void)?
     private(set) var shownTexts: [String] = []
     private(set) var hideReasons: [String] = []
+    /// Records slide attempts (and declines them, like the protocol default) so tests can assert
+    /// which accept paths even try to slide versus re-anchor through a present.
+    private(set) var advanceInlineCalls: [(remaining: String, inserted: String)] = []
 
     init(state: OverlayState = .hidden(reason: "initial")) {
         self.state = state
+    }
+
+    func advanceInline(to remainingText: String, insertedText: String) -> Bool {
+        advanceInlineCalls.append((remainingText, insertedText))
+        return false
     }
 
     func showSuggestion(_ text: String, geometry: SuggestionOverlayGeometry) {

--- a/CotabbyTests/SuggestionOverlayStabilityGateTests.swift
+++ b/CotabbyTests/SuggestionOverlayStabilityGateTests.swift
@@ -18,12 +18,13 @@ final class SuggestionOverlayStabilityGateTests: XCTestCase {
     private static func geometry(
         caretRect: CGRect = caretRect,
         inputFrameRect: CGRect? = inputFrame,
+        caretQuality: CaretGeometryQuality = .exact,
         focusChangeSequence: UInt64 = 7
     ) -> SuggestionOverlayGeometry {
         SuggestionOverlayGeometry(
             caretRect: caretRect,
             inputFrameRect: inputFrameRect,
-            caretQuality: .exact,
+            caretQuality: caretQuality,
             observedCharWidth: 8,
             isRightToLeft: false,
             focusChangeSequence: focusChangeSequence
@@ -327,6 +328,73 @@ final class SuggestionOverlayStabilityGateTests: XCTestCase {
                 newInputFrameRect: Self.inputFrame,
                 newFocusChangeSequence: 7,
                 isAwaitingPostInsertionSync: false
+            )
+        )
+    }
+
+    // MARK: - Layout-estimated anchors (TextKit mirror hosts)
+
+    func test_layoutEstimatedAnchor_ignoresRawCaretDrift() {
+        // The held anchor came from the hidden text layout; fresh snapshots still carry the RAW
+        // resolver caret (an AXFrame proportional guess), which routinely sits a word or more
+        // away. Treating that gap as drift re-presented and re-estimated on every reconcile
+        // tick, and around accepts it was the jerk-left-then-back: with text and field unchanged
+        // the estimate cannot move, so the gate must hold.
+        let current: OverlayState = .visible(
+            text: " again",
+            geometry: Self.geometry(
+                caretRect: CGRect(x: 320, y: 210, width: 2, height: 18),
+                caretQuality: .layoutEstimated
+            ),
+            mode: .inline
+        )
+
+        XCTAssertFalse(
+            SuggestionOverlayStabilityGate.shouldRePresent(
+                currentOverlay: current,
+                newText: " again",
+                newCaretRect: Self.caretRect,
+                newInputFrameRect: Self.inputFrame,
+                newFocusChangeSequence: 7
+            )
+        )
+    }
+
+    func test_layoutEstimatedAnchor_stillReAnchorsOnFrameTextOrFieldChange() {
+        // The estimate is a pure function of (text, field frame, style): when one of its real
+        // inputs changes, or the field itself does, the re-anchor must still happen.
+        let current: OverlayState = .visible(
+            text: " again",
+            geometry: Self.geometry(caretQuality: .layoutEstimated),
+            mode: .inline
+        )
+
+        XCTAssertTrue(
+            SuggestionOverlayStabilityGate.shouldRePresent(
+                currentOverlay: current,
+                newText: " again",
+                newCaretRect: Self.caretRect,
+                newInputFrameRect: Self.inputFrame.offsetBy(dx: 40, dy: 0),
+                newFocusChangeSequence: 7
+            ),
+            "A field-frame move re-positions the estimate and must re-anchor"
+        )
+        XCTAssertTrue(
+            SuggestionOverlayStabilityGate.shouldRePresent(
+                currentOverlay: current,
+                newText: " different",
+                newCaretRect: Self.caretRect,
+                newInputFrameRect: Self.inputFrame,
+                newFocusChangeSequence: 7
+            )
+        )
+        XCTAssertTrue(
+            SuggestionOverlayStabilityGate.shouldRePresent(
+                currentOverlay: current,
+                newText: " again",
+                newCaretRect: Self.caretRect,
+                newInputFrameRect: Self.inputFrame,
+                newFocusChangeSequence: 8
             )
         )
     }


### PR DESCRIPTION
## Summary

Follow-up to #690 targeting the surface the jitter report was actually about: hosts whose caret anchor comes from the hidden TextKit layout estimate (`.layoutEstimated`, the #670 mirror), where every word accept jerked the remaining ghost left and then back right.

The publish-window hold merged in #690 already removes the biggest mechanism here (it is quality-agnostic): during the pre-publish window the +30ms refresh used to re-run the mirror against the OLD text with no pending insertion, anchoring the tail a full word left, and the next poll snapped it back. Two mirror-specific motion sources remained:

- **The width slide pre-empted the estimator.** `advanceInline` slid the panel by a font-measured width, bypassing exactly the re-anchor the caret repair was designed to perform on these hosts (the estimator is fed the pending insertion and models the true advance, soft wrap included). The slid anchor then disagreed with the next estimate by the ghost-vs-host font error, and the settle read as a jerk. Accepts on a layout-estimated overlay now skip the slide and re-present through the repair, landing exactly where the post-publish estimate will reproduce, so the accept itself is the only movement.
- **The gate compared the mirror anchor against the raw resolver caret.** Fresh snapshots carry the RAW caret (an AXFrame proportional guess, or a derived rect the repair overrode), a different coordinate system that routinely sits a word or more from the estimate. That false "drift" exceeded the 6pt tolerance on essentially every reconcile tick, forcing re-presents and re-estimates. For layout-estimated overlays the gate now ignores raw-caret drift entirely: the estimate is a pure function of (text, field frame, style), so only those inputs, or a field switch, can re-anchor.

Net accept cycle on a mirror host: one anchored advance at the keystroke (estimator with pending insertion), hold through the publish window (#690), hold on the post-publish tick (the fresh estimate is byte-identical to the held one, and raw drift is no longer consulted). Nothing moves after the accept.

Also annotates `ControlTokenMarkers`, `TerminalAppDetector`, and `BrowserAppDetector` as `nonisolated`: three Swift 6 forward-compat warnings that arrived with the surface-classifier merge, same root cause and same fix pattern as #684, restoring the zero-warning build.

## Validation

```
xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' \
  -skip-testing:CotabbyTests/FoundationModelDriftEvalTests \
  CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
# ** TEST SUCCEEDED ** 1537 tests, 0 failures, 0 crashes

# Clean build emits 0 project warnings again (3 before this branch).

swiftlint lint --quiet
# 0 findings on the files this PR touches
```

New regression locks:
- Gate: a layout-estimated anchor ignores word-width raw-caret drift (the per-tick flap), and still re-anchors on a field-frame move, text change, or focus-sequence change (the estimate's real inputs).
- Coordinator rig: an accept on a `.layoutEstimated` overlay never calls `advanceInline` and re-presents the tail through the estimator path; an accept on trusted-exact geometry still attempts the slide first with the right arguments.

## Linked issues

Refs #690 and #670. Reported directly: "if text mirror is used to create caret position, every time accept word, the suggestion jerks left then goes back".

## Risk / rollout notes

- Behavior changes are scoped to overlays whose held geometry quality is `.layoutEstimated`; exact and derived hosts keep #690's behavior bit-for-bit.
- Skipping the slide costs one estimator run per accept on mirror hosts; the estimator memoizes on (text, frame) and the accept path already tolerated this cost on the multi-line fallback.
- With raw-caret drift ignored for mirror anchors, a host whose caret legitimately moves while text, frame, and focus sequence all stay identical would not re-anchor; no such host behavior is known (the raw caret was never this anchor's input in the first place).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes post-accept caret jitter on TextKit-mirror hosts (overlays whose position comes from the hidden layout estimator rather than raw AX caret data) by addressing two root causes that #690's publish-window hold did not cover.

- **Acceptance path (`SuggestionCoordinator+Acceptance.swift`)**: `presentAdvancedOverlay` now skips `advanceInline` (width-based slide) for layout-estimated overlays and routes directly through `presentOverlay`, where the layout repair is fed the pending insertion and places the tail exactly where the post-publish estimate will reproduce it.
- **Stability gate (`SuggestionOverlayStabilityGate.swift`)**: The caret-drift re-anchor check is skipped for `.layoutEstimated` quality; only frame moves, text changes, and focus-sequence changes can demand a re-anchor, eliminating the per-tick false-drift that the raw resolver caret was causing.
- **Swift 6 warnings**: `BrowserAppDetector`, `ControlTokenMarkers`, and `TerminalAppDetector` are annotated `nonisolated` following the same pattern as #684.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the targeted hosts; the behavior change is narrowly scoped to `.layoutEstimated` overlays and exact/derived hosts are unaffected.

Core logic is correct and backed by focused regression tests. Two spots in `SuggestionCoordinator+Acceptance.swift` warrant attention: the `nil` quality arm silently routes to the slide rather than the estimator, and the type-ahead path lacks the matching guard for layout-estimated overlays.

Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift — the `nil` quality branch in `presentAdvancedOverlay` and the unguarded slide in `advanceActiveSessionIfTypedCharactersMatch` are the two spots worth a second look.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift | Adds a layout-estimated guard in `presentAdvancedOverlay` to skip `advanceInline` and route through the estimator path; the `nil` overlay-state arm and the unguarded type-ahead path are worth a follow-up |
| Cotabby/Support/SuggestionOverlayStabilityGate.swift | Caret-drift block is now guarded by `caretQuality != .layoutEstimated`; only frame, text, and focus-sequence checks remain active for mirror-host overlays — well-reasoned and correctly scoped |
| Cotabby/Support/BrowserAppDetector.swift | Added `nonisolated` keyword to the enum for Swift 6 forward-compatibility; no behaviour change |
| Cotabby/Support/ControlTokenMarkers.swift | Added `nonisolated` keyword to the enum for Swift 6 forward-compatibility; no behaviour change |
| Cotabby/Support/TerminalAppDetector.swift | Added `nonisolated` keyword to the enum for Swift 6 forward-compatibility; no behaviour change |
| CotabbyTests/SuggestionCoordinatorPredictionTests.swift | Two new regression tests lock in the layout-estimated skip-slide and the trusted-geometry slide-first contract; both are well-structured and cover the key dispatch branches |
| CotabbyTests/SuggestionCoordinatorTestSupport.swift | Adds an `advanceInline` override to `RigOverlayController` that records calls and always returns `false`; allows tests to distinguish slide-attempt paths from re-present paths |
| CotabbyTests/SuggestionOverlayStabilityGateTests.swift | Two new gate tests cover the layout-estimated raw-drift ignore case and the re-anchor-on-real-input cases (frame move, text change, focus-sequence change); parameter helper updated to support `caretQuality` |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Word Accept - Tab keystroke] --> B{overlayState visible?}
    B -- No --> C[heldOverlayQuality = nil]
    B -- Yes --> D[heldOverlayQuality = geometry.caretQuality]
    C --> E{quality != .layoutEstimated?}
    D --> E
    E -- Yes, nil or exact/derived --> F[advanceInline attempt]
    F -- returns true --> G[Slide succeeded, return]
    F -- returns false --> H[Fall through to estimator path]
    E -- No, .layoutEstimated --> H
    H --> I[predictedCaretRect from liveContext]
    I --> J[presentOverlay with pendingInsertion]
    J --> K[layoutRepairedAnchor runs estimator]
    K --> L[Anchor placed by layout estimate]

    subgraph StabilityGate [Reconcile tick — shouldRePresent]
        M{caretQuality == .layoutEstimated?} -- Yes --> N[Skip caret-drift check]
        M -- No --> O[Check caret drift > 6pt]
        O -- Exceeds tolerance --> P[Re-anchor]
        N --> Q[Frame / text / focus-seq checks only]
        Q --> R{Any real input changed?}
        R -- Yes --> P
        R -- No --> S[Hold geometry]
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift`, line 509-518 ([link](https://github.com/fujacob/cotabby/blob/7e371b3b1730d8eafad7d7a52c0279020b102e52/Cotabby/App/Coordinators/SuggestionCoordinator+Acceptance.swift#L509-L518)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Type-ahead path lacks the layout-estimated slide guard**

   `advanceActiveSessionIfTypedCharactersMatch` still calls `advanceInline` unconditionally; if the slide returns `false` it falls back to `session.baseContext.caretRect`, the raw resolver caret from session start. For a layout-estimated overlay that is the same coordinate mismatch this PR eliminates for Tab-accepts, meaning a user who types through the suggestion on a TextKit-mirror host could still see a one-frame jitter on the type-match advance. The PR scope is Tab-accept jitter, so this is not a regression, but the inconsistency is worth noting for a follow-up.

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Flayout-estimated-accept-stillness%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Flayout-estimated-accept-stillness%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BAcceptance.swift%0ALine%3A%20509-518%0A%0AComment%3A%0A**Type-ahead%20path%20lacks%20the%20layout-estimated%20slide%20guard**%0A%0A%60advanceActiveSessionIfTypedCharactersMatch%60%20still%20calls%20%60advanceInline%60%20unconditionally%3B%20if%20the%20slide%20returns%20%60false%60%20it%20falls%20back%20to%20%60session.baseContext.caretRect%60%2C%20the%20raw%20resolver%20caret%20from%20session%20start.%20For%20a%20layout-estimated%20overlay%20that%20is%20the%20same%20coordinate%20mismatch%20this%20PR%20eliminates%20for%20Tab-accepts%2C%20meaning%20a%20user%20who%20types%20through%20the%20suggestion%20on%20a%20TextKit-mirror%20host%20could%20still%20see%20a%20one-frame%20jitter%20on%20the%20type-match%20advance.%20The%20PR%20scope%20is%20Tab-accept%20jitter%2C%20so%20this%20is%20not%20a%20regression%2C%20but%20the%20inconsistency%20is%20worth%20noting%20for%20a%20follow-up.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=691&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BAcceptance.swift%0ALine%3A%20509-518%0A%0AComment%3A%0A**Type-ahead%20path%20lacks%20the%20layout-estimated%20slide%20guard**%0A%0A%60advanceActiveSessionIfTypedCharactersMatch%60%20still%20calls%20%60advanceInline%60%20unconditionally%3B%20if%20the%20slide%20returns%20%60false%60%20it%20falls%20back%20to%20%60session.baseContext.caretRect%60%2C%20the%20raw%20resolver%20caret%20from%20session%20start.%20For%20a%20layout-estimated%20overlay%20that%20is%20the%20same%20coordinate%20mismatch%20this%20PR%20eliminates%20for%20Tab-accepts%2C%20meaning%20a%20user%20who%20types%20through%20the%20suggestion%20on%20a%20TextKit-mirror%20host%20could%20still%20see%20a%20one-frame%20jitter%20on%20the%20type-match%20advance.%20The%20PR%20scope%20is%20Tab-accept%20jitter%2C%20so%20this%20is%20not%20a%20regression%2C%20but%20the%20inconsistency%20is%20worth%20noting%20for%20a%20follow-up.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=691&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Flayout-estimated-accept-stillness%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Flayout-estimated-accept-stillness%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BAcceptance.swift%3A250-259%0A**%60nil%60%20quality%20treated%20identically%20to%20a%20trusted%20caret**%0A%0AWhen%20%60overlayState%60%20is%20not%20%60.visible%60%2C%20%60heldOverlayQuality%60%20is%20%60nil%60%2C%20and%20%60nil%20!%3D%20.layoutEstimated%60%20evaluates%20to%20%60true%60%2C%20so%20the%20code%20attempts%20%60advanceInline%60%20before%20falling%20back%20to%20the%20estimator.%20In%20practice%20%60presentAdvancedOverlay%60%20is%20only%20reached%20via%20the%20%60.advanced%60%20branch%20where%20an%20overlay%20should%20be%20visible%2C%20so%20the%20%60nil%60%20arm%20is%20unreachable%20under%20normal%20operation.%20However%2C%20if%20the%20overlay%20were%20hidden%20between%20acceptance%20validation%20and%20this%20call%20%28e.g.%20by%20a%20concurrent%20reconcile%29%2C%20the%20nil%20case%20silently%20routes%20to%20the%20slide%20path%20rather%20than%20the%20estimator%20%E2%80%94%20the%20opposite%20of%20the%20safe%20default.%20A%20guard-with-early-fallthrough%20or%20an%20explicit%20%60nil%60%20%E2%86%92%20skip-slide%20mapping%20would%20make%20the%20intent%20clearer%20and%20remove%20the%20latent%20ambiguity.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BAcceptance.swift%3A509-518%0A**Type-ahead%20path%20lacks%20the%20layout-estimated%20slide%20guard**%0A%0A%60advanceActiveSessionIfTypedCharactersMatch%60%20still%20calls%20%60advanceInline%60%20unconditionally%3B%20if%20the%20slide%20returns%20%60false%60%20it%20falls%20back%20to%20%60session.baseContext.caretRect%60%2C%20the%20raw%20resolver%20caret%20from%20session%20start.%20For%20a%20layout-estimated%20overlay%20that%20is%20the%20same%20coordinate%20mismatch%20this%20PR%20eliminates%20for%20Tab-accepts%2C%20meaning%20a%20user%20who%20types%20through%20the%20suggestion%20on%20a%20TextKit-mirror%20host%20could%20still%20see%20a%20one-frame%20jitter%20on%20the%20type-match%20advance.%20The%20PR%20scope%20is%20Tab-accept%20jitter%2C%20so%20this%20is%20not%20a%20regression%2C%20but%20the%20inconsistency%20is%20worth%20noting%20for%20a%20follow-up.%0A%0A&repo=fujacob%2Fcotabby&pr=691&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BAcceptance.swift%3A250-259%0A**%60nil%60%20quality%20treated%20identically%20to%20a%20trusted%20caret**%0A%0AWhen%20%60overlayState%60%20is%20not%20%60.visible%60%2C%20%60heldOverlayQuality%60%20is%20%60nil%60%2C%20and%20%60nil%20!%3D%20.layoutEstimated%60%20evaluates%20to%20%60true%60%2C%20so%20the%20code%20attempts%20%60advanceInline%60%20before%20falling%20back%20to%20the%20estimator.%20In%20practice%20%60presentAdvancedOverlay%60%20is%20only%20reached%20via%20the%20%60.advanced%60%20branch%20where%20an%20overlay%20should%20be%20visible%2C%20so%20the%20%60nil%60%20arm%20is%20unreachable%20under%20normal%20operation.%20However%2C%20if%20the%20overlay%20were%20hidden%20between%20acceptance%20validation%20and%20this%20call%20%28e.g.%20by%20a%20concurrent%20reconcile%29%2C%20the%20nil%20case%20silently%20routes%20to%20the%20slide%20path%20rather%20than%20the%20estimator%20%E2%80%94%20the%20opposite%20of%20the%20safe%20default.%20A%20guard-with-early-fallthrough%20or%20an%20explicit%20%60nil%60%20%E2%86%92%20skip-slide%20mapping%20would%20make%20the%20intent%20clearer%20and%20remove%20the%20latent%20ambiguity.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FApp%2FCoordinators%2FSuggestionCoordinator%2BAcceptance.swift%3A509-518%0A**Type-ahead%20path%20lacks%20the%20layout-estimated%20slide%20guard**%0A%0A%60advanceActiveSessionIfTypedCharactersMatch%60%20still%20calls%20%60advanceInline%60%20unconditionally%3B%20if%20the%20slide%20returns%20%60false%60%20it%20falls%20back%20to%20%60session.baseContext.caretRect%60%2C%20the%20raw%20resolver%20caret%20from%20session%20start.%20For%20a%20layout-estimated%20overlay%20that%20is%20the%20same%20coordinate%20mismatch%20this%20PR%20eliminates%20for%20Tab-accepts%2C%20meaning%20a%20user%20who%20types%20through%20the%20suggestion%20on%20a%20TextKit-mirror%20host%20could%20still%20see%20a%20one-frame%20jitter%20on%20the%20type-match%20advance.%20The%20PR%20scope%20is%20Tab-accept%20jitter%2C%20so%20this%20is%20not%20a%20regression%2C%20but%20the%20inconsistency%20is%20worth%20noting%20for%20a%20follow-up.%0A%0A&repo=fujacob%2Fcotabby&pr=691&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(overlay): hold TextKit-mirror anchor..."](https://github.com/fujacob/cotabby/commit/7e371b3b1730d8eafad7d7a52c0279020b102e52) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37148979)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->