### PR TITLE
feat(overlay): route TextKit-estimated carets to a popup anchored at the caret

### DIFF
--- a/Cotabby/Models/CompletionRenderMode.swift
+++ b/Cotabby/Models/CompletionRenderMode.swift
@@ -27,6 +27,13 @@ nonisolated enum CompletionRenderMode: Equatable, Sendable {
         /// drifts as the user types.
         case caretGeometryEstimated
 
+        /// Caret quality is `.layoutEstimated`: the host exposed no usable caret, but Cotabby's
+        /// hidden-TextKit layout repair produced a confident caret estimate. We deliberately route
+        /// these to the card rather than inline ghost text, but unlike `.caretGeometryEstimated` the
+        /// card anchors to that estimated caret (one line below it) instead of the whole field rect,
+        /// so the popup tracks the cursor the TextKit layout located.
+        case caretLayoutEstimated
+
         /// The caret sits mid-line: real characters follow it before the next line break. Inline
         /// ghost text would draw on top of those trailing characters, so the suggestion is promoted
         /// to the card, which anchors to the caret rect (the geometry is trustworthy here) and sits

--- a/Cotabby/Support/CompletionRenderModePolicy.swift
+++ b/Cotabby/Support/CompletionRenderModePolicy.swift
@@ -108,15 +108,25 @@ struct CompletionRenderModePolicy: Equatable, Sendable {
             return .mirror(reason: reason)
 
         case .auto:
-            // Only `.estimated` geometry triggers auto-mirror. `.derived` already lands close enough
-            // to the real caret to render inline ghost text confidently; promoting it would over-fire
-            // the card for hosts that work fine today (Gmail, Outlook, Discord text-marker path).
-            // `.layoutEstimated` deliberately falls through to inline as well: it only exists when
-            // the caret layout repair accepted a hidden-text-layout estimate, and rendering inline
-            // on that estimate is the entire point of the repair.
-            return geometry.caretQuality == .estimated
-                ? .mirror(reason: .caretGeometryEstimated)
-                : .inline
+            // `.derived` and `.exact` land close enough to the real caret to render inline ghost
+            // text confidently; promoting them would over-fire the card for hosts that work fine
+            // today (Gmail, Outlook, Discord text-marker path).
+            //
+            // Both estimate qualities go to the card, but with different anchors. `.estimated` has no
+            // usable caret at all, so the card anchors to the field rect (`.caretGeometryEstimated`).
+            // `.layoutEstimated` means the hidden-TextKit repair produced a confident caret estimate:
+            // we still prefer the card over inline ghost text (the estimate is good enough to place a
+            // popup, not to paint glyphs the eye will scrutinize against the host's own text), but we
+            // anchor that popup to the estimated caret (`.caretLayoutEstimated`) so it tracks the
+            // cursor TextKit located instead of floating below the whole field.
+            switch geometry.caretQuality {
+            case .estimated:
+                return .mirror(reason: .caretGeometryEstimated)
+            case .layoutEstimated:
+                return .mirror(reason: .caretLayoutEstimated)
+            case .exact, .derived:
+                return .inline
+            }
         }
     }
 }

--- a/Cotabby/Support/MirrorOverlayLayout.swift
+++ b/Cotabby/Support/MirrorOverlayLayout.swift
@@ -175,6 +175,21 @@ struct MirrorOverlayLayout: Equatable {
             // height as unreliable; the extra slack keeps the card from overlapping the typed line.
             return geometry.caretRect.minY - Metrics.caretFallbackVerticalOffset
 
+        case .caretLayoutEstimated:
+            // The hidden-TextKit repair located the caret, so anchor to that estimated caret rect
+            // rather than the whole field — the popup should track the cursor, not float below the
+            // document. The one-line offset (not the tight `anchorGap`) drops the card a full line
+            // beneath the estimated caret so it never overlaps the line being typed, which matters
+            // most here because the estimate's exact baseline is less certain than a real AX caret.
+            // Fall back to the field rect, then the tight caret offset, only if the estimate is empty.
+            if !geometry.caretRect.isEmpty {
+                return geometry.caretRect.minY - Metrics.caretFallbackVerticalOffset
+            }
+            if let inputFrame = geometry.inputFrameRect?.standardized, !inputFrame.isEmpty {
+                return inputFrame.minY - Metrics.anchorGap
+            }
+            return geometry.caretRect.minY - Metrics.caretFallbackVerticalOffset
+
         case .userPreference, .perAppOverride, .caretMidLine:
             // Caret geometry is trustworthy in these cases. Sit just under the caret line so the
             // popup tracks the cursor like the inline ghost does, instead of floating below the

--- a/CotabbyTests/CompletionRenderModePolicyTests.swift
+++ b/CotabbyTests/CompletionRenderModePolicyTests.swift
@@ -230,21 +230,22 @@ final class CompletionRenderModePolicyTests: XCTestCase {
 
     // MARK: - Layout-estimated geometry (caret layout repair)
 
-    func test_auto_returnsInlineForLayoutEstimatedCaretGeometry() {
-        // `.layoutEstimated` only exists when the caret layout repair accepted a hidden-text-layout
-        // estimate; rendering inline on that estimate is the entire point of the repair.
+    func test_auto_returnsLayoutEstimatedMirrorForLayoutEstimatedCaretGeometry() {
+        // `.layoutEstimated` means the hidden-TextKit repair produced a confident caret estimate. We
+        // route it to the card (good enough to place a popup, not to paint inline glyphs the eye
+        // scrutinizes against host text) but anchor that popup to the estimated caret.
         let policy = CompletionRenderModePolicy(userPreference: .auto)
         let geometry = CotabbyTestFixtures.overlayGeometry(caretQuality: .layoutEstimated)
 
         XCTAssertEqual(
             policy.mode(for: geometry, bundleIdentifier: "com.microsoft.VSCode"),
-            .inline
+            .mirror(reason: .caretLayoutEstimated)
         )
     }
 
-    func test_auto_midLineCaret_promotesLayoutEstimatedGeometryToMirror() {
-        // The repair fixes geometry, not the mid-line rule: characters after the caret still have
-        // no inline home, so the card promotion applies to repaired geometry too.
+    func test_auto_midLineCaret_keepsLayoutEstimatedReasonRatherThanOverwriting() {
+        // Layout-estimated geometry already routes to the card, so the mid-line promotion (which only
+        // upgrades inline results) never runs: the more specific caret-layout reason is retained.
         let policy = CompletionRenderModePolicy(userPreference: .auto)
         let geometry = CotabbyTestFixtures.overlayGeometry(
             caretQuality: .layoutEstimated,
@@ -253,7 +254,7 @@ final class CompletionRenderModePolicyTests: XCTestCase {
 
         XCTAssertEqual(
             policy.mode(for: geometry, bundleIdentifier: "com.microsoft.VSCode"),
-            .mirror(reason: .caretMidLine)
+            .mirror(reason: .caretLayoutEstimated)
         )
     }
 

--- a/CotabbyTests/MirrorOverlayLayoutTests.swift
+++ b/CotabbyTests/MirrorOverlayLayoutTests.swift
@@ -139,6 +139,36 @@ final class MirrorOverlayLayoutTests: XCTestCase {
         )
     }
 
+    func test_make_layoutEstimatedReasonAnchorsToCaretLine_notInputField() {
+        // Same geometry as the estimated test, but `.caretLayoutEstimated` means the hidden-TextKit
+        // repair located the caret, so the card must track that estimated caret (sit just below it)
+        // rather than dropping to the field's bottom edge ~100pt away.
+        let geometry = CotabbyTestFixtures.overlayGeometry(
+            caretRect: CGRect(x: 720, y: 500, width: 2, height: 18),
+            inputFrameRect: CGRect(x: 400, y: 400, width: 640, height: 200)
+        )
+
+        let layout = MirrorOverlayLayout.make(
+            suggestion: "hello",
+            geometry: geometry,
+            visibleFrame: screen,
+            showsAcceptanceHint: true,
+            reason: .caretLayoutEstimated
+        )
+
+        // Card sits one line below the estimated caret line, not at the field's bottom edge.
+        XCTAssertLessThan(
+            layout.panelFrame.maxY,
+            geometry.caretRect.minY,
+            "Layout-estimated popup should sit below the estimated caret line"
+        )
+        XCTAssertGreaterThan(
+            layout.panelFrame.maxY,
+            geometry.inputFrameRect!.minY + 40,
+            "Layout-estimated popup should NOT drop down to the field's bottom edge"
+        )
+    }
+
     // MARK: - Fallback when input frame missing
 
     func test_make_fallsBackToCaretRectWhenInputFrameMissing() {


### PR DESCRIPTION
## Summary

For `.estimated` hosts (no usable AX caret), Cotabby's hidden-TextKit layout repair produces a confident caret estimate, surfaced as `.layoutEstimated` quality. Previously that rendered **inline** ghost text. Inline glyphs drawn on an estimate get scrutinized against the host's own text and read as misplaced, so this routes `.layoutEstimated` to the **popup card** instead — but anchors the card to the estimated caret (one line below it) rather than the whole field rect, so the popup tracks the cursor TextKit located instead of floating at the bottom of the document.

Behavior by caret quality under Auto is now:

| quality | before | after |
|---|---|---|
| `.exact` / `.derived` | inline | inline (unchanged) |
| `.estimated` (no caret) | popup, field-anchored | popup, field-anchored (unchanged) |
| `.layoutEstimated` (TextKit repair) | **inline** | **popup, anchored 1 line below the estimated caret** |

A new `.caretLayoutEstimated` `MirrorReason` keeps this distinct from the no-usable-caret `.caretGeometryEstimated` case (which still anchors to the field rect, since its caret can't be trusted). The mid-line override is unaffected: `.layoutEstimated` is already a card, so the override (which only upgrades inline results) no longer relabels it.

## Validation

```
xcodebuild ... build -derivedDataPath build/DerivedData            # ** BUILD SUCCEEDED **
xcodebuild ... test -only-testing:CotabbyTests/CompletionRenderModePolicyTests \
  -only-testing:CotabbyTests/MirrorOverlayLayoutTests \
  -only-testing:CotabbyTests/SuggestionCaretLayoutRepairTests \
  -only-testing:CotabbyTests/SuggestionOverlayStabilityGateTests \
  -only-testing:CotabbyTests/SuggestionCoordinatorPredictionTests \
  CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO                 # ** TEST SUCCEEDED **
swiftlint lint --quiet                                             # exit 0
```

Updated the two policy tests that pinned `.layoutEstimated` → inline, and added a `MirrorOverlayLayout` test asserting the new reason anchors below the estimated caret line (not the field bottom).

## Linked issues

<!-- none -->

## Risk / rollout notes

- Behavior change for `.estimated`/TextKit-repaired hosts only (e.g. some Electron/web editors): they now show the popup card instead of inline ghost text. Hosts on `.exact`/`.derived` are untouched.
- Pure render-mode/layout change; no settings, schema, or persistence impact. New `MirrorReason` case is `String`-backed so the debug `label` and `OverlayState.detail` pick it up with no other edits.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR routes `.layoutEstimated`-quality carets (produced by Cotabby's hidden-TextKit layout repair) to the popup card instead of inline ghost text, and anchors that popup one line below the estimated caret position rather than at the field rectangle used by the no-caret `.estimated` path.

- **`CompletionRenderMode`** gains a new `MirrorReason.caretLayoutEstimated` case, keeping the TextKit-repair path distinct from the no-caret `.caretGeometryEstimated` path in diagnostics and layout.
- **`CompletionRenderModePolicy`** replaces a ternary with an exhaustive `switch` on `caretQuality`; `.layoutEstimated` now returns `.mirror(reason: .caretLayoutEstimated)`, and the mid-line promotion correctly no-ops for already-mirrored results.
- **`MirrorOverlayLayout.computeAnchorTopY`** adds a `caretLayoutEstimated` branch that anchors to the estimated caret rect with `caretFallbackVerticalOffset` (22 pt) rather than the tight 8 pt gap used for fully trusted carets, with field-rect and last-resort fallbacks mirroring the existing patterns.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change only affects hosts whose caret quality resolves to `.layoutEstimated` (TextKit-repaired Electron/web editors) and is a pure render-mode routing change with no persistence or schema impact.

The logic is sound and the new tests cover the primary happy-path behavior. Two small gaps keep this from a clean score: the `computeAnchorTopY` doc comment does not document the new case, and there is no test pinning `alwaysInline` + `.layoutEstimated` quality — a combination that previously shared behavior with `.auto` and is now subtly distinct.

`MirrorOverlayLayout.swift` — the `computeAnchorTopY` header comment should be extended to describe the new case; `CompletionRenderModePolicyTests.swift` — worth adding a test for the `alwaysInline` + `.layoutEstimated` combination.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/Models/CompletionRenderMode.swift | Adds `caretLayoutEstimated` to `MirrorReason` with a clear doc comment; no logic changes, clean addition. |
| Cotabby/Support/CompletionRenderModePolicy.swift | Replaces ternary with an exhaustive switch on `caretQuality`; `.layoutEstimated` now returns `.mirror(reason: .caretLayoutEstimated)` instead of `.inline`. Logic is correct and the mid-line guard correctly skips already-mirror results. |
| Cotabby/Support/MirrorOverlayLayout.swift | Adds `caretLayoutEstimated` branch to `computeAnchorTopY`; anchors below estimated caret with `caretFallbackVerticalOffset`. The doc comment for `computeAnchorTopY` does not document the new case, leaving an incomplete description of the anchor-selection logic. |
| CotabbyTests/CompletionRenderModePolicyTests.swift | Updates two existing tests and adds tests for `.layoutEstimated` policy behavior; missing coverage for `alwaysInline` + `.layoutEstimated` quality combination. |
| CotabbyTests/MirrorOverlayLayoutTests.swift | Adds `test_make_layoutEstimatedReasonAnchorsToCaretLine_notInputField` with correct AppKit-coordinate assertions confirming the popup tracks the estimated caret rather than the field bottom. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[caretQuality] --> B{switch}
    B -- .exact / .derived --> C[.inline]
    C --> D{isCaretAtEndOfLine?}
    D -- yes --> E[render inline]
    D -- no --> F[.mirror reason: .caretMidLine]
    B -- .estimated --> G[.mirror reason: .caretGeometryEstimated]
    G --> H[anchorTopY = inputFrame.minY - anchorGap]
    B -- .layoutEstimated --> I[.mirror reason: .caretLayoutEstimated]
    I --> J{caretRect.isEmpty?}
    J -- no --> K[anchorTopY = caretRect.minY - caretFallbackVerticalOffset]
    J -- yes --> L{inputFrame available?}
    L -- yes --> M[anchorTopY = inputFrame.minY - anchorGap]
    L -- no --> N[anchorTopY = caretRect.minY - caretFallbackVerticalOffset]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `Cotabby/Support/MirrorOverlayLayout.swift`, line 152-165 ([link](https://github.com/fujacob/cotabby/blob/7c99ed8484772210b109d6029244f23cf33d19e1/Cotabby/Support/MirrorOverlayLayout.swift#L152-L165)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Doc comment doesn't cover `.caretLayoutEstimated`**

   The `computeAnchorTopY` header documents only `.caretGeometryEstimated` and the trusted-caret reasons (`.userPreference`, `.perAppOverride`, `.caretMidLine`). A reader consulting just this comment to understand the anchor strategy gets no hint that `.caretLayoutEstimated` exists or that it anchors to the estimated caret instead of the field rect. Consider adding a third bullet to the existing `- .caretGeometryEstimated` / `- .userPreference …` list describing the new case and why it uses `caretFallbackVerticalOffset` rather than `anchorGap`.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Festimated-force-popup-textkit%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Festimated-force-popup-textkit%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FSupport%2FMirrorOverlayLayout.swift%0ALine%3A%20152-165%0A%0AComment%3A%0A**Doc%20comment%20doesn't%20cover%20%60.caretLayoutEstimated%60**%0A%0AThe%20%60computeAnchorTopY%60%20header%20documents%20only%20%60.caretGeometryEstimated%60%20and%20the%20trusted-caret%20reasons%20%28%60.userPreference%60%2C%20%60.perAppOverride%60%2C%20%60.caretMidLine%60%29.%20A%20reader%20consulting%20just%20this%20comment%20to%20understand%20the%20anchor%20strategy%20gets%20no%20hint%20that%20%60.caretLayoutEstimated%60%20exists%20or%20that%20it%20anchors%20to%20the%20estimated%20caret%20instead%20of%20the%20field%20rect.%20Consider%20adding%20a%20third%20bullet%20to%20the%20existing%20%60-%20.caretGeometryEstimated%60%20%2F%20%60-%20.userPreference%20%E2%80%A6%60%20list%20describing%20the%20new%20case%20and%20why%20it%20uses%20%60caretFallbackVerticalOffset%60%20rather%20than%20%60anchorGap%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=694&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FSupport%2FMirrorOverlayLayout.swift%0ALine%3A%20152-165%0A%0AComment%3A%0A**Doc%20comment%20doesn't%20cover%20%60.caretLayoutEstimated%60**%0A%0AThe%20%60computeAnchorTopY%60%20header%20documents%20only%20%60.caretGeometryEstimated%60%20and%20the%20trusted-caret%20reasons%20%28%60.userPreference%60%2C%20%60.perAppOverride%60%2C%20%60.caretMidLine%60%29.%20A%20reader%20consulting%20just%20this%20comment%20to%20understand%20the%20anchor%20strategy%20gets%20no%20hint%20that%20%60.caretLayoutEstimated%60%20exists%20or%20that%20it%20anchors%20to%20the%20estimated%20caret%20instead%20of%20the%20field%20rect.%20Consider%20adding%20a%20third%20bullet%20to%20the%20existing%20%60-%20.caretGeometryEstimated%60%20%2F%20%60-%20.userPreference%20%E2%80%A6%60%20list%20describing%20the%20new%20case%20and%20why%20it%20uses%20%60caretFallbackVerticalOffset%60%20rather%20than%20%60anchorGap%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=694&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>


2. `CotabbyTests/CompletionRenderModePolicyTests.swift`, line 43-53 ([link](https://github.com/fujacob/cotabby/blob/7c99ed8484772210b109d6029244f23cf33d19e1/CotabbyTests/CompletionRenderModePolicyTests.swift#L43-L53)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **No test for `alwaysInline` + `.layoutEstimated` quality**

   The existing `test_alwaysInline_keepsInlineEvenForEstimatedGeometry` covers `.estimated` caret quality, but not `.layoutEstimated`. Before this PR, `.layoutEstimated` fell through to `.inline` in `.auto` mode, making it share behavior with `alwaysInline`. Now that `.auto` routes `.layoutEstimated` to `.mirror`, it's worth pinning explicitly that `alwaysInline` still returns `.inline` for `.layoutEstimated` quality, so a future change to the `alwaysInline` branch can't silently regress it.

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Festimated-force-popup-textkit%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Festimated-force-popup-textkit%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20CotabbyTests%2FCompletionRenderModePolicyTests.swift%0ALine%3A%2043-53%0A%0AComment%3A%0A**No%20test%20for%20%60alwaysInline%60%20%2B%20%60.layoutEstimated%60%20quality**%0A%0AThe%20existing%20%60test_alwaysInline_keepsInlineEvenForEstimatedGeometry%60%20covers%20%60.estimated%60%20caret%20quality%2C%20but%20not%20%60.layoutEstimated%60.%20Before%20this%20PR%2C%20%60.layoutEstimated%60%20fell%20through%20to%20%60.inline%60%20in%20%60.auto%60%20mode%2C%20making%20it%20share%20behavior%20with%20%60alwaysInline%60.%20Now%20that%20%60.auto%60%20routes%20%60.layoutEstimated%60%20to%20%60.mirror%60%2C%20it's%20worth%20pinning%20explicitly%20that%20%60alwaysInline%60%20still%20returns%20%60.inline%60%20for%20%60.layoutEstimated%60%20quality%2C%20so%20a%20future%20change%20to%20the%20%60alwaysInline%60%20branch%20can't%20silently%20regress%20it.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=694&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20CotabbyTests%2FCompletionRenderModePolicyTests.swift%0ALine%3A%2043-53%0A%0AComment%3A%0A**No%20test%20for%20%60alwaysInline%60%20%2B%20%60.layoutEstimated%60%20quality**%0A%0AThe%20existing%20%60test_alwaysInline_keepsInlineEvenForEstimatedGeometry%60%20covers%20%60.estimated%60%20caret%20quality%2C%20but%20not%20%60.layoutEstimated%60.%20Before%20this%20PR%2C%20%60.layoutEstimated%60%20fell%20through%20to%20%60.inline%60%20in%20%60.auto%60%20mode%2C%20making%20it%20share%20behavior%20with%20%60alwaysInline%60.%20Now%20that%20%60.auto%60%20routes%20%60.layoutEstimated%60%20to%20%60.mirror%60%2C%20it's%20worth%20pinning%20explicitly%20that%20%60alwaysInline%60%20still%20returns%20%60.inline%60%20for%20%60.layoutEstimated%60%20quality%2C%20so%20a%20future%20change%20to%20the%20%60alwaysInline%60%20branch%20can't%20silently%20regress%20it.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=694&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Festimated-force-popup-textkit%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Festimated-force-popup-textkit%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FSupport%2FMirrorOverlayLayout.swift%3A152-165%0A**Doc%20comment%20doesn't%20cover%20%60.caretLayoutEstimated%60**%0A%0AThe%20%60computeAnchorTopY%60%20header%20documents%20only%20%60.caretGeometryEstimated%60%20and%20the%20trusted-caret%20reasons%20%28%60.userPreference%60%2C%20%60.perAppOverride%60%2C%20%60.caretMidLine%60%29.%20A%20reader%20consulting%20just%20this%20comment%20to%20understand%20the%20anchor%20strategy%20gets%20no%20hint%20that%20%60.caretLayoutEstimated%60%20exists%20or%20that%20it%20anchors%20to%20the%20estimated%20caret%20instead%20of%20the%20field%20rect.%20Consider%20adding%20a%20third%20bullet%20to%20the%20existing%20%60-%20.caretGeometryEstimated%60%20%2F%20%60-%20.userPreference%20%E2%80%A6%60%20list%20describing%20the%20new%20case%20and%20why%20it%20uses%20%60caretFallbackVerticalOffset%60%20rather%20than%20%60anchorGap%60.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabbyTests%2FCompletionRenderModePolicyTests.swift%3A43-53%0A**No%20test%20for%20%60alwaysInline%60%20%2B%20%60.layoutEstimated%60%20quality**%0A%0AThe%20existing%20%60test_alwaysInline_keepsInlineEvenForEstimatedGeometry%60%20covers%20%60.estimated%60%20caret%20quality%2C%20but%20not%20%60.layoutEstimated%60.%20Before%20this%20PR%2C%20%60.layoutEstimated%60%20fell%20through%20to%20%60.inline%60%20in%20%60.auto%60%20mode%2C%20making%20it%20share%20behavior%20with%20%60alwaysInline%60.%20Now%20that%20%60.auto%60%20routes%20%60.layoutEstimated%60%20to%20%60.mirror%60%2C%20it's%20worth%20pinning%20explicitly%20that%20%60alwaysInline%60%20still%20returns%20%60.inline%60%20for%20%60.layoutEstimated%60%20quality%2C%20so%20a%20future%20change%20to%20the%20%60alwaysInline%60%20branch%20can't%20silently%20regress%20it.%0A%0A&repo=fujacob%2Fcotabby&pr=694&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FSupport%2FMirrorOverlayLayout.swift%3A152-165%0A**Doc%20comment%20doesn't%20cover%20%60.caretLayoutEstimated%60**%0A%0AThe%20%60computeAnchorTopY%60%20header%20documents%20only%20%60.caretGeometryEstimated%60%20and%20the%20trusted-caret%20reasons%20%28%60.userPreference%60%2C%20%60.perAppOverride%60%2C%20%60.caretMidLine%60%29.%20A%20reader%20consulting%20just%20this%20comment%20to%20understand%20the%20anchor%20strategy%20gets%20no%20hint%20that%20%60.caretLayoutEstimated%60%20exists%20or%20that%20it%20anchors%20to%20the%20estimated%20caret%20instead%20of%20the%20field%20rect.%20Consider%20adding%20a%20third%20bullet%20to%20the%20existing%20%60-%20.caretGeometryEstimated%60%20%2F%20%60-%20.userPreference%20%E2%80%A6%60%20list%20describing%20the%20new%20case%20and%20why%20it%20uses%20%60caretFallbackVerticalOffset%60%20rather%20than%20%60anchorGap%60.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabbyTests%2FCompletionRenderModePolicyTests.swift%3A43-53%0A**No%20test%20for%20%60alwaysInline%60%20%2B%20%60.layoutEstimated%60%20quality**%0A%0AThe%20existing%20%60test_alwaysInline_keepsInlineEvenForEstimatedGeometry%60%20covers%20%60.estimated%60%20caret%20quality%2C%20but%20not%20%60.layoutEstimated%60.%20Before%20this%20PR%2C%20%60.layoutEstimated%60%20fell%20through%20to%20%60.inline%60%20in%20%60.auto%60%20mode%2C%20making%20it%20share%20behavior%20with%20%60alwaysInline%60.%20Now%20that%20%60.auto%60%20routes%20%60.layoutEstimated%60%20to%20%60.mirror%60%2C%20it's%20worth%20pinning%20explicitly%20that%20%60alwaysInline%60%20still%20returns%20%60.inline%60%20for%20%60.layoutEstimated%60%20quality%2C%20so%20a%20future%20change%20to%20the%20%60alwaysInline%60%20branch%20can't%20silently%20regress%20it.%0A%0A&repo=fujacob%2Fcotabby&pr=694&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(overlay): route TextKit-estimated c..."](https://github.com/fujacob/cotabby/commit/7c99ed8484772210b109d6029244f23cf33d19e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37160932)</sub>

<!-- /greptile_comment -->