### PR TITLE
Migrate default suggestion fade speed

### DIFF
--- a/Cotabby/Support/Settings/SuggestionSettingsStore.swift
+++ b/Cotabby/Support/Settings/SuggestionSettingsStore.swift
@@ -54,12 +54,18 @@ struct SuggestionSettingsStore {
     /// Duration in seconds of the suggestion fade-in ramp, surfaced as a Slow-to-Fast speed slider.
     /// The band is narrow on purpose: below the floor the ramp is imperceptible (reads as an instant
     /// snap), and above the ceiling the ghost text feels like it lags the caret rather than settling
-    /// in at it. 0.05s is the fastest slider tick, so new installs get the most responsive fade
-    /// while users can still choose a slower transition. Lower is a faster fade.
+    /// in at it. 0.10s maps to the second-fastest slider tick: quick enough to feel responsive while
+    /// leaving one faster step for users who want a nearly instant appearance. Lower is a faster fade.
     static let minimumFadeInDuration: Double = 0.05
     static let maximumFadeInDuration: Double = 0.30
-    static let defaultFadeInDuration: Double = 0.05
+    static let defaultFadeInDuration: Double = 0.10
     static let fadeInDurationStep: Double = 0.05
+
+    /// `v0.6.1-beta` shipped the speed control with 0.05s as its default. Keep that value explicit:
+    /// the one-time migration below must distinguish the old default from a genuinely customized
+    /// duration without conflating the new default with the slider's minimum.
+    private static let previousDefaultFadeInDuration: Double = 0.05
+    private static let currentFadeInDurationDefaultRevision = 1
 
     /// Hard upper bound on the persisted Extended Context blob, in characters. Sized to match what the
     /// engines actually consume rather than what they can store: the OSS base path renders this as a
@@ -130,6 +136,7 @@ struct SuggestionSettingsStore {
     private static let streamWhileGeneratingDefaultsKey = "cotabbyStreamSuggestionsWhileGenerating"
     private static let fadeInSuggestionsDefaultsKey = "cotabbyFadeInSuggestions"
     private static let fadeInDurationSecondsDefaultsKey = "cotabbyFadeInDurationSeconds"
+    private static let fadeInDurationDefaultRevisionDefaultsKey = "cotabbyFadeInDurationDefaultRevision"
     private static let acceptanceKeyCodeDefaultsKey = "cotabbyAcceptanceKeyCode"
     private static let acceptanceKeyModifiersDefaultsKey = "cotabbyAcceptanceKeyModifiers"
     private static let acceptanceKeyLabelDefaultsKey = "cotabbyAcceptanceKeyLabel"
@@ -200,6 +207,9 @@ struct SuggestionSettingsStore {
         autoAcceptTrailingPunctuationDefaultsKey,
         addSpaceAfterAcceptDefaultsKey,
         streamWhileGeneratingDefaultsKey,
+        fadeInSuggestionsDefaultsKey,
+        fadeInDurationSecondsDefaultsKey,
+        fadeInDurationDefaultRevisionDefaultsKey,
         acceptanceKeyCodeDefaultsKey,
         acceptanceKeyModifiersDefaultsKey,
         acceptanceKeyLabelDefaultsKey,
@@ -416,14 +426,23 @@ struct SuggestionSettingsStore {
         let resolvedFadeInSuggestions =
             userDefaults.object(forKey: Self.fadeInSuggestionsDefaultsKey) as? Bool
                 ?? Self.defaultFadeInSuggestions
-        // Absent key means the user has never touched the speed slider, so use the product default.
-        // A present value is clamped to the band in case a hand-edited default lands outside it.
-        let resolvedFadeInDurationSeconds: Double =
+        let persistedFadeInDurationSeconds: Double? =
             if userDefaults.object(forKey: Self.fadeInDurationSecondsDefaultsKey) == nil {
-                Self.defaultFadeInDuration
+                nil
             } else {
                 Self.clampedFadeInDuration(userDefaults.double(forKey: Self.fadeInDurationSecondsDefaultsKey))
             }
+        let fadeInDurationDefaultRevision =
+            userDefaults.object(forKey: Self.fadeInDurationDefaultRevisionDefaultsKey) as? Int ?? 0
+        // `load` writes defaults back, so key presence alone cannot tell us whether someone changed
+        // the slider in v0.6.1-beta. That was the only public build with this setting, and it seeded
+        // 0.05s. On the first launch after this revision, move only that old-default value (or a truly
+        // absent value) to 0.10s. A non-default duration is a real selection and survives unchanged.
+        // The revision marker makes this one-shot, so choosing the fastest 0.05s tick afterward sticks.
+        let resolvedFadeInDurationSeconds = Self.resolvedFadeInDuration(
+            persisted: persistedFadeInDurationSeconds,
+            appliedDefaultRevision: fadeInDurationDefaultRevision
+        )
 
         let resolvedAcceptanceKeyCode = CGKeyCode(
             userDefaults.object(forKey: Self.acceptanceKeyCodeDefaultsKey) as? Int
@@ -885,6 +904,14 @@ struct SuggestionSettingsStore {
 
     func saveFadeInDurationSeconds(_ seconds: Double) {
         userDefaults.set(seconds, forKey: Self.fadeInDurationSecondsDefaultsKey)
+        let persistedRevision =
+            userDefaults.object(forKey: Self.fadeInDurationDefaultRevisionDefaultsKey) as? Int ?? 0
+        if persistedRevision < Self.currentFadeInDurationDefaultRevision {
+            userDefaults.set(
+                Self.currentFadeInDurationDefaultRevision,
+                forKey: Self.fadeInDurationDefaultRevisionDefaultsKey
+            )
+        }
     }
 
     func saveAcceptanceKey(keyCode: CGKeyCode, modifiers: ShortcutModifierMask, label: String) {
@@ -997,6 +1024,18 @@ struct SuggestionSettingsStore {
         }
 
         return min(maximumFadeInDuration, max(minimumFadeInDuration, value))
+    }
+
+    /// Applies a product-default change once while keeping a person's non-default selection stable.
+    /// After the revision is recorded, even the old 0.05s value is treated as an intentional choice.
+    private static func resolvedFadeInDuration(persisted: Double?, appliedDefaultRevision: Int) -> Double {
+        guard appliedDefaultRevision < currentFadeInDurationDefaultRevision else {
+            return persisted ?? defaultFadeInDuration
+        }
+        guard let persisted else {
+            return defaultFadeInDuration
+        }
+        return persisted == previousDefaultFadeInDuration ? defaultFadeInDuration : persisted
     }
 
     static func normalizedHexString(_ hex: String?) -> String? {

--- a/CotabbyTests/Support/Settings/SuggestionSettingsStoreTests.swift
+++ b/CotabbyTests/Support/Settings/SuggestionSettingsStoreTests.swift
@@ -213,19 +213,19 @@ final class SuggestionSettingsStoreTests: XCTestCase {
         XCTAssertTrue(data.fadeInSuggestions)
     }
 
-    func test_load_fadeInDurationDefaultsToFastestTick() async {
+    func test_load_fadeInDurationDefaultsToSecondFastestTick() async {
         let defaults = makeIsolatedDefaults()
 
         let data = SuggestionSettingsStore(userDefaults: defaults).load(configuration: .standard)
 
-        // The UI reflects duration across the slider range, so the shortest 0.05s duration maps
-        // to speed-axis 0.30: the rightmost, fastest tick in Appearance settings.
-        XCTAssertEqual(SuggestionSettingsStore.defaultFadeInDuration, 0.05, accuracy: 0.0001)
+        // The UI reflects duration across the slider range, so 0.10s maps to speed-axis 0.25:
+        // the second-fastest tick in the 0.05...0.30 band shown in Appearance settings.
+        XCTAssertEqual(SuggestionSettingsStore.defaultFadeInDuration, 0.10, accuracy: 0.0001)
         XCTAssertEqual(
             SuggestionSettingsStore.minimumFadeInDuration
                 + SuggestionSettingsStore.maximumFadeInDuration
                 - SuggestionSettingsStore.defaultFadeInDuration,
-            0.30,
+            0.25,
             accuracy: 0.0001
         )
         XCTAssertEqual(
@@ -233,6 +233,44 @@ final class SuggestionSettingsStoreTests: XCTestCase {
             SuggestionSettingsStore.defaultFadeInDuration,
             accuracy: 0.0001
         )
+    }
+
+    func test_load_migratesShippedFastestDefaultWithoutReenablingFade() async {
+        let defaults = makeIsolatedDefaults()
+        // v0.6.1-beta wrote its 0.05s default during every load, even when the slider was untouched.
+        defaults.set(0.05, forKey: "cotabbyFadeInDurationSeconds")
+        defaults.set(false, forKey: "cotabbyFadeInSuggestions")
+
+        let data = SuggestionSettingsStore(userDefaults: defaults).load(configuration: .standard)
+
+        XCTAssertEqual(data.fadeInDurationSeconds, 0.10, accuracy: 0.0001)
+        XCTAssertFalse(data.fadeInSuggestions, "speed migration must not re-enable a disabled fade")
+        XCTAssertEqual(defaults.integer(forKey: "cotabbyFadeInDurationDefaultRevision"), 1)
+    }
+
+    func test_load_preservesCustomizedFadeInDurationDuringDefaultMigration() async {
+        let defaults = makeIsolatedDefaults()
+        defaults.set(0.25, forKey: "cotabbyFadeInDurationSeconds")
+
+        let data = SuggestionSettingsStore(userDefaults: defaults).load(configuration: .standard)
+
+        XCTAssertEqual(data.fadeInDurationSeconds, 0.25, accuracy: 0.0001)
+        XCTAssertEqual(defaults.integer(forKey: "cotabbyFadeInDurationDefaultRevision"), 1)
+    }
+
+    func test_load_preservesFastestTickChosenAfterDefaultMigration() async {
+        let defaults = makeIsolatedDefaults()
+        let store = SuggestionSettingsStore(userDefaults: defaults)
+        // First launch upgrades the shipped default and records the one-time revision.
+        defaults.set(0.05, forKey: "cotabbyFadeInDurationSeconds")
+        XCTAssertEqual(store.load(configuration: .standard).fadeInDurationSeconds, 0.10, accuracy: 0.0001)
+
+        // The same numeric value now comes from an explicit slider selection and must remain fastest.
+        store.saveFadeInDurationSeconds(0.05)
+
+        let data = store.load(configuration: .standard)
+
+        XCTAssertEqual(data.fadeInDurationSeconds, 0.05, accuracy: 0.0001)
     }
 
     func test_load_clampsOutOfRangeFadeInDuration() async {
@@ -595,6 +633,8 @@ final class SuggestionSettingsStoreTests: XCTestCase {
         store.saveAutoAcceptTrailingPunctuation(false)
         store.saveAddSpaceAfterAccept(true)
         store.saveStreamSuggestionsWhileGenerating(true)
+        store.saveFadeInSuggestions(false)
+        store.saveFadeInDurationSeconds(0.25)
         store.saveAcceptanceKey(keyCode: 36, modifiers: [], label: "Return")
         store.saveFullAcceptanceKey(keyCode: 49, modifiers: [], label: "Space")
         store.saveGlobalToggleKey(keyCode: 47, modifiers: [], label: ".")


### PR DESCRIPTION
## Summary

Set the default suggestion fade to 0.10 seconds, which is the second-fastest tick shown in Appearance settings. Add a revisioned one-time migration so users still on the shipped 0.05-second default adopt 0.10 seconds, while non-default speed selections and the independent fade-enabled toggle remain unchanged.

## Validation

- `swiftlint lint --quiet` — passed.
- `xcodebuild -quiet -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' -derivedDataPath build/DerivedData build` — passed.
- `xcodebuild -quiet -project Cotabby.xcodeproj -scheme Cotabby -destination 'platform=macOS' -derivedDataPath build/DerivedData build-for-testing` — passed.
- Focused `SuggestionSettingsStoreTests` compiled, but local execution hit the repository's known app-host signing mismatch: `Cotabby.app` and `CotabbyTests.xctest` have different Team IDs. CI remains the execution authority.

## Linked issues

None.

## Risk / rollout notes

- `v0.6.1-beta` was the only public release containing the speed control and shipped 0.05 seconds as its default. The migration uses that release boundary: pre-revision 0.05-second values (and absent values) move to 0.10 seconds exactly once; other persisted durations are preserved.
- The migration revision is recorded separately, so a user who chooses the fastest 0.05-second tick after upgrading keeps that choice on future launches.
- Fade enablement is persisted under a separate key and is never changed by the speed migration.
- Reset All Settings now includes the fade toggle, duration, and migration revision in the store-owned preference key set.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes the out-of-box suggestion fade duration from 0.05 s (fastest slider tick) to 0.10 s (second-fastest tick) and adds a one-time migration so v0.6.1-beta users who never manually adjusted the slider are upgraded automatically, while genuine custom selections and the independent fade-enabled toggle are left untouched.

- `SuggestionSettingsStore.swift` — updates `defaultFadeInDuration`, adds `previousDefaultFadeInDuration`/`currentFadeInDurationDefaultRevision` constants, threads `persistedFadeInDurationSeconds` as an `Optional<Double>` through `load`, and adds `resolvedFadeInDuration(persisted:appliedDefaultRevision:)` plus revision write-back inside `saveFadeInDurationSeconds`.
- `SuggestionSettingsStoreTests.swift` — renames the existing default-value test to match the new tick, and adds three focused tests covering the migration (old-default upgrade, custom-value preservation, post-migration intentional re-selection of 0.05 s).

<h3>Confidence Score: 5/5</h3>

Safe to merge — the migration is narrowly scoped, one-shot, and well-tested against all four user-state permutations.

The migration correctly distinguishes the three persisted states (absent, old default 0.05, custom value) using a revision counter, and the write-back in load() stamps that counter atomically via saveFadeInDurationSeconds. All meaningful paths are covered by the new tests, including the critical post-migration re-selection of 0.05 s, fade-toggle independence, and the reset-all scope. No logic errors or missing edge cases were found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cotabby/Support/Settings/SuggestionSettingsStore.swift | Migration logic is well-structured: persisted value is kept Optional, the one-time resolver correctly branches on revision, and the write-back in load() stamps the revision via saveFadeInDurationSeconds. No logic errors found. |
| CotabbyTests/Support/Settings/SuggestionSettingsStoreTests.swift | Tests cover the four meaningful migration paths (fresh install, old-default upgrade, custom value, post-migration re-selection of 0.05 s) plus the fade-toggle independence guard. Reset-all now exercises the new keys. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[load called] --> B{fadeInDurationSecondsDefaultsKey present?}
    B -- No --> C[persisted = nil]
    B -- Yes --> D[persisted = clamped value]
    C --> E[resolvedFadeInDuration\npersisted: nil, revision: R]
    D --> E
    E --> F{revision >= 1?}
    F -- Yes\nMigration already ran --> G[return persisted ?? 0.10]
    F -- No\nFirst launch after upgrade --> H{persisted == nil?}
    H -- Yes\nFresh install --> I[return 0.10 default]
    H -- No --> J{persisted == 0.05\nold shipped default?}
    J -- Yes\nMigrate --> K[return 0.10]
    J -- No\nCustom selection --> L[return persisted unchanged]
    G --> M[data.fadeInDurationSeconds]
    I --> M
    K --> M
    L --> M
    M --> N[write-back: saveFadeInDurationSeconds\nsets duration + bumps revision to 1]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[load called] --> B{fadeInDurationSecondsDefaultsKey present?}
    B -- No --> C[persisted = nil]
    B -- Yes --> D[persisted = clamped value]
    C --> E[resolvedFadeInDuration\npersisted: nil, revision: R]
    D --> E
    E --> F{revision >= 1?}
    F -- Yes\nMigration already ran --> G[return persisted ?? 0.10]
    F -- No\nFirst launch after upgrade --> H{persisted == nil?}
    H -- Yes\nFresh install --> I[return 0.10 default]
    H -- No --> J{persisted == 0.05\nold shipped default?}
    J -- Yes\nMigrate --> K[return 0.10]
    J -- No\nCustom selection --> L[return persisted unchanged]
    G --> M[data.fadeInDurationSeconds]
    I --> M
    K --> M
    L --> M
    M --> N[write-back: saveFadeInDurationSeconds\nsets duration + bumps revision to 1]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Migrate default suggestion fade speed"](https://github.com/fujacob/cotabby/commit/f31f18797283758cd7d956cdd378c91a3d7c22a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45542779)</sub>

<!-- /greptile_comment -->