### PR TITLE
Fix default local development signing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,8 @@ You need:
 - Xcode with Command Line Tools installed.
 - An Apple ID added to Xcode (Settings > Accounts) if you want to launch the app from the IDE. A
   free account is enough; the paid Apple Developer Program is not required for local development.
-  Run `scripts/dev-setup.sh` once to configure signing (see Local Setup).
+  Contributors outside Cotabby's default development team run `scripts/dev-setup.sh` once to
+  configure a local override (see Local Setup).
 - SwiftLint for local lint checks. CI installs it with Homebrew when needed.
 - XcodeGen if you need to change the project structure (targets, build settings, dependencies,
   or scheme). Install it with `brew install xcodegen`. CI installs it the same way.
@@ -40,7 +41,8 @@ Apple Silicon is strongly recommended for local model-runtime work.
 
 ## Local Setup
 
-Clone the repo, configure local signing, and open the project:
+Clone the repo and open the project. If your Apple ID is not on Cotabby's development team, run the
+one-time signing setup first:
 
 ```sh
 git clone https://github.com/FuJacob/Cotabby.git
@@ -49,11 +51,12 @@ scripts/dev-setup.sh
 open Cotabby.xcodeproj
 ```
 
-`scripts/dev-setup.sh` writes a gitignored `Config/Signing.local.xcconfig` with your Apple
-Development team id, so local builds sign as you. The team is deliberately not hardcoded in
-`project.yml`, so the repo builds for any contributor without being on the maintainer's team. If
-you have not added an Apple ID to Xcode yet, do that first under Settings > Accounts (a free
-account is enough), then re-run the script. To set the team by hand instead, copy
+The committed `Config/Signing.xcconfig` defaults to Cotabby's development team, which lets team
+members build immediately without Xcode modifying the generated project. `scripts/dev-setup.sh`
+writes a gitignored `Config/Signing.local.xcconfig` with a contributor's own Apple Development team
+id; that local value overrides the shared default and persists across pulls and project
+regeneration. If you have not added an Apple ID to Xcode yet, do that first under Settings >
+Accounts (a free account is enough), then re-run the script. To set the team by hand instead, copy
 `Config/Signing.local.xcconfig.example` to `Config/Signing.local.xcconfig`, or pass it explicitly:
 `DEVELOPMENT_TEAM=XXXXXXXXXX scripts/dev-setup.sh`.
 
@@ -119,8 +122,8 @@ xcodebuild \
 ```
 
 `CODE_SIGNING_ALLOWED=NO` keeps the build command usable on machines that do not have the project
-owner's signing certificate. Use Xcode with your own team selected when you need to launch the app
-locally.
+owner's signing certificate. Use the shared team or your gitignored local override when you need to
+launch the app locally.
 
 ## Run
 

--- a/Config/Signing.xcconfig
+++ b/Config/Signing.xcconfig
@@ -1,17 +1,16 @@
 // Code signing for local development.
 //
-// DEVELOPMENT_TEAM is deliberately empty here, and absent from project.yml, so the repo can be
-// cloned and built by any contributor rather than only members of the maintainer's Apple team.
-// Each developer supplies their own team in Config/Signing.local.xcconfig (gitignored). Generate
-// it with
+// The shared default is Cotabby's development team so maintainers can pull main and immediately
+// run the app without Xcode writing a personal choice into the generated project.pbxproj. A
+// contributor who is not on that team overrides it once in Config/Signing.local.xcconfig
+// (gitignored). Generate that override with
 //
 //   scripts/dev-setup.sh
 //
 // or copy Config/Signing.local.xcconfig.example and fill it in by hand.
 //
-// The trailing `?` makes the include optional: a fresh clone with no local file still resolves
-// (empty team), which is fine for `xcodebuild ... CODE_SIGNING_ALLOWED=NO` compile checks and for
-// CI. A real team is only needed to launch the signed app from Xcode.
+// The trailing `?` makes the include optional. Unsigned compile checks and CI still pass
+// CODE_SIGNING_ALLOWED=NO, so they do not need access to the shared team or a local override.
 //
 // This file lives in a subdirectory on purpose. XcodeGen names the group for a root-level file
 // reference after the checkout directory, which differs between clones and CI and would break the
@@ -21,6 +20,6 @@
 // DEVELOPMENT_TEAM must not be set in project.yml's build settings either: project-level build
 // settings outrank an xcconfig, so a value there would silently override this file.
 
-DEVELOPMENT_TEAM =
+DEVELOPMENT_TEAM = G946M8K23B
 
 #include? "Signing.local.xcconfig"

--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -1943,15 +1943,15 @@
 				LastUpgradeCheck = 2600;
 				TargetAttributes = {
 					59F15B162977174E700D0CAA = {
-						DevelopmentTeam = "";
+						DevelopmentTeam = G946M8K23B;
 						ProvisioningStyle = Automatic;
 					};
 					622CFE93F0FE48C8243E060C = {
-						DevelopmentTeam = "";
+						DevelopmentTeam = G946M8K23B;
 						ProvisioningStyle = Automatic;
 					};
 					AB3DFA4CFA5EBC6161F02A30 = {
-						DevelopmentTeam = "";
+						DevelopmentTeam = G946M8K23B;
 						ProvisioningStyle = Automatic;
 					};
 				};

--- a/project.yml
+++ b/project.yml
@@ -84,13 +84,13 @@ settings:
       ENABLE_NS_ASSERTIONS: NO
       MTL_ENABLE_DEBUG_INFO: NO
       SWIFT_COMPILATION_MODE: wholemodule
-# Per-developer signing lives in an xcconfig, not here, so any contributor can build the repo
-# without being on the maintainer's Apple team. `Config/Signing.xcconfig` (committed) leaves
-# DEVELOPMENT_TEAM empty and optionally includes the gitignored `Config/Signing.local.xcconfig`
-# that `scripts/dev-setup.sh` writes. It sits in a subdirectory on purpose: a root-level config
-# file makes XcodeGen name a group after the checkout directory, which drifts between clones and
-# CI. DEVELOPMENT_TEAM must also stay out of the build settings above: project-level settings
-# outrank an xcconfig, so a value there would override the local file.
+# Signing lives in xcconfig files, not the generated project. `Config/Signing.xcconfig` (committed)
+# supplies Cotabby's team as the maintainer-friendly default and optionally includes the gitignored
+# `Config/Signing.local.xcconfig` that `scripts/dev-setup.sh` writes for contributors on another
+# team. It sits in a subdirectory on purpose: a root-level config file makes XcodeGen name a group
+# after the checkout directory, which drifts between clones and CI. DEVELOPMENT_TEAM must also stay
+# out of the build settings above: project/target settings outrank an xcconfig and would prevent the
+# local override from winning.
 configFiles:
   Debug: Config/Signing.xcconfig
   Release: Config/Signing.xcconfig

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -2,10 +2,10 @@
 #
 # dev-setup.sh - generate Config/Signing.local.xcconfig so you can build and run Cotabby locally.
 #
-# Cotabby's project.yml does not hardcode an Apple team, so any contributor can build the repo.
-# To launch the signed app from Xcode you supply your own team id once. This script detects it
-# from your Apple Development signing certificate and writes the gitignored
-# Config/Signing.local.xcconfig.
+# Cotabby's shared xcconfig defaults to the maintainer team so its members can build immediately.
+# Contributors on another team supply their own team id once. This script detects it from an Apple
+# Development signing certificate and writes the gitignored Config/Signing.local.xcconfig, whose
+# value overrides the shared default without dirtying the generated Xcode project.
 #
 # Usage:
 #   scripts/dev-setup.sh                              # auto-detect your team id


### PR DESCRIPTION
## Summary

Default local signing to Cotabby's development team through the shared signing xcconfig, so maintainers can pull `main` and run the dev scheme without Xcode dirtying the generated project. Contributors on other teams retain the one-time, gitignored `Signing.local.xcconfig` override.

## Validation

- `xcodebuild -project Cotabby.xcodeproj -scheme 'Cotabby Dev' -configuration Debug -destination 'platform=macOS' -derivedDataPath build/DerivedData-DefaultTeam build` — `BUILD SUCCEEDED`; resolved team `G946M8K23B` and signed with the local Apple Development certificate.
- `xcodebuild ... -showBuildSettings` — resolved `DEVELOPMENT_TEAM = G946M8K23B` and `PRODUCT_BUNDLE_IDENTIFIER = com.jacobfu.tabby.dev` without a local signing file.
- `swiftlint lint --strict --quiet` — exit 0.
- `xcodegen generate` followed by `git diff --check` — generated project matches `project.yml`; exit 0.
- `bash -n scripts/dev-setup.sh` — exit 0.

## Linked issues

None.

## Risk / rollout notes

The shared team only affects signed local builds. CI and contributor compile checks continue to use `CODE_SIGNING_ALLOWED=NO`; contributors who need to run the app with another team can run `scripts/dev-setup.sh` once, and its gitignored override wins over the shared default.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes the default local signing setup for the macOS app.

- Adds Cotabby's development team as the shared signing default.
- Regenerates the Xcode project with the new signing metadata.
- Updates contributor docs and setup comments for local signing overrides.

<h3>Confidence Score: 4/5</h3>

The local signing override path can still pick the maintainer team in Xcode automatic signing.

- The xcconfig include order lets `Signing.local.xcconfig` override the shared default.
- The generated project also commits `DevelopmentTeam = G946M8K23B` in target attributes.
- Contributors outside that team can hit provisioning failures despite creating the documented local override.

Cotabby.xcodeproj/project.pbxproj

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Config/Signing.xcconfig | Adds the shared default team before the optional local include, so local xcconfig overrides can still win. |
| Cotabby.xcodeproj/project.pbxproj | Regenerates signing metadata with the maintainer team in target attributes, which can conflict with contributor overrides. |
| project.yml | Updates comments describing the shared default team and gitignored local override. |
| scripts/dev-setup.sh | Updates script comments only; the local xcconfig generation behavior is unchanged. |
| CONTRIBUTING.md | Updates setup instructions for maintainers using the shared team and contributors using a local override. |

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Fdefault-development-team%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fdefault-development-team%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby.xcodeproj%2Fproject.pbxproj%3A1945%0A**Target%20Metadata%20Overrides%20Signing**%0A%0AWhen%20a%20contributor%20creates%20%60Config%2FSigning.local.xcconfig%60%20with%20their%20own%20team%2C%20these%20automatic-signing%20target%20attributes%20can%20still%20make%20Xcode%20provision%20the%20targets%20with%20%60G946M8K23B%60.%20Contributors%20outside%20that%20team%20can%20then%20fail%20local%20signed%20builds%20even%20though%20the%20documented%20override%20resolves%20%60DEVELOPMENT_TEAM%60%20to%20their%20own%20team.%0A%0A&repo=fujacob%2Fcotabby&pr=779&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby.xcodeproj%2Fproject.pbxproj%3A1945%0A**Target%20Metadata%20Overrides%20Signing**%0A%0AWhen%20a%20contributor%20creates%20%60Config%2FSigning.local.xcconfig%60%20with%20their%20own%20team%2C%20these%20automatic-signing%20target%20attributes%20can%20still%20make%20Xcode%20provision%20the%20targets%20with%20%60G946M8K23B%60.%20Contributors%20outside%20that%20team%20can%20then%20fail%20local%20signed%20builds%20even%20though%20the%20documented%20override%20resolves%20%60DEVELOPMENT_TEAM%60%20to%20their%20own%20team.%0A%0A&repo=fujacob%2Fcotabby&pr=779&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Fix default local development signing"](https://github.com/fujacob/cotabby/commit/070c15b681db2d501661357360cf8cb4df55f7e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43446170)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->