### PR TITLE
fix: wrong popup shadow rendering after #652 and #566

### DIFF
--- a/Cotabby/UI/MenuBarPopoverDismisser.swift
+++ b/Cotabby/UI/MenuBarPopoverDismisser.swift
@@ -63,19 +63,31 @@ final class MenuBarPopoverDismisser: ObservableObject {
 /// real backing window without affecting layout.
 struct MenuBarPopoverDismisserBinder: NSViewRepresentable {
     let dismisser: MenuBarPopoverDismisser
+    let onWindowBind: (NSWindow) -> Void
+
+    init(
+        dismisser: MenuBarPopoverDismisser,
+        onWindowBind: @escaping (NSWindow) -> Void = { _ in }
+    ) {
+        self.dismisser = dismisser
+        self.onWindowBind = onWindowBind
+    }
 
     func makeNSView(context: Context) -> WindowBindingView {
         let view = WindowBindingView()
         view.dismisser = dismisser
+        view.onWindowBind = onWindowBind
         return view
     }
 
     func updateNSView(_ nsView: WindowBindingView, context: Context) {
         nsView.dismisser = dismisser
+        nsView.onWindowBind = onWindowBind
     }
 
     final class WindowBindingView: NSView {
         weak var dismisser: MenuBarPopoverDismisser?
+        var onWindowBind: ((NSWindow) -> Void)?
 
         override func viewDidMoveToWindow() {
             super.viewDidMoveToWindow()
@@ -83,6 +95,7 @@ struct MenuBarPopoverDismisserBinder: NSViewRepresentable {
             // case keeps a stale reference from outliving the actual popover instance.
             if let window {
                 dismisser?.hostWindow = window
+                onWindowBind?(window)
             }
         }
     }

--- a/Cotabby/UI/MenuBarView.swift
+++ b/Cotabby/UI/MenuBarView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 /// File overview:
@@ -46,7 +47,12 @@ struct MenuBarView: View {
                 runtimeModel.refreshAvailableModels()
             }
         )
-        .background(MenuBarPopoverDismisserBinder(dismisser: popoverDismisser))
+        .background(
+            MenuBarPopoverDismisserBinder(
+                dismisser: popoverDismisser,
+                onWindowBind: configureMenuBarWindowIfNeeded
+            )
+        )
         .onAppear {
             permissionManager.refresh()
             runtimeModel.refreshAvailableModels()
@@ -90,6 +96,12 @@ struct MenuBarView: View {
     /// `CFBundleShortVersionString`, the same canonical source the About pane uses.
     private var appShortVersion: String? {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+    }
+
+    private func configureMenuBarWindowIfNeeded(_ window: NSWindow) {
+        if #available(macOS 26.0, *) {
+            MenuBarWindowChromeConfigurator.configure(window)
+        }
     }
 
     // MARK: - Quick controls
@@ -468,11 +480,6 @@ struct MenuBarView: View {
 /// `MenuBarExtra`. Keeping this as a dedicated modifier gives the UI a narrow boundary for one
 /// platform-specific presentation rule without mixing availability checks into the main view body.
 private struct MenuBarWindowBackgroundModifier: ViewModifier {
-    /// Corner radius of the macOS 26 popover window, measured against the system chrome. The opaque
-    /// fill is clipped to this so it reaches the rounded edge of the non-opaque window. It is an
-    /// intentional coupling to a system measurement: if a future macOS changes the popover shape,
-    /// this is the single value to update (too small leaves a transparent sliver that re-detaches
-    /// the shadow; too large is harmlessly clipped by the window mask).
     private static let macOS26PopoverCornerRadius: CGFloat = 16
 
     @ViewBuilder
@@ -485,15 +492,21 @@ private struct MenuBarWindowBackgroundModifier: ViewModifier {
             // is why #492 (translucent material) recurred as #646 even after #566 swapped the
             // material for an opaque color, which the system still re-routed through the backdrop.
             //
-            // Draw the fill as ordinary content instead. A plain `.background` renders as a normal
-            // opaque layer rather than the glass backdrop, and we clip it to the native popover
-            // shape (see `macOS26PopoverCornerRadius`) so it covers the whole non-opaque window up
-            // to the rounded edge. The popup then reads as one solid rounded panel that the system
-            // shadow can hug, with no desktop bleed-through.
-            content.background {
-                RoundedRectangle(cornerRadius: Self.macOS26PopoverCornerRadius, style: .continuous)
-                    .fill(Color(nsColor: .windowBackgroundColor))
-            }
+            // Draw the panel as ordinary SwiftUI content and make the native host window clear in
+            // `MenuBarWindowChromeConfigurator`. On macOS 26 the host adds its own rounded frame
+            // outside the content; keeping both surfaces visible is what creates the double
+            // outline. By owning the one visible rounded surface here, the menu has a single border
+            // regardless of how much padding the system host reserves around it.
+            content
+                .background {
+                    RoundedRectangle(cornerRadius: Self.macOS26PopoverCornerRadius, style: .continuous)
+                        .fill(Color(nsColor: .windowBackgroundColor))
+                        .shadow(color: .black.opacity(0.28), radius: 18, x: 0, y: 8)
+                }
+                .overlay {
+                    RoundedRectangle(cornerRadius: Self.macOS26PopoverCornerRadius, style: .continuous)
+                        .stroke(Color(nsColor: .separatorColor).opacity(0.7), lineWidth: 1)
+                }
         } else if #available(macOS 15.0, *) {
             // MenuBarExtra's `.window` style already gives us native rounded window chrome. Place
             // the fill at the hosting window instead of this view's local bounds so it reaches the
@@ -504,5 +517,30 @@ private struct MenuBarWindowBackgroundModifier: ViewModifier {
         } else {
             content
         }
+    }
+}
+
+/// Configures the AppKit window behind `MenuBarExtra(.window)` on macOS 26.
+///
+/// SwiftUI owns the menu contents, but the double-outline regression lives one layer above SwiftUI:
+/// macOS 26 gives the menu popover a larger non-opaque host window than the SwiftUI root view. A
+/// normal SwiftUI background can stop at that root view and read as a second rounded panel. This
+/// helper clears the actual `NSWindow` and its content view so the SwiftUI panel remains the only
+/// visible rounded shape.
+@available(macOS 26.0, *)
+private enum MenuBarWindowChromeConfigurator {
+    static func configure(_ window: NSWindow) {
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        window.hasShadow = false
+
+        for backingView in [window.contentView, window.contentView?.superview].compactMap({ $0 }) {
+            backingView.wantsLayer = true
+            backingView.layer?.backgroundColor = NSColor.clear.cgColor
+            backingView.layer?.borderWidth = 0
+            backingView.layer?.shadowOpacity = 0
+            backingView.layer?.masksToBounds = false
+        }
+        window.invalidateShadow()
     }
 }


### PR DESCRIPTION
## Summary

This fixes the shadow and double-outline regression introduced by the interaction between the fixes for #566 and #652 on macOS 26. The menu bar popover now binds to and configures the underlying host `NSWindow`, ensuring the native host window remains visually transparent while a single SwiftUI-rendered panel surface owns the visible background, border, and shadow.

## Validation

- Built and ran Cotabby on macOS 26.
- Verified that the menu bar popover no longer displays an extra rounded outline around the popup.
- Verified that the popup shadow appears correctly and matches the native popover shape.
- Verified that light and dark mode appearance changes continue to render correctly.
- Verified that existing popover dismissal behavior still works after binding to the host window.

## Linked issues

Fixes #704

## Risk / rollout notes

- Changes are limited to the menu bar popover presentation path on macOS 26.
- Introduces direct configuration of the underlying `NSWindow` used by `MenuBarExtra(.window)`.
- No data model, settings, migration, or persistence changes.
- Older macOS versions continue to use their existing presentation paths unchanged.

Solves #704

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a shadow and double-outline regression on macOS 26 where the `MenuBarExtra(.window)` popover rendered both the native host window's rounded chrome and the SwiftUI fill layer as separate visible surfaces. The fix clears the native `NSWindow` chrome via a new `MenuBarWindowChromeConfigurator` helper and transfers visual ownership of the background, border, and shadow entirely to a SwiftUI-rendered `RoundedRectangle`.

- **`MenuBarWindowChromeConfigurator`** (macOS 26 only): sets `window.isOpaque = false`, `backgroundColor = .clear`, `hasShadow = false`, and strips layer chrome from `contentView` and its superview so the host window is fully transparent.
- **`MenuBarWindowBackgroundModifier`** (macOS 26 branch): adds a SwiftUI `.shadow()` and `.overlay` stroke border to the fill rect, making this SwiftUI layer the sole visible rounded surface.
- **`MenuBarPopoverDismisserBinder`**: gains an `onWindowBind` callback so `MenuBarView` can invoke `configureMenuBarWindowIfNeeded` the moment the host window becomes available.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the targeted macOS 26 regression; older macOS paths are untouched.

The macOS 26 fix is carefully gated and the changed logic is well-reasoned. The two areas that warrant a second look are the `window.invalidateShadow()` call (harmless dead code after `hasShadow = false`) and the direct manipulation of `contentView?.superview` — AppKit's internal NSThemeFrame — which is undocumented and could quietly stop working in a future macOS 26 point release if the view hierarchy gains an intermediate layer.

MenuBarView.swift — specifically the `MenuBarWindowChromeConfigurator.configure` method and its access to `contentView?.superview`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/UI/MenuBarView.swift | Adds `MenuBarWindowChromeConfigurator` (macOS 26 only) that strips the host NSWindow's native chrome and shadow, then draws a single SwiftUI-rendered rounded panel with its own fill, border, and shadow. Two minor concerns: `invalidateShadow()` is a no-op after `hasShadow = false`, and accessing `contentView?.superview` (NSThemeFrame) is fragile undocumented API. |
| Cotabby/UI/MenuBarPopoverDismisser.swift | Extends `MenuBarPopoverDismisserBinder` with an `onWindowBind` callback (defaulting to a no-op) so callers can react to the host window becoming available. The callback is correctly threaded through `makeNSView` and `updateNSView`, and fires in `viewDidMoveToWindow` guarded behind a non-nil window check. Straightforward and safe. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant SwiftUI
    participant Binder as MenuBarPopoverDismisserBinder
    participant WBV as WindowBindingView
    participant Configurator as MenuBarWindowChromeConfigurator
    participant NSWin as NSWindow

    SwiftUI->>Binder: makeNSView(context:)
    Binder->>WBV: create view, set onWindowBind
    SwiftUI->>WBV: add to window hierarchy
    WBV->>WBV: viewDidMoveToWindow()
    WBV->>Configurator: onWindowBind(window)
    Configurator->>NSWin: "isOpaque = false"
    Configurator->>NSWin: "backgroundColor = .clear"
    Configurator->>NSWin: "hasShadow = false"
    Configurator->>NSWin: contentView layer — clear bg, no border, no shadow
    Configurator->>NSWin: contentView.superview layer — clear bg, no border, no shadow
    Note over SwiftUI,NSWin: SwiftUI RoundedRectangle now owns fill + shadow + border
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22codex%2F704-fix-popup-shadow%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2F704-fix-popup-shadow%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FMenuBarView.swift%3A537-543%0A**Modifying%20%60contentView%3F.superview%60%20%28NSThemeFrame%29%20is%20fragile%20internal%20API**%0A%0A%60window.contentView%3F.superview%60%20resolves%20to%20AppKit's%20private%20%60NSThemeFrame%60.%20While%20%60compactMap%60%20safely%20handles%20a%20nil%20superview%2C%20setting%20%60wantsLayer%60%2C%20%60borderWidth%60%2C%20%60shadowOpacity%60%2C%20and%20%60masksToBounds%60%20directly%20on%20that%20internal%20view%20relies%20on%20an%20undocumented%2C%20stable%20view-hierarchy%20assumption.%20A%20future%20macOS%2026%20point%20release%20could%20introduce%20an%20intermediate%20wrapper%20between%20%60NSWindow%60%20and%20its%20%60contentView%60%2C%20silently%20bypassing%20these%20property%20writes%20and%20re-exposing%20the%20double-outline.%20Consider%20logging%20a%20warning%20when%20%60contentView%3F.superview%60%20is%20the%20class%20name%20you%20expect%20so%20regressions%20surface%20early%20rather%20than%20silently.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FUI%2FMenuBarView.swift%3A544-546%0A%60window.invalidateShadow%28%29%60%20is%20a%20no-op%20here%20because%20%60window.hasShadow%60%20was%20set%20to%20%60false%60%20on%20the%20line%20above%20%E2%80%94%20there%20is%20no%20native%20Cocoa%20shadow%20left%20for%20the%20window%20manager%20to%20redraw.%20The%20shadow%20is%20owned%20entirely%20by%20SwiftUI's%20%60.shadow%28%29%60%20modifier%20on%20the%20fill%20rectangle.%20Remove%20or%20replace%20with%20an%20explanatory%20comment%20to%20avoid%20implying%20it%20has%20an%20effect.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Note%3A%20invalidateShadow%28%29%20is%20intentionally%20omitted%20here%20%E2%80%94%20hasShadow%20is%20false%20so%20the%0A%20%20%20%20%20%20%20%20%2F%2F%20native%20window%20manager%20shadow%20is%20disabled%2C%20and%20the%20visible%20shadow%20is%20owned%20by%20the%0A%20%20%20%20%20%20%20%20%2F%2F%20SwiftUI%20.shadow%28%29%20modifier%20on%20the%20fill%20rectangle.%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=707&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FUI%2FMenuBarView.swift%3A537-543%0A**Modifying%20%60contentView%3F.superview%60%20%28NSThemeFrame%29%20is%20fragile%20internal%20API**%0A%0A%60window.contentView%3F.superview%60%20resolves%20to%20AppKit's%20private%20%60NSThemeFrame%60.%20While%20%60compactMap%60%20safely%20handles%20a%20nil%20superview%2C%20setting%20%60wantsLayer%60%2C%20%60borderWidth%60%2C%20%60shadowOpacity%60%2C%20and%20%60masksToBounds%60%20directly%20on%20that%20internal%20view%20relies%20on%20an%20undocumented%2C%20stable%20view-hierarchy%20assumption.%20A%20future%20macOS%2026%20point%20release%20could%20introduce%20an%20intermediate%20wrapper%20between%20%60NSWindow%60%20and%20its%20%60contentView%60%2C%20silently%20bypassing%20these%20property%20writes%20and%20re-exposing%20the%20double-outline.%20Consider%20logging%20a%20warning%20when%20%60contentView%3F.superview%60%20is%20the%20class%20name%20you%20expect%20so%20regressions%20surface%20early%20rather%20than%20silently.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FUI%2FMenuBarView.swift%3A544-546%0A%60window.invalidateShadow%28%29%60%20is%20a%20no-op%20here%20because%20%60window.hasShadow%60%20was%20set%20to%20%60false%60%20on%20the%20line%20above%20%E2%80%94%20there%20is%20no%20native%20Cocoa%20shadow%20left%20for%20the%20window%20manager%20to%20redraw.%20The%20shadow%20is%20owned%20entirely%20by%20SwiftUI's%20%60.shadow%28%29%60%20modifier%20on%20the%20fill%20rectangle.%20Remove%20or%20replace%20with%20an%20explanatory%20comment%20to%20avoid%20implying%20it%20has%20an%20effect.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Note%3A%20invalidateShadow%28%29%20is%20intentionally%20omitted%20here%20%E2%80%94%20hasShadow%20is%20false%20so%20the%0A%20%20%20%20%20%20%20%20%2F%2F%20native%20window%20manager%20shadow%20is%20disabled%2C%20and%20the%20visible%20shadow%20is%20owned%20by%20the%0A%20%20%20%20%20%20%20%20%2F%2F%20SwiftUI%20.shadow%28%29%20modifier%20on%20the%20fill%20rectangle.%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=707&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(MenuBar): enhance popover window con..."](https://github.com/fujacob/cotabby/commit/85fbff5627dc8dbd4d1c09b980a3127564a8651a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37415637)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->