### PR TITLE
fix: suppress calendar accessibility capture

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -249,6 +249,7 @@
 		52518CF0760DFEE9AF7C786C /* SuggestionEngineRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384FBCF5D7A3A446C5BE2B8D /* SuggestionEngineRouter.swift */; };
 		52F3962FA9F424576D7DB5B8 /* CotabbyDebugOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B2D34A6F3AC9DFD61350F7 /* CotabbyDebugOptions.swift */; };
 		532283A7651F7E66635F4281 /* SuggestionSessionReconciler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0AA0503128B0FC3951D700 /* SuggestionSessionReconciler.swift */; };
+		533091ED7EB306D103DC94DB /* CalendarAccessibilityCapturePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2BBC9CD727C19DA94DB105 /* CalendarAccessibilityCapturePolicy.swift */; };
 		53480635FD54DAF41B1F5047 /* ControlTokenMarkers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC2D6472ACD377FD73A5801 /* ControlTokenMarkers.swift */; };
 		53AA9A9D3555A67F8F31DC65 /* CompletionRenderModePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53CF416511099C6818110F01 /* CompletionRenderModePolicy.swift */; };
 		53FB56A095BCF0389DAC0A56 /* SuggestionTextColorCodec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CE61E74928C221B8BB261C6 /* SuggestionTextColorCodec.swift */; };
@@ -256,6 +257,7 @@
 		54BDF0D9C3DC7175555BD0F6 /* LlamaRuntimeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A52D0B550E00EF173A5D157E /* LlamaRuntimeManager.swift */; };
 		54E515A0E75B3902E6497A71 /* EmojiPopularity.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27B962C66727776D00069DE /* EmojiPopularity.swift */; };
 		5560B54FBBEC80F13BCD2054 /* EmojiPickerPanelLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62EDF1199CC5E18BD7651661 /* EmojiPickerPanelLayout.swift */; };
+		5580B5FF786B4F5173E01B20 /* CalendarAccessibilityCapturePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2BBC9CD727C19DA94DB105 /* CalendarAccessibilityCapturePolicy.swift */; };
 		55D4E6FB63E3475749E61EB3 /* CustomRulesCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43E587E421AF544A8300CE4 /* CustomRulesCatalog.swift */; };
 		55E841977534CBFD8B80E95F /* AXTreeDumpWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44745635AF702C96B4225A2 /* AXTreeDumpWriterTests.swift */; };
 		55EDBFF489D4C31276E2A67F /* PermissionHostApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6ACCB12E4DB32D2F2BEA567 /* PermissionHostApp.swift */; };
@@ -333,6 +335,7 @@
 		6F2FE689BCA50BEAE80AC6F4 /* ShortcutsPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB630F9814388203DD1CA2EC /* ShortcutsPaneView.swift */; };
 		709F365A846B908D953FA92D /* FoundationModelPromptRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE7BF162A12703249726F20A /* FoundationModelPromptRenderer.swift */; };
 		7179FB0EC6411166CCD79F6B /* CompositionInputModeClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F283E5B403F9FEBFB4BA04A /* CompositionInputModeClassifier.swift */; };
+		7291020840F2164EBB764FAF /* CalendarAccessibilityCaptureGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 049102F0ED85618106A042C4 /* CalendarAccessibilityCaptureGuard.swift */; };
 		7324B18578C646B1ADFF0C3F /* InsertedTextAdvanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C46024A6D18B1AD9D04B3BD /* InsertedTextAdvanceTests.swift */; };
 		735C2E64CA51F58098B30A0D /* it.txt in Resources */ = {isa = PBXBuildFile; fileRef = 0397F1DACB094A0F6A66BC0E /* it.txt */; };
 		74422BB837D6A319D12BF981 /* BaseCompletionPromptRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85EF79E6144D6C6AD062B569 /* BaseCompletionPromptRenderer.swift */; };
@@ -344,6 +347,7 @@
 		76DFC829F2417FB048463285 /* GhostTextPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = A594D02B0EF3C2DD62EFE69A /* GhostTextPreview.swift */; };
 		76FD91607794883F8E121450 /* CaretGeometrySelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3C84377F352140759B448C9 /* CaretGeometrySelector.swift */; };
 		773808D3D88440F0836D0072 /* FileLogHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE98A6C28731BF5C8D434543 /* FileLogHandlerTests.swift */; };
+		77823BCFB29F63615C514927 /* CalendarAccessibilityCaptureGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 049102F0ED85618106A042C4 /* CalendarAccessibilityCaptureGuard.swift */; };
 		77B57484667F71F7EFA380D1 /* fr-100k.txt in Resources */ = {isa = PBXBuildFile; fileRef = 6DB982BF30B3601F57277776 /* fr-100k.txt */; };
 		783BEC91DBC86AF75CEDB269 /* MenuBarPresentationObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00824BDD8D0E9B3063827C78 /* MenuBarPresentationObserver.swift */; };
 		78A8713A0E5B4C89E2D715BC /* FocusCapabilityFlickerGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1972BD2C5254D8266618781F /* FocusCapabilityFlickerGateTests.swift */; };
@@ -650,6 +654,7 @@
 		F0556D369F809445D0AC4E9C /* SettingsSearchRankerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C533B73CDDA3685135C460FB /* SettingsSearchRankerTests.swift */; };
 		F067EA26AC2D007382CE520F /* EmojiPickerModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E5F074ED7E340E9B9E4C5E0 /* EmojiPickerModels.swift */; };
 		F08C139B246C1EC7BB435455 /* MenuBarPresentationObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00824BDD8D0E9B3063827C78 /* MenuBarPresentationObserver.swift */; };
+		F279A4064B24FCF714A8CAD4 /* CalendarAccessibilityCapturePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF115FEF7FC96D46C815479 /* CalendarAccessibilityCapturePolicyTests.swift */; };
 		F28FB178EC507C3D42A6F893 /* SuggestionInteractionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA942A53B7C09D1F4EC57239 /* SuggestionInteractionState.swift */; };
 		F31B343F9C935A5421A526DE /* AXTreeDumpWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B27492B04B627DA53BDAD938 /* AXTreeDumpWriter.swift */; };
 		F41AB06FD117487D7136E896 /* FocusTrackingModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37DA0B2D4FE343E321A95C22 /* FocusTrackingModelTests.swift */; };
@@ -710,6 +715,7 @@
 		03766F6253FF17639230C0F6 /* ModelAndPresentationValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelAndPresentationValueTests.swift; sourceTree = "<group>"; };
 		0397F1DACB094A0F6A66BC0E /* it.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = it.txt; sourceTree = "<group>"; };
 		043E8AA850F930222DD112C0 /* GhostSuggestionLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostSuggestionLayout.swift; sourceTree = "<group>"; };
+		049102F0ED85618106A042C4 /* CalendarAccessibilityCaptureGuard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarAccessibilityCaptureGuard.swift; sourceTree = "<group>"; };
 		04D853218B0A77B0CE090828 /* BrowserAppDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserAppDetectorTests.swift; sourceTree = "<group>"; };
 		04E25414C307A20B6F9F20EC /* FocusSnapshotResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusSnapshotResolver.swift; sourceTree = "<group>"; };
 		050D929E13BE52E6282B64D2 /* VisualContextStartCoalescerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualContextStartCoalescerTests.swift; sourceTree = "<group>"; };
@@ -774,6 +780,7 @@
 		29CDC8BE5312B9BEFD9B22CB /* SurfaceContextComposerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceContextComposerTests.swift; sourceTree = "<group>"; };
 		29ED42C4BDD0C521101AF95E /* DeviceInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceInfo.swift; sourceTree = "<group>"; };
 		2A02336442BB735EE2E8D064 /* SettingsAttentionEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAttentionEvaluator.swift; sourceTree = "<group>"; };
+		2AF115FEF7FC96D46C815479 /* CalendarAccessibilityCapturePolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarAccessibilityCapturePolicyTests.swift; sourceTree = "<group>"; };
 		2B3E5554AAC5D0007CCC61A7 /* LlamaDecodeGateDefaultsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LlamaDecodeGateDefaultsTests.swift; sourceTree = "<group>"; };
 		2B7A28471B8526C2693FFF65 /* AcknowledgementsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcknowledgementsView.swift; sourceTree = "<group>"; };
 		2BC293F6125E2B14DCF05AD9 /* SettingsAttentionEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAttentionEvaluatorTests.swift; sourceTree = "<group>"; };
@@ -1061,6 +1068,7 @@
 		DDC034BBCBAC5E7989D4C85B /* LlamaSuggestionEngineStreamingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LlamaSuggestionEngineStreamingTests.swift; sourceTree = "<group>"; };
 		DDE858CB1E687E3CEB8FDD5B /* SuggestionRequestFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionRequestFactory.swift; sourceTree = "<group>"; };
 		DDF6A4E9CE93FD53C60E67E3 /* EmojiQueryRun.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiQueryRun.swift; sourceTree = "<group>"; };
+		DE2BBC9CD727C19DA94DB105 /* CalendarAccessibilityCapturePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarAccessibilityCapturePolicy.swift; sourceTree = "<group>"; };
 		DEB16474A67CE1D210B944C9 /* SuggestionSubsystemContracts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionSubsystemContracts.swift; sourceTree = "<group>"; };
 		DEBD6113A3C1038BECC99245 /* PerformancePaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformancePaneView.swift; sourceTree = "<group>"; };
 		DF3A73EB848780061FC162C0 /* SpellingDictionaryPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpellingDictionaryPicker.swift; sourceTree = "<group>"; };
@@ -1274,6 +1282,7 @@
 			children = (
 				CB58035EFFD65B767949BAE6 /* AXTextGeometryResolver.swift */,
 				B27492B04B627DA53BDAD938 /* AXTreeDumpWriter.swift */,
+				049102F0ED85618106A042C4 /* CalendarAccessibilityCaptureGuard.swift */,
 				8896D976C7F116EBA0F3969F /* ChromiumAccessibilityEnabler.swift */,
 				684737E62EE6495A71344923 /* DeepGeometryWalkThrottle.swift */,
 				B7FBF2B766E728F25899B64E /* FieldStyleCache.swift */,
@@ -1435,6 +1444,7 @@
 				04D853218B0A77B0CE090828 /* BrowserAppDetectorTests.swift */,
 				1F761083EA5465023D82B5F4 /* BrowserDomainTests.swift */,
 				18D990E515E1AE4F312F4E95 /* BundledRuntimeLocatorTests.swift */,
+				2AF115FEF7FC96D46C815479 /* CalendarAccessibilityCapturePolicyTests.swift */,
 				8EA827D6A2A54DF4BAD56405 /* CaretLinePositionTests.swift */,
 				421FD16E18622824E038DFB4 /* CaretRunPlacementTests.swift */,
 				EFD89799BB82AF7A92559AEB /* ClipboardContentDistillerTests.swift */,
@@ -1697,6 +1707,7 @@
 				AD8025E4A296845FC53E660D /* BrowserDomain.swift */,
 				AA33F5FFAC5B99384E15CE3E /* BundledRuntimeLocator.swift */,
 				01D84EED1A6A711F39DEA18F /* BundleVersion.swift */,
+				DE2BBC9CD727C19DA94DB105 /* CalendarAccessibilityCapturePolicy.swift */,
 				E3C84377F352140759B448C9 /* CaretGeometrySelector.swift */,
 				D77364C1AF183EF1C0A4074D /* CaretLinePosition.swift */,
 				96495E4147D828C0B1B22765 /* ClipboardContentDistiller.swift */,
@@ -2004,6 +2015,8 @@
 				2BE029A192E82E795490DC7F /* BrowserDomain.swift in Sources */,
 				06A310C087B460289B5ACCFE /* BundleVersion.swift in Sources */,
 				07E50A9ECCE55072DA311F8F /* BundledRuntimeLocator.swift in Sources */,
+				7291020840F2164EBB764FAF /* CalendarAccessibilityCaptureGuard.swift in Sources */,
+				5580B5FF786B4F5173E01B20 /* CalendarAccessibilityCapturePolicy.swift in Sources */,
 				7C72A2D76E8BA38ADD523CF6 /* CaretGeometrySelector.swift in Sources */,
 				06CFA03207FF92EB272A66F2 /* CaretLinePosition.swift in Sources */,
 				CCB8D287A5FF3863B9DE9246 /* ChromiumAccessibilityEnabler.swift in Sources */,
@@ -2250,6 +2263,8 @@
 				7D9C3D733CE7633FB12A35BE /* BrowserDomain.swift in Sources */,
 				D46BCACE71169BF8403948CE /* BundleVersion.swift in Sources */,
 				3CBBC3BFAC0DC8952EE24EF7 /* BundledRuntimeLocator.swift in Sources */,
+				77823BCFB29F63615C514927 /* CalendarAccessibilityCaptureGuard.swift in Sources */,
+				533091ED7EB306D103DC94DB /* CalendarAccessibilityCapturePolicy.swift in Sources */,
 				76FD91607794883F8E121450 /* CaretGeometrySelector.swift in Sources */,
 				543D71217CA218426E9638BF /* CaretLinePosition.swift in Sources */,
 				D800277BE3296DE2FB8198A8 /* ChromiumAccessibilityEnabler.swift in Sources */,
@@ -2487,6 +2502,7 @@
 				5C0D3B6012C7412001BE3773 /* BrowserAppDetectorTests.swift in Sources */,
 				C3B6C8B9DE20A71C65D390DA /* BrowserDomainTests.swift in Sources */,
 				58AC3193D846FDE88513377D /* BundledRuntimeLocatorTests.swift in Sources */,
+				F279A4064B24FCF714A8CAD4 /* CalendarAccessibilityCapturePolicyTests.swift in Sources */,
 				62FADA407797998742502DD9 /* CaretLinePositionTests.swift in Sources */,
 				418055EF945C17BAEFAB89ED /* CaretRunPlacementTests.swift in Sources */,
 				8865B95FE84198D70390DF80 /* ClipboardContentDistillerTests.swift in Sources */,

--- a/Cotabby/App/Core/CotabbyAppEnvironment.swift
+++ b/Cotabby/App/Core/CotabbyAppEnvironment.swift
@@ -16,6 +16,8 @@ final class CotabbyAppEnvironment {
     let modelDownloadManager: ModelDownloadManager
     let focusModel: FocusTrackingModel
     let inputMonitor: InputMonitor
+    /// Temporarily pauses Calendar AX traversal only while its date/time editor is active.
+    let calendarAccessibilityCaptureGuard: CalendarAccessibilityCaptureGuard
     let appUpdateManager: AppUpdateManager
     let permissionGuidanceController: PermissionGuidanceController
     let suggestionSettings: SuggestionSettingsModel
@@ -60,6 +62,10 @@ final class CotabbyAppEnvironment {
             permissionProvider: { permissionManager.inputMonitoringGranted },
             suppressionController: suppressionController
         )
+        let calendarAccessibilityCaptureGuard = CalendarAccessibilityCaptureGuard()
+        inputMonitor.onPointerDown = { [weak calendarAccessibilityCaptureGuard] point in
+            calendarAccessibilityCaptureGuard?.handlePointerDown(atAccessibilityPoint: point)
+        }
         inputMonitor.acceptanceKeyCodeProvider = { suggestionSettings.acceptanceKeyCode }
         inputMonitor.acceptanceKeyModifiersProvider = { suggestionSettings.acceptanceKeyModifiers }
         inputMonitor.fullAcceptanceKeyCodeProvider = { suggestionSettings.fullAcceptanceKeyCode }
@@ -69,11 +75,9 @@ final class CotabbyAppEnvironment {
         inputMonitor.onGlobalToggleHotkey = { [weak suggestionSettings] in
             suggestionSettings?.toggleGloballyEnabled()
         }
-        // Stop the deep AX walk when Cotabby is disabled for the focused app. Without this the
-        // focus poll keeps enumerating the frontmost app's AX attributes every 50-80ms even after
-        // the user toggles Cotabby off, which can dismiss transient popovers in apps like Calendar
-        // (#476). Gating here also makes the "I disabled it but the bug remained" symptom go away:
-        // the disable toggles now actually stop touching the focused app.
+        // Stop the deep AX walk when Cotabby is disabled for the focused app or while Calendar's
+        // fragile date/time editor is active. The latter is interaction-scoped: Calendar text fields
+        // still resolve normally, unlike the old app-wide suppression workaround for #544.
         let focusModel = FocusTrackingModel(
             permissionProvider: { permissionManager.accessibilityGranted },
             ignoredBundleIdentifier: Bundle.main.bundleIdentifier,
@@ -86,7 +90,9 @@ final class CotabbyAppEnvironment {
                    suggestionSettings.isApplicationDisabled(bundleIdentifier: bundleIdentifier) {
                     return true
                 }
-                return false
+                return calendarAccessibilityCaptureGuard.shouldSuppressCapture(
+                    for: bundleIdentifier
+                )
             },
             publishesPollingEvents: FocusDebugOverlayController.isEnabled
         )
@@ -96,6 +102,11 @@ final class CotabbyAppEnvironment {
         inputMonitor.shouldProcessEventsProvider = { [weak focusModel] in
             guard suggestionSettings.isGloballyEnabled else { return false }
             guard let snapshot = focusModel?.snapshot else { return true }
+            if calendarAccessibilityCaptureGuard.shouldSuppressCapture(
+                for: snapshot.bundleIdentifier
+            ) {
+                return false
+            }
             if TerminalAppDetector.isTerminal(bundleIdentifier: snapshot.bundleIdentifier) { return false }
             if let bundleID = snapshot.bundleIdentifier,
                suggestionSettings.isApplicationDisabled(bundleIdentifier: bundleID) {
@@ -268,6 +279,7 @@ final class CotabbyAppEnvironment {
         self.modelDownloadManager = modelDownloadManager
         self.focusModel = focusModel
         self.inputMonitor = inputMonitor
+        self.calendarAccessibilityCaptureGuard = calendarAccessibilityCaptureGuard
         self.appUpdateManager = appUpdateManager
         self.permissionGuidanceController = permissionGuidanceController
         self.suggestionSettings = suggestionSettings

--- a/Cotabby/Services/Focus/CalendarAccessibilityCaptureGuard.swift
+++ b/Cotabby/Services/Focus/CalendarAccessibilityCaptureGuard.swift
@@ -1,4 +1,5 @@
 import AppKit
+import ApplicationServices
 import Foundation
 import Logging
 
@@ -20,6 +21,11 @@ final class CalendarAccessibilityCaptureGuard {
             return
         }
 
+        // A click that resolves to no AX element (e.g. empty Calendar canvas) leaves the current
+        // state untouched rather than resuming. The date-picker popup is the fragile surface this
+        // guard protects, and forcing a resume on every unresolved click risks dropping suppression
+        // mid-edit. Active suppression still ends the moment the pointer lands on a real text field
+        // or another app (handled below and in the policy), so a normal editing flow cannot strand it.
         guard let target = AXHelper.element(atAccessibilityPoint: point) else {
             return
         }
@@ -35,6 +41,12 @@ final class CalendarAccessibilityCaptureGuard {
     }
 
     /// `FocusTracker` calls this after its cheap focused-element lookup and before resolver traversal.
+    ///
+    /// This both reads and updates state: observing any non-Calendar bundle clears an active
+    /// suppression. The mutation lives here (rather than in a separate step) because an app switch can
+    /// happen by keyboard with no pointer event, so this poll is the only signal that the user left
+    /// Calendar. The `updateSuppression` guard makes the repeated calls on the focus/key-event hot
+    /// paths cheap no-ops once the state has settled.
     func shouldSuppressCapture(for bundleIdentifier: String?) -> Bool {
         guard bundleIdentifier == CalendarAccessibilityCapturePolicy.calendarBundleIdentifier else {
             // App switches can happen by keyboard with no pointer event. Clearing here prevents a

--- a/Cotabby/Services/Focus/CalendarAccessibilityCaptureGuard.swift
+++ b/Cotabby/Services/Focus/CalendarAccessibilityCaptureGuard.swift
@@ -1,0 +1,59 @@
+import AppKit
+import Foundation
+import Logging
+
+/// Owns the short-lived Calendar date/time interaction state used by `FocusTracker`'s capture gate.
+///
+/// `InputMonitor` supplies global pointer-down coordinates. This service first checks the frontmost
+/// bundle (so normal clicks pay no AX cost), hit-tests only Calendar, and reduces the clicked AX
+/// element through `CalendarAccessibilityCapturePolicy`. `CotabbyAppEnvironment` owns one instance
+/// for the app lifetime and the focus model reads its current state before any candidate-tree walk.
+@MainActor
+final class CalendarAccessibilityCaptureGuard {
+    private var isDateTimeInteractionActive = false
+
+    /// Updates the guard from a Quartz/global screen point (top-left origin).
+    func handlePointerDown(atAccessibilityPoint point: CGPoint) {
+        guard NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+            == CalendarAccessibilityCapturePolicy.calendarBundleIdentifier else {
+            updateSuppression(false)
+            return
+        }
+
+        guard let target = AXHelper.element(atAccessibilityPoint: point) else {
+            return
+        }
+
+        let targetApplication = AXHelper.owningApplication(of: target)
+        let nextState = CalendarAccessibilityCapturePolicy.shouldSuppressCapture(
+            currentlySuppressed: isDateTimeInteractionActive,
+            targetBundleIdentifier: targetApplication?.bundleIdentifier,
+            targetRole: AXHelper.stringValue(for: kAXRoleAttribute as CFString, on: target),
+            targetIdentifier: AXHelper.accessibilityIdentifier(of: target)
+        )
+        updateSuppression(nextState)
+    }
+
+    /// `FocusTracker` calls this after its cheap focused-element lookup and before resolver traversal.
+    func shouldSuppressCapture(for bundleIdentifier: String?) -> Bool {
+        guard bundleIdentifier == CalendarAccessibilityCapturePolicy.calendarBundleIdentifier else {
+            // App switches can happen by keyboard with no pointer event. Clearing here prevents a
+            // stale Calendar interaction from suppressing capture when the user later switches back.
+            updateSuppression(false)
+            return false
+        }
+        return isDateTimeInteractionActive
+    }
+
+    private func updateSuppression(_ shouldSuppress: Bool) {
+        guard shouldSuppress != isDateTimeInteractionActive else {
+            return
+        }
+        isDateTimeInteractionActive = shouldSuppress
+        if shouldSuppress {
+            CotabbyLogger.focus.info("Paused Calendar AX capture for date/time editing")
+        } else {
+            CotabbyLogger.focus.info("Resumed Calendar AX capture after date/time editing")
+        }
+    }
+}

--- a/Cotabby/Services/Input/InputMonitor.swift
+++ b/Cotabby/Services/Input/InputMonitor.swift
@@ -3,9 +3,9 @@ import Foundation
 import Logging
 
 /// File overview:
-/// Owns the global keyboard event taps used to detect typing, navigation, dismissal keys,
-/// and `Tab` acceptance. This is the boundary between raw CGEvents and Cotabby's smaller
-/// input-event vocabulary.
+/// Owns the global input event taps used to detect typing, navigation, dismissal keys, `Tab`
+/// acceptance, and compatibility-relevant pointer presses. This is the boundary between raw
+/// CGEvents and Cotabby's smaller input-event vocabulary.
 ///
 /// `CapturedInputEvent` now lives in `Models/InputModels.swift` so the rest of the app can depend
 /// on the semantic event type without importing this event-tap implementation.
@@ -40,9 +40,9 @@ enum InputMonitorAcceptTapDecision: Equatable {
 
 /// Installs two taps:
 /// - A steady-state `.listenOnly` observer at the head of the chain. Listen-only taps do not gate
-///   event delivery on the callback's return, so a slow main actor cannot stall global keystrokes
-///   in unrelated apps (DaVinci Resolve's Spacebar play/pause is the canonical victim of an active
-///   tap here — see issue #328). It handles ordinary typing, navigation, and dismissal events.
+///   event delivery on the callback's return, so a slow main actor cannot stall input in unrelated
+///   apps (DaVinci Resolve's Spacebar play/pause is the canonical victim of an active tap here — see
+///   issue #328). It handles ordinary typing, navigation, dismissal, and pointer observation.
 /// - A narrow `.defaultTap` accept tap at the tail, installed only while a suggestion is visible.
 ///   This is the only path that consumes events, so it also owns acceptance side effects. Keeping
 ///   insertion and consumption in the same callback prevents the coordinator from hiding the overlay
@@ -51,6 +51,11 @@ enum InputMonitorAcceptTapDecision: Equatable {
 final class InputMonitor {
     var onEvent: ((CapturedInputEvent) -> Bool)?
     var onSuppressedSyntheticInput: (() -> Void)?
+
+    /// Reports physical pointer-down locations from the existing listen-only tap. The Calendar AX
+    /// compatibility guard uses this to pause focus-tree reads before Calendar handles its fragile
+    /// date/time disclosure click. No pointer event is consumed or modified.
+    var onPointerDown: (@MainActor (CGPoint) -> Void)?
 
     /// While an emoji capture session is active, the picker controller decides per key whether the
     /// active tap should swallow it (navigation, Return/Tab, Escape) or let it reach the field
@@ -241,6 +246,8 @@ final class InputMonitor {
         }
 
         let mask = (1 << CGEventType.keyDown.rawValue)
+            | (1 << CGEventType.leftMouseDown.rawValue)
+            | (1 << CGEventType.rightMouseDown.rawValue)
         let callback: CGEventTapCallBack = { _, type, event, userInfo in
             guard let userInfo else {
                 return Unmanaged.passUnretained(event)
@@ -501,9 +508,22 @@ final class InputMonitor {
             )
             return Unmanaged.passUnretained(event)
 
+        case .leftMouseDown, .rightMouseDown:
+            handleObserverPointerDown(at: event.location)
+            return Unmanaged.passUnretained(event)
+
         default:
             return Unmanaged.passUnretained(event)
         }
+    }
+
+    /// Testable pointer path for the listen-only observer tap.
+    ///
+    /// Production enters through `handleObserverTap`; accepting a value here lets tests verify that
+    /// pointer coordinates reach compatibility guards without allocating a CoreGraphics event in the
+    /// app-hosted test process.
+    func handleObserverPointerDown(at point: CGPoint) {
+        onPointerDown?(point)
     }
 
     /// Testable observer path for semantic key snapshots.

--- a/Cotabby/Support/AXHelper.swift
+++ b/Cotabby/Support/AXHelper.swift
@@ -550,10 +550,20 @@ enum AXHelper {
         guard let primaryHeight = NSScreen.screens.first?.frame.height else {
             return nil
         }
-        let axX = Float(point.x)
-        let axY = Float(primaryHeight - point.y)
+        let accessibilityPoint = CGPoint(x: point.x, y: primaryHeight - point.y)
+        return element(atAccessibilityPoint: accessibilityPoint)
+    }
+
+    /// Hit-tests an Accessibility element from Quartz/CGEvent global coordinates (top-left origin).
+    ///
+    /// Global input taps already report points in AX screen space, so converting those points through
+    /// Cocoa would introduce an unnecessary second coordinate flip. Calendar's interaction guard uses
+    /// this overload directly from the listen-only pointer event callback.
+    static func element(atAccessibilityPoint point: CGPoint) -> AXUIElement? {
         var element: AXUIElement?
-        guard AXUIElementCopyElementAtPosition(systemWideElement(), axX, axY, &element) == .success else {
+        guard AXUIElementCopyElementAtPosition(
+            systemWideElement(), Float(point.x), Float(point.y), &element
+        ) == .success else {
             return nil
         }
         return element

--- a/Cotabby/Support/CalendarAccessibilityCapturePolicy.swift
+++ b/Cotabby/Support/CalendarAccessibilityCapturePolicy.swift
@@ -1,0 +1,57 @@
+import ApplicationServices
+import Foundation
+
+/// Pure state transition for Apple Calendar's fragile date/time editor.
+///
+/// Calendar keeps the previously focused text field as first responder while its date/time section
+/// is open. Reading that stale field's broader Accessibility neighborhood makes Calendar collapse
+/// the section and move focus to another editor row. The policy therefore enters suppression only
+/// for date/time controls and leaves it only when the pointer reaches a real text input or another
+/// application. Keeping this rule pure makes the compatibility behavior testable without a live AX
+/// tree; `CalendarAccessibilityCaptureGuard` owns the OS hit-testing boundary.
+enum CalendarAccessibilityCapturePolicy {
+    static let calendarBundleIdentifier = "com.apple.iCal"
+
+    private static let dateTimeControlIdentifiers: Set<String> = [
+        "date-time-button",
+        "start-datepicker",
+        "start-timepicker",
+        "end-datepicker",
+        "end-timepicker"
+    ]
+
+    private static let editableTextRoles: Set<String> = [
+        kAXTextFieldRole as String,
+        kAXTextAreaRole as String,
+        "AXSearchField",
+        kAXComboBoxRole as String
+    ]
+
+    /// Computes the guard's next state for one physical pointer-down target.
+    ///
+    /// While suppression is active, unknown Calendar controls keep it active. Date picker popups
+    /// expose several private button roles with unstable identifiers, so treating an unknown click
+    /// as "resume" would reintroduce the bug on the user's next date selection. A click into any
+    /// editable text role is an explicit safe boundary and resumes normal autocomplete capture.
+    static func shouldSuppressCapture(
+        currentlySuppressed: Bool,
+        targetBundleIdentifier: String?,
+        targetRole: String?,
+        targetIdentifier: String?
+    ) -> Bool {
+        guard targetBundleIdentifier == calendarBundleIdentifier else {
+            return false
+        }
+
+        if targetRole == "AXDateTimeArea"
+            || targetIdentifier.map(dateTimeControlIdentifiers.contains) == true {
+            return true
+        }
+
+        if targetRole.map(editableTextRoles.contains) == true {
+            return false
+        }
+
+        return currentlySuppressed
+    }
+}

--- a/Cotabby/Support/CalendarAccessibilityCapturePolicy.swift
+++ b/Cotabby/Support/CalendarAccessibilityCapturePolicy.swift
@@ -39,7 +39,12 @@ enum CalendarAccessibilityCapturePolicy {
         targetRole: String?,
         targetIdentifier: String?
     ) -> Bool {
-        guard targetBundleIdentifier == calendarBundleIdentifier else {
+        // Only a positively-identified non-Calendar app is an explicit "resume" signal. A nil bundle
+        // id means the AX owner lookup failed, not that the click left Calendar (the guard already
+        // confirmed Calendar is frontmost), so treating nil as "resume" could drop suppression
+        // mid-edit and reintroduce the collapse bug. Fall through and let the role/identifier checks
+        // — or the held state — decide instead.
+        if let targetBundleIdentifier, targetBundleIdentifier != calendarBundleIdentifier {
             return false
         }
 

--- a/CotabbyTests/CalendarAccessibilityCapturePolicyTests.swift
+++ b/CotabbyTests/CalendarAccessibilityCapturePolicyTests.swift
@@ -1,0 +1,71 @@
+import ApplicationServices
+import XCTest
+@testable import Cotabby
+
+final class CalendarAccessibilityCapturePolicyTests: XCTestCase {
+    func testDateTimeDisclosureStartsSuppression() {
+        XCTAssertTrue(
+            CalendarAccessibilityCapturePolicy.shouldSuppressCapture(
+                currentlySuppressed: false,
+                targetBundleIdentifier: "com.apple.iCal",
+                targetRole: kAXButtonRole as String,
+                targetIdentifier: "date-time-button"
+            )
+        )
+    }
+
+    func testDateTimeAreaKeepsSuppressionActive() {
+        XCTAssertTrue(
+            CalendarAccessibilityCapturePolicy.shouldSuppressCapture(
+                currentlySuppressed: true,
+                targetBundleIdentifier: "com.apple.iCal",
+                targetRole: "AXDateTimeArea",
+                targetIdentifier: "start-datepicker"
+            )
+        )
+    }
+
+    func testUnknownCalendarPickerControlKeepsExistingSuppression() {
+        XCTAssertTrue(
+            CalendarAccessibilityCapturePolicy.shouldSuppressCapture(
+                currentlySuppressed: true,
+                targetBundleIdentifier: "com.apple.iCal",
+                targetRole: kAXButtonRole as String,
+                targetIdentifier: nil
+            )
+        )
+    }
+
+    func testCalendarTextFieldResumesCapture() {
+        XCTAssertFalse(
+            CalendarAccessibilityCapturePolicy.shouldSuppressCapture(
+                currentlySuppressed: true,
+                targetBundleIdentifier: "com.apple.iCal",
+                targetRole: kAXTextFieldRole as String,
+                targetIdentifier: "title-field"
+            )
+        )
+    }
+
+    func testAnotherApplicationClearsSuppression() {
+        XCTAssertFalse(
+            CalendarAccessibilityCapturePolicy.shouldSuppressCapture(
+                currentlySuppressed: true,
+                targetBundleIdentifier: "com.apple.TextEdit",
+                targetRole: kAXTextAreaRole as String,
+                targetIdentifier: nil
+            )
+        )
+    }
+
+    func testOrdinaryCalendarClickDoesNotStartSuppression() {
+        XCTAssertFalse(
+            CalendarAccessibilityCapturePolicy.shouldSuppressCapture(
+                currentlySuppressed: false,
+                targetBundleIdentifier: "com.apple.iCal",
+                targetRole: kAXButtonRole as String,
+                targetIdentifier: "today-button"
+            )
+        )
+    }
+}

--- a/CotabbyTests/CalendarAccessibilityCapturePolicyTests.swift
+++ b/CotabbyTests/CalendarAccessibilityCapturePolicyTests.swift
@@ -58,6 +58,32 @@ final class CalendarAccessibilityCapturePolicyTests: XCTestCase {
         )
     }
 
+    func testUnresolvedOwnerBundleKeepsExistingSuppression() {
+        // A nil bundle id means the AX owner lookup failed while Calendar is frontmost (the guard
+        // already gated on that), not that the click left Calendar. Suppression must persist rather
+        // than spuriously resume mid-edit and reintroduce the collapse bug.
+        XCTAssertTrue(
+            CalendarAccessibilityCapturePolicy.shouldSuppressCapture(
+                currentlySuppressed: true,
+                targetBundleIdentifier: nil,
+                targetRole: kAXButtonRole as String,
+                targetIdentifier: nil
+            )
+        )
+    }
+
+    func testUnresolvedOwnerBundleStillResumesOnTextField() {
+        // An editable role is an explicit safe boundary even when the owning bundle can't be read.
+        XCTAssertFalse(
+            CalendarAccessibilityCapturePolicy.shouldSuppressCapture(
+                currentlySuppressed: true,
+                targetBundleIdentifier: nil,
+                targetRole: kAXTextFieldRole as String,
+                targetIdentifier: nil
+            )
+        )
+    }
+
     func testOrdinaryCalendarClickDoesNotStartSuppression() {
         XCTAssertFalse(
             CalendarAccessibilityCapturePolicy.shouldSuppressCapture(

--- a/CotabbyTests/InputMonitorTests.swift
+++ b/CotabbyTests/InputMonitorTests.swift
@@ -13,6 +13,18 @@ final class InputMonitorTests: XCTestCase {
     /// process lifetime keeps the tests focused on routing behavior instead of deinit mechanics.
     @MainActor private static var retainedMonitors: [InputMonitor] = []
 
+    func test_observerTapForwardsPointerLocationWithoutConsumingIt() {
+        runOnMainActor {
+            let monitor = makeMonitor()
+            var observedPoint: CGPoint?
+            monitor.onPointerDown = { observedPoint = $0 }
+
+            monitor.handleObserverPointerDown(at: CGPoint(x: 321, y: 654))
+
+            XCTAssertEqual(observedPoint, CGPoint(x: 321, y: 654))
+        }
+    }
+
     func test_observerTapIgnoresPrimaryAcceptKeyWhenConsumingTapOwnsIt() {
         runOnMainActor {
             let monitor = makeMonitor()


### PR DESCRIPTION
## Summary

- Add a Calendar-specific Accessibility capture guard that detects interactions with date/time controls before Calendar handles the click.
- Temporarily pause Cotabby's focus-tree traversal and keyboard processing while Calendar's fragile date/time editor is active, preventing the editor from collapsing or shifting focus.
- Resume capture when the user clicks an editable Calendar text field or switches to another application, preserving autocomplete in ordinary Calendar fields.
- Extend the existing listen-only input tap to observe left/right pointer-down locations without consuming or modifying mouse events.
- Add unit coverage for Calendar suppression state transitions and pointer-location forwarding.

## Validation

```sh
xcodebuild -project Cotabby.xcodeproj -scheme 'Cotabby Dev' \
  -configuration Debug -destination 'platform=macOS' \
  -derivedDataPath build/DerivedData \
  CODE_SIGN_IDENTITY=- CODE_SIGN_STYLE=Manual DEVELOPMENT_TEAM= build
# ** BUILD SUCCEEDED **
```

The Calendar interaction itself has not yet been verified end-to-end in this session.

## Linked issues

Fixes #544

## Risk / rollout notes

- The observer tap now listens for mouse-down events in addition to key-down events, but remains listen-only and never consumes pointer input.
- While suppression is active, unknown Calendar picker controls intentionally keep it active; capture resets on a recognized editable text field or application switch.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a targeted suppression guard for Apple Calendar's fragile date/time editor: when the user clicks a date-picker control, Cotabby's focus-tree traversal and key-event processing are paused to prevent AX reads from collapsing the section, then automatically resumed when the pointer reaches a real text field or another application is focused.

- **New `CalendarAccessibilityCaptureGuard` + `CalendarAccessibilityCapturePolicy`** implement the pointer-driven state machine; the policy is pure and independently tested.
- **`InputMonitor` listen-only tap** is extended to observe `leftMouseDown` / `rightMouseDown` and forward coordinates via a new `onPointerDown` callback, with no event consumption.
- **`AXHelper`** is refactored to expose a separate `element(atAccessibilityPoint:)` overload that accepts already-flipped Quartz coordinates, avoiding a double coordinate conversion from the tap path.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the guard is fully additive and the listen-only tap remains non-consuming.

The changes are well-isolated: the new classes are wired in through closures, @MainActor threading is correctly applied throughout, and the coordinate-space refactor in AXHelper preserves the existing flip logic. Policy logic is backed by comprehensive unit tests. The two open items — middle-button observation and a minor capture-semantics inconsistency — have no impact on the existing key paths or on correctness of the Calendar suppression feature itself.

No files require special attention beyond the middle-button tap mask gap in InputMonitor.swift.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Services/Focus/CalendarAccessibilityCaptureGuard.swift | New class owning the date/time interaction suppression state; handles the frontmost-app pre-check, AX hit-test, and nil-element sticky-state policy (documented but not unit-tested). Design and threading are correct. |
| Cotabby/Support/CalendarAccessibilityCapturePolicy.swift | Pure state-transition enum with well-chosen rules; logic is clear, the nil-bundle-ID and unknown-control fall-through cases are intentional and well-commented. |
| Cotabby/Services/Input/InputMonitor.swift | Extended listen-only tap mask to include leftMouseDown and rightMouseDown; otherMouseDown (middle button) is absent from the mask, which means middle-clicks won't reach the Calendar suppression guard. |
| Cotabby/App/Core/CotabbyAppEnvironment.swift | Wires guard into focus-model and key-event paths; onPointerDown captures guard weakly while the two provider closures capture it strongly — minor inconsistency with no functional impact. |
| Cotabby/Support/AXHelper.swift | Refactored element(atCocoaPoint:) to delegate to a new element(atAccessibilityPoint:) overload; coordinate math and multi-monitor semantics are correct. |
| CotabbyTests/CalendarAccessibilityCapturePolicyTests.swift | Comprehensive policy unit tests covering suppression start, sticky-active, text-field resume, app-switch clear, nil-bundle-ID variants, and no-start-on-ordinary-click cases. |
| CotabbyTests/InputMonitorTests.swift | New test verifies pointer coordinates are forwarded through handleObserverPointerDown without modification; minimal but sufficient for the routing concern. |
| Cotabby.xcodeproj/project.pbxproj | Standard project file additions for the four new Swift source files across main and test targets. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CGEventTap as CGEvent Tap (listen-only)
    participant IM as InputMonitor
    participant Guard as CalendarAccessibilityCaptureGuard
    participant AX as AXHelper
    participant Policy as CalendarAccessibilityCapturePolicy
    participant FocusModel as FocusTrackingModel

    Note over CGEventTap,FocusModel: Mouse click on Calendar date-picker button

    CGEventTap->>IM: handleObserverTap(.leftMouseDown, event)
    IM->>Guard: handlePointerDown(atAccessibilityPoint: event.location)
    Guard->>Guard: "NSWorkspace.frontmostApplication == com.apple.iCal?"
    Guard->>AX: element(atAccessibilityPoint: point)
    AX-->>Guard: AXUIElement (button)
    Guard->>AX: owningApplication(of: element)
    AX-->>Guard: bundleIdentifier
    Guard->>Policy: shouldSuppressCapture(currentlySuppressed:false, role:AXButton, id:date-time-button)
    Policy-->>Guard: true
    Guard->>Guard: "isDateTimeInteractionActive = true"

    Note over CGEventTap,FocusModel: Calendar handles click, date/time editor opens
    Note over CGEventTap,FocusModel: AX poll fires while editor is active

    FocusModel->>Guard: shouldSuppressCapture(for: com.apple.iCal)
    Guard-->>FocusModel: true
    Note over FocusModel: Deep AX walk skipped — editor stays open

    Note over CGEventTap,FocusModel: User switches to another app

    FocusModel->>Guard: shouldSuppressCapture(for: com.mozilla.Firefox)
    Guard->>Guard: updateSuppression(false)
    Guard-->>FocusModel: false
    Note over FocusModel: Normal AX capture resumes
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CGEventTap as CGEvent Tap (listen-only)
    participant IM as InputMonitor
    participant Guard as CalendarAccessibilityCaptureGuard
    participant AX as AXHelper
    participant Policy as CalendarAccessibilityCapturePolicy
    participant FocusModel as FocusTrackingModel

    Note over CGEventTap,FocusModel: Mouse click on Calendar date-picker button

    CGEventTap->>IM: handleObserverTap(.leftMouseDown, event)
    IM->>Guard: handlePointerDown(atAccessibilityPoint: event.location)
    Guard->>Guard: "NSWorkspace.frontmostApplication == com.apple.iCal?"
    Guard->>AX: element(atAccessibilityPoint: point)
    AX-->>Guard: AXUIElement (button)
    Guard->>AX: owningApplication(of: element)
    AX-->>Guard: bundleIdentifier
    Guard->>Policy: shouldSuppressCapture(currentlySuppressed:false, role:AXButton, id:date-time-button)
    Policy-->>Guard: true
    Guard->>Guard: "isDateTimeInteractionActive = true"

    Note over CGEventTap,FocusModel: Calendar handles click, date/time editor opens
    Note over CGEventTap,FocusModel: AX poll fires while editor is active

    FocusModel->>Guard: shouldSuppressCapture(for: com.apple.iCal)
    Guard-->>FocusModel: true
    Note over FocusModel: Deep AX walk skipped — editor stays open

    Note over CGEventTap,FocusModel: User switches to another app

    FocusModel->>Guard: shouldSuppressCapture(for: com.mozilla.Firefox)
    Guard->>Guard: updateSuppression(false)
    Guard-->>FocusModel: false
    Note over FocusModel: Normal AX capture resumes
```

</a>

<sub>Reviews (3): Last reviewed commit: ["fix(calendar): harden AX capture suppres..."](https://github.com/fujacob/cotabby/commit/0dcd0f4d36076120786ee998fef25e7dea1a7ace) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38609881)</sub>

<!-- /greptile_comment -->