### PR TITLE
Check for updates once daily

### DIFF
--- a/Cotabby/Services/Utilities/AppUpdateManager.swift
+++ b/Cotabby/Services/Utilities/AppUpdateManager.swift
@@ -17,6 +17,11 @@ final class AppUpdateManager {
 
     private var isStarted = false
 
+    /// Sparkle persists this setting in user defaults, which take precedence over the value in
+    /// `CotabbyInfo.plist`. Reapplying the product policy repairs older installs that may have saved
+    /// a shorter development interval while the plist still gives fresh installs the same default.
+    private static let automaticCheckInterval: TimeInterval = 24 * 60 * 60
+
     private static let debugCheckForUpdatesOnLaunchArgument = "-Cotabby-check-for-updates-on-launch"
     private static let publicKeyPlaceholder = "REPLACE_WITH_GENERATED_SPARKLE_PUBLIC_ED_KEY"
 
@@ -53,18 +58,12 @@ final class AppUpdateManager {
             return
         }
 
+        // Configure the interval before starting so Sparkle's first scheduling decision uses the
+        // daily cadence together with its persisted last-check date.
+        updaterController.updater.updateCheckInterval = Self.automaticCheckInterval
         updaterController.startUpdater()
         isStarted = true
         log("Sparkle updater started.")
-
-        // Check once on every launch. Sparkle's scheduled check only fires on launch when the
-        // interval has already elapsed, so frequent users (who reopen within a day) would never
-        // see a check on open. This is a *background* check: it silently does nothing when the app
-        // is up to date and only surfaces UI when an update is actually available — unlike
-        // `checkForUpdates()`, which always shows a result dialog and is reserved for the manual
-        // "Check for Updates" button. The daily `SUScheduledCheckInterval` then covers long-running
-        // sessions where the app stays open for days.
-        updaterController.updater.checkForUpdatesInBackground()
 
         #if DEBUG
         if ProcessInfo.processInfo.arguments.contains(Self.debugCheckForUpdatesOnLaunchArgument) {

--- a/Cotabby/Services/Utilities/AppUpdateManager.swift
+++ b/Cotabby/Services/Utilities/AppUpdateManager.swift
@@ -60,10 +60,19 @@ final class AppUpdateManager {
 
         // Configure the interval before starting so Sparkle's first scheduling decision uses the
         // daily cadence together with its persisted last-check date.
-        updaterController.updater.updateCheckInterval = Self.automaticCheckInterval
+        let updater = updaterController.updater
+        updater.updateCheckInterval = Self.automaticCheckInterval
         updaterController.startUpdater()
         isStarted = true
         log("Sparkle updater started.")
+
+        // Catch up immediately when the app returns after the daily interval. Recent launches leave
+        // the check to Sparkle's scheduler, so reopening Cotabby cannot bypass the daily cadence.
+        let shouldCatchUp = updater.lastUpdateCheckDate
+            .map { Date().timeIntervalSince($0) >= Self.automaticCheckInterval } ?? true
+        if shouldCatchUp {
+            updater.checkForUpdatesInBackground()
+        }
 
         #if DEBUG
         if ProcessInfo.processInfo.arguments.contains(Self.debugCheckForUpdatesOnLaunchArgument) {


### PR DESCRIPTION
## Summary
- enforce a 24-hour Sparkle update-check interval for existing and new installations
- remove the unconditional background update check on every app launch
- preserve manual update checks from the menu bar and Settings

Fixes #768

## Root cause
Sparkle persists its update interval in user defaults, which take precedence over the value in `CotabbyInfo.plist`. Existing installations could therefore retain a shorter interval. Cotabby also called `checkForUpdatesInBackground()` on every launch, bypassing Sparkle's normal last-check scheduling.

## User impact
Automatic update checks now occur at most once per day. Sparkle continues to use its persisted last-check date, while users can still request an immediate check manually.

## Validation
- [x] `git diff --check`
- [x] `plutil -lint CotabbyInfo.plist`
- [x] unsigned production build: `xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO -quiet`
- [x] verified the built app contains `SUScheduledCheckInterval = 86400`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes Sparkle update checks to follow a daily cadence. The main changes are:

- Applies a 24-hour automatic update-check interval in code.
- Starts Sparkle with that interval before scheduling begins.
- Replaces the launch-time unconditional background check with a last-check-date catch-up check.
- Keeps manual update checks available through existing UI paths.

<h3>Confidence Score: 4/5</h3>

This is close, but one launch-check behavior should be fixed before merging.

- The catch-up path can still run a background update check when automatic checks are disabled.
- The interval and last-check-date logic otherwise matches the intended daily cadence.

Cotabby/Services/Utilities/AppUpdateManager.swift

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Services/Utilities/AppUpdateManager.swift | Applies the daily Sparkle interval and adds a launch catch-up check based on the persisted last-check date. |

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22codex%2Fupdate-daily-check-cadence%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fupdate-daily-check-cadence%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FServices%2FUtilities%2FAppUpdateManager.swift%3A73-75%0A**Respect%20Disabled%20Checks**%0A%0AWhen%20automatic%20update%20checks%20are%20disabled%2C%20this%20catch-up%20path%20can%20still%20call%20%60checkForUpdatesInBackground%28%29%60%20after%20the%20stored%20last-check%20date%20is%20missing%20or%20older%20than%2024%20hours.%20That%20makes%20launch%20contact%20the%20update%20feed%20even%20though%20the%20user%20disabled%20automatic%20checks.%20Gate%20the%20catch-up%20call%20on%20%60automaticallyChecksForUpdates%60%20so%20manual%20checks%20still%20work%20while%20automatic%20launch%20checks%20stay%20off.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20if%20updater.automaticallyChecksForUpdates%20%26%26%20shouldCatchUp%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20updater.checkForUpdatesInBackground%28%29%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=771&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FServices%2FUtilities%2FAppUpdateManager.swift%3A73-75%0A**Respect%20Disabled%20Checks**%0A%0AWhen%20automatic%20update%20checks%20are%20disabled%2C%20this%20catch-up%20path%20can%20still%20call%20%60checkForUpdatesInBackground%28%29%60%20after%20the%20stored%20last-check%20date%20is%20missing%20or%20older%20than%2024%20hours.%20That%20makes%20launch%20contact%20the%20update%20feed%20even%20though%20the%20user%20disabled%20automatic%20checks.%20Gate%20the%20catch-up%20call%20on%20%60automaticallyChecksForUpdates%60%20so%20manual%20checks%20still%20work%20while%20automatic%20launch%20checks%20stay%20off.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20if%20updater.automaticallyChecksForUpdates%20%26%26%20shouldCatchUp%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20updater.checkForUpdatesInBackground%28%29%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=fujacob%2Fcotabby&pr=771&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["fix: catch up overdue update checks at l..."](https://github.com/fujacob/cotabby/commit/f5d078c34980e45f00f1c814f8ba502da84dc939) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41854018)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->