### PR TITLE
refactor(settings): regroup acceptance toggles under Writing, split General behavior

### DIFF
--- a/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
@@ -45,7 +45,11 @@ struct GeneralPaneView: View {
                 }
             }
 
-            Section("Behavior") {
+            // Split from the old catch-all "Behavior" group: what the model is allowed to read
+            // (Context) reads differently from what a suggestion may contain (Suggestions). The
+            // acceptance toggles that used to live here now sit with Writing, next to the other
+            // controls that shape inserted text.
+            Section("Context") {
                 Toggle(isOn: clipboardContextEnabledBinding) {
                     SettingsRowLabel(
                         title: "Include Clipboard Context",
@@ -61,30 +65,14 @@ struct GeneralPaneView: View {
                         systemImage: "macwindow"
                     )
                 }
+            }
 
+            Section("Suggestions") {
                 Toggle(isOn: multiLineEnabledBinding) {
                     SettingsRowLabel(
                         title: "Allow Multi-line Suggestions",
                         description: "Allow continuations that span more than one line. Off keeps suggestions to a single line.",
                         systemImage: "text.alignleft"
-                    )
-                }
-
-                Toggle(isOn: autoAcceptTrailingPunctuationBinding) {
-                    SettingsRowLabel(
-                        title: "Accept Punctuation With Word",
-                        description: "When you accept a word, also accept the punctuation that follows it " +
-                            "(commas, periods) so you don't have to type it.",
-                        systemImage: "textformat.abc"
-                    )
-                }
-
-                Toggle(isOn: addSpaceAfterAcceptBinding) {
-                    SettingsRowLabel(
-                        title: "Add Space After Accepting",
-                        description: "When accepting a suggestion finishes a word, also add a space so you can " +
-                            "keep typing. Skipped when it already ends in punctuation or a space.",
-                        systemImage: "space"
                     )
                 }
 
@@ -196,20 +184,6 @@ struct GeneralPaneView: View {
         Binding(
             get: { suggestionSettings.isMultiLineEnabled },
             set: { suggestionSettings.setMultiLineEnabled($0) }
-        )
-    }
-
-    private var autoAcceptTrailingPunctuationBinding: Binding<Bool> {
-        Binding(
-            get: { suggestionSettings.autoAcceptTrailingPunctuation },
-            set: { suggestionSettings.setAutoAcceptTrailingPunctuation($0) }
-        )
-    }
-
-    private var addSpaceAfterAcceptBinding: Binding<Bool> {
-        Binding(
-            get: { suggestionSettings.addSpaceAfterAccept },
-            set: { suggestionSettings.setAddSpaceAfterAccept($0) }
         )
     }
 

--- a/Cotabby/UI/Settings/Panes/WritingPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/WritingPaneView.swift
@@ -45,6 +45,28 @@ struct WritingPaneView: View {
                 }
             }
 
+            // What an accept inserts beyond the bare word. These shape the written output, so they sit
+            // with Writing rather than General; the accept keys themselves live in the Shortcuts pane.
+            Section("Acceptance") {
+                Toggle(isOn: autoAcceptTrailingPunctuationBinding) {
+                    SettingsRowLabel(
+                        title: "Accept Punctuation With Word",
+                        description: "When you accept a word, also accept the punctuation that follows it " +
+                            "(commas, periods) so you don't have to type it.",
+                        systemImage: "textformat.abc"
+                    )
+                }
+
+                Toggle(isOn: addSpaceAfterAcceptBinding) {
+                    SettingsRowLabel(
+                        title: "Add Space After Accepting",
+                        description: "When accepting a suggestion finishes a word, also add a space so you can " +
+                            "keep typing. Skipped when it already ends in punctuation or a space.",
+                        systemImage: "space"
+                    )
+                }
+            }
+
             Section("Corrections") {
                 Toggle(isOn: suppressCompletionsOnTypoBinding) {
                     SettingsRowLabel(
@@ -125,6 +147,20 @@ struct WritingPaneView: View {
         Binding(
             get: { suggestionSettings.selectedWordCountPreset },
             set: { suggestionSettings.selectWordCountPreset($0) }
+        )
+    }
+
+    private var autoAcceptTrailingPunctuationBinding: Binding<Bool> {
+        Binding(
+            get: { suggestionSettings.autoAcceptTrailingPunctuation },
+            set: { suggestionSettings.setAutoAcceptTrailingPunctuation($0) }
+        )
+    }
+
+    private var addSpaceAfterAcceptBinding: Binding<Bool> {
+        Binding(
+            get: { suggestionSettings.addSpaceAfterAccept },
+            set: { suggestionSettings.setAddSpaceAfterAccept($0) }
         )
     }
 

--- a/Cotabby/UI/Settings/SettingsIndex.swift
+++ b/Cotabby/UI/Settings/SettingsIndex.swift
@@ -16,8 +16,6 @@ enum SettingsItem: String, CaseIterable, Identifiable {
     case includeClipboardContext
     case includeAppContext
     case allowMultiLine
-    case acceptPunctuation
-    case addSpaceAfterAccept
     case inlineMacros
     case onboarding
     // Appearance
@@ -36,6 +34,8 @@ enum SettingsItem: String, CaseIterable, Identifiable {
     case emojiHistory
     // Writing
     case length
+    case acceptPunctuation
+    case addSpaceAfterAccept
     case name
     case languages
     case customRules
@@ -222,14 +222,14 @@ enum SettingsItem: String, CaseIterable, Identifiable {
     var category: SettingsCategory {
         switch self {
         case .enableGlobally, .fastMode, .openAtLogin, .includeClipboardContext, .includeAppContext,
-             .allowMultiLine, .acceptPunctuation, .addSpaceAfterAccept, .inlineMacros, .onboarding:
+             .allowMultiLine, .inlineMacros, .onboarding:
             return .general
         case .suggestionDisplay, .streamWhileGenerating, .showFieldIndicator, .showWordCount, .showKeyHint,
              .ghostTextColor, .ghostTextOpacity, .ghostTextSize:
             return .appearance
         case .emojiPicker, .emojiSkinTone, .emojiPeopleStyle, .emojiHistory:
             return .emoji
-        case .length, .name, .languages, .customRules,
+        case .length, .acceptPunctuation, .addSpaceAfterAccept, .name, .languages, .customRules,
              .hideSuggestionsOnTypo, .offerTypoCorrections, .spellingDictionaries, .automaticallyFixTypos:
             return .writing
         case .extendedContext, .contextLivePreview:


### PR DESCRIPTION
## Summary

The two acceptance toggles lived in General > Behavior, mixed in with context
sources and macros where they read as out of place. They govern what an accept
inserts, so they now sit in a new **Writing > Acceptance** section next to the
other controls that shape inserted text. General's catch-all Behavior section is
split into **Context** (clipboard/app) and **Suggestions** (multi-line/macros)
so each group reads cleanly.

- Moved "Accept Punctuation With Word" and "Add Space After Accepting" to Writing.
- Split General > Behavior into Context + Suggestions.
- Updated the Settings search index so both toggles resolve to the Writing pane.

## Validation

```
swiftlint lint --quiet
# exit 0

xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build \
  -derivedDataPath build/DerivedData
# ** BUILD SUCCEEDED **
```

Pure presentation move: the same bindings drive the same `SuggestionSettingsModel`
setters, so stored preferences and behavior are unchanged. Existing SettingsIndex
tests (title/symbol/keywords presence, id uniqueness, search) are category-agnostic
and unaffected.

## Linked issues

None.

## Risk / rollout notes

- UI-only reorganization. No settings schema or storage change; toggle state and
  acceptance behavior are identical.
- Search keywords for both toggles are unchanged, so existing queries still surface
  them (now pointing at the Writing pane).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reorganizes the Settings UI by splitting the old General > Behavior catch-all into two focused sections (Context and Suggestions) and relocating the two acceptance toggles to a new Writing > Acceptance section where they fit more naturally alongside other output-shaping controls.

- **GeneralPaneView**: "Behavior" replaced by "Context" (clipboard/app toggles) and "Suggestions" (multi-line/macros); the acceptance bindings are fully removed.
- **WritingPaneView**: New "Acceptance" section inserted between "Length" and "Corrections" with both toggles wired to the same `SuggestionSettingsModel` setters as before.
- **SettingsIndex**: `acceptPunctuation` and `addSpaceAfterAccept` cases moved to the Writing declaration block and their `category` switch arms updated to return `.writing`, keeping search routing accurate.

<h3>Confidence Score: 5/5</h3>

Pure UI reorganization — no settings schema, storage, or behavioral change; safe to merge.

All three files touch only presentation layer code: section labels, toggle placement, and the search index routing. The underlying SuggestionSettingsModel bindings are identical to the originals, and the category switch in SettingsIndex is updated to match, so search still routes to the correct pane. No logic paths, data mutations, or persistence are involved.

No files require special attention; the only note is a minor docstring gap in WritingPaneView.swift.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/UI/Settings/Panes/GeneralPaneView.swift | Old "Behavior" section split into "Context" (clipboard/app) and "Suggestions" (multi-line/macros); acceptance toggles and their bindings removed cleanly. |
| Cotabby/UI/Settings/Panes/WritingPaneView.swift | New "Acceptance" section added between "Length" and "Corrections"; both toggles and their bindings are correctly wired to the same SuggestionSettingsModel setters. File-level docstring omits the new section. |
| Cotabby/UI/Settings/SettingsIndex.swift | acceptPunctuation and addSpaceAfterAccept cases moved from the General block to the Writing block; category switch updated correctly to return .writing for both. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph BEFORE["Before (General > Behavior)"]
        B_Behavior["Behavior"]
        B_Behavior --> B_Clipboard["Include Clipboard Context"]
        B_Behavior --> B_App["Include App Context"]
        B_Behavior --> B_MultiLine["Allow Multi-line Suggestions"]
        B_Behavior --> B_Punct["Accept Punctuation With Word ❌"]
        B_Behavior --> B_Space["Add Space After Accepting ❌"]
        B_Behavior --> B_Macros["Inline Macros"]
    end

    subgraph AFTER_G["After (General)"]
        A_Context["Context"]
        A_Context --> A_Clipboard["Include Clipboard Context"]
        A_Context --> A_App["Include App Context"]
        A_Suggestions["Suggestions"]
        A_Suggestions --> A_MultiLine["Allow Multi-line Suggestions"]
        A_Suggestions --> A_Macros["Inline Macros"]
    end

    subgraph AFTER_W["After (Writing)"]
        A_Acceptance["Acceptance ✅"]
        A_Acceptance --> A_Punct["Accept Punctuation With Word"]
        A_Acceptance --> A_Space["Add Space After Accepting"]
    end

    B_Punct -->|moved| A_Punct
    B_Space -->|moved| A_Space
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cotabby/UI/Settings/Panes/WritingPaneView.swift`, line 3-6 ([link](https://github.com/fujacob/cotabby/blob/93682e84cba30dfc419b2ad589856cfdbe06d799/Cotabby/UI/Settings/Panes/WritingPaneView.swift#L3-L6)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The file-level docstring lists what the Writing pane owns but doesn't mention the new "Acceptance" section, so a reader skimming the header won't know these toggles live here.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22settings-acceptance-regroup%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22settings-acceptance-regroup%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FSettings%2FPanes%2FWritingPaneView.swift%0ALine%3A%203-6%0A%0AComment%3A%0AThe%20file-level%20docstring%20lists%20what%20the%20Writing%20pane%20owns%20but%20doesn't%20mention%20the%20new%20%22Acceptance%22%20section%2C%20so%20a%20reader%20skimming%20the%20header%20won't%20know%20these%20toggles%20live%20here.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20File%20overview%3A%0A%2F%2F%2F%20%22Writing%22%20detail%20pane%20of%20the%20redesigned%20Settings%20window.%20Owns%20how%20the%20completion%20reads%3A%0A%2F%2F%2F%20preferred%20length%2C%20acceptance%20behaviour%20%28punctuation%20and%20trailing%20space%29%2C%20profile%20%28display%20name%29%2C%0A%2F%2F%2F%20preferred%20response%20languages%2C%20and%20the%20user's%20custom%20style%20rules.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=696&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FUI%2FSettings%2FPanes%2FWritingPaneView.swift%0ALine%3A%203-6%0A%0AComment%3A%0AThe%20file-level%20docstring%20lists%20what%20the%20Writing%20pane%20owns%20but%20doesn't%20mention%20the%20new%20%22Acceptance%22%20section%2C%20so%20a%20reader%20skimming%20the%20header%20won't%20know%20these%20toggles%20live%20here.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20File%20overview%3A%0A%2F%2F%2F%20%22Writing%22%20detail%20pane%20of%20the%20redesigned%20Settings%20window.%20Owns%20how%20the%20completion%20reads%3A%0A%2F%2F%2F%20preferred%20length%2C%20acceptance%20behaviour%20%28punctuation%20and%20trailing%20space%29%2C%20profile%20%28display%20name%29%2C%0A%2F%2F%2F%20preferred%20response%20languages%2C%20and%20the%20user's%20custom%20style%20rules.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=696&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22settings-acceptance-regroup%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22settings-acceptance-regroup%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FSettings%2FPanes%2FWritingPaneView.swift%3A3-6%0AThe%20file-level%20docstring%20lists%20what%20the%20Writing%20pane%20owns%20but%20doesn't%20mention%20the%20new%20%22Acceptance%22%20section%2C%20so%20a%20reader%20skimming%20the%20header%20won't%20know%20these%20toggles%20live%20here.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20File%20overview%3A%0A%2F%2F%2F%20%22Writing%22%20detail%20pane%20of%20the%20redesigned%20Settings%20window.%20Owns%20how%20the%20completion%20reads%3A%0A%2F%2F%2F%20preferred%20length%2C%20acceptance%20behaviour%20%28punctuation%20and%20trailing%20space%29%2C%20profile%20%28display%20name%29%2C%0A%2F%2F%2F%20preferred%20response%20languages%2C%20and%20the%20user's%20custom%20style%20rules.%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=696&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FSettings%2FPanes%2FWritingPaneView.swift%3A3-6%0AThe%20file-level%20docstring%20lists%20what%20the%20Writing%20pane%20owns%20but%20doesn't%20mention%20the%20new%20%22Acceptance%22%20section%2C%20so%20a%20reader%20skimming%20the%20header%20won't%20know%20these%20toggles%20live%20here.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20File%20overview%3A%0A%2F%2F%2F%20%22Writing%22%20detail%20pane%20of%20the%20redesigned%20Settings%20window.%20Owns%20how%20the%20completion%20reads%3A%0A%2F%2F%2F%20preferred%20length%2C%20acceptance%20behaviour%20%28punctuation%20and%20trailing%20space%29%2C%20profile%20%28display%20name%29%2C%0A%2F%2F%2F%20preferred%20response%20languages%2C%20and%20the%20user's%20custom%20style%20rules.%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=696&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["refactor(settings): group acceptance tog..."](https://github.com/fujacob/cotabby/commit/93682e84cba30dfc419b2ad589856cfdbe06d799) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37165666)</sub>

<!-- /greptile_comment -->