### PR TITLE
Fix build: initialize fadeIn properties in SuggestionSettingsModel.init

### DIFF
--- a/Cotabby/Models/SuggestionSettingsModel.swift
+++ b/Cotabby/Models/SuggestionSettingsModel.swift
@@ -206,6 +206,8 @@ final class SuggestionSettingsModel: ObservableObject {
         autoAcceptTrailingPunctuation = data.autoAcceptTrailingPunctuation
         addSpaceAfterAccept = data.addSpaceAfterAccept
         streamSuggestionsWhileGenerating = data.streamSuggestionsWhileGenerating
+        fadeInSuggestions = data.fadeInSuggestions
+        fadeInDurationSeconds = data.fadeInDurationSeconds
         acceptanceKeyCode = data.acceptanceKeyCode
         acceptanceKeyModifiers = data.acceptanceKeyModifiers
         acceptanceKeyLabel = data.acceptanceKeyLabel


### PR DESCRIPTION
## Summary

`SuggestionSettingsModel.init` doesn't initialize `fadeInSuggestions` / `fadeInDurationSeconds` — the two `@Published` properties added by the opacity-ramp change (#749). They're assigned in `resetToDefaults` but not in `init`, so Swift rejects the initializer ("return from initializer without initializing all stored properties") and `main` currently fails to compile (the `xcodebuild (macOS)` CI check is red). This adds the two missing assignments in `init`, mirroring `resetToDefaults`.

## Validation

```
xcodebuild build -project Cotabby.xcodeproj -scheme Cotabby \
  -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO
# ** BUILD SUCCEEDED **   (current main fails to build without this change)

swiftlint lint --config .swiftlint.yml --quiet
# exit 0
```

The same fix on a feature branch also passes the full suite: `xcodebuild test … CODE_SIGNING_ALLOWED=NO` → `** TEST SUCCEEDED **`, 1652 tests, 0 failures.

## Linked issues

None.

## Risk / rollout notes

Two-line change, no behavior difference — these values were already assigned everywhere except `init`. Restores a green build on `main`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores a broken build on `main` by adding the two missing property initializations (`fadeInSuggestions` and `fadeInDurationSeconds`) introduced by PR #749 to `SuggestionSettingsModel.init`. Swift's definite initialization rules require every stored property to be set before the initializer returns, so the omission caused a compile error.

- Adds `fadeInSuggestions = data.fadeInSuggestions` and `fadeInDurationSeconds = data.fadeInDurationSeconds` to `init`, mirroring their existing assignments in `resetToDefaults`.
- The fix re-establishes the documented invariant that the `init` assignment list and the `resetToDefaults` assignment list stay in sync, which is enforced by a dedicated unit test.

<h3>Confidence Score: 5/5</h3>

Safe to merge — two-line addition that unblocks the build with no behavioral change.

The change adds two property assignments that were clearly supposed to be in `init` all along — they exist in `resetToDefaults` and are read everywhere the overlay renderer touches fade settings. The values flow from the same `store.load` call that populates every other property, so there is no new logic to reason about and no risk of wrong defaults. The `init`/`resetToDefaults` parity is tested, meaning the test suite will catch any future drift.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Models/SuggestionSettingsModel.swift | Adds the two missing init assignments for fadeInSuggestions and fadeInDurationSeconds; restores the init/resetToDefaults parity invariant and fixes the compilation error. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant SuggestionSettingsModel
    participant SuggestionSettingsStore
    participant SuggestionSettingsData

    Caller->>SuggestionSettingsModel: init(configuration:userDefaults:)
    SuggestionSettingsModel->>SuggestionSettingsStore: load(configuration:)
    SuggestionSettingsStore-->>SuggestionSettingsModel: SuggestionSettingsData
    Note over SuggestionSettingsModel: Assign all @Published properties from data
    Note over SuggestionSettingsModel: (including fadeInSuggestions + fadeInDurationSeconds — added by this PR)
    SuggestionSettingsModel-->>Caller: fully initialized instance

    Caller->>SuggestionSettingsModel: resetToDefaults()
    SuggestionSettingsModel->>SuggestionSettingsStore: resetToDefaults(configuration:)
    SuggestionSettingsStore-->>SuggestionSettingsModel: SuggestionSettingsData (defaults)
    Note over SuggestionSettingsModel: Re-fans all @Published properties (mirrors init)
    SuggestionSettingsModel-->>Caller: settings reset
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant SuggestionSettingsModel
    participant SuggestionSettingsStore
    participant SuggestionSettingsData

    Caller->>SuggestionSettingsModel: init(configuration:userDefaults:)
    SuggestionSettingsModel->>SuggestionSettingsStore: load(configuration:)
    SuggestionSettingsStore-->>SuggestionSettingsModel: SuggestionSettingsData
    Note over SuggestionSettingsModel: Assign all @Published properties from data
    Note over SuggestionSettingsModel: (including fadeInSuggestions + fadeInDurationSeconds — added by this PR)
    SuggestionSettingsModel-->>Caller: fully initialized instance

    Caller->>SuggestionSettingsModel: resetToDefaults()
    SuggestionSettingsModel->>SuggestionSettingsStore: resetToDefaults(configuration:)
    SuggestionSettingsStore-->>SuggestionSettingsModel: SuggestionSettingsData (defaults)
    Note over SuggestionSettingsModel: Re-fans all @Published properties (mirrors init)
    SuggestionSettingsModel-->>Caller: settings reset
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Fix build: initialize fadeIn properties ..."](https://github.com/fujacob/cotabby/commit/376c7bcc784ea8f1f920d7a50862daa844ecc67f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40361639)</sub>

<!-- /greptile_comment -->