### PR TITLE
feat(settings): add Reset All Settings to restore every preference to its default

### DIFF
--- a/Cotabby/Models/SuggestionSettingsModel.swift
+++ b/Cotabby/Models/SuggestionSettingsModel.swift
@@ -126,6 +126,10 @@ final class SuggestionSettingsModel: ObservableObject {
     /// routes every load and save through it.
     private let store: SuggestionSettingsStore
 
+    /// Retained so `resetToDefaults` can re-resolve the same first-launch values the app shipped with
+    /// (a few defaults — word-count preset, profile name, debounce/poll cadence — come from here).
+    private let configuration: SuggestionConfiguration
+
     // Public default constants re-exported from `SuggestionSettingsStore` (the single source of
     // truth) so the Settings UI can keep referencing them as `SuggestionSettingsModel.X`.
     static let defaultAcceptanceKeyCode = SuggestionSettingsStore.defaultAcceptanceKeyCode
@@ -151,6 +155,72 @@ final class SuggestionSettingsModel: ObservableObject {
         let store = SuggestionSettingsStore(userDefaults: userDefaults)
         let data = store.load(configuration: configuration)
         self.store = store
+        self.configuration = configuration
+
+        isGloballyEnabled = data.isGloballyEnabled
+        showIndicator = data.showIndicator
+        showAcceptanceHint = data.showAcceptanceHint
+        disabledAppRules = data.disabledAppRules
+        suggestInIntegratedTerminals = data.suggestInIntegratedTerminals
+        customSuggestionTextColorHex = data.customSuggestionTextColorHex
+        ghostTextOpacity = data.ghostTextOpacity
+        ghostTextSizeMultiplier = data.ghostTextSizeMultiplier
+        selectedEngine = data.selectedEngine
+        selectedWordCountPreset = data.selectedWordCountPreset
+        isUsingCustomWordCountRange = data.isUsingCustomWordCountRange
+        customWordCountLowWords = data.customWordCountLowWords
+        customWordCountHighWords = data.customWordCountHighWords
+        isClipboardContextEnabled = data.isClipboardContextEnabled
+        isSurfaceContextEnabled = data.isSurfaceContextEnabled
+        isFastModeEnabled = data.isFastModeEnabled
+        suppressCompletionsOnTypo = data.suppressCompletionsOnTypo
+        offerTypoCorrections = data.offerTypoCorrections
+        enabledSpellingDictionaryCodes = data.enabledSpellingDictionaryCodes
+        automaticallyFixTypos = data.automaticallyFixTypos
+        isPerformanceTrackingEnabled = data.isPerformanceTrackingEnabled
+        isMenuBarWordCountVisible = data.isMenuBarWordCountVisible
+        mirrorPreference = data.mirrorPreference
+        userName = data.userName
+        customRules = data.customRules
+        responseLanguages = data.responseLanguages
+        extendedContext = data.extendedContext
+        debounceMilliseconds = data.debounceMilliseconds
+        focusPollIntervalMilliseconds = data.focusPollIntervalMilliseconds
+        isMultiLineEnabled = data.isMultiLineEnabled
+        isEmojiPickerEnabled = data.isEmojiPickerEnabled
+        isMacroExpansionEnabled = data.isMacroExpansionEnabled
+        preferredEmojiSkinTone = data.preferredEmojiSkinTone
+        preferredEmojiGender = data.preferredEmojiGender
+        autoAcceptTrailingPunctuation = data.autoAcceptTrailingPunctuation
+        addSpaceAfterAccept = data.addSpaceAfterAccept
+        streamSuggestionsWhileGenerating = data.streamSuggestionsWhileGenerating
+        acceptanceKeyCode = data.acceptanceKeyCode
+        acceptanceKeyModifiers = data.acceptanceKeyModifiers
+        acceptanceKeyLabel = data.acceptanceKeyLabel
+        fullAcceptanceKeyCode = data.fullAcceptanceKeyCode
+        fullAcceptanceKeyModifiers = data.fullAcceptanceKeyModifiers
+        fullAcceptanceKeyLabel = data.fullAcceptanceKeyLabel
+        globalToggleKeyCode = data.globalToggleKeyCode
+        globalToggleKeyModifiers = data.globalToggleKeyModifiers
+        globalToggleKeyLabel = data.globalToggleKeyLabel
+        acceptanceGranularity = data.acceptanceGranularity
+        isPowerBasedModelSwitchingEnabled = data.isPowerBasedModelSwitchingEnabled
+        batteryEngine = data.batteryEngine
+        batteryModelFilename = data.batteryModelFilename
+        pluggedInEngine = data.pluggedInEngine
+        pluggedInModelFilename = data.pluggedInModelFilename
+    }
+
+    /// Restores every preference this facade owns to its first-launch default and persists the reset.
+    ///
+    /// The store clears its keys and re-resolves defaults; this then re-fans the pristine values across
+    /// the `@Published` properties so SwiftUI, the snapshot publisher, and every live reader (overlay,
+    /// input monitor, coordinator) pick up the defaults immediately, with no relaunch. The assignment
+    /// list mirrors `init` on purpose — `test_resetToDefaults_restoresEveryFieldToItsDefault` fails if
+    /// the two ever drift. Scope matches the store: unrelated app state (onboarding, the lifetime
+    /// accepted-word count, emoji history, the login-item flag) is intentionally left untouched.
+    func resetToDefaults() {
+        let data = store.resetToDefaults(configuration: configuration)
 
         isGloballyEnabled = data.isGloballyEnabled
         showIndicator = data.showIndicator

--- a/Cotabby/Support/SuggestionSettingsStore.swift
+++ b/Cotabby/Support/SuggestionSettingsStore.swift
@@ -124,6 +124,70 @@ struct SuggestionSettingsStore {
     private static let pluggedInEngineDefaultsKey = "cotabbyPluggedInEngine"
     private static let pluggedInModelFilenameDefaultsKey = "cotabbyPluggedInModelFilename"
 
+    /// Every persisted-preference key this store owns, in one place so `resetToDefaults` clears the
+    /// full set. App state that is deliberately *not* a preference lives under other keys and is
+    /// intentionally excluded: onboarding progress, the one-time login-item default flag, the lifetime
+    /// accepted-word count, emoji usage history, and the performance/quality metrics. A new preference
+    /// key must be added here; `test_resetToDefaults_clearsAllKeysAndReloadsDefaults` fails if one is
+    /// missed. The legacy single-language key is included so a reset also scrubs a value a migration
+    /// would otherwise resurrect.
+    private static let allPreferenceDefaultsKeys: [String] = [
+        isGloballyEnabledDefaultsKey,
+        disabledAppRulesDefaultsKey,
+        suggestInIntegratedTerminalsDefaultsKey,
+        showCaretIndicatorDefaultsKey,
+        selectedIndicatorModeDefaultsKey,
+        showAcceptanceHintDefaultsKey,
+        customSuggestionTextColorHexDefaultsKey,
+        ghostTextOpacityDefaultsKey,
+        ghostTextSizeMultiplierDefaultsKey,
+        selectedEngineDefaultsKey,
+        selectedWordCountPresetDefaultsKey,
+        usingCustomWordCountRangeDefaultsKey,
+        customWordCountLowWordsDefaultsKey,
+        customWordCountHighWordsDefaultsKey,
+        clipboardContextEnabledDefaultsKey,
+        surfaceContextEnabledDefaultsKey,
+        fastModeEnabledDefaultsKey,
+        suppressCompletionsOnTypoDefaultsKey,
+        offerTypoCorrectionsDefaultsKey,
+        spellingDictionaryCodesDefaultsKey,
+        automaticallyFixTyposDefaultsKey,
+        performanceTrackingEnabledDefaultsKey,
+        menuBarWordCountVisibleDefaultsKey,
+        mirrorPreferenceDefaultsKey,
+        userNameDefaultsKey,
+        customRulesDefaultsKey,
+        extendedContextDefaultsKey,
+        responseLanguagesDefaultsKey,
+        legacyResponseLanguageDefaultsKey,
+        debounceMillisecondsDefaultsKey,
+        focusPollIntervalMillisecondsDefaultsKey,
+        multiLineEnabledDefaultsKey,
+        emojiPickerEnabledDefaultsKey,
+        macroExpansionEnabledDefaultsKey,
+        preferredEmojiSkinToneDefaultsKey,
+        preferredEmojiGenderDefaultsKey,
+        autoAcceptTrailingPunctuationDefaultsKey,
+        addSpaceAfterAcceptDefaultsKey,
+        streamWhileGeneratingDefaultsKey,
+        acceptanceKeyCodeDefaultsKey,
+        acceptanceKeyModifiersDefaultsKey,
+        acceptanceKeyLabelDefaultsKey,
+        fullAcceptanceKeyCodeDefaultsKey,
+        fullAcceptanceKeyModifiersDefaultsKey,
+        fullAcceptanceKeyLabelDefaultsKey,
+        globalToggleKeyCodeDefaultsKey,
+        globalToggleKeyModifiersDefaultsKey,
+        globalToggleKeyLabelDefaultsKey,
+        acceptanceGranularityDefaultsKey,
+        powerModelSwitchingEnabledDefaultsKey,
+        batteryEngineDefaultsKey,
+        batteryModelFilenameDefaultsKey,
+        pluggedInEngineDefaultsKey,
+        pluggedInModelFilenameDefaultsKey
+    ]
+
     // MARK: - Load
 
     /// Resolves every preference from `UserDefaults`, applying first-launch defaults and the legacy
@@ -467,6 +531,21 @@ struct SuggestionSettingsStore {
         userDefaults.removeObject(forKey: "cotabbyCustomIndicatorImageData")
 
         return data
+    }
+
+    // MARK: - Reset
+
+    /// Clears every persisted preference this store owns, then re-resolves and writes back the
+    /// first-launch defaults, returning the pristine `SuggestionSettingsData`. Routing through `load`
+    /// means the same migrations and write-back the app relies on at launch also run here, so the
+    /// reset is durable on the next launch and cannot drift from normal startup. Scope is exactly the
+    /// keys in `allPreferenceDefaultsKeys`; unrelated app state (onboarding, login-item flag, counters,
+    /// usage history, metrics) is left untouched.
+    func resetToDefaults(configuration: SuggestionConfiguration) -> SuggestionSettingsData {
+        for key in Self.allPreferenceDefaultsKeys {
+            userDefaults.removeObject(forKey: key)
+        }
+        return load(configuration: configuration)
     }
 
     // MARK: - Save (one method per field; the facade routes its setters through these)

--- a/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
+++ b/Cotabby/UI/Settings/Panes/GeneralPaneView.swift
@@ -11,6 +11,10 @@ struct GeneralPaneView: View {
     @ObservedObject var permissionManager: PermissionManager
     let onShowWelcome: () -> Void
 
+    /// Gates the destructive reset behind an explicit confirmation so a stray click can't wipe a
+    /// user's entire configuration.
+    @State private var isShowingResetConfirmation = false
+
     var body: some View {
         SettingsPaneScaffold {
             Section("Status") {
@@ -107,6 +111,33 @@ struct GeneralPaneView: View {
                 .settingsItem(.onboarding)
             }
 
+            Section("Reset") {
+                LabeledContent {
+                    Button("Reset All Settings…", role: .destructive) {
+                        isShowingResetConfirmation = true
+                    }
+                } label: {
+                    SettingsRowLabel(
+                        title: "Reset All Settings",
+                        description: "Restore every Cotabby setting to its original default. This does not change " +
+                            "macOS permissions, your Open at Login choice, or your accepted-word count.",
+                        systemImage: "arrow.counterclockwise"
+                    )
+                }
+                .settingsItem(.resetAllSettings)
+            }
+        }
+        .confirmationDialog(
+            "Reset all settings to their defaults?",
+            isPresented: $isShowingResetConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Reset All Settings", role: .destructive) {
+                suggestionSettings.resetToDefaults()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Every Cotabby setting returns to its original default. This can't be undone.")
         }
     }
 

--- a/Cotabby/UI/Settings/SettingsIndex.swift
+++ b/Cotabby/UI/Settings/SettingsIndex.swift
@@ -21,6 +21,7 @@ enum SettingsItem: String, CaseIterable, Identifiable {
     case allowMultiLine
     case inlineMacros
     case onboarding
+    case resetAllSettings
     // Appearance
     case suggestionDisplay
     case streamWhileGenerating
@@ -100,6 +101,7 @@ enum SettingsItem: String, CaseIterable, Identifiable {
         case .addSpaceAfterAccept: return "Add Space After Accepting"
         case .inlineMacros: return "Inline Macros"
         case .onboarding: return "Onboarding"
+        case .resetAllSettings: return "Reset All Settings"
         case .suggestionDisplay: return "Suggestion Display"
         case .streamWhileGenerating: return "Stream Suggestions While Generating"
         case .showFieldIndicator: return "Show Field Indicator"
@@ -167,6 +169,7 @@ enum SettingsItem: String, CaseIterable, Identifiable {
         case .addSpaceAfterAccept: return "space"
         case .inlineMacros: return "slash.circle"
         case .onboarding: return "graduationcap"
+        case .resetAllSettings: return "arrow.counterclockwise"
         case .suggestionDisplay: return "text.cursor"
         case .streamWhileGenerating: return "text.append"
         case .showFieldIndicator: return "dot.viewfinder"
@@ -225,7 +228,7 @@ enum SettingsItem: String, CaseIterable, Identifiable {
     var category: SettingsCategory {
         switch self {
         case .enableGlobally, .fastMode, .openAtLogin, .includeClipboardContext, .includeAppContext,
-             .allowMultiLine, .inlineMacros, .onboarding:
+             .allowMultiLine, .inlineMacros, .onboarding, .resetAllSettings:
             return .general
         case .suggestionDisplay, .streamWhileGenerating, .showFieldIndicator, .showWordCount, .showKeyHint,
              .ghostTextColor, .ghostTextOpacity, .ghostTextSize:
@@ -269,6 +272,7 @@ enum SettingsItem: String, CaseIterable, Identifiable {
         case .addSpaceAfterAccept: return "Add a space when an accept finishes a word."
         case .inlineMacros: return "Type / for dates, math, units, currency, and randoms."
         case .onboarding: return "Replay the first-run setup walkthrough."
+        case .resetAllSettings: return "Restore every Cotabby setting to its original default."
         case .suggestionDisplay: return "Inline ghost text, popup card, or automatic per app."
         case .streamWhileGenerating: return "Reveal ghost text token by token as the model writes."
         case .showFieldIndicator: return "Show a small icon when a field is ready for suggestions."
@@ -358,6 +362,10 @@ enum SettingsItem: String, CaseIterable, Identifiable {
         case .onboarding:
             return ["welcome", "guide", "tutorial", "intro", "help", "getting started",
                     "first run", "walkthrough"]
+        case .resetAllSettings:
+            return ["reset", "defaults", "default", "restore", "factory reset", "factory settings",
+                    "clear settings", "start over", "revert", "wipe", "erase", "restore defaults",
+                    "reset everything"]
         case .suggestionDisplay:
             return ["inline", "popup", "ghost", "card", "display", "mirror", "auto",
                     "appearance", "style", "show suggestion", "rendering", "ui"]

--- a/CotabbyTests/SuggestionSettingsModelTests.swift
+++ b/CotabbyTests/SuggestionSettingsModelTests.swift
@@ -113,6 +113,135 @@ final class SuggestionSettingsModelTests: XCTestCase {
         XCTAssertEqual(reloaded.pluggedInModelFilename, "big.gguf")
     }
 
+    // MARK: - Reset to defaults
+
+    func test_resetToDefaults_restoresEveryFieldToItsDefault() {
+        // Seed the fields that have no facade setter (keybindings, debounce/poll, list-valued prefs)
+        // straight through a store on the same suite, so the model loads them non-default and the
+        // assertions below would catch a missing line in `resetToDefaults`'s fan-out for any of them.
+        let seed = SuggestionSettingsStore(userDefaults: defaults)
+        seed.saveAcceptanceKey(keyCode: 36, modifiers: [], label: "Return")
+        seed.saveFullAcceptanceKey(keyCode: 49, modifiers: [], label: "Space")
+        seed.saveGlobalToggleKey(keyCode: 47, modifiers: [], label: ".")
+        seed.saveDebounceMilliseconds(15)
+        seed.saveFocusPollIntervalMilliseconds(30)
+        seed.saveResponseLanguages(["French"])
+        seed.saveCustomRules(["Be terse"])
+        seed.saveEnabledSpellingDictionaryCodes([])
+        seed.saveDisabledAppRules(
+            [DisabledApplicationRule(bundleIdentifier: "com.example.app", displayName: "Example")]
+        )
+
+        let model = makeModel()
+
+        // Dirty every field reachable through a setter with a genuine non-default value.
+        model.setGloballyEnabled(false)
+        model.selectEngine(.appleIntelligence)
+        model.selectWordCountPreset(.fourToSeven)
+        model.setUsingCustomWordCountRange(true)
+        model.setCustomWordCountRange(low: 3, high: 9)
+        model.setClipboardContextEnabled(true)
+        model.setSurfaceContextEnabled(false)
+        model.setFastModeEnabled(true)
+        model.setSuppressCompletionsOnTypo(false)
+        model.setOfferTypoCorrections(false)
+        model.setAutomaticallyFixTypos(true)
+        model.setPerformanceTrackingEnabled(true)
+        model.setMenuBarWordCountVisible(false)
+        model.setMirrorPreference(.alwaysMirror)
+        model.setMultiLineEnabled(true)
+        model.setEmojiPickerEnabled(false)
+        model.setMacroExpansionEnabled(false)
+        model.setPreferredEmojiSkinTone(.mediumDark)
+        model.setPreferredEmojiGender(.female)
+        model.setAutoAcceptTrailingPunctuation(false)
+        model.setAddSpaceAfterAccept(true)
+        model.setStreamSuggestionsWhileGenerating(true)
+        model.setAcceptanceGranularity(.phrase)
+        model.setSuggestInIntegratedTerminals(true)
+        model.setShowIndicator(false)
+        model.setShowAcceptanceHint(false)
+        model.setUserName("Ada")
+        model.setExtendedContext("Glossary: cotabby means tea whisk")
+        model.setGhostTextOpacity(SuggestionSettingsModel.minimumGhostTextOpacity)
+        model.setGhostTextSizeMultiplier(SuggestionSettingsModel.maximumGhostTextSizeMultiplier)
+        model.setCustomSuggestionTextColorHex("#a1b2c3")
+        model.setPowerBasedModelSwitchingEnabled(true)
+        model.setBatteryEngine(.appleIntelligence)
+        model.setBatteryModelFilename("small.gguf")
+        model.setPluggedInEngine(.appleIntelligence)
+        model.setPluggedInModelFilename("big.gguf")
+
+        model.resetToDefaults()
+
+        // A model freshly loaded on a clean suite IS the default state; compare field-for-field so a
+        // dropped assignment in `resetToDefaults` (or a missed store key) fails here.
+        let pristineSuite = "cotabby.test.settingsModel.pristine.\(UUID().uuidString)"
+        let pristineDefaults = UserDefaults(suiteName: pristineSuite)!
+        pristineDefaults.removePersistentDomain(forName: pristineSuite)
+        addTeardownBlock { pristineDefaults.removePersistentDomain(forName: pristineSuite) }
+        let pristine = SuggestionSettingsModel(configuration: .standard, userDefaults: pristineDefaults)
+
+        XCTAssertEqual(model.isGloballyEnabled, pristine.isGloballyEnabled)
+        XCTAssertEqual(model.selectedEngine, pristine.selectedEngine)
+        XCTAssertEqual(model.selectedWordCountPreset, pristine.selectedWordCountPreset)
+        XCTAssertEqual(model.isUsingCustomWordCountRange, pristine.isUsingCustomWordCountRange)
+        XCTAssertEqual(model.customWordCountLowWords, pristine.customWordCountLowWords)
+        XCTAssertEqual(model.customWordCountHighWords, pristine.customWordCountHighWords)
+        XCTAssertEqual(model.isClipboardContextEnabled, pristine.isClipboardContextEnabled)
+        XCTAssertEqual(model.isSurfaceContextEnabled, pristine.isSurfaceContextEnabled)
+        XCTAssertEqual(model.isFastModeEnabled, pristine.isFastModeEnabled)
+        XCTAssertEqual(model.suppressCompletionsOnTypo, pristine.suppressCompletionsOnTypo)
+        XCTAssertEqual(model.offerTypoCorrections, pristine.offerTypoCorrections)
+        XCTAssertEqual(model.automaticallyFixTypos, pristine.automaticallyFixTypos)
+        XCTAssertEqual(model.isPerformanceTrackingEnabled, pristine.isPerformanceTrackingEnabled)
+        XCTAssertEqual(model.isMenuBarWordCountVisible, pristine.isMenuBarWordCountVisible)
+        XCTAssertEqual(model.mirrorPreference, pristine.mirrorPreference)
+        XCTAssertEqual(model.isMultiLineEnabled, pristine.isMultiLineEnabled)
+        XCTAssertEqual(model.isEmojiPickerEnabled, pristine.isEmojiPickerEnabled)
+        XCTAssertEqual(model.isMacroExpansionEnabled, pristine.isMacroExpansionEnabled)
+        XCTAssertEqual(model.preferredEmojiSkinTone, pristine.preferredEmojiSkinTone)
+        XCTAssertEqual(model.preferredEmojiGender, pristine.preferredEmojiGender)
+        XCTAssertEqual(model.autoAcceptTrailingPunctuation, pristine.autoAcceptTrailingPunctuation)
+        XCTAssertEqual(model.addSpaceAfterAccept, pristine.addSpaceAfterAccept)
+        XCTAssertEqual(model.streamSuggestionsWhileGenerating, pristine.streamSuggestionsWhileGenerating)
+        XCTAssertEqual(model.acceptanceGranularity, pristine.acceptanceGranularity)
+        XCTAssertEqual(model.suggestInIntegratedTerminals, pristine.suggestInIntegratedTerminals)
+        XCTAssertEqual(model.showIndicator, pristine.showIndicator)
+        XCTAssertEqual(model.showAcceptanceHint, pristine.showAcceptanceHint)
+        XCTAssertEqual(model.userName, pristine.userName)
+        XCTAssertEqual(model.extendedContext, pristine.extendedContext)
+        XCTAssertEqual(model.ghostTextOpacity, pristine.ghostTextOpacity)
+        XCTAssertEqual(model.ghostTextSizeMultiplier, pristine.ghostTextSizeMultiplier)
+        XCTAssertEqual(model.customSuggestionTextColorHex, pristine.customSuggestionTextColorHex)
+        XCTAssertEqual(model.isPowerBasedModelSwitchingEnabled, pristine.isPowerBasedModelSwitchingEnabled)
+        XCTAssertEqual(model.batteryEngine, pristine.batteryEngine)
+        XCTAssertEqual(model.batteryModelFilename, pristine.batteryModelFilename)
+        XCTAssertEqual(model.pluggedInEngine, pristine.pluggedInEngine)
+        XCTAssertEqual(model.pluggedInModelFilename, pristine.pluggedInModelFilename)
+        // Seeded (no-setter) fields:
+        XCTAssertEqual(model.acceptanceKeyCode, pristine.acceptanceKeyCode)
+        XCTAssertEqual(model.acceptanceKeyLabel, pristine.acceptanceKeyLabel)
+        XCTAssertEqual(model.fullAcceptanceKeyCode, pristine.fullAcceptanceKeyCode)
+        XCTAssertEqual(model.fullAcceptanceKeyLabel, pristine.fullAcceptanceKeyLabel)
+        XCTAssertEqual(model.globalToggleKeyCode, pristine.globalToggleKeyCode)
+        XCTAssertEqual(model.globalToggleKeyLabel, pristine.globalToggleKeyLabel)
+        XCTAssertEqual(model.debounceMilliseconds, pristine.debounceMilliseconds)
+        XCTAssertEqual(model.focusPollIntervalMilliseconds, pristine.focusPollIntervalMilliseconds)
+        XCTAssertEqual(model.responseLanguages, pristine.responseLanguages)
+        XCTAssertEqual(model.customRules, pristine.customRules)
+        XCTAssertEqual(model.enabledSpellingDictionaryCodes, pristine.enabledSpellingDictionaryCodes)
+        XCTAssertEqual(model.disabledAppRules, pristine.disabledAppRules)
+
+        // Durable: a fresh model on the same suite reads the defaults the reset persisted.
+        let reloaded = makeModel()
+        XCTAssertEqual(reloaded.isGloballyEnabled, pristine.isGloballyEnabled)
+        XCTAssertEqual(reloaded.userName, pristine.userName)
+        XCTAssertEqual(reloaded.mirrorPreference, pristine.mirrorPreference)
+        XCTAssertEqual(reloaded.acceptanceKeyCode, pristine.acceptanceKeyCode)
+        XCTAssertTrue(reloaded.disabledAppRules.isEmpty)
+    }
+
     // MARK: - Power profiles
 
     func test_powerProfiles_mapEngineAndFilenameIntoProfileValues() {

--- a/CotabbyTests/SuggestionSettingsStoreTests.swift
+++ b/CotabbyTests/SuggestionSettingsStoreTests.swift
@@ -424,6 +424,78 @@ final class SuggestionSettingsStoreTests: XCTestCase {
         XCTAssertEqual(data.enabledSpellingDictionaryCodes, [])
     }
 
+    // MARK: - Reset to defaults
+
+    func test_resetToDefaults_clearsAllKeysAndReloadsDefaults() async {
+        // Baseline: defaults resolved from a clean suite.
+        let pristine = SuggestionSettingsStore(userDefaults: makeIsolatedDefaults())
+            .load(configuration: .standard)
+
+        let defaults = makeIsolatedDefaults()
+        let store = SuggestionSettingsStore(userDefaults: defaults)
+
+        // Dirty every persisted field with a genuine non-default (correct types, through the same save
+        // methods the facade uses), plus the legacy single-language key. If `resetToDefaults` misses
+        // any key, the reloaded data stays != pristine and the Equatable check below fails loudly.
+        store.saveGloballyEnabled(false)
+        store.saveDisabledAppRules(
+            [DisabledApplicationRule(bundleIdentifier: "com.example.app", displayName: "Example")]
+        )
+        store.saveSuggestInIntegratedTerminals(true)
+        store.saveShowIndicator(false)
+        store.saveShowAcceptanceHint(false)
+        store.saveCustomSuggestionTextColorHex("A1B2C3")
+        store.saveGhostTextOpacity(0.4)
+        store.saveGhostTextSizeMultiplier(1.2)
+        store.saveSelectedEngine(.appleIntelligence)
+        store.saveSelectedWordCountPreset(.fourToSeven)
+        store.saveUsingCustomWordCountRange(true)
+        store.saveCustomWordCountRange(low: 3, high: 9)
+        store.saveClipboardContextEnabled(true)
+        store.saveSurfaceContextEnabled(false)
+        store.saveFastModeEnabled(true)
+        store.saveSuppressCompletionsOnTypo(false)
+        store.saveOfferTypoCorrections(false)
+        store.saveEnabledSpellingDictionaryCodes([])
+        store.saveAutomaticallyFixTypos(true)
+        store.savePerformanceTrackingEnabled(true)
+        store.saveMenuBarWordCountVisible(false)
+        store.saveMirrorPreference(.alwaysMirror)
+        store.saveUserName("Ada")
+        store.saveCustomRules(["Be terse"])
+        store.saveExtendedContext("glossary")
+        store.saveResponseLanguages([])
+        store.saveDebounceMilliseconds(15)
+        store.saveFocusPollIntervalMilliseconds(30)
+        store.saveMultiLineEnabled(true)
+        store.saveEmojiPickerEnabled(false)
+        store.saveMacroExpansionEnabled(false)
+        store.savePreferredEmojiSkinTone(.mediumDark)
+        store.savePreferredEmojiGender(.female)
+        store.saveAutoAcceptTrailingPunctuation(false)
+        store.saveAddSpaceAfterAccept(true)
+        store.saveStreamSuggestionsWhileGenerating(true)
+        store.saveAcceptanceKey(keyCode: 36, modifiers: [], label: "Return")
+        store.saveFullAcceptanceKey(keyCode: 49, modifiers: [], label: "Space")
+        store.saveGlobalToggleKey(keyCode: 47, modifiers: [], label: ".")
+        store.saveAcceptanceGranularity(.phrase)
+        store.savePowerBasedModelSwitchingEnabled(true)
+        store.saveBatteryEngine(.appleIntelligence)
+        store.saveBatteryModelFilename("small.gguf")
+        store.savePluggedInEngine(.appleIntelligence)
+        store.savePluggedInModelFilename("big.gguf")
+        defaults.set("Spanish", forKey: "cotabbyResponseLanguage")
+
+        // Sanity: the dirty values really landed, so the assertions below aren't vacuous.
+        XCTAssertNotEqual(store.load(configuration: .standard), pristine)
+
+        let afterReset = store.resetToDefaults(configuration: .standard)
+
+        XCTAssertEqual(afterReset, pristine)
+        XCTAssertEqual(store.load(configuration: .standard), pristine, "reset must persist for the next launch")
+        XCTAssertNil(defaults.object(forKey: "cotabbyResponseLanguage"), "the legacy key must be scrubbed too")
+    }
+
     // MARK: - helpers
 
     /// Each store test gets its own isolated UserDefaults so state cannot leak between cases.


### PR DESCRIPTION
## Summary

Adds a **Reset All Settings** action (General pane, behind a confirmation dialog) that restores every preference Cotabby persists to its first-launch default — useful for support ("try resetting to defaults") and for undoing a tangle of toggles without reinstalling.

## Validation

Built and tested locally (macOS 26, Apple Silicon):

```
xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' test \
  -derivedDataPath build/DerivedData \
  -only-testing:CotabbyTests/SuggestionSettingsStoreTests \
  -only-testing:CotabbyTests/SuggestionSettingsModelTests \
  -only-testing:CotabbyTests/SettingsIndexTests \
  CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
# ** TEST SUCCEEDED **  Executed 66 tests, 0 failures

swiftlint lint --quiet
# exit 0, no violations
```

Test coverage added:
- `SuggestionSettingsStoreTests.test_resetToDefaults_clearsAllKeysAndReloadsDefaults` — dirties every persisted field (correct types, via the real save methods) plus the legacy single-language key, resets, and asserts the reloaded `SuggestionSettingsData` equals the pristine defaults and that the legacy key is scrubbed. A missed key fails the `Equatable` comparison.
- `SuggestionSettingsModelTests.test_resetToDefaults_restoresEveryFieldToItsDefault` — sets every setter-reachable field non-default and seeds the no-setter fields (keybindings, debounce/poll, list prefs) through the store, resets, and asserts all `@Published` properties match a freshly-loaded pristine model and persist across a reload. A dropped line in the fan-out fails here.
- `SettingsIndexTests` still green with the new `.resetAllSettings` entry.

I have not manually clicked through the confirmation dialog in a running app this session; the reset logic and persistence are covered by the tests above.

## Linked issues

None.

## Risk / rollout notes

- **Destructive, behind a confirmation.** The action shows a `confirmationDialog` with a destructive "Reset All Settings" button before doing anything.
- **Scope = the preferences `SuggestionSettingsStore` owns.** `resetToDefaults` routes through `load`, so the same migrations and unconditional write-back used at launch also run, making the reset durable and impossible to drift from normal startup. The full key list lives in one place (`allPreferenceDefaultsKeys`); a new preference key must be added there, and the store reset test fails if one is missed.
- **Deliberately *not* reset** (not preferences, or owned elsewhere): onboarding progress, the one-time Open-at-Login default flag, the lifetime accepted-word count, emoji usage history, performance/quality metrics, the selected model filename, per-app/per-domain disable lists' separate stores, and the LM Studio source toggle. The UI subtitle calls out that permissions, Open at Login, and the accepted-word count are left alone.
- **Live, no relaunch.** The facade re-publishes every value, so the Settings UI, the snapshot publisher, and live readers (overlay, input monitor, coordinator) reflect defaults immediately.
- No new files; no `project.pbxproj` change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a **Reset All Settings** action to the General pane that restores every `SuggestionSettingsStore`-owned preference to its first-launch default, live and without a relaunch, behind a destructive confirmation dialog.

- `SuggestionSettingsStore` gains an `allPreferenceDefaultsKeys` list (~54 keys) and `resetToDefaults(configuration:)` which clears those keys then re-resolves defaults via `load()` — routing through `load` means migrations and write-back also run, keeping the reset durable and in sync with normal startup.
- `SuggestionSettingsModel` stores the `SuggestionConfiguration` at init time and adds `resetToDefaults()` that fans the store's return value across all `@Published` properties, triggering immediate live updates to the Settings UI, overlay, and coordinator.
- `GeneralPaneView` adds a "Reset" section with a `confirmationDialog` gating the destructive action; `SettingsIndex` registers the new `.resetAllSettings` entry with display metadata and search keywords.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the destructive action is gated behind a confirmation dialog, the reset routes through the existing load/write-back path so it cannot diverge from normal startup, and the test coverage is thorough.

The store-level and model-level logic are correct and well-tested. The main thing worth a follow-up look is that `resetToDefaults()` assigns ~50 `@Published` properties sequentially, which fires intermediate Combine snapshots. Whether those intermediate states reach live readers depends on whether every downstream subscriber uses a main-queue hop; confirming that assumption would close the loop.

Cotabby/Models/SuggestionSettingsModel.swift — the sequential @Published fan-out and the duplicated assignment block are both worth a second look.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/Support/SuggestionSettingsStore.swift | Adds allPreferenceDefaultsKeys (exhaustive list of all ~54 persisted-preference keys) and resetToDefaults(configuration:) that clears those keys then re-resolves defaults via load(); logic is correct and the key list matches every key defined in the file. |
| Cotabby/Models/SuggestionSettingsModel.swift | Stores configuration for reuse in reset; adds resetToDefaults() that fans the store's return value across all ~50 @Published properties — the same sequential assignment block that appears in init, causing many intermediate Combine emissions during reset. |
| Cotabby/UI/Settings/Panes/GeneralPaneView.swift | Adds a "Reset" section with a destructive Button gated behind a confirmationDialog; state management with isShowingResetConfirmation is correct and the dialog wording clearly conveys irreversibility. |
| Cotabby/UI/Settings/SettingsIndex.swift | Adds .resetAllSettings case to the enum with display name, icon, category (.general), description, and search keywords — all consistent with existing entries. |
| CotabbyTests/SuggestionSettingsStoreTests.swift | Adds test_resetToDefaults_clearsAllKeysAndReloadsDefaults which dirties every persisted key via real save methods, resets, and verifies Equatable equality with a pristine baseline; legacy key scrubbing is also explicitly checked. |
| CotabbyTests/SuggestionSettingsModelTests.swift | Adds test_resetToDefaults_restoresEveryFieldToItsDefault which seeds no-setter fields through the store, dirties all setter-reachable fields, resets, and checks every @Published property against a pristine model including a reload durability check. |

</details>



<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    actor User
    participant GeneralPaneView
    participant SuggestionSettingsModel
    participant SuggestionSettingsStore
    participant UserDefaults

    User->>GeneralPaneView: clicks "Reset All Settings…"
    GeneralPaneView->>GeneralPaneView: "isShowingResetConfirmation = true"
    GeneralPaneView-->>User: confirmationDialog("Reset all settings to their defaults?")
    User->>GeneralPaneView: clicks destructive "Reset All Settings"
    GeneralPaneView->>SuggestionSettingsModel: resetToDefaults()
    SuggestionSettingsModel->>SuggestionSettingsStore: resetToDefaults(configuration:)
    loop for each key in allPreferenceDefaultsKeys (~54 keys)
        SuggestionSettingsStore->>UserDefaults: removeObject(forKey:)
    end
    SuggestionSettingsStore->>SuggestionSettingsStore: load(configuration:)
    Note over SuggestionSettingsStore: resolves first-launch defaults,<br/>writes them back unconditionally
    SuggestionSettingsStore-->>SuggestionSettingsModel: SuggestionSettingsData (pristine defaults)
    loop "for each @Published property (~50 fields)"
        SuggestionSettingsModel->>SuggestionSettingsModel: assign from data
        Note right of SuggestionSettingsModel: fires objectWillChange & snapshotPublisher per field
    end
    SuggestionSettingsModel-->>GeneralPaneView: "@Published updates propagate to SwiftUI"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    actor User
    participant GeneralPaneView
    participant SuggestionSettingsModel
    participant SuggestionSettingsStore
    participant UserDefaults

    User->>GeneralPaneView: clicks "Reset All Settings…"
    GeneralPaneView->>GeneralPaneView: "isShowingResetConfirmation = true"
    GeneralPaneView-->>User: confirmationDialog("Reset all settings to their defaults?")
    User->>GeneralPaneView: clicks destructive "Reset All Settings"
    GeneralPaneView->>SuggestionSettingsModel: resetToDefaults()
    SuggestionSettingsModel->>SuggestionSettingsStore: resetToDefaults(configuration:)
    loop for each key in allPreferenceDefaultsKeys (~54 keys)
        SuggestionSettingsStore->>UserDefaults: removeObject(forKey:)
    end
    SuggestionSettingsStore->>SuggestionSettingsStore: load(configuration:)
    Note over SuggestionSettingsStore: resolves first-launch defaults,<br/>writes them back unconditionally
    SuggestionSettingsStore-->>SuggestionSettingsModel: SuggestionSettingsData (pristine defaults)
    loop "for each @Published property (~50 fields)"
        SuggestionSettingsModel->>SuggestionSettingsModel: assign from data
        Note right of SuggestionSettingsModel: fires objectWillChange & snapshotPublisher per field
    end
    SuggestionSettingsModel-->>GeneralPaneView: "@Published updates propagate to SwiftUI"
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `Cotabby/Models/SuggestionSettingsModel.swift`, line 222-277 ([link](https://github.com/fujacob/cotabby/blob/f69f71c2ca3a2a2fa49b19496bd203a364492ae6/Cotabby/Models/SuggestionSettingsModel.swift#L222-L277)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Sequential @Published assignments fire ~50 intermediate Combine emissions**

   `resetToDefaults()` assigns each `@Published` property one by one. Each assignment synchronously sends a new value through the `snapshotPublisher` chain (via `CombineLatest4`), so any downstream subscriber that receives on the current thread (without `receive(on: DispatchQueue.main)`) will process ~50 partially-reset snapshots — e.g., `isGloballyEnabled = true` resolved before `selectedEngine` is back to default. Subscribers using `receive(on: DispatchQueue.main)` or `receive(on: RunLoop.main)` coalesce these into a single delivery after the method returns, which is likely the case for the coordinator and overlay. If that assumption holds everywhere, there is no functional issue; if any subscriber receives synchronously, it sees intermediate inconsistent state during the reset. Consider confirming all live readers of `snapshotPublisher` use a main-queue hop.

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Freset-all-settings%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Freset-all-settings%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FModels%2FSuggestionSettingsModel.swift%0ALine%3A%20222-277%0A%0AComment%3A%0A**Sequential%20%40Published%20assignments%20fire%20~50%20intermediate%20Combine%20emissions**%0A%0A%60resetToDefaults%28%29%60%20assigns%20each%20%60%40Published%60%20property%20one%20by%20one.%20Each%20assignment%20synchronously%20sends%20a%20new%20value%20through%20the%20%60snapshotPublisher%60%20chain%20%28via%20%60CombineLatest4%60%29%2C%20so%20any%20downstream%20subscriber%20that%20receives%20on%20the%20current%20thread%20%28without%20%60receive%28on%3A%20DispatchQueue.main%29%60%29%20will%20process%20~50%20partially-reset%20snapshots%20%E2%80%94%20e.g.%2C%20%60isGloballyEnabled%20%3D%20true%60%20resolved%20before%20%60selectedEngine%60%20is%20back%20to%20default.%20Subscribers%20using%20%60receive%28on%3A%20DispatchQueue.main%29%60%20or%20%60receive%28on%3A%20RunLoop.main%29%60%20coalesce%20these%20into%20a%20single%20delivery%20after%20the%20method%20returns%2C%20which%20is%20likely%20the%20case%20for%20the%20coordinator%20and%20overlay.%20If%20that%20assumption%20holds%20everywhere%2C%20there%20is%20no%20functional%20issue%3B%20if%20any%20subscriber%20receives%20synchronously%2C%20it%20sees%20intermediate%20inconsistent%20state%20during%20the%20reset.%20Consider%20confirming%20all%20live%20readers%20of%20%60snapshotPublisher%60%20use%20a%20main-queue%20hop.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=751&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FModels%2FSuggestionSettingsModel.swift%0ALine%3A%20222-277%0A%0AComment%3A%0A**Sequential%20%40Published%20assignments%20fire%20~50%20intermediate%20Combine%20emissions**%0A%0A%60resetToDefaults%28%29%60%20assigns%20each%20%60%40Published%60%20property%20one%20by%20one.%20Each%20assignment%20synchronously%20sends%20a%20new%20value%20through%20the%20%60snapshotPublisher%60%20chain%20%28via%20%60CombineLatest4%60%29%2C%20so%20any%20downstream%20subscriber%20that%20receives%20on%20the%20current%20thread%20%28without%20%60receive%28on%3A%20DispatchQueue.main%29%60%29%20will%20process%20~50%20partially-reset%20snapshots%20%E2%80%94%20e.g.%2C%20%60isGloballyEnabled%20%3D%20true%60%20resolved%20before%20%60selectedEngine%60%20is%20back%20to%20default.%20Subscribers%20using%20%60receive%28on%3A%20DispatchQueue.main%29%60%20or%20%60receive%28on%3A%20RunLoop.main%29%60%20coalesce%20these%20into%20a%20single%20delivery%20after%20the%20method%20returns%2C%20which%20is%20likely%20the%20case%20for%20the%20coordinator%20and%20overlay.%20If%20that%20assumption%20holds%20everywhere%2C%20there%20is%20no%20functional%20issue%3B%20if%20any%20subscriber%20receives%20synchronously%2C%20it%20sees%20intermediate%20inconsistent%20state%20during%20the%20reset.%20Consider%20confirming%20all%20live%20readers%20of%20%60snapshotPublisher%60%20use%20a%20main-queue%20hop.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=751&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>


2. `Cotabby/Models/SuggestionSettingsModel.swift`, line 159-277 ([link](https://github.com/fujacob/cotabby/blob/f69f71c2ca3a2a2fa49b19496bd203a364492ae6/Cotabby/Models/SuggestionSettingsModel.swift#L159-L277)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Identical 50-line assignment block duplicated between `init` and `resetToDefaults()`**

   Both methods assign the same ~50 properties from a `SuggestionSettingsData` value, and they must stay in sync whenever a new field is added. The test net (comparing against a pristine model) will catch a missed line at test time, but the duplication still grows the maintenance surface. A small private helper — `func apply(_ data: SuggestionSettingsData)` — would reduce the risk to a single site without changing observable behavior. The PR description acknowledges the pattern; this is just a note that the refactor path remains available.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Freset-all-settings%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Freset-all-settings%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FModels%2FSuggestionSettingsModel.swift%0ALine%3A%20159-277%0A%0AComment%3A%0A**Identical%2050-line%20assignment%20block%20duplicated%20between%20%60init%60%20and%20%60resetToDefaults%28%29%60**%0A%0ABoth%20methods%20assign%20the%20same%20~50%20properties%20from%20a%20%60SuggestionSettingsData%60%20value%2C%20and%20they%20must%20stay%20in%20sync%20whenever%20a%20new%20field%20is%20added.%20The%20test%20net%20%28comparing%20against%20a%20pristine%20model%29%20will%20catch%20a%20missed%20line%20at%20test%20time%2C%20but%20the%20duplication%20still%20grows%20the%20maintenance%20surface.%20A%20small%20private%20helper%20%E2%80%94%20%60func%20apply%28_%20data%3A%20SuggestionSettingsData%29%60%20%E2%80%94%20would%20reduce%20the%20risk%20to%20a%20single%20site%20without%20changing%20observable%20behavior.%20The%20PR%20description%20acknowledges%20the%20pattern%3B%20this%20is%20just%20a%20note%20that%20the%20refactor%20path%20remains%20available.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=751&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FModels%2FSuggestionSettingsModel.swift%0ALine%3A%20159-277%0A%0AComment%3A%0A**Identical%2050-line%20assignment%20block%20duplicated%20between%20%60init%60%20and%20%60resetToDefaults%28%29%60**%0A%0ABoth%20methods%20assign%20the%20same%20~50%20properties%20from%20a%20%60SuggestionSettingsData%60%20value%2C%20and%20they%20must%20stay%20in%20sync%20whenever%20a%20new%20field%20is%20added.%20The%20test%20net%20%28comparing%20against%20a%20pristine%20model%29%20will%20catch%20a%20missed%20line%20at%20test%20time%2C%20but%20the%20duplication%20still%20grows%20the%20maintenance%20surface.%20A%20small%20private%20helper%20%E2%80%94%20%60func%20apply%28_%20data%3A%20SuggestionSettingsData%29%60%20%E2%80%94%20would%20reduce%20the%20risk%20to%20a%20single%20site%20without%20changing%20observable%20behavior.%20The%20PR%20description%20acknowledges%20the%20pattern%3B%20this%20is%20just%20a%20note%20that%20the%20refactor%20path%20remains%20available.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=751&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22feat%2Freset-all-settings%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Freset-all-settings%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FModels%2FSuggestionSettingsModel.swift%3A222-277%0A**Sequential%20%40Published%20assignments%20fire%20~50%20intermediate%20Combine%20emissions**%0A%0A%60resetToDefaults%28%29%60%20assigns%20each%20%60%40Published%60%20property%20one%20by%20one.%20Each%20assignment%20synchronously%20sends%20a%20new%20value%20through%20the%20%60snapshotPublisher%60%20chain%20%28via%20%60CombineLatest4%60%29%2C%20so%20any%20downstream%20subscriber%20that%20receives%20on%20the%20current%20thread%20%28without%20%60receive%28on%3A%20DispatchQueue.main%29%60%29%20will%20process%20~50%20partially-reset%20snapshots%20%E2%80%94%20e.g.%2C%20%60isGloballyEnabled%20%3D%20true%60%20resolved%20before%20%60selectedEngine%60%20is%20back%20to%20default.%20Subscribers%20using%20%60receive%28on%3A%20DispatchQueue.main%29%60%20or%20%60receive%28on%3A%20RunLoop.main%29%60%20coalesce%20these%20into%20a%20single%20delivery%20after%20the%20method%20returns%2C%20which%20is%20likely%20the%20case%20for%20the%20coordinator%20and%20overlay.%20If%20that%20assumption%20holds%20everywhere%2C%20there%20is%20no%20functional%20issue%3B%20if%20any%20subscriber%20receives%20synchronously%2C%20it%20sees%20intermediate%20inconsistent%20state%20during%20the%20reset.%20Consider%20confirming%20all%20live%20readers%20of%20%60snapshotPublisher%60%20use%20a%20main-queue%20hop.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FModels%2FSuggestionSettingsModel.swift%3A159-277%0A**Identical%2050-line%20assignment%20block%20duplicated%20between%20%60init%60%20and%20%60resetToDefaults%28%29%60**%0A%0ABoth%20methods%20assign%20the%20same%20~50%20properties%20from%20a%20%60SuggestionSettingsData%60%20value%2C%20and%20they%20must%20stay%20in%20sync%20whenever%20a%20new%20field%20is%20added.%20The%20test%20net%20%28comparing%20against%20a%20pristine%20model%29%20will%20catch%20a%20missed%20line%20at%20test%20time%2C%20but%20the%20duplication%20still%20grows%20the%20maintenance%20surface.%20A%20small%20private%20helper%20%E2%80%94%20%60func%20apply%28_%20data%3A%20SuggestionSettingsData%29%60%20%E2%80%94%20would%20reduce%20the%20risk%20to%20a%20single%20site%20without%20changing%20observable%20behavior.%20The%20PR%20description%20acknowledges%20the%20pattern%3B%20this%20is%20just%20a%20note%20that%20the%20refactor%20path%20remains%20available.%0A%0A&repo=fujacob%2Fcotabby&pr=751&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACotabby%2FModels%2FSuggestionSettingsModel.swift%3A222-277%0A**Sequential%20%40Published%20assignments%20fire%20~50%20intermediate%20Combine%20emissions**%0A%0A%60resetToDefaults%28%29%60%20assigns%20each%20%60%40Published%60%20property%20one%20by%20one.%20Each%20assignment%20synchronously%20sends%20a%20new%20value%20through%20the%20%60snapshotPublisher%60%20chain%20%28via%20%60CombineLatest4%60%29%2C%20so%20any%20downstream%20subscriber%20that%20receives%20on%20the%20current%20thread%20%28without%20%60receive%28on%3A%20DispatchQueue.main%29%60%29%20will%20process%20~50%20partially-reset%20snapshots%20%E2%80%94%20e.g.%2C%20%60isGloballyEnabled%20%3D%20true%60%20resolved%20before%20%60selectedEngine%60%20is%20back%20to%20default.%20Subscribers%20using%20%60receive%28on%3A%20DispatchQueue.main%29%60%20or%20%60receive%28on%3A%20RunLoop.main%29%60%20coalesce%20these%20into%20a%20single%20delivery%20after%20the%20method%20returns%2C%20which%20is%20likely%20the%20case%20for%20the%20coordinator%20and%20overlay.%20If%20that%20assumption%20holds%20everywhere%2C%20there%20is%20no%20functional%20issue%3B%20if%20any%20subscriber%20receives%20synchronously%2C%20it%20sees%20intermediate%20inconsistent%20state%20during%20the%20reset.%20Consider%20confirming%20all%20live%20readers%20of%20%60snapshotPublisher%60%20use%20a%20main-queue%20hop.%0A%0A%23%23%23%20Issue%202%20of%202%0ACotabby%2FModels%2FSuggestionSettingsModel.swift%3A159-277%0A**Identical%2050-line%20assignment%20block%20duplicated%20between%20%60init%60%20and%20%60resetToDefaults%28%29%60**%0A%0ABoth%20methods%20assign%20the%20same%20~50%20properties%20from%20a%20%60SuggestionSettingsData%60%20value%2C%20and%20they%20must%20stay%20in%20sync%20whenever%20a%20new%20field%20is%20added.%20The%20test%20net%20%28comparing%20against%20a%20pristine%20model%29%20will%20catch%20a%20missed%20line%20at%20test%20time%2C%20but%20the%20duplication%20still%20grows%20the%20maintenance%20surface.%20A%20small%20private%20helper%20%E2%80%94%20%60func%20apply%28_%20data%3A%20SuggestionSettingsData%29%60%20%E2%80%94%20would%20reduce%20the%20risk%20to%20a%20single%20site%20without%20changing%20observable%20behavior.%20The%20PR%20description%20acknowledges%20the%20pattern%3B%20this%20is%20just%20a%20note%20that%20the%20refactor%20path%20remains%20available.%0A%0A&repo=fujacob%2Fcotabby&pr=751&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(settings): add Reset All Settings t..."](https://github.com/fujacob/cotabby/commit/f69f71c2ca3a2a2fa49b19496bd203a364492ae6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38782846)</sub>

<!-- /greptile_comment -->