### PR TITLE
feat: Add e2e support for MLX models

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -13,7 +13,6 @@
 		021197C88AF19DEA715C849B /* FileLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8C2569A8217EE9BD3B197F /* FileLogHandler.swift */; };
 		029B10EE4D659BAAF2C48FBE /* EmojiPopularity.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27B962C66727776D00069DE /* EmojiPopularity.swift */; };
 		02DA43985CDAE6859014F14F /* SuggestionOverlayPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D598CC3134879999D567455 /* SuggestionOverlayPresenter.swift */; };
-		02E1220621D53FACAB782090 /* Models in Frameworks */ = {isa = PBXBuildFile; productRef = B32AD571116137450BBA90C5 /* Models */; };
 		02FE7E7D0CC26AB67307D6D3 /* ru.txt in Resources */ = {isa = PBXBuildFile; fileRef = D8C2663427BC5219EA415D00 /* ru.txt */; };
 		0333B3CE8F189DD1BEC4AD26 /* MenuBarSections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A810F9D28A18BA6F2066C7 /* MenuBarSections.swift */; };
 		0431AE1DBEE36C90C7F39C19 /* CustomRulesCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43E587E421AF544A8300CE4 /* CustomRulesCatalog.swift */; };
@@ -254,7 +253,6 @@
 		50E1247BE6A952AB1B12C444 /* PowerSourceMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB235F0DEA53295DAF8B4FA0 /* PowerSourceMonitor.swift */; };
 		513066CA00F0E9A5E7358A4E /* PermissionReminderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 168A0DBF62BEF674B96CEBD2 /* PermissionReminderView.swift */; };
 		51C069603DA16830868F1628 /* LanguageTagsEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7CDA90E128350BFF1A9D66 /* LanguageTagsEditor.swift */; };
-		51E0E7102D02979D04C268B6 /* Generation in Frameworks */ = {isa = PBXBuildFile; productRef = CD961480BD400417743F21BA /* Generation */; };
 		52518CF0760DFEE9AF7C786C /* SuggestionEngineRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384FBCF5D7A3A446C5BE2B8D /* SuggestionEngineRouter.swift */; };
 		52F3962FA9F424576D7DB5B8 /* CotabbyDebugOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B2D34A6F3AC9DFD61350F7 /* CotabbyDebugOptions.swift */; };
 		532283A7651F7E66635F4281 /* SuggestionSessionReconciler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0AA0503128B0FC3951D700 /* SuggestionSessionReconciler.swift */; };
@@ -333,7 +331,6 @@
 		6A8454A989104AE150308BCF /* it-100k.txt in Resources */ = {isa = PBXBuildFile; fileRef = 2D8AA55C2B730110E8598F91 /* it-100k.txt */; };
 		6AE0B46FB52D189D94E1F79A /* WordCountFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E0513E3B23937B099A3CFF2 /* WordCountFormatterTests.swift */; };
 		6BE0C8F9D054A2C0D9018001 /* ConfidenceSuppressionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BD71ECC2AE4821B643E0935 /* ConfidenceSuppressionPolicy.swift */; };
-		6C370B59299A404DE42DF588 /* Models in Frameworks */ = {isa = PBXBuildFile; productRef = 0320FAC335116DE7DCA21791 /* Models */; };
 		6C59B369AAC6948C53E41654 /* DebouncePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB23CDF7CAA1DEAD606B46B3 /* DebouncePolicyTests.swift */; };
 		6CBEF02FCDFCF406E378C27C /* SuggestionInteractionStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB1D4F2681FAF59014AE115 /* SuggestionInteractionStateTests.swift */; };
 		6D0E79CF3C1A8CE53046FCE5 /* AXTextGeometryResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C046CB4F3CB4BFE9391DB5DE /* AXTextGeometryResolverTests.swift */; };
@@ -618,7 +615,6 @@
 		D80D98F6C7B86AAF8C831865 /* he-100k.txt in Resources */ = {isa = PBXBuildFile; fileRef = 7C9BB65FA5FC42B89766B037 /* he-100k.txt */; };
 		D81AC2294A64E7A95B29E081 /* fr.txt in Resources */ = {isa = PBXBuildFile; fileRef = 5DCA3E46621815A19300365F /* fr.txt */; };
 		D90C889A623A928F4F5FDC7B /* HardwareCapabilityProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41BBD5A4BA08CABE77860886 /* HardwareCapabilityProbe.swift */; };
-		D92A31EBB31D63E5A6BE6F33 /* Generation in Frameworks */ = {isa = PBXBuildFile; productRef = 8BC79D134D992A6342EDC71D /* Generation */; };
 		D9C51DEDF01033E276A479CE /* AXTextGeometryResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB58035EFFD65B767949BAE6 /* AXTextGeometryResolver.swift */; };
 		DA23422A2CF77CFD3B1283C8 /* OnboardingTemplateFeatureListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D814BBA41CF29E8DD9954651 /* OnboardingTemplateFeatureListTests.swift */; };
 		DAD77998F793468D4D64B705 /* DateMacroEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F671FE53CDEAE9091EFBCE45 /* DateMacroEvaluator.swift */; };
@@ -1161,8 +1157,6 @@
 				40412351B908B9B19FCD39B3 /* MLXLMCommon in Frameworks */,
 				A6370D0DE8669F25DEDACD59 /* Tokenizers in Frameworks */,
 				30AE3C5C8CFAE7DA4C68D6FB /* Hub in Frameworks */,
-				D92A31EBB31D63E5A6BE6F33 /* Generation in Frameworks */,
-				02E1220621D53FACAB782090 /* Models in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1180,8 +1174,6 @@
 				25C1921549D3691662A7F2F7 /* MLXLMCommon in Frameworks */,
 				EDFB4B3DD979A80E69E61081 /* Tokenizers in Frameworks */,
 				BFFBA299521A41C3879CB1C6 /* Hub in Frameworks */,
-				51E0E7102D02979D04C268B6 /* Generation in Frameworks */,
-				6C370B59299A404DE42DF588 /* Models in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1880,8 +1872,6 @@
 				359D454B426D7866DAD422DA /* MLXLMCommon */,
 				13E923E68B6A4BD0F3B18E75 /* Tokenizers */,
 				A8A6E5D6EDF5710071B4C7A6 /* Hub */,
-				CD961480BD400417743F21BA /* Generation */,
-				0320FAC335116DE7DCA21791 /* Models */,
 			);
 			productName = "Cotabby Dev";
 			productReference = 4BC92317837813ACA5051177 /* Cotabby Dev.app */;
@@ -1911,8 +1901,6 @@
 				C74A89874731CE8C6D285B4E /* MLXLMCommon */,
 				1CE8530F0ED104DD40248A25 /* Tokenizers */,
 				0A5609A3639D6B6B2ACB0BA2 /* Hub */,
-				8BC79D134D992A6342EDC71D /* Generation */,
-				B32AD571116137450BBA90C5 /* Models */,
 			);
 			productName = Cotabby;
 			productReference = 262BE2F1E97389FE8D7A5FB9 /* Cotabby.app */;
@@ -3158,11 +3146,6 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		0320FAC335116DE7DCA21791 /* Models */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 3D0C3DA536F35C2B7738A2FC /* XCRemoteSwiftPackageReference "swift-transformers" */;
-			productName = Models;
-		};
 		0A5609A3639D6B6B2ACB0BA2 /* Hub */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 3D0C3DA536F35C2B7738A2FC /* XCRemoteSwiftPackageReference "swift-transformers" */;
@@ -3228,20 +3211,10 @@
 			package = 413C306D13ADDD8B5C747551 /* XCRemoteSwiftPackageReference "swift-log" */;
 			productName = InMemoryLogging;
 		};
-		8BC79D134D992A6342EDC71D /* Generation */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 3D0C3DA536F35C2B7738A2FC /* XCRemoteSwiftPackageReference "swift-transformers" */;
-			productName = Generation;
-		};
 		A8A6E5D6EDF5710071B4C7A6 /* Hub */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 3D0C3DA536F35C2B7738A2FC /* XCRemoteSwiftPackageReference "swift-transformers" */;
 			productName = Hub;
-		};
-		B32AD571116137450BBA90C5 /* Models */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 3D0C3DA536F35C2B7738A2FC /* XCRemoteSwiftPackageReference "swift-transformers" */;
-			productName = Models;
 		};
 		BAADA69C6172DD7F4A642E93 /* Sparkle */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -3257,11 +3230,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = F8E600050524CEB6097DBCBF /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
 			productName = MLXLMCommon;
-		};
-		CD961480BD400417743F21BA /* Generation */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 3D0C3DA536F35C2B7738A2FC /* XCRemoteSwiftPackageReference "swift-transformers" */;
-			productName = Generation;
 		};
 		D11AB0F962CCC5BD79B630CA /* CotabbyInference */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -175,6 +175,10 @@
 		3AC2F7F221F7C59242B06DFC /* InputSuppressionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1F9CEBAB0F330F8E7B61D8 /* InputSuppressionController.swift */; };
 		3AFDA4A5BE9486A1B367815B /* SettingsNavigationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1AC5EC06664F49A6AE2B17 /* SettingsNavigationModel.swift */; };
 		3B3E08D1204E85F3776D8853 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = BAADA69C6172DD7F4A642E93 /* Sparkle */; };
+		920000000000000000000201 /* MLXLLM in Frameworks */ = {isa = PBXBuildFile; productRef = 920000000000000000000301 /* MLXLLM */; };
+		920000000000000000000202 /* MLXLMCommon in Frameworks */ = {isa = PBXBuildFile; productRef = 920000000000000000000302 /* MLXLMCommon */; };
+		920000000000000000000204 /* HuggingFace in Frameworks */ = {isa = PBXBuildFile; productRef = 920000000000000000000304 /* HuggingFace */; };
+		920000000000000000000205 /* Tokenizers in Frameworks */ = {isa = PBXBuildFile; productRef = 920000000000000000000305 /* Tokenizers */; };
 		3B5F96F9CC6D4D81B470DB2C /* EmojiSynonymCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF474064973F4752F79BB041 /* EmojiSynonymCatalogTests.swift */; };
 		3BB16F9F9F84C7A8D87DF044 /* es-100l.txt in Resources */ = {isa = PBXBuildFile; fileRef = 620D393D3B7E687A08FA9446 /* es-100l.txt */; };
 		3BC4FCF9A51F57A0A8F6944D /* ArithmeticEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F7ED2D9D71CFAD9A30977E9 /* ArithmeticEvaluator.swift */; };
@@ -254,6 +258,13 @@
 		53FB56A095BCF0389DAC0A56 /* SuggestionTextColorCodec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CE61E74928C221B8BB261C6 /* SuggestionTextColorCodec.swift */; };
 		543D71217CA218426E9638BF /* CaretLinePosition.swift in Sources */ = {isa = PBXBuildFile; fileRef = D77364C1AF183EF1C0A4074D /* CaretLinePosition.swift */; };
 		54BDF0D9C3DC7175555BD0F6 /* LlamaRuntimeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A52D0B550E00EF173A5D157E /* LlamaRuntimeManager.swift */; };
+		920000000000000000000007 /* MlxRuntimeLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 920000000000000000000107 /* MlxRuntimeLocatorTests.swift */; };
+		920000000000000000000001 /* MlxRuntimeModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 920000000000000000000101 /* MlxRuntimeModels.swift */; };
+		920000000000000000000002 /* MlxRuntimeBootstrapModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 920000000000000000000102 /* MlxRuntimeBootstrapModel.swift */; };
+		920000000000000000000003 /* MlxRuntimeLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 920000000000000000000103 /* MlxRuntimeLocator.swift */; };
+		920000000000000000000004 /* MlxRuntimeCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 920000000000000000000104 /* MlxRuntimeCore.swift */; };
+		920000000000000000000005 /* MlxRuntimeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 920000000000000000000105 /* MlxRuntimeManager.swift */; };
+		920000000000000000000006 /* MlxSuggestionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 920000000000000000000106 /* MlxSuggestionEngine.swift */; };
 		54E515A0E75B3902E6497A71 /* EmojiPopularity.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27B962C66727776D00069DE /* EmojiPopularity.swift */; };
 		5560B54FBBEC80F13BCD2054 /* EmojiPickerPanelLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62EDF1199CC5E18BD7651661 /* EmojiPickerPanelLayout.swift */; };
 		55D4E6FB63E3475749E61EB3 /* CustomRulesCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43E587E421AF544A8300CE4 /* CustomRulesCatalog.swift */; };
@@ -778,6 +789,7 @@
 		2B3E5554AAC5D0007CCC61A7 /* LlamaDecodeGateDefaultsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LlamaDecodeGateDefaultsTests.swift; sourceTree = "<group>"; };
 		2B7A28471B8526C2693FFF65 /* AcknowledgementsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcknowledgementsView.swift; sourceTree = "<group>"; };
 		2BC293F6125E2B14DCF05AD9 /* SettingsAttentionEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAttentionEvaluatorTests.swift; sourceTree = "<group>"; };
+		920000000000000000000107 /* MlxRuntimeLocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MlxRuntimeLocatorTests.swift; sourceTree = "<group>"; };
 		2D1F9CEBAB0F330F8E7B61D8 /* InputSuppressionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputSuppressionController.swift; sourceTree = "<group>"; };
 		2D7360A6D4261989A66658ED /* SentenceBoundaryClassifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentenceBoundaryClassifierTests.swift; sourceTree = "<group>"; };
 		2D8AA55C2B730110E8598F91 /* it-100k.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "it-100k.txt"; sourceTree = "<group>"; };
@@ -843,6 +855,12 @@
 		5F34AE24BB7C99D66E1F3904 /* InputModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputModels.swift; sourceTree = "<group>"; };
 		60629DFE309C1A4BD8A7FB3B /* RuntimeBootstrapModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimeBootstrapModel.swift; sourceTree = "<group>"; };
 		620D393D3B7E687A08FA9446 /* es-100l.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "es-100l.txt"; sourceTree = "<group>"; };
+		920000000000000000000101 /* MlxRuntimeModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MlxRuntimeModels.swift; sourceTree = "<group>"; };
+		920000000000000000000102 /* MlxRuntimeBootstrapModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MlxRuntimeBootstrapModel.swift; sourceTree = "<group>"; };
+		920000000000000000000103 /* MlxRuntimeLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MlxRuntimeLocator.swift; sourceTree = "<group>"; };
+		920000000000000000000104 /* MlxRuntimeCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MlxRuntimeCore.swift; sourceTree = "<group>"; };
+		920000000000000000000105 /* MlxRuntimeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MlxRuntimeManager.swift; sourceTree = "<group>"; };
+		920000000000000000000106 /* MlxSuggestionEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MlxSuggestionEngine.swift; sourceTree = "<group>"; };
 		62BD2ADED33249F5BA53D0AD /* EmojiPickerControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiPickerControllerTests.swift; sourceTree = "<group>"; };
 		62EDF1199CC5E18BD7651661 /* EmojiPickerPanelLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiPickerPanelLayout.swift; sourceTree = "<group>"; };
 		63F7C6D15674B3043C4CEEAC /* WelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
@@ -1116,13 +1134,17 @@
 		658F2109EF7F1517DEA48DEB /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
-			files = (
-				3B3E08D1204E85F3776D8853 /* Sparkle in Frameworks */,
-				9F2FDCABCC941CBECAA3B4AB /* CotabbyInference in Frameworks */,
-				7FC103944F4EF39DB965F469 /* InMemoryLogging in Frameworks */,
-				8DA36F1521B6A59D8C20AC59 /* Logging in Frameworks */,
-				A7A1B9BE242959B3EE396D27 /* LaunchAtLogin in Frameworks */,
-			);
+				files = (
+					3B3E08D1204E85F3776D8853 /* Sparkle in Frameworks */,
+					9F2FDCABCC941CBECAA3B4AB /* CotabbyInference in Frameworks */,
+					7FC103944F4EF39DB965F469 /* InMemoryLogging in Frameworks */,
+					8DA36F1521B6A59D8C20AC59 /* Logging in Frameworks */,
+					A7A1B9BE242959B3EE396D27 /* LaunchAtLogin in Frameworks */,
+					920000000000000000000201 /* MLXLLM in Frameworks */,
+					920000000000000000000202 /* MLXLMCommon in Frameworks */,
+					920000000000000000000204 /* HuggingFace in Frameworks */,
+					920000000000000000000205 /* Tokenizers in Frameworks */,
+				);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		D66643968D3BCEBA2ADCF895 /* Frameworks */ = {
@@ -1367,6 +1389,8 @@
 				5F34AE24BB7C99D66E1F3904 /* InputModels.swift */,
 				BF4BB93056F291FD24EFAD22 /* LanguageCatalog.swift */,
 				A804F4DB6FD9BC8C27B2B65F /* LlamaRuntimeModels.swift */,
+				920000000000000000000102 /* MlxRuntimeBootstrapModel.swift */,
+				920000000000000000000101 /* MlxRuntimeModels.swift */,
 				4451D6673112575DF24C4A48 /* OnboardingTemplate.swift */,
 				979A7867966180A545BB44C4 /* PerformanceMetricsStore.swift */,
 				9D82FFC568527700EC17C07D /* PermissionModels.swift */,
@@ -1508,6 +1532,7 @@
 				52BAFA2F989C3C4F7FB892B5 /* MarkerSelectionSynthesizerTests.swift */,
 				1274F897631B1B3A835D157F /* MidWordContinuationPolicyTests.swift */,
 				FC83D14A7557BC0196E59007 /* MirrorOverlayLayoutTests.swift */,
+				920000000000000000000107 /* MlxRuntimeLocatorTests.swift */,
 				03766F6253FF17639230C0F6 /* ModelAndPresentationValueTests.swift */,
 				A829F28F01FAE76CA7244BBC /* ModelFileValidatorTests.swift */,
 				5EED3CD2BC7B48DF35DEE562 /* OCRTextHygieneTests.swift */,
@@ -1743,6 +1768,7 @@
 				A863F41C0C03D7B4AC5DC002 /* MarkerSelectionSynthesizer.swift */,
 				357C18383B047F24A531BDCD /* MidWordContinuationPolicy.swift */,
 				54150A507B03221F137D539B /* MirrorOverlayLayout.swift */,
+				920000000000000000000103 /* MlxRuntimeLocator.swift */,
 				B22FDEB3B1DCC9ADE906CC73 /* OCRTextHygiene.swift */,
 				2578311F4ABCB3CDFF795A86 /* OnboardingFlowSteps.swift */,
 				24F613F0E2F7046E6532A09C /* OnboardingTemplateFeatureList.swift */,
@@ -1793,6 +1819,9 @@
 				944065A858D9BC936CB12B23 /* LlamaRuntimeCore.swift */,
 				A52D0B550E00EF173A5D157E /* LlamaRuntimeManager.swift */,
 				BE04620C905041680116BE80 /* LlamaSuggestionEngine.swift */,
+				920000000000000000000104 /* MlxRuntimeCore.swift */,
+				920000000000000000000105 /* MlxRuntimeManager.swift */,
+				920000000000000000000106 /* MlxSuggestionEngine.swift */,
 				384FBCF5D7A3A446C5BE2B8D /* SuggestionEngineRouter.swift */,
 			);
 			path = Runtime;
@@ -1841,10 +1870,14 @@
 			packageProductDependencies = (
 				BAADA69C6172DD7F4A642E93 /* Sparkle */,
 				48A46AD6B613CF06072603E4 /* CotabbyInference */,
-				88921938DC814625ED57D605 /* InMemoryLogging */,
-				5A60D1467BBFECB3DFEB39C2 /* Logging */,
-				7B0278A63FEEE8DEDB6C50DB /* LaunchAtLogin */,
-			);
+					88921938DC814625ED57D605 /* InMemoryLogging */,
+					5A60D1467BBFECB3DFEB39C2 /* Logging */,
+					7B0278A63FEEE8DEDB6C50DB /* LaunchAtLogin */,
+					920000000000000000000301 /* MLXLLM */,
+					920000000000000000000302 /* MLXLMCommon */,
+					920000000000000000000304 /* HuggingFace */,
+					920000000000000000000305 /* Tokenizers */,
+				);
 			productName = Cotabby;
 			productReference = 262BE2F1E97389FE8D7A5FB9 /* Cotabby.app */;
 			productType = "com.apple.product-type.application";
@@ -1882,7 +1915,6 @@
 						ProvisioningStyle = Automatic;
 					};
 					622CFE93F0FE48C8243E060C = {
-						DevelopmentTeam = G946M8K23B;
 						ProvisioningStyle = Automatic;
 					};
 					AB3DFA4CFA5EBC6161F02A30 = {
@@ -1902,10 +1934,13 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				537E79EE0EEF2030A5923ED9 /* XCRemoteSwiftPackageReference "cotabbyinference" */,
-				16E10845516A4DE793CC1BF6 /* XCRemoteSwiftPackageReference "LaunchAtLogin-Modern" */,
-				D8563066187C38DAA4206016 /* XCRemoteSwiftPackageReference "Sparkle" */,
-				413C306D13ADDD8B5C747551 /* XCRemoteSwiftPackageReference "swift-log" */,
-			);
+					16E10845516A4DE793CC1BF6 /* XCRemoteSwiftPackageReference "LaunchAtLogin-Modern" */,
+					D8563066187C38DAA4206016 /* XCRemoteSwiftPackageReference "Sparkle" */,
+					413C306D13ADDD8B5C747551 /* XCRemoteSwiftPackageReference "swift-log" */,
+					920000000000000000000401 /* XCRemoteSwiftPackageReference "mlx-swift-lm" */,
+					920000000000000000000402 /* XCRemoteSwiftPackageReference "swift-huggingface" */,
+					920000000000000000000403 /* XCRemoteSwiftPackageReference "swift-transformers" */,
+				);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 3725B1A195A06A4F014B75B1 /* Products */;
 			projectDirPath = "";
@@ -2355,6 +2390,12 @@
 				BBBD7B4628BA1160DD6B4BDB /* MacroModels.swift in Sources */,
 				0B378201616831626DEC3AB6 /* MacroReferenceSheet.swift in Sources */,
 				3FF6B7DE34A01C4AB7FA54E3 /* MacroTriggerStateMachine.swift in Sources */,
+				920000000000000000000002 /* MlxRuntimeBootstrapModel.swift in Sources */,
+				920000000000000000000004 /* MlxRuntimeCore.swift in Sources */,
+				920000000000000000000003 /* MlxRuntimeLocator.swift in Sources */,
+				920000000000000000000005 /* MlxRuntimeManager.swift in Sources */,
+				920000000000000000000001 /* MlxRuntimeModels.swift in Sources */,
+				920000000000000000000006 /* MlxSuggestionEngine.swift in Sources */,
 				5C119807B84F84B0B1B1C2D5 /* MarkerSelectionSynthesizer.swift in Sources */,
 				0BEBB33EB75B59EE83C6FE44 /* MenuBarPopoverDismisser.swift in Sources */,
 				F08C139B246C1EC7BB435455 /* MenuBarPresentationObserver.swift in Sources */,
@@ -2561,6 +2602,7 @@
 				87806DE08881D11F2608A13D /* MarkerSelectionSynthesizerTests.swift in Sources */,
 				7C36DBA762E19C8C31676D44 /* MidWordContinuationPolicyTests.swift in Sources */,
 				14D77F0B8A195AC2FA8D24A9 /* MirrorOverlayLayoutTests.swift in Sources */,
+				920000000000000000000007 /* MlxRuntimeLocatorTests.swift in Sources */,
 				25D4FC8D191A50F63E6391F9 /* ModelAndPresentationValueTests.swift in Sources */,
 				65478B0DABF5460C32D4C458 /* ModelFileValidatorTests.swift in Sources */,
 				3F5630CFB7BA40B900E832A1 /* OCRTextHygieneTests.swift in Sources */,
@@ -2692,6 +2734,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = C4BVFMK9V2;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
@@ -2919,6 +2962,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = C4BVFMK9V2;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
@@ -3046,6 +3090,30 @@
 				version = 2.9.1;
 			};
 		};
+		920000000000000000000401 /* XCRemoteSwiftPackageReference "mlx-swift-lm" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/ml-explore/mlx-swift-lm";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.31.3;
+			};
+		};
+		920000000000000000000402 /* XCRemoteSwiftPackageReference "swift-huggingface" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/huggingface/swift-huggingface";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.9.0;
+			};
+		};
+		920000000000000000000403 /* XCRemoteSwiftPackageReference "swift-transformers" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/huggingface/swift-transformers";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.3.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -3098,6 +3166,26 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 16E10845516A4DE793CC1BF6 /* XCRemoteSwiftPackageReference "LaunchAtLogin-Modern" */;
 			productName = LaunchAtLogin;
+		};
+		920000000000000000000301 /* MLXLLM */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 920000000000000000000401 /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
+			productName = MLXLLM;
+		};
+		920000000000000000000302 /* MLXLMCommon */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 920000000000000000000401 /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
+			productName = MLXLMCommon;
+		};
+		920000000000000000000304 /* HuggingFace */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 920000000000000000000402 /* XCRemoteSwiftPackageReference "swift-huggingface" */;
+			productName = HuggingFace;
+		};
+		920000000000000000000305 /* Tokenizers */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 920000000000000000000403 /* XCRemoteSwiftPackageReference "swift-transformers" */;
+			productName = Tokenizers;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		021197C88AF19DEA715C849B /* FileLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8C2569A8217EE9BD3B197F /* FileLogHandler.swift */; };
 		029B10EE4D659BAAF2C48FBE /* EmojiPopularity.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27B962C66727776D00069DE /* EmojiPopularity.swift */; };
 		02DA43985CDAE6859014F14F /* SuggestionOverlayPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D598CC3134879999D567455 /* SuggestionOverlayPresenter.swift */; };
+		02E1220621D53FACAB782090 /* Models in Frameworks */ = {isa = PBXBuildFile; productRef = B32AD571116137450BBA90C5 /* Models */; };
 		02FE7E7D0CC26AB67307D6D3 /* ru.txt in Resources */ = {isa = PBXBuildFile; fileRef = D8C2663427BC5219EA415D00 /* ru.txt */; };
 		0333B3CE8F189DD1BEC4AD26 /* MenuBarSections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A810F9D28A18BA6F2066C7 /* MenuBarSections.swift */; };
 		0431AE1DBEE36C90C7F39C19 /* CustomRulesCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43E587E421AF544A8300CE4 /* CustomRulesCatalog.swift */; };
@@ -152,6 +153,7 @@
 		2F227738D7834B1A7A81D1D6 /* ModelDownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51020F8CD58338BD643FBF63 /* ModelDownloadManager.swift */; };
 		2FC40D4BFDD05C2401D7A5E9 /* SuggestionInserter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3D1125B962CBE0269EEDDB /* SuggestionInserter.swift */; };
 		303652F15C0FE55595669D81 /* SpellingDictionaryResourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D562A73C7C680F2AA65F9F7F /* SpellingDictionaryResourceTests.swift */; };
+		30AE3C5C8CFAE7DA4C68D6FB /* Hub in Frameworks */ = {isa = PBXBuildFile; productRef = 0A5609A3639D6B6B2ACB0BA2 /* Hub */; };
 		30D4728580451C7D3BDF42E3 /* SurfaceContextCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CF6B7FFBF77B4290F5F2FB8 /* SurfaceContextCache.swift */; };
 		30F3F2B6D13CD583136CD787 /* AXHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC70775535A3428991025AB8 /* AXHelper.swift */; };
 		3112A355E61878A6A6D1FDF8 /* EmojiQueryRun.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDF6A4E9CE93FD53C60E67E3 /* EmojiQueryRun.swift */; };
@@ -252,6 +254,7 @@
 		50E1247BE6A952AB1B12C444 /* PowerSourceMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB235F0DEA53295DAF8B4FA0 /* PowerSourceMonitor.swift */; };
 		513066CA00F0E9A5E7358A4E /* PermissionReminderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 168A0DBF62BEF674B96CEBD2 /* PermissionReminderView.swift */; };
 		51C069603DA16830868F1628 /* LanguageTagsEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7CDA90E128350BFF1A9D66 /* LanguageTagsEditor.swift */; };
+		51E0E7102D02979D04C268B6 /* Generation in Frameworks */ = {isa = PBXBuildFile; productRef = CD961480BD400417743F21BA /* Generation */; };
 		52518CF0760DFEE9AF7C786C /* SuggestionEngineRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384FBCF5D7A3A446C5BE2B8D /* SuggestionEngineRouter.swift */; };
 		52F3962FA9F424576D7DB5B8 /* CotabbyDebugOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B2D34A6F3AC9DFD61350F7 /* CotabbyDebugOptions.swift */; };
 		532283A7651F7E66635F4281 /* SuggestionSessionReconciler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0AA0503128B0FC3951D700 /* SuggestionSessionReconciler.swift */; };
@@ -330,6 +333,7 @@
 		6A8454A989104AE150308BCF /* it-100k.txt in Resources */ = {isa = PBXBuildFile; fileRef = 2D8AA55C2B730110E8598F91 /* it-100k.txt */; };
 		6AE0B46FB52D189D94E1F79A /* WordCountFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E0513E3B23937B099A3CFF2 /* WordCountFormatterTests.swift */; };
 		6BE0C8F9D054A2C0D9018001 /* ConfidenceSuppressionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BD71ECC2AE4821B643E0935 /* ConfidenceSuppressionPolicy.swift */; };
+		6C370B59299A404DE42DF588 /* Models in Frameworks */ = {isa = PBXBuildFile; productRef = 0320FAC335116DE7DCA21791 /* Models */; };
 		6C59B369AAC6948C53E41654 /* DebouncePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB23CDF7CAA1DEAD606B46B3 /* DebouncePolicyTests.swift */; };
 		6CBEF02FCDFCF406E378C27C /* SuggestionInteractionStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB1D4F2681FAF59014AE115 /* SuggestionInteractionStateTests.swift */; };
 		6D0E79CF3C1A8CE53046FCE5 /* AXTextGeometryResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C046CB4F3CB4BFE9391DB5DE /* AXTextGeometryResolverTests.swift */; };
@@ -471,6 +475,7 @@
 		A3AFE27EDE956ADC04C91C94 /* SymSpellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B32482EABE9EA979C40C8A8F /* SymSpellTests.swift */; };
 		A5A6CE0EF01CA6A9AFA7A400 /* RequestID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DC693E00430F46E41CB56E6 /* RequestID.swift */; };
 		A614AD79BE724ABA3721613B /* MacroModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = B41F06FEF208B30ECCF23A6F /* MacroModels.swift */; };
+		A6370D0DE8669F25DEDACD59 /* Tokenizers in Frameworks */ = {isa = PBXBuildFile; productRef = 1CE8530F0ED104DD40248A25 /* Tokenizers */; };
 		A67B3F97DAEBEC7CA9B1215E /* PerDomainDisableSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25C3087D4A9F4DC52FD5A69 /* PerDomainDisableSettings.swift */; };
 		A6DAD9EB9AE88A319EADAC7B /* WindowScreenshotService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B0121E7BB173F8A2B0B108 /* WindowScreenshotService.swift */; };
 		A736C52C0D280A35946E37A3 /* SurfaceContextComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C602357DDED5D11C8B4567FB /* SurfaceContextComposer.swift */; };
@@ -548,6 +553,7 @@
 		BEF746D51C69FE426376C89A /* SystemResourceSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A5D63F390E9B7A7FE343FE /* SystemResourceSampler.swift */; };
 		BF60D99576F60321078464AD /* SystemSettingsWindowLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5976600F428C1265121D4C0C /* SystemSettingsWindowLocator.swift */; };
 		BFCA7FAFDAEBF586AB615567 /* ClipboardRelevanceFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90B0D133AB77A2503FB08827 /* ClipboardRelevanceFilterTests.swift */; };
+		BFFBA299521A41C3879CB1C6 /* Hub in Frameworks */ = {isa = PBXBuildFile; productRef = A8A6E5D6EDF5710071B4C7A6 /* Hub */; };
 		C0537A515AED443F6C61DB2A /* MenuBarSections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A810F9D28A18BA6F2066C7 /* MenuBarSections.swift */; };
 		C0B833234748E82D3382631A /* emoji.json in Resources */ = {isa = PBXBuildFile; fileRef = C379D77029D6E88C8C1B9AF7 /* emoji.json */; };
 		C0F757D74758B76DA2962BC5 /* LlamaDecodeGateDefaultsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B3E5554AAC5D0007CCC61A7 /* LlamaDecodeGateDefaultsTests.swift */; };
@@ -612,6 +618,7 @@
 		D80D98F6C7B86AAF8C831865 /* he-100k.txt in Resources */ = {isa = PBXBuildFile; fileRef = 7C9BB65FA5FC42B89766B037 /* he-100k.txt */; };
 		D81AC2294A64E7A95B29E081 /* fr.txt in Resources */ = {isa = PBXBuildFile; fileRef = 5DCA3E46621815A19300365F /* fr.txt */; };
 		D90C889A623A928F4F5FDC7B /* HardwareCapabilityProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41BBD5A4BA08CABE77860886 /* HardwareCapabilityProbe.swift */; };
+		D92A31EBB31D63E5A6BE6F33 /* Generation in Frameworks */ = {isa = PBXBuildFile; productRef = 8BC79D134D992A6342EDC71D /* Generation */; };
 		D9C51DEDF01033E276A479CE /* AXTextGeometryResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB58035EFFD65B767949BAE6 /* AXTextGeometryResolver.swift */; };
 		DA23422A2CF77CFD3B1283C8 /* OnboardingTemplateFeatureListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D814BBA41CF29E8DD9954651 /* OnboardingTemplateFeatureListTests.swift */; };
 		DAD77998F793468D4D64B705 /* DateMacroEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F671FE53CDEAE9091EFBCE45 /* DateMacroEvaluator.swift */; };
@@ -660,6 +667,7 @@
 		ED0843752B297D7E9DB2C468 /* EmojiTriggerStateMachineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723E1EFA85D2E61B6C5F33E8 /* EmojiTriggerStateMachineTests.swift */; };
 		ED51AE49BAD6DD5BD177F4F1 /* WelcomePersonalizeStepView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB4548AF1ED25F574CCFA680 /* WelcomePersonalizeStepView.swift */; };
 		ED9C51B0D7056F0753AADF2D /* GhostSuggestionLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043E8AA850F930222DD112C0 /* GhostSuggestionLayout.swift */; };
+		EDFB4B3DD979A80E69E61081 /* Tokenizers in Frameworks */ = {isa = PBXBuildFile; productRef = 13E923E68B6A4BD0F3B18E75 /* Tokenizers */; };
 		EE2C9177CE615298595215A8 /* SuggestionOverlayPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D598CC3134879999D567455 /* SuggestionOverlayPresenter.swift */; };
 		EE87886AC1BFC8BB3DE09762 /* HuggingFaceModelBrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78E49BDA7F3A42455C4C5350 /* HuggingFaceModelBrowserView.swift */; };
 		EECC350990615799496E2760 /* MlxRuntimeLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6AC50885060D00352EC390 /* MlxRuntimeLocator.swift */; };
@@ -1151,6 +1159,10 @@
 				A38F892919E0B8C84F1BAC3D /* MLX in Frameworks */,
 				185179B79D6AB2C3D24B7E7F /* MLXLLM in Frameworks */,
 				40412351B908B9B19FCD39B3 /* MLXLMCommon in Frameworks */,
+				A6370D0DE8669F25DEDACD59 /* Tokenizers in Frameworks */,
+				30AE3C5C8CFAE7DA4C68D6FB /* Hub in Frameworks */,
+				D92A31EBB31D63E5A6BE6F33 /* Generation in Frameworks */,
+				02E1220621D53FACAB782090 /* Models in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1166,6 +1178,10 @@
 				47E5F10D324E05B5091B63F9 /* MLX in Frameworks */,
 				2597836335B3B94E318BF342 /* MLXLLM in Frameworks */,
 				25C1921549D3691662A7F2F7 /* MLXLMCommon in Frameworks */,
+				EDFB4B3DD979A80E69E61081 /* Tokenizers in Frameworks */,
+				BFFBA299521A41C3879CB1C6 /* Hub in Frameworks */,
+				51E0E7102D02979D04C268B6 /* Generation in Frameworks */,
+				6C370B59299A404DE42DF588 /* Models in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1862,6 +1878,10 @@
 				3DEA36E5901BE1DFC1C5834B /* MLX */,
 				2F735A2CC8DFFDD231F2B70F /* MLXLLM */,
 				359D454B426D7866DAD422DA /* MLXLMCommon */,
+				13E923E68B6A4BD0F3B18E75 /* Tokenizers */,
+				A8A6E5D6EDF5710071B4C7A6 /* Hub */,
+				CD961480BD400417743F21BA /* Generation */,
+				0320FAC335116DE7DCA21791 /* Models */,
 			);
 			productName = "Cotabby Dev";
 			productReference = 4BC92317837813ACA5051177 /* Cotabby Dev.app */;
@@ -1889,6 +1909,10 @@
 				82C74713220922574F13FEBD /* MLX */,
 				E4D21E9305E92FF59BBD3702 /* MLXLLM */,
 				C74A89874731CE8C6D285B4E /* MLXLMCommon */,
+				1CE8530F0ED104DD40248A25 /* Tokenizers */,
+				0A5609A3639D6B6B2ACB0BA2 /* Hub */,
+				8BC79D134D992A6342EDC71D /* Generation */,
+				B32AD571116137450BBA90C5 /* Models */,
 			);
 			productName = Cotabby;
 			productReference = 262BE2F1E97389FE8D7A5FB9 /* Cotabby.app */;
@@ -3134,6 +3158,26 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		0320FAC335116DE7DCA21791 /* Models */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3D0C3DA536F35C2B7738A2FC /* XCRemoteSwiftPackageReference "swift-transformers" */;
+			productName = Models;
+		};
+		0A5609A3639D6B6B2ACB0BA2 /* Hub */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3D0C3DA536F35C2B7738A2FC /* XCRemoteSwiftPackageReference "swift-transformers" */;
+			productName = Hub;
+		};
+		13E923E68B6A4BD0F3B18E75 /* Tokenizers */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3D0C3DA536F35C2B7738A2FC /* XCRemoteSwiftPackageReference "swift-transformers" */;
+			productName = Tokenizers;
+		};
+		1CE8530F0ED104DD40248A25 /* Tokenizers */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3D0C3DA536F35C2B7738A2FC /* XCRemoteSwiftPackageReference "swift-transformers" */;
+			productName = Tokenizers;
+		};
 		2F735A2CC8DFFDD231F2B70F /* MLXLLM */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = F8E600050524CEB6097DBCBF /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
@@ -3184,6 +3228,21 @@
 			package = 413C306D13ADDD8B5C747551 /* XCRemoteSwiftPackageReference "swift-log" */;
 			productName = InMemoryLogging;
 		};
+		8BC79D134D992A6342EDC71D /* Generation */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3D0C3DA536F35C2B7738A2FC /* XCRemoteSwiftPackageReference "swift-transformers" */;
+			productName = Generation;
+		};
+		A8A6E5D6EDF5710071B4C7A6 /* Hub */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3D0C3DA536F35C2B7738A2FC /* XCRemoteSwiftPackageReference "swift-transformers" */;
+			productName = Hub;
+		};
+		B32AD571116137450BBA90C5 /* Models */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3D0C3DA536F35C2B7738A2FC /* XCRemoteSwiftPackageReference "swift-transformers" */;
+			productName = Models;
+		};
 		BAADA69C6172DD7F4A642E93 /* Sparkle */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = D8563066187C38DAA4206016 /* XCRemoteSwiftPackageReference "Sparkle" */;
@@ -3198,6 +3257,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = F8E600050524CEB6097DBCBF /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
 			productName = MLXLMCommon;
+		};
+		CD961480BD400417743F21BA /* Generation */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3D0C3DA536F35C2B7738A2FC /* XCRemoteSwiftPackageReference "swift-transformers" */;
+			productName = Generation;
 		};
 		D11AB0F962CCC5BD79B630CA /* CotabbyInference */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -175,10 +175,6 @@
 		3AC2F7F221F7C59242B06DFC /* InputSuppressionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1F9CEBAB0F330F8E7B61D8 /* InputSuppressionController.swift */; };
 		3AFDA4A5BE9486A1B367815B /* SettingsNavigationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1AC5EC06664F49A6AE2B17 /* SettingsNavigationModel.swift */; };
 		3B3E08D1204E85F3776D8853 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = BAADA69C6172DD7F4A642E93 /* Sparkle */; };
-		920000000000000000000201 /* MLXLLM in Frameworks */ = {isa = PBXBuildFile; productRef = 920000000000000000000301 /* MLXLLM */; };
-		920000000000000000000202 /* MLXLMCommon in Frameworks */ = {isa = PBXBuildFile; productRef = 920000000000000000000302 /* MLXLMCommon */; };
-		920000000000000000000204 /* HuggingFace in Frameworks */ = {isa = PBXBuildFile; productRef = 920000000000000000000304 /* HuggingFace */; };
-		920000000000000000000205 /* Tokenizers in Frameworks */ = {isa = PBXBuildFile; productRef = 920000000000000000000305 /* Tokenizers */; };
 		3B5F96F9CC6D4D81B470DB2C /* EmojiSynonymCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF474064973F4752F79BB041 /* EmojiSynonymCatalogTests.swift */; };
 		3BB16F9F9F84C7A8D87DF044 /* es-100l.txt in Resources */ = {isa = PBXBuildFile; fileRef = 620D393D3B7E687A08FA9446 /* es-100l.txt */; };
 		3BC4FCF9A51F57A0A8F6944D /* ArithmeticEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F7ED2D9D71CFAD9A30977E9 /* ArithmeticEvaluator.swift */; };
@@ -190,6 +186,7 @@
 		3D82280EFF7F7E9F3FFF45ED /* LlamaEvalScoring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 906011A6C9D66EEBAF3B5CC0 /* LlamaEvalScoring.swift */; };
 		3E1DBB2ABCB2404B59173534 /* SettingsIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34EF2406E7A384F3325AAF9A /* SettingsIndex.swift */; };
 		3E28FFB8F7D91D3B39968E73 /* SuggestionSubsystemContracts.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB16474A67CE1D210B944C9 /* SuggestionSubsystemContracts.swift */; };
+		3E3AE27E30EFE1B9C8D384F9 /* MlxRuntimeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2291774E6FFDEB8A301EE2 /* MlxRuntimeManager.swift */; };
 		3E6BD683DA505C9737463890 /* SettingsNavigationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1AC5EC06664F49A6AE2B17 /* SettingsNavigationModel.swift */; };
 		3E78D03ABA7141D344AB8285 /* he.txt in Resources */ = {isa = PBXBuildFile; fileRef = C9C000E46A1E404932F89C81 /* he.txt */; };
 		3EF0A298B5590571B1C37282 /* FieldStyleCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7FBF2B766E728F25899B64E /* FieldStyleCache.swift */; };
@@ -258,13 +255,6 @@
 		53FB56A095BCF0389DAC0A56 /* SuggestionTextColorCodec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CE61E74928C221B8BB261C6 /* SuggestionTextColorCodec.swift */; };
 		543D71217CA218426E9638BF /* CaretLinePosition.swift in Sources */ = {isa = PBXBuildFile; fileRef = D77364C1AF183EF1C0A4074D /* CaretLinePosition.swift */; };
 		54BDF0D9C3DC7175555BD0F6 /* LlamaRuntimeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A52D0B550E00EF173A5D157E /* LlamaRuntimeManager.swift */; };
-		920000000000000000000007 /* MlxRuntimeLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 920000000000000000000107 /* MlxRuntimeLocatorTests.swift */; };
-		920000000000000000000001 /* MlxRuntimeModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 920000000000000000000101 /* MlxRuntimeModels.swift */; };
-		920000000000000000000002 /* MlxRuntimeBootstrapModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 920000000000000000000102 /* MlxRuntimeBootstrapModel.swift */; };
-		920000000000000000000003 /* MlxRuntimeLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 920000000000000000000103 /* MlxRuntimeLocator.swift */; };
-		920000000000000000000004 /* MlxRuntimeCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 920000000000000000000104 /* MlxRuntimeCore.swift */; };
-		920000000000000000000005 /* MlxRuntimeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 920000000000000000000105 /* MlxRuntimeManager.swift */; };
-		920000000000000000000006 /* MlxSuggestionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 920000000000000000000106 /* MlxSuggestionEngine.swift */; };
 		54E515A0E75B3902E6497A71 /* EmojiPopularity.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27B962C66727776D00069DE /* EmojiPopularity.swift */; };
 		5560B54FBBEC80F13BCD2054 /* EmojiPickerPanelLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62EDF1199CC5E18BD7651661 /* EmojiPickerPanelLayout.swift */; };
 		55D4E6FB63E3475749E61EB3 /* CustomRulesCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43E587E421AF544A8300CE4 /* CustomRulesCatalog.swift */; };
@@ -293,6 +283,7 @@
 		5CED06E89FBEF557DCD6C684 /* SuggestionFocusFreshnessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A896811745673061AF3612 /* SuggestionFocusFreshnessTests.swift */; };
 		5CF34E01F13FB242817057E2 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 6F134BAB5BC7015B9B2354AF /* Sparkle */; };
 		5D083F544CF36CF6DFA34CB1 /* GhostTextColorPreset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E44E393DD58B978B1EAB6CF /* GhostTextColorPreset.swift */; };
+		5D18807F6620EC8E0F6E5D84 /* MlxRuntimeCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74D807BD678501F50FF76BA5 /* MlxRuntimeCore.swift */; };
 		5DF31F465A3A1233260BD3A4 /* EngineAndModelPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC9ECD5408B0F5708149B5C0 /* EngineAndModelPaneView.swift */; };
 		5E10EFC426217CB7218A5847 /* CotabbyTestFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF1E065C7FFB697FCEB2FA5C /* CotabbyTestFixtures.swift */; };
 		5E77261BAF8365B69F08DB67 /* FieldEdgeIconIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBD5FCB8CC56AA6138382B2C /* FieldEdgeIconIndicatorView.swift */; };
@@ -349,6 +340,8 @@
 		74422BB837D6A319D12BF981 /* BaseCompletionPromptRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85EF79E6144D6C6AD062B569 /* BaseCompletionPromptRenderer.swift */; };
 		744B06C2488156B178675615 /* PermissionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85BF316556FDA64CB8AD07B6 /* PermissionManager.swift */; };
 		746BC62993602F78147FF8B0 /* EmojiMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1441B2D89DAE6878DAD11F17 /* EmojiMatcher.swift */; };
+		748D647243B51A34B0B4D157 /* MlxRuntimeBootstrapModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FDEADDC9D17C4BE05C94E0B /* MlxRuntimeBootstrapModel.swift */; };
+		74A817DE73EBC09078EAF739 /* MlxRuntimeModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B5F0FD48E04F7D52C575370 /* MlxRuntimeModels.swift */; };
 		74E0082BA8D7E80C2E038EAA /* EmojiPickerModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7F3EB7B874C836BF75F15D /* EmojiPickerModelsTests.swift */; };
 		753C5A939E986B1A0FB25664 /* StaticTextRunWalkThrottle.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0C3E6241B0F35C7A2C85965 /* StaticTextRunWalkThrottle.swift */; };
 		753DC144B9394A35A3F395DA /* SettingsSidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BADB38D0160B47637572FC5E /* SettingsSidebarView.swift */; };
@@ -358,6 +351,7 @@
 		77B57484667F71F7EFA380D1 /* fr-100k.txt in Resources */ = {isa = PBXBuildFile; fileRef = 6DB982BF30B3601F57277776 /* fr-100k.txt */; };
 		783BEC91DBC86AF75CEDB269 /* MenuBarPresentationObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00824BDD8D0E9B3063827C78 /* MenuBarPresentationObserver.swift */; };
 		78A8713A0E5B4C89E2D715BC /* FocusCapabilityFlickerGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1972BD2C5254D8266618781F /* FocusCapabilityFlickerGateTests.swift */; };
+		78D8718F788C8E317E09AA83 /* MlxRuntimeLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6AC50885060D00352EC390 /* MlxRuntimeLocator.swift */; };
 		78FAE5DB691A1B71042B9D20 /* AboutPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3FA53BBC3D81503C1D17477 /* AboutPaneView.swift */; };
 		793BA44D503D61B44D133716 /* SuggestionSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 960F3FDBF283347594F30494 /* SuggestionSettingsStore.swift */; };
 		799691376DD3EE52E5F0F7FB /* FocusCapabilityResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70367FCC1E0F08EE3B8EB26F /* FocusCapabilityResolver.swift */; };
@@ -403,6 +397,7 @@
 		88BCD795A14E1C9308F7BB31 /* SuggestionAvailabilityEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05B0439348261163B37C508 /* SuggestionAvailabilityEvaluatorTests.swift */; };
 		89329024F050602EFBC7CC6B /* FocusTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C9FDF029F7828CAF3FE8850 /* FocusTracker.swift */; };
 		8A47597B097058832453C2FF /* LlamaSuggestionEvalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A691EB51A7B93D1FAC38657F /* LlamaSuggestionEvalTests.swift */; };
+		8AD8F9879A809BAB617136D5 /* MlxRuntimeLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51C5F044670C03F9C6A6EE0 /* MlxRuntimeLocatorTests.swift */; };
 		8B26F7B26358438D6EB88C2E /* PerformanceMetricsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C0FCC5CCF6AE528E3C4DDA7 /* PerformanceMetricsStoreTests.swift */; };
 		8B2DFC860803C0A7C4D34A36 /* ContextBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54EF3C7F5D9D6F3FA50FD51C /* ContextBuffer.swift */; };
 		8D0F66DD1E6C988368A4545D /* DownloadFileRescuer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B4A2E2DD6733658EC05BD8 /* DownloadFileRescuer.swift */; };
@@ -416,6 +411,7 @@
 		90F287ED3B23FB2AB3EF8CCE /* SuggestionTextNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B424E2AC97C99D335B0D5751 /* SuggestionTextNormalizer.swift */; };
 		914266D314BBBCE2EAB5CBA7 /* OCRTextHygiene.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22FDEB3B1DCC9ADE906CC73 /* OCRTextHygiene.swift */; };
 		91ADE463EE72D77E0D3EBBCA /* TickMarkSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67586807ACE8EB13C9014535 /* TickMarkSlider.swift */; };
+		91B02B35C0DD0641AAA600D3 /* MlxRuntimeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2291774E6FFDEB8A301EE2 /* MlxRuntimeManager.swift */; };
 		91C27021750AC03AA4A0115A /* HuggingFaceAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110CB0B53016644EF7840301 /* HuggingFaceAPIClient.swift */; };
 		91D1F16B8C5DA281D4B7F699 /* CustomRulesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD752451330486FE270018B0 /* CustomRulesTests.swift */; };
 		91D8189EFCD1BA992EA6F038 /* ConfidenceSuppressionPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06FF2B0A3094A952A8EBA9B5 /* ConfidenceSuppressionPolicyTests.swift */; };
@@ -426,6 +422,7 @@
 		934885ACC2DEA20B27F10948 /* PromptContextSanitizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D80CC2CCAAFE3F23FB8C37A /* PromptContextSanitizerTests.swift */; };
 		93524F3B861292206EE635CD /* FocusSessionScopedCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E504DABB83411B3FA0B8DC5 /* FocusSessionScopedCache.swift */; };
 		93EBF0366891222B7DD6C38D /* OCRTextHygiene.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22FDEB3B1DCC9ADE906CC73 /* OCRTextHygiene.swift */; };
+		94BC7884FCEB7845D906D3A5 /* MlxRuntimeCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74D807BD678501F50FF76BA5 /* MlxRuntimeCore.swift */; };
 		94F037A3F9D7CE52CC70CA0F /* SpellingDictionaryPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF3A73EB848780061FC162C0 /* SpellingDictionaryPicker.swift */; };
 		952729C6514FBC40D6E7D1D4 /* CotabbyInference in Frameworks */ = {isa = PBXBuildFile; productRef = D11AB0F962CCC5BD79B630CA /* CotabbyInference */; };
 		956BC802BDD3C7C3EA7F084A /* EmojiQueryRun.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDF6A4E9CE93FD53C60E67E3 /* EmojiQueryRun.swift */; };
@@ -478,12 +475,14 @@
 		A8A294534897C461CA5968F3 /* UnitConversionEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82E7794DF60664B1FA8F6E7B /* UnitConversionEvaluator.swift */; };
 		A93A741C8C3973687D28F0B6 /* SuggestionEngineModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADBE3E6CC585C1683787C877 /* SuggestionEngineModels.swift */; };
 		A982E243A4D8BC1BF7504B3E /* SuggestionInteractionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA942A53B7C09D1F4EC57239 /* SuggestionInteractionState.swift */; };
+		A9A0DB7F2188824C8810535B /* MlxRuntimeModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B5F0FD48E04F7D52C575370 /* MlxRuntimeModels.swift */; };
 		AA0B5EC6BC922E143971F8AD /* TextLayoutCaretEstimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF8DC1860CCF0DFA3A3DFD7 /* TextLayoutCaretEstimator.swift */; };
 		AA2419299B395D420FA930F5 /* FocusSnapshotResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04E25414C307A20B6F9F20EC /* FocusSnapshotResolver.swift */; };
 		AA2E09FF7E430D66ECA8ECD5 /* CotabbyApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC1EDFB535AAA2EE0D67828A /* CotabbyApp.swift */; };
 		AB5D37BA744546F14C5566E8 /* AppearancePaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFBE491B3CA04FE9069B7B0F /* AppearancePaneView.swift */; };
 		AB9C9C001F97F9D14F8B192A /* TerminalAppDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F4C4A7EAF886E0CC945BFEF /* TerminalAppDetector.swift */; };
 		AC4A369EC73115E1F698934D /* SuggestionCoordinator+Input.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22544F4B756E3E4144497D17 /* SuggestionCoordinator+Input.swift */; };
+		AC7DE9FD05D698309588E9FD /* MlxRuntimeBootstrapModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FDEADDC9D17C4BE05C94E0B /* MlxRuntimeBootstrapModel.swift */; };
 		ACC1D8C50007AA193271F977 /* PerformancePaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBD6113A3C1038BECC99245 /* PerformancePaneView.swift */; };
 		AD0FE3F0F75A40B827109589 /* SettingsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3350EDE01ED5125520C79D53 /* SettingsCoordinator.swift */; };
 		AD361AA6F90A5E5F6F5005BF /* SpellingDictionaryCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D9DF8723AF32C058BFACDE /* SpellingDictionaryCatalog.swift */; };
@@ -578,6 +577,7 @@
 		CC98B842D10574C5206BEFA7 /* FocusCapabilityResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70367FCC1E0F08EE3B8EB26F /* FocusCapabilityResolver.swift */; };
 		CCB8D287A5FF3863B9DE9246 /* ChromiumAccessibilityEnabler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8896D976C7F116EBA0F3969F /* ChromiumAccessibilityEnabler.swift */; };
 		CCC83DC5AE51C17F153D5A6A /* PermissionModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D82FFC568527700EC17C07D /* PermissionModels.swift */; };
+		CEAD9B510D7751C9BA2595BD /* MlxSuggestionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B499656D8C451E2F3395357 /* MlxSuggestionEngine.swift */; };
 		CF2EADEEEF5AA63FB9B9EA8E /* SuggestionInserter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3D1125B962CBE0269EEDDB /* SuggestionInserter.swift */; };
 		CF39EB76C3ECF8F764C1B4FB /* DeviceInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29ED42C4BDD0C521101AF95E /* DeviceInfo.swift */; };
 		CF4205B85D881B8176590D25 /* FocusSnapshotResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04E25414C307A20B6F9F20EC /* FocusSnapshotResolver.swift */; };
@@ -656,6 +656,7 @@
 		ED9C51B0D7056F0753AADF2D /* GhostSuggestionLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043E8AA850F930222DD112C0 /* GhostSuggestionLayout.swift */; };
 		EE2C9177CE615298595215A8 /* SuggestionOverlayPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D598CC3134879999D567455 /* SuggestionOverlayPresenter.swift */; };
 		EE87886AC1BFC8BB3DE09762 /* HuggingFaceModelBrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78E49BDA7F3A42455C4C5350 /* HuggingFaceModelBrowserView.swift */; };
+		EECC350990615799496E2760 /* MlxRuntimeLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6AC50885060D00352EC390 /* MlxRuntimeLocator.swift */; };
 		EF0DE5E045F328F1E912A02A /* AppsPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9C1C921A1CDA2ADFC39EA01 /* AppsPaneView.swift */; };
 		EF5BAB96DDADABB86F9E02D9 /* SyntheticReplacePlannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71031E8DB171047318B92FC /* SyntheticReplacePlannerTests.swift */; };
 		F04D9470439699DB1F016000 /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA0117B322C625F6D4BBEAB /* MenuBarView.swift */; };
@@ -682,6 +683,7 @@
 		FA25762161F068F59BEC86EB /* DecodeStopPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12ABBCE23A946C22894945B /* DecodeStopPolicy.swift */; };
 		FAC7FFC78BEBF62D5B7A2EFB /* DownloadOutcomeClassifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E217A66717D78E1E49350EC8 /* DownloadOutcomeClassifierTests.swift */; };
 		FB0E2CE46002270A254E5FB3 /* ContextLivePreviewField.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1FAD890FBC2D0351C0E3C60 /* ContextLivePreviewField.swift */; };
+		FB6DAE3AC4BD774018A12B79 /* MlxSuggestionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B499656D8C451E2F3395357 /* MlxSuggestionEngine.swift */; };
 		FBEDA005ECD53CD645CD4C64 /* EmojiPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3384FD33776960103D6E22A9 /* EmojiPickerView.swift */; };
 		FC0C0C43EEC80325FE699B5A /* InsertionSafetyGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D472F9F396672E57873303B /* InsertionSafetyGate.swift */; };
 		FC255241A3B34A5717F09B36 /* InsertionStrategySelectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2960080A726E51198225147A /* InsertionStrategySelectorTests.swift */; };
@@ -753,6 +755,7 @@
 		19BE12C28A4AB8A4A58C2FF7 /* SettingsPaneScaffold.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPaneScaffold.swift; sourceTree = "<group>"; };
 		19DB9558F4D3AFB108D71649 /* SuggestionStateHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionStateHelperTests.swift; sourceTree = "<group>"; };
 		1A8414BEB7E34F57607E37FE /* EmojiVariantResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiVariantResolver.swift; sourceTree = "<group>"; };
+		1B5F0FD48E04F7D52C575370 /* MlxRuntimeModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MlxRuntimeModels.swift; sourceTree = "<group>"; };
 		1BA30E71C21C77BB6EA4C166 /* TokenCountEstimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenCountEstimator.swift; sourceTree = "<group>"; };
 		1BD71ECC2AE4821B643E0935 /* ConfidenceSuppressionPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfidenceSuppressionPolicy.swift; sourceTree = "<group>"; };
 		1C201A65A6B040F90C528A3B /* MacroTriggerStateMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacroTriggerStateMachine.swift; sourceTree = "<group>"; };
@@ -764,6 +767,7 @@
 		1ED1EA9282E0AC7592E60889 /* SuggestionCoordinator+Prediction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SuggestionCoordinator+Prediction.swift"; sourceTree = "<group>"; };
 		1F761083EA5465023D82B5F4 /* BrowserDomainTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDomainTests.swift; sourceTree = "<group>"; };
 		1F7ED2D9D71CFAD9A30977E9 /* ArithmeticEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArithmeticEvaluator.swift; sourceTree = "<group>"; };
+		1FDEADDC9D17C4BE05C94E0B /* MlxRuntimeBootstrapModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MlxRuntimeBootstrapModel.swift; sourceTree = "<group>"; };
 		210F9AD332273FE2EB3A9A01 /* WebContentFieldDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebContentFieldDetectorTests.swift; sourceTree = "<group>"; };
 		21CB3008986BE7FD2A4D9132 /* WelcomeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeCoordinator.swift; sourceTree = "<group>"; };
 		224438039A86E5619294EAF7 /* EmojiUsageStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiUsageStoreTests.swift; sourceTree = "<group>"; };
@@ -789,7 +793,6 @@
 		2B3E5554AAC5D0007CCC61A7 /* LlamaDecodeGateDefaultsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LlamaDecodeGateDefaultsTests.swift; sourceTree = "<group>"; };
 		2B7A28471B8526C2693FFF65 /* AcknowledgementsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcknowledgementsView.swift; sourceTree = "<group>"; };
 		2BC293F6125E2B14DCF05AD9 /* SettingsAttentionEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAttentionEvaluatorTests.swift; sourceTree = "<group>"; };
-		920000000000000000000107 /* MlxRuntimeLocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MlxRuntimeLocatorTests.swift; sourceTree = "<group>"; };
 		2D1F9CEBAB0F330F8E7B61D8 /* InputSuppressionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputSuppressionController.swift; sourceTree = "<group>"; };
 		2D7360A6D4261989A66658ED /* SentenceBoundaryClassifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentenceBoundaryClassifierTests.swift; sourceTree = "<group>"; };
 		2D8AA55C2B730110E8598F91 /* it-100k.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "it-100k.txt"; sourceTree = "<group>"; };
@@ -824,6 +827,7 @@
 		470A7DAE3D6A2C873B395AE3 /* SuggestionEngineModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionEngineModelsTests.swift; sourceTree = "<group>"; };
 		474560E524C1D74BAB1570DA /* SecureFieldDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureFieldDetectorTests.swift; sourceTree = "<group>"; };
 		4793D4EA5D36D7E5CC216C27 /* LanguageSupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageSupportTests.swift; sourceTree = "<group>"; };
+		4A6AC50885060D00352EC390 /* MlxRuntimeLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MlxRuntimeLocator.swift; sourceTree = "<group>"; };
 		4B8665A5495891F9E3DDA48B /* de-100k.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "de-100k.txt"; sourceTree = "<group>"; };
 		4BC92317837813ACA5051177 /* Cotabby Dev.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Cotabby Dev.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4C174D8294858BF9DF3D361D /* SuggestionCoordinatorTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionCoordinatorTestSupport.swift; sourceTree = "<group>"; };
@@ -855,12 +859,6 @@
 		5F34AE24BB7C99D66E1F3904 /* InputModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputModels.swift; sourceTree = "<group>"; };
 		60629DFE309C1A4BD8A7FB3B /* RuntimeBootstrapModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimeBootstrapModel.swift; sourceTree = "<group>"; };
 		620D393D3B7E687A08FA9446 /* es-100l.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "es-100l.txt"; sourceTree = "<group>"; };
-		920000000000000000000101 /* MlxRuntimeModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MlxRuntimeModels.swift; sourceTree = "<group>"; };
-		920000000000000000000102 /* MlxRuntimeBootstrapModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MlxRuntimeBootstrapModel.swift; sourceTree = "<group>"; };
-		920000000000000000000103 /* MlxRuntimeLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MlxRuntimeLocator.swift; sourceTree = "<group>"; };
-		920000000000000000000104 /* MlxRuntimeCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MlxRuntimeCore.swift; sourceTree = "<group>"; };
-		920000000000000000000105 /* MlxRuntimeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MlxRuntimeManager.swift; sourceTree = "<group>"; };
-		920000000000000000000106 /* MlxSuggestionEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MlxSuggestionEngine.swift; sourceTree = "<group>"; };
 		62BD2ADED33249F5BA53D0AD /* EmojiPickerControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiPickerControllerTests.swift; sourceTree = "<group>"; };
 		62EDF1199CC5E18BD7651661 /* EmojiPickerPanelLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiPickerPanelLayout.swift; sourceTree = "<group>"; };
 		63F7C6D15674B3043C4CEEAC /* WelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
@@ -873,6 +871,7 @@
 		684737E62EE6495A71344923 /* DeepGeometryWalkThrottle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepGeometryWalkThrottle.swift; sourceTree = "<group>"; };
 		6A44BEC8C23FF227731DD0CD /* FocusCapabilityFlickerGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusCapabilityFlickerGate.swift; sourceTree = "<group>"; };
 		6B2D97BAA3618A7D0357AC44 /* SuggestionWorkController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionWorkController.swift; sourceTree = "<group>"; };
+		6C2291774E6FFDEB8A301EE2 /* MlxRuntimeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MlxRuntimeManager.swift; sourceTree = "<group>"; };
 		6C34A98E5B05DB3F4FE81E70 /* ScreenTextExtractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenTextExtractorTests.swift; sourceTree = "<group>"; };
 		6CF1FBAABEF545B620AF8D78 /* ru-100k.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "ru-100k.txt"; sourceTree = "<group>"; };
 		6D4C1EF008B9DFA753D561D3 /* LlamaEvalScoringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LlamaEvalScoringTests.swift; sourceTree = "<group>"; };
@@ -890,6 +889,7 @@
 		72B13136DF7318F3E96DF0D3 /* SuggestionCoordinator+Acceptance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SuggestionCoordinator+Acceptance.swift"; sourceTree = "<group>"; };
 		733BF6287BDE599B02A12271 /* CurrentWordSpellChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentWordSpellChecker.swift; sourceTree = "<group>"; };
 		74BD1D4DB27D5D96D1E06096 /* DisplayCoordinateConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayCoordinateConverter.swift; sourceTree = "<group>"; };
+		74D807BD678501F50FF76BA5 /* MlxRuntimeCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MlxRuntimeCore.swift; sourceTree = "<group>"; };
 		7513810E78F3C94FE972EB07 /* LGPL-3.0.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "LGPL-3.0.txt"; sourceTree = "<group>"; };
 		75396860978E81EFAA506CD4 /* EmojiQueryRunTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiQueryRunTests.swift; sourceTree = "<group>"; };
 		764659D09C3F0E8FBD267102 /* EmojiPickerPanelController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiPickerPanelController.swift; sourceTree = "<group>"; };
@@ -948,6 +948,7 @@
 		9AA0117B322C625F6D4BBEAB /* MenuBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarView.swift; sourceTree = "<group>"; };
 		9ABC808DE01AF9AD04E38943 /* OnboardingStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingStyle.swift; sourceTree = "<group>"; };
 		9B3179B40A81DF121D1221C6 /* StaticTextRunWalkThrottleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticTextRunWalkThrottleTests.swift; sourceTree = "<group>"; };
+		9B499656D8C451E2F3395357 /* MlxSuggestionEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MlxSuggestionEngine.swift; sourceTree = "<group>"; };
 		9B55A4362AB7F0528C661C4C /* SuggestionTextNormalizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionTextNormalizerTests.swift; sourceTree = "<group>"; };
 		9B84BAE361626891F19DC9DB /* ScreenshotContextGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotContextGenerator.swift; sourceTree = "<group>"; };
 		9BC3BE51EFE0A1B2B13BD02B /* SuggestionAnchorCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionAnchorCacheTests.swift; sourceTree = "<group>"; };
@@ -1035,6 +1036,7 @@
 		C3A35FAA742408D002B75920 /* WebContentFieldDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebContentFieldDetector.swift; sourceTree = "<group>"; };
 		C451E144D220D5C63372A8C0 /* AppSurfaceClassifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSurfaceClassifierTests.swift; sourceTree = "<group>"; };
 		C49F67B3EEB2F2A577A54085 /* DeviceInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceInfoTests.swift; sourceTree = "<group>"; };
+		C51C5F044670C03F9C6A6EE0 /* MlxRuntimeLocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MlxRuntimeLocatorTests.swift; sourceTree = "<group>"; };
 		C533B73CDDA3685135C460FB /* SettingsSearchRankerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSearchRankerTests.swift; sourceTree = "<group>"; };
 		C602357DDED5D11C8B4567FB /* SurfaceContextComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceContextComposer.swift; sourceTree = "<group>"; };
 		C648EBB10D7F8E0B904DEC91 /* de.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = de.txt; sourceTree = "<group>"; };
@@ -1134,17 +1136,13 @@
 		658F2109EF7F1517DEA48DEB /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
-				files = (
-					3B3E08D1204E85F3776D8853 /* Sparkle in Frameworks */,
-					9F2FDCABCC941CBECAA3B4AB /* CotabbyInference in Frameworks */,
-					7FC103944F4EF39DB965F469 /* InMemoryLogging in Frameworks */,
-					8DA36F1521B6A59D8C20AC59 /* Logging in Frameworks */,
-					A7A1B9BE242959B3EE396D27 /* LaunchAtLogin in Frameworks */,
-					920000000000000000000201 /* MLXLLM in Frameworks */,
-					920000000000000000000202 /* MLXLMCommon in Frameworks */,
-					920000000000000000000204 /* HuggingFace in Frameworks */,
-					920000000000000000000205 /* Tokenizers in Frameworks */,
-				);
+			files = (
+				3B3E08D1204E85F3776D8853 /* Sparkle in Frameworks */,
+				9F2FDCABCC941CBECAA3B4AB /* CotabbyInference in Frameworks */,
+				7FC103944F4EF39DB965F469 /* InMemoryLogging in Frameworks */,
+				8DA36F1521B6A59D8C20AC59 /* Logging in Frameworks */,
+				A7A1B9BE242959B3EE396D27 /* LaunchAtLogin in Frameworks */,
+			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		D66643968D3BCEBA2ADCF895 /* Frameworks */ = {
@@ -1389,8 +1387,8 @@
 				5F34AE24BB7C99D66E1F3904 /* InputModels.swift */,
 				BF4BB93056F291FD24EFAD22 /* LanguageCatalog.swift */,
 				A804F4DB6FD9BC8C27B2B65F /* LlamaRuntimeModels.swift */,
-				920000000000000000000102 /* MlxRuntimeBootstrapModel.swift */,
-				920000000000000000000101 /* MlxRuntimeModels.swift */,
+				1FDEADDC9D17C4BE05C94E0B /* MlxRuntimeBootstrapModel.swift */,
+				1B5F0FD48E04F7D52C575370 /* MlxRuntimeModels.swift */,
 				4451D6673112575DF24C4A48 /* OnboardingTemplate.swift */,
 				979A7867966180A545BB44C4 /* PerformanceMetricsStore.swift */,
 				9D82FFC568527700EC17C07D /* PermissionModels.swift */,
@@ -1532,7 +1530,7 @@
 				52BAFA2F989C3C4F7FB892B5 /* MarkerSelectionSynthesizerTests.swift */,
 				1274F897631B1B3A835D157F /* MidWordContinuationPolicyTests.swift */,
 				FC83D14A7557BC0196E59007 /* MirrorOverlayLayoutTests.swift */,
-				920000000000000000000107 /* MlxRuntimeLocatorTests.swift */,
+				C51C5F044670C03F9C6A6EE0 /* MlxRuntimeLocatorTests.swift */,
 				03766F6253FF17639230C0F6 /* ModelAndPresentationValueTests.swift */,
 				A829F28F01FAE76CA7244BBC /* ModelFileValidatorTests.swift */,
 				5EED3CD2BC7B48DF35DEE562 /* OCRTextHygieneTests.swift */,
@@ -1768,7 +1766,7 @@
 				A863F41C0C03D7B4AC5DC002 /* MarkerSelectionSynthesizer.swift */,
 				357C18383B047F24A531BDCD /* MidWordContinuationPolicy.swift */,
 				54150A507B03221F137D539B /* MirrorOverlayLayout.swift */,
-				920000000000000000000103 /* MlxRuntimeLocator.swift */,
+				4A6AC50885060D00352EC390 /* MlxRuntimeLocator.swift */,
 				B22FDEB3B1DCC9ADE906CC73 /* OCRTextHygiene.swift */,
 				2578311F4ABCB3CDFF795A86 /* OnboardingFlowSteps.swift */,
 				24F613F0E2F7046E6532A09C /* OnboardingTemplateFeatureList.swift */,
@@ -1819,9 +1817,9 @@
 				944065A858D9BC936CB12B23 /* LlamaRuntimeCore.swift */,
 				A52D0B550E00EF173A5D157E /* LlamaRuntimeManager.swift */,
 				BE04620C905041680116BE80 /* LlamaSuggestionEngine.swift */,
-				920000000000000000000104 /* MlxRuntimeCore.swift */,
-				920000000000000000000105 /* MlxRuntimeManager.swift */,
-				920000000000000000000106 /* MlxSuggestionEngine.swift */,
+				74D807BD678501F50FF76BA5 /* MlxRuntimeCore.swift */,
+				6C2291774E6FFDEB8A301EE2 /* MlxRuntimeManager.swift */,
+				9B499656D8C451E2F3395357 /* MlxSuggestionEngine.swift */,
 				384FBCF5D7A3A446C5BE2B8D /* SuggestionEngineRouter.swift */,
 			);
 			path = Runtime;
@@ -1870,14 +1868,10 @@
 			packageProductDependencies = (
 				BAADA69C6172DD7F4A642E93 /* Sparkle */,
 				48A46AD6B613CF06072603E4 /* CotabbyInference */,
-					88921938DC814625ED57D605 /* InMemoryLogging */,
-					5A60D1467BBFECB3DFEB39C2 /* Logging */,
-					7B0278A63FEEE8DEDB6C50DB /* LaunchAtLogin */,
-					920000000000000000000301 /* MLXLLM */,
-					920000000000000000000302 /* MLXLMCommon */,
-					920000000000000000000304 /* HuggingFace */,
-					920000000000000000000305 /* Tokenizers */,
-				);
+				88921938DC814625ED57D605 /* InMemoryLogging */,
+				5A60D1467BBFECB3DFEB39C2 /* Logging */,
+				7B0278A63FEEE8DEDB6C50DB /* LaunchAtLogin */,
+			);
 			productName = Cotabby;
 			productReference = 262BE2F1E97389FE8D7A5FB9 /* Cotabby.app */;
 			productType = "com.apple.product-type.application";
@@ -1915,6 +1909,7 @@
 						ProvisioningStyle = Automatic;
 					};
 					622CFE93F0FE48C8243E060C = {
+						DevelopmentTeam = G946M8K23B;
 						ProvisioningStyle = Automatic;
 					};
 					AB3DFA4CFA5EBC6161F02A30 = {
@@ -1934,13 +1929,13 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				537E79EE0EEF2030A5923ED9 /* XCRemoteSwiftPackageReference "cotabbyinference" */,
-					16E10845516A4DE793CC1BF6 /* XCRemoteSwiftPackageReference "LaunchAtLogin-Modern" */,
-					D8563066187C38DAA4206016 /* XCRemoteSwiftPackageReference "Sparkle" */,
-					413C306D13ADDD8B5C747551 /* XCRemoteSwiftPackageReference "swift-log" */,
-					920000000000000000000401 /* XCRemoteSwiftPackageReference "mlx-swift-lm" */,
-					920000000000000000000402 /* XCRemoteSwiftPackageReference "swift-huggingface" */,
-					920000000000000000000403 /* XCRemoteSwiftPackageReference "swift-transformers" */,
-				);
+				16E10845516A4DE793CC1BF6 /* XCRemoteSwiftPackageReference "LaunchAtLogin-Modern" */,
+				D8563066187C38DAA4206016 /* XCRemoteSwiftPackageReference "Sparkle" */,
+				F8E600050524CEB6097DBCBF /* XCRemoteSwiftPackageReference "mlx-swift-lm" */,
+				63EFE006E3CB4F9F5261D8F0 /* XCRemoteSwiftPackageReference "swift-huggingface" */,
+				413C306D13ADDD8B5C747551 /* XCRemoteSwiftPackageReference "swift-log" */,
+				3D0C3DA536F35C2B7738A2FC /* XCRemoteSwiftPackageReference "swift-transformers" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 3725B1A195A06A4F014B75B1 /* Products */;
 			projectDirPath = "";
@@ -2152,6 +2147,12 @@
 				F04D9470439699DB1F016000 /* MenuBarView.swift in Sources */,
 				29ABB5488251FD8089D74F51 /* MidWordContinuationPolicy.swift in Sources */,
 				A3913860E04446A86833D39B /* MirrorOverlayLayout.swift in Sources */,
+				748D647243B51A34B0B4D157 /* MlxRuntimeBootstrapModel.swift in Sources */,
+				94BC7884FCEB7845D906D3A5 /* MlxRuntimeCore.swift in Sources */,
+				78D8718F788C8E317E09AA83 /* MlxRuntimeLocator.swift in Sources */,
+				91B02B35C0DD0641AAA600D3 /* MlxRuntimeManager.swift in Sources */,
+				A9A0DB7F2188824C8810535B /* MlxRuntimeModels.swift in Sources */,
+				FB6DAE3AC4BD774018A12B79 /* MlxSuggestionEngine.swift in Sources */,
 				1F714771EE793A5AF92F1E2B /* ModelDownloadManager.swift in Sources */,
 				DD065767BC8B557C839464FE /* ModelFileValidator.swift in Sources */,
 				914266D314BBBCE2EAB5CBA7 /* OCRTextHygiene.swift in Sources */,
@@ -2390,12 +2391,6 @@
 				BBBD7B4628BA1160DD6B4BDB /* MacroModels.swift in Sources */,
 				0B378201616831626DEC3AB6 /* MacroReferenceSheet.swift in Sources */,
 				3FF6B7DE34A01C4AB7FA54E3 /* MacroTriggerStateMachine.swift in Sources */,
-				920000000000000000000002 /* MlxRuntimeBootstrapModel.swift in Sources */,
-				920000000000000000000004 /* MlxRuntimeCore.swift in Sources */,
-				920000000000000000000003 /* MlxRuntimeLocator.swift in Sources */,
-				920000000000000000000005 /* MlxRuntimeManager.swift in Sources */,
-				920000000000000000000001 /* MlxRuntimeModels.swift in Sources */,
-				920000000000000000000006 /* MlxSuggestionEngine.swift in Sources */,
 				5C119807B84F84B0B1B1C2D5 /* MarkerSelectionSynthesizer.swift in Sources */,
 				0BEBB33EB75B59EE83C6FE44 /* MenuBarPopoverDismisser.swift in Sources */,
 				F08C139B246C1EC7BB435455 /* MenuBarPresentationObserver.swift in Sources */,
@@ -2404,6 +2399,12 @@
 				5E92E3C1EB41D482FC06BC52 /* MenuBarView.swift in Sources */,
 				9CEBD6AF4405F1BBE0E3D16C /* MidWordContinuationPolicy.swift in Sources */,
 				31515DDD173535C4AC777853 /* MirrorOverlayLayout.swift in Sources */,
+				AC7DE9FD05D698309588E9FD /* MlxRuntimeBootstrapModel.swift in Sources */,
+				5D18807F6620EC8E0F6E5D84 /* MlxRuntimeCore.swift in Sources */,
+				EECC350990615799496E2760 /* MlxRuntimeLocator.swift in Sources */,
+				3E3AE27E30EFE1B9C8D384F9 /* MlxRuntimeManager.swift in Sources */,
+				74A817DE73EBC09078EAF739 /* MlxRuntimeModels.swift in Sources */,
+				CEAD9B510D7751C9BA2595BD /* MlxSuggestionEngine.swift in Sources */,
 				2F227738D7834B1A7A81D1D6 /* ModelDownloadManager.swift in Sources */,
 				317883210D1D1D5CD654E562 /* ModelFileValidator.swift in Sources */,
 				93EBF0366891222B7DD6C38D /* OCRTextHygiene.swift in Sources */,
@@ -2602,7 +2603,7 @@
 				87806DE08881D11F2608A13D /* MarkerSelectionSynthesizerTests.swift in Sources */,
 				7C36DBA762E19C8C31676D44 /* MidWordContinuationPolicyTests.swift in Sources */,
 				14D77F0B8A195AC2FA8D24A9 /* MirrorOverlayLayoutTests.swift in Sources */,
-				920000000000000000000007 /* MlxRuntimeLocatorTests.swift in Sources */,
+				8AD8F9879A809BAB617136D5 /* MlxRuntimeLocatorTests.swift in Sources */,
 				25D4FC8D191A50F63E6391F9 /* ModelAndPresentationValueTests.swift in Sources */,
 				65478B0DABF5460C32D4C458 /* ModelFileValidatorTests.swift in Sources */,
 				3F5630CFB7BA40B900E832A1 /* OCRTextHygieneTests.swift in Sources */,
@@ -2734,7 +2735,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = C4BVFMK9V2;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
@@ -2962,7 +2962,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = C4BVFMK9V2;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
@@ -3066,6 +3065,14 @@
 				minimumVersion = 1.1.0;
 			};
 		};
+		3D0C3DA536F35C2B7738A2FC /* XCRemoteSwiftPackageReference "swift-transformers" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/huggingface/swift-transformers";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.3.0;
+			};
+		};
 		413C306D13ADDD8B5C747551 /* XCRemoteSwiftPackageReference "swift-log" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/apple/swift-log.git";
@@ -3082,6 +3089,14 @@
 				kind = branch;
 			};
 		};
+		63EFE006E3CB4F9F5261D8F0 /* XCRemoteSwiftPackageReference "swift-huggingface" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/huggingface/swift-huggingface";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.9.0;
+			};
+		};
 		D8563066187C38DAA4206016 /* XCRemoteSwiftPackageReference "Sparkle" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/sparkle-project/Sparkle";
@@ -3090,28 +3105,12 @@
 				version = 2.9.1;
 			};
 		};
-		920000000000000000000401 /* XCRemoteSwiftPackageReference "mlx-swift-lm" */ = {
+		F8E600050524CEB6097DBCBF /* XCRemoteSwiftPackageReference "mlx-swift-lm" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ml-explore/mlx-swift-lm";
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 3.31.3;
-			};
-		};
-		920000000000000000000402 /* XCRemoteSwiftPackageReference "swift-huggingface" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/huggingface/swift-huggingface";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.9.0;
-			};
-		};
-		920000000000000000000403 /* XCRemoteSwiftPackageReference "swift-transformers" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/huggingface/swift-transformers";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.3.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -3166,26 +3165,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 16E10845516A4DE793CC1BF6 /* XCRemoteSwiftPackageReference "LaunchAtLogin-Modern" */;
 			productName = LaunchAtLogin;
-		};
-		920000000000000000000301 /* MLXLLM */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 920000000000000000000401 /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
-			productName = MLXLLM;
-		};
-		920000000000000000000302 /* MLXLMCommon */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 920000000000000000000401 /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
-			productName = MLXLMCommon;
-		};
-		920000000000000000000304 /* HuggingFace */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 920000000000000000000402 /* XCRemoteSwiftPackageReference "swift-huggingface" */;
-			productName = HuggingFace;
-		};
-		920000000000000000000305 /* Tokenizers */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 920000000000000000000403 /* XCRemoteSwiftPackageReference "swift-transformers" */;
-			productName = Tokenizers;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		1681C0F22323FB1156579D99 /* AGPL-3.0.txt in Resources */ = {isa = PBXBuildFile; fileRef = 6F0EE728C0B1A7AD6B19CD0C /* AGPL-3.0.txt */; };
 		175C4FA56C29DEE58C2D4D7E /* SuggestionSettingsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86460C747AA883FDE756BDBA /* SuggestionSettingsModel.swift */; };
 		18382D1919D90E3C1EE143C2 /* AppSurfaceClassifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C451E144D220D5C63372A8C0 /* AppSurfaceClassifierTests.swift */; };
+		185179B79D6AB2C3D24B7E7F /* MLXLLM in Frameworks */ = {isa = PBXBuildFile; productRef = E4D21E9305E92FF59BBD3702 /* MLXLLM */; };
 		18680D0D66469A2954A50B6C /* SuggestionQualityMetricsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81718CA62FBC775A6CEBCED1 /* SuggestionQualityMetricsStore.swift */; };
 		1899BC5A35DC96B4D04B18A5 /* es.txt in Resources */ = {isa = PBXBuildFile; fileRef = 0B6816DF5D33863F966240B4 /* es.txt */; };
 		18F8E078D0CE6B3AF2C6AFFC /* WelcomeHeroDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6FE1277859A1402F8FB7E4E /* WelcomeHeroDemo.swift */; };
@@ -115,6 +116,8 @@
 		257C2A5D299365C1D98527A8 /* SpellingLanguageResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0348A7053E5683C68879A71A /* SpellingLanguageResolver.swift */; };
 		258EAFB0292290C88520E915 /* SystemSettingsWindowLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5976600F428C1265121D4C0C /* SystemSettingsWindowLocator.swift */; };
 		258EC4BDDBD31A4509B668AE /* SuggestionAnchorCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = E99C99D2782EAF0492F964EF /* SuggestionAnchorCache.swift */; };
+		2597836335B3B94E318BF342 /* MLXLLM in Frameworks */ = {isa = PBXBuildFile; productRef = 2F735A2CC8DFFDD231F2B70F /* MLXLLM */; };
+		25C1921549D3691662A7F2F7 /* MLXLMCommon in Frameworks */ = {isa = PBXBuildFile; productRef = 359D454B426D7866DAD422DA /* MLXLMCommon */; };
 		25D4FC8D191A50F63E6391F9 /* ModelAndPresentationValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03766F6253FF17639230C0F6 /* ModelAndPresentationValueTests.swift */; };
 		25F91CEF38400FD1ADB6B1AF /* CompletionRenderModePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D504BEB224E0C176F5FCFF6E /* CompletionRenderModePolicyTests.swift */; };
 		261FA692D19C48E53D6999BC /* DeepGeometryWalkThrottle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684737E62EE6495A71344923 /* DeepGeometryWalkThrottle.swift */; };
@@ -196,6 +199,7 @@
 		3FCEF50FDD9EE01AE3711083 /* AXTreeDumpWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B27492B04B627DA53BDAD938 /* AXTreeDumpWriter.swift */; };
 		3FF6B7DE34A01C4AB7FA54E3 /* MacroTriggerStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C201A65A6B040F90C528A3B /* MacroTriggerStateMachine.swift */; };
 		400E1A5145FC8C5BA2FAED0A /* DeepGeometryWalkThrottle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684737E62EE6495A71344923 /* DeepGeometryWalkThrottle.swift */; };
+		40412351B908B9B19FCD39B3 /* MLXLMCommon in Frameworks */ = {isa = PBXBuildFile; productRef = C74A89874731CE8C6D285B4E /* MLXLMCommon */; };
 		4086A1B07488C4D3D43D86C9 /* KeyboardInputSourceMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 534F1297DEF3547D0DE56FB2 /* KeyboardInputSourceMonitor.swift */; };
 		4134ADBE464D00BB748BD9AE /* GeneralPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07480CE96ED0EBD94817C6B1 /* GeneralPaneView.swift */; };
 		418055EF945C17BAEFAB89ED /* CaretRunPlacementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 421FD16E18622824E038DFB4 /* CaretRunPlacementTests.swift */; };
@@ -1145,6 +1149,8 @@
 				8DA36F1521B6A59D8C20AC59 /* Logging in Frameworks */,
 				A7A1B9BE242959B3EE396D27 /* LaunchAtLogin in Frameworks */,
 				A38F892919E0B8C84F1BAC3D /* MLX in Frameworks */,
+				185179B79D6AB2C3D24B7E7F /* MLXLLM in Frameworks */,
+				40412351B908B9B19FCD39B3 /* MLXLMCommon in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1158,6 +1164,8 @@
 				FEF2CF888D8709D1FB0D2B20 /* Logging in Frameworks */,
 				D1D7D50E5C620042CEA3A77E /* LaunchAtLogin in Frameworks */,
 				47E5F10D324E05B5091B63F9 /* MLX in Frameworks */,
+				2597836335B3B94E318BF342 /* MLXLLM in Frameworks */,
+				25C1921549D3691662A7F2F7 /* MLXLMCommon in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1852,6 +1860,8 @@
 				6F27073D2818C0218C3F4370 /* Logging */,
 				E0AA9F90B83B823132880E6F /* LaunchAtLogin */,
 				3DEA36E5901BE1DFC1C5834B /* MLX */,
+				2F735A2CC8DFFDD231F2B70F /* MLXLLM */,
+				359D454B426D7866DAD422DA /* MLXLMCommon */,
 			);
 			productName = "Cotabby Dev";
 			productReference = 4BC92317837813ACA5051177 /* Cotabby Dev.app */;
@@ -1877,6 +1887,8 @@
 				5A60D1467BBFECB3DFEB39C2 /* Logging */,
 				7B0278A63FEEE8DEDB6C50DB /* LaunchAtLogin */,
 				82C74713220922574F13FEBD /* MLX */,
+				E4D21E9305E92FF59BBD3702 /* MLXLLM */,
+				C74A89874731CE8C6D285B4E /* MLXLMCommon */,
 			);
 			productName = Cotabby;
 			productReference = 262BE2F1E97389FE8D7A5FB9 /* Cotabby.app */;
@@ -3122,6 +3134,16 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		2F735A2CC8DFFDD231F2B70F /* MLXLLM */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F8E600050524CEB6097DBCBF /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
+			productName = MLXLLM;
+		};
+		359D454B426D7866DAD422DA /* MLXLMCommon */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F8E600050524CEB6097DBCBF /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
+			productName = MLXLMCommon;
+		};
 		3DEA36E5901BE1DFC1C5834B /* MLX */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = F8E600050524CEB6097DBCBF /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
@@ -3172,6 +3194,11 @@
 			package = 413C306D13ADDD8B5C747551 /* XCRemoteSwiftPackageReference "swift-log" */;
 			productName = InMemoryLogging;
 		};
+		C74A89874731CE8C6D285B4E /* MLXLMCommon */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F8E600050524CEB6097DBCBF /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
+			productName = MLXLMCommon;
+		};
 		D11AB0F962CCC5BD79B630CA /* CotabbyInference */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 537E79EE0EEF2030A5923ED9 /* XCRemoteSwiftPackageReference "cotabbyinference" */;
@@ -3181,6 +3208,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 16E10845516A4DE793CC1BF6 /* XCRemoteSwiftPackageReference "LaunchAtLogin-Modern" */;
 			productName = LaunchAtLogin;
+		};
+		E4D21E9305E92FF59BBD3702 /* MLXLLM */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F8E600050524CEB6097DBCBF /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
+			productName = MLXLLM;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -218,6 +218,7 @@
 		475FB7450EEC3C1B16E66CC4 /* LLMIOFileHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9030FAAB468119A0236284A6 /* LLMIOFileHandlerTests.swift */; };
 		47654BDCFD2DE6D4DE85D7FE /* LanguageTagsEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7CDA90E128350BFF1A9D66 /* LanguageTagsEditor.swift */; };
 		4767E0C7B4997069EA7ADBD7 /* GhostFontSizeStabilizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9458F0820B3161FE9CF1DDAF /* GhostFontSizeStabilizer.swift */; };
+		47E5F10D324E05B5091B63F9 /* MLX in Frameworks */ = {isa = PBXBuildFile; productRef = 3DEA36E5901BE1DFC1C5834B /* MLX */; };
 		47EBA122ABE99932326D9E4A /* CompletionRenderMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A03E565A11581FD2150B142 /* CompletionRenderMode.swift */; };
 		47FDCB1CFF8FA171F5EE1A01 /* SelfCaptureGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68BE6A22BA0D42C8DD9868C /* SelfCaptureGate.swift */; };
 		4882DF865737ECDC4925F44B /* GeneralPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07480CE96ED0EBD94817C6B1 /* GeneralPaneView.swift */; };
@@ -461,6 +462,7 @@
 		A2B3F4D38BCB0FED452B2A3F /* FocusTrackingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D42CD456B4B3C988B148A6 /* FocusTrackingModel.swift */; };
 		A335FBC828C3803200070F5D /* EmojiPickerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A3B81B92E0743C6152ED8DD /* EmojiPickerController.swift */; };
 		A36481222BB5B2A67349D389 /* ApplicationBundleMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A168A7B6A7AD11559B60C56B /* ApplicationBundleMetadataTests.swift */; };
+		A38F892919E0B8C84F1BAC3D /* MLX in Frameworks */ = {isa = PBXBuildFile; productRef = 82C74713220922574F13FEBD /* MLX */; };
 		A3913860E04446A86833D39B /* MirrorOverlayLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54150A507B03221F137D539B /* MirrorOverlayLayout.swift */; };
 		A3AFE27EDE956ADC04C91C94 /* SymSpellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B32482EABE9EA979C40C8A8F /* SymSpellTests.swift */; };
 		A5A6CE0EF01CA6A9AFA7A400 /* RequestID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DC693E00430F46E41CB56E6 /* RequestID.swift */; };
@@ -1142,6 +1144,7 @@
 				7FC103944F4EF39DB965F469 /* InMemoryLogging in Frameworks */,
 				8DA36F1521B6A59D8C20AC59 /* Logging in Frameworks */,
 				A7A1B9BE242959B3EE396D27 /* LaunchAtLogin in Frameworks */,
+				A38F892919E0B8C84F1BAC3D /* MLX in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1154,6 +1157,7 @@
 				C4805FA1A6CD552E572D7012 /* InMemoryLogging in Frameworks */,
 				FEF2CF888D8709D1FB0D2B20 /* Logging in Frameworks */,
 				D1D7D50E5C620042CEA3A77E /* LaunchAtLogin in Frameworks */,
+				47E5F10D324E05B5091B63F9 /* MLX in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1847,6 +1851,7 @@
 				C42F41C6497D6199DA27D6CD /* InMemoryLogging */,
 				6F27073D2818C0218C3F4370 /* Logging */,
 				E0AA9F90B83B823132880E6F /* LaunchAtLogin */,
+				3DEA36E5901BE1DFC1C5834B /* MLX */,
 			);
 			productName = "Cotabby Dev";
 			productReference = 4BC92317837813ACA5051177 /* Cotabby Dev.app */;
@@ -1871,6 +1876,7 @@
 				88921938DC814625ED57D605 /* InMemoryLogging */,
 				5A60D1467BBFECB3DFEB39C2 /* Logging */,
 				7B0278A63FEEE8DEDB6C50DB /* LaunchAtLogin */,
+				82C74713220922574F13FEBD /* MLX */,
 			);
 			productName = Cotabby;
 			productReference = 262BE2F1E97389FE8D7A5FB9 /* Cotabby.app */;
@@ -3116,6 +3122,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		3DEA36E5901BE1DFC1C5834B /* MLX */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F8E600050524CEB6097DBCBF /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
+			productName = MLX;
+		};
 		48A46AD6B613CF06072603E4 /* CotabbyInference */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 537E79EE0EEF2030A5923ED9 /* XCRemoteSwiftPackageReference "cotabbyinference" */;
@@ -3140,6 +3151,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 16E10845516A4DE793CC1BF6 /* XCRemoteSwiftPackageReference "LaunchAtLogin-Modern" */;
 			productName = LaunchAtLogin;
+		};
+		82C74713220922574F13FEBD /* MLX */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F8E600050524CEB6097DBCBF /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
+			productName = MLX;
 		};
 		88921938DC814625ED57D605 /* InMemoryLogging */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -152,7 +152,6 @@
 		2F227738D7834B1A7A81D1D6 /* ModelDownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51020F8CD58338BD643FBF63 /* ModelDownloadManager.swift */; };
 		2FC40D4BFDD05C2401D7A5E9 /* SuggestionInserter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3D1125B962CBE0269EEDDB /* SuggestionInserter.swift */; };
 		303652F15C0FE55595669D81 /* SpellingDictionaryResourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D562A73C7C680F2AA65F9F7F /* SpellingDictionaryResourceTests.swift */; };
-		30AE3C5C8CFAE7DA4C68D6FB /* Hub in Frameworks */ = {isa = PBXBuildFile; productRef = 0A5609A3639D6B6B2ACB0BA2 /* Hub */; };
 		30D4728580451C7D3BDF42E3 /* SurfaceContextCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CF6B7FFBF77B4290F5F2FB8 /* SurfaceContextCache.swift */; };
 		30F3F2B6D13CD583136CD787 /* AXHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC70775535A3428991025AB8 /* AXHelper.swift */; };
 		3112A355E61878A6A6D1FDF8 /* EmojiQueryRun.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDF6A4E9CE93FD53C60E67E3 /* EmojiQueryRun.swift */; };
@@ -550,7 +549,6 @@
 		BEF746D51C69FE426376C89A /* SystemResourceSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A5D63F390E9B7A7FE343FE /* SystemResourceSampler.swift */; };
 		BF60D99576F60321078464AD /* SystemSettingsWindowLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5976600F428C1265121D4C0C /* SystemSettingsWindowLocator.swift */; };
 		BFCA7FAFDAEBF586AB615567 /* ClipboardRelevanceFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90B0D133AB77A2503FB08827 /* ClipboardRelevanceFilterTests.swift */; };
-		BFFBA299521A41C3879CB1C6 /* Hub in Frameworks */ = {isa = PBXBuildFile; productRef = A8A6E5D6EDF5710071B4C7A6 /* Hub */; };
 		C0537A515AED443F6C61DB2A /* MenuBarSections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A810F9D28A18BA6F2066C7 /* MenuBarSections.swift */; };
 		C0B833234748E82D3382631A /* emoji.json in Resources */ = {isa = PBXBuildFile; fileRef = C379D77029D6E88C8C1B9AF7 /* emoji.json */; };
 		C0F757D74758B76DA2962BC5 /* LlamaDecodeGateDefaultsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B3E5554AAC5D0007CCC61A7 /* LlamaDecodeGateDefaultsTests.swift */; };
@@ -1156,7 +1154,6 @@
 				185179B79D6AB2C3D24B7E7F /* MLXLLM in Frameworks */,
 				40412351B908B9B19FCD39B3 /* MLXLMCommon in Frameworks */,
 				A6370D0DE8669F25DEDACD59 /* Tokenizers in Frameworks */,
-				30AE3C5C8CFAE7DA4C68D6FB /* Hub in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1173,7 +1170,6 @@
 				2597836335B3B94E318BF342 /* MLXLLM in Frameworks */,
 				25C1921549D3691662A7F2F7 /* MLXLMCommon in Frameworks */,
 				EDFB4B3DD979A80E69E61081 /* Tokenizers in Frameworks */,
-				BFFBA299521A41C3879CB1C6 /* Hub in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1871,7 +1867,6 @@
 				2F735A2CC8DFFDD231F2B70F /* MLXLLM */,
 				359D454B426D7866DAD422DA /* MLXLMCommon */,
 				13E923E68B6A4BD0F3B18E75 /* Tokenizers */,
-				A8A6E5D6EDF5710071B4C7A6 /* Hub */,
 			);
 			productName = "Cotabby Dev";
 			productReference = 4BC92317837813ACA5051177 /* Cotabby Dev.app */;
@@ -1900,7 +1895,6 @@
 				E4D21E9305E92FF59BBD3702 /* MLXLLM */,
 				C74A89874731CE8C6D285B4E /* MLXLMCommon */,
 				1CE8530F0ED104DD40248A25 /* Tokenizers */,
-				0A5609A3639D6B6B2ACB0BA2 /* Hub */,
 			);
 			productName = Cotabby;
 			productReference = 262BE2F1E97389FE8D7A5FB9 /* Cotabby.app */;
@@ -3146,11 +3140,6 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		0A5609A3639D6B6B2ACB0BA2 /* Hub */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 3D0C3DA536F35C2B7738A2FC /* XCRemoteSwiftPackageReference "swift-transformers" */;
-			productName = Hub;
-		};
 		13E923E68B6A4BD0F3B18E75 /* Tokenizers */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 3D0C3DA536F35C2B7738A2FC /* XCRemoteSwiftPackageReference "swift-transformers" */;
@@ -3210,11 +3199,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 413C306D13ADDD8B5C747551 /* XCRemoteSwiftPackageReference "swift-log" */;
 			productName = InMemoryLogging;
-		};
-		A8A6E5D6EDF5710071B4C7A6 /* Hub */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 3D0C3DA536F35C2B7738A2FC /* XCRemoteSwiftPackageReference "swift-transformers" */;
-			productName = Hub;
 		};
 		BAADA69C6172DD7F4A642E93 /* Sparkle */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Cotabby/App/Coordinators/SettingsCoordinator.swift
+++ b/Cotabby/App/Coordinators/SettingsCoordinator.swift
@@ -17,6 +17,7 @@ final class SettingsCoordinator: NSObject, NSWindowDelegate {
     private let suggestionSettings: SuggestionSettingsModel
     private let foundationModelAvailabilityService: FoundationModelAvailabilityService
     private let runtimeModel: RuntimeBootstrapModel
+    private let mlxRuntimeModel: MlxRuntimeBootstrapModel
     private let modelDownloadManager: ModelDownloadManager
     private let huggingFaceSearchService: HuggingFaceSearchService
     private let performanceMetricsStore: PerformanceMetricsStore
@@ -34,6 +35,7 @@ final class SettingsCoordinator: NSObject, NSWindowDelegate {
         suggestionSettings: SuggestionSettingsModel,
         foundationModelAvailabilityService: FoundationModelAvailabilityService,
         runtimeModel: RuntimeBootstrapModel,
+        mlxRuntimeModel: MlxRuntimeBootstrapModel,
         modelDownloadManager: ModelDownloadManager,
         huggingFaceSearchService: HuggingFaceSearchService,
         performanceMetricsStore: PerformanceMetricsStore,
@@ -48,6 +50,7 @@ final class SettingsCoordinator: NSObject, NSWindowDelegate {
         self.suggestionSettings = suggestionSettings
         self.foundationModelAvailabilityService = foundationModelAvailabilityService
         self.runtimeModel = runtimeModel
+        self.mlxRuntimeModel = mlxRuntimeModel
         self.modelDownloadManager = modelDownloadManager
         self.huggingFaceSearchService = huggingFaceSearchService
         self.performanceMetricsStore = performanceMetricsStore
@@ -76,6 +79,7 @@ final class SettingsCoordinator: NSObject, NSWindowDelegate {
                     suggestionSettings: suggestionSettings,
                     foundationModelAvailabilityService: foundationModelAvailabilityService,
                     runtimeModel: runtimeModel,
+                    mlxRuntimeModel: mlxRuntimeModel,
                     modelDownloadManager: modelDownloadManager,
                     huggingFaceSearchService: huggingFaceSearchService,
                     performanceMetricsStore: performanceMetricsStore,

--- a/Cotabby/App/Core/AppDelegate.swift
+++ b/Cotabby/App/Core/AppDelegate.swift
@@ -17,6 +17,7 @@ import Logging
 final class AppDelegate: NSObject, NSApplicationDelegate {
     let permissionManager: PermissionManager
     let runtimeModel: RuntimeBootstrapModel
+    let mlxRuntimeModel: MlxRuntimeBootstrapModel
     let modelDownloadManager: ModelDownloadManager
     let focusModel: FocusTrackingModel
     let inputMonitor: InputMonitor
@@ -49,6 +50,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         self.environment = environment
         permissionManager = environment.permissionManager
         runtimeModel = environment.runtimeModel
+        mlxRuntimeModel = environment.mlxRuntimeModel
         modelDownloadManager = environment.modelDownloadManager
         focusModel = environment.focusModel
         inputMonitor = environment.inputMonitor
@@ -68,6 +70,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // These closures bridge events across subsystems without forcing those subsystems
         // to know about each other directly.
         runtimeModel.onWillReloadModel = { [weak suggestionCoordinator] in
+            suggestionCoordinator?.prepareForRuntimeModelSwitch()
+        }
+        mlxRuntimeModel.onWillReloadModel = { [weak suggestionCoordinator] in
             suggestionCoordinator?.prepareForRuntimeModelSwitch()
         }
 
@@ -189,6 +194,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         focusModel.stop()
 
         runtimeModel.shutdownSync(timeoutSeconds: 1.5)
+        mlxRuntimeModel.shutdownSync(timeoutSeconds: 1.5)
     }
 
     /// Shows or hides the field-edge Cotabby icon based on focus state, global enable, per-app
@@ -216,6 +222,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         switch suggestionSettings.selectedEngine {
         case .llamaOpenSource:
             runtimeModel.startIfNeeded()
+        case .mlx:
+            mlxRuntimeModel.startIfNeeded()
         case .appleIntelligence:
             break
         }
@@ -225,6 +233,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// warm the runtime only if the current engine choice needs it.
     private func handleModelDirectoryChange() {
         runtimeModel.refreshAvailableModels()
+        mlxRuntimeModel.refreshAvailableModels()
         startRuntimeIfPreferredEngineRequiresIt()
     }
 

--- a/Cotabby/App/Core/CotabbyApp.swift
+++ b/Cotabby/App/Core/CotabbyApp.swift
@@ -16,6 +16,7 @@ struct CotabbyApp: App {
             MenuBarView(
                 permissionManager: appDelegate.permissionManager,
                 runtimeModel: appDelegate.runtimeModel,
+                mlxRuntimeModel: appDelegate.mlxRuntimeModel,
                 modelDownloadManager: appDelegate.modelDownloadManager,
                 focusModel: appDelegate.focusModel,
                 permissionGuidanceController: appDelegate.permissionGuidanceController,

--- a/Cotabby/App/Core/CotabbyAppEnvironment.swift
+++ b/Cotabby/App/Core/CotabbyAppEnvironment.swift
@@ -13,6 +13,7 @@ import Logging
 final class CotabbyAppEnvironment {
     let permissionManager: PermissionManager
     let runtimeModel: RuntimeBootstrapModel
+    let mlxRuntimeModel: MlxRuntimeBootstrapModel
     let modelDownloadManager: ModelDownloadManager
     let focusModel: FocusTrackingModel
     let inputMonitor: InputMonitor
@@ -50,6 +51,8 @@ final class CotabbyAppEnvironment {
         )
         let runtimeManager = LlamaRuntimeManager()
         let runtimeModel = RuntimeBootstrapModel(runtimeManager: runtimeManager)
+        let mlxRuntimeManager = MlxRuntimeManager()
+        let mlxRuntimeModel = MlxRuntimeBootstrapModel(runtimeManager: mlxRuntimeManager)
         let modelDownloadManager = ModelDownloadManager()
         let suggestionSettings = SuggestionSettingsModel(configuration: configuration)
         let foundationModelAvailabilityService = FoundationModelAvailabilityService()
@@ -160,10 +163,14 @@ final class CotabbyAppEnvironment {
             suggestionSettings: suggestionSettings,
             foundationModelEngine: foundationModelEngine,
             llamaEngine: LlamaSuggestionEngine(runtimeManager: runtimeManager),
+            mlxEngine: MlxSuggestionEngine(runtimeManager: mlxRuntimeManager),
             performanceMetricsStore: performanceMetricsStore,
             qualityMetricsStore: qualityMetricsStore,
             llamaModelNameProvider: { [weak runtimeManager] in
                 runtimeManager?.currentModelFilename
+            },
+            mlxModelNameProvider: { [weak mlxRuntimeManager] in
+                mlxRuntimeManager?.currentModelID
             }
         )
 
@@ -178,6 +185,7 @@ final class CotabbyAppEnvironment {
             suggestionSettings: suggestionSettings,
             foundationModelAvailabilityService: foundationModelAvailabilityService,
             runtimeModel: runtimeModel,
+            mlxRuntimeModel: mlxRuntimeModel,
             modelDownloadManager: modelDownloadManager,
             huggingFaceSearchService: huggingFaceSearchService,
             performanceMetricsStore: performanceMetricsStore,
@@ -265,6 +273,7 @@ final class CotabbyAppEnvironment {
 
         self.permissionManager = permissionManager
         self.runtimeModel = runtimeModel
+        self.mlxRuntimeModel = mlxRuntimeModel
         self.modelDownloadManager = modelDownloadManager
         self.focusModel = focusModel
         self.inputMonitor = inputMonitor

--- a/Cotabby/Models/MlxRuntimeBootstrapModel.swift
+++ b/Cotabby/Models/MlxRuntimeBootstrapModel.swift
@@ -1,0 +1,192 @@
+import Combine
+import Foundation
+import Logging
+
+/// File overview:
+/// Publishes app-facing MLX runtime lifecycle state and remembers the selected MLX snapshot.
+///
+/// This is a sibling of `RuntimeBootstrapModel`, not a replacement. The llama bootstrap owns a
+/// selected GGUF filename; this type owns a selected MLX model ID that points at a snapshot
+/// directory. Keeping those concerns apart lets Settings show both local backends without teaching
+/// either runtime manager about the other's storage format.
+@MainActor
+final class MlxRuntimeBootstrapModel: ObservableObject {
+    @Published private(set) var state: RuntimeBootstrapState
+    @Published private(set) var diagnostics: MlxRuntimeDiagnostics
+    @Published private(set) var availableModels: [MlxRuntimeModelOption]
+    @Published private(set) var selectedModelID: String?
+
+    private let runtimeManager: MlxRuntimeManager
+    private let userDefaults: UserDefaults
+    private var cancellables = Set<AnyCancellable>()
+    private var runtimeTask: Task<Void, Never>?
+
+    var onWillReloadModel: (() -> Void)?
+
+    private static let selectedModelDefaultsKey = "cotabbySelectedMlxModelID"
+
+    init(
+        runtimeManager: MlxRuntimeManager,
+        userDefaults: UserDefaults = .standard
+    ) {
+        self.runtimeManager = runtimeManager
+        self.userDefaults = userDefaults
+        state = runtimeManager.state
+        diagnostics = runtimeManager.diagnostics
+        availableModels = runtimeManager.availableModels
+
+        let persistedID = userDefaults.string(forKey: Self.selectedModelDefaultsKey)
+        let initialSelection = Self.initialSelectedModelID(
+            persistedID,
+            availableModels: runtimeManager.availableModels
+        )
+        selectedModelID = initialSelection
+        persistSelectedModelID(initialSelection)
+        runtimeManager.configureSelectedModel(id: initialSelection)
+
+        runtimeManager.$state
+            .sink { [weak self] state in
+                self?.state = state
+            }
+            .store(in: &cancellables)
+
+        runtimeManager.$diagnostics
+            .sink { [weak self] diagnostics in
+                self?.diagnostics = diagnostics
+            }
+            .store(in: &cancellables)
+
+        runtimeManager.$availableModels
+            .sink { [weak self] availableModels in
+                self?.applyAvailableModels(availableModels)
+            }
+            .store(in: &cancellables)
+    }
+
+    func refreshAvailableModels() {
+        runtimeManager.refreshAvailableModels()
+    }
+
+    func startIfNeeded() {
+        guard runtimeTask == nil, !availableModels.isEmpty else {
+            return
+        }
+
+        runtimeTask = Task { [weak self] in
+            guard let self else { return }
+            defer { self.runtimeTask = nil }
+
+            do {
+                try await self.runtimeManager.prepare()
+            } catch {
+                CotabbyLogger.runtime.error("MLX runtime startup failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    func selectModel(_ modelID: String) async {
+        guard availableModels.contains(where: { $0.id == modelID }) else {
+            return
+        }
+
+        if selectedModelID == modelID, case .ready = state {
+            return
+        }
+
+        guard runtimeTask == nil else {
+            return
+        }
+
+        selectedModelID = modelID
+        persistSelectedModelID(modelID)
+        onWillReloadModel?()
+
+        runtimeTask = Task { [weak self] in
+            guard let self else { return }
+            defer { self.runtimeTask = nil }
+
+            do {
+                try await self.runtimeManager.selectModel(id: modelID)
+            } catch {
+                CotabbyLogger.runtime.error("MLX runtime model switch failed: \(error.localizedDescription)")
+            }
+        }
+
+        await runtimeTask?.value
+    }
+
+    func stop() {
+        runtimeTask?.cancel()
+        runtimeTask = nil
+        runtimeManager.stop()
+    }
+
+    func stopAndWait() async {
+        runtimeTask?.cancel()
+        runtimeTask = nil
+        await runtimeManager.stopAndWait()
+    }
+
+    func shutdownSync(timeoutSeconds: TimeInterval) {
+        runtimeTask?.cancel()
+        runtimeTask = nil
+        runtimeManager.shutdownSync(timeoutSeconds: timeoutSeconds)
+    }
+
+    private static func initialSelectedModelID(
+        _ persistedID: String?,
+        availableModels: [MlxRuntimeModelOption]
+    ) -> String? {
+        guard !availableModels.isEmpty else {
+            return nil
+        }
+
+        if let persistedID,
+           availableModels.contains(where: { $0.id == persistedID }) {
+            return persistedID
+        }
+
+        return availableModels.first?.id
+    }
+
+    private func persistSelectedModelID(_ id: String?) {
+        userDefaults.set(id, forKey: Self.selectedModelDefaultsKey)
+    }
+
+    private func applyAvailableModels(_ availableModels: [MlxRuntimeModelOption]) {
+        self.availableModels = availableModels
+
+        let persistedID = userDefaults.string(forKey: Self.selectedModelDefaultsKey)
+        let resolvedSelection = Self.resolvedSelectedModelID(
+            currentSelection: selectedModelID,
+            persistedSelection: persistedID,
+            availableModels: availableModels
+        )
+
+        selectedModelID = resolvedSelection
+        persistSelectedModelID(resolvedSelection)
+        runtimeManager.configureSelectedModel(id: resolvedSelection)
+    }
+
+    private static func resolvedSelectedModelID(
+        currentSelection: String?,
+        persistedSelection: String?,
+        availableModels: [MlxRuntimeModelOption]
+    ) -> String? {
+        guard !availableModels.isEmpty else {
+            return nil
+        }
+
+        if let currentSelection,
+           availableModels.contains(where: { $0.id == currentSelection }) {
+            return currentSelection
+        }
+
+        if let persistedSelection,
+           availableModels.contains(where: { $0.id == persistedSelection }) {
+            return persistedSelection
+        }
+
+        return availableModels.first?.id
+    }
+}

--- a/Cotabby/Models/MlxRuntimeBootstrapModel.swift
+++ b/Cotabby/Models/MlxRuntimeBootstrapModel.swift
@@ -20,6 +20,7 @@ final class MlxRuntimeBootstrapModel: ObservableObject {
     private let userDefaults: UserDefaults
     private var cancellables = Set<AnyCancellable>()
     private var runtimeTask: Task<Void, Never>?
+    private var runtimeTaskID: UUID?
 
     var onWillReloadModel: (() -> Void)?
 
@@ -72,9 +73,11 @@ final class MlxRuntimeBootstrapModel: ObservableObject {
             return
         }
 
+        let taskID = UUID()
+        runtimeTaskID = taskID
         runtimeTask = Task { [weak self] in
             guard let self else { return }
-            defer { self.runtimeTask = nil }
+            defer { self.clearRuntimeTask(ifCurrent: taskID) }
 
             do {
                 try await self.runtimeManager.prepare()
@@ -93,17 +96,18 @@ final class MlxRuntimeBootstrapModel: ObservableObject {
             return
         }
 
-        guard runtimeTask == nil else {
-            return
-        }
-
         selectedModelID = modelID
         persistSelectedModelID(modelID)
         onWillReloadModel?()
 
-        runtimeTask = Task { [weak self] in
+        // A picker change supersedes startup or an older switch. Cancelling before publishing the
+        // replacement preserves the latest user intent while the manager tears down stale work.
+        runtimeTask?.cancel()
+        let taskID = UUID()
+        runtimeTaskID = taskID
+        let task = Task { [weak self] in
             guard let self else { return }
-            defer { self.runtimeTask = nil }
+            defer { self.clearRuntimeTask(ifCurrent: taskID) }
 
             do {
                 try await self.runtimeManager.selectModel(id: modelID)
@@ -111,26 +115,39 @@ final class MlxRuntimeBootstrapModel: ObservableObject {
                 CotabbyLogger.runtime.error("MLX runtime model switch failed: \(error.localizedDescription)")
             }
         }
+        runtimeTask = task
 
-        await runtimeTask?.value
+        await task.value
     }
 
     func stop() {
         runtimeTask?.cancel()
         runtimeTask = nil
+        runtimeTaskID = nil
         runtimeManager.stop()
     }
 
     func stopAndWait() async {
         runtimeTask?.cancel()
         runtimeTask = nil
+        runtimeTaskID = nil
         await runtimeManager.stopAndWait()
     }
 
     func shutdownSync(timeoutSeconds: TimeInterval) {
         runtimeTask?.cancel()
         runtimeTask = nil
+        runtimeTaskID = nil
         runtimeManager.shutdownSync(timeoutSeconds: timeoutSeconds)
+    }
+
+    /// Clears task state only when the completing task is still the active bootstrap operation.
+    /// A cancelled task may finish after its replacement starts, so unconditional cleanup would
+    /// make `startIfNeeded` believe no work is running and permit duplicate model loads.
+    private func clearRuntimeTask(ifCurrent taskID: UUID) {
+        guard runtimeTaskID == taskID else { return }
+        runtimeTask = nil
+        runtimeTaskID = nil
     }
 
     private static func initialSelectedModelID(

--- a/Cotabby/Models/MlxRuntimeModels.swift
+++ b/Cotabby/Models/MlxRuntimeModels.swift
@@ -1,0 +1,197 @@
+import Foundation
+
+/// File overview:
+/// Defines the MLX-side local runtime values: discovered model snapshots, bootstrap diagnostics,
+/// runtime configuration, generation options, and user-visible errors.
+///
+/// This file exists as a separate boundary from `LlamaRuntimeModels` because MLX models are
+/// directory snapshots (weights + tokenizer + config), while llama.cpp models are single GGUF
+/// files. Keeping the shapes separate prevents the UI from pretending those storage formats are
+/// interchangeable just because both are local and private.
+
+/// One discovered MLX model snapshot that can be selected for autocomplete generation.
+///
+/// A snapshot is a directory, usually from Hugging Face, containing at least `config.json`, tokenizer
+/// files, and one or more weight shards. The directory URL is the durable load path; `id` is the
+/// stable picker identity persisted across launches.
+struct MlxRuntimeModelOption: Equatable, Hashable, Sendable, Identifiable {
+    let id: String
+    let url: URL
+
+    var displayName: String {
+        MlxRuntimeModelCatalog.displayName(for: id)
+    }
+
+    var actualModelName: String {
+        id
+    }
+}
+
+/// Downloadable MLX model metadata used by Settings and onboarding once MLX catalogs are exposed.
+///
+/// Unlike `DownloadableRuntimeModel`, this describes a snapshot repository rather than one direct
+/// file URL. The first implementation can import local directories; the same value type is ready for
+/// a later snapshot downloader that fetches all required files into `MlxRuntime/`.
+struct DownloadableMlxRuntimeModel: Equatable, Hashable, Sendable, Identifiable {
+    let repositoryID: String
+    let displayName: String
+    let approximateSizeInGigabytes: Double
+    let revision: String?
+
+    var id: String { repositoryID }
+    var approximateSizeLabel: String { String(format: "~%.1f GB", approximateSizeInGigabytes) }
+}
+
+enum MlxRuntimeModelCatalog {
+    static func displayName(for modelID: String) -> String {
+        switch modelID {
+        case "mlx-community/Qwen3-4B-4bit":
+            return "Qwen3 4B MLX"
+        case "mlx-community/gemma-3-1b-it-qat-4bit":
+            return "Gemma 3 1B MLX"
+        default:
+            return modelID.components(separatedBy: "/").last ?? modelID
+        }
+    }
+
+    /// Conservative starter catalog. These are not automatically downloaded yet; they establish the
+    /// product-facing IDs and size expectations for the directory-aware downloader work.
+    static let downloadableModels: [DownloadableMlxRuntimeModel] = [
+        DownloadableMlxRuntimeModel(
+            repositoryID: "mlx-community/gemma-3-1b-it-qat-4bit",
+            displayName: displayName(for: "mlx-community/gemma-3-1b-it-qat-4bit"),
+            approximateSizeInGigabytes: 0.8,
+            revision: nil
+        ),
+        DownloadableMlxRuntimeModel(
+            repositoryID: "mlx-community/Qwen3-4B-4bit",
+            displayName: displayName(for: "mlx-community/Qwen3-4B-4bit"),
+            approximateSizeInGigabytes: 2.5,
+            revision: nil
+        )
+    ]
+}
+
+/// Startup configuration for the MLX runtime.
+///
+/// `runtimeDirectoryPath` is optional so tests and advanced local setups can point at a temporary
+/// model root. The app default is the user-writable Application Support directory.
+struct MlxRuntimeConfiguration: Equatable, Sendable {
+    let runtimeDirectoryPath: String?
+    let preferredModelIDs: [String]
+    let maxKVSize: Int?
+    let kvBits: Int?
+    let prefillStepSize: Int
+
+    static let `default` = MlxRuntimeConfiguration(
+        runtimeDirectoryPath: nil,
+        preferredModelIDs: [
+            "mlx-community/gemma-3-1b-it-qat-4bit",
+            "mlx-community/Qwen3-4B-4bit"
+        ],
+        maxKVSize: nil,
+        kvBits: nil,
+        prefillStepSize: 512
+    )
+}
+
+/// Concrete local MLX model selected during bootstrap.
+struct ResolvedMlxRuntime: Equatable, Sendable {
+    let runtimeDirectoryURL: URL
+    let modelDirectoryURL: URL
+    let modelID: String
+    let modelDisplayName: String
+}
+
+/// Operator-facing MLX diagnostics displayed in Settings and logs.
+struct MlxRuntimeDiagnostics: Equatable, Sendable {
+    var runtimeDirectoryPath: String?
+    var modelDirectoryPath: String?
+    var backendName: String?
+    var contextWindowTokens: Int?
+    var maxKVSize: Int?
+    var kvBits: Int?
+    var prefillStepSize: Int?
+    var lastLoadStatus: String?
+    var lastError: String?
+    var lastCacheStatus: String?
+}
+
+/// Immutable runtime metadata captured after the MLX model has been prepared.
+struct PreparedMlxRuntime: Sendable {
+    let resolvedRuntime: ResolvedMlxRuntime
+    let backendName: String
+    let contextWindowTokens: Int?
+    let maxKVSize: Int?
+    let kvBits: Int?
+    let prefillStepSize: Int
+}
+
+/// Runtime failures surfaced before or during MLX generation.
+enum MlxRuntimeError: LocalizedError {
+    case unavailable(String)
+    case cancelled
+    case generationFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unavailable(let message), .generationFailed(let message):
+            return message
+        case .cancelled:
+            return "MLX runtime work was cancelled."
+        }
+    }
+}
+
+/// Small helper for the MLX cache-reuse state machine.
+///
+/// This pure type is deliberately independent from `MLXLMCommon.KVCache` so its reuse math can be
+/// tested without loading a model. Runtime code uses the decision to decide whether to trim and
+/// reuse its backend cache or throw it away and prefill fresh.
+struct MlxPromptCacheDecision: Equatable, Sendable {
+    enum Action: Equatable, Sendable {
+        case fresh(reason: String)
+        case reuse(commonPrefixTokens: Int)
+    }
+
+    let action: Action
+}
+
+enum MlxPromptCachePlanner {
+    static func decision(
+        cachedTokens: [Int],
+        newTokens: [Int],
+        cachedFingerprint: String?,
+        newFingerprint: String,
+        cacheIsTrimmable: Bool
+    ) -> MlxPromptCacheDecision {
+        guard cacheIsTrimmable else {
+            return MlxPromptCacheDecision(action: .fresh(reason: "cache_not_trimmable"))
+        }
+        guard cachedFingerprint == newFingerprint else {
+            return MlxPromptCacheDecision(action: .fresh(reason: "sampling_changed"))
+        }
+        guard !cachedTokens.isEmpty, !newTokens.isEmpty else {
+            return MlxPromptCacheDecision(action: .fresh(reason: "empty_prompt"))
+        }
+
+        let commonPrefix = commonPrefixCount(cachedTokens, newTokens)
+        guard commonPrefix > 0 else {
+            return MlxPromptCacheDecision(action: .fresh(reason: "no_shared_prefix"))
+        }
+
+        // Keep at most prompt-prefix state. The sampled continuation is trimmed after every
+        // generation, so reusing the full prompt is valid; callers still need to prefill any suffix
+        // beyond this prefix before sampling.
+        return MlxPromptCacheDecision(action: .reuse(commonPrefixTokens: min(commonPrefix, newTokens.count)))
+    }
+
+    static func commonPrefixCount<Element: Equatable>(_ lhs: [Element], _ rhs: [Element]) -> Int {
+        var index = 0
+        let limit = min(lhs.count, rhs.count)
+        while index < limit, lhs[index] == rhs[index] {
+            index += 1
+        }
+        return index
+    }
+}

--- a/Cotabby/Models/SuggestionEngineModels.swift
+++ b/Cotabby/Models/SuggestionEngineModels.swift
@@ -6,10 +6,12 @@ import Foundation
 ///
 /// The important architectural distinction is:
 /// - a local GGUF file is a model option inside the llama runtime
+/// - a local MLX snapshot is a model option inside the MLX runtime
 /// - Apple Intelligence vs. local llama is an engine choice above the runtime layer
 enum SuggestionEngineKind: String, CaseIterable, Equatable, Hashable, Sendable, Identifiable {
     case appleIntelligence
     case llamaOpenSource
+    case mlx
 
     var id: String { rawValue }
 
@@ -18,7 +20,9 @@ enum SuggestionEngineKind: String, CaseIterable, Equatable, Hashable, Sendable, 
         case .appleIntelligence:
             return "Apple Intelligence"
         case .llamaOpenSource:
-            return "Open Source"
+            return "Open Source (GGUF)"
+        case .mlx:
+            return "MLX"
         }
     }
 
@@ -31,6 +35,8 @@ enum SuggestionEngineKind: String, CaseIterable, Equatable, Hashable, Sendable, 
             return "apple.logo"
         case .llamaOpenSource:
             return "cpu.fill"
+        case .mlx:
+            return "cpu"
         }
     }
 
@@ -38,7 +44,7 @@ enum SuggestionEngineKind: String, CaseIterable, Equatable, Hashable, Sendable, 
         switch self {
         case .appleIntelligence:
             return false
-        case .llamaOpenSource:
+        case .llamaOpenSource, .mlx:
             return true
         }
     }

--- a/Cotabby/Models/SuggestionSubsystemContracts.swift
+++ b/Cotabby/Models/SuggestionSubsystemContracts.swift
@@ -175,6 +175,16 @@ extension LlamaRuntimeGenerating {
     }
 }
 
+/// Behavior-shaped view of the MLX runtime used by `MlxSuggestionEngine`.
+///
+/// It intentionally mirrors `LlamaRuntimeGenerating`: both local backends receive the same rendered
+/// base-completion prompt and sampling controls, but each runtime owns its own cache correctness.
+@MainActor
+protocol MlxRuntimeGenerating: AnyObject {
+    func generate(prompt: String, cachedPrefixBytes: Int?, options: LlamaGenerationOptions) async throws -> String
+    func resetPromptCache()
+}
+
 @MainActor
 protocol SuggestionSettingsProviding: AnyObject {
     var snapshot: SuggestionSettingsSnapshot { get }

--- a/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
+++ b/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
@@ -367,7 +367,6 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
     ) -> (output: LlamaGenerationOutput, engineCancelled: Bool) {
         var generatedText = ""
         var tokensGenerated = 0
-        var sumLogprob = 0.0
         var stopReason = "budget_exhausted"
         var engineCancelled = false
 
@@ -392,19 +391,9 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
                 stopReason = "eos"
                 break
             }
-            // The raw distribution's most-likely token is end-of-generation: the model wants to
-            // stop here even though the stochastic sampler drew something else. Finalize with the
-            // text accumulated so far and discard the sampled-but-unwanted token; this is the
-            // anti-rambling stop the sentence classifier cannot express (lists, fragments, code).
-            if options.stopAtArgmaxEOG, result.argmax_is_eog {
-                stopReason = "argmax_eog"
-                break
-            }
-
             let piece = Self.extractPiece(result)
             generatedText += piece
             tokensGenerated += 1
-            sumLogprob += Double(result.logprob)
             // Cumulative text, not the delta: consumers render whole partials, and cumulative
             // semantics make late or reordered deliveries harmless downstream.
             onPartialRawText?(generatedText)
@@ -436,51 +425,16 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
             ]
         )
 
-        // The average is only meaningful when the engine actually computed per-token logprobs,
-        // which is keyed on the floor being enabled (see setComputeLogprob at sequence setup).
-        let averageLogprob: Double? = options.confidenceFloor > -.infinity && tokensGenerated > 0
-            ? sumLogprob / Double(tokensGenerated)
-            : nil
-        if Self.shouldSuppress(sumLogprob: sumLogprob, tokensGenerated: tokensGenerated, options: options) {
-            let suppressed = LlamaGenerationOutput(
-                text: "",
-                averageLogprob: averageLogprob,
-                suppressedByLowConfidence: true
-            )
-            return (suppressed, engineCancelled)
-        }
+        // The currently resolved CotabbyInference package exposes the sampler text/EOS/cancel
+        // result, but not per-token logprobs or argmax-EOG metadata. Surface nil confidence here
+        // so callers can distinguish "not computed by this backend" from a strong/weak score.
+        let averageLogprob: Double? = nil
         let output = LlamaGenerationOutput(
             text: generatedText,
             averageLogprob: averageLogprob,
             suppressedByLowConfidence: false
         )
         return (output, engineCancelled)
-    }
-
-    /// Low-confidence gate for the sampled decoder: drop completions the model itself was unsure
-    /// about. Disabled by default (confidenceFloor == -infinity). The KV-trim defer in `generate`
-    /// still runs because the caller returns "" rather than throwing.
-    private static func shouldSuppress(
-        sumLogprob: Double,
-        tokensGenerated: Int,
-        options: LlamaGenerationOptions
-    ) -> Bool {
-        guard tokensGenerated > 0 else { return false }
-        let averageLogprob = sumLogprob / Double(tokensGenerated)
-        let suppress = ConfidenceSuppressionPolicy.shouldSuppress(
-            averageLogprob: averageLogprob,
-            floor: options.confidenceFloor
-        )
-        if suppress {
-            CotabbyLogger.runtime.debug(
-                "Suppressed low-confidence completion",
-                metadata: [
-                    "tokens_generated": .stringConvertible(tokensGenerated),
-                    "avg_logprob": .stringConvertible(averageLogprob)
-                ]
-            )
-        }
-        return suppress
     }
 
     // MARK: - Cache and lifecycle
@@ -574,20 +528,6 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
                     if engine.trimKV(autocompleteSequenceID, Int32(reusableTokenCount)) {
                         let remaining = Array(promptTokens[reusableTokenCount...])
                         if !remaining.isEmpty {
-                            // Seed for the reuse path is sampled at the end of this decodePrompt;
-                            // apply the word-continuation constraint to it like the fresh path does.
-                            engine.setForceWordContinuation(
-                                autocompleteSequenceID,
-                                options.forceWordContinuation
-                            )
-                            // Per-token log-probabilities cost two O(vocab) passes each in the
-                            // engine; only compute them when the confidence gate would actually
-                            // read them. Re-assert per request: the floor is not part of the
-                            // sampling fingerprint, so a reused sequence must not carry a stale flag.
-                            engine.setComputeLogprob(
-                                autocompleteSequenceID,
-                                options.confidenceFloor > -.infinity
-                            )
                             setAbortTarget(autocompleteSequenceID)
                             var mutableRemaining = remaining
                             let status = engine.decodePrompt(
@@ -643,14 +583,6 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
         guard seqID >= 0 else {
             throw LlamaRuntimeError.generationFailed("Unable to create inference sequence.")
         }
-
-        // The engine samples the first (seed) token at the end of decodePrompt, so set the
-        // word-continuation constraint here, before decoding.
-        engine.setForceWordContinuation(seqID, options.forceWordContinuation)
-        // Skip the engine's per-token log-probability work (two O(vocab) passes per token)
-        // whenever confidence suppression is disabled — the shipping default — since the value
-        // would be summed and then discarded.
-        engine.setComputeLogprob(seqID, options.confidenceFloor > -.infinity)
 
         setAbortTarget(seqID)
         var tokens = promptTokens
@@ -726,8 +658,7 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
             top_p: Float(options.topP),
             min_p: Float(options.minP),
             repetition_penalty: Float(options.repetitionPenalty),
-            seed: options.seed ?? Self.defaultSamplerSeed,
-            single_line: options.singleLine
+            seed: options.seed ?? Self.defaultSamplerSeed
         )
     }
 

--- a/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
+++ b/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
@@ -651,15 +651,19 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
     private static let defaultSamplerSeed: UInt32 = 0x00C0_FFEE
 
     private static func samplingConfig(from options: LlamaGenerationOptions) -> SamplingConfig {
-        SamplingConfig(
-            max_prediction_tokens: Int32(options.maxPredictionTokens),
-            temperature: Float(options.temperature),
-            top_k: Int32(options.topK),
-            top_p: Float(options.topP),
-            min_p: Float(options.minP),
-            repetition_penalty: Float(options.repetitionPenalty),
-            seed: options.seed ?? Self.defaultSamplerSeed
-        )
+        // `SamplingConfig` is a C++ interop struct from CotabbyInference. Assigning each field keeps
+        // Swift's type checker out of a large bridged initializer expression and makes package API
+        // additions obvious at this boundary.
+        var config = SamplingConfig()
+        config.max_prediction_tokens = Int32(options.maxPredictionTokens)
+        config.temperature = Float(options.temperature)
+        config.top_k = Int32(options.topK)
+        config.top_p = Float(options.topP)
+        config.min_p = Float(options.minP)
+        config.repetition_penalty = Float(options.repetitionPenalty)
+        config.seed = options.seed ?? Self.defaultSamplerSeed
+        config.single_line = options.singleLine
+        return config
     }
 
     private static func reusableTokenCount(commonTokenPrefix: Int, newPromptTokenCount: Int) -> Int {
@@ -685,6 +689,7 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
         let minP: Double
         let repetitionPenalty: Double
         let seed: UInt32?
+        let singleLine: Bool
 
         init(options: LlamaGenerationOptions) {
             maxPredictionTokens = options.maxPredictionTokens
@@ -694,6 +699,7 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
             minP = options.minP
             repetitionPenalty = options.repetitionPenalty
             seed = options.seed
+            singleLine = options.singleLine
         }
     }
 }

--- a/Cotabby/Services/Runtime/MlxRuntimeCore.swift
+++ b/Cotabby/Services/Runtime/MlxRuntimeCore.swift
@@ -1,0 +1,530 @@
+import Foundation
+import Logging
+import MLX
+import MLXLLM
+import MLXLMCommon
+import Tokenizers
+
+/// File overview:
+/// Owns MLX model lifecycle and the autocomplete KV-cache state.
+///
+/// This is the MLX counterpart to `LlamaRuntimeCore`: the manager publishes UI state, while this
+/// core owns backend correctness. The cache bookkeeping lives here because prompt tokens, sampled
+/// tokens, and backend cache objects must stay in lockstep; spreading that across UI-facing types
+/// would make cancellation and stale-cache bugs much easier to introduce.
+nonisolated final class MlxRuntimeCore: @unchecked Sendable {
+    private var preparedRuntime: PreparedMlxRuntime?
+    private var modelContainer: ModelContainer?
+    private var autocompleteCache: [KVCache]?
+
+    private let autocompleteLock = NSLock()
+    private var autocompletePromptBytes: [UInt8] = []
+    private var autocompletePromptTokens: [Int] = []
+    private var autocompleteSamplingFingerprint: String?
+
+    private var autocompleteCacheIsPresent = false
+
+    private let lifecycleCondition = NSCondition()
+    private var activeOperationCount = 0
+    private var isShuttingDown = false
+
+    func prepare(
+        resolvedRuntime: ResolvedMlxRuntime,
+        configuration: MlxRuntimeConfiguration
+    ) async throws -> PreparedMlxRuntime {
+        if let preparedRuntime,
+           preparedRuntime.resolvedRuntime.modelDirectoryURL == resolvedRuntime.modelDirectoryURL {
+            return preparedRuntime
+        }
+
+        if preparedRuntime != nil {
+            shutdown()
+        }
+
+        CotabbyLogger.runtime.info(
+            "Loading MLX model",
+            metadata: [
+                "model_id": .string(resolvedRuntime.modelID),
+                "model_path": .string(resolvedRuntime.modelDirectoryURL.path),
+                "prefill_step_size": .stringConvertible(configuration.prefillStepSize),
+                "max_kv_size": .string(configuration.maxKVSize.map(String.init) ?? "none"),
+                "kv_bits": .string(configuration.kvBits.map(String.init) ?? "none")
+            ]
+        )
+
+        do {
+            // Importing `MLXLLM` above registers its model factory trampoline. Loading still happens
+            // from Cotabby's local snapshot directory, so generation remains local after download.
+            let container = try await loadModelContainer(
+                from: resolvedRuntime.modelDirectoryURL,
+                using: MlxLocalTokenizerLoader()
+            )
+            let contextWindowTokens = Self.contextWindowTokens(in: resolvedRuntime.modelDirectoryURL)
+            let preparedRuntime = PreparedMlxRuntime(
+                resolvedRuntime: resolvedRuntime,
+                backendName: "MLX Swift LM",
+                contextWindowTokens: contextWindowTokens,
+                maxKVSize: configuration.maxKVSize,
+                kvBits: configuration.kvBits,
+                prefillStepSize: configuration.prefillStepSize
+            )
+
+            modelContainer = container
+            self.preparedRuntime = preparedRuntime
+            resetPromptCache()
+            CotabbyLogger.runtime.info(
+                "MLX model loaded",
+                metadata: [
+                    "model_id": .string(resolvedRuntime.modelID),
+                    "backend": .string(preparedRuntime.backendName),
+                    "context_window_tokens": .string(contextWindowTokens.map(String.init) ?? "unknown")
+                ]
+            )
+            return preparedRuntime
+        } catch is CancellationError {
+            throw MlxRuntimeError.cancelled
+        } catch let error as MlxRuntimeError {
+            throw error
+        } catch {
+            throw MlxRuntimeError.unavailable(
+                "Unable to load MLX model from \(resolvedRuntime.modelDirectoryURL.path): \(error.localizedDescription)"
+            )
+        }
+    }
+
+    func generate(
+        prompt: String,
+        cachedPrefixBytes: Int?,
+        options: LlamaGenerationOptions,
+        configuration: MlxRuntimeConfiguration
+    ) async throws -> String {
+        guard let preparedRuntime, let modelContainer else {
+            throw MlxRuntimeError.unavailable("The MLX model is not loaded.")
+        }
+
+        lifecycleCondition.lock()
+        guard !isShuttingDown else {
+            lifecycleCondition.unlock()
+            throw MlxRuntimeError.unavailable("The MLX runtime is shutting down.")
+        }
+        activeOperationCount += 1
+        lifecycleCondition.unlock()
+
+        defer {
+            lifecycleCondition.lock()
+            activeOperationCount -= 1
+            lifecycleCondition.broadcast()
+            lifecycleCondition.unlock()
+        }
+
+        let promptBytes = Array(prompt.utf8)
+        let allPromptTokens = await modelContainer.encode(prompt)
+        guard !allPromptTokens.isEmpty else {
+            CotabbyLogger.runtime.error(
+                "MLX tokenization returned no prompt tokens",
+                metadata: ["prompt_bytes": .stringConvertible(promptBytes.count)]
+            )
+            throw MlxRuntimeError.generationFailed("MLX tokenization returned no prompt tokens.")
+        }
+
+        let maxPromptTokens = preparedRuntime.contextWindowTokens.map {
+            max(1, $0 - options.maxPredictionTokens)
+        }
+        let promptTokens: [Int]
+        let adjustedCachedPrefixBytes: Int?
+        if let maxPromptTokens, allPromptTokens.count > maxPromptTokens {
+            promptTokens = Array(allPromptTokens.suffix(maxPromptTokens))
+            adjustedCachedPrefixBytes = nil
+        } else {
+            promptTokens = allPromptTokens
+            adjustedCachedPrefixBytes = cachedPrefixBytes
+        }
+
+        CotabbyLogger.runtime.debug(
+            "MLX decode start",
+            metadata: [
+                "prompt_tokens": .stringConvertible(promptTokens.count),
+                "max_tokens": .stringConvertible(options.maxPredictionTokens),
+                "cached_prefix_bytes": .string(adjustedCachedPrefixBytes.map(String.init) ?? "none")
+            ]
+        )
+
+        let fingerprint = samplingFingerprint(options: options, configuration: configuration)
+        let generationParameters = Self.generateParameters(options: options, configuration: configuration)
+
+        autocompleteLock.lock()
+        defer { autocompleteLock.unlock() }
+
+        let preparedPrompt = preparePromptCache(
+            promptTokens: promptTokens,
+            promptBytes: promptBytes,
+            fingerprint: fingerprint,
+            cachedPrefixBytes: adjustedCachedPrefixBytes
+        )
+        logCacheDecision(preparedPrompt.decision)
+
+        let generated = try await modelContainer.perform { context in
+            let cache = autocompleteCache ?? context.model.newCache(parameters: generationParameters)
+            autocompleteCache = cache
+            // Tokens must be a 1-D (L,) array: MLX Swift LM adds the batch axis itself inside its
+            // decode loop (`model(previous[text: .newAxis], …)`). Pre-adding `[.newAxis]` here would
+            // double-batch the prompt, collapsing the hidden-state shape and aborting the first
+            // attention matmul (`[quantized_matmul] … does not match …`). Every canonical
+            // `LMInput(tokens:)` usage in mlx-swift-lm passes the bare `MLXArray(tokens)`.
+            let input = LMInput(tokens: MLXArray(preparedPrompt.inputTokens))
+            let stream = try generateTokens(
+                input: input,
+                cache: cache,
+                parameters: generationParameters,
+                context: context
+            )
+            return try await Self.collectGeneratedText(
+                stream: stream,
+                tokenizer: context.tokenizer,
+                options: options
+            )
+        }
+
+        if let autocompleteCache, generated.tokensGenerated > 0 {
+            _ = trimPromptCache(autocompleteCache, numTokens: generated.tokensGenerated)
+        }
+
+        autocompletePromptBytes = promptBytes
+        autocompletePromptTokens = promptTokens
+        autocompleteSamplingFingerprint = fingerprint
+        autocompleteCacheIsPresent = autocompleteCache != nil
+
+        CotabbyLogger.runtime.debug(
+            "MLX decode end",
+            metadata: [
+                "tokens_generated": .stringConvertible(generated.tokensGenerated),
+                "chars_generated": .stringConvertible(generated.text.count),
+                "stop_reason": .string(generated.stopReason)
+            ]
+        )
+
+        return generated.text
+    }
+
+    func resetPromptCache() {
+        autocompleteLock.lock()
+        defer { autocompleteLock.unlock() }
+        resetPromptCacheLocked()
+    }
+
+    func shutdown(timeoutSeconds: TimeInterval? = nil) {
+        CotabbyLogger.runtime.info(
+            "MLX runtime shutdown requested",
+            metadata: [
+                "timeout_seconds": .string(timeoutSeconds.map { String(format: "%.1f", $0) } ?? "unbounded")
+            ]
+        )
+        lifecycleCondition.lock()
+        isShuttingDown = true
+
+        if let timeoutSeconds {
+            let deadline = Date(timeIntervalSinceNow: timeoutSeconds)
+            while activeOperationCount > 0 {
+                if !lifecycleCondition.wait(until: deadline) { break }
+            }
+        } else {
+            while activeOperationCount > 0 {
+                lifecycleCondition.wait()
+            }
+        }
+        lifecycleCondition.unlock()
+
+        resetPromptCache()
+        preparedRuntime = nil
+        modelContainer = nil
+        CotabbyLogger.runtime.info("MLX runtime shutdown complete")
+
+        lifecycleCondition.lock()
+        isShuttingDown = false
+        lifecycleCondition.unlock()
+    }
+
+    private var cacheIsTrimmable: Bool {
+        guard let autocompleteCache else { return false }
+        return canTrimPromptCache(autocompleteCache)
+    }
+
+    private func resetPromptCacheLocked() {
+        autocompletePromptBytes = []
+        autocompletePromptTokens = []
+        autocompleteSamplingFingerprint = nil
+        autocompleteCache = nil
+        autocompleteCacheIsPresent = false
+        CotabbyLogger.runtime.debug("MLX prompt cache reset")
+    }
+
+    private func logCacheDecision(_ decision: MlxPromptCacheDecision) {
+        switch decision.action {
+        case .fresh(let reason):
+            CotabbyLogger.runtime.debug(
+                "MLX cache fresh prefill",
+                metadata: ["cache_reset_reason": .string(reason)]
+            )
+        case .reuse(let commonPrefixTokens):
+            CotabbyLogger.runtime.debug(
+                "MLX cache reuse",
+                metadata: ["cache_reuse_tokens": .stringConvertible(commonPrefixTokens)]
+            )
+        }
+    }
+
+    private func samplingFingerprint(
+        options: LlamaGenerationOptions,
+        configuration: MlxRuntimeConfiguration
+    ) -> String {
+        [
+            String(options.maxPredictionTokens),
+            String(options.temperature),
+            String(options.topK),
+            String(options.topP),
+            String(options.minP),
+            String(options.repetitionPenalty),
+            String(options.seed ?? 0),
+            String(configuration.maxKVSize ?? -1),
+            String(configuration.kvBits ?? -1),
+            String(configuration.prefillStepSize)
+        ].joined(separator: "|")
+    }
+
+    private struct PreparedPromptCacheInput: Sendable {
+        let decision: MlxPromptCacheDecision
+        let inputTokens: [Int]
+    }
+
+    private func preparePromptCache(
+        promptTokens: [Int],
+        promptBytes: [UInt8],
+        fingerprint: String,
+        cachedPrefixBytes: Int?
+    ) -> PreparedPromptCacheInput {
+        let decision = MlxPromptCachePlanner.decision(
+            cachedTokens: autocompletePromptTokens,
+            newTokens: promptTokens,
+            cachedFingerprint: autocompleteSamplingFingerprint,
+            newFingerprint: fingerprint,
+            cacheIsTrimmable: cacheIsTrimmable
+        )
+
+        guard case .reuse(let commonPrefixTokens) = decision.action,
+              let cachedPrefixBytes, cachedPrefixBytes > 0,
+              Self.commonPrefixCount(autocompletePromptBytes, promptBytes) > 0,
+              let autocompleteCache
+        else {
+            resetPromptCacheLocked()
+            return PreparedPromptCacheInput(decision: decision, inputTokens: promptTokens)
+        }
+
+        // MLX's generator consumes input tokens against the cache. If the cache already contains the
+        // full prompt, keep all but the final token and replay that last token so the next-token
+        // logits are produced from a valid autoregressive step rather than an empty input.
+        let maxReusableTokenCount = max(0, promptTokens.count - 1)
+        let reusableTokenCount = min(commonPrefixTokens, maxReusableTokenCount)
+        let tokensToTrim = max(0, autocompletePromptTokens.count - reusableTokenCount)
+        if tokensToTrim > 0 {
+            let trimmed = trimPromptCache(autocompleteCache, numTokens: tokensToTrim)
+            if trimmed != tokensToTrim {
+                resetPromptCacheLocked()
+                return PreparedPromptCacheInput(
+                    decision: MlxPromptCacheDecision(action: .fresh(reason: "cache_trim_failed")),
+                    inputTokens: promptTokens
+                )
+            }
+        }
+
+        return PreparedPromptCacheInput(
+            decision: decision,
+            inputTokens: Array(promptTokens[reusableTokenCount...])
+        )
+    }
+
+    private static func generateParameters(
+        options: LlamaGenerationOptions,
+        configuration: MlxRuntimeConfiguration
+    ) -> GenerateParameters {
+        GenerateParameters(
+            maxTokens: options.maxPredictionTokens,
+            maxKVSize: configuration.maxKVSize,
+            kvBits: configuration.kvBits,
+            temperature: Float(options.temperature),
+            topP: Float(options.topP),
+            topK: options.topK,
+            minP: Float(options.minP),
+            repetitionPenalty: options.repetitionPenalty == 1 ? nil : Float(options.repetitionPenalty),
+            prefillStepSize: configuration.prefillStepSize
+        )
+    }
+
+    private struct GeneratedText: Sendable {
+        let text: String
+        let tokensGenerated: Int
+        let stopReason: String
+    }
+
+    private static func collectGeneratedText(
+        stream: AsyncStream<TokenGeneration>,
+        tokenizer: any MLXLMCommon.Tokenizer,
+        options: LlamaGenerationOptions
+    ) async throws -> GeneratedText {
+        var generatedText = ""
+        var tokensGenerated = 0
+        var stopReason = "budget_exhausted"
+        var detokenizer = NaiveStreamingDetokenizer(tokenizer: tokenizer)
+
+        for await event in stream {
+            try Task.checkCancellation()
+
+            switch event {
+            case .token(let token):
+                tokensGenerated += 1
+                detokenizer.append(token: token)
+                guard let piece = detokenizer.next() else {
+                    continue
+                }
+                generatedText += piece
+
+                if options.singleLine, generatedText.contains(where: \.isNewline) {
+                    generatedText = String(generatedText.prefix { !$0.isNewline })
+                    stopReason = "newline"
+                    return GeneratedText(
+                        text: generatedText,
+                        tokensGenerated: tokensGenerated,
+                        stopReason: stopReason
+                    )
+                }
+
+                if DecodeStopPolicy.shouldStop(
+                    accumulated: generatedText,
+                    tokensGenerated: tokensGenerated,
+                    minimumTokens: options.sentenceStopMinimumTokens
+                ) {
+                    stopReason = "sentence_boundary"
+                    return GeneratedText(
+                        text: generatedText,
+                        tokensGenerated: tokensGenerated,
+                        stopReason: stopReason
+                    )
+                }
+            case .info(let info):
+                stopReason = Self.stopReasonDescription(info.stopReason)
+                return GeneratedText(
+                    text: generatedText,
+                    tokensGenerated: info.generationTokenCount,
+                    stopReason: stopReason
+                )
+            }
+        }
+
+        return GeneratedText(
+            text: generatedText,
+            tokensGenerated: tokensGenerated,
+            stopReason: stopReason
+        )
+    }
+
+    private static func stopReasonDescription(_ reason: GenerateStopReason) -> String {
+        switch reason {
+        case .stop:
+            return "eos"
+        case .length:
+            return "budget_exhausted"
+        case .cancelled:
+            return "cancelled"
+        }
+    }
+
+    private static func commonPrefixCount<Element: Equatable>(_ lhs: [Element], _ rhs: [Element]) -> Int {
+        var index = 0
+        let limit = min(lhs.count, rhs.count)
+        while index < limit, lhs[index] == rhs[index] {
+            index += 1
+        }
+        return index
+    }
+
+    private static func contextWindowTokens(in modelDirectoryURL: URL) -> Int? {
+        let configURL = modelDirectoryURL.appendingPathComponent("config.json")
+        guard let data = try? Data(contentsOf: configURL),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return nil
+        }
+
+        let keys = [
+            "max_position_embeddings",
+            "model_max_length",
+            "max_sequence_length",
+            "seq_length",
+            "n_positions"
+        ]
+        for key in keys {
+            if let value = object[key] as? Int {
+                return value
+            }
+            if let value = object[key] as? NSNumber {
+                return value.intValue
+            }
+        }
+        return nil
+    }
+}
+
+/// Bridges Swift Transformers tokenizers into MLX Swift LM's small tokenizer protocol.
+///
+/// MLX ships macros that generate this adapter, but Xcode command-line builds require explicit
+/// macro approval. Keeping the bridge as ordinary Swift preserves the same runtime behavior while
+/// avoiding a build-time trust prompt for Cotabby contributors and CI.
+private struct MlxLocalTokenizerLoader: MLXLMCommon.TokenizerLoader {
+    func load(from directory: URL) async throws -> any MLXLMCommon.Tokenizer {
+        let upstream = try await Tokenizers.AutoTokenizer.from(modelFolder: directory)
+        return MlxTokenizerBridge(upstream)
+    }
+}
+
+private struct MlxTokenizerBridge: MLXLMCommon.Tokenizer {
+    private let upstream: any Tokenizers.Tokenizer
+
+    init(_ upstream: any Tokenizers.Tokenizer) {
+        self.upstream = upstream
+    }
+
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+        upstream.encode(text: text, addSpecialTokens: addSpecialTokens)
+    }
+
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+        upstream.decode(tokens: tokenIds, skipSpecialTokens: skipSpecialTokens)
+    }
+
+    func convertTokenToId(_ token: String) -> Int? {
+        upstream.convertTokenToId(token)
+    }
+
+    func convertIdToToken(_ id: Int) -> String? {
+        upstream.convertIdToToken(id)
+    }
+
+    var bosToken: String? { upstream.bosToken }
+    var eosToken: String? { upstream.eosToken }
+    var unknownToken: String? { upstream.unknownToken }
+
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] {
+        do {
+            return try upstream.applyChatTemplate(
+                messages: messages,
+                tools: tools,
+                additionalContext: additionalContext
+            )
+        } catch Tokenizers.TokenizerError.missingChatTemplate {
+            throw MLXLMCommon.TokenizerError.missingChatTemplate
+        }
+    }
+}

--- a/Cotabby/Services/Runtime/MlxRuntimeCore.swift
+++ b/Cotabby/Services/Runtime/MlxRuntimeCore.swift
@@ -17,7 +17,12 @@ nonisolated final class MlxRuntimeCore: @unchecked Sendable {
     private var modelContainer: ModelContainer?
     private var autocompleteCache: [KVCache]?
 
-    private let autocompleteLock = NSLock()
+    /// Serializes the whole cache-backed decode without relying on thread ownership.
+    ///
+    /// Generation suspends while MLX produces tokens and may resume on another cooperative-pool
+    /// thread. Unlike `NSLock`, a semaphore may be signalled from that different thread, so it is
+    /// safe to hold across the `await` while still preventing overlapping cache mutations.
+    private let autocompleteSemaphore = DispatchSemaphore(value: 1)
     private var autocompletePromptBytes: [UInt8] = []
     private var autocompletePromptTokens: [Int] = []
     private var autocompleteSamplingFingerprint: String?
@@ -152,8 +157,9 @@ nonisolated final class MlxRuntimeCore: @unchecked Sendable {
         let fingerprint = samplingFingerprint(options: options, configuration: configuration)
         let generationParameters = Self.generateParameters(options: options, configuration: configuration)
 
-        autocompleteLock.lock()
-        defer { autocompleteLock.unlock() }
+        autocompleteSemaphore.wait()
+        defer { autocompleteSemaphore.signal() }
+        try Task.checkCancellation()
 
         let preparedPrompt = preparePromptCache(
             promptTokens: promptTokens,
@@ -163,26 +169,35 @@ nonisolated final class MlxRuntimeCore: @unchecked Sendable {
         )
         logCacheDecision(preparedPrompt.decision)
 
-        let generated = try await modelContainer.perform { context in
-            let cache = autocompleteCache ?? context.model.newCache(parameters: generationParameters)
-            autocompleteCache = cache
-            // Tokens must be a 1-D (L,) array: MLX Swift LM adds the batch axis itself inside its
-            // decode loop (`model(previous[text: .newAxis], …)`). Pre-adding `[.newAxis]` here would
-            // double-batch the prompt, collapsing the hidden-state shape and aborting the first
-            // attention matmul (`[quantized_matmul] … does not match …`). Every canonical
-            // `LMInput(tokens:)` usage in mlx-swift-lm passes the bare `MLXArray(tokens)`.
-            let input = LMInput(tokens: MLXArray(preparedPrompt.inputTokens))
-            let stream = try generateTokens(
-                input: input,
-                cache: cache,
-                parameters: generationParameters,
-                context: context
-            )
-            return try await Self.collectGeneratedText(
-                stream: stream,
-                tokenizer: context.tokenizer,
-                options: options
-            )
+        let generated: GeneratedText
+        do {
+            generated = try await modelContainer.perform { context in
+                let cache = autocompleteCache ?? context.model.newCache(parameters: generationParameters)
+                autocompleteCache = cache
+                // Tokens must be a 1-D (L,) array: MLX Swift LM adds the batch axis itself inside its
+                // decode loop (`model(previous[text: .newAxis], …)`). Pre-adding `[.newAxis]` here would
+                // double-batch the prompt, collapsing the hidden-state shape and aborting the first
+                // attention matmul (`[quantized_matmul] … does not match …`). Every canonical
+                // `LMInput(tokens:)` usage in mlx-swift-lm passes the bare `MLXArray(tokens)`.
+                let input = LMInput(tokens: MLXArray(preparedPrompt.inputTokens))
+                let stream = try generateTokens(
+                    input: input,
+                    cache: cache,
+                    parameters: generationParameters,
+                    context: context
+                )
+                return try await Self.collectGeneratedText(
+                    stream: stream,
+                    tokenizer: context.tokenizer,
+                    options: options
+                )
+            }
+        } catch {
+            // MLX mutates the cache as it evaluates prompt and generated tokens. If generation is
+            // cancelled or throws, the exact processed depth is unavailable, so retaining the old
+            // prompt metadata would make the next reuse decision trim against a different cache.
+            resetPromptCacheLocked()
+            throw error
         }
 
         if let autocompleteCache, generated.tokensGenerated > 0 {
@@ -207,8 +222,8 @@ nonisolated final class MlxRuntimeCore: @unchecked Sendable {
     }
 
     func resetPromptCache() {
-        autocompleteLock.lock()
-        defer { autocompleteLock.unlock() }
+        autocompleteSemaphore.wait()
+        defer { autocompleteSemaphore.signal() }
         resetPromptCacheLocked()
     }
 

--- a/Cotabby/Services/Runtime/MlxRuntimeManager.swift
+++ b/Cotabby/Services/Runtime/MlxRuntimeManager.swift
@@ -1,0 +1,285 @@
+import Combine
+import Foundation
+import Logging
+
+/// File overview:
+/// Publishes MLX runtime bootstrap state and user-facing diagnostics.
+///
+/// The manager is `@MainActor` because SwiftUI observes it. Heavy work is delegated to
+/// `MlxRuntimeCore` on detached tasks, preserving the same ownership pattern as the llama runtime:
+/// UI state here, backend correctness in the core.
+@MainActor
+final class MlxRuntimeManager: ObservableObject {
+    @Published private(set) var state: RuntimeBootstrapState = .idle
+    @Published private(set) var diagnostics = MlxRuntimeDiagnostics()
+    @Published private(set) var availableModels: [MlxRuntimeModelOption] = []
+
+    private let configuration: MlxRuntimeConfiguration
+    private let runtimeLocator: MlxRuntimeLocator
+    private let core: MlxRuntimeCore
+    private var startupTask: Task<PreparedMlxRuntime, Error>?
+    private var startupModelID: String?
+    private var cachedRuntime: PreparedMlxRuntime?
+    private var selectedModelID: String?
+
+    var currentModelID: String? {
+        selectedModelID
+    }
+
+    convenience init() {
+        self.init(
+            configuration: .default,
+            runtimeLocator: MlxRuntimeLocator()
+        )
+    }
+
+    init(
+        configuration: MlxRuntimeConfiguration,
+        runtimeLocator: MlxRuntimeLocator
+    ) {
+        self.configuration = configuration
+        self.runtimeLocator = runtimeLocator
+        core = MlxRuntimeCore()
+        refreshAvailableModels()
+    }
+
+    func refreshAvailableModels() {
+        availableModels = runtimeLocator.availableModels(configuration: configuration)
+        selectedModelID = normalizedModelID(selectedModelID)
+        CotabbyLogger.runtime.info("Discovered \(self.availableModels.count) MLX model(s)")
+    }
+
+    func configureSelectedModel(id: String?) {
+        selectedModelID = normalizedModelID(id)
+        CotabbyLogger.runtime.info("Configured selected MLX model: \(self.selectedModelID ?? "none")")
+    }
+
+    func prepare() async throws {
+        _ = try await preparedRuntime()
+    }
+
+    func selectModel(id: String) async throws {
+        CotabbyLogger.runtime.info("Selecting MLX model: \(id)")
+        guard let normalizedID = normalizedModelID(id) else {
+            let error = MlxRuntimeError.unavailable("The selected MLX model \(id) is unavailable.")
+            diagnostics.lastError = error.localizedDescription
+            throw error
+        }
+
+        selectedModelID = normalizedID
+
+        if cachedRuntime?.resolvedRuntime.modelID == normalizedID {
+            return
+        }
+
+        startupTask?.cancel()
+        startupTask = nil
+        startupModelID = nil
+        cachedRuntime = nil
+
+        _ = try await preparedRuntime()
+    }
+
+    func generate(
+        prompt: String,
+        cachedPrefixBytes: Int? = nil,
+        options: LlamaGenerationOptions
+    ) async throws -> String {
+        _ = try await preparedRuntime()
+        let core = self.core
+        let configuration = self.configuration
+
+        do {
+            let task = Task.detached {
+                try await core.generate(
+                    prompt: prompt,
+                    cachedPrefixBytes: cachedPrefixBytes,
+                    options: options,
+                    configuration: configuration
+                )
+            }
+            return try await withTaskCancellationHandler {
+                let partial = try await task.value
+                try Task.checkCancellation()
+                return partial
+            } onCancel: {
+                task.cancel()
+            }
+        } catch is CancellationError {
+            CotabbyLogger.runtime.debug("MLX generation cancelled")
+            throw MlxRuntimeError.cancelled
+        } catch let error as MlxRuntimeError {
+            CotabbyLogger.runtime.error("MLX generation runtime error: \(error.localizedDescription)")
+            diagnostics.lastError = error.localizedDescription
+            throw error
+        } catch {
+            CotabbyLogger.runtime.error("MLX generation failed: \(error.localizedDescription)")
+            let runtimeError = MlxRuntimeError.generationFailed(error.localizedDescription)
+            diagnostics.lastError = runtimeError.localizedDescription
+            throw runtimeError
+        }
+    }
+
+    func resetPromptCache() {
+        core.resetPromptCache()
+        diagnostics.lastCacheStatus = "Reset"
+    }
+
+    func stop() {
+        CotabbyLogger.runtime.info("MLX runtime stop requested")
+        prepareForStop()
+        Task.detached { [core] in
+            core.shutdown()
+        }
+    }
+
+    func stopAndWait() async {
+        prepareForStop()
+        await Task.detached { [core] in
+            core.shutdown()
+        }.value
+    }
+
+    func shutdownSync(timeoutSeconds: TimeInterval) {
+        prepareForStop()
+        core.shutdown(timeoutSeconds: timeoutSeconds)
+    }
+
+    private func prepareForStop() {
+        startupTask?.cancel()
+        startupTask = nil
+        startupModelID = nil
+        cachedRuntime = nil
+
+        diagnostics.lastLoadStatus = "Stopped"
+        state = .idle
+    }
+
+    private func preparedRuntime() async throws -> PreparedMlxRuntime {
+        let resolvedRuntime = try resolveSelectedRuntime()
+        let requestedModelID = resolvedRuntime.modelID
+
+        if let cachedRuntime,
+           cachedRuntime.resolvedRuntime.modelDirectoryURL == resolvedRuntime.modelDirectoryURL {
+            CotabbyLogger.runtime.trace("Using cached MLX runtime for \(requestedModelID)")
+            return cachedRuntime
+        }
+
+        if let startupTask {
+            if startupModelID == requestedModelID {
+                CotabbyLogger.runtime.debug("Reusing in-flight MLX startup for \(requestedModelID)")
+                return try await awaitPreparedRuntime(startupTask)
+            }
+
+            CotabbyLogger.runtime.info("MLX model changed to \(requestedModelID), cancelling previous startup")
+            startupTask.cancel()
+            self.startupTask = nil
+            startupModelID = nil
+        }
+
+        cachedRuntime = nil
+        state = .starting("Initializing the in-process MLX runtime.")
+        diagnostics.lastError = nil
+        diagnostics.lastLoadStatus = "Starting"
+        diagnostics.modelDirectoryPath = resolvedRuntime.modelDirectoryURL.path
+        diagnostics.runtimeDirectoryPath = resolvedRuntime.runtimeDirectoryURL.path
+
+        let startupTask = Task.detached { [core, configuration] in
+            try await core.prepare(
+                resolvedRuntime: resolvedRuntime,
+                configuration: configuration
+            )
+        }
+        self.startupTask = startupTask
+        startupModelID = requestedModelID
+        CotabbyLogger.runtime.info("Loading MLX \(resolvedRuntime.modelDisplayName) into memory")
+        state = .loading("Loading \(resolvedRuntime.modelDisplayName) into MLX.")
+
+        return try await awaitPreparedRuntime(startupTask)
+    }
+
+    private func resolveSelectedRuntime() throws -> ResolvedMlxRuntime {
+        do {
+            return try runtimeLocator.resolve(
+                configuration: configuration,
+                selectedModelID: selectedModelID
+            )
+        } catch {
+            let runtimeError = MlxRuntimeError.unavailable(error.localizedDescription)
+            diagnostics.lastError = runtimeError.localizedDescription
+            diagnostics.lastLoadStatus = "Failed"
+            state = .failed(runtimeError.localizedDescription)
+            throw runtimeError
+        }
+    }
+
+    private func normalizedModelID(_ id: String?) -> String? {
+        guard !availableModels.isEmpty else {
+            return nil
+        }
+
+        guard let id else {
+            return availableModels.first?.id
+        }
+
+        if availableModels.contains(where: { $0.id == id }) {
+            return id
+        }
+
+        return availableModels.first?.id
+    }
+
+    private func awaitPreparedRuntime(
+        _ startupTask: Task<PreparedMlxRuntime, Error>
+    ) async throws -> PreparedMlxRuntime {
+        do {
+            let preparedRuntime = try await startupTask.value
+            cachedRuntime = preparedRuntime
+            apply(preparedRuntime)
+            self.startupTask = nil
+            startupModelID = nil
+            return preparedRuntime
+        } catch is CancellationError {
+            self.startupTask = nil
+            startupModelID = nil
+            throw MlxRuntimeError.cancelled
+        } catch let error as MlxRuntimeError {
+            self.startupTask = nil
+            startupModelID = nil
+            diagnostics.lastError = error.localizedDescription
+            diagnostics.lastLoadStatus = "Failed"
+            state = .failed(error.localizedDescription)
+            throw error
+        } catch {
+            self.startupTask = nil
+            startupModelID = nil
+            let runtimeError = MlxRuntimeError.unavailable(error.localizedDescription)
+            diagnostics.lastError = runtimeError.localizedDescription
+            diagnostics.lastLoadStatus = "Failed"
+            state = .failed(runtimeError.localizedDescription)
+            throw runtimeError
+        }
+    }
+
+    private func apply(_ preparedRuntime: PreparedMlxRuntime) {
+        let model = preparedRuntime.resolvedRuntime.modelDisplayName
+        CotabbyLogger.runtime.info(
+            "MLX runtime ready: model=\(model)",
+            metadata: ["backend": .string(preparedRuntime.backendName)]
+        )
+        diagnostics.runtimeDirectoryPath = preparedRuntime.resolvedRuntime.runtimeDirectoryURL.path
+        diagnostics.modelDirectoryPath = preparedRuntime.resolvedRuntime.modelDirectoryURL.path
+        diagnostics.backendName = preparedRuntime.backendName
+        diagnostics.contextWindowTokens = preparedRuntime.contextWindowTokens
+        diagnostics.maxKVSize = preparedRuntime.maxKVSize
+        diagnostics.kvBits = preparedRuntime.kvBits
+        diagnostics.prefillStepSize = preparedRuntime.prefillStepSize
+        diagnostics.lastLoadStatus = "Loaded"
+        diagnostics.lastError = nil
+        diagnostics.lastCacheStatus = "Ready"
+
+        state = .ready("Loaded \(preparedRuntime.resolvedRuntime.modelDisplayName) with MLX.")
+    }
+}
+
+extension MlxRuntimeManager: MlxRuntimeGenerating {}

--- a/Cotabby/Services/Runtime/MlxSuggestionEngine.swift
+++ b/Cotabby/Services/Runtime/MlxSuggestionEngine.swift
@@ -1,0 +1,241 @@
+import CoreGraphics
+import Foundation
+import Logging
+
+/// File overview:
+/// Adapts the MLX runtime to Cotabby's inline-completion pipeline.
+///
+/// The runtime manager speaks in prompts and backend options. The suggestion engine speaks in
+/// `SuggestionRequest` and `SuggestionResult`, so it owns prompt-cache hints, normalization,
+/// logging, and error vocabulary. This mirrors the llama path and keeps the coordinator unaware of
+/// concrete backend details.
+@MainActor
+final class MlxSuggestionEngine {
+    private let runtimeManager: MlxRuntimeGenerating
+    private var promptCacheHintTracker = MlxPromptCacheHintTracker()
+
+    init(runtimeManager: MlxRuntimeGenerating) {
+        self.runtimeManager = runtimeManager
+    }
+
+    func generateSuggestion(for request: SuggestionRequest) async throws -> SuggestionResult {
+        let baseMetadata: Logger.Metadata = [
+            "request_id": .string(request.requestID),
+            "engine": .string("mlx")
+        ]
+        do {
+            let startTime = Date()
+            let cachedPrefixBytes = promptCacheHintTracker.cachedPrefixBytes(for: request)
+            let hintDesc = cachedPrefixBytes.map(String.init) ?? "none"
+            CotabbyLogger.suggestion.debug(
+                "MLX generating",
+                metadata: baseMetadata.merging([
+                    "prompt_bytes": .stringConvertible(request.prompt.utf8.count),
+                    "cache_hint_bytes": .string(hintDesc),
+                    "max_tokens": .stringConvertible(request.maxPredictionTokens)
+                ]) { _, new in new }
+            )
+
+            let rawSuggestion = try await runtimeManager.generate(
+                prompt: request.prompt,
+                cachedPrefixBytes: cachedPrefixBytes,
+                options: LlamaGenerationOptions(
+                    maxPredictionTokens: request.maxPredictionTokens,
+                    temperature: request.temperature,
+                    topK: request.topK,
+                    topP: request.topP,
+                    minP: request.minP,
+                    repetitionPenalty: request.repetitionPenalty,
+                    seed: request.randomSeed,
+                    singleLine: !request.isMultiLineEnabled,
+                    forceWordContinuation: MidWordContinuationPolicy.shouldForceContinuation(
+                        precedingText: request.context.precedingText,
+                        trailingText: request.context.trailingText
+                    )
+                )
+            )
+            try Task.checkCancellation()
+
+            promptCacheHintTracker.recordSuccessfulRequest(request)
+            let normalization = SuggestionTextNormalizer.normalizeDetailed(rawSuggestion, for: request)
+            let normalizedSuggestion = normalization.text
+            let latency = Date().timeIntervalSince(startTime)
+            let latencyMs = Int(latency * 1000)
+            let suppressionReason = normalization.suppression?.rawValue ?? "none"
+
+            CotabbyLogger.suggestion.debug(
+                "MLX generated",
+                metadata: baseMetadata.merging([
+                    "raw_chars": .stringConvertible(rawSuggestion.count),
+                    "normalized_chars": .stringConvertible(normalizedSuggestion.count),
+                    "suppression_reason": .string(suppressionReason),
+                    "latency_ms": .stringConvertible(latencyMs)
+                ]) { _, new in new }
+            )
+            CotabbyLogger.llmIO.debug(
+                "mlx generation",
+                metadata: baseMetadata.merging([
+                    "prompt": .string(request.prompt),
+                    "completion_raw": .string(rawSuggestion),
+                    "completion_normalized": .string(normalizedSuggestion),
+                    "prompt_bytes": .stringConvertible(request.prompt.utf8.count),
+                    "raw_chars": .stringConvertible(rawSuggestion.count),
+                    "normalized_chars": .stringConvertible(normalizedSuggestion.count),
+                    "suppression_reason": .string(suppressionReason),
+                    "latency_ms": .stringConvertible(latencyMs),
+                    "cache_hint_bytes": .string(hintDesc),
+                    "max_tokens": .stringConvertible(request.maxPredictionTokens)
+                ]) { _, new in new }
+            )
+
+            return SuggestionResult(
+                generation: request.generation,
+                rawText: rawSuggestion,
+                text: normalizedSuggestion,
+                latency: latency
+            )
+        } catch is CancellationError {
+            CotabbyLogger.suggestion.debug("MLX generation cancelled", metadata: baseMetadata)
+            throw SuggestionClientError.cancelled
+        } catch MlxRuntimeError.cancelled {
+            CotabbyLogger.suggestion.debug("MLX generation cancelled (runtime task)", metadata: baseMetadata)
+            throw SuggestionClientError.cancelled
+        } catch let error as MlxRuntimeError {
+            CotabbyLogger.suggestion.error(
+                "MLX runtime error, resetting cache: \(error.localizedDescription)",
+                metadata: baseMetadata
+            )
+            await resetCachedGenerationContext()
+            throw SuggestionClientError.unavailable(error.localizedDescription)
+        } catch let error as SuggestionClientError {
+            CotabbyLogger.suggestion.error(
+                "MLX suggestion client error, resetting cache: \(error.localizedDescription)",
+                metadata: baseMetadata
+            )
+            await resetCachedGenerationContext()
+            throw error
+        } catch {
+            CotabbyLogger.suggestion.error(
+                "Unexpected MLX generation error, resetting cache: \(error.localizedDescription)",
+                metadata: baseMetadata
+            )
+            await resetCachedGenerationContext()
+            throw SuggestionClientError.generationFailed(error.localizedDescription)
+        }
+    }
+
+    func resetCachedGenerationContext() async {
+        promptCacheHintTracker.reset()
+        runtimeManager.resetPromptCache()
+    }
+}
+
+extension MlxSuggestionEngine: SuggestionGenerating {}
+
+/// Tracks the previous successful MLX request so the engine can advertise a byte-prefix reuse hint
+/// to `MlxRuntimeManager`. The runtime still validates token-level reuse after tokenization; this
+/// Swift-side hint is just a cheap way to skip work when the editing context obviously changed.
+struct MlxPromptCacheHintTracker: Equatable {
+    private var lastRequest: CachedRequest?
+
+    mutating func cachedPrefixBytes(for request: SuggestionRequest) -> Int? {
+        let nextRequest = CachedRequest(request: request)
+        guard let lastRequest else {
+            return nil
+        }
+
+        guard lastRequest.focusKey == nextRequest.focusKey,
+              lastRequest.samplingFingerprint == nextRequest.samplingFingerprint
+        else {
+            self.lastRequest = nil
+            return nil
+        }
+
+        return MlxPromptCachePlanner.commonPrefixCount(lastRequest.promptBytes, nextRequest.promptBytes)
+    }
+
+    mutating func recordSuccessfulRequest(_ request: SuggestionRequest) {
+        lastRequest = CachedRequest(request: request)
+    }
+
+    mutating func reset() {
+        lastRequest = nil
+    }
+}
+
+private extension MlxPromptCacheHintTracker {
+    struct CachedRequest: Equatable {
+        let focusKey: FocusKey
+        let samplingFingerprint: SamplingFingerprint
+        let promptBytes: [UInt8]
+
+        init(request: SuggestionRequest) {
+            focusKey = FocusKey(context: request.context)
+            samplingFingerprint = SamplingFingerprint(request: request)
+            promptBytes = Array(request.prompt.utf8)
+        }
+    }
+
+    struct FocusKey: Equatable {
+        let bundleIdentifier: String
+        let processIdentifier: Int32
+        let role: String
+        let subrole: String?
+        let fieldAnchor: FieldAnchor
+
+        init(context: FocusedInputContext) {
+            bundleIdentifier = context.bundleIdentifier
+            processIdentifier = context.processIdentifier
+            role = context.role
+            subrole = context.subrole
+            fieldAnchor = FieldAnchor(
+                inputFrame: context.inputFrameRect,
+                fallbackElementIdentifier: context.elementIdentifier
+            )
+        }
+    }
+
+    struct FieldAnchor: Equatable {
+        let roundedInputFrame: RoundedRect?
+        let fallbackElementIdentifier: String?
+
+        nonisolated init(inputFrame: CGRect?, fallbackElementIdentifier: String) {
+            roundedInputFrame = inputFrame.map(RoundedRect.init(rect:))
+            self.fallbackElementIdentifier = roundedInputFrame == nil ? fallbackElementIdentifier : nil
+        }
+    }
+
+    struct RoundedRect: Equatable {
+        let minX: Int
+        let minY: Int
+        let width: Int
+        let height: Int
+
+        nonisolated init(rect: CGRect) {
+            minX = Int(rect.minX.rounded())
+            minY = Int(rect.minY.rounded())
+            width = Int(rect.width.rounded())
+            height = Int(rect.height.rounded())
+        }
+    }
+
+    struct SamplingFingerprint: Equatable {
+        let maxPredictionTokens: Int
+        let temperature: Double
+        let topK: Int
+        let topP: Double
+        let minP: Double
+        let repetitionPenalty: Double
+        let randomSeed: UInt32?
+
+        init(request: SuggestionRequest) {
+            maxPredictionTokens = request.maxPredictionTokens
+            temperature = request.temperature
+            topK = request.topK
+            topP = request.topP
+            minP = request.minP
+            repetitionPenalty = request.repetitionPenalty
+            randomSeed = request.randomSeed
+        }
+    }
+}

--- a/Cotabby/Services/Runtime/SuggestionEngineRouter.swift
+++ b/Cotabby/Services/Runtime/SuggestionEngineRouter.swift
@@ -10,27 +10,33 @@ final class SuggestionEngineRouter {
     private let suggestionSettings: SuggestionSettingsModel
     private let foundationModelEngine: any SuggestionGenerating
     private let llamaEngine: any SuggestionGenerating
+    private let mlxEngine: any SuggestionGenerating
     private let performanceMetricsStore: PerformanceMetricsStore
     private let qualityMetricsStore: SuggestionQualityMetricsStore
     /// Closure that returns the currently selected llama model filename (e.g. `Qwen3-0.6B-Q8_0.gguf`).
     /// A closure instead of a direct `LlamaRuntimeManager` reference keeps the router from depending
     /// on the concrete runtime type — useful for tests that want to fake the model label.
     private let llamaModelNameProvider: @MainActor () -> String?
+    private let mlxModelNameProvider: @MainActor () -> String?
 
     init(
         suggestionSettings: SuggestionSettingsModel,
         foundationModelEngine: any SuggestionGenerating,
         llamaEngine: any SuggestionGenerating,
+        mlxEngine: any SuggestionGenerating,
         performanceMetricsStore: PerformanceMetricsStore,
         qualityMetricsStore: SuggestionQualityMetricsStore,
-        llamaModelNameProvider: @escaping @MainActor () -> String?
+        llamaModelNameProvider: @escaping @MainActor () -> String?,
+        mlxModelNameProvider: @escaping @MainActor () -> String?
     ) {
         self.suggestionSettings = suggestionSettings
         self.foundationModelEngine = foundationModelEngine
         self.llamaEngine = llamaEngine
+        self.mlxEngine = mlxEngine
         self.performanceMetricsStore = performanceMetricsStore
         self.qualityMetricsStore = qualityMetricsStore
         self.llamaModelNameProvider = llamaModelNameProvider
+        self.mlxModelNameProvider = mlxModelNameProvider
     }
 
     func generateSuggestion(for request: SuggestionRequest) async throws -> SuggestionResult {
@@ -73,6 +79,11 @@ final class SuggestionEngineRouter {
             recordPerformanceMetric(modelName: llamaModelNameProvider() ?? "Llama", latency: result.latency)
             recordQualityOutcome(result)
             return result
+        case .mlx:
+            CotabbyLogger.suggestion.debug("Routing to MLX engine", metadata: metadata)
+            let result = try await mlxEngine.generateSuggestion(for: request)
+            recordPerformanceMetric(modelName: mlxModelNameProvider() ?? "MLX", latency: result.latency)
+            return result
         }
     }
 
@@ -104,6 +115,8 @@ final class SuggestionEngineRouter {
             return "apple_intelligence"
         case .llamaOpenSource:
             return "llama"
+        case .mlx:
+            return "mlx"
         }
     }
 
@@ -113,6 +126,7 @@ final class SuggestionEngineRouter {
     func resetCachedGenerationContext() async {
         await foundationModelEngine.resetCachedGenerationContext()
         await llamaEngine.resetCachedGenerationContext()
+        await mlxEngine.resetCachedGenerationContext()
     }
 
     /// Forwards the warmup hook only to the currently selected engine. The inactive backend has
@@ -124,6 +138,8 @@ final class SuggestionEngineRouter {
             await foundationModelEngine.prewarm(for: request)
         case .llamaOpenSource:
             await llamaEngine.prewarm(for: request)
+        case .mlx:
+            await mlxEngine.prewarm(for: request)
         }
     }
 

--- a/Cotabby/Services/Utilities/ModelDownloadManager.swift
+++ b/Cotabby/Services/Utilities/ModelDownloadManager.swift
@@ -59,6 +59,7 @@ final class ModelDownloadManager: ObservableObject {
     var onModelDirectoryChanged: (() -> Void)?
 
     private let runtimeDirectoryURL: URL
+    private let mlxRuntimeDirectoryURL: URL
     private var runtimeSearchDirectories: [URL]
     /// GGUF filenames discovered across every search directory, recomputed whenever the search set
     /// or on-disk contents change. Cached so the per-catalog-model install check in
@@ -70,6 +71,7 @@ final class ModelDownloadManager: ObservableObject {
         let primaryDirectoryURL =
             runtimeDirectoryURL ?? BundledRuntimeLocator.userRuntimeDirectoryURL()
         self.runtimeDirectoryURL = primaryDirectoryURL
+        self.mlxRuntimeDirectoryURL = MlxRuntimeLocator.userRuntimeDirectoryURL()
         runtimeSearchDirectories = Self.resolveSearchDirectories(primary: primaryDirectoryURL)
 
         refreshModelStates()
@@ -97,6 +99,12 @@ final class ModelDownloadManager: ObservableObject {
     /// are read-only and surfaced only through the model picker, not this control.
     var modelsDirectoryPath: String {
         runtimeDirectoryURL.path
+    }
+
+    /// Separate MLX snapshot directory. MLX models are folders rather than single GGUF files, so the
+    /// path is surfaced independently to keep the user's mental model clear.
+    var mlxModelsDirectoryPath: String {
+        mlxRuntimeDirectoryURL.path
     }
 
     /// Re-reads the current search directories (including the LM Studio source when toggled) and
@@ -210,6 +218,20 @@ final class ModelDownloadManager: ObservableObject {
         }
 
         NSWorkspace.shared.open(runtimeDirectoryURL)
+    }
+
+    func openMlxModelsDirectory() {
+        do {
+            try ensureDirectoryExists(mlxRuntimeDirectoryURL)
+        } catch {
+            CotabbyLogger.models.error(
+                "Failed to ensure MLX runtime directory before opening: \(error.localizedDescription)",
+                metadata: ["directory": .string(mlxRuntimeDirectoryURL.path)]
+            )
+            return
+        }
+
+        NSWorkspace.shared.open(mlxRuntimeDirectoryURL)
     }
 
     func importModel() {
@@ -390,8 +412,12 @@ final class ModelDownloadManager: ObservableObject {
     }
 
     private func ensureRuntimeDirectoryExists() throws {
+        try ensureDirectoryExists(runtimeDirectoryURL)
+    }
+
+    private func ensureDirectoryExists(_ directoryURL: URL) throws {
         try FileManager.default.createDirectory(
-            at: runtimeDirectoryURL,
+            at: directoryURL,
             withIntermediateDirectories: true
         )
     }

--- a/Cotabby/Support/MlxRuntimeLocator.swift
+++ b/Cotabby/Support/MlxRuntimeLocator.swift
@@ -1,0 +1,277 @@
+import Foundation
+
+/// File overview:
+/// Discovers locally installed MLX model snapshots from user-writable storage.
+///
+/// This boundary is intentionally pure filesystem logic. It does not load MLX, create tokenizers, or
+/// publish UI state. That keeps model discovery deterministic and testable while leaving runtime
+/// lifecycle decisions to `MlxRuntimeManager`.
+
+enum MlxRuntimeLocatorError: LocalizedError {
+    case runtimeDirectoryMissing(String)
+    case modelMissing(String)
+    case namedModelMissing(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .runtimeDirectoryMissing(let path):
+            return "MLX runtime directory is missing at \(path)."
+        case .modelMissing(let path):
+            return "No MLX model snapshot was found at \(path)."
+        case .namedModelMissing(let modelID):
+            return "The MLX model \(modelID) was not found."
+        }
+    }
+}
+
+struct MlxRuntimeLocator {
+    private struct RuntimeCandidate {
+        let runtimeDirectoryURL: URL
+        let modelDirectoryURL: URL
+    }
+
+    static let runtimeFolderName = "MlxRuntime"
+
+    let bundle: Bundle
+
+    init(bundle: Bundle = .main) {
+        self.bundle = bundle
+    }
+
+    /// Returns the user-writable MLX runtime directory used for snapshot imports/downloads.
+    static func userRuntimeDirectoryURL(bundle: Bundle = .main) -> URL {
+        let appSupportRoot =
+            FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+        let appFolderName =
+            (bundle.object(forInfoDictionaryKey: "CFBundleName") as? String) ?? "Cotabby"
+        return
+            appSupportRoot
+            .appendingPathComponent(appFolderName, isDirectory: true)
+            .appendingPathComponent(Self.runtimeFolderName, isDirectory: true)
+    }
+
+    /// Finds model snapshot directories that look loadable by MLX Swift LM.
+    ///
+    /// A valid snapshot needs `config.json`, at least one tokenizer file, and at least one weight
+    /// file. We intentionally avoid deep semantic validation here; the runtime load path remains the
+    /// authority for architecture/tokenizer correctness.
+    static func discoverModelSnapshotURLs(in directoryURL: URL, maxDepth: Int = 3) -> [URL] {
+        let fileManager = FileManager.default
+        guard let enumerator = fileManager.enumerator(
+            at: directoryURL,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles, .skipsPackageDescendants]
+        ) else {
+            return []
+        }
+
+        var results: [URL] = []
+        for case let url as URL in enumerator {
+            if enumerator.level > maxDepth {
+                enumerator.skipDescendants()
+                continue
+            }
+            guard (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true else {
+                continue
+            }
+            if isModelSnapshotDirectory(url) {
+                results.append(url)
+                enumerator.skipDescendants()
+            }
+        }
+        return results
+    }
+
+    static func isModelSnapshotDirectory(_ directoryURL: URL) -> Bool {
+        let fileManager = FileManager.default
+        let configURL = directoryURL.appendingPathComponent("config.json", isDirectory: false)
+        guard fileManager.fileExists(atPath: configURL.path) else {
+            return false
+        }
+
+        let tokenizerNames = [
+            "tokenizer.json",
+            "tokenizer.model",
+            "vocab.json"
+        ]
+        let hasTokenizer = tokenizerNames.contains { name in
+            fileManager.fileExists(
+                atPath: directoryURL.appendingPathComponent(name, isDirectory: false).path
+            )
+        }
+        guard hasTokenizer else {
+            return false
+        }
+
+        guard let contents = try? fileManager.contentsOfDirectory(
+            at: directoryURL,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return false
+        }
+
+        return contents.contains { url in
+            let ext = url.pathExtension.lowercased()
+            let name = url.lastPathComponent.lowercased()
+            return ext == "safetensors" || ext == "npz" || name.hasSuffix(".bin")
+        }
+    }
+
+    func resolve(configuration: MlxRuntimeConfiguration) throws -> ResolvedMlxRuntime {
+        try resolve(configuration: configuration, selectedModelID: nil)
+    }
+
+    func resolve(
+        configuration: MlxRuntimeConfiguration,
+        selectedModelID: String?
+    ) throws -> ResolvedMlxRuntime {
+        var lastError: Error?
+
+        for candidate in runtimeCandidates(for: configuration) {
+            do {
+                let modelOptions = try availableModels(
+                    candidate: candidate,
+                    preferredModelIDs: configuration.preferredModelIDs
+                )
+                let selectedOption: MlxRuntimeModelOption
+                if let selectedModelID {
+                    guard let matchingOption = modelOptions.first(where: { $0.id == selectedModelID }) else {
+                        throw MlxRuntimeLocatorError.namedModelMissing(selectedModelID)
+                    }
+                    selectedOption = matchingOption
+                } else if let firstOption = modelOptions.first {
+                    selectedOption = firstOption
+                } else {
+                    throw MlxRuntimeLocatorError.modelMissing(candidate.modelDirectoryURL.path)
+                }
+
+                return resolvedRuntime(from: selectedOption, candidate: candidate)
+            } catch {
+                lastError = error
+            }
+        }
+
+        throw lastError
+            ?? MlxRuntimeLocatorError.runtimeDirectoryMissing("No MLX runtime candidates were available.")
+    }
+
+    func availableModels(configuration: MlxRuntimeConfiguration) -> [MlxRuntimeModelOption] {
+        var merged: [MlxRuntimeModelOption] = []
+        var seenIDs = Set<String>()
+
+        for candidate in runtimeCandidates(for: configuration) {
+            guard let modelOptions = try? availableModels(
+                candidate: candidate,
+                preferredModelIDs: configuration.preferredModelIDs
+            ) else {
+                continue
+            }
+
+            for option in modelOptions where seenIDs.insert(option.id).inserted {
+                merged.append(option)
+            }
+        }
+
+        return merged
+    }
+
+    private func runtimeCandidates(for configuration: MlxRuntimeConfiguration) -> [RuntimeCandidate] {
+        if let runtimeDirectoryPath = configuration.runtimeDirectoryPath,
+           !runtimeDirectoryPath.isEmpty {
+            let runtimeDirectoryURL = URL(fileURLWithPath: runtimeDirectoryPath, isDirectory: true)
+            return [
+                RuntimeCandidate(
+                    runtimeDirectoryURL: runtimeDirectoryURL,
+                    modelDirectoryURL: runtimeDirectoryURL
+                )
+            ]
+        }
+
+        let userDir = Self.userRuntimeDirectoryURL(bundle: bundle)
+        return [
+            RuntimeCandidate(
+                runtimeDirectoryURL: userDir,
+                modelDirectoryURL: userDir
+            )
+        ]
+    }
+
+    private func availableModels(
+        candidate: RuntimeCandidate,
+        preferredModelIDs: [String]
+    ) throws -> [MlxRuntimeModelOption] {
+        let fileManager = FileManager.default
+        var isDirectory = ObjCBool(false)
+
+        guard
+            fileManager.fileExists(atPath: candidate.runtimeDirectoryURL.path, isDirectory: &isDirectory),
+            isDirectory.boolValue
+        else {
+            throw MlxRuntimeLocatorError.runtimeDirectoryMissing(candidate.runtimeDirectoryURL.path)
+        }
+
+        let discoveredURLs = Self.discoverModelSnapshotURLs(in: candidate.modelDirectoryURL)
+        guard !discoveredURLs.isEmpty else {
+            throw MlxRuntimeLocatorError.modelMissing(candidate.modelDirectoryURL.path)
+        }
+
+        var optionsByID: [String: MlxRuntimeModelOption] = [:]
+        for url in discoveredURLs {
+            let modelID = modelID(for: url, relativeTo: candidate.modelDirectoryURL)
+            guard optionsByID[modelID] == nil else { continue }
+            optionsByID[modelID] = MlxRuntimeModelOption(id: modelID, url: url)
+        }
+
+        var ordered: [MlxRuntimeModelOption] = []
+        var seenIDs = Set<String>()
+        for preferredID in preferredModelIDs {
+            guard let option = optionsByID[preferredID],
+                  seenIDs.insert(preferredID).inserted
+            else {
+                continue
+            }
+            ordered.append(option)
+        }
+
+        let sortedDiscovered = optionsByID.values.sorted {
+            $0.id.localizedCaseInsensitiveCompare($1.id) == .orderedAscending
+        }
+        for option in sortedDiscovered where seenIDs.insert(option.id).inserted {
+            ordered.append(option)
+        }
+
+        guard !ordered.isEmpty else {
+            throw MlxRuntimeLocatorError.modelMissing(candidate.modelDirectoryURL.path)
+        }
+        return ordered
+    }
+
+    /// Preserves common Hugging Face nesting (`publisher/repo`) as the model ID while still
+    /// supporting a flat imported folder by using the final directory name.
+    private func modelID(for modelURL: URL, relativeTo rootURL: URL) -> String {
+        let rootPath = rootURL.standardizedFileURL.path
+        let modelPath = modelURL.standardizedFileURL.path
+        guard modelPath.hasPrefix(rootPath) else {
+            return modelURL.lastPathComponent
+        }
+
+        let suffix = modelPath.dropFirst(rootPath.count).trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        return suffix.isEmpty ? modelURL.lastPathComponent : suffix
+    }
+
+    private func resolvedRuntime(
+        from modelOption: MlxRuntimeModelOption,
+        candidate: RuntimeCandidate
+    ) -> ResolvedMlxRuntime {
+        ResolvedMlxRuntime(
+            runtimeDirectoryURL: candidate.runtimeDirectoryURL,
+            modelDirectoryURL: modelOption.url,
+            modelID: modelOption.id,
+            modelDisplayName: modelOption.displayName
+        )
+    }
+}

--- a/Cotabby/Support/OnboardingTemplateRecommender.swift
+++ b/Cotabby/Support/OnboardingTemplateRecommender.swift
@@ -29,9 +29,9 @@ enum OnboardingTemplateRecommender {
         engine: SuggestionEngineKind
     ) -> ResolvedTemplatePlan {
         let model: DownloadableRuntimeModel? =
-            engine == .appleIntelligence
-            ? nil
-            : downloadableModel(filename: template.openSourceModelFilename)
+            engine == .llamaOpenSource
+            ? downloadableModel(filename: template.openSourceModelFilename)
+            : nil
 
         return ResolvedTemplatePlan(
             template: template,
@@ -87,14 +87,15 @@ enum OnboardingTemplateRecommender {
     }
 
     /// The single tier to highlight as the safe default under the chosen engine. Apple Intelligence
-    /// has no size cost, so Everyday is the obvious balance; on Open Source we keep low-memory Macs
-    /// on Quick and everyone else on Everyday. Powerful is never the default — it is an opt-in for
-    /// users who deliberately want the big model.
+    /// has no size cost, so Everyday is the obvious balance; MLX is not offered in onboarding yet,
+    /// so it follows that no-download default if selected programmatically. On Open Source we keep
+    /// low-memory Macs on Quick and everyone else on Everyday. Powerful is never the default — it is
+    /// an opt-in for users who deliberately want the big model.
     static func recommendedTemplate(
         hardware: HardwareCapability,
         engine: SuggestionEngineKind
     ) -> OnboardingTemplate {
-        if engine == .appleIntelligence {
+        if engine == .appleIntelligence || engine == .mlx {
             return .everyday
         }
         if hardware.physicalMemoryGigabytes < everydayWarnBelowGigabytes {

--- a/Cotabby/Support/SettingsAttentionEvaluator.swift
+++ b/Cotabby/Support/SettingsAttentionEvaluator.swift
@@ -21,7 +21,7 @@ enum SettingsAttentionEvaluator {
         let foundationModelAvailable: Bool
         let foundationModelMessage: String
         let llamaRuntimeFailedReason: String?
-        var mlxRuntimeFailedReason: String? = nil
+        var mlxRuntimeFailedReason: String?
     }
 
     /// Returns the set of categories that should render an attention dot in the sidebar.

--- a/Cotabby/Support/SettingsAttentionEvaluator.swift
+++ b/Cotabby/Support/SettingsAttentionEvaluator.swift
@@ -21,6 +21,7 @@ enum SettingsAttentionEvaluator {
         let foundationModelAvailable: Bool
         let foundationModelMessage: String
         let llamaRuntimeFailedReason: String?
+        var mlxRuntimeFailedReason: String? = nil
     }
 
     /// Returns the set of categories that should render an attention dot in the sidebar.
@@ -38,6 +39,10 @@ enum SettingsAttentionEvaluator {
             }
         case .llamaOpenSource:
             if inputs.llamaRuntimeFailedReason != nil {
+                categories.insert(.engineAndModel)
+            }
+        case .mlx:
+            if inputs.mlxRuntimeFailedReason != nil {
                 categories.insert(.engineAndModel)
             }
         }
@@ -63,6 +68,10 @@ enum SettingsAttentionEvaluator {
                 return inputs.foundationModelMessage
             case .llamaOpenSource:
                 guard let reason = inputs.llamaRuntimeFailedReason,
+                      !reason.isEmpty else { return nil }
+                return reason
+            case .mlx:
+                guard let reason = inputs.mlxRuntimeFailedReason,
                       !reason.isEmpty else { return nil }
                 return reason
             }

--- a/Cotabby/Support/SuggestionRequestFactory.swift
+++ b/Cotabby/Support/SuggestionRequestFactory.swift
@@ -153,7 +153,7 @@ enum SuggestionRequestFactory {
         case .appleIntelligence:
             maxCharacters = configuration.maxPrefixCharactersFoundationModel
             maxWords = configuration.maxPrefixWordsFoundationModel
-        case .llamaOpenSource:
+        case .llamaOpenSource, .mlx:
             maxCharacters = configuration.maxPrefixCharacters
             maxWords = configuration.maxPrefixWords
         }
@@ -251,7 +251,7 @@ enum SuggestionRequestFactory {
         switch selectedEngine {
         case .appleIntelligence:
             return FoundationModelPromptRenderer.promptPreview(for: request)
-        case .llamaOpenSource:
+        case .llamaOpenSource, .mlx:
             return request.prompt
         }
     }

--- a/Cotabby/UI/MenuBarView.swift
+++ b/Cotabby/UI/MenuBarView.swift
@@ -16,6 +16,7 @@ import SwiftUI
 struct MenuBarView: View {
     @ObservedObject var permissionManager: PermissionManager
     @ObservedObject var runtimeModel: RuntimeBootstrapModel
+    @ObservedObject var mlxRuntimeModel: MlxRuntimeBootstrapModel
     @ObservedObject var modelDownloadManager: ModelDownloadManager
     @ObservedObject var focusModel: FocusTrackingModel
     let permissionGuidanceController: PermissionGuidanceController
@@ -45,6 +46,7 @@ struct MenuBarView: View {
             MenuBarPresentationObserver {
                 permissionManager.refresh()
                 runtimeModel.refreshAvailableModels()
+                mlxRuntimeModel.refreshAvailableModels()
             }
         )
         .background(
@@ -56,6 +58,7 @@ struct MenuBarView: View {
         .onAppear {
             permissionManager.refresh()
             runtimeModel.refreshAvailableModels()
+            mlxRuntimeModel.refreshAvailableModels()
         }
     }
 
@@ -172,8 +175,13 @@ struct MenuBarView: View {
                         .foregroundStyle(.orange)
                 }
 
-                if suggestionSettings.selectedEngine.supportsLocalModelManagement {
-                    modelRow
+                switch suggestionSettings.selectedEngine {
+                case .llamaOpenSource:
+                    llamaModelRow
+                case .mlx:
+                    mlxModelRow
+                case .appleIntelligence:
+                    EmptyView()
                 }
 
                 MenuBarPickerRow(title: "Length") {
@@ -203,7 +211,7 @@ struct MenuBarView: View {
     /// `.truncationMode` modifiers are unreliable here because AppKit's native popup ignores them
     /// for the selected-value label.
     @ViewBuilder
-    private var modelRow: some View {
+    private var llamaModelRow: some View {
         MenuBarPickerRow(title: "Model") {
             HStack(spacing: 6) {
                 if runtimeModel.availableModels.isEmpty {
@@ -234,6 +242,48 @@ struct MenuBarView: View {
                 Button {
                     modelDownloadManager.refreshModelStates()
                     runtimeModel.refreshAvailableModels()
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                }
+                .buttonStyle(.borderless)
+                .controlSize(.small)
+            }
+        }
+    }
+
+    /// MLX model selector. MLX models are snapshot directories, so the picker tags model IDs rather
+    /// than GGUF filenames.
+    @ViewBuilder
+    private var mlxModelRow: some View {
+        MenuBarPickerRow(title: "MLX Model") {
+            HStack(spacing: 6) {
+                if mlxRuntimeModel.availableModels.isEmpty {
+                    Text("No MLX models found")
+                        .foregroundStyle(.secondary)
+                        .font(.subheadline)
+                } else {
+                    Picker("MLX Model", selection: selectedMlxModelBinding) {
+                        ForEach(mlxRuntimeModel.availableModels) { model in
+                            Text(model.displayName)
+                                .tag(model.id)
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                    .frame(maxWidth: .infinity)
+                    .disabled(mlxRuntimePickerDisabled)
+                }
+
+                Button {
+                    modelDownloadManager.openMlxModelsDirectory()
+                } label: {
+                    Image(systemName: "folder")
+                }
+                .buttonStyle(.borderless)
+                .controlSize(.small)
+
+                Button {
+                    mlxRuntimeModel.refreshAvailableModels()
                 } label: {
                     Image(systemName: "arrow.clockwise")
                 }
@@ -450,8 +500,32 @@ struct MenuBarView: View {
         }
     }
 
+    private var selectedMlxModelBinding: Binding<String> {
+        Binding(
+            get: {
+                mlxRuntimeModel.selectedModelID
+                    ?? mlxRuntimeModel.availableModels.first?.id
+                    ?? ""
+            },
+            set: { modelID in
+                Task {
+                    await mlxRuntimeModel.selectModel(modelID)
+                }
+            }
+        )
+    }
+
     private var runtimePickerDisabled: Bool {
         switch runtimeModel.state {
+        case .starting, .loading:
+            return true
+        case .idle, .ready, .failed:
+            return false
+        }
+    }
+
+    private var mlxRuntimePickerDisabled: Bool {
+        switch mlxRuntimeModel.state {
         case .starting, .loading:
             return true
         case .idle, .ready, .failed:

--- a/Cotabby/UI/Onboarding/WelcomeTemplateStepView.swift
+++ b/Cotabby/UI/Onboarding/WelcomeTemplateStepView.swift
@@ -331,6 +331,8 @@ private struct TemplateCard: View {
         case .llamaOpenSource:
             guard let model = plan.modelToDownload else { return "Local model" }
             return "\(model.displayName) · \(model.approximateSizeLabel) download"
+        case .mlx:
+            return "MLX · local snapshot"
         }
     }
 

--- a/Cotabby/UI/Onboarding/WelcomeView.swift
+++ b/Cotabby/UI/Onboarding/WelcomeView.swift
@@ -517,6 +517,8 @@ extension WelcomeView {
                 return false
             }
             return state == .downloaded || state.isDownloading
+        case .mlx:
+            return true
         }
     }
 

--- a/Cotabby/UI/Settings/Panes/EngineAndModelPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/EngineAndModelPaneView.swift
@@ -10,6 +10,7 @@ struct EngineAndModelPaneView: View {
     @ObservedObject var suggestionSettings: SuggestionSettingsModel
     @ObservedObject var foundationModelAvailabilityService: FoundationModelAvailabilityService
     @ObservedObject var runtimeModel: RuntimeBootstrapModel
+    @ObservedObject var mlxRuntimeModel: MlxRuntimeBootstrapModel
     @ObservedObject var modelDownloadManager: ModelDownloadManager
     @ObservedObject var huggingFaceSearchService: HuggingFaceSearchService
 
@@ -49,6 +50,8 @@ struct EngineAndModelPaneView: View {
                 appleIntelligenceSections
             case .llamaOpenSource:
                 openSourceSections
+            case .mlx:
+                mlxSections
             }
         }
         .onAppear {
@@ -314,6 +317,101 @@ struct EngineAndModelPaneView: View {
         }
     }
 
+    // MARK: - MLX
+
+    @ViewBuilder
+    private var mlxSections: some View {
+        Section("Runtime") {
+            LabeledContent {
+                Text(mlxRuntimeModel.state.summary)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.trailing)
+                    .fixedSize(horizontal: false, vertical: true)
+            } label: {
+                SettingsRowLabel(
+                    title: "Status",
+                    description: "Whether the selected MLX snapshot is loaded and ready. " +
+                        "MLX uses Apple Silicon acceleration through the MLX Swift runtime."
+                )
+            }
+
+            if let cacheStatus = mlxRuntimeModel.diagnostics.lastCacheStatus {
+                LabeledContent("KV Cache") {
+                    Text(cacheStatus)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+
+        Section("MLX Models") {
+            Text("MLX models are local snapshot folders containing weights, config, and tokenizer files.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            if mlxRuntimeModel.availableModels.isEmpty {
+                Text("No MLX snapshots found. Add a snapshot folder below.")
+                    .foregroundStyle(.secondary)
+            } else {
+                Picker(selection: selectedMlxModelBinding) {
+                    ForEach(mlxRuntimeModel.availableModels) { model in
+                        Text(model.displayName).tag(model.id)
+                    }
+                } label: {
+                    SettingsRowLabel(
+                        title: "Selected MLX Model",
+                        description: "Which local MLX snapshot generates suggestions. " +
+                            "Larger models are slower but can produce stronger continuations."
+                    )
+                }
+            }
+        }
+
+        Section("Folder") {
+            LabeledContent("Path") {
+                VStack(alignment: .trailing, spacing: 8) {
+                    Text(modelDownloadManager.mlxModelsDirectoryPath)
+                        .font(.callout.monospaced())
+                        .textSelection(.enabled)
+                        .multilineTextAlignment(.trailing)
+
+                    HStack(spacing: 8) {
+                        Button("Open Folder") {
+                            modelDownloadManager.openMlxModelsDirectory()
+                        }
+
+                        Button("Refresh") {
+                            mlxRuntimeModel.refreshAvailableModels()
+                        }
+                    }
+                }
+            }
+        }
+
+        if !MlxRuntimeModelCatalog.downloadableModels.isEmpty {
+            Section("Recommended") {
+                ForEach(MlxRuntimeModelCatalog.downloadableModels) { model in
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(model.displayName)
+                            Text("\(model.repositoryID) · \(model.approximateSizeLabel)")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer(minLength: 0)
+                    }
+                }
+            }
+        }
+
+        if !mlxRuntimeModel.availableModels.isEmpty {
+            Section("Installed") {
+                ForEach(mlxRuntimeModel.availableModels) { model in
+                    installedMlxModelRow(model)
+                }
+            }
+        }
+    }
+
     @ViewBuilder
     private func installedModelRow(_ model: RuntimeModelOption) -> some View {
         HStack {
@@ -344,6 +442,28 @@ struct EngineAndModelPaneView: View {
         }
     }
 
+    @ViewBuilder
+    private func installedMlxModelRow(_ model: MlxRuntimeModelOption) -> some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(model.displayName)
+
+                if model.displayName != model.actualModelName {
+                    Text(model.actualModelName)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Spacer(minLength: 0)
+
+            if model.id == mlxRuntimeModel.selectedModelID {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.tint)
+            }
+        }
+    }
+
     // MARK: - Callout
 
     /// Surface the engine's failure mode at the top of the pane so it sits next to the controls
@@ -359,6 +479,9 @@ struct EngineAndModelPaneView: View {
             )
         case .llamaOpenSource:
             guard case .failed(let detail) = runtimeModel.state else { return nil }
+            return SettingsPaneCallout(tone: .warning, message: detail)
+        case .mlx:
+            guard case .failed(let detail) = mlxRuntimeModel.state else { return nil }
             return SettingsPaneCallout(tone: .warning, message: detail)
         }
     }
@@ -381,6 +504,19 @@ struct EngineAndModelPaneView: View {
             },
             set: { filename in
                 Task { await runtimeModel.selectModel(filename) }
+            }
+        )
+    }
+
+    private var selectedMlxModelBinding: Binding<String> {
+        Binding(
+            get: {
+                mlxRuntimeModel.selectedModelID
+                    ?? mlxRuntimeModel.availableModels.first?.id
+                    ?? ""
+            },
+            set: { modelID in
+                Task { await mlxRuntimeModel.selectModel(modelID) }
             }
         )
     }

--- a/Cotabby/UI/Settings/Panes/HomePaneView.swift
+++ b/Cotabby/UI/Settings/Panes/HomePaneView.swift
@@ -17,6 +17,7 @@ struct HomePaneView: View {
     @ObservedObject var permissionManager: PermissionManager
     @ObservedObject var foundationModelAvailabilityService: FoundationModelAvailabilityService
     @ObservedObject var runtimeModel: RuntimeBootstrapModel
+    @ObservedObject var mlxRuntimeModel: MlxRuntimeBootstrapModel
     let attentionCategories: Set<SettingsCategory>
 
     @State private var query = ""
@@ -325,6 +326,10 @@ struct HomePaneView: View {
             let selected = runtimeModel.availableModels
                 .first { $0.filename == runtimeModel.selectedModelFilename }
             return selected?.displayName ?? "No model selected"
+        case .mlx:
+            let selected = mlxRuntimeModel.availableModels
+                .first { $0.id == mlxRuntimeModel.selectedModelID }
+            return selected?.displayName ?? "No MLX model selected"
         }
     }
 

--- a/Cotabby/UI/Settings/SettingsContainerView.swift
+++ b/Cotabby/UI/Settings/SettingsContainerView.swift
@@ -19,6 +19,7 @@ struct SettingsContainerView: View {
     @ObservedObject var suggestionSettings: SuggestionSettingsModel
     @ObservedObject var foundationModelAvailabilityService: FoundationModelAvailabilityService
     @ObservedObject var runtimeModel: RuntimeBootstrapModel
+    @ObservedObject var mlxRuntimeModel: MlxRuntimeBootstrapModel
     @ObservedObject var modelDownloadManager: ModelDownloadManager
     @ObservedObject var huggingFaceSearchService: HuggingFaceSearchService
     @ObservedObject var performanceMetricsStore: PerformanceMetricsStore
@@ -96,7 +97,8 @@ struct SettingsContainerView: View {
                 selectedEngine: suggestionSettings.selectedEngine,
                 foundationModelAvailable: foundationModelAvailabilityService.isAvailable,
                 foundationModelMessage: foundationModelAvailabilityService.userVisibleMessage,
-                llamaRuntimeFailedReason: runtimeModel.state.failureDetail
+                llamaRuntimeFailedReason: runtimeModel.state.failureDetail,
+                mlxRuntimeFailedReason: mlxRuntimeModel.state.failureDetail
             )
         )
     }
@@ -111,6 +113,7 @@ struct SettingsContainerView: View {
                 permissionManager: permissionManager,
                 foundationModelAvailabilityService: foundationModelAvailabilityService,
                 runtimeModel: runtimeModel,
+                mlxRuntimeModel: mlxRuntimeModel,
                 attentionCategories: attentionCategories
             )
         case .general:
@@ -131,6 +134,7 @@ struct SettingsContainerView: View {
                 suggestionSettings: suggestionSettings,
                 foundationModelAvailabilityService: foundationModelAvailabilityService,
                 runtimeModel: runtimeModel,
+                mlxRuntimeModel: mlxRuntimeModel,
                 modelDownloadManager: modelDownloadManager,
                 huggingFaceSearchService: huggingFaceSearchService
             )

--- a/CotabbyTests/MlxRuntimeLocatorTests.swift
+++ b/CotabbyTests/MlxRuntimeLocatorTests.swift
@@ -1,0 +1,128 @@
+import XCTest
+@testable import Cotabby
+
+/// Tests the pure MLX runtime discovery and prompt-cache planning rules.
+///
+/// These belong in the test target rather than a runtime integration suite because neither concern
+/// needs Metal, tokenizers, or an actual model load. That boundary keeps the MLX storage contract
+/// easy to validate while the concrete backend adapter continues to evolve.
+final class MlxRuntimeLocatorTests: XCTestCase {
+    func test_discoverModelSnapshotURLs_requiresConfigTokenizerAndWeights() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let valid = root
+            .appendingPathComponent("mlx-community", isDirectory: true)
+            .appendingPathComponent("Tiny-4bit", isDirectory: true)
+        let missingTokenizer = root.appendingPathComponent("missing-tokenizer", isDirectory: true)
+        let missingWeights = root.appendingPathComponent("missing-weights", isDirectory: true)
+        try makeSnapshot(at: valid)
+        try makeSnapshot(at: missingTokenizer, includeTokenizer: false)
+        try makeSnapshot(at: missingWeights, includeWeights: false)
+
+        let discovered = MlxRuntimeLocator.discoverModelSnapshotURLs(in: root)
+
+        XCTAssertEqual(discovered.map(\.standardizedFileURL), [valid.standardizedFileURL])
+    }
+
+    func test_availableModels_preservesHuggingFaceStyleIDsAndPreferredOrder() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let qwen = root
+            .appendingPathComponent("mlx-community", isDirectory: true)
+            .appendingPathComponent("Qwen3-4B-4bit", isDirectory: true)
+        let gemma = root
+            .appendingPathComponent("mlx-community", isDirectory: true)
+            .appendingPathComponent("gemma-3-1b-it-qat-4bit", isDirectory: true)
+        try makeSnapshot(at: qwen)
+        try makeSnapshot(at: gemma)
+
+        let configuration = MlxRuntimeConfiguration(
+            runtimeDirectoryPath: root.path,
+            preferredModelIDs: ["mlx-community/gemma-3-1b-it-qat-4bit"],
+            maxKVSize: nil,
+            kvBits: nil,
+            prefillStepSize: 256
+        )
+
+        let models = MlxRuntimeLocator().availableModels(configuration: configuration)
+
+        XCTAssertEqual(
+            models.map(\.id),
+            [
+                "mlx-community/gemma-3-1b-it-qat-4bit",
+                "mlx-community/Qwen3-4B-4bit"
+            ]
+        )
+    }
+
+    func test_resolveUsesSelectedModelWhenAvailable() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let flatModel = root.appendingPathComponent("LocalModel", isDirectory: true)
+        try makeSnapshot(at: flatModel)
+        let configuration = MlxRuntimeConfiguration(
+            runtimeDirectoryPath: root.path,
+            preferredModelIDs: [],
+            maxKVSize: 1024,
+            kvBits: 4,
+            prefillStepSize: 128
+        )
+
+        let resolved = try MlxRuntimeLocator().resolve(
+            configuration: configuration,
+            selectedModelID: "LocalModel"
+        )
+
+        XCTAssertEqual(resolved.modelID, "LocalModel")
+        XCTAssertEqual(resolved.modelDirectoryURL.standardizedFileURL, flatModel.standardizedFileURL)
+    }
+
+    func test_promptCachePlanner_reusesSharedPrefixWhenSamplingMatches() {
+        let decision = MlxPromptCachePlanner.decision(
+            cachedTokens: [1, 2, 3, 4],
+            newTokens: [1, 2, 3, 9],
+            cachedFingerprint: "same",
+            newFingerprint: "same",
+            cacheIsTrimmable: true
+        )
+
+        XCTAssertEqual(decision.action, .reuse(commonPrefixTokens: 3))
+    }
+
+    func test_promptCachePlanner_usesFreshCacheWhenSamplingChanges() {
+        let decision = MlxPromptCachePlanner.decision(
+            cachedTokens: [1, 2, 3],
+            newTokens: [1, 2, 3],
+            cachedFingerprint: "old",
+            newFingerprint: "new",
+            cacheIsTrimmable: true
+        )
+
+        XCTAssertEqual(decision.action, .fresh(reason: "sampling_changed"))
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cotabby-mlx-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    private func makeSnapshot(
+        at directory: URL,
+        includeTokenizer: Bool = true,
+        includeWeights: Bool = true
+    ) throws {
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try Data("{}".utf8).write(to: directory.appendingPathComponent("config.json"))
+        if includeTokenizer {
+            try Data("{}".utf8).write(to: directory.appendingPathComponent("tokenizer.json"))
+        }
+        if includeWeights {
+            try Data([0x01, 0x02]).write(to: directory.appendingPathComponent("model.safetensors"))
+        }
+    }
+}

--- a/CotabbyTests/PromptPolicyTests.swift
+++ b/CotabbyTests/PromptPolicyTests.swift
@@ -307,9 +307,11 @@ final class SuggestionEngineRouterTests: XCTestCase {
             suggestionSettings: settings,
             foundationModelEngine: appleEngine,
             llamaEngine: openSourceEngine,
+            mlxEngine: StubSuggestionEngine(behavior: .success(fallbackResult)),
             performanceMetricsStore: PerformanceMetricsStore(userDefaults: makeUserDefaults()),
             qualityMetricsStore: SuggestionQualityMetricsStore(userDefaults: makeUserDefaults()),
-            llamaModelNameProvider: { nil }
+            llamaModelNameProvider: { nil },
+            mlxModelNameProvider: { nil }
         )
 
         let result = try await router.generateSuggestion(for: request)

--- a/CotabbyTests/SettingsAttentionEvaluatorTests.swift
+++ b/CotabbyTests/SettingsAttentionEvaluatorTests.swift
@@ -10,14 +10,16 @@ final class SettingsAttentionEvaluatorTests: XCTestCase {
         selectedEngine: SuggestionEngineKind = .llamaOpenSource,
         foundationModelAvailable: Bool = true,
         foundationModelMessage: String = "Apple Intelligence is available.",
-        llamaRuntimeFailedReason: String? = nil
+        llamaRuntimeFailedReason: String? = nil,
+        mlxRuntimeFailedReason: String? = nil
     ) -> SettingsAttentionEvaluator.Inputs {
         SettingsAttentionEvaluator.Inputs(
             permissionsGranted: permissionsGranted,
             selectedEngine: selectedEngine,
             foundationModelAvailable: foundationModelAvailable,
             foundationModelMessage: foundationModelMessage,
-            llamaRuntimeFailedReason: llamaRuntimeFailedReason
+            llamaRuntimeFailedReason: llamaRuntimeFailedReason,
+            mlxRuntimeFailedReason: mlxRuntimeFailedReason
         )
     }
 
@@ -67,6 +69,16 @@ final class SettingsAttentionEvaluatorTests: XCTestCase {
         XCTAssertEqual(categories, [.engineAndModel])
     }
 
+    func test_mlxRuntimeFailed_flagsEngineAndModel() {
+        let categories = SettingsAttentionEvaluator.categoriesNeedingAttention(
+            makeInputs(
+                selectedEngine: .mlx,
+                mlxRuntimeFailedReason: "MLX model failed to load."
+            )
+        )
+        XCTAssertEqual(categories, [.engineAndModel])
+    }
+
     func test_callout_permissions_returnsActionableMessage() {
         let message = SettingsAttentionEvaluator.calloutMessage(
             for: .permissions,
@@ -93,6 +105,15 @@ final class SettingsAttentionEvaluatorTests: XCTestCase {
         )
         let message = SettingsAttentionEvaluator.calloutMessage(for: .engineAndModel, inputs: inputs)
         XCTAssertEqual(message, "Couldn't open the GGUF file.")
+    }
+
+    func test_callout_engineAndModel_mlx_echoesRuntimeFailureReason() {
+        let inputs = makeInputs(
+            selectedEngine: .mlx,
+            mlxRuntimeFailedReason: "Couldn't open the MLX snapshot."
+        )
+        let message = SettingsAttentionEvaluator.calloutMessage(for: .engineAndModel, inputs: inputs)
+        XCTAssertEqual(message, "Couldn't open the MLX snapshot.")
     }
 
     func test_callout_engineAndModel_healthyEngine_isNil() {

--- a/CotabbyTests/SuggestionEngineModelsTests.swift
+++ b/CotabbyTests/SuggestionEngineModelsTests.swift
@@ -7,7 +7,7 @@ import XCTest
 final class SuggestionEngineModelsTests: XCTestCase {
     func test_suggestionEngineKind_displayLabelsArePinnedProductCopy() {
         XCTAssertEqual(SuggestionEngineKind.appleIntelligence.displayLabel, "Apple Intelligence")
-        XCTAssertEqual(SuggestionEngineKind.llamaOpenSource.displayLabel, "Open Source")
+        XCTAssertEqual(SuggestionEngineKind.llamaOpenSource.displayLabel, "Open Source (GGUF)")
     }
 
     func test_suggestionEngineKind_systemImageNamesArePinnedSharedGlyphs() {
@@ -18,7 +18,7 @@ final class SuggestionEngineModelsTests: XCTestCase {
     }
 
     func test_suggestionEngineKind_idMatchesRawValueForEveryCase() {
-        XCTAssertEqual(SuggestionEngineKind.allCases.count, 2)
+        XCTAssertEqual(SuggestionEngineKind.allCases.count, 3)
         for kind in SuggestionEngineKind.allCases {
             XCTAssertEqual(kind.id, kind.rawValue)
         }

--- a/CotabbyTests/SuggestionEngineRouterTests.swift
+++ b/CotabbyTests/SuggestionEngineRouterTests.swift
@@ -18,6 +18,7 @@ final class SuggestionEngineRouterRoutingTests: XCTestCase {
         let settings: SuggestionSettingsModel
         let foundation: ScriptedEngine
         let llama: ScriptedEngine
+        let mlx: ScriptedEngine
         let metrics: PerformanceMetricsStore
     }
 
@@ -51,7 +52,8 @@ final class SuggestionEngineRouterRoutingTests: XCTestCase {
     private func makeRig(
         engine: SuggestionEngineKind,
         performanceTracking: Bool = true,
-        llamaModelName: String? = "test-model.gguf"
+        llamaModelName: String? = "test-model.gguf",
+        mlxModelName: String? = "test-mlx-model"
     ) -> Rig {
         let suiteName = "cotabby.test.router.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
@@ -62,16 +64,19 @@ final class SuggestionEngineRouterRoutingTests: XCTestCase {
         let metrics = PerformanceMetricsStore(userDefaults: defaults)
         let foundation = ScriptedEngine()
         let llama = ScriptedEngine()
+        let mlx = ScriptedEngine()
         let router = SuggestionEngineRouter(
             suggestionSettings: settings,
             foundationModelEngine: foundation,
             llamaEngine: llama,
+            mlxEngine: mlx,
             performanceMetricsStore: metrics,
             qualityMetricsStore: SuggestionQualityMetricsStore(userDefaults: defaults),
-            llamaModelNameProvider: { llamaModelName }
+            llamaModelNameProvider: { llamaModelName },
+            mlxModelNameProvider: { mlxModelName }
         )
         Self.retained.append(contentsOf: [router, settings, metrics] as [AnyObject])
-        return Rig(router: router, settings: settings, foundation: foundation, llama: llama, metrics: metrics)
+        return Rig(router: router, settings: settings, foundation: foundation, llama: llama, mlx: mlx, metrics: metrics)
     }
 
     func test_appleIntelligenceSelection_routesToFoundationEngineAndRecordsMetric() async throws {
@@ -102,6 +107,17 @@ final class SuggestionEngineRouterRoutingTests: XCTestCase {
         _ = try await rig.router.generateSuggestion(for: CotabbyTestFixtures.suggestionRequest())
 
         XCTAssertEqual(rig.metrics.entries.first?.modelName, "Llama")
+    }
+
+    func test_mlxSelection_routesToMlxEngineAndRecordsTheModelName() async throws {
+        let rig = makeRig(engine: .mlx)
+
+        _ = try await rig.router.generateSuggestion(for: CotabbyTestFixtures.suggestionRequest())
+
+        XCTAssertEqual(rig.mlx.requests.count, 1)
+        XCTAssertTrue(rig.foundation.requests.isEmpty)
+        XCTAssertTrue(rig.llama.requests.isEmpty)
+        XCTAssertEqual(rig.metrics.entries.first?.modelName, "test-mlx-model")
     }
 
     func test_performanceTrackingOff_recordsNothing() async throws {
@@ -167,11 +183,19 @@ final class SuggestionEngineRouterRoutingTests: XCTestCase {
         await appleRig.router.prewarm(for: CotabbyTestFixtures.suggestionRequest())
         XCTAssertEqual(appleRig.foundation.prewarmCount, 1)
         XCTAssertEqual(appleRig.llama.prewarmCount, 0)
+        XCTAssertEqual(appleRig.mlx.prewarmCount, 0)
 
         let llamaRig = makeRig(engine: .llamaOpenSource)
         await llamaRig.router.prewarm(for: CotabbyTestFixtures.suggestionRequest())
         XCTAssertEqual(llamaRig.foundation.prewarmCount, 0)
         XCTAssertEqual(llamaRig.llama.prewarmCount, 1)
+        XCTAssertEqual(llamaRig.mlx.prewarmCount, 0)
+
+        let mlxRig = makeRig(engine: .mlx)
+        await mlxRig.router.prewarm(for: CotabbyTestFixtures.suggestionRequest())
+        XCTAssertEqual(mlxRig.foundation.prewarmCount, 0)
+        XCTAssertEqual(mlxRig.llama.prewarmCount, 0)
+        XCTAssertEqual(mlxRig.mlx.prewarmCount, 1)
     }
 
     func test_resetCachedGenerationContext_fansOutToBothEngines() async {
@@ -181,6 +205,7 @@ final class SuggestionEngineRouterRoutingTests: XCTestCase {
 
         XCTAssertEqual(rig.foundation.resetCount, 1)
         XCTAssertEqual(rig.llama.resetCount, 1, "Switching engines must not leave stale state behind")
+        XCTAssertEqual(rig.mlx.resetCount, 1, "Switching engines must not leave stale state behind")
     }
 
     func test_unavailableEngine_throwsItsConfiguredMessage() async {

--- a/CotabbyTests/SuggestionSettingsStoreTests.swift
+++ b/CotabbyTests/SuggestionSettingsStoreTests.swift
@@ -184,6 +184,16 @@ final class SuggestionSettingsStoreTests: XCTestCase {
         XCTAssertTrue(data.acceptanceKeyModifiers.isEmpty)
     }
 
+    func test_saveThenLoad_roundTripsMlxEngineSelection() async {
+        let defaults = makeIsolatedDefaults()
+        let store = SuggestionSettingsStore(userDefaults: defaults)
+
+        store.saveSelectedEngine(.mlx)
+
+        let data = store.load(configuration: .standard)
+        XCTAssertEqual(data.selectedEngine, .mlx)
+    }
+
     func test_load_clampsOutOfRangeGhostTextOpacity() async {
         let defaults = makeIsolatedDefaults()
         // Below the floor: must clamp up rather than render the suggestion invisible.

--- a/project.yml
+++ b/project.yml
@@ -8,6 +8,15 @@ options:
   groupSortPosition: top
   xcodeVersion: "2600"
 packages:
+  mlx-swift-lm:
+    url: https://github.com/ml-explore/mlx-swift-lm
+    from: 3.31.3
+  swift-huggingface:
+    url: https://github.com/huggingface/swift-huggingface
+    from: 0.9.0
+  swift-transformers:
+    url: https://github.com/huggingface/swift-transformers
+    from: 1.3.0
   Sparkle:
     url: https://github.com/sparkle-project/Sparkle
     exactVersion: 2.9.1

--- a/project.yml
+++ b/project.yml
@@ -121,6 +121,14 @@ targetTemplates:
         product: MLXLLM
       - package: mlx-swift-lm
         product: MLXLMCommon
+      - package: swift-transformers
+        product: Tokenizers
+      - package: swift-transformers
+        product: Hub
+      - package: swift-transformers
+        product: Generation
+      - package: swift-transformers
+        product: Models
     settings:
       base:
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon

--- a/project.yml
+++ b/project.yml
@@ -115,6 +115,8 @@ targetTemplates:
         product: Logging
       - package: LaunchAtLogin
         product: LaunchAtLogin
+      - package: mlx-swift-lm
+        product: MLX
     settings:
       base:
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon

--- a/project.yml
+++ b/project.yml
@@ -123,8 +123,6 @@ targetTemplates:
         product: MLXLMCommon
       - package: swift-transformers
         product: Tokenizers
-      - package: swift-transformers
-        product: Hub
     settings:
       base:
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon

--- a/project.yml
+++ b/project.yml
@@ -125,10 +125,6 @@ targetTemplates:
         product: Tokenizers
       - package: swift-transformers
         product: Hub
-      - package: swift-transformers
-        product: Generation
-      - package: swift-transformers
-        product: Models
     settings:
       base:
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon

--- a/project.yml
+++ b/project.yml
@@ -117,6 +117,10 @@ targetTemplates:
         product: LaunchAtLogin
       - package: mlx-swift-lm
         product: MLX
+      - package: mlx-swift-lm
+        product: MLXLLM
+      - package: mlx-swift-lm
+        product: MLXLMCommon
     settings:
       base:
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon


### PR DESCRIPTION
## Summary
- Add MLX model engine to run MLX models
- Add basic ui for switching to mlx engine in menu

## Follow ups:
- Refine UI
- HF search and download
- default models
- optimize and bug test

<!--
One or two sentences: what changed and why. Skip the play-by-play.
The diff already shows what; this section should explain why.
-->

## Validation

<!--
What you actually ran and what you actually saw, not what you intended to run.
Examples:

  xcodebuild test -project Cotabby.xcodeproj -scheme Cotabby \
    -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO
  # ** TEST SUCCEEDED **  N tests, 0 failures

  swiftlint lint --config .swiftlint.yml --quiet
  # exit 0

For UI changes, attach a screenshot or short screen recording.
For changes that can't be verified end-to-end yet, say so explicitly.
-->

## Linked issues

<!--
Use `Fixes #N` to auto-close on merge, `Refs #N` to link without closing.
-->

## Risk / rollout notes

<!--
Anything reviewers should know that isn't visible from the diff:
- Schema, settings, or pbxproj migrations
- Behavior changes that touch existing user flows
- Performance characteristics worth flagging
- Follow-up issues filed (link them)

Skip this section entirely if there's nothing to flag.
-->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an MLX engine backend to Cotabby, enabling local inference via Apple Silicon's MLX runtime. It introduces `MlxRuntimeCore`, `MlxRuntimeManager`, `MlxSuggestionEngine`, `MlxRuntimeBootstrapModel`, and `MlxRuntimeLocator` as a parallel stack to the existing Llama path, and wires the new engine into the router, settings UI, and menu bar.

- The core MLX runtime uses a `DispatchSemaphore` (correctly safe across `await` suspension) to serialize KV-cache mutations, with proper cache invalidation on cancellation and a careful prompt-token reuse planner.
- The menu bar engine picker's `selectedEngineBinding` setter maps any non-Apple-Intelligence engine pick to a `.llama(filename:)` power profile when power-based switching is on — so selecting \"MLX\" while that feature is enabled silently applies a Llama profile, causing the picker to immediately revert to \"Open Source (GGUF)\".
- The `PowerProfile` enum has no `.mlx` case, and `applyPowerProfile` has no MLX branch, confirming the power-switching integration is incomplete and that this path needs a guard or an explicit exclusion for MLX until it is added.

<h3>Confidence Score: 4/5</h3>

The change is safe to merge with the understanding that MLX and power-based model switching cannot both be used at the same time without a silent mismatch in the menu bar.

The menu bar engine picker actively applies a Llama power profile when the user picks MLX while power-based switching is on — the selection appears to succeed but immediately reverts, leaving the user on the wrong engine with no explanation. The rest of the MLX stack (core, manager, engine, locator, settings pane) is well-structured and follows the Llama patterns closely.

Cotabby/UI/MenuBarView.swift — the selectedEngineBinding setter; Cotabby/Services/Runtime/SuggestionEngineRouter.swift — ongoing gaps from prior review.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Services/Runtime/MlxRuntimeCore.swift | New file: owns MLX model loading, KV-cache state, and token generation. Uses DispatchSemaphore (correctly safe across await suspension) to serialize cache mutations. Cache reset on cancellation is handled. Duplicates commonPrefixCount from MlxPromptCachePlanner (flagged in prior review). |
| Cotabby/Services/Runtime/MlxRuntimeManager.swift | New file: MainActor-bound runtime manager; correctly mirrors the LlamaRuntimeManager cancel-and-restart pattern. Lifecycle transitions and error propagation look sound. |
| Cotabby/Services/Runtime/MlxSuggestionEngine.swift | New file: adapts MLX runtime to the suggestion pipeline. Prompt-cache hint tracker is clean. Error vocabulary and normalization match the Llama path. |
| Cotabby/Services/Runtime/SuggestionEngineRouter.swift | MLX case routes correctly but omits recordQualityOutcome and bypasses the onPartial streaming path (both flagged in prior review). No new issues beyond those. |
| Cotabby/Models/MlxRuntimeBootstrapModel.swift | New file: publishes lifecycle state and persists selected model ID. selectModel correctly cancels any in-flight task before launching a replacement. startIfNeeded guards on runtimeTask==nil. |
| Cotabby/UI/MenuBarView.swift | Adds mlxModelRow and selectedMlxModelBinding. The selectedEngineBinding setter maps MLX to a .llama(filename:) profile when power-based switching is on, silently activating Llama instead of MLX (P1). |
| Cotabby/Support/MlxRuntimeLocator.swift | New file: pure filesystem discovery of MLX snapshot directories. Snapshot validation heuristic is reasonable. modelID derivation preserves HF publisher/repo nesting. |
| Cotabby/Models/MlxRuntimeModels.swift | New file: clean value-type definitions for MLX options, config, diagnostics, and MlxPromptCachePlanner. commonPrefixCount is duplicated in MlxRuntimeCore (prior review). |
| Cotabby/UI/Settings/Panes/EngineAndModelPaneView.swift | Adds mlxSections with runtime status, model picker, folder controls, and recommended catalog. No issues found. |
| Cotabby/App/Core/CotabbyAppEnvironment.swift | Composes MlxRuntimeManager and MlxRuntimeBootstrapModel correctly. Power-profile switching only covers appleIntelligence and llama — MLX is not integrated into power profiles, consistent with the PowerProfile enum, but contributes to the menu-bar engine binding bug. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as MenuBarView / SettingsPaneView
    participant Router as SuggestionEngineRouter
    participant BootstrapModel as MlxRuntimeBootstrapModel
    participant Manager as MlxRuntimeManager
    participant Core as MlxRuntimeCore
    participant MLX as MLX Swift LM

    UI->>BootstrapModel: selectModel(id:)
    BootstrapModel->>BootstrapModel: cancel runtimeTask, update selectedModelID
    BootstrapModel->>Manager: selectModel(id:)
    Manager->>Core: prepare(resolvedRuntime:configuration:)
    Core->>MLX: loadModelContainer(from:using:)
    MLX-->>Core: ModelContainer
    Core-->>Manager: PreparedMlxRuntime
    Manager-->>BootstrapModel: "state = .ready"

    UI->>Router: generateSuggestion(for:)
    Router->>Router: "selectedEngine == .mlx"
    Router->>MlxSuggestionEngine: generateSuggestion(for:)
    MlxSuggestionEngine->>Manager: generate(prompt:cachedPrefixBytes:options:)
    Manager->>Core: generate(prompt:cachedPrefixBytes:options:configuration:) [detached]
    Core->>Core: autocompleteSemaphore.wait()
    Core->>Core: preparePromptCache(...)
    Core->>MLX: "modelContainer.perform { generateTokens(...) }"
    MLX-->>Core: "AsyncStream<TokenGeneration>"
    Core->>Core: collectGeneratedText(stream:tokenizer:options:)
    Core-->>Manager: String
    Manager-->>MlxSuggestionEngine: String
    MlxSuggestionEngine->>MlxSuggestionEngine: SuggestionTextNormalizer.normalizeDetailed(...)
    MlxSuggestionEngine-->>Router: SuggestionResult
    Router->>Router: recordPerformanceMetric(...)
    Router-->>UI: SuggestionResult
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as MenuBarView / SettingsPaneView
    participant Router as SuggestionEngineRouter
    participant BootstrapModel as MlxRuntimeBootstrapModel
    participant Manager as MlxRuntimeManager
    participant Core as MlxRuntimeCore
    participant MLX as MLX Swift LM

    UI->>BootstrapModel: selectModel(id:)
    BootstrapModel->>BootstrapModel: cancel runtimeTask, update selectedModelID
    BootstrapModel->>Manager: selectModel(id:)
    Manager->>Core: prepare(resolvedRuntime:configuration:)
    Core->>MLX: loadModelContainer(from:using:)
    MLX-->>Core: ModelContainer
    Core-->>Manager: PreparedMlxRuntime
    Manager-->>BootstrapModel: "state = .ready"

    UI->>Router: generateSuggestion(for:)
    Router->>Router: "selectedEngine == .mlx"
    Router->>MlxSuggestionEngine: generateSuggestion(for:)
    MlxSuggestionEngine->>Manager: generate(prompt:cachedPrefixBytes:options:)
    Manager->>Core: generate(prompt:cachedPrefixBytes:options:configuration:) [detached]
    Core->>Core: autocompleteSemaphore.wait()
    Core->>Core: preparePromptCache(...)
    Core->>MLX: "modelContainer.perform { generateTokens(...) }"
    MLX-->>Core: "AsyncStream<TokenGeneration>"
    Core->>Core: collectGeneratedText(stream:tokenizer:options:)
    Core-->>Manager: String
    Manager-->>MlxSuggestionEngine: String
    MlxSuggestionEngine->>MlxSuggestionEngine: SuggestionTextNormalizer.normalizeDetailed(...)
    MlxSuggestionEngine-->>Router: SuggestionResult
    Router->>Router: recordPerformanceMetric(...)
    Router-->>UI: SuggestionResult
```

</a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22james%2Fimplement-mlx%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22james%2Fimplement-mlx%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FMenuBarView.swift%3A404-423%0A**MLX%20engine%20selection%20silently%20switches%20to%20Llama%20when%20power-based%20switching%20is%20on**%0A%0AThe%20%60else%60%20branch%20maps%20every%20non-Apple-Intelligence%20engine%20pick%20to%20%60.llama%28filename%3A%29%60.%20When%20the%20user%20selects%20%22MLX%22%20from%20the%20menu%20bar%20while%20power-based%20switching%20is%20enabled%2C%20the%20code%20constructs%20a%20%60.llama%60%20profile%20with%20the%20currently%20selected%20Llama%20filename%20and%20applies%20it.%20%60applyPowerProfile%60%20then%20calls%20%60suggestionSettings.selectEngine%28.llamaOpenSource%29%60%2C%20so%20the%20picker%20immediately%20reverts%20to%20%22Open%20Source%20%28GGUF%29%22%20and%20MLX%20is%20never%20activated.%20There%20is%20no%20%60.mlx%60%20case%20in%20%60PowerProfile%60%2C%20so%20there%20is%20no%20correct%20profile%20to%20construct%20here%20either%3B%20the%20path%20needs%20to%20be%20guarded%20or%20explicitly%20excluded%20until%20MLX%20is%20integrated%20into%20the%20power-profile%20system.%0A%0A&repo=fujacob%2Fcotabby&pr=750&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FUI%2FMenuBarView.swift%3A404-423%0A**MLX%20engine%20selection%20silently%20switches%20to%20Llama%20when%20power-based%20switching%20is%20on**%0A%0AThe%20%60else%60%20branch%20maps%20every%20non-Apple-Intelligence%20engine%20pick%20to%20%60.llama%28filename%3A%29%60.%20When%20the%20user%20selects%20%22MLX%22%20from%20the%20menu%20bar%20while%20power-based%20switching%20is%20enabled%2C%20the%20code%20constructs%20a%20%60.llama%60%20profile%20with%20the%20currently%20selected%20Llama%20filename%20and%20applies%20it.%20%60applyPowerProfile%60%20then%20calls%20%60suggestionSettings.selectEngine%28.llamaOpenSource%29%60%2C%20so%20the%20picker%20immediately%20reverts%20to%20%22Open%20Source%20%28GGUF%29%22%20and%20MLX%20is%20never%20activated.%20There%20is%20no%20%60.mlx%60%20case%20in%20%60PowerProfile%60%2C%20so%20there%20is%20no%20correct%20profile%20to%20construct%20here%20either%3B%20the%20path%20needs%20to%20be%20guarded%20or%20explicitly%20excluded%20until%20MLX%20is%20integrated%20into%20the%20power-profile%20system.%0A%0A&repo=fujacob%2Fcotabby&pr=750&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (6): Last reviewed commit: ["fix mlx runtime review findings"](https://github.com/fujacob/cotabby/commit/8327d47bcaf66dbe174e6566e400f33dd88e7dfe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38781234)</sub>

<!-- /greptile_comment -->