### PR TITLE
Redesign emoji + suggestion popups as a shared minimal dark HUD

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -137,7 +137,9 @@
 		2C6159231472A849F15BD0AE /* ScreenFrameReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5484C8A04B9C00CF79D589EB /* ScreenFrameReader.swift */; };
 		2CCF87FD35BF2C438EEA606D /* SelfCaptureGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68BE6A22BA0D42C8DD9868C /* SelfCaptureGate.swift */; };
 		2CDF880348D439708BD4F792 /* ru.txt in Resources */ = {isa = PBXBuildFile; fileRef = D8C2663427BC5219EA415D00 /* ru.txt */; };
+		2D32B63CB58FBC5BC2EA7125 /* PopupChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565AB9A1265315C500FE5BDF /* PopupChrome.swift */; };
 		2D93881A6AE7DA50698600A3 /* SystemMetricsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 807148A920E003DEF8BA6092 /* SystemMetricsStore.swift */; };
+		2DA8DFFE8DF9B6AD71E28417 /* PopupChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565AB9A1265315C500FE5BDF /* PopupChrome.swift */; };
 		2DF5A3826AAB99C279EBB8DE /* InputMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B81DD30EB657368AACE9625A /* InputMonitor.swift */; };
 		2E0FC35AA7D717B978033ED1 /* LlamaRuntimeModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A804F4DB6FD9BC8C27B2B65F /* LlamaRuntimeModels.swift */; };
 		2E3DEB7E89D0146274596F2E /* SettingsContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB0CE9AB1286367BA2E82392 /* SettingsContainerView.swift */; };
@@ -826,6 +828,7 @@
 		5484C8A04B9C00CF79D589EB /* ScreenFrameReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenFrameReader.swift; sourceTree = "<group>"; };
 		54BC85605541E913EE57B258 /* ExtendedContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtendedContextTests.swift; sourceTree = "<group>"; };
 		54EF3C7F5D9D6F3FA50FD51C /* ContextBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextBuffer.swift; sourceTree = "<group>"; };
+		565AB9A1265315C500FE5BDF /* PopupChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupChrome.swift; sourceTree = "<group>"; };
 		5664E34B23FBDF69292FEF43 /* FoundationModelSuggestionEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoundationModelSuggestionEngine.swift; sourceTree = "<group>"; };
 		5976600F428C1265121D4C0C /* SystemSettingsWindowLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemSettingsWindowLocator.swift; sourceTree = "<group>"; };
 		59E299BE2E9D42A33D5D2F5D /* ScreenTextExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenTextExtractor.swift; sourceTree = "<group>"; };
@@ -1628,6 +1631,7 @@
 				83A810F9D28A18BA6F2066C7 /* MenuBarSections.swift */,
 				BD42C7E2852F59BEF7972663 /* MenuBarStatusLabelView.swift */,
 				9AA0117B322C625F6D4BBEAB /* MenuBarView.swift */,
+				565AB9A1265315C500FE5BDF /* PopupChrome.swift */,
 				5484C8A04B9C00CF79D589EB /* ScreenFrameReader.swift */,
 				DF3A73EB848780061FC162C0 /* SpellingDictionaryPicker.swift */,
 				FB317C82CE2CBC69056BA4B8 /* TagChip.swift */,
@@ -2139,6 +2143,7 @@
 				9A82FB431A61719F275623B8 /* PermissionOverlayWindowController.swift in Sources */,
 				513066CA00F0E9A5E7358A4E /* PermissionReminderView.swift in Sources */,
 				D553BAA6C9F478533BD4A221 /* PermissionsPaneView.swift in Sources */,
+				2D32B63CB58FBC5BC2EA7125 /* PopupChrome.swift in Sources */,
 				C607A624A0FB697486C56B8E /* PowerSourceMonitor.swift in Sources */,
 				FEC24B9C23274B9FA1F0072E /* PromptContextSanitizer.swift in Sources */,
 				982BA68A53CEE0F45D41F3D3 /* PromptSectionBudget.swift in Sources */,
@@ -2385,6 +2390,7 @@
 				61EC9D635D416115E7C96E0F /* PermissionOverlayWindowController.swift in Sources */,
 				610650A14AC5E8EDDC81B4E9 /* PermissionReminderView.swift in Sources */,
 				39571AB31481959CD5C223AE /* PermissionsPaneView.swift in Sources */,
+				2DA8DFFE8DF9B6AD71E28417 /* PopupChrome.swift in Sources */,
 				50E1247BE6A952AB1B12C444 /* PowerSourceMonitor.swift in Sources */,
 				98E2E14A069384C1088CDB44 /* PromptContextSanitizer.swift in Sources */,
 				3C561CD717064F9250200667 /* PromptSectionBudget.swift in Sources */,

--- a/Cotabby/App/Coordinators/EmojiPickerController.swift
+++ b/Cotabby/App/Coordinators/EmojiPickerController.swift
@@ -182,11 +182,14 @@ final class EmojiPickerController {
             return .escape
         case 36, 76:                      // Return, Keypad Enter: dismiss and pass through, never commit
             return .dismissExternally
-        case 126:
+        // The picker is now a horizontal ribbon, so Left/Right drive the selection alongside Up/Down.
+        // `.up` means "previous" and `.down` means "next" in the 1-D match list (the names predate the
+        // ribbon). With no matches the state machine lets these pass through, so the caret still moves.
+        case 126, 123:                    // Up, Left: previous glyph
             return .navigate(.up)
-        case 125:
+        case 125, 124:                    // Down, Right: next glyph
             return .navigate(.down)
-        case 123, 124, 117:               // Left, Right, Forward-Delete: caret moved, end capture
+        case 117:                         // Forward-Delete: text changed under the caret, end capture
             return .dismissExternally
         case 51:
             // Option + Backspace deletes a whole word, which the single-character query model can't

--- a/Cotabby/Services/UI/EmojiPickerPanelController.swift
+++ b/Cotabby/Services/UI/EmojiPickerPanelController.swift
@@ -27,7 +27,7 @@ final class EmojiPickerPanelController: EmojiPickerPanelPresenting {
 
     private lazy var panel: EmojiPickerPanel = {
         let panel = EmojiPickerPanel(
-            contentRect: CGRect(x: 0, y: 0, width: EmojiPickerMetrics.width, height: EmojiPickerMetrics.rowHeight),
+            contentRect: CGRect(origin: .zero, size: EmojiPickerMetrics.contentSize(matchCount: 0)),
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: true

--- a/Cotabby/Services/UI/OverlayController.swift
+++ b/Cotabby/Services/UI/OverlayController.swift
@@ -575,7 +575,6 @@ private struct GhostKeycap: View {
 /// floating text label. We do not try to disguise the card as the host editor; Cotypist's product
 /// language ("preview") is the right framing here.
 private struct MirrorOverlayView: View {
-    @Environment(\.colorScheme) var colorScheme
     let layout: MirrorOverlayLayout
     let customColor: Color?
     let keycapLabel: String?
@@ -584,16 +583,15 @@ private struct MirrorOverlayView: View {
     /// inline ghost, and the next-accept-word highlight is suppressed (the correction is one unit).
     let isCorrection: Bool
 
+    /// The card is now a committed-dark HUD in every host appearance, so the suggestion text is
+    /// always the light-on-dark value rather than branching on the system scheme (which would bake
+    /// dark-gray text onto the dark card over a light host). The correction green likewise uses the
+    /// dark-appropriate tone.
     private var ghostColor: Color {
         if isCorrection {
-            return SuggestionCorrectionStyle.color(for: colorScheme).opacity(opacity)
+            return SuggestionCorrectionStyle.color(for: .dark).opacity(opacity)
         }
-        let baseColor = customColor
-            ?? (
-                colorScheme == .dark
-                    ? Color(red: 0.85, green: 0.85, blue: 0.85)
-                    : Color(red: 0.25, green: 0.25, blue: 0.25)
-            )
+        let baseColor = customColor ?? Color(red: 0.85, green: 0.85, blue: 0.85)
         return baseColor.opacity(opacity)
     }
 
@@ -629,16 +627,6 @@ private struct MirrorOverlayView: View {
         return attributed
     }
 
-    private var backdropColor: Color {
-        colorScheme == .dark
-            ? Color(white: 0.16).opacity(0.96)
-            : Color(white: 0.98).opacity(0.96)
-    }
-
-    private var borderColor: Color {
-        colorScheme == .dark ? Color(white: 0.28) : Color(white: 0.82)
-    }
-
     var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: 6) {
             Text(styledSuggestion)
@@ -650,19 +638,13 @@ private struct MirrorOverlayView: View {
             }
         }
         .padding(.horizontal, 10)
-        .padding(.vertical, 6)
-        .background(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(backdropColor)
-                .shadow(color: .black.opacity(0.12), radius: 6, x: 0, y: 2)
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .stroke(borderColor, lineWidth: 0.5)
-        )
-        // The panel itself is sized by MirrorOverlayLayout to the card dimensions, so we don't
-        // need fixedSize here — the view fills the panel exactly.
+        .padding(.vertical, 4)
+        // The panel itself is sized by MirrorOverlayLayout to the card dimensions, so the content
+        // fills the panel exactly and the shared chrome paints the committed-dark backdrop. The
+        // forced-dark scheme inside `popupHUDChrome` is what flips `styledSuggestion` and the keycap
+        // to their light variants, so the popup reads the same dark over a white host as a dark one.
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .popupHUDChrome()
         // Right-to-left hosts get the SwiftUI environment flip so the keycap lands on the leading
         // side of the suggestion text, mirroring how RTL languages read.
         .environment(\.layoutDirection, layout.isRightToLeft ? .rightToLeft : .leftToRight)

--- a/Cotabby/Support/EmojiPickerPanelLayout.swift
+++ b/Cotabby/Support/EmojiPickerPanelLayout.swift
@@ -7,20 +7,36 @@ import CoreGraphics
 ///
 /// All rectangles are in AppKit screen coordinates (bottom-left origin, y increases upward), the
 /// same space `FocusedInputSnapshot.caretRect` already uses.
+/// Pure geometry for the two-row emoji picker: a typed-query row above a horizontal ribbon of
+/// ranked glyphs. The window width hugs the ribbon's cells up to `maxVisibleCells` (then the ribbon
+/// scrolls), so the panel stays compact for a narrow result set instead of reserving a fixed slab.
 enum EmojiPickerMetrics {
-    static let width: CGFloat = 300
-    static let rowHeight: CGFloat = 30
-    static let headerHeight: CGFloat = 26
-    static let dividerHeight: CGFloat = 1
-    static let listVerticalPadding: CGFloat = 8
-    static let maxVisibleRows = 8
+    /// Square cell that holds one glyph and its selection chip.
+    static let cellSize: CGFloat = 30
+    /// Gap between adjacent ribbon cells.
+    static let cellSpacing: CGFloat = 2
+    /// Leading/trailing inset shared by the query row and the ribbon.
+    static let horizontalInset: CGFloat = 8
+    /// Height of the typed-query row sitting above the ribbon.
+    static let queryRowHeight: CGFloat = 22
+    /// Height of the glyph ribbon row (the cell plus a little vertical breathing room).
+    static let ribbonRowHeight: CGFloat = 40
+    /// How many cells are shown before the ribbon scrolls horizontally.
+    static let maxVisibleCells = 8
+    /// Floor so a one- or two-match ribbon (or the bare-":" empty state) never collapses to a sliver.
+    static let minWidth: CGFloat = 132
 
-    /// The panel size for a given number of matches. An empty result still reserves one row so the
-    /// panel never collapses to nothing when the query is empty.
+    /// The panel size for a given number of matches. An empty result still reserves the ribbon row
+    /// so the panel never collapses to nothing when the query is empty or matches nothing.
     static func contentSize(matchCount: Int) -> CGSize {
-        let rows = matchCount == 0 ? 1 : min(matchCount, maxVisibleRows)
-        let listHeight = CGFloat(rows) * rowHeight + (matchCount == 0 ? 0 : listVerticalPadding)
-        return CGSize(width: width, height: headerHeight + dividerHeight + listHeight)
+        let cells = matchCount == 0 ? 0 : min(matchCount, maxVisibleCells)
+        let ribbonWidth = cells == 0
+            ? minWidth
+            : CGFloat(cells) * cellSize + CGFloat(cells - 1) * cellSpacing + horizontalInset * 2
+        return CGSize(
+            width: max(minWidth, ribbonWidth),
+            height: queryRowHeight + ribbonRowHeight
+        )
     }
 }
 

--- a/Cotabby/Support/MirrorOverlayLayout.swift
+++ b/Cotabby/Support/MirrorOverlayLayout.swift
@@ -47,9 +47,10 @@ struct MirrorOverlayLayout: Equatable {
         /// card. Large enough that the card does not look like it is part of the field.
         static let anchorGap: CGFloat = 8
 
-        /// Internal padding inside the card around the text + keycap row.
+        /// Internal padding inside the card around the text + keycap row. Must stay in lockstep with
+        /// the `.padding` on `MirrorOverlayView`, since the card fills this computed panel frame.
         static let horizontalPadding: CGFloat = 10
-        static let verticalPadding: CGFloat = 6
+        static let verticalPadding: CGFloat = 4
 
         /// Estimated keycap pill width (matches GhostKeycap's roughly 28pt label + spacing). Used to
         /// reserve room for the acceptance hint when computing card width.

--- a/Cotabby/Support/MirrorOverlayLayout.swift
+++ b/Cotabby/Support/MirrorOverlayLayout.swift
@@ -56,11 +56,10 @@ struct MirrorOverlayLayout: Equatable {
         /// reserve room for the acceptance hint when computing card width.
         static let keycapReservation: CGFloat = 36
 
-        /// Width budget caps. We do not want a card that spans the whole monitor for a long
-        /// completion; clamp to a comfortable reading width with horizontal scrolling-style ellipsis
-        /// handled by SwiftUI lineLimit.
+        /// Width budget cap. The card hugs short suggestions instead of imposing a minimum text
+        /// width, while long completions clamp to a comfortable reading width and SwiftUI supplies
+        /// the trailing ellipsis.
         static let maxCardWidth: CGFloat = 520
-        static let minCardWidth: CGFloat = 120
 
         /// Distance the card must keep from screen edges so it never clips against the menu bar or
         /// dock. The visibleFrame already excludes those, but a small inset still looks more
@@ -99,11 +98,10 @@ struct MirrorOverlayLayout: Equatable {
         let measuredTextWidth = measuredWidth(of: normalizedSuggestion, fontSize: scaledFontSize)
         let keycapReservation = showsAcceptanceHint ? Metrics.keycapReservation : 0
 
-        // Reserve the keycap on top of the text width, not inside the min/max clamp. Otherwise a
-        // short suggestion (measured width below `minCardWidth`) gets the same card as one with the
-        // hint disabled because the minimum floor absorbs the reservation.
+        // Reserve the keycap on top of the measured text width so the panel follows the actual
+        // suggestion rather than carrying empty space from an arbitrary minimum card width.
         let textBudget = max(0, Metrics.maxCardWidth - keycapReservation)
-        let textContentWidth = min(textBudget, max(Metrics.minCardWidth, measuredTextWidth))
+        let textContentWidth = min(textBudget, measuredTextWidth)
         let contentWidth = textContentWidth + keycapReservation
         let cardWidth = contentWidth + (Metrics.horizontalPadding * 2)
         let cardHeight = ceil(scaledFontSize * 1.6) + (Metrics.verticalPadding * 2)

--- a/Cotabby/UI/EmojiPickerView.swift
+++ b/Cotabby/UI/EmojiPickerView.swift
@@ -4,18 +4,19 @@ import SwiftUI
 /// File overview:
 /// The SwiftUI content hosted inside the floating emoji picker panel. It is a pure renderer of
 /// `EmojiPickerViewModel`: the trigger state machine and controller own all behavior, while this view
-/// only reflects the current query, matches, and highlighted row. Keyboard navigation arrives through
+/// only reflects the current query, matches, and selected glyph. Keyboard navigation arrives through
 /// the global event tap (not the panel, which never becomes key), so this view does not handle key
-/// input. Mouse clicks on a row report the index back through `onSelect`.
+/// input. Mouse clicks on a cell report the index back through `onSelect`.
 
 /// Observable state the controller pushes into the panel. Kept tiny so selection moves re-render only
-/// the row highlight and scroll position, not the whole list.
+/// the highlighted cell and scroll position, not the whole ribbon.
 @MainActor
 final class EmojiPickerViewModel: ObservableObject {
     @Published var query: String = ""
     @Published var matches: [EmojiMatch] = []
     @Published var selectedIndex: Int = 0
-    /// The accept-word key label shown on the highlighted row; `nil` hides the keycap.
+    /// The accept-word key label. Retained for the panel contract; the minimal ribbon no longer draws
+    /// a per-cell keycap, so it is currently unused by the view.
     @Published var acceptKeyLabel: String?
 }
 
@@ -25,119 +26,89 @@ struct EmojiPickerView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            header
-            Divider()
-            content
+            queryRow
+            ribbon
         }
-        .frame(width: EmojiPickerMetrics.width)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .stroke(Color.primary.opacity(0.1), lineWidth: 0.5)
-        )
+        .frame(width: EmojiPickerMetrics.contentSize(matchCount: model.matches.count).width)
+        .popupHUDChrome()
     }
 
-    private var header: some View {
-        HStack(spacing: 0) {
-            Text(":")
-                .foregroundStyle(.secondary)
-            Text(model.query)
-                .foregroundStyle(.primary)
+    /// Row 1: the live ":query" the user is typing. Echoing it titles the ribbon and confirms which
+    /// query produced these glyphs, since the ribbon itself shows no per-glyph names.
+    private var queryRow: some View {
+        HStack(spacing: 1) {
+            Text(":").foregroundStyle(PopupTheme.secondaryText)
+            Text(model.query).foregroundStyle(PopupTheme.primaryText)
             Spacer(minLength: 0)
         }
         .font(.system(size: 12, weight: .medium, design: .monospaced))
         .lineLimit(1)
-        .padding(.horizontal, 10)
-        .frame(height: EmojiPickerMetrics.headerHeight)
+        .padding(.horizontal, EmojiPickerMetrics.horizontalInset)
+        .frame(height: EmojiPickerMetrics.queryRowHeight)
     }
 
+    /// Row 2: ranked glyphs left-to-right, the selection moved by the arrow keys. Scrolls horizontally
+    /// once the match count passes `maxVisibleCells`, keeping the selected cell centered in view.
     @ViewBuilder
-    private var content: some View {
+    private var ribbon: some View {
         if model.matches.isEmpty {
-            if model.query.isEmpty {
-                Color.clear.frame(height: EmojiPickerMetrics.rowHeight)
-            } else {
-                Text("No emoji found")
-                    .font(.system(size: 12))
-                    .foregroundStyle(.secondary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal, 10)
-                    .frame(height: EmojiPickerMetrics.rowHeight)
-            }
+            emptyRibbon
         } else {
             ScrollViewReader { proxy in
-                ScrollView {
-                    LazyVStack(spacing: 0) {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: EmojiPickerMetrics.cellSpacing) {
                         ForEach(model.matches.indices, id: \.self) { index in
-                            EmojiPickerRow(
-                                match: model.matches[index],
-                                isSelected: index == model.selectedIndex,
-                                acceptKeyLabel: index == model.selectedIndex ? model.acceptKeyLabel : nil
+                            EmojiRibbonCell(
+                                glyph: model.matches[index].glyph,
+                                isSelected: index == model.selectedIndex
                             )
                             .id(index)
                             .contentShape(Rectangle())
                             .onTapGesture { onSelect(index) }
                         }
                     }
-                    .padding(.vertical, 4)
+                    .padding(.horizontal, EmojiPickerMetrics.horizontalInset)
                 }
+                .frame(height: EmojiPickerMetrics.ribbonRowHeight)
                 .onChange(of: model.selectedIndex) { _, newValue in
-                    proxy.scrollTo(newValue, anchor: .center)
+                    withAnimation(.easeOut(duration: 0.12)) {
+                        proxy.scrollTo(newValue, anchor: .center)
+                    }
                 }
             }
         }
     }
 
-}
-
-private struct EmojiPickerRow: View {
-    let match: EmojiMatch
-    let isSelected: Bool
-    let acceptKeyLabel: String?
-
-    var body: some View {
-        HStack(spacing: 8) {
-            Text(match.glyph)
-                .font(.system(size: 18))
-            Text(":\(match.primaryAlias):")
-                .font(.system(size: 13))
-                .foregroundStyle(isSelected ? Color.white : Color.primary)
-                .lineLimit(1)
-                .truncationMode(.tail)
-            Spacer(minLength: 0)
-            if let acceptKeyLabel {
-                EmojiKeycap(label: acceptKeyLabel, onAccent: isSelected)
-            }
+    /// Empty state. A bare ":" with no recents reserves the ribbon row so the panel keeps its shape; a
+    /// typed query that matches nothing says so rather than showing a blank strip.
+    @ViewBuilder
+    private var emptyRibbon: some View {
+        if model.query.isEmpty {
+            Color.clear.frame(height: EmojiPickerMetrics.ribbonRowHeight)
+        } else {
+            Text("No emoji")
+                .font(.system(size: 12))
+                .foregroundStyle(PopupTheme.secondaryText)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, EmojiPickerMetrics.horizontalInset)
+                .frame(height: EmojiPickerMetrics.ribbonRowHeight)
         }
-        .padding(.horizontal, 10)
-        .frame(height: EmojiPickerMetrics.rowHeight)
-        .background(
-            RoundedRectangle(cornerRadius: 6, style: .continuous)
-                .fill(isSelected ? Color.accentColor : Color.clear)
-        )
-        .padding(.horizontal, 4)
     }
 }
 
-/// Small keycap pill on the highlighted row, mirroring the user's configured word-accept shortcut.
-private struct EmojiKeycap: View {
-    let label: String
-    let onAccent: Bool
+/// One ribbon glyph. The selected cell gets a soft white chip (the calm Spotlight-style highlight);
+/// the rest are bare so the row reads as a clean line of emoji.
+private struct EmojiRibbonCell: View {
+    let glyph: String
+    let isSelected: Bool
 
     var body: some View {
-        Text(label)
-            .font(.system(size: 10, weight: .medium, design: .rounded))
-            .foregroundStyle(onAccent ? Color.white : Color.secondary)
-            .padding(.horizontal, 5)
-            .padding(.vertical, 2)
+        Text(glyph)
+            .font(.system(size: 20))
+            .frame(width: EmojiPickerMetrics.cellSize, height: EmojiPickerMetrics.cellSize)
             .background(
-                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .fill(onAccent ? Color.white.opacity(0.22) : Color.primary.opacity(0.08))
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(isSelected ? PopupTheme.selectionFill : Color.clear)
             )
-            .overlay(
-                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .stroke(onAccent ? Color.white.opacity(0.35) : Color.primary.opacity(0.15), lineWidth: 1)
-            )
-            .fixedSize()
     }
 }

--- a/Cotabby/UI/EmojiPickerView.swift
+++ b/Cotabby/UI/EmojiPickerView.swift
@@ -15,9 +15,9 @@ final class EmojiPickerViewModel: ObservableObject {
     @Published var query: String = ""
     @Published var matches: [EmojiMatch] = []
     @Published var selectedIndex: Int = 0
-    /// The accept-word key label. Retained for the panel contract; the minimal ribbon no longer draws
-    /// a per-cell keycap, so it is currently unused by the view.
-    @Published var acceptKeyLabel: String?
+    /// Retained for the panel contract, but deliberately not published: the minimal ribbon does not
+    /// draw a keycap, so updates should not invalidate the SwiftUI view hierarchy.
+    var acceptKeyLabel: String?
 }
 
 struct EmojiPickerView: View {

--- a/Cotabby/UI/InlinePreviewView.swift
+++ b/Cotabby/UI/InlinePreviewView.swift
@@ -23,19 +23,15 @@ struct InlinePreviewView: View {
         HStack(spacing: 8) {
             Text(model.previewText)
                 .font(.system(size: 13, weight: .medium, design: .rounded))
-                .foregroundStyle(.primary)
+                .foregroundStyle(PopupTheme.primaryText)
                 .lineLimit(1)
             if let label = model.acceptKeyLabel {
                 InlinePreviewKeycap(label: label)
             }
         }
         .padding(.horizontal, 12)
-        .frame(height: 30)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .stroke(Color.primary.opacity(0.1), lineWidth: 0.5)
-        )
+        .frame(height: 28)
+        .popupHUDChrome()
         .contentShape(Rectangle())
         .onTapGesture { onTap() }
         .fixedSize()
@@ -49,16 +45,16 @@ private struct InlinePreviewKeycap: View {
     var body: some View {
         Text(label)
             .font(.system(size: 10, weight: .medium, design: .rounded))
-            .foregroundStyle(.secondary)
+            .foregroundStyle(PopupTheme.secondaryText)
             .padding(.horizontal, 5)
             .padding(.vertical, 2)
             .background(
                 RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .fill(Color.primary.opacity(0.08))
+                    .fill(Color.white.opacity(0.10))
             )
             .overlay(
                 RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .stroke(Color.primary.opacity(0.15), lineWidth: 1)
+                    .stroke(PopupTheme.hairline, lineWidth: 1)
             )
             .fixedSize()
     }

--- a/Cotabby/UI/Onboarding/OnboardingFeatureShowcase.swift
+++ b/Cotabby/UI/Onboarding/OnboardingFeatureShowcase.swift
@@ -329,7 +329,9 @@ private struct EmojiPickerDemoCard: View {
     private let leadIn = "Nice work "
     private let trigger = ":smi"
     private let chosenGlyph = "😄"
-    private let candidates: [(glyph: String, alias: String)] = [("😄", "smile"), ("😁", "smiley")]
+    private let candidates: [(glyph: String, alias: String)] = [
+        ("😄", "smile"), ("😁", "smiley"), ("😊", "blush"), ("😆", "laughing"), ("😅", "sweat_smile")
+    ]
 
     var body: some View {
         DemoCard(caption: "Inline emoji", contentHeight: 124) {
@@ -403,88 +405,50 @@ private struct EmojiPickerDemoCard: View {
     }
 }
 
-/// Scaled-down replica of the real inline emoji popup (`EmojiPickerView`): a `.regularMaterial`
-/// panel with a monospaced query header, a divider, and the candidate rows.
+/// Scaled-down replica of the real inline emoji popup (`EmojiPickerView`): the committed-dark HUD
+/// with a monospaced query row above a horizontal ribbon of ranked glyphs, the first selected.
 private struct DemoEmojiPopup: View {
     let query: String
     let candidates: [(glyph: String, alias: String)]
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            HStack(spacing: 0) {
-                Text(":").foregroundStyle(.secondary)
-                Text(query).foregroundStyle(.primary)
+            HStack(spacing: 1) {
+                Text(":").foregroundStyle(PopupTheme.secondaryText)
+                Text(query).foregroundStyle(PopupTheme.primaryText)
                 Spacer(minLength: 0)
             }
             .font(.system(size: 12, weight: .medium, design: .monospaced))
-            .padding(.horizontal, 10)
-            .frame(height: 26)
+            .padding(.horizontal, 8)
+            .frame(height: 22)
 
-            Divider()
-
-            VStack(spacing: 0) {
+            HStack(spacing: 2) {
                 ForEach(Array(candidates.enumerated()), id: \.element.alias) { index, candidate in
-                    DemoEmojiRow(glyph: candidate.glyph, alias: candidate.alias, isSelected: index == 0)
+                    DemoEmojiRibbonCell(glyph: candidate.glyph, isSelected: index == 0)
                 }
             }
-            .padding(.vertical, 4)
+            .padding(.horizontal, 8)
+            .frame(height: 40)
         }
-        .frame(width: 210)
-        .background(
-            RoundedRectangle(cornerRadius: 10, style: .continuous).fill(.regularMaterial)
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .stroke(Color.primary.opacity(0.1), lineWidth: 0.5)
-        )
-        .shadow(color: .black.opacity(0.18), radius: 8, y: 4)
+        .frame(width: 174)
+        .popupHUDChrome()
+        .shadow(color: .black.opacity(0.28), radius: 8, y: 4)
     }
 }
 
-private struct DemoEmojiRow: View {
+/// One ribbon glyph in the onboarding replica, mirroring the real `EmojiRibbonCell`.
+private struct DemoEmojiRibbonCell: View {
     let glyph: String
-    let alias: String
     let isSelected: Bool
 
     var body: some View {
-        HStack(spacing: 8) {
-            Text(glyph).font(.system(size: 18))
-            Text(":\(alias):")
-                .font(.system(size: 13))
-                .foregroundStyle(isSelected ? Color.white : Color.primary)
-                .lineLimit(1)
-            Spacer(minLength: 0)
-            if isSelected {
-                DemoEmojiKeycap(label: "Tab")
-            }
-        }
-        .padding(.horizontal, 10)
-        .frame(height: 30)
-        .background(
-            RoundedRectangle(cornerRadius: 6, style: .continuous)
-                .fill(isSelected ? Color.accentColor : Color.clear)
-        )
-        .padding(.horizontal, 4)
-    }
-}
-
-/// The on-accent keycap variant from `EmojiPickerView` (shown only on the highlighted row).
-private struct DemoEmojiKeycap: View {
-    let label: String
-
-    var body: some View {
-        Text(label)
-            .font(.system(size: 10, weight: .medium, design: .rounded))
-            .foregroundStyle(Color.white)
-            .padding(.horizontal, 5)
-            .padding(.vertical, 2)
+        Text(glyph)
+            .font(.system(size: 20))
+            .frame(width: 30, height: 30)
             .background(
-                RoundedRectangle(cornerRadius: 6, style: .continuous).fill(Color.white.opacity(0.22))
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(isSelected ? PopupTheme.selectionFill : Color.clear)
             )
-            .overlay(
-                RoundedRectangle(cornerRadius: 6, style: .continuous).stroke(Color.white.opacity(0.35), lineWidth: 1)
-            )
-            .fixedSize()
     }
 }
 

--- a/Cotabby/UI/Onboarding/OnboardingFeatureShowcase.swift
+++ b/Cotabby/UI/Onboarding/OnboardingFeatureShowcase.swift
@@ -444,7 +444,7 @@ private struct DemoEmojiRibbonCell: View {
     var body: some View {
         Text(glyph)
             .font(.system(size: 20))
-            .frame(width: 30, height: 30)
+            .frame(width: EmojiPickerMetrics.cellSize, height: EmojiPickerMetrics.cellSize)
             .background(
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
                     .fill(isSelected ? PopupTheme.selectionFill : Color.clear)

--- a/Cotabby/UI/PopupChrome.swift
+++ b/Cotabby/UI/PopupChrome.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+/// File overview:
+/// One shared visual language for every Cotabby surface that floats near the caret: the inline
+/// emoji picker, the suggestion "popup" card (mirror mode), and the macro inline preview. Before
+/// this they each carried their own `.regularMaterial` + border styling and drifted apart; routing
+/// all three through `PopupTheme`/`PopupHUDChrome` keeps them identical and lets a restyle land in
+/// one place.
+///
+/// The look is a *committed-dark* HUD: a deterministic charcoal gradient rather than an adaptive
+/// material. Determinism is the point — the popup must read the same dark over a white Pages window
+/// as over a black terminal, so it always looks like an ephemeral system overlay instead of a bright
+/// card competing with the host document. (An adaptive material would invert to light over a light
+/// host, which is exactly the "intrusive bright box" we are moving away from.)
+enum PopupTheme {
+    /// Shared corner radius. Continuous curvature; sized to look right on both the short single-line
+    /// cards (~28pt tall) and the taller two-row emoji popup (~62pt) without going pill-round.
+    static let cornerRadius: CGFloat = 10
+
+    /// The dark backdrop. A subtle top-to-bottom gradient (lighter crown, darker base) reads as a
+    /// lit surface rather than a flat black rectangle, which is what keeps it from looking cheap.
+    static let backgroundGradient = LinearGradient(
+        colors: [Color(white: 0.17), Color(white: 0.11)],
+        startPoint: .top,
+        endPoint: .bottom
+    )
+
+    /// Hairline edge that separates the dark panel from a dark host behind it.
+    static let hairline = Color.white.opacity(0.12)
+
+    /// Selection wash for the active row/cell. A soft white fill (the Spotlight/menu idiom) instead
+    /// of a saturated accent bar, so the highlight guides the eye without shouting.
+    static let selectionFill = Color.white.opacity(0.16)
+
+    /// Primary and secondary text tuned for legibility on the charcoal backdrop.
+    static let primaryText = Color.white.opacity(0.95)
+    static let secondaryText = Color.white.opacity(0.5)
+}
+
+/// Applies the committed-dark HUD backdrop, hairline border, and clip shape, and pins the subtree to
+/// the dark color scheme so `.primary`/`.secondary` and any nested chrome resolve to their light
+/// variants on the dark surface without each call site re-specifying colors.
+struct PopupHUDChrome: ViewModifier {
+    var cornerRadius: CGFloat = PopupTheme.cornerRadius
+
+    func body(content: Content) -> some View {
+        content
+            .background(
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .fill(PopupTheme.backgroundGradient)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .strokeBorder(PopupTheme.hairline, lineWidth: 0.5)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+            // Outermost so the backdrop, border, and all descendant content share the forced scheme.
+            .environment(\.colorScheme, .dark)
+    }
+}
+
+extension View {
+    /// Wraps the view in the shared dark popup chrome. `cornerRadius` defaults to `PopupTheme`.
+    func popupHUDChrome(cornerRadius: CGFloat = PopupTheme.cornerRadius) -> some View {
+        modifier(PopupHUDChrome(cornerRadius: cornerRadius))
+    }
+}

--- a/CotabbyTests/EmojiPickerControllerTests.swift
+++ b/CotabbyTests/EmojiPickerControllerTests.swift
@@ -99,6 +99,43 @@ final class EmojiPickerControllerTests: XCTestCase {
         }
     }
 
+    func test_rightArrowNavigatesAndIsConsumedWhenMatchesPresent() {
+        runOnMainActor {
+            let harness = Harness(precedingText: ":smile")
+            harness.openAndType(":smile")   // matches present
+
+            // The picker is a horizontal ribbon now: Right (124) moves the selection instead of
+            // dismissing, so it is consumed before the host sees it and the panel stays open.
+            XCTAssertTrue(harness.controller.observe(Harness.keyEvent(124)))
+            XCTAssertEqual(harness.controller.decideCaptureKey(Harness.monitorKey(124)), .consume)
+            XCTAssertFalse(harness.panel.isHidden)
+        }
+    }
+
+    func test_leftArrowNavigatesAndIsConsumedWhenMatchesPresent() {
+        runOnMainActor {
+            let harness = Harness(precedingText: ":smile")
+            harness.openAndType(":smile")
+
+            XCTAssertTrue(harness.controller.observe(Harness.keyEvent(123)))
+            XCTAssertEqual(harness.controller.decideCaptureKey(Harness.monitorKey(123)), .consume)
+            XCTAssertFalse(harness.panel.isHidden)
+        }
+    }
+
+    func test_arrowWithNoMatchesPassesThroughAndClosesCapture() {
+        runOnMainActor {
+            let harness = Harness(precedingText: ":zzzzz")
+            harness.openAndType(":zzzzz")   // no catalog match
+
+            // With nothing to move through, the arrow must reach the host (so the caret still moves)
+            // and the capture closes rather than trapping the key.
+            XCTAssertTrue(harness.controller.observe(Harness.keyEvent(124)))
+            XCTAssertEqual(harness.controller.decideCaptureKey(Harness.monitorKey(124)), .passThrough)
+            XCTAssertTrue(harness.panel.isHidden)
+        }
+    }
+
     // MARK: - Harness
 
     @MainActor

--- a/CotabbyTests/EmojiPickerPanelLayoutTests.swift
+++ b/CotabbyTests/EmojiPickerPanelLayoutTests.swift
@@ -10,25 +10,23 @@ final class EmojiPickerPanelLayoutTests: XCTestCase {
 
     private let visibleFrame = CGRect(x: 0, y: 0, width: 1000, height: 800)
 
-    func test_contentSize_reservesOneRowWhenEmpty() {
+    func test_contentSize_reservesRibbonRowWhenEmpty() {
         let size = EmojiPickerMetrics.contentSize(matchCount: 0)
-        let expectedHeight = EmojiPickerMetrics.headerHeight
-            + EmojiPickerMetrics.dividerHeight
-            + EmojiPickerMetrics.rowHeight
+        let expectedHeight = EmojiPickerMetrics.queryRowHeight + EmojiPickerMetrics.ribbonRowHeight
 
-        XCTAssertEqual(size.width, EmojiPickerMetrics.width)
+        XCTAssertEqual(size.width, EmojiPickerMetrics.minWidth)
         XCTAssertEqual(size.height, expectedHeight)
     }
 
-    func test_contentSize_capsAtMaxVisibleRows() {
+    func test_contentSize_capsAtMaxVisibleCells() {
         let size = EmojiPickerMetrics.contentSize(matchCount: 20)
-        let visibleRowsHeight = CGFloat(EmojiPickerMetrics.maxVisibleRows) * EmojiPickerMetrics.rowHeight
-            + EmojiPickerMetrics.listVerticalPadding
-        let expectedHeight = EmojiPickerMetrics.headerHeight
-            + EmojiPickerMetrics.dividerHeight
-            + visibleRowsHeight
+        let cells = CGFloat(EmojiPickerMetrics.maxVisibleCells)
+        let expectedWidth = cells * EmojiPickerMetrics.cellSize
+            + (cells - 1) * EmojiPickerMetrics.cellSpacing
+            + EmojiPickerMetrics.horizontalInset * 2
 
-        XCTAssertEqual(size.height, expectedHeight)
+        XCTAssertEqual(size.width, expectedWidth)
+        XCTAssertEqual(size.height, EmojiPickerMetrics.queryRowHeight + EmojiPickerMetrics.ribbonRowHeight)
     }
 
     func test_frame_sitsBelowCaretWhenItFits() {
@@ -52,7 +50,8 @@ final class EmojiPickerPanelLayoutTests: XCTestCase {
     }
 
     func test_frame_clampsToRightEdge() {
-        let caret = CGRect(x: 850, y: 400, width: 2, height: 16)
+        // Caret far enough right that even the compact ribbon overflows the visible frame.
+        let caret = CGRect(x: 950, y: 400, width: 2, height: 16)
         let size = EmojiPickerMetrics.contentSize(matchCount: 3)
 
         let frame = EmojiPickerPanelLayout.frame(caretRect: caret, contentSize: size, visibleFrame: visibleFrame)

--- a/CotabbyTests/MirrorOverlayLayoutTests.swift
+++ b/CotabbyTests/MirrorOverlayLayoutTests.swift
@@ -346,9 +346,9 @@ final class MirrorOverlayLayoutTests: XCTestCase {
             reason: .userPreference
         )
 
-        // Card width: 120pt text floor + 36pt keycap + 2 * 10pt padding. Height: ceil(13 * 1.6) + 12.
-        // Anchor top: field minY (100) - 8pt gap = 92; center: field midX (200).
-        XCTAssertEqual(layout.panelFrame, CGRect(x: 112, y: 59, width: 176, height: 33))
+        // Card width: 120pt text floor + 36pt keycap + 2 * 10pt padding. Height: ceil(13 * 1.6) + 8.
+        // Anchor top: field minY (100) - 8pt gap = 92, minus the 29pt card height; center: field midX.
+        XCTAssertEqual(layout.panelFrame, CGRect(x: 112, y: 63, width: 176, height: 29))
     }
 
     func test_make_emptyCaretRectAndMissingInputFrame_clampsToScreenMargin() {
@@ -367,7 +367,7 @@ final class MirrorOverlayLayoutTests: XCTestCase {
             reason: .userPreference
         )
 
-        XCTAssertEqual(layout.panelFrame, CGRect(x: 12, y: 12, width: 176, height: 33))
+        XCTAssertEqual(layout.panelFrame, CGRect(x: 12, y: 12, width: 176, height: 29))
     }
 
     // MARK: - Visible frame smaller than the card
@@ -390,7 +390,7 @@ final class MirrorOverlayLayoutTests: XCTestCase {
             reason: .userPreference
         )
 
-        XCTAssertEqual(layout.panelFrame, CGRect(x: 12, y: 12, width: 176, height: 33))
+        XCTAssertEqual(layout.panelFrame, CGRect(x: 12, y: 12, width: 176, height: 29))
     }
 
     // MARK: - Acceptance-hint reservation

--- a/CotabbyTests/MirrorOverlayLayoutTests.swift
+++ b/CotabbyTests/MirrorOverlayLayoutTests.swift
@@ -346,9 +346,12 @@ final class MirrorOverlayLayoutTests: XCTestCase {
             reason: .userPreference
         )
 
-        // Card width: 120pt text floor + 36pt keycap + 2 * 10pt padding. Height: ceil(13 * 1.6) + 8.
-        // Anchor top: field minY (100) - 8pt gap = 92, minus the 29pt card height; center: field midX.
-        XCTAssertEqual(layout.panelFrame, CGRect(x: 112, y: 63, width: 176, height: 29))
+        // The popup should hug the measured "hi" text plus its keycap and padding rather than
+        // retaining the old 120pt minimum text area. Height and anchor behavior remain unchanged.
+        XCTAssertLessThan(layout.panelFrame.width, 176)
+        XCTAssertEqual(layout.panelFrame.height, 29)
+        XCTAssertEqual(layout.panelFrame.midX, geometry.inputFrameRect!.midX)
+        XCTAssertEqual(layout.panelFrame.minY, 63)
     }
 
     func test_make_emptyCaretRectAndMissingInputFrame_clampsToScreenMargin() {
@@ -367,7 +370,9 @@ final class MirrorOverlayLayoutTests: XCTestCase {
             reason: .userPreference
         )
 
-        XCTAssertEqual(layout.panelFrame, CGRect(x: 12, y: 12, width: 176, height: 29))
+        XCTAssertEqual(layout.panelFrame.origin, CGPoint(x: 12, y: 12))
+        XCTAssertLessThan(layout.panelFrame.width, 176)
+        XCTAssertEqual(layout.panelFrame.height, 29)
     }
 
     // MARK: - Visible frame smaller than the card
@@ -390,7 +395,9 @@ final class MirrorOverlayLayoutTests: XCTestCase {
             reason: .userPreference
         )
 
-        XCTAssertEqual(layout.panelFrame, CGRect(x: 12, y: 12, width: 176, height: 29))
+        XCTAssertEqual(layout.panelFrame.origin, CGPoint(x: 12, y: 12))
+        XCTAssertLessThan(layout.panelFrame.width, 176)
+        XCTAssertEqual(layout.panelFrame.height, 29)
     }
 
     // MARK: - Acceptance-hint reservation

--- a/CotabbyTests/MirrorOverlayLayoutTests.swift
+++ b/CotabbyTests/MirrorOverlayLayoutTests.swift
@@ -381,7 +381,7 @@ final class MirrorOverlayLayoutTests: XCTestCase {
         // When the visible frame cannot contain the card at all (tiny screen or extreme zoom), the
         // min/max clamp inverts; the layout must pin to the leading margin on both axes rather
         // than producing a frame outside the screen.
-        let tinyScreen = CGRect(x: 0, y: 0, width: 150, height: 28)
+        let tinyScreen = CGRect(x: 0, y: 0, width: 80, height: 28)
         let geometry = CotabbyTestFixtures.overlayGeometry(
             caretRect: CGRect(x: 60, y: 200, width: 2, height: 18),
             inputFrameRect: nil


### PR DESCRIPTION
## Summary

Makes the two floating popups feel like ephemeral system overlays instead of bright cards competing with the document. The `:emoji:` picker and the suggestion **popup** card (mirror mode) each carried their own `.regularMaterial` styling and had drifted apart; both now route through one shared, committed-dark HUD (`PopupChrome`) that reads the same dark over a white host as over a dark one. The emoji picker is also restructured from a tall vertical list into a compact **two-row** layout: the live `:query` on top, a horizontal ribbon of ranked glyphs below, moved with the arrow keys.

## Validation

```
xcodebuild ... build           -> ** BUILD SUCCEEDED **
xcodebuild ... build-for-testing -> ** TEST BUILD SUCCEEDED **
xcodebuild ... test -only-testing:CotabbyTests/EmojiPickerPanelLayoutTests \
  -only-testing:CotabbyTests/EmojiPickerControllerTests \
  -only-testing:CotabbyTests/MirrorOverlayLayoutTests CODE_SIGNING_ALLOWED=NO
  -> ** TEST SUCCEEDED **  (incl. 3 new arrow-key nav tests)
swiftlint lint --quiet <changed files> -> exit 0
```

Rendered the redesigned popups over both a light and a dark host with an `ImageRenderer` harness (since removed): the committed-dark chrome, hairline, and light text are identical across host appearances, and the ribbon's soft selection chip lands on the highlighted glyph. (`ImageRenderer` does not lay out `ScrollView` subviews, so the real ribbon row snapshots blank; verified the cells via a non-scrolling proxy. The live `NSHostingView` panel scrolls normally.)

## Linked issues

None.

## Risk / rollout notes

- **New file** `Cotabby/UI/PopupChrome.swift` -> ran `xcodegen generate`; the `project.pbxproj` change is only the added file reference.
- **Emoji nav behavior change:** Left/Right arrows now move the ribbon selection (previously they dismissed the picker). Up/Down still navigate. With no matches, all arrows still pass through so the host caret moves and the capture closes. Covered by new controller tests.
- **Committed dark:** the suggestion popup card and the macro preview are now dark in *every* host appearance (previously adaptive light/dark). The mirror card is also ~4pt slimmer (vertical padding 6 -> 4); `MirrorOverlayLayout` and its geometry tests were updated in lockstep.
- Onboarding's emoji replica (`DemoEmojiPopup`) was updated to the new ribbon so onboarding doesn't show a stale design.
- No settings, schema, or persistence migrations.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR consolidates the emoji picker, suggestion popup card, and macro inline preview into a single shared dark HUD (`PopupChrome`), replacing per-surface `.regularMaterial` styling with a deterministic charcoal gradient that reads identically over both light and dark host documents. The emoji picker is also restructured from a scrollable vertical list into a compact two-row layout (`:query` row + horizontal glyph ribbon) with Left/Right arrow navigation.

- **`PopupChrome.swift`** introduces `PopupTheme` (tokens) and `PopupHUDChrome` (modifier), applied uniformly across `EmojiPickerView`, `InlinePreviewView`, and `MirrorOverlayView` — reducing per-site color branching to zero.
- **`EmojiPickerController`** remaps Left/Right arrows from `dismissExternally` to `navigate(.up/.down)`, with pass-through preserved when no matches are present; three new controller tests cover all branches.
- **`MirrorOverlayLayout`** removes the `minCardWidth` floor so cards hug short suggestions, and trims `verticalPadding` from 6→4 in lockstep with the view change; geometry tests were updated accordingly.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The changes are scoped to visual chrome and keyboard routing with no persistence, settings, or schema impact, and all new behavior is covered by tests.

The shared `PopupChrome` is a well-contained new file with deterministic, non-adaptive styling applied consistently across three surfaces. The arrow-key behavior change in `EmojiPickerController` is explicit, fully commented, and covered by three new tests that verify both the consume and pass-through branches. Layout metric changes in `MirrorOverlayLayout` are reflected in the updated geometry tests. No logic paths were left untested or undocumented.

No files require special attention. The only nits are in the onboarding demo replica, which does not affect production behavior.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Cotabby/UI/PopupChrome.swift | New shared HUD chrome. `PopupTheme` centralises all visual tokens; `PopupHUDChrome` modifier correctly applies background, hairline overlay, clip shape, and forced dark environment. Design is clean and well-documented. |
| Cotabby/UI/EmojiPickerView.swift | Restructured from vertical list to horizontal ribbon. Uses `EmojiPickerMetrics` constants throughout, animated `ScrollViewReader` centering on selection change, and de-published `acceptKeyLabel` as intended. No issues. |
| Cotabby/UI/Onboarding/OnboardingFeatureShowcase.swift | Demo popup updated to match new ribbon design. `DemoEmojiRibbonCell` correctly uses `EmojiPickerMetrics.cellSize`, but `DemoEmojiPopup` still hardcodes frame width (174) and raw spacing/padding literals instead of the shared metrics constants. |
| Cotabby/App/Coordinators/EmojiPickerController.swift | Left/Right arrows now drive ribbon navigation instead of dismissing. The `117` (Forward-Delete) case correctly kept as `dismissExternally`. New controller tests cover all three branches. |
| Cotabby/Support/MirrorOverlayLayout.swift | Removed `minCardWidth` floor so the card hugs short suggestions; `verticalPadding` dropped from 6→4 in lockstep with the view padding change. Geometry tests updated consistently. |
| Cotabby/Services/UI/OverlayController.swift | Adaptive `backdropColor`/`borderColor` helpers removed; ghost text now uses fixed dark-scheme values. `popupHUDChrome()` applied; vertical padding reduced from 6→4. `colorScheme` environment property removed as no longer needed. |
| Cotabby/UI/InlinePreviewView.swift | Switched from `.regularMaterial` to `popupHUDChrome()`; keycap colors updated to use `PopupTheme` tokens. Height trimmed from 30→28. All changes consistent with the shared chrome contract. |
| CotabbyTests/EmojiPickerControllerTests.swift | Three new tests added for ribbon arrow-key navigation: right with matches (consume), left with matches (consume), and any arrow with no matches (passThrough + panel hidden). Good coverage of the new behavior contract. |

</details>



<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    KEY[Key event from global tap]
    CTRL[EmojiPickerController.decideCaptureKey]
    MATCHES{matches.isEmpty?}

    KEY --> CTRL

    CTRL -->|Left 123 / Up 126| NAV_UP[navigate up]
    CTRL -->|Right 124 / Down 125| NAV_DOWN[navigate down]
    CTRL -->|Escape| DISMISS[dismiss]
    CTRL -->|Return / Enter| DISMISS_EXT[dismissExternally]
    CTRL -->|Forward-Delete 117| DISMISS_EXT

    NAV_UP --> MATCHES
    NAV_DOWN --> MATCHES

    MATCHES -->|No| PASSTHROUGH[passThrough: host caret moves, capture closes]
    MATCHES -->|Yes| CONSUME[consume: selectedIndex updates, ribbon scrolls]

    CONSUME --> VIEW[EmojiPickerView]
    VIEW --> RIBBON[HStack ribbon]
    VIEW --> QUERYROW[queryRow]
    RIBBON -->|onChange selectedIndex| SCROLL[proxy.scrollTo center, animated]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    KEY[Key event from global tap]
    CTRL[EmojiPickerController.decideCaptureKey]
    MATCHES{matches.isEmpty?}

    KEY --> CTRL

    CTRL -->|Left 123 / Up 126| NAV_UP[navigate up]
    CTRL -->|Right 124 / Down 125| NAV_DOWN[navigate down]
    CTRL -->|Escape| DISMISS[dismiss]
    CTRL -->|Return / Enter| DISMISS_EXT[dismissExternally]
    CTRL -->|Forward-Delete 117| DISMISS_EXT

    NAV_UP --> MATCHES
    NAV_DOWN --> MATCHES

    MATCHES -->|No| PASSTHROUGH[passThrough: host caret moves, capture closes]
    MATCHES -->|Yes| CONSUME[consume: selectedIndex updates, ribbon scrolls]

    CONSUME --> VIEW[EmojiPickerView]
    VIEW --> RIBBON[HStack ribbon]
    VIEW --> QUERYROW[queryRow]
    RIBBON -->|onChange selectedIndex| SCROLL[proxy.scrollTo center, animated]
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cotabby/Support/EmojiPickerPanelLayout.swift`, line 1-12 ([link](https://github.com/fujacob/cotabby/blob/e22fa5b09c0b9b1ad717b841e1f1ef194396e046/Cotabby/Support/EmojiPickerPanelLayout.swift#L1-L12)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Doubled file-level doc comment after the merge**

   The old "Pure geometry for the emoji picker panel: how big it is…" paragraph and the new "Pure geometry for the two-row emoji picker…" paragraph were both left as a single contiguous doc comment block before the `EmojiPickerMetrics` enum. Only one should be the file overview; the other is now redundant or misplaced as an enum-level doc comment.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22emoji-picker-minimal%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22emoji-picker-minimal%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FSupport%2FEmojiPickerPanelLayout.swift%0ALine%3A%201-12%0A%0AComment%3A%0A**Doubled%20file-level%20doc%20comment%20after%20the%20merge**%0A%0AThe%20old%20%22Pure%20geometry%20for%20the%20emoji%20picker%20panel%3A%20how%20big%20it%20is%E2%80%A6%22%20paragraph%20and%20the%20new%20%22Pure%20geometry%20for%20the%20two-row%20emoji%20picker%E2%80%A6%22%20paragraph%20were%20both%20left%20as%20a%20single%20contiguous%20doc%20comment%20block%20before%20the%20%60EmojiPickerMetrics%60%20enum.%20Only%20one%20should%20be%20the%20file%20overview%3B%20the%20other%20is%20now%20redundant%20or%20misplaced%20as%20an%20enum-level%20doc%20comment.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=753&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Cotabby%2FSupport%2FEmojiPickerPanelLayout.swift%0ALine%3A%201-12%0A%0AComment%3A%0A**Doubled%20file-level%20doc%20comment%20after%20the%20merge**%0A%0AThe%20old%20%22Pure%20geometry%20for%20the%20emoji%20picker%20panel%3A%20how%20big%20it%20is%E2%80%A6%22%20paragraph%20and%20the%20new%20%22Pure%20geometry%20for%20the%20two-row%20emoji%20picker%E2%80%A6%22%20paragraph%20were%20both%20left%20as%20a%20single%20contiguous%20doc%20comment%20block%20before%20the%20%60EmojiPickerMetrics%60%20enum.%20Only%20one%20should%20be%20the%20file%20overview%3B%20the%20other%20is%20now%20redundant%20or%20misplaced%20as%20an%20enum-level%20doc%20comment.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=fujacob%2Fcotabby&pr=753&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Fix mirror layout clamp test"](https://github.com/fujacob/cotabby/commit/9a42ab8b919a3a86705986910ed0c941a51c270d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38784121)</sub>

<!-- /greptile_comment -->