### PR TITLE
Fix estimated caret alignment and fade defaults

### DIFF
--- a/Cotabby/Services/Focus/AXTextGeometryResolver.swift
+++ b/Cotabby/Services/Focus/AXTextGeometryResolver.swift
@@ -175,8 +175,11 @@ struct AXTextGeometryResolver {
                 )
                 let clampedX = min(estimatedX, cocoaRect.maxX)
                 return CaretGeometryResult(
-                    rect: CGRect(
-                        x: clampedX, y: cocoaRect.minY, width: 2, height: cocoaRect.height),
+                    rect: estimatedCaretRect(
+                        in: cocoaRect,
+                        x: clampedX,
+                        text: text
+                    ),
                     quality: .estimated
                 )
             }
@@ -218,6 +221,23 @@ struct AXTextGeometryResolver {
         )
 
         return cocoaRect.minX + estimatedWidth
+    }
+
+    /// Converts an AX field frame into a one-line caret rect without pretending that the field's
+    /// full chrome height is a text line. Single-line controls (such as browser omniboxes) center
+    /// their text inside a substantially taller AX frame; using that frame verbatim makes
+    /// caret-centered overlays land roughly one line too low. Explicit multiline values keep the
+    /// last line at the field's bottom because the AX-only fallback cannot infer scrolling or
+    /// paragraph layout safely.
+    func estimatedCaretRect(in fieldFrame: CGRect, x: CGFloat, text: String) -> CGRect {
+        let font = NSFont.systemFont(ofSize: 15)
+        let estimatedLineHeight = ceil(font.ascender - font.descender + font.leading)
+        let caretHeight = min(estimatedLineHeight, fieldFrame.height)
+        let caretY = text.contains(where: \.isNewline)
+            ? fieldFrame.minY
+            : fieldFrame.midY - (caretHeight / 2)
+
+        return CGRect(x: x, y: caretY, width: 2, height: caretHeight)
     }
 
     /// Walks AXStaticText children of a text container to find the one containing the caret,

--- a/Cotabby/Services/Focus/AXTextGeometryResolver.swift
+++ b/Cotabby/Services/Focus/AXTextGeometryResolver.swift
@@ -177,7 +177,7 @@ struct AXTextGeometryResolver {
                 return CaretGeometryResult(
                     rect: estimatedCaretRect(
                         in: cocoaRect,
-                        x: clampedX,
+                        caretX: clampedX,
                         text: text
                     ),
                     quality: .estimated
@@ -229,7 +229,7 @@ struct AXTextGeometryResolver {
     /// caret-centered overlays land roughly one line too low. Explicit multiline values keep the
     /// last line at the field's bottom because the AX-only fallback cannot infer scrolling or
     /// paragraph layout safely.
-    func estimatedCaretRect(in fieldFrame: CGRect, x: CGFloat, text: String) -> CGRect {
+    func estimatedCaretRect(in fieldFrame: CGRect, caretX: CGFloat, text: String) -> CGRect {
         let font = NSFont.systemFont(ofSize: 15)
         let estimatedLineHeight = ceil(font.ascender - font.descender + font.leading)
         let caretHeight = min(estimatedLineHeight, fieldFrame.height)
@@ -237,7 +237,7 @@ struct AXTextGeometryResolver {
             ? fieldFrame.minY
             : fieldFrame.midY - (caretHeight / 2)
 
-        return CGRect(x: x, y: caretY, width: 2, height: caretHeight)
+        return CGRect(x: caretX, y: caretY, width: 2, height: caretHeight)
     }
 
     /// Walks AXStaticText children of a text container to find the one containing the caret,

--- a/Cotabby/Support/SuggestionSettingsStore.swift
+++ b/Cotabby/Support/SuggestionSettingsStore.swift
@@ -47,14 +47,18 @@ struct SuggestionSettingsStore {
     static let defaultGhostTextSizeMultiplier: Double = 1.0
     static let ghostTextSizeMultiplierStep: Double = 0.1
 
+    /// New installs start with fades enabled; the renderer still yields to macOS Reduce Motion, so
+    /// this product default never overrides the user's accessibility preference.
+    static let defaultFadeInSuggestions = true
+
     /// Duration in seconds of the suggestion fade-in ramp, surfaced as a Slow-to-Fast speed slider.
     /// The band is narrow on purpose: below the floor the ramp is imperceptible (reads as an instant
     /// snap), and above the ceiling the ghost text feels like it lags the caret rather than settling
-    /// in at it. 0.15s — the value the fade shipped with before it became tunable — is the out-of-box
-    /// default, so existing installs are unchanged. Lower is a faster fade.
+    /// in at it. 0.10s maps to the second-fastest slider tick: quick enough to feel responsive while
+    /// leaving one faster step for users who want a nearly instant appearance. Lower is a faster fade.
     static let minimumFadeInDuration: Double = 0.05
     static let maximumFadeInDuration: Double = 0.30
-    static let defaultFadeInDuration: Double = 0.15
+    static let defaultFadeInDuration: Double = 0.10
     static let fadeInDurationStep: Double = 0.05
 
     /// Hard upper bound on the persisted Extended Context blob, in characters. Sized to match what the
@@ -410,10 +414,10 @@ struct SuggestionSettingsStore {
         // ghost text to snap in instantly can turn it off, and the overlay suppresses it under
         // Reduce Motion regardless. Existing installs (no key) get the fade on the next launch.
         let resolvedFadeInSuggestions =
-            userDefaults.object(forKey: Self.fadeInSuggestionsDefaultsKey) as? Bool ?? true
-        // Absent key means the user has never touched the speed slider: seed the shipped 0.15s so
-        // the fade is byte-for-byte what it was before the duration became tunable. A present value
-        // is clamped to the band in case a hand-edited default lands outside it.
+            userDefaults.object(forKey: Self.fadeInSuggestionsDefaultsKey) as? Bool
+                ?? Self.defaultFadeInSuggestions
+        // Absent key means the user has never touched the speed slider, so use the product default.
+        // A present value is clamped to the band in case a hand-edited default lands outside it.
         let resolvedFadeInDurationSeconds: Double =
             if userDefaults.object(forKey: Self.fadeInDurationSecondsDefaultsKey) == nil {
                 Self.defaultFadeInDuration

--- a/CotabbyTests/AXTextGeometryResolverTests.swift
+++ b/CotabbyTests/AXTextGeometryResolverTests.swift
@@ -121,6 +121,28 @@ final class AXTextGeometryResolverTests: XCTestCase {
         XCTAssertNotNil(result)
     }
 
+    // MARK: - AXFrame-only estimated caret line
+
+    func test_estimatedCaretRect_centersSingleLineInsideFieldChrome() {
+        let field = CGRect(x: 100, y: 200, width: 500, height: 54)
+
+        let caret = resolver.estimatedCaretRect(in: field, x: 420, text: "hello world")
+
+        XCTAssertEqual(caret.midY, field.midY, accuracy: 0.001)
+        XCTAssertLessThan(caret.height, field.height)
+        XCTAssertEqual(caret.minX, 420)
+        XCTAssertEqual(caret.width, 2)
+    }
+
+    func test_estimatedCaretRect_bottomAlignsExplicitMultilineValue() {
+        let field = CGRect(x: 100, y: 200, width: 500, height: 120)
+
+        let caret = resolver.estimatedCaretRect(in: field, x: 420, text: "first\nsecond")
+
+        XCTAssertEqual(caret.minY, field.minY, accuracy: 0.001)
+        XCTAssertLessThan(caret.height, field.height)
+    }
+
     // MARK: - rectIsNearAnchor (the optimistic-BoundsForRange safety check)
 
     /// The anchor-rejection boundary is the whole point of dropping the `supportsBoundsForRange`

--- a/CotabbyTests/AXTextGeometryResolverTests.swift
+++ b/CotabbyTests/AXTextGeometryResolverTests.swift
@@ -126,7 +126,7 @@ final class AXTextGeometryResolverTests: XCTestCase {
     func test_estimatedCaretRect_centersSingleLineInsideFieldChrome() {
         let field = CGRect(x: 100, y: 200, width: 500, height: 54)
 
-        let caret = resolver.estimatedCaretRect(in: field, x: 420, text: "hello world")
+        let caret = resolver.estimatedCaretRect(in: field, caretX: 420, text: "hello world")
 
         XCTAssertEqual(caret.midY, field.midY, accuracy: 0.001)
         XCTAssertLessThan(caret.height, field.height)
@@ -137,7 +137,7 @@ final class AXTextGeometryResolverTests: XCTestCase {
     func test_estimatedCaretRect_bottomAlignsExplicitMultilineValue() {
         let field = CGRect(x: 100, y: 200, width: 500, height: 120)
 
-        let caret = resolver.estimatedCaretRect(in: field, x: 420, text: "first\nsecond")
+        let caret = resolver.estimatedCaretRect(in: field, caretX: 420, text: "first\nsecond")
 
         XCTAssertEqual(caret.minY, field.minY, accuracy: 0.001)
         XCTAssertLessThan(caret.height, field.height)

--- a/CotabbyTests/SuggestionSettingsStoreTests.swift
+++ b/CotabbyTests/SuggestionSettingsStoreTests.swift
@@ -209,15 +209,25 @@ final class SuggestionSettingsStoreTests: XCTestCase {
 
         let data = SuggestionSettingsStore(userDefaults: defaults).load(configuration: .standard)
 
+        XCTAssertTrue(SuggestionSettingsStore.defaultFadeInSuggestions)
         XCTAssertTrue(data.fadeInSuggestions)
     }
 
-    func test_load_fadeInDurationDefaultsToShippedValue() async {
+    func test_load_fadeInDurationDefaultsToSecondFastestTick() async {
         let defaults = makeIsolatedDefaults()
 
         let data = SuggestionSettingsStore(userDefaults: defaults).load(configuration: .standard)
 
-        // Absent key must seed the shipped 0.15s so the fade is unchanged for existing installs.
+        // The UI reflects duration across the slider range, so 0.10s maps to speed-axis 0.25:
+        // the second-fastest tick in the 0.05...0.30 band shown in Appearance settings.
+        XCTAssertEqual(SuggestionSettingsStore.defaultFadeInDuration, 0.10, accuracy: 0.0001)
+        XCTAssertEqual(
+            SuggestionSettingsStore.minimumFadeInDuration
+                + SuggestionSettingsStore.maximumFadeInDuration
+                - SuggestionSettingsStore.defaultFadeInDuration,
+            0.25,
+            accuracy: 0.0001
+        )
         XCTAssertEqual(
             data.fadeInDurationSeconds,
             SuggestionSettingsStore.defaultFadeInDuration,


### PR DESCRIPTION
## What changed

- normalize AXFrame-only caret geometry to a one-line rect instead of returning the field's full chrome height
- vertically center single-line values in their AX field frame while preserving conservative multiline alignment
- default suggestion fades to enabled at `0.10s`, which maps to the second-fastest Appearance slider tick
- add deterministic coverage for the geometry and first-launch settings defaults

## Why

When a host exposes only its AX field frame, Cotabby labels the primary geometry as `estimated`. The fallback previously reused the whole field frame as the caret rect. Caret-centered presentation then treated the field chrome's bottom/full height as a text line, placing the suggestion roughly one line too low in tall single-line controls such as browser omniboxes.

The fade default also still used the older `0.15s` duration, which put a fresh install one tick slower than the desired starting position. The fade was already implicitly on; it is now an explicit product default alongside the new duration.

## User impact

- estimated primary AX geometry aligns with visible single-line text without promoting or invoking TextKit
- fresh installs and Reset All Settings start with Fade In Suggestions enabled at the second-fastest tick
- existing explicitly saved fade settings remain unchanged, and macOS Reduce Motion still suppresses the animation

## Validation

- unsigned full app build succeeded
- `AXTextGeometryResolverTests`: 10 tests, 0 failures, 3 live-AX tests skipped because the test host lacks Accessibility permission
- `SuggestionSettingsStoreTests` + `SuggestionSettingsModelTests`: 70 tests, 0 failures

The default signed test invocation cannot run locally because the project has no development team configured; the unsigned build and targeted tests succeed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adjusts estimated caret geometry and fade defaults. The main changes are:

- AXFrame-only caret fallback now returns a one-line estimated rect.
- Single-line estimated carets are centered inside tall field frames.
- Fade-in suggestions now have an explicit enabled default.
- The default fade duration changes to 0.10s.
- Tests cover the new geometry and settings defaults.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Services/Focus/AXTextGeometryResolver.swift | Adds a caret-sized AXFrame fallback rect with centered single-line behavior and conservative multiline placement. |
| Cotabby/Support/SuggestionSettingsStore.swift | Adds explicit fade defaults and changes the absent-key fade duration default to 0.10s while preserving present values. |
| CotabbyTests/AXTextGeometryResolverTests.swift | Adds deterministic tests for estimated caret rect sizing and vertical placement. |
| CotabbyTests/SuggestionSettingsStoreTests.swift | Updates settings tests for the explicit fade-enabled default and new fade duration default. |

<sub>Reviews (1): Last reviewed commit: ["Fix SwiftLint identifier violation"](https://github.com/fujacob/cotabby/commit/3f1903b9139fa13bd71b9edcf84818e1840444bb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43442577)</sub>

<!-- /greptile_comment -->