### PR TITLE
feat(settings): make typo Corrections a progressive-disclosure hierarchy

### DIFF
--- a/Cotabby/UI/Settings/Panes/WritingPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/WritingPaneView.swift
@@ -70,40 +70,57 @@ struct WritingPaneView: View {
                 .settingsItem(.addSpaceAfterAccept)
             }
 
-            Section("Corrections") {
+            // Typo handling is a dependency chain, so the UI discloses it progressively rather than
+            // showing every control at once. The master gate ("Hide Suggestions on Typo") detects
+            // misspellings; the correction actions only function while it is on; the dictionaries
+            // only matter once an action can consume them. Revealing each level when it becomes
+            // relevant — instead of dimming dependents in place — makes the hierarchy unmistakable:
+            // turning the gate off removes the controls that depend on it. This is the established
+            // master/dependent idiom in this app (see `EmojiPaneView`). The earlier flat layout put
+            // all three toggles at the same visual level, so it was not obvious the gate governed the
+            // other two.
+            Section("Typos") {
                 Toggle(isOn: suppressCompletionsOnTypoBinding) {
                     SettingsRowLabel(
                         title: "Hide Suggestions on Typo",
-                        description: "Stops normal completions while the current word appears misspelled.",
+                        description: "Pauses normal completions while the current word looks misspelled. " +
+                            "Turn this on to use the correction options.",
                         systemImage: "eye.slash"
                     )
                 }
                 .settingsItem(.hideSuggestionsOnTypo)
+            }
 
-                Toggle(isOn: offerTypoCorrectionsBinding) {
-                    SettingsRowLabel(
-                        title: "Offer Corrections on Typo",
-                        description: "Shows a green replacement you can apply with your accept key.",
-                        systemImage: "checkmark.bubble"
-                    )
+            if suggestionSettings.suppressCompletionsOnTypo {
+                Section("Corrections") {
+                    Toggle(isOn: offerTypoCorrectionsBinding) {
+                        SettingsRowLabel(
+                            title: "Offer Corrections on Typo",
+                            description: "Shows a green replacement you can apply with your accept key.",
+                            systemImage: "checkmark.bubble"
+                        )
+                    }
+                    .settingsItem(.offerTypoCorrections)
+
+                    Toggle(isOn: automaticallyFixTyposBinding) {
+                        SettingsRowLabel(
+                            title: "Automatically Fix Typos",
+                            description: "After you press Space, replaces a misspelled word without requiring your accept key.",
+                            systemImage: "checkmark.circle"
+                        )
+                    }
+                    .settingsItem(.automaticallyFixTypos)
                 }
-                .disabled(!suggestionSettings.suppressCompletionsOnTypo)
-                .settingsItem(.offerTypoCorrections)
 
-                Toggle(isOn: automaticallyFixTyposBinding) {
-                    SettingsRowLabel(
-                        title: "Automatically Fix Typos",
-                        description: "After you press Space, replaces a misspelled word without requiring your accept key.",
-                        systemImage: "checkmark.circle"
-                    )
+                // Dictionaries rank candidates for the two correction actions above, so they only
+                // appear once at least one action is on. With neither active, choosing a dictionary
+                // would have no observable effect.
+                if suggestionSettings.offerTypoCorrections || suggestionSettings.automaticallyFixTypos {
+                    Section("Spelling Dictionaries") {
+                        SpellingDictionaryPicker(suggestionSettings: suggestionSettings)
+                            .settingsItem(.spellingDictionaries)
+                    }
                 }
-                .disabled(!suggestionSettings.suppressCompletionsOnTypo)
-                .settingsItem(.automaticallyFixTypos)
-
-                Divider()
-
-                SpellingDictionaryPicker(suggestionSettings: suggestionSettings)
-                    .settingsItem(.spellingDictionaries)
             }
 
             Section("Profile") {

--- a/Cotabby/UI/SpellingDictionaryPicker.swift
+++ b/Cotabby/UI/SpellingDictionaryPicker.swift
@@ -5,25 +5,16 @@ import SwiftUI
 /// This view owns presentation only. `SuggestionSettingsModel` normalizes and persists each toggle,
 /// while `SpellingLanguageResolver` and `SymSpellCorrector` own runtime selection and loading. Keeping
 /// those responsibilities separate prevents a Settings view from constructing heavyweight indexes.
+///
+/// Relevance gating lives in the parent (`WritingPaneView`): the picker is only rendered once the
+/// typo gate and at least one correction action are on, so the checkboxes here are always live and
+/// carry no self-disabling logic. The enclosing `Section("Spelling Dictionaries")` supplies the
+/// header, so this view starts straight at its explanatory caption.
 struct SpellingDictionaryPicker: View {
     @ObservedObject var suggestionSettings: SuggestionSettingsModel
 
-    /// The dictionary choices only change behavior when a correction can actually be produced and
-    /// surfaced. The typo gate must be armed (`suppressCompletionsOnTypo`) and at least one
-    /// correction path active: both "Offer Corrections on Typo" and "Automatically Fix Typos" rank
-    /// candidates through the enabled SymSpell dictionaries (see `TypoGate`/`bestCorrection`). When
-    /// none of those is on, ticking a dictionary has no observable effect, so we disable the
-    /// checkboxes, mirroring how the correction toggles disable themselves when the gate is off.
-    private var dictionariesAffectCorrections: Bool {
-        suggestionSettings.suppressCompletionsOnTypo
-            && (suggestionSettings.offerTypoCorrections || suggestionSettings.automaticallyFixTypos)
-    }
-
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text("Spelling Dictionaries")
-                .font(.system(size: 13, weight: .medium))
-
             Text(
                 "Choose which bundled dictionaries Cotabby may use for frequency-ranked corrections. "
                     + "With several enabled, Cotabby selects one from the surrounding text."
@@ -51,7 +42,6 @@ struct SpellingDictionaryPicker: View {
                     .toggleStyle(.checkbox)
                 }
             }
-            .disabled(!dictionariesAffectCorrections)
 
             Text(
                 "Indexes load on demand and Cotabby keeps at most two in memory. If no bundled "


### PR DESCRIPTION
## Summary

The Writing pane rendered "Hide Suggestions on Typo", "Offer Corrections on Typo", and "Automatically Fix Typos" as three flat peers, with the latter two (and the dictionary picker) merely dimmed when the first was off. The gate relationship was invisible, so toggling off "Hide Suggestions on Typo" silently killed the other controls with nothing to explain why (it briefly read as a freeze).

This reframes the section as the master/dependent progressive-disclosure idiom already used by `EmojiPaneView`: the gate lives alone in a **Typos** section; the **Corrections** actions appear only once it is on; the **Spelling Dictionaries** picker appears only once a correction action that can consume it is on. Revealing each level when it becomes relevant, instead of dimming dependents in place, makes the dependency unmistakable.

## Validation

- `swiftlint lint --quiet` — exit 0
- `xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build` — **BUILD SUCCEEDED**
- Rendered the new `WritingPaneView` layout offscreen via `NSHostingView` across all three disclosure states and inspected each:
  - **Gate off:** only the *Typos* section, with copy telling the user enabling it unlocks corrections. No dimmed orphans.
  - **Gate on:** *Corrections* section appears with both actions, fully interactive.
  - **A correction action on:** *Spelling Dictionaries* section appears with its own header (no double title) and the checkboxes.

| Gate off | Gate on | Fully disclosed |
| --- | --- | --- |
| Typos only | Typos + Corrections | Typos + Corrections + Spelling Dictionaries |

## Linked issues

None.

## Risk / rollout notes

- Presentation only: no change to `SuggestionSettingsModel`, the persisted settings, or the typo/correction runtime behavior. The same three booleans drive the same gate logic; only their disclosure changes.
- Row titles are unchanged, so the Settings search index (`SettingsIndex`) keeps resolving these rows. Section headers are cosmetic and not referenced by search.
- `SpellingDictionaryPicker` dropped its inline "Spelling Dictionaries" title and its self-disabling logic; it is now always rendered live and gated purely by the parent's visibility condition. Its only caller is `WritingPaneView`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR converts the flat \"Corrections\" section in `WritingPaneView` into a three-level progressive-disclosure hierarchy: a **Typos** gate section always shown, a **Corrections** section that appears only once the gate is on, and a **Spelling Dictionaries** section that appears only once at least one correction action is active. `SpellingDictionaryPicker` drops its own inline heading and `disabled()` guard in favour of pure parent-controlled visibility.

- The restructuring is presentation-only: `SuggestionSettingsModel`, all three persisted booleans, and the runtime `TypoGate` logic are untouched.
- The implementation correctly mirrors the `EmojiPaneView` master/dependent idiom already established in the codebase, and all four `SettingsIndex` entries remain registered so Settings search still resolves each row.

<h3>Confidence Score: 4/5</h3>

The change is pure UI restructuring with no model, persistence, or runtime logic touched — low risk to merge.

All three typo-related settings — and the dictionary picker — are conditionally removed from the view hierarchy when their gate is off. This means a Settings search that resolves one of those items while the gate is off navigates to the Writing pane but cannot scroll to or pulse the target row, leaving the user stranded with no visual feedback. The rest of the change is clean and follows the established EmojiPaneView pattern.

The conditional rendering blocks in `WritingPaneView.swift` (lines 94–123) are the area to examine for the search-navigation edge case.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/Settings/Panes/WritingPaneView.swift | Restructured typo/correction/dictionary controls from a flat disabled-peer layout into a three-level progressive-disclosure hierarchy using conditional `if` blocks and separate `Section` headings. No model or binding logic changed. |
| Cotabby/UI/SpellingDictionaryPicker.swift | Removed the `dictionariesAffectCorrections` guard and its `.disabled()` call, and dropped the inline "Spelling Dictionaries" heading; gating is now fully delegated to the parent's conditional render. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["WritingPaneView renders"] --> B["Section: Typos\n(always visible)\n─────────────────\nHide Suggestions on Typo toggle"]
    B --> C{suppressCompletionsOnTypo?}
    C -- "false (gate off)" --> D["No further typo sections rendered\n(Corrections + Dictionaries hidden)"]
    C -- "true (gate on)" --> E["Section: Corrections\n─────────────────\nOffer Corrections on Typo toggle\nAutomatically Fix Typos toggle"]
    E --> F{offerTypoCorrections\nor automaticallyFixTypos?}
    F -- "false (neither on)" --> G["Spelling Dictionaries section hidden"]
    F -- "true (at least one on)" --> H["Section: Spelling Dictionaries\n─────────────────\nSpellingDictionaryPicker\n(always live — no disabled logic)"]
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Fcorrections-progressive-disclosure%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fcorrections-progressive-disclosure%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FSettings%2FPanes%2FWritingPaneView.swift%3A94-123%0A**Search-navigation%20silently%20drops%20when%20dependent%20rows%20are%20hidden**%0A%0AWhen%20%60suppressCompletionsOnTypo%60%20is%20%60false%60%2C%20the%20%60.offerTypoCorrections%60%2C%20%60.automaticallyFixTypos%60%2C%20and%20%60.spellingDictionaries%60%20anchors%20are%20not%20in%20the%20view%20hierarchy.%20If%20the%20user%20finds%20one%20of%20those%20items%20via%20Settings%20search%20while%20the%20gate%20is%20off%2C%20%60SettingsNavigationModel.reveal%28_%3A%29%60%20correctly%20switches%20to%20the%20Writing%20pane%2C%20but%20%60SettingsPaneScaffold%60's%20%60scrollTo%60%20call%20targets%20a%20non-existent%20anchor%20and%20silently%20no-ops%20%E2%80%94%20no%20scroll%20and%20no%20arrival%20pulse.%20The%20user%20lands%20on%20the%20pane%20with%20nothing%20highlighted%20and%20no%20indication%20of%20why.%0A%0AWith%20the%20old%20flat%20layout%2C%20all%20three%20rows%20were%20always%20rendered%20%28just%20%60.disabled%28%29%60%29%2C%20so%20the%20scroll%20target%20was%20always%20present.%20This%20PR%20removes%20that%20guarantee.%20The%20same%20edge%20case%20exists%20today%20in%20%60EmojiPaneView%60%20for%20emoji%20sub-settings%2C%20so%20this%20is%20consistent%20with%20the%20existing%20pattern%20%E2%80%94%20but%20it's%20worth%20noting%20since%20the%20typo%20sub-settings%20are%20more%20likely%20to%20be%20searched%20independently%20%28e.g.%2C%20a%20user%20searching%20%22Spelling%20Dictionaries%22%20to%20choose%20a%20language%20before%20realising%20the%20gate%20exists%29.%0A%0AA%20lightweight%20mitigation%20used%20elsewhere%20is%20to%20gate%20search%20result%20surfacing%20on%20the%20dependent%20condition%2C%20or%20to%20auto-enable%20the%20gate%20when%20search%20navigates%20directly%20to%20a%20dependent%20item.%0A%0A&repo=fujacob%2Fcotabby&pr=702&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FSettings%2FPanes%2FWritingPaneView.swift%3A94-123%0A**Search-navigation%20silently%20drops%20when%20dependent%20rows%20are%20hidden**%0A%0AWhen%20%60suppressCompletionsOnTypo%60%20is%20%60false%60%2C%20the%20%60.offerTypoCorrections%60%2C%20%60.automaticallyFixTypos%60%2C%20and%20%60.spellingDictionaries%60%20anchors%20are%20not%20in%20the%20view%20hierarchy.%20If%20the%20user%20finds%20one%20of%20those%20items%20via%20Settings%20search%20while%20the%20gate%20is%20off%2C%20%60SettingsNavigationModel.reveal%28_%3A%29%60%20correctly%20switches%20to%20the%20Writing%20pane%2C%20but%20%60SettingsPaneScaffold%60's%20%60scrollTo%60%20call%20targets%20a%20non-existent%20anchor%20and%20silently%20no-ops%20%E2%80%94%20no%20scroll%20and%20no%20arrival%20pulse.%20The%20user%20lands%20on%20the%20pane%20with%20nothing%20highlighted%20and%20no%20indication%20of%20why.%0A%0AWith%20the%20old%20flat%20layout%2C%20all%20three%20rows%20were%20always%20rendered%20%28just%20%60.disabled%28%29%60%29%2C%20so%20the%20scroll%20target%20was%20always%20present.%20This%20PR%20removes%20that%20guarantee.%20The%20same%20edge%20case%20exists%20today%20in%20%60EmojiPaneView%60%20for%20emoji%20sub-settings%2C%20so%20this%20is%20consistent%20with%20the%20existing%20pattern%20%E2%80%94%20but%20it's%20worth%20noting%20since%20the%20typo%20sub-settings%20are%20more%20likely%20to%20be%20searched%20independently%20%28e.g.%2C%20a%20user%20searching%20%22Spelling%20Dictionaries%22%20to%20choose%20a%20language%20before%20realising%20the%20gate%20exists%29.%0A%0AA%20lightweight%20mitigation%20used%20elsewhere%20is%20to%20gate%20search%20result%20surfacing%20on%20the%20dependent%20condition%2C%20or%20to%20auto-enable%20the%20gate%20when%20search%20navigates%20directly%20to%20a%20dependent%20item.%0A%0A&repo=fujacob%2Fcotabby&pr=702&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(settings): make typo Corrections a ..."](https://github.com/fujacob/cotabby/commit/77901274339c13928693c3980a7a83d6416a62e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37241065)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->