### PR TITLE
Tighten popup placement at the caret edge

### DIFF
--- a/Cotabby/Support/Presentation/MirrorOverlayLayout.swift
+++ b/Cotabby/Support/Presentation/MirrorOverlayLayout.swift
@@ -44,9 +44,10 @@ struct MirrorOverlayLayout: Equatable {
         /// distance, not to match the host editor (mirror is explicitly a preview, not a forgery).
         static let fontSize: CGFloat = 13
 
-        /// Vertical gap between the bottom of the input field (or caret rect) and the top of the
-        /// card. Large enough that the card does not look like it is part of the field.
-        static let anchorGap: CGFloat = 8
+        /// Tight visual gap between the bottom of the input field (or caret rect) and the top of
+        /// the card. The card already has a distinct backdrop, so it does not need a full text-row
+        /// buffer to read as separate UI.
+        static let anchorGap: CGFloat = 1
 
         /// Internal padding inside the card around the text + keycap row. Must stay in lockstep with
         /// the `.padding` on `MirrorOverlayView`, since the card fills this computed panel frame.
@@ -66,10 +67,6 @@ struct MirrorOverlayLayout: Equatable {
         /// dock. The visibleFrame already excludes those, but a small inset still looks more
         /// intentional than touching the edge.
         static let screenMargin: CGFloat = 12
-
-        /// Vertical offset used when only the caret rect is available (no input frame). Spans about
-        /// one line height so the card sits just below the caret line rather than on top of it.
-        static let caretFallbackVerticalOffset: CGFloat = 22
     }
 
     /// Computes the layout for one presentation.
@@ -108,9 +105,7 @@ struct MirrorOverlayLayout: Equatable {
         let cardHeight = ceil(scaledFontSize * 1.6) + (Metrics.verticalPadding * 2)
 
         let anchorTopY = computeAnchorTopY(geometry: geometry, reason: reason)
-        let anchorCenterX = computeAnchorCenterX(geometry: geometry)
-
-        var originX = anchorCenterX - (cardWidth / 2)
+        var originX = computeAnchorOriginX(geometry: geometry, cardWidth: cardWidth)
         // Card sits BELOW the field/caret. AppKit screen coordinates are bottom-up, so subtracting
         // the card height from the anchor's bottom edge places the card just under the anchor line.
         var originY = anchorTopY - cardHeight
@@ -179,24 +174,21 @@ struct MirrorOverlayLayout: Equatable {
             if let inputFrame = geometry.inputFrameRect?.standardized, !inputFrame.isEmpty {
                 return inputFrame.minY - Metrics.anchorGap
             }
-            // Caret-rect fallback uses the larger offset because in `.estimated` we treat the caret
-            // height as unreliable; the extra slack keeps the card from overlapping the typed line.
-            return geometry.caretRect.minY - Metrics.caretFallbackVerticalOffset
+            return geometry.caretRect.minY - Metrics.anchorGap
 
         case .caretLayoutEstimated:
             // The hidden-TextKit repair located the caret, so anchor to that estimated caret rect
             // rather than the whole field — the popup should track the cursor, not float below the
-            // document. The one-line offset (not the tight `anchorGap`) drops the card a full line
-            // beneath the estimated caret so it never overlaps the line being typed, which matters
-            // most here because the estimate's exact baseline is less certain than a real AX caret.
-            // Fall back to the field rect, then the tight caret offset, only if the estimate is empty.
+            // document. Keep the same tight visual gap used for trusted caret geometry: the caret
+            // rect already describes the full line box, so another line-height offset would create
+            // an unnecessary blank row between the typed line and the card.
             if !geometry.caretRect.isEmpty {
-                return geometry.caretRect.minY - Metrics.caretFallbackVerticalOffset
+                return geometry.caretRect.minY - Metrics.anchorGap
             }
             if let inputFrame = geometry.inputFrameRect?.standardized, !inputFrame.isEmpty {
                 return inputFrame.minY - Metrics.anchorGap
             }
-            return geometry.caretRect.minY - Metrics.caretFallbackVerticalOffset
+            return geometry.caretRect.minY - Metrics.anchorGap
 
         case .userPreference, .perAppOverride, .caretMidLine:
             // Caret geometry is trustworthy in these cases. Sit just under the caret line so the
@@ -208,20 +200,28 @@ struct MirrorOverlayLayout: Equatable {
             if let inputFrame = geometry.inputFrameRect?.standardized, !inputFrame.isEmpty {
                 return inputFrame.minY - Metrics.anchorGap
             }
-            return geometry.caretRect.minY - Metrics.caretFallbackVerticalOffset
+            return geometry.caretRect.minY - Metrics.anchorGap
         }
     }
 
-    /// Horizontal center the card aligns to. Prefer the caret's X because the user's eye is already
-    /// near the caret; only fall back to the field center if the caret rect looks degenerate.
-    private static func computeAnchorCenterX(geometry: SuggestionOverlayGeometry) -> CGFloat {
+    /// Aligns the card's leading edge with the caret: the left edge starts at the caret's trailing
+    /// edge for LTR text, while the right edge starts at the caret's trailing edge for RTL text.
+    /// A degenerate caret falls back to centering the card beneath the field.
+    private static func computeAnchorOriginX(
+        geometry: SuggestionOverlayGeometry,
+        cardWidth: CGFloat
+    ) -> CGFloat {
         if geometry.caretRect.width > 0 || geometry.caretRect.minX > 0 {
-            return geometry.caretRect.midX
+            return geometry.isRightToLeft
+                ? geometry.caretRect.minX - cardWidth
+                : geometry.caretRect.maxX
         }
         if let inputFrame = geometry.inputFrameRect?.standardized, !inputFrame.isEmpty {
-            return inputFrame.midX
+            return inputFrame.midX - (cardWidth / 2)
         }
-        return geometry.caretRect.midX
+        return geometry.isRightToLeft
+            ? geometry.caretRect.minX - cardWidth
+            : geometry.caretRect.maxX
     }
 
     /// The leading run of `suggestionText` the accept-word key will insert next, reused from the real

--- a/CotabbyTests/Support/Presentation/MirrorOverlayLayoutTests.swift
+++ b/CotabbyTests/Support/Presentation/MirrorOverlayLayoutTests.swift
@@ -9,11 +9,11 @@ final class MirrorOverlayLayoutTests: XCTestCase {
 
     private let screen = CGRect(x: 0, y: 0, width: 1440, height: 900)
 
-    // MARK: - Anchoring to the input field
+    // MARK: - Anchoring below the caret line
 
-    func test_make_anchorsBelowInputFrameWhenAvailable() {
-        // Field sits in the middle of the screen with its bottom edge at y=400. The card should
-        // appear below it (lower y in AppKit's bottom-up coordinate system).
+    func test_make_anchorsTightlyBelowCaretWhenInputFrameIsAvailable() {
+        // The caret line sits inside the field chrome. The card follows the visible text line with
+        // a tight gap instead of adding the field's bottom padding to its vertical offset.
         let geometry = CotabbyTestFixtures.overlayGeometry(
             caretRect: CGRect(x: 720, y: 405, width: 2, height: 18),
             inputFrameRect: CGRect(x: 400, y: 400, width: 640, height: 30)
@@ -27,16 +27,17 @@ final class MirrorOverlayLayoutTests: XCTestCase {
             reason: .caretGeometryEstimated
         )
 
-        XCTAssertLessThan(
+        XCTAssertEqual(
             layout.panelFrame.maxY,
-            geometry.inputFrameRect!.minY,
-            "Card should sit below the input field"
+            geometry.caretRect.minY - 1,
+            accuracy: 0.001,
+            "Card should sit tightly below the visible caret line"
         )
         XCTAssertEqual(layout.suggestionText, "tomorrow afternoon")
         XCTAssertEqual(layout.reason, .caretGeometryEstimated)
     }
 
-    func test_make_centersCardOnCaretX() {
+    func test_make_alignsLeftCardEdgeToLTRCaret() {
         let caretX: CGFloat = 720
         let geometry = CotabbyTestFixtures.overlayGeometry(
             caretRect: CGRect(x: caretX, y: 500, width: 2, height: 18),
@@ -51,11 +52,34 @@ final class MirrorOverlayLayoutTests: XCTestCase {
             reason: .userPreference
         )
 
-        // Card center should be within 1pt of caret center after .integral rounding.
-        XCTAssertLessThanOrEqual(
-            abs(layout.panelFrame.midX - (caretX + 1)),
-            1.5,
-            "Card center should align horizontally to caret X"
+        XCTAssertEqual(
+            layout.panelFrame.minX,
+            geometry.caretRect.maxX,
+            accuracy: 0.001,
+            "LTR card should begin at the caret's trailing edge"
+        )
+    }
+
+    func test_make_alignsRightCardEdgeToRTLCaret() {
+        let geometry = CotabbyTestFixtures.overlayGeometry(
+            caretRect: CGRect(x: 720, y: 500, width: 2, height: 18),
+            inputFrameRect: CGRect(x: 400, y: 480, width: 640, height: 30),
+            isRightToLeft: true
+        )
+
+        let layout = MirrorOverlayLayout.make(
+            suggestion: "hello",
+            geometry: geometry,
+            visibleFrame: screen,
+            showsAcceptanceHint: false,
+            reason: .userPreference
+        )
+
+        XCTAssertEqual(
+            layout.panelFrame.maxX,
+            geometry.caretRect.minX,
+            accuracy: 0.001,
+            "RTL card should end at the caret's trailing edge"
         )
     }
 
@@ -79,12 +103,11 @@ final class MirrorOverlayLayoutTests: XCTestCase {
             reason: .userPreference
         )
 
-        // Card must sit close to the caret line (within one card-height worth of slack), not at the
-        // field's bottom edge.
-        XCTAssertLessThan(
+        XCTAssertEqual(
             userPreferenceLayout.panelFrame.maxY,
-            geometry.caretRect.minY,
-            "User-forced popup should sit below the caret line"
+            geometry.caretRect.minY - 1,
+            accuracy: 0.001,
+            "User-forced popup should sit tightly below the caret line"
         )
         XCTAssertGreaterThan(
             userPreferenceLayout.panelFrame.maxY,
@@ -107,10 +130,33 @@ final class MirrorOverlayLayoutTests: XCTestCase {
             reason: .perAppOverride
         )
 
-        XCTAssertLessThan(
+        XCTAssertEqual(
             layout.panelFrame.maxY,
-            geometry.caretRect.minY,
-            "Per-app forced popup should also sit below the caret line, not the field"
+            geometry.caretRect.minY - 1,
+            accuracy: 0.001,
+            "Per-app forced popup should also sit tightly below the caret line"
+        )
+    }
+
+    func test_make_midLinePopupUsesTightCaretGap() {
+        let geometry = CotabbyTestFixtures.overlayGeometry(
+            caretRect: CGRect(x: 720, y: 500, width: 2, height: 18),
+            inputFrameRect: CGRect(x: 400, y: 400, width: 640, height: 200)
+        )
+
+        let layout = MirrorOverlayLayout.make(
+            suggestion: "hello",
+            geometry: geometry,
+            visibleFrame: screen,
+            showsAcceptanceHint: true,
+            reason: .caretMidLine
+        )
+
+        XCTAssertEqual(
+            layout.panelFrame.maxY,
+            geometry.caretRect.minY - 1,
+            accuracy: 0.001,
+            "Mid-line popup should sit tightly below the trustworthy caret line"
         )
     }
 
@@ -133,7 +179,7 @@ final class MirrorOverlayLayoutTests: XCTestCase {
 
         XCTAssertEqual(
             layout.panelFrame.maxY,
-            geometry.caretRect.minY - 8,
+            geometry.caretRect.minY - 1,
             accuracy: 0.001,
             "Estimated popup should sit directly below the centered text line"
         )
@@ -164,7 +210,7 @@ final class MirrorOverlayLayoutTests: XCTestCase {
 
         XCTAssertEqual(
             layout.panelFrame.maxY,
-            frame.minY - 8,
+            frame.minY - 1,
             accuracy: 0.001,
             "Multiline AXFrame fallback should remain below the field bottom"
         )
@@ -187,11 +233,13 @@ final class MirrorOverlayLayoutTests: XCTestCase {
             reason: .caretLayoutEstimated
         )
 
-        // Card sits one line below the estimated caret line, not at the field's bottom edge.
-        XCTAssertLessThan(
+        // The estimated caret already represents the complete line box, so the card should use a
+        // tight visual gap rather than inserting another blank text row.
+        XCTAssertEqual(
             layout.panelFrame.maxY,
-            geometry.caretRect.minY,
-            "Layout-estimated popup should sit below the estimated caret line"
+            geometry.caretRect.minY - 1,
+            accuracy: 0.001,
+            "Layout-estimated popup should sit tightly below the estimated caret line"
         )
         XCTAssertGreaterThan(
             layout.panelFrame.maxY,
@@ -216,10 +264,8 @@ final class MirrorOverlayLayoutTests: XCTestCase {
             reason: .caretGeometryEstimated
         )
 
-        // The card should still land below the caret rect since no field rect is available. The
-        // fallback uses a fixed vertical offset, so the card's maxY is strictly less than the caret
-        // rect's minY (with some tolerance for the gap).
-        XCTAssertLessThan(layout.panelFrame.maxY, geometry.caretRect.minY)
+        // The card should still use the shared tight gap below the caret when no field is available.
+        XCTAssertEqual(layout.panelFrame.maxY, geometry.caretRect.minY - 1, accuracy: 0.001)
     }
 
     // MARK: - Screen-edge clamping
@@ -382,7 +428,7 @@ final class MirrorOverlayLayoutTests: XCTestCase {
         XCTAssertLessThan(layout.panelFrame.width, 176)
         XCTAssertEqual(layout.panelFrame.height, 29)
         XCTAssertEqual(layout.panelFrame.midX, geometry.inputFrameRect!.midX)
-        XCTAssertEqual(layout.panelFrame.minY, 63)
+        XCTAssertEqual(layout.panelFrame.minY, 70)
     }
 
     func test_make_emptyCaretRectAndMissingInputFrame_clampsToScreenMargin() {


### PR DESCRIPTION
## Summary

- align the popup leading edge with the caret instead of centering the card
- use direction-aware LTR and RTL caret-edge anchoring
- reduce the vertical caret gap from 8/22 points to 1 point
- update popup layout assertions for the new placement

## Why

The caret rectangle already represents the full text line. Adding a full-row uncertainty buffer left an unnecessary blank row between the typed text and popup.

## Validation

Placement tests were updated. The final adjustment was not rerun locally at the requester’s direction.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens the mirror-overlay popup placement in two ways: it aligns the card's leading edge with the caret position (LTR: `caretRect.maxX`, RTL: `caretRect.minX`) instead of centering on the caret midpoint, and it collapses all vertical anchor gaps down to a uniform 1pt `anchorGap`.

- **Horizontal**: `computeAnchorCenterX` is replaced by `computeAnchorOriginX`, which returns the card's `originX` directly; a degenerate caret still falls back to centering on the input field, and a new RTL test covers the mirrored case.
- **Vertical**: `anchorGap` drops from 8pt to 1pt and `caretFallbackVerticalOffset` (22pt) is removed entirely; all reason branches — including `.caretLayoutEstimated` — now share the same 1pt gap.
- **Tests**: Assertions are tightened from loose `XCTAssertLessThan` bounds to exact `XCTAssertEqual` with 0.001 accuracy; one `minY` assertion is a hardcoded derived value rather than an expression over the geometry and metrics constants.

<h3>Confidence Score: 3/5</h3>

Visually safe for trusted-caret paths; the estimated-caret path loses its safety margin without local confirmation.

The horizontal caret-edge alignment and anchorGap reduction are well-motivated and the tests verify both LTR and RTL directions. The concern is the `.caretLayoutEstimated` branch: the 22pt offset it previously had was there precisely because the hidden-TextKit repair produces an approximate caret rect whose baseline accuracy is uncertain. Collapsing to 1pt means a 2-3pt underestimate of the line bottom causes the card to paint over the typed text. The PR description explicitly notes the final adjustment was not rerun locally, so that specific case has no empirical validation.

MirrorOverlayLayout.swift — specifically the `.caretLayoutEstimated` branch in `computeAnchorTopY` and the removal of `caretFallbackVerticalOffset`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/Presentation/MirrorOverlayLayout.swift | Replaces caret-center X alignment with caret-edge X alignment (LTR: card starts at caretRect.maxX, RTL: card ends at caretRect.minX); reduces anchorGap from 8 to 1pt and removes caretFallbackVerticalOffset (22pt), applying the tight 1pt gap uniformly including to caretLayoutEstimated where the estimate accuracy is uncertain. |
| CotabbyTests/Support/Presentation/MirrorOverlayLayoutTests.swift | Updates vertical assertions from loose less-than checks to exact equality with 0.001 accuracy; adds new RTL alignment test and caretMidLine tight-gap test; updates one hardcoded minY assertion from 63 to 70 to match the new anchorGap. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[MirrorOverlayLayout.make] --> B[computeAnchorTopY]
    A --> C[computeAnchorOriginX]
    B --> D{reason}
    D -->|caretGeometryEstimated| E{caretRect empty?}
    D -->|caretLayoutEstimated| F{caretRect empty?}
    D -->|userPreference / perAppOverride / caretMidLine| G{caretRect empty?}
    E -->|No| H[caretRect.minY - 1pt]
    E -->|Yes| I{inputFrame?}
    I -->|Yes| J[inputFrame.minY - 1pt]
    I -->|No| K[caretRect.minY - 1pt fallback]
    F -->|No| H
    F -->|Yes| I
    G -->|No| H
    G -->|Yes| I
    C --> L{caret degenerate?}
    L -->|No| M{isRightToLeft?}
    M -->|LTR| N[caretRect.maxX]
    M -->|RTL| O[caretRect.minX - cardWidth]
    L -->|Yes| P{inputFrame?}
    P -->|Yes| Q[inputFrame.midX - cardWidth/2]
    P -->|No| M
    H & J & K --> R[originY = anchorTopY - cardHeight]
    N & O & Q --> S[originX = result]
    R & S --> T[Clamp to screen edges]
    T --> U[CGRect.integral - panelFrame]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[MirrorOverlayLayout.make] --> B[computeAnchorTopY]
    A --> C[computeAnchorOriginX]
    B --> D{reason}
    D -->|caretGeometryEstimated| E{caretRect empty?}
    D -->|caretLayoutEstimated| F{caretRect empty?}
    D -->|userPreference / perAppOverride / caretMidLine| G{caretRect empty?}
    E -->|No| H[caretRect.minY - 1pt]
    E -->|Yes| I{inputFrame?}
    I -->|Yes| J[inputFrame.minY - 1pt]
    I -->|No| K[caretRect.minY - 1pt fallback]
    F -->|No| H
    F -->|Yes| I
    G -->|No| H
    G -->|Yes| I
    C --> L{caret degenerate?}
    L -->|No| M{isRightToLeft?}
    M -->|LTR| N[caretRect.maxX]
    M -->|RTL| O[caretRect.minX - cardWidth]
    L -->|Yes| P{inputFrame?}
    P -->|Yes| Q[inputFrame.midX - cardWidth/2]
    P -->|No| M
    H & J & K --> R[originY = anchorTopY - cardHeight]
    N & O & Q --> S[originX = result]
    R & S --> T[Clamp to screen edges]
    T --> U[CGRect.integral - panelFrame]
```

</a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22fujacob%2Fcotabby%22%20on%20the%20existing%20branch%20%22codex%2Ftighten-popup-caret-gap%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ftighten-popup-caret-gap%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0ACotabby%2FSupport%2FPresentation%2FMirrorOverlayLayout.swift%3A179-191%0A**%60caretLayoutEstimated%60%20safety%20buffer%20fully%20removed**%0A%0AThe%20old%2022-point%20offset%20for%20this%20case%20was%20explicitly%20justified%20as%20a%20guard%20against%20inaccuracy%20in%20the%20hidden-TextKit%20repair%3A%20_%22the%20estimate's%20exact%20baseline%20is%20less%20certain%20than%20a%20real%20AX%20caret.%22_%20The%20new%201pt%20gap%20gives%20zero%20tolerance%20for%20estimation%20error%20%E2%80%94%20if%20an%20app's%20TextKit%20repair%20places%20%60caret.minY%60%20even%202%E2%80%933%20pt%20below%20the%20actual%20bottom%20of%20the%20glyph%20line%2C%20the%20card%20overlaps%20the%20text%20being%20typed.%20The%20PR%20description%20notes%20that%20the%20final%20adjustment%20was%20not%20rerun%20locally%2C%20so%20this%20specific%20case%20has%20no%20empirical%20confirmation%20that%201pt%20is%20sufficient%20clearance.%0A%0A%23%23%23%20Issue%202%20of%203%0ACotabbyTests%2FSupport%2FPresentation%2FMirrorOverlayLayoutTests.swift%3A430-431%0A**Hardcoded%20%60minY%60%20assertion%20is%20fragile**%0A%0AThe%20value%20%6070%60%20is%20implicitly%20%60inputFrame.minY%20%E2%88%92%20anchorGap%20%E2%88%92%20cardHeight%20%3D%20100%20%E2%88%92%201%20%E2%88%92%2029%60.%20If%20%60Metrics.anchorGap%60%2C%20%60Metrics.verticalPadding%60%2C%20or%20the%20%60ceil%28fontSize%20*%201.6%29%60%20formula%20changes%2C%20this%20assertion%20silently%20breaks%20with%20no%20readable%20signal%20about%20what%20changed.%0A%0A%23%23%23%20Issue%203%20of%203%0ACotabby%2FSupport%2FPresentation%2FMirrorOverlayLayout.swift%3A207-208%0A**RTL%20comment%20describes%20the%20wrong%20edge%20of%20the%20caret**%0A%0AThe%20doc%20comment%20says%20_%22the%20right%20edge%20starts%20at%20the%20caret's%20trailing%20edge%20for%20RTL%20text.%22_%20The%20code%20aligns%20%60panelFrame.maxX%60%20with%20%60caretRect.minX%60%20%E2%80%94%20the%20LEFT%20side%20of%20the%20caret%20beam%20in%20screen%20coordinates.%20For%20RTL%20text%20the%20visual%20trailing%20end%20is%20to%20the%20left%2C%20so%20the%20intent%20is%20correct%2C%20but%20saying%20_%22trailing%20edge%22_%20in%20a%20direction-neutral%20way%20is%20ambiguous%3B%20it%20would%20be%20clearer%20as%20_%22the%20card's%20right%20edge%20aligns%20with%20%60caretRect.minX%60%2C%20the%20visual%20trailing%20side%20in%20RTL.%22_%0A%0A&repo=fujacob%2Fcotabby&pr=804&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0ACotabby%2FSupport%2FPresentation%2FMirrorOverlayLayout.swift%3A179-191%0A**%60caretLayoutEstimated%60%20safety%20buffer%20fully%20removed**%0A%0AThe%20old%2022-point%20offset%20for%20this%20case%20was%20explicitly%20justified%20as%20a%20guard%20against%20inaccuracy%20in%20the%20hidden-TextKit%20repair%3A%20_%22the%20estimate's%20exact%20baseline%20is%20less%20certain%20than%20a%20real%20AX%20caret.%22_%20The%20new%201pt%20gap%20gives%20zero%20tolerance%20for%20estimation%20error%20%E2%80%94%20if%20an%20app's%20TextKit%20repair%20places%20%60caret.minY%60%20even%202%E2%80%933%20pt%20below%20the%20actual%20bottom%20of%20the%20glyph%20line%2C%20the%20card%20overlaps%20the%20text%20being%20typed.%20The%20PR%20description%20notes%20that%20the%20final%20adjustment%20was%20not%20rerun%20locally%2C%20so%20this%20specific%20case%20has%20no%20empirical%20confirmation%20that%201pt%20is%20sufficient%20clearance.%0A%0A%23%23%23%20Issue%202%20of%203%0ACotabbyTests%2FSupport%2FPresentation%2FMirrorOverlayLayoutTests.swift%3A430-431%0A**Hardcoded%20%60minY%60%20assertion%20is%20fragile**%0A%0AThe%20value%20%6070%60%20is%20implicitly%20%60inputFrame.minY%20%E2%88%92%20anchorGap%20%E2%88%92%20cardHeight%20%3D%20100%20%E2%88%92%201%20%E2%88%92%2029%60.%20If%20%60Metrics.anchorGap%60%2C%20%60Metrics.verticalPadding%60%2C%20or%20the%20%60ceil%28fontSize%20*%201.6%29%60%20formula%20changes%2C%20this%20assertion%20silently%20breaks%20with%20no%20readable%20signal%20about%20what%20changed.%0A%0A%23%23%23%20Issue%203%20of%203%0ACotabby%2FSupport%2FPresentation%2FMirrorOverlayLayout.swift%3A207-208%0A**RTL%20comment%20describes%20the%20wrong%20edge%20of%20the%20caret**%0A%0AThe%20doc%20comment%20says%20_%22the%20right%20edge%20starts%20at%20the%20caret's%20trailing%20edge%20for%20RTL%20text.%22_%20The%20code%20aligns%20%60panelFrame.maxX%60%20with%20%60caretRect.minX%60%20%E2%80%94%20the%20LEFT%20side%20of%20the%20caret%20beam%20in%20screen%20coordinates.%20For%20RTL%20text%20the%20visual%20trailing%20end%20is%20to%20the%20left%2C%20so%20the%20intent%20is%20correct%2C%20but%20saying%20_%22trailing%20edge%22_%20in%20a%20direction-neutral%20way%20is%20ambiguous%3B%20it%20would%20be%20clearer%20as%20_%22the%20card's%20right%20edge%20aligns%20with%20%60caretRect.minX%60%2C%20the%20visual%20trailing%20side%20in%20RTL.%22_%0A%0A&repo=fujacob%2Fcotabby&pr=804&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Tighten popup placement at the caret edg..."](https://github.com/fujacob/cotabby/commit/ee9ce0a54400b7b434277f82816ed80d23eff617) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45531631)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->