### PR TITLE
Update Cotabby for single-sequence inference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,10 @@ Runtime generation is split by responsibility:
 cache/decode, and shutdown work serialized while heavy generation runs away from MainActor. The
 manager should publish state; the core should own native correctness.
 
+Cotabby owns one autocomplete sequence. CotabbyInference therefore exposes one live native sequence
+backed by llama.cpp slot zero; a changing external sequence ID rejects stale handles after reset.
+The Swift generation loop owns the maximum output-token budget.
+
 ## UI And Overlays
 
 - `OverlayController` owns the ghost-text panel lifecycle and positioning.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -239,6 +239,10 @@ LlamaRuntimeCore is a nonisolated lock/condition-protected native boundary, not 
 autocomplete lock serializes cache/decode state, and its lifecycle condition prevents shutdown from
 racing active native work. Heavy work runs away from MainActor.
 
+The app and CotabbyInference intentionally expose one live autocomplete sequence. The package uses
+one llama.cpp sequence slot and a changing external ID to reject stale work after a reset; the Swift
+generation loop remains the single owner of the output-token budget.
+
 [BaseCompletionPromptRenderer.swift](Cotabby/Support/Prompting/BaseCompletionPromptRenderer.swift) renders a
 base-model text continuation with optional budgeted context and the caret prefix last. It does not
 wrap a base GGUF in an instruction conversation. [FoundationModelPromptRenderer.swift](Cotabby/Support/Prompting/FoundationModelPromptRenderer.swift)

--- a/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
+++ b/Cotabby/Services/Runtime/LlamaRuntimeCore.swift
@@ -4,13 +4,14 @@ import CotabbyInference
 
 /// File overview:
 /// Owns the C++ inference engine and manages the autocomplete KV cache lifecycle. This is the
-/// lowest-level runtime boundary in the app: it loads the GGUF model, manages concurrent
-/// sequences, tokenizes prompts, samples continuations, and frees native resources on shutdown.
+/// lowest-level runtime boundary in the app: it loads the GGUF model, owns Cotabby's single
+/// autocomplete sequence, tokenizes prompts, samples continuations, and frees native resources on
+/// shutdown.
 ///
-/// The engine handles thread safety internally via per-sequence mutexes. This class is
-/// `@unchecked Sendable` rather than an `actor` so native work can execute away from MainActor.
-/// `autocompleteLock` serializes autocomplete-specific KV-cache state. A separate
-/// `lifecycleCondition` prevents `shutdown()` from unloading the model while generation is in flight.
+/// The engine serializes its one mutable llama context internally. This class is `@unchecked
+/// Sendable` rather than an `actor` so native work can execute away from MainActor.
+/// `autocompleteLock` serializes autocomplete-specific KV-cache state, while a separate
+/// `lifecycleCondition` prevents `shutdown()` from unloading the model during generation.
 
 /// Immutable runtime metadata captured after a model has been successfully prepared.
 struct PreparedLlamaRuntime: Sendable {
@@ -717,16 +718,18 @@ nonisolated final class LlamaRuntimeCore: @unchecked Sendable {
     private static let defaultSamplerSeed: UInt32 = 0x00C0_FFEE
 
     private static func samplingConfig(from options: LlamaGenerationOptions) -> SamplingConfig {
-        SamplingConfig(
-            max_prediction_tokens: Int32(options.maxPredictionTokens),
-            temperature: Float(options.temperature),
-            top_k: Int32(options.topK),
-            top_p: Float(options.topP),
-            min_p: Float(options.minP),
-            repetition_penalty: Float(options.repetitionPenalty),
-            seed: options.seed ?? Self.defaultSamplerSeed,
-            single_line: options.singleLine
-        )
+        // Assign the fields after default construction so the app remains source-compatible while
+        // CotabbyInference removes native configuration fields that Swift never consumed. C++
+        // aggregate memberwise initializers otherwise require every imported field at the call site.
+        var config = SamplingConfig()
+        config.temperature = Float(options.temperature)
+        config.top_k = Int32(options.topK)
+        config.top_p = Float(options.topP)
+        config.min_p = Float(options.minP)
+        config.repetition_penalty = Float(options.repetitionPenalty)
+        config.seed = options.seed ?? Self.defaultSamplerSeed
+        config.single_line = options.singleLine
+        return config
     }
 
     private static func reusableTokenCount(commonTokenPrefix: Int, newPromptTokenCount: Int) -> Int {


### PR DESCRIPTION
## Summary

Make the Swift llama bridge source-compatible with the simplified one-sequence CotabbyInference API, and document that the app owns one autocomplete sequence and the output-token budget. Default-constructing the C++ aggregate keeps this app change compatible with both the old and new package revisions, allowing it to land first without breaking main.

## Validation

- `xcodegen generate` — project regenerated with no project-file diff.
- `xcodebuild -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' build -derivedDataPath build/DerivedData -quiet` against CotabbyInference `main` — exit 0.
- The same build against CotabbyInference commit `8f3979d` on `chore/single-sequence-runtime` — exit 0.

## Linked issues

None.

## Risk / rollout notes

This is a compatibility bridge for the coordinated CotabbyInference cleanup. Runtime generation limits remain owned by the existing Swift loop; no user-facing policy changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adapts `LlamaRuntimeCore` to stay source-compatible with a forthcoming CotabbyInference API simplification that removes C++ aggregate fields Swift never needed, and documents the single-sequence ownership contract in both AGENTS.md and ARCHITECTURE.md.

- `samplingConfig` now default-constructs `SamplingConfig()` and assigns only the fields Swift actually uses, dropping the explicit `max_prediction_tokens` pass-through; the Swift `for _ in 0 ..< options.maxPredictionTokens` loop at line 373 remains the sole token-budget owner.
- Documentation in both AGENTS.md and ARCHITECTURE.md gains a new paragraph clarifying that Cotabby owns exactly one autocomplete sequence, that CotabbyInference backs it with llama.cpp slot zero, and that the Swift generation loop controls the output-token ceiling.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core runtime behaviour is unchanged and the compatibility bridge is validated against both package revisions.

The only behavioural delta at the C++ boundary is that max_prediction_tokens now arrives as the aggregate zero-initialized default instead of options.maxPredictionTokens. The Swift token loop remains the authoritative budget enforcer, so this is inert today. A future C++ change that reads the stored config limit inside sampleNext could silently produce zero tokens, worth keeping in mind when reviewing the companion CotabbyInference PR.

The companion CotabbyInference change (commit 8f3979d on chore/single-sequence-runtime) should be reviewed in tandem with LlamaRuntimeCore.swift to confirm that sampleNext never reads max_prediction_tokens from the sequence config.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Services/Runtime/LlamaRuntimeCore.swift | Replaces memberwise SamplingConfig initializer with default-construction + field assignment; notably drops max_prediction_tokens from the C++ config (token budget remains in Swift's for loop). Comment explains intentional compatibility bridge. |
| AGENTS.md | Adds a paragraph documenting single-sequence ownership and Swift-loop token budget; consistent with code intent. |
| ARCHITECTURE.md | Adds matching paragraph clarifying single live sequence design and Swift loop budget ownership; consistent with AGENTS.md and code. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Swift as Swift (LlamaRuntimeCore)
    participant Engine as CotabbyInferenceEngine (C++)
    participant KV as llama.cpp KV Cache (slot 0)

    Note over Swift,KV: Single autocomplete sequence lifecycle

    Swift->>Swift: samplingConfig(from: options) — SamplingConfig() + field assign
    Swift->>Engine: createSequence(config) → seqID
    Engine->>KV: allocate slot 0

    Swift->>Engine: decodePrompt(seqID, tokens, count, offset)
    Engine->>KV: prefill prompt tokens

    loop Swift owns token budget (options.maxPredictionTokens)
        Swift->>Engine: sampleNext(seqID)
        Engine-->>Swift: SampleResult (piece / is_eos / was_cancelled)
        alt Task.isCancelled or EOS or argmax_eog
            Swift->>Swift: break loop
        end
    end

    Swift->>Engine: trimKV(seqID, promptTokenCount)
    Note over KV: KV restored to prompt-only state for next request

    Note over Swift,KV: On reset / abort
    Swift->>Engine: destroySequence(seqID)
    Engine->>KV: free slot 0
    Swift->>Swift: "autocompleteSequenceID = -1"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Swift as Swift (LlamaRuntimeCore)
    participant Engine as CotabbyInferenceEngine (C++)
    participant KV as llama.cpp KV Cache (slot 0)

    Note over Swift,KV: Single autocomplete sequence lifecycle

    Swift->>Swift: samplingConfig(from: options) — SamplingConfig() + field assign
    Swift->>Engine: createSequence(config) → seqID
    Engine->>KV: allocate slot 0

    Swift->>Engine: decodePrompt(seqID, tokens, count, offset)
    Engine->>KV: prefill prompt tokens

    loop Swift owns token budget (options.maxPredictionTokens)
        Swift->>Engine: sampleNext(seqID)
        Engine-->>Swift: SampleResult (piece / is_eos / was_cancelled)
        alt Task.isCancelled or EOS or argmax_eog
            Swift->>Swift: break loop
        end
    end

    Swift->>Engine: trimKV(seqID, promptTokenCount)
    Note over KV: KV restored to prompt-only state for next request

    Note over Swift,KV: On reset / abort
    Swift->>Engine: destroySequence(seqID)
    Engine->>KV: free slot 0
    Swift->>Swift: "autocompleteSequenceID = -1"
```

</a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22chore%2Fupdate-single-sequence-inference%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2Fupdate-single-sequence-inference%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%3A720-733%0A%60max_prediction_tokens%60%20silently%20dropped%20from%20C%2B%2B%20boundary%20config.%20The%20old%20call%20explicitly%20passed%20%60Int32%28options.maxPredictionTokens%29%60%20as%20%60max_prediction_tokens%60%3B%20default-constructing%20%60SamplingConfig%28%29%60%20leaves%20that%20field%20at%20its%20C%2B%2B%20aggregate%20zero-initialization%20default%20%280%29.%20The%20Swift%20%60for%20_%20in%200%20..%3C%20options.maxPredictionTokens%60%20loop%20at%20line%20373%20is%20the%20authoritative%20budget%20owner%20and%20is%20unchanged%2C%20so%20this%20is%20fine%20as%20long%20as%20%60sampleNext%60%20is%20stateless%20with%20respect%20to%20%60max_prediction_tokens%60.%20If%20a%20future%20C%2B%2B%20revision%20adds%20an%20internal%20guard%20in%20%60sampleNext%60%20that%20reads%20the%20sequence's%20stored%20config%20limit%20and%20short-circuits%20on%200%2C%20every%20decode%20would%20silently%20produce%20zero%20tokens.%20Since%20the%20PR%20validates%20builds%20against%20both%20package%20revisions%20and%20the%20comment%20calls%20this%20field%20%22never%20consumed%2C%22%20this%20is%20currently%20safe%2C%20but%20worth%20flagging%20for%20reviewers%20of%20the%20companion%20CotabbyInference%20change.%0A%0A&repo=fujacob%2Fcotabby&pr=803&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACotabby%2FServices%2FRuntime%2FLlamaRuntimeCore.swift%3A720-733%0A%60max_prediction_tokens%60%20silently%20dropped%20from%20C%2B%2B%20boundary%20config.%20The%20old%20call%20explicitly%20passed%20%60Int32%28options.maxPredictionTokens%29%60%20as%20%60max_prediction_tokens%60%3B%20default-constructing%20%60SamplingConfig%28%29%60%20leaves%20that%20field%20at%20its%20C%2B%2B%20aggregate%20zero-initialization%20default%20%280%29.%20The%20Swift%20%60for%20_%20in%200%20..%3C%20options.maxPredictionTokens%60%20loop%20at%20line%20373%20is%20the%20authoritative%20budget%20owner%20and%20is%20unchanged%2C%20so%20this%20is%20fine%20as%20long%20as%20%60sampleNext%60%20is%20stateless%20with%20respect%20to%20%60max_prediction_tokens%60.%20If%20a%20future%20C%2B%2B%20revision%20adds%20an%20internal%20guard%20in%20%60sampleNext%60%20that%20reads%20the%20sequence's%20stored%20config%20limit%20and%20short-circuits%20on%200%2C%20every%20decode%20would%20silently%20produce%20zero%20tokens.%20Since%20the%20PR%20validates%20builds%20against%20both%20package%20revisions%20and%20the%20comment%20calls%20this%20field%20%22never%20consumed%2C%22%20this%20is%20currently%20safe%2C%20but%20worth%20flagging%20for%20reviewers%20of%20the%20companion%20CotabbyInference%20change.%0A%0A&repo=fujacob%2Fcotabby&pr=803&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Update Cotabby for single-sequence infer..."](https://github.com/fujacob/cotabby/commit/b5f85fbd0fa371a6a46a3578d2206871f3121332) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45295590)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->