### PR TITLE
Fix XcodeGen project drift

### DIFF
--- a/Cotabby.xcodeproj/project.pbxproj
+++ b/Cotabby.xcodeproj/project.pbxproj
@@ -328,6 +328,7 @@
 		66C23A7C2FCDE0266FF425F8 /* ApplicationBundleMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 352AF5B2834FEE1F597394E4 /* ApplicationBundleMetadata.swift */; };
 		66D0D9F605AF462F569A5CFD /* SpellingLanguageResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0871985CB1F877EC422E18C /* SpellingLanguageResolverTests.swift */; };
 		66D9E37B12A9265D4733E72E /* LlamaRuntimeCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 944065A858D9BC936CB12B23 /* LlamaRuntimeCore.swift */; };
+		67F9E4AD54E17A17FC825D74 /* OllamaPreloadWorkControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4660F0FA8500594314C6D5C /* OllamaPreloadWorkControllerTests.swift */; };
 		68DA5F93B7185B4F5E6DB4C3 /* it.txt in Resources */ = {isa = PBXBuildFile; fileRef = 0397F1DACB094A0F6A66BC0E /* it.txt */; };
 		6955C3A4D7AB3EEF7FA7C469 /* InputSuppressionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1F9CEBAB0F330F8E7B61D8 /* InputSuppressionController.swift */; };
 		695E431AC3FF79769E2C5EEF /* SuggestionQualityMetricsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CC566AC1DE33FD0CD30E1E /* SuggestionQualityMetricsStoreTests.swift */; };
@@ -1017,6 +1018,7 @@
 		B3B09064903B760D6DF2DF7D /* DecodeStopPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodeStopPolicyTests.swift; sourceTree = "<group>"; };
 		B41F06FEF208B30ECCF23A6F /* MacroModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacroModels.swift; sourceTree = "<group>"; };
 		B424E2AC97C99D335B0D5751 /* SuggestionTextNormalizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionTextNormalizer.swift; sourceTree = "<group>"; };
+		B4660F0FA8500594314C6D5C /* OllamaPreloadWorkControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OllamaPreloadWorkControllerTests.swift; sourceTree = "<group>"; };
 		B4B4A2E2DD6733658EC05BD8 /* DownloadFileRescuer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadFileRescuer.swift; sourceTree = "<group>"; };
 		B4CC566AC1DE33FD0CD30E1E /* SuggestionQualityMetricsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionQualityMetricsStoreTests.swift; sourceTree = "<group>"; };
 		B6ACCB12E4DB32D2F2BEA567 /* PermissionHostApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionHostApp.swift; sourceTree = "<group>"; };
@@ -1565,6 +1567,7 @@
 				03766F6253FF17639230C0F6 /* ModelAndPresentationValueTests.swift */,
 				A829F28F01FAE76CA7244BBC /* ModelFileValidatorTests.swift */,
 				5EED3CD2BC7B48DF35DEE562 /* OCRTextHygieneTests.swift */,
+				B4660F0FA8500594314C6D5C /* OllamaPreloadWorkControllerTests.swift */,
 				A4B220D9A25174A43E7A258B /* OnboardingFlowStepTests.swift */,
 				D814BBA41CF29E8DD9954651 /* OnboardingTemplateFeatureListTests.swift */,
 				01B72736E416910878E8E493 /* OnboardingTemplateRecommenderTests.swift */,
@@ -2651,6 +2654,7 @@
 				25D4FC8D191A50F63E6391F9 /* ModelAndPresentationValueTests.swift in Sources */,
 				65478B0DABF5460C32D4C458 /* ModelFileValidatorTests.swift in Sources */,
 				3F5630CFB7BA40B900E832A1 /* OCRTextHygieneTests.swift in Sources */,
+				67F9E4AD54E17A17FC825D74 /* OllamaPreloadWorkControllerTests.swift in Sources */,
 				8D9F33F49E880956D0571574 /* OnboardingFlowStepTests.swift in Sources */,
 				DA23422A2CF77CFD3B1283C8 /* OnboardingTemplateFeatureListTests.swift in Sources */,
 				D648DD70AD847F67B77CE052 /* OnboardingTemplateRecommenderTests.swift in Sources */,


### PR DESCRIPTION
## Summary

Regenerate the committed Xcode project so it includes `OllamaPreloadWorkControllerTests.swift`, matching the `CotabbyTests` directory declared by `project.yml`. This restores the XcodeGen drift gate on `main` after the compatibility revert removed the generated test reference.

## Validation

- `xcodegen generate` twice; the second generation produced byte-identical project output
- `swiftlint lint --quiet`; exit 0
- `xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build -derivedDataPath build/DerivedData`; **BUILD SUCCEEDED**
- `xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build-for-testing -derivedDataPath build/DerivedData`; **TEST BUILD SUCCEEDED**

## Linked issues

None.

## Risk / rollout notes

Generated-project-only change. It restores one existing test file to the `CotabbyTests` target and does not change production runtime behavior.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR regenerates the committed Xcode project to restore `OllamaPreloadWorkControllerTests.swift` to the `CotabbyTests` target after a compatibility revert dropped the generated reference. The file exists on disk at `CotabbyTests/OllamaPreloadWorkControllerTests.swift` and is covered by the `path: CotabbyTests` declaration in `project.yml`.

- Adds four consistent PBX entries in `project.pbxproj`: a `PBXFileReference`, a group child entry, a `PBXBuildFile`, and a `Sources` build phase reference — all with unique UUIDs and correct cross-references.
- No production code is changed; this is a generated-file-only update that restores the XcodeGen drift gate to a passing state.

<h3>Confidence Score: 5/5</h3>

Safe to merge — only adds the missing test file reference back to the generated project, with no changes to production code.

The change is purely regenerated project scaffolding. The test file already exists on disk and is declared in project.yml; the four new PBX entries are structurally correct with unique UUIDs and consistent cross-references. No production logic, build settings, or existing entries are touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby.xcodeproj/project.pbxproj | Adds four PBX entries to include OllamaPreloadWorkControllerTests.swift in the CotabbyTests target: PBXFileReference, group child, PBXBuildFile, and Sources build phase entry — all consistent and UUID-unique. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[project.yml\nCotabbyTests source: CotabbyTests/] --> B[xcodegen generate]
    B --> C[project.pbxproj]
    C --> D{OllamaPreloadWorkControllerTests.swift\nreferenced?}
    D -- Before PR: NO --> E[XcodeGen drift gate fails\nTest file on disk but not in target]
    D -- After PR: YES --> F[CotabbyTests target\nincludes all sources]
    F --> G[Drift gate passes\nBuild & test succeed]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[project.yml\nCotabbyTests source: CotabbyTests/] --> B[xcodegen generate]
    B --> C[project.pbxproj]
    C --> D{OllamaPreloadWorkControllerTests.swift\nreferenced?}
    D -- Before PR: NO --> E[XcodeGen drift gate fails\nTest file on disk but not in target]
    D -- After PR: YES --> F[CotabbyTests target\nincludes all sources]
    F --> G[Drift gate passes\nBuild & test succeed]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Fix XcodeGen project drift"](https://github.com/fujacob/cotabby/commit/bfe47ac7e0c151aa4386f6bed5fcf856b47530bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44706947)</sub>

<!-- /greptile_comment -->