### PR TITLE
Preload default Ollama model before suggestions

### DIFF
--- a/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
+++ b/Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift
@@ -118,8 +118,9 @@ extension SuggestionCoordinator {
             state = .idle
             // The user is now on a new editable surface and is likely to type soon. Prime the
             // selected engine in the background so weight loading and instruction tokenization
-            // happen before the first real `respond` instead of inside its critical path. Llama's
-            // default `prewarm` is a no-op, so this call is FM-only by design.
+            // happen before the first real `respond` instead of inside its critical path. The
+            // external endpoint also uses this hook to cold-load default local Ollama separately
+            // from the aggressively cancellable autocomplete request.
             prewarmEngineForCurrentField(rawContext: focusedContext)
         }
 

--- a/Cotabby/Models/OpenAICompatibleEndpointModels.swift
+++ b/Cotabby/Models/OpenAICompatibleEndpointModels.swift
@@ -126,6 +126,17 @@ nonisolated struct OpenAICompatibleEndpointConfiguration: Equatable, Sendable {
         baseURL.appendingPathComponent(path, isDirectory: false)
     }
 
+    /// Cotabby's default endpoint is specifically the local Ollama server. Ollama's preload API
+    /// lives outside its OpenAI-compatible `/v1` namespace, so this narrowly scoped URL avoids
+    /// sending Ollama-only requests to arbitrary LM Studio, vLLM, or hosted endpoints.
+    var defaultOllamaGenerateURL: URL? {
+        guard baseURL.absoluteString == Self.defaultBaseURLString,
+              var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)
+        else { return nil }
+        components.path = "/api/generate"
+        return components.url
+    }
+
     var privacyWarning: String? {
         switch hostScope {
         case .loopback:

--- a/Cotabby/Services/Runtime/OpenAICompatibleAPIClient.swift
+++ b/Cotabby/Services/Runtime/OpenAICompatibleAPIClient.swift
@@ -50,6 +50,29 @@ final class OpenAICompatibleAPIClient {
         return payload.data.sorted { $0.id.localizedCaseInsensitiveCompare($1.id) == .orderedAscending }
     }
 
+    /// Loads the selected model through Ollama's native API without tying that cold start to a
+    /// cancellable autocomplete request. Returning `false` means the configured endpoint is not
+    /// Cotabby's known local Ollama default, so callers can treat warmup as an intentional no-op.
+    func preloadDefaultOllamaModel(
+        configuration: OpenAICompatibleEndpointConfiguration,
+        apiKey: String?
+    ) async throws -> Bool {
+        guard !configuration.modelName.isEmpty else {
+            throw OpenAICompatibleEndpointError.emptyModelName
+        }
+        guard let url = configuration.defaultOllamaGenerateURL else { return false }
+
+        var request = URLRequest(url: url, timeoutInterval: 120)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyHeaders(to: &request, apiKey: apiKey)
+        request.httpBody = try encoder.encode(OllamaPreloadRequest(model: configuration.modelName))
+
+        let (_, response) = try await session.data(for: request)
+        try Self.validate(response)
+        return true
+    }
+
     func generate(
         configuration: OpenAICompatibleEndpointConfiguration,
         apiKey: String?,
@@ -240,6 +263,20 @@ nonisolated enum OpenAICompatibleSSEDecoder {
 
 private nonisolated struct ModelListResponse: Decodable {
     let data: [OpenAICompatibleModelOption]
+}
+
+/// Ollama treats an empty, non-streaming generate request as a model load. `keep_alive = -1`
+/// keeps the weights resident until Ollama is stopped or explicitly asked to unload them.
+private nonisolated struct OllamaPreloadRequest: Encodable {
+    let model: String
+    let prompt = ""
+    let stream = false
+    let keepAlive = -1
+
+    private enum CodingKeys: String, CodingKey {
+        case model, prompt, stream
+        case keepAlive = "keep_alive"
+    }
 }
 
 private nonisolated struct CompletionRequest: Encodable {

--- a/Cotabby/Services/Runtime/OpenAICompatibleSuggestionEngine.swift
+++ b/Cotabby/Services/Runtime/OpenAICompatibleSuggestionEngine.swift
@@ -125,4 +125,28 @@ final class OpenAICompatibleSuggestionEngine: SuggestionGenerating {
     }
 
     func resetCachedGenerationContext() async {}
+
+    /// Best-effort Ollama cold-start work runs through a request that is independent from the
+    /// coordinator's cancellable prediction task. Typing again can therefore discard stale
+    /// autocomplete work without aborting the model load that future requests need.
+    func prewarm(for _: SuggestionRequest) async {
+        do {
+            let configuration = try configurationProvider()
+            let didPreload = try await client.preloadDefaultOllamaModel(
+                configuration: configuration,
+                apiKey: try apiKeyProvider()
+            )
+            guard didPreload else { return }
+            CotabbyLogger.runtime.info(
+                "Preloaded default Ollama model",
+                metadata: ["model": .string(configuration.modelName)]
+            )
+        } catch is CancellationError {
+            // App shutdown may cancel this opportunistic work; warmup never becomes user-facing.
+        } catch {
+            CotabbyLogger.runtime.warning(
+                "Default Ollama model preload failed: \(error.localizedDescription)"
+            )
+        }
+    }
 }

--- a/CotabbyTests/OpenAICompatibleAPIClientTests.swift
+++ b/CotabbyTests/OpenAICompatibleAPIClientTests.swift
@@ -72,11 +72,13 @@ final class OpenAICompatibleAPIClientTests: XCTestCase {
         let loopback = try configuration(baseURL: " http://127.0.0.1:11434/ ")
         XCTAssertEqual(loopback.baseURL.absoluteString, "http://127.0.0.1:11434/v1")
         XCTAssertEqual(loopback.apiURL(path: "models").absoluteString, "http://127.0.0.1:11434/v1/models")
+        XCTAssertEqual(loopback.defaultOllamaGenerateURL?.absoluteString, "http://127.0.0.1:11434/api/generate")
         XCTAssertEqual(loopback.hostScope, .loopback)
         XCTAssertNil(loopback.privacyWarning)
 
         let lan = try configuration(baseURL: "http://192.168.1.50:8000/v1/")
         XCTAssertEqual(lan.baseURL.absoluteString, "http://192.168.1.50:8000/v1")
+        XCTAssertNil(lan.defaultOllamaGenerateURL)
         XCTAssertEqual(lan.hostScope, .localNetwork)
         XCTAssertNotNil(lan.privacyWarning)
 
@@ -184,6 +186,43 @@ final class OpenAICompatibleAPIClientTests: XCTestCase {
 
         XCTAssertEqual(output, " hello")
         XCTAssertEqual(partials, [" hel", " hello"])
+    }
+
+    func test_defaultOllamaPreload_usesNativeRouteLongTimeoutAndKeepsModelResident() async throws {
+        let client = makeClient()
+        EndpointStubURLProtocol.handler = { request in
+            XCTAssertEqual(request.url?.absoluteString, "http://127.0.0.1:11434/api/generate")
+            XCTAssertEqual(request.timeoutInterval, 120)
+            XCTAssertEqual(request.httpMethod, "POST")
+            let json = try Self.jsonBody(request)
+            XCTAssertEqual(json["model"] as? String, "gemma4:12b-mlx")
+            XCTAssertEqual(json["prompt"] as? String, "")
+            XCTAssertEqual(json["stream"] as? Bool, false)
+            XCTAssertEqual(json["keep_alive"] as? Int, -1)
+            return Self.response(request: request, body: #"{"done":true}"#)
+        }
+
+        let didPreload = try await client.preloadDefaultOllamaModel(
+            configuration: configuration(),
+            apiKey: nil
+        )
+
+        XCTAssertTrue(didPreload)
+    }
+
+    func test_nonDefaultEndpoint_doesNotReceiveOllamaPreloadRequest() async throws {
+        let client = makeClient()
+        EndpointStubURLProtocol.handler = { _ in
+            XCTFail("A generic endpoint must not receive Ollama's native preload request")
+            throw URLError(.badServerResponse)
+        }
+
+        let didPreload = try await client.preloadDefaultOllamaModel(
+            configuration: configuration(baseURL: "https://models.example.com/v1"),
+            apiKey: nil
+        )
+
+        XCTAssertFalse(didPreload)
     }
 
     func test_chatGeneration_postsSingleUserMessageAndReadsDeltaContent() async throws {


### PR DESCRIPTION
## Summary

Preload Cotabby's default local Ollama model through its native API before the first autocomplete request, so cancellable typing work cannot abort the model's cold start. The preload has a 120-second timeout and keeps the model resident, while non-Ollama OpenAI-compatible endpoints remain untouched.

## Validation

- `swiftlint lint --quiet` — exited 0.
- `xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build-for-testing -derivedDataPath build/DerivedData` — **TEST BUILD SUCCEEDED**.
- `xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build -derivedDataPath build/DerivedData` — **BUILD SUCCEEDED**.
- Focused `OpenAICompatibleAPIClientTests` execution could not load the app-hosted test bundle because the host and bundle have different Team IDs, the repository's documented local signing limitation. Compilation and linking of the test bundle succeeded.

## Linked issues

None.

## Risk / rollout notes

The Ollama-only preload is deliberately restricted to Cotabby's exact default endpoint (`http://127.0.0.1:11434/v1`). Custom OpenAI-compatible endpoints continue using only the standard API, and preload failures remain best-effort warnings rather than user-facing generation failures.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds native Ollama preloading for Cotabby's default local endpoint. The main changes are:

- A default-only `/api/generate` URL derived from the OpenAI-compatible base URL.
- A preload request that keeps the selected Ollama model resident.
- OpenAI-compatible engine prewarm logic that runs the preload best-effort.
- Tests for the default Ollama route and non-default endpoint no-op behavior.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after a small cleanup to avoid repeated local preloads.

- The native Ollama request is limited to the exact default loopback endpoint.
- The payload and timeout are covered by focused tests.
- Repeated focus changes can start duplicate preload requests for the same model.

Cotabby/Services/Runtime/OpenAICompatibleSuggestionEngine.swift

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/App/Coordinators/SuggestionCoordinator+Input.swift | Updates the prewarm comment to include the OpenAI-compatible Ollama preload path. |
| Cotabby/Models/OpenAICompatibleEndpointModels.swift | Adds a default-only native Ollama generate URL derived from the existing base URL. |
| Cotabby/Services/Runtime/OpenAICompatibleAPIClient.swift | Adds the native Ollama preload request and status validation. |
| Cotabby/Services/Runtime/OpenAICompatibleSuggestionEngine.swift | Adds best-effort preload behavior, with a duplicate-request cleanup noted for repeated focus changes. |
| CotabbyTests/OpenAICompatibleAPIClientTests.swift | Adds coverage for Ollama URL derivation, preload payload fields, timeout, and non-default endpoint behavior. |

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22fix%2Follama-cold-start%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Follama-cold-start%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FServices%2FRuntime%2FOpenAICompatibleSuggestionEngine.swift%3A135-138%0A**Duplicate%20Ollama%20Preloads**%0A%0AWhen%20focus%20moves%20across%20editable%20fields%20while%20the%20default%20Ollama%20model%20is%20still%20loading%2C%20each%20prewarm%20call%20starts%20another%20120-second%20%60%2Fapi%2Fgenerate%60%20request%20for%20the%20same%20model.%20These%20tasks%20are%20not%20tracked%20or%20cancelled%20by%20the%20prediction%20work%20controller%2C%20so%20rapid%20focus%20changes%20can%20queue%20duplicated%20local%20model-load%20work%20before%20the%20first%20autocomplete%20request.%0A%0A&repo=fujacob%2Fcotabby&pr=781&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FServices%2FRuntime%2FOpenAICompatibleSuggestionEngine.swift%3A135-138%0A**Duplicate%20Ollama%20Preloads**%0A%0AWhen%20focus%20moves%20across%20editable%20fields%20while%20the%20default%20Ollama%20model%20is%20still%20loading%2C%20each%20prewarm%20call%20starts%20another%20120-second%20%60%2Fapi%2Fgenerate%60%20request%20for%20the%20same%20model.%20These%20tasks%20are%20not%20tracked%20or%20cancelled%20by%20the%20prediction%20work%20controller%2C%20so%20rapid%20focus%20changes%20can%20queue%20duplicated%20local%20model-load%20work%20before%20the%20first%20autocomplete%20request.%0A%0A&repo=fujacob%2Fcotabby&pr=781&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Preload default Ollama model before sugg..."](https://github.com/fujacob/cotabby/commit/5551fb8e65d754d90ab1b415a8390287fa8b5179) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43447466)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->