### PR TITLE
Default suggestion fade to fastest speed

### DIFF
--- a/Cotabby/Support/SuggestionSettingsStore.swift
+++ b/Cotabby/Support/SuggestionSettingsStore.swift
@@ -54,11 +54,11 @@ struct SuggestionSettingsStore {
     /// Duration in seconds of the suggestion fade-in ramp, surfaced as a Slow-to-Fast speed slider.
     /// The band is narrow on purpose: below the floor the ramp is imperceptible (reads as an instant
     /// snap), and above the ceiling the ghost text feels like it lags the caret rather than settling
-    /// in at it. 0.10s maps to the second-fastest slider tick: quick enough to feel responsive while
-    /// leaving one faster step for users who want a nearly instant appearance. Lower is a faster fade.
+    /// in at it. 0.05s is the fastest slider tick, so new installs get the most responsive fade
+    /// while users can still choose a slower transition. Lower is a faster fade.
     static let minimumFadeInDuration: Double = 0.05
     static let maximumFadeInDuration: Double = 0.30
-    static let defaultFadeInDuration: Double = 0.10
+    static let defaultFadeInDuration: Double = 0.05
     static let fadeInDurationStep: Double = 0.05
 
     /// Hard upper bound on the persisted Extended Context blob, in characters. Sized to match what the

--- a/CotabbyTests/SuggestionSettingsStoreTests.swift
+++ b/CotabbyTests/SuggestionSettingsStoreTests.swift
@@ -213,19 +213,19 @@ final class SuggestionSettingsStoreTests: XCTestCase {
         XCTAssertTrue(data.fadeInSuggestions)
     }
 
-    func test_load_fadeInDurationDefaultsToSecondFastestTick() async {
+    func test_load_fadeInDurationDefaultsToFastestTick() async {
         let defaults = makeIsolatedDefaults()
 
         let data = SuggestionSettingsStore(userDefaults: defaults).load(configuration: .standard)
 
-        // The UI reflects duration across the slider range, so 0.10s maps to speed-axis 0.25:
-        // the second-fastest tick in the 0.05...0.30 band shown in Appearance settings.
-        XCTAssertEqual(SuggestionSettingsStore.defaultFadeInDuration, 0.10, accuracy: 0.0001)
+        // The UI reflects duration across the slider range, so the shortest 0.05s duration maps
+        // to speed-axis 0.30: the rightmost, fastest tick in Appearance settings.
+        XCTAssertEqual(SuggestionSettingsStore.defaultFadeInDuration, 0.05, accuracy: 0.0001)
         XCTAssertEqual(
             SuggestionSettingsStore.minimumFadeInDuration
                 + SuggestionSettingsStore.maximumFadeInDuration
                 - SuggestionSettingsStore.defaultFadeInDuration,
-            0.25,
+            0.30,
             accuracy: 0.0001
         )
         XCTAssertEqual(


### PR DESCRIPTION
## Summary

Set the default suggestion fade duration to the fastest Appearance-slider tick (0.05 seconds) so new installs start with the most responsive fade-in behavior.

## Validation

- `swiftlint lint --quiet` — exit 0.
- `xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO -jobs 1 build-for-testing` — **TEST BUILD SUCCEEDED**.
- `xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO test-without-building -only-testing:CotabbyTests/SuggestionSettingsStoreTests` — **TEST EXECUTE SUCCEEDED**, 42 tests, 0 failures.

## Linked issues

None.

## Risk / rollout notes

Low risk. This affects only users without a persisted fade-speed preference; saved user settings continue to win. No schema, project, or runtime changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the default suggestion fade-in speed faster.

- Sets the default fade-in duration to `0.05` seconds.
- Updates the setting comment to describe the fastest slider tick.
- Updates the default-duration test expectation.

<h3>Confidence Score: 4/5</h3>

The changed default path has one contained reset behavior issue.

- Missing-key loads use the new fastest duration as intended.
- Persisted user values continue to win as intended.
- Resetting defaults can keep an old persisted fade duration and skip the new default.

Cotabby/Support/SuggestionSettingsStore.swift

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/SuggestionSettingsStore.swift | Changes the default fade-in duration to the fastest supported tick. |
| CotabbyTests/SuggestionSettingsStoreTests.swift | Updates the default fade-in duration test to expect the fastest tick mapping. |

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22codex%2Fdefault-fast-fade%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fdefault-fast-fade%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FSupport%2FSuggestionSettingsStore.swift%3A62%0A**Reset%20Keeps%20Stale%20Duration**%0A%0AWhen%20a%20user%20already%20has%20%60cotabbyFadeInDurationSeconds%60%20persisted%20at%20the%20old%20%600.10%60%20value%2C%20reset-to-defaults%20does%20not%20remove%20that%20key%2C%20so%20%60load%28%29%60%20keeps%20reading%20the%20stale%20value%20instead%20of%20this%20new%20%600.05%60%20default.%20The%20visible%20result%20is%20that%20resetting%20Appearance%20settings%20can%20leave%20the%20fade%20speed%20on%20the%20old%20second-fastest%20tick%20instead%20of%20the%20new%20fastest%20default.%0A%0A&repo=fujacob%2Fcotabby&pr=782&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FSupport%2FSuggestionSettingsStore.swift%3A62%0A**Reset%20Keeps%20Stale%20Duration**%0A%0AWhen%20a%20user%20already%20has%20%60cotabbyFadeInDurationSeconds%60%20persisted%20at%20the%20old%20%600.10%60%20value%2C%20reset-to-defaults%20does%20not%20remove%20that%20key%2C%20so%20%60load%28%29%60%20keeps%20reading%20the%20stale%20value%20instead%20of%20this%20new%20%600.05%60%20default.%20The%20visible%20result%20is%20that%20resetting%20Appearance%20settings%20can%20leave%20the%20fade%20speed%20on%20the%20old%20second-fastest%20tick%20instead%20of%20the%20new%20fastest%20default.%0A%0A&repo=fujacob%2Fcotabby&pr=782&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Default suggestion fade to fastest speed"](https://github.com/fujacob/cotabby/commit/e68ece2005786b7534884dd1c31de86668ed9804) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43447913)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->